### PR TITLE
hu-05: run the TokenHub decision-feed consumer in the control plane

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1926,6 +1926,12 @@ def create_app(
     app = FastAPI(title="MAC Control Plane", version="0.1.0")
     app.state.control_plane = cp
     app.state.auth_tokens = tokens
+    # ADR 0001 hu-05: stream TokenHub's routing decisions into observability so
+    # "why am I on provider X / model Y?" is answerable. No-op unless
+    # MAC_TOKENHUB_EVENTS_URL / TOKENHUB_URL (+ admin token) is configured.
+    from mac.tokenhub_feed import start_background_consumer
+
+    app.state.tokenhub_feed_thread = start_background_consumer(cp.observability)
     app.state.hermes_startup = build_hermes_startup_report()
     if (
         os.environ.get("MAC_REQUIRE_HERMES_STARTUP_READY", "").strip().lower()

--- a/src/mac/tokenhub_feed.py
+++ b/src/mac/tokenhub_feed.py
@@ -203,10 +203,12 @@ def start_background_consumer(
     """
     env = env or os.environ
     url = url or events_url_from_env(env)
-    if not url or not observability:
-        return None
     if token is None:
         token = admin_token_from_env(env) or None
+    # The /admin/v1/events feed requires admin auth, so without a token we'd just
+    # loop-retry 401s. Stay a clean no-op until BOTH url and admin token are set.
+    if not url or not token or not observability:
+        return None
 
     def _run() -> None:
         import time

--- a/src/mac/tokenhub_feed.py
+++ b/src/mac/tokenhub_feed.py
@@ -20,14 +20,18 @@ The SSE parser and the event→record mapping are pure and unit-tested;
 from __future__ import annotations
 
 import json
+import os
 import urllib.request
-from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, Mapping, Optional, Tuple
 
 __all__ = [
     "iter_sse_events",
     "event_to_record",
     "record_event",
     "stream_decisions",
+    "events_url_from_env",
+    "admin_token_from_env",
+    "start_background_consumer",
     "ROUTE_EVENT_NAMES",
 ]
 
@@ -155,3 +159,70 @@ def stream_decisions(
             if should_stop is not None and should_stop():
                 break
     return recorded
+
+
+def events_url_from_env(env: Optional[Mapping[str, str]] = None) -> str:
+    """Resolve the TokenHub SSE feed URL: explicit ``MAC_TOKENHUB_EVENTS_URL``,
+    else derive from ``TOKENHUB_URL`` + ``/admin/v1/events`` (the SSE route)."""
+    env = env or os.environ
+    explicit = (env.get("MAC_TOKENHUB_EVENTS_URL") or "").strip()
+    if explicit:
+        return explicit
+    base = (env.get("TOKENHUB_URL") or "").strip().rstrip("/")
+    return base + "/admin/v1/events" if base else ""
+
+
+def admin_token_from_env(env: Optional[Mapping[str, str]] = None) -> str:
+    """The TokenHub *admin* token (the /admin/v1 feed needs admin auth, not the
+    agent chat key)."""
+    env = env or os.environ
+    for key in ("MAC_TOKENHUB_ADMIN_TOKEN", "TOKENHUB_ADMIN_TOKEN"):
+        value = (env.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def start_background_consumer(
+    observability: Any,
+    *,
+    url: Optional[str] = None,
+    token: Optional[str] = None,
+    env: Optional[Mapping[str, str]] = None,
+    reconnect_delay: float = 5.0,
+    _spawn: Optional[Callable[[Callable[[], None]], Any]] = None,
+) -> Any:
+    """Launch a daemon thread that streams TokenHub decisions into ``observability``,
+    reconnecting on drop. **No-op (returns None)** if no events URL is configured
+    or no observability — so it is safe to call unconditionally at control-plane
+    startup. The mac store is thread-safe (lock + ``check_same_thread=False``),
+    so writing observations from this thread is fine.
+
+    ``_spawn`` is injectable for tests (so we can verify gating/derivation without
+    starting a real thread or connecting to TokenHub).
+    """
+    env = env or os.environ
+    url = url or events_url_from_env(env)
+    if not url or not observability:
+        return None
+    if token is None:
+        token = admin_token_from_env(env) or None
+
+    def _run() -> None:
+        import time
+
+        while True:
+            try:
+                stream_decisions(url, observability, token=token)
+            except Exception:
+                pass
+            time.sleep(reconnect_delay)
+
+    if _spawn is not None:
+        return _spawn(_run)
+
+    import threading
+
+    thread = threading.Thread(target=_run, name="tokenhub-feed", daemon=True)
+    thread.start()
+    return thread

--- a/tests/test_tokenhub_feed.py
+++ b/tests/test_tokenhub_feed.py
@@ -3,9 +3,12 @@
 import json
 
 from mac.tokenhub_feed import (
+    admin_token_from_env,
     event_to_record,
+    events_url_from_env,
     iter_sse_events,
     record_event,
+    start_background_consumer,
 )
 
 
@@ -101,3 +104,31 @@ def test_record_event_tolerates_skips_and_no_observability():
             raise AssertionError("should not be called for skipped event")
 
     assert record_event(FakeObs(), "heartbeat", {}) is None
+
+
+def test_events_url_from_env():
+    assert events_url_from_env({}) == ""
+    assert events_url_from_env({"TOKENHUB_URL": "http://hub:8090/"}) == "http://hub:8090/admin/v1/events"
+    # explicit override wins
+    assert events_url_from_env({"TOKENHUB_URL": "http://hub:8090", "MAC_TOKENHUB_EVENTS_URL": "http://x/e"}) == "http://x/e"
+
+
+def test_admin_token_from_env_precedence():
+    assert admin_token_from_env({}) == ""
+    assert admin_token_from_env({"TOKENHUB_ADMIN_TOKEN": "t2"}) == "t2"
+    assert admin_token_from_env({"MAC_TOKENHUB_ADMIN_TOKEN": "t1", "TOKENHUB_ADMIN_TOKEN": "t2"}) == "t1"
+
+
+def test_start_background_consumer_gating():
+    obs = object()
+    # No URL configured -> no-op, does not spawn.
+    spawned = []
+    assert start_background_consumer(obs, env={}, _spawn=lambda r: spawned.append(r)) is None
+    assert spawned == []
+    # No observability -> no-op even with a URL.
+    assert start_background_consumer(None, env={"TOKENHUB_URL": "http://hub:8090"}, _spawn=lambda r: spawned.append(r)) is None
+    assert spawned == []
+    # URL + observability -> spawns the runner.
+    sentinel = object()
+    out = start_background_consumer(obs, env={"TOKENHUB_URL": "http://hub:8090"}, _spawn=lambda r: (spawned.append(r), sentinel)[1])
+    assert out is sentinel and len(spawned) == 1 and callable(spawned[0])

--- a/tests/test_tokenhub_feed.py
+++ b/tests/test_tokenhub_feed.py
@@ -125,10 +125,14 @@ def test_start_background_consumer_gating():
     spawned = []
     assert start_background_consumer(obs, env={}, _spawn=lambda r: spawned.append(r)) is None
     assert spawned == []
-    # No observability -> no-op even with a URL.
-    assert start_background_consumer(None, env={"TOKENHUB_URL": "http://hub:8090"}, _spawn=lambda r: spawned.append(r)) is None
+    # URL but no admin token -> no-op (the /admin/v1/events feed needs auth).
+    assert start_background_consumer(obs, env={"TOKENHUB_URL": "http://hub:8090"}, _spawn=lambda r: spawned.append(r)) is None
     assert spawned == []
-    # URL + observability -> spawns the runner.
+    # No observability -> no-op even with url + token.
+    full_env = {"TOKENHUB_URL": "http://hub:8090", "TOKENHUB_ADMIN_TOKEN": "adm"}
+    assert start_background_consumer(None, env=full_env, _spawn=lambda r: spawned.append(r)) is None
+    assert spawned == []
+    # URL + token + observability -> spawns the runner.
     sentinel = object()
-    out = start_background_consumer(obs, env={"TOKENHUB_URL": "http://hub:8090"}, _spawn=lambda r: (spawned.append(r), sentinel)[1])
+    out = start_background_consumer(obs, env=full_env, _spawn=lambda r: (spawned.append(r), sentinel)[1])
     assert out is sentinel and len(spawned) == 1 and callable(spawned[0])


### PR DESCRIPTION
## What

Wires the hu-05 TokenHub decision-feed consumer (built in `mac.tokenhub_feed`)
into the control-plane startup so provider routing decisions become legible
observability — closing the "inexplicable provider behavior" dark spot.

- `start_background_consumer(cp.observability)` launches a daemon thread that
  streams TokenHub's `/admin/v1/events` SSE feed and records each decision as a
  `tokenhub.route.*` observation, attributed to the agent via `api_key_name`.
- **Gated**: no-op unless `MAC_TOKENHUB_EVENTS_URL` (or `TOKENHUB_URL`, deriving
  `/admin/v1/events`) is set; the feed needs the TokenHub **admin** token
  (`MAC_TOKENHUB_ADMIN_TOKEN`/`TOKENHUB_ADMIN_TOKEN`).
- Reconnects on drop. The mac store is thread-safe (`check_same_thread=False` +
  lock), so writing from the thread is safe.
- `events_url_from_env` / `admin_token_from_env` / `start_background_consumer`
  with gating + derivation tests (injectable `_spawn`, no real thread/connection).

## Activation

Provide the TokenHub admin token to the hub's `mac.env` (deploy follow-up). Until
then the consumer is a clean no-op.

## Not in this PR (deliberately)

The vestigial cleanup (remove the now-dead deploy clone/patch/separate-venv +
`MAC_HERMES_AGENT_DIR` + `hermes_startup` string-surgery shims) is **harmless to
leave** (the live in-process gateway doesn't use them) but spans 13 interdependent
functions across a tested 1,900-line module and a 5,000-line deploy script whose
behavior is only validatable by an actual fleet deploy. It warrants a
canary-validated pass, not a blind edit merged into a working fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)