### PR TITLE
Close mem-08; add 'dreaming' self-improving memory feature set (dream-00..07)

### DIFF
--- a/.tickets/dream-00.md
+++ b/.tickets/dream-00.md
@@ -1,0 +1,40 @@
+---
+id: dream-00
+status: open
+deps: []
+links: ['mem-08']
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: claude-dreaming-article
+discovered_via: external_article_review
+---
+# EPIC: self-improving "dreaming" memory (article-derived feature set)
+
+Source: mindstudio.ai "Claude Dreaming" / self-improving agent memory.
+The article's loop is *exactly* mac's nap cycle (mem-08), so this epic
+**extends** the existing `run_nap_cycle` (begin→consolidate→complete) and
+three-tier memory (Qdrant long/medium + `memory_records`) rather than
+building anything parallel.
+
+## Article loop → mac mapping
+
+| Article step | mac today | Gap → ticket |
+|---|---|---|
+| 1. Session record (inputs, outputs, tool calls, reasoning, outcomes) | scattered observability events + task_history | unified per-session record → **dream-01** |
+| 2. Pattern extraction / meta-reasoning across sessions | `consolidate_nap` does per-group *summaries* only | LLM meta-reasoning pass → **dream-02** |
+| 3. Structured consolidation outputs (preference profiles, decision rules, knowledge snippets, failure patterns) | freeform summaries | typed `mac.dream.v1` artifacts → **dream-03** |
+| 3. Tiering / salience / decay / forgetting | tiers exist; NO importance score, NO decay | salience + decay/forget → **dream-04** |
+| 4. Integration at session start (pull consolidated, proactively) | medium-tier retrieval exists; not turn-primed | session-start priming + proactive recall → **dream-05** |
+| 4. Orchestrator reads sub-agents' consolidated memory for system-wide patterns/routing | none | fleet/hub-level dream → **dream-06** |
+| 7. Auditable/correctable by humans; over-generalization is inference not fact; sensitive-data handling | none | confidence + review/correct + redaction → **dream-07** |
+
+## Sequencing
+dream-01 (input quality) → dream-02/03 (the dream itself) → dream-04 (hygiene)
+→ dream-05 (use) → dream-06 (fleet) → dream-07 (safety, cross-cutting).
+
+## Non-goals
+No second event loop, no new store, no Python rewrite of TokenHub. Everything
+hangs off `run_nap_cycle` and the existing vector tiers.

--- a/.tickets/dream-01.md
+++ b/.tickets/dream-01.md
@@ -1,0 +1,30 @@
+---
+id: dream-01
+status: open
+deps: []
+links: ['mem-08', 'dream-02']
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: claude-dreaming-article
+discovered_via: external_article_review
+---
+# Session-record assembly: high-signal input for the dream
+
+**Article step 1 + guardrail "memory quality depends on session quality."**
+The dream is only as good as its input. Today the consolidator walks
+`memory_records`; the article wants a *session record* = inputs, outputs,
+tool calls, intermediate reasoning, outcomes.
+
+## Acceptance Criteria
+- [ ] A `session_record` view/assembler that, for an agent + time window,
+      stitches: the turn transcript, tool calls + results, the task(s) worked,
+      the evidence/verdict outcome, and provider decisions
+      (`hermes.provider.resolved` + `tokenhub.route.*` from hu-01/hu-05).
+- [ ] `consolidate_nap` consumes session records (not raw `memory_records`)
+      as its unit of review; low-signal sessions (no tool calls, < N tokens)
+      are flagged `low_signal` and down-weighted, not summarized into noise.
+- [ ] Unit test: a session with a failed task + retry produces a record whose
+      `outcome` reflects the failure (so dream-02 can mine it).

--- a/.tickets/dream-02.md
+++ b/.tickets/dream-02.md
@@ -1,0 +1,33 @@
+---
+id: dream-02
+status: open
+deps: ['dream-01']
+links: ['dream-03']
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: claude-dreaming-article
+discovered_via: external_article_review
+---
+# Meta-reasoning pass: extract recurring patterns in the nap
+
+**Article step 2 — "meta-reasoning, thinking about its own thinking."**
+Add an LLM pass inside `run_nap_cycle` (via the in-process gateway) that reads
+the window's session records (dream-01) and emits *generalizable insights*:
+request types seen often, approaches that succeeded vs. failed, edge cases
+that caused confusion.
+
+## Acceptance Criteria
+- [ ] `consolidate_nap` gains a meta-reasoning step that calls the gateway
+      (reuse the agent's resolved provider; cost-bounded, single call/nap) and
+      returns typed candidates (feeds dream-03), not prose.
+- [ ] Failure-safe: a gateway error during the pass is captured in
+      `consolidation_error` and the nap still completes (mem-08 invariant —
+      never strand the agent in DRAINING). Offline/no-provider → skip the pass,
+      fall back to today's group summaries.
+- [ ] The pass is gated by `MAC_DREAM_META_REASONING` (default off until proven)
+      so it can be rolled out per-agent.
+- [ ] Test: a window with 3 failed "push" sessions yields a candidate
+      failure-pattern insight.

--- a/.tickets/dream-03.md
+++ b/.tickets/dream-03.md
@@ -1,0 +1,32 @@
+---
+id: dream-03
+status: open
+deps: ['dream-02']
+links: ['dream-04', 'dream-05']
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: claude-dreaming-article
+discovered_via: external_article_review
+---
+# Typed consolidation artifacts (mac.dream.v1) + medium-tier embedding
+
+**Article step 3 — structured outputs, not raw logs.** Define a schema and
+persist four artifact kinds the article names:
+1. `preference_profile` — per user / task-type preferences.
+2. `decision_rule` — refined "when X, do Y" rules.
+3. `knowledge_snippet` — curated reusable facts.
+4. `failure_pattern` — flagged things to avoid.
+
+## Acceptance Criteria
+- [ ] `mac.dream.v1` schema (validated like the evidence manifests) with the
+      four kinds, each carrying `confidence`, `support_count` (how many
+      sessions), `source_session_ids`, `created_by`, `nap_run_id`.
+- [ ] dream-02 candidates are written as typed `memory_records`
+      (record_type `dream:<kind>`) and embedded into the **medium** tier so
+      retrieval (dream-05) can pull them.
+- [ ] Idempotent: re-running a nap over the same window updates/merges
+      artifacts by stable key, doesn't duplicate (cf. mem-05 idempotency).
+- [ ] Test: round-trips all four kinds; invalid kind rejected by the validator.

--- a/.tickets/dream-04.md
+++ b/.tickets/dream-04.md
@@ -1,0 +1,30 @@
+---
+id: dream-04
+status: open
+deps: ['dream-03']
+links: ['project-mac-observability-bloat']
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: claude-dreaming-article
+discovered_via: external_article_review
+---
+# Salience scoring + decay/forgetting across the memory tiers
+
+**Article §3 gap.** mac has long/medium tiers but no importance score, no
+decay, no forgetting — so the tier only grows (cf. observability bloat). Add
+the hygiene the article implies ("distill noise into high-signal knowledge").
+
+## Acceptance Criteria
+- [ ] Each dream artifact (dream-03) gets a `salience` score from
+      support_count × recency × confidence × usage (incremented when dream-05
+      actually retrieves it).
+- [ ] A decay job (runs inside the nap) demotes stale low-salience artifacts
+      medium→archive and prunes archive past a TTL; high-salience artifacts are
+      promoted/kept in long tier.
+- [ ] Bounded + reversible: a `MAC_DREAM_FORGET_DRY_RUN` mode reports what would
+      be forgotten without deleting; counts are emitted as observations.
+- [ ] Test: a never-retrieved low-confidence artifact decays below threshold and
+      is archived after the simulated TTL; a frequently-retrieved one survives.

--- a/.tickets/dream-05.md
+++ b/.tickets/dream-05.md
@@ -1,0 +1,30 @@
+---
+id: dream-05
+status: open
+deps: ['dream-03', 'dream-04']
+links: ['mem-08']
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: claude-dreaming-article
+discovered_via: external_article_review
+---
+# Session-start priming + proactive recall of consolidated memory
+
+**Article step 4 + §5.** "Claude pulls from the consolidated memory layer —
+not raw logs — to shape behavior" and "surfaces relevant insights without being
+asked." Wire dream artifacts into the hermes runtime's context assembly.
+
+## Acceptance Criteria
+- [ ] At session/turn start the gateway retrieves top-salience dream artifacts
+      relevant to the user + task (medium-tier vector search, dream-03/04) and
+      injects a compact "what I've learned" block into context — consolidated
+      artifacts only, never raw session logs.
+- [ ] Proactive surfacing: if a `failure_pattern` matches the current request,
+      the agent is prompted to avoid it (the article's "without being asked").
+- [ ] Bounded token budget + `MAC_DREAM_PRIMING` gate; retrieval increments the
+      artifact `usage` counter feeding dream-04 salience.
+- [ ] Test: a stored `decision_rule` for a task-type is retrieved and present in
+      assembled context for a matching request.

--- a/.tickets/dream-06.md
+++ b/.tickets/dream-06.md
@@ -1,0 +1,30 @@
+---
+id: dream-06
+status: open
+deps: ['dream-03']
+links: ['reference-rocky-fleet']
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: claude-dreaming-article
+discovered_via: external_article_review
+---
+# Orchestrator/fleet-level cross-agent consolidation
+
+**Article §4 — multi-agent compounding.** "An orchestrating agent reads
+consolidated memories from sub-agents to develop a higher-level understanding
+of system-wide performance patterns" and routes accordingly ("if the research
+agent struggles with a data source, route differently").
+
+## Acceptance Criteria
+- [ ] A hub-level fleet dream that aggregates per-agent dream artifacts
+      (rocky/natasha/bullwinkle) into fleet-scoped `failure_pattern` /
+      `decision_rule` artifacts (subject_type `fleet`).
+- [ ] Surfaces routing signals: e.g. "agent X repeatedly fails task-type Y" →
+      an observation the dispatcher/claim logic can consult.
+- [ ] Read-only w.r.t. agent memories (aggregates, never mutates a sub-agent's
+      tier). Runs on its own (longer) cadence than per-agent naps.
+- [ ] Test: two agents' failure_patterns on the same task-type roll up into one
+      fleet artifact with combined support_count.

--- a/.tickets/dream-07.md
+++ b/.tickets/dream-07.md
@@ -1,0 +1,31 @@
+---
+id: dream-07
+status: open
+deps: ['dream-03']
+links: ['dream-05']
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: claude-dreaming-article
+discovered_via: external_article_review
+---
+# Guardrails: confidence, human audit/correct, redaction
+
+**Article §7.** Consolidations are *inferences, not facts*; they can
+over-generalize from few examples; session logs hold sensitive data. Memory
+must be auditable + correctable by humans.
+
+## Acceptance Criteria
+- [ ] Over-generalization guard: artifacts below a `support_count`/`confidence`
+      floor are marked `provisional` and excluded from proactive surfacing
+      (dream-05) until corroborated by more sessions.
+- [ ] Human workflow: `mac dream list/show/correct/forget` to review artifacts,
+      edit/annotate, or tombstone a wrong one (tombstones are respected by
+      future naps so they don't resurrect).
+- [ ] Redaction: a secret/PII scrub on session records before they enter the
+      dream (reuse the evidence secret-scrub path); sensitive fields never land
+      in a persisted artifact.
+- [ ] Test: a provisional artifact is excluded from priming; a corrected
+      artifact's edit survives the next nap; a tombstoned one is not recreated.

--- a/.tickets/mem-08.md
+++ b/.tickets/mem-08.md
@@ -1,6 +1,6 @@
 ---
 id: mem-08
-status: open
+status: closed
 deps: [mem-06, mem-07]
 links: []
 created: 2026-05-29T02:21:13Z
@@ -29,3 +29,7 @@ audit: memory-tier-2026-05-28
 - After one nap cycle on rocky: `nap_runs` > 0, `memory_records` count grows, `vector_refs` count grows.
 
 Blocked by mem-06, mem-07.
+
+## Resolution (2026-05-31)
+
+Implemented and live. ControlPlane.run_nap_cycle (services.py:6324) drives the full lifecycle in one shot — begin_nap (agent→DRAINING, nap_run created) → consolidate_nap (summarize since last nap, embed into medium tier) → complete_nap (agent→IDLE, nap_run completed). Completion runs in a finally block so a consolidation failure can never strand the agent in DRAINING or leave a nap_run uncompleted; a busy agent (active lease) is reported as skipped rather than failing the batch. The mac-nap-tick systemd timer (deploy/systemd/mac-nap-tick.service, installed via install-nap-tick-service.sh) wakes every 15 min, runs `mac nap due --format=agent-ids | xargs mac nap cycle`, and was verified live on rocky (commit 1201858). The historical '3 begun / 0 completed' rows were the pre-fix state from the old begin-without-complete path; the consolidator now always calls complete_nap.


### PR DESCRIPTION
## Summary
- **mem-08 closed**: `run_nap_cycle` drives the full begin→consolidate→**complete** nap lifecycle (completion in a `finally` so a consolidation failure can never strand an agent in DRAINING); the `mac-nap-tick` systemd timer drives it (verified live on rocky, commit 1201858). The historical "3 begun / 0 completed" rows were the pre-fix begin-without-complete path.
- **`dream-00..07`**: extracted the mindstudio "Claude dreaming" self-improving agent-memory feature set and mapped it faithfully onto mac's *existing* nap cycle + 3-tier memory (no second loop, no new store). Epic + 7 sub-tickets:
  - dream-01 session-record assembly (high-signal input)
  - dream-02 meta-reasoning pattern-extraction pass
  - dream-03 typed `mac.dream.v1` artifacts (preference profiles / decision rules / knowledge snippets / failure patterns)
  - dream-04 salience scoring + decay/forgetting
  - dream-05 session-start priming + proactive recall
  - dream-06 orchestrator/fleet cross-agent consolidation
  - dream-07 confidence + human audit/correct + redaction guardrails

Backlog after this merge: `mac-73cz`, `mac-nyx7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)