### PR TITLE
Add NVIDIA NIM image-generation backend for the fleet (img-01)

### DIFF
--- a/.tickets/img-01.md
+++ b/.tickets/img-01.md
@@ -1,0 +1,51 @@
+---
+id: img-01
+status: open
+deps: []
+links: []
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 2
+assignee:
+mac-task-id:
+audit: image-generation-enablement
+discovered_via: user_request
+---
+# Give rocky / natasha / bullwinkle the ability to generate images (NVIDIA NIM)
+
+The hermes runtime already ships a core `image_generate` tool (in
+`_HERMES_CORE_TOOLS`, so it's offered to every agent) gated by a provider
+`check_fn`. This adds an NVIDIA NIM backend so that tool becomes usable on the
+fleet, using the `NVIDIA_API_KEY` the deploy already plumbs — no new external
+secret beyond an NVIDIA key with image-NIM access.
+
+## Done (code, this session)
+
+- [x] `plugins/image_gen/nvidia/` backend (FLUX.1-dev/schnell + SDXL) — handles
+      both NVIDIA genai request dialects (flux flat body / stability
+      `text_prompts`) and normalizes the several base64 response shapes; saves
+      to `$HERMES_HOME/cache/images/` (gateway then delivers to Slack).
+- [x] `tests/test_image_gen_nvidia.py` (7 tests): response-shape parsing,
+      dialects/aspect, explicit-model kwarg, success→saved-file, missing-key,
+      HTTP-error hinting.
+- [x] Deploy plumbing: `NVIDIA_API_KEY` is no longer stripped from the agent
+      env (the NVIDIA *base URLs* still are, so chat stays pinned to TokenHub);
+      when the key is present the deploy writes `image_gen.provider: nvidia`
+      (+ `model: flux.1-dev`) into `~/.hermes/config.yaml`.
+- [x] Documented in `deploy/systemd/mac.env.example`.
+
+## Activation (operator)
+
+1. Provide an NVIDIA key with image-NIM access at `build.nvidia.com` in the
+   fleet config: `NVIDIA_API_KEY` (fleet-wide) or `NVIDIA_API_KEY__ROCKY` /
+   `__NATASHA` / `__BULLWINKLE` (per-agent).
+2. Redeploy the fleet (or hot-set the key in each agent's `~/.hermes/.env` +
+   add `image_gen:\n  provider: nvidia` to `~/.hermes/config.yaml` + restart
+   the gateway).
+
+## Acceptance Criteria (to close)
+
+- [ ] On each of rocky/natasha/bullwinkle, `image_gen.provider` resolves to
+      `nvidia` and `check_image_generation_requirements()` is True.
+- [ ] E2E: ask each agent (via Slack) "generate an image of X" → an image file
+      is produced and delivered. (Blocked until the operator supplies the key.)

--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -2820,7 +2820,10 @@ if not tokenhub_url and not tokenhub_key:
     raise SystemExit(0)
 
 updates: dict[str, str | None] = {
-    "NVIDIA_API_KEY": None,
+    # Preserve a provided NVIDIA_API_KEY (the NIM image-gen backend reads it).
+    # The NVIDIA *base URLs* are still stripped below so chat never routes to
+    # NVIDIA directly — the gateway provider stays pinned to "custom"/TokenHub.
+    "NVIDIA_API_KEY": (source.get("NVIDIA_API_KEY") or "").strip() or None,
     "NVIDIA_API_BASE": None,
     "NVIDIA_BASE_URL": None,
     "ANTHROPIC_API_KEY": None,
@@ -2975,6 +2978,19 @@ if tokenhub_key:
         output.append("TOKENHUB_API_KEY=%s" % tokenhub_key)
     env_path.write_text("\n".join(output) + "\n", encoding="utf-8")
     env_path.chmod(0o600)
+
+# Image generation backend: when this agent carries an NVIDIA_API_KEY (a NIM
+# image key the operator opted into via the fleet config), make NVIDIA the
+# active ``image_gen`` provider so the core ``image_generate`` tool surfaces.
+# Chat is unaffected — it stays pinned to the "tokenhub" model/provider above.
+nvidia_image_key = str(env.get("NVIDIA_API_KEY") or "").strip()
+if nvidia_image_key:
+    image_gen_cfg = config.get("image_gen") if isinstance(config.get("image_gen"), dict) else {}
+    image_gen_cfg = dict(image_gen_cfg)
+    image_gen_cfg["provider"] = "nvidia"
+    image_gen_cfg.setdefault("model", "flux.1-dev")
+    config["image_gen"] = image_gen_cfg
+    print("Image generation: NVIDIA NIM backend enabled (model=%s)" % image_gen_cfg["model"])
 
 config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
 config_path.chmod(0o600)
@@ -3830,7 +3846,10 @@ if derived_firecrawl_url:
     values["HERMES_WEB_EXTRACT_BACKEND"] = "firecrawl"
 
 provider_secret_keys = (
-    "NVIDIA_API_KEY",
+    # NVIDIA_API_KEY is intentionally NOT stripped: it's the NVIDIA NIM
+    # image-generation backend's key. Chat routing is unaffected because the
+    # NVIDIA base URLs (below) are still removed and the gateway provider is
+    # pinned to "custom"/TokenHub.
     "NVIDIA_API_BASE",
     "NVIDIA_BASE_URL",
     "ANTHROPIC_API_KEY",

--- a/deploy/systemd/mac.env.example
+++ b/deploy/systemd/mac.env.example
@@ -56,6 +56,16 @@ MAC_HERMES_GATEWAY_MODEL=*
 HERMES_INFERENCE_PROVIDER=custom
 HERMES_INFERENCE_MODEL=*
 
+# Image generation (optional). When NVIDIA_API_KEY is set, the deploy enables
+# the NVIDIA NIM image_gen backend (FLUX.1 / SDXL) and the agent's core
+# `image_generate` tool becomes usable. The key must have image-NIM access at
+# build.nvidia.com. Chat routing is unaffected — it stays pinned to TokenHub
+# (only the NVIDIA base URLs are stripped, never this key). Provide it per-agent
+# via the fleet config (NVIDIA_API_KEY or NVIDIA_API_KEY__<AGENT>).
+# NVIDIA_API_KEY=nvapi-REPLACE_ME
+# Optional model override (default flux.1-dev): flux.1-dev | flux.1-schnell | sdxl
+# NVIDIA_IMAGE_MODEL=flux.1-dev
+
 # Supervisor/topology metadata. Fleet deploy sets this dynamically to systemd,
 # launchd, or supervisord.
 # MAC_SUPERVISOR_KIND=systemd

--- a/src/mac/_hermes/plugins/image_gen/nvidia/__init__.py
+++ b/src/mac/_hermes/plugins/image_gen/nvidia/__init__.py
@@ -1,0 +1,395 @@
+"""NVIDIA NIM image generation backend.
+
+Exposes NVIDIA-hosted text-to-image NIMs (``ai.api.nvidia.com/v1/genai``) as an
+:class:`ImageGenProvider`. Uses the ``NVIDIA_API_KEY`` the fleet already plumbs
+for chat routing — no new external secret. Output is base64 → saved under
+``$HERMES_HOME/cache/images/``.
+
+Models (each a virtual id so the ``hermes tools`` picker / ``image_gen.model``
+config key behave like any other multi-model backend):
+
+    flux.1-dev      ~15s   high-quality general text-to-image (default)
+    flux.1-schnell  ~5s    fast, few-step distillation
+    sdxl            ~10s   classic Stable Diffusion XL
+
+NVIDIA's genai image endpoints are model-specific and use two request
+"dialects": the FLUX models take a flat ``{"prompt", "width", "height",
+"steps", "cfg_scale"}`` body, while the Stability (SDXL) models take a
+``{"text_prompts": [...]}`` body. Both return base64 in one of a few response
+shapes; :func:`_extract_b64` normalizes them.
+
+Selection precedence (first hit wins):
+
+1. ``NVIDIA_IMAGE_MODEL`` env var (escape hatch for scripts / tests)
+2. ``image_gen.nvidia.model`` in ``config.yaml``
+3. ``image_gen.model`` in ``config.yaml`` (when it's one of our ids)
+4. :data:`DEFAULT_MODEL` — ``flux.1-dev``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint / catalog
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_URL = "https://ai.api.nvidia.com/v1/genai"
+
+
+def _base_url() -> str:
+    """Resolve the genai image base URL (env override, else the public host).
+
+    NVIDIA's *image* NIMs live under ``ai.api.nvidia.com/v1/genai`` — a
+    different host from the OpenAI-compatible chat base (``NVIDIA_BASE_URL`` /
+    ``integrate.api.nvidia.com``), so we don't reuse that. Override with
+    ``NVIDIA_IMAGE_BASE_URL`` for an on-prem NIM.
+    """
+    raw = (os.environ.get("NVIDIA_IMAGE_BASE_URL") or "").strip()
+    return (raw or DEFAULT_BASE_URL).rstrip("/")
+
+
+# ``endpoint`` is the model path appended to the base URL. ``dialect`` selects
+# the request-body builder. ``steps`` / ``cfg_scale`` are model-tuned defaults.
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "flux.1-dev": {
+        "endpoint": "black-forest-labs/flux.1-dev",
+        "dialect": "flux",
+        "display": "FLUX.1 [dev]",
+        "speed": "~15s",
+        "strengths": "High-quality general text-to-image — default",
+        "steps": 50,
+        "cfg_scale": 3.5,
+    },
+    "flux.1-schnell": {
+        "endpoint": "black-forest-labs/flux.1-schnell",
+        "dialect": "flux",
+        "display": "FLUX.1 [schnell]",
+        "speed": "~5s",
+        "strengths": "Fast few-step distillation",
+        "steps": 4,
+        "cfg_scale": 0.0,
+    },
+    "sdxl": {
+        "endpoint": "stabilityai/stable-diffusion-xl",
+        "dialect": "stability",
+        "display": "Stable Diffusion XL",
+        "speed": "~10s",
+        "strengths": "Classic SDXL",
+        "steps": 25,
+        "cfg_scale": 5.0,
+    },
+}
+
+DEFAULT_MODEL = "flux.1-dev"
+
+# FLUX accepts explicit width/height (multiples of 64). SDXL is fixed 1024².
+_FLUX_SIZES: Dict[str, Tuple[int, int]] = {
+    "landscape": (1344, 768),
+    "square": (1024, 1024),
+    "portrait": (768, 1344),
+}
+
+
+def _load_image_gen_config() -> Dict[str, Any]:
+    """Read the ``image_gen`` section from config.yaml ({} on any failure)."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _resolve_model(explicit: Optional[str] = None) -> Tuple[str, Dict[str, Any]]:
+    """Decide which model id to use and return ``(model_id, meta)``.
+
+    ``explicit`` is the model the tool dispatcher passed through from
+    ``image_gen.model`` config; it wins over config re-reads but not over the
+    ``NVIDIA_IMAGE_MODEL`` env escape hatch.
+    """
+    env_override = os.environ.get("NVIDIA_IMAGE_MODEL")
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    if isinstance(explicit, str) and explicit in _MODELS:
+        return explicit, _MODELS[explicit]
+
+    cfg = _load_image_gen_config()
+    nvidia_cfg = cfg.get("nvidia") if isinstance(cfg.get("nvidia"), dict) else {}
+    candidate: Optional[str] = None
+    if isinstance(nvidia_cfg, dict):
+        value = nvidia_cfg.get("model")
+        if isinstance(value, str) and value in _MODELS:
+            candidate = value
+    if candidate is None:
+        top = cfg.get("model")
+        if isinstance(top, str) and top in _MODELS:
+            candidate = top
+
+    if candidate is not None:
+        return candidate, _MODELS[candidate]
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _build_payload(meta: Dict[str, Any], prompt: str, aspect: str) -> Dict[str, Any]:
+    """Build the request body for the model's dialect."""
+    if meta["dialect"] == "stability":
+        # Stability (SDXL) dialect — text_prompts array, fixed-ish geometry.
+        return {
+            "text_prompts": [{"text": prompt, "weight": 1.0}],
+            "cfg_scale": meta["cfg_scale"],
+            "sampler": "K_DPM_2_ANCESTRAL",
+            "seed": 0,
+            "steps": meta["steps"],
+        }
+    # FLUX dialect — flat body with explicit width/height.
+    width, height = _FLUX_SIZES.get(aspect, _FLUX_SIZES["square"])
+    return {
+        "prompt": prompt,
+        "mode": "base",
+        "cfg_scale": meta["cfg_scale"],
+        "width": width,
+        "height": height,
+        "seed": 0,
+        "steps": meta["steps"],
+    }
+
+
+def _strip_data_uri(value: str) -> str:
+    """Strip a leading ``data:image/...;base64,`` prefix if present."""
+    if isinstance(value, str) and value.startswith("data:"):
+        comma = value.find(",")
+        if comma != -1:
+            return value[comma + 1 :]
+    return value
+
+
+def _extract_b64(data: Any) -> Optional[str]:
+    """Pull base64 image bytes out of the several NVIDIA genai response shapes.
+
+    Handles: ``{"artifacts":[{"base64": ...}]}`` (Stability/SDXL and some FLUX),
+    ``{"image": ...}`` / ``{"b64_json": ...}`` (FLUX flat), and the
+    OpenAI-compatible ``{"data":[{"b64_json": ...}]}`` / ``{"images":[...]}``.
+    """
+    if not isinstance(data, dict):
+        return None
+    artifacts = data.get("artifacts")
+    if isinstance(artifacts, list) and artifacts:
+        first = artifacts[0]
+        if isinstance(first, dict):
+            b64 = first.get("base64") or first.get("b64_json")
+            if isinstance(b64, str) and b64:
+                return _strip_data_uri(b64)
+    for key in ("image", "b64_json"):
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return _strip_data_uri(value)
+    for list_key in ("data", "images"):
+        seq = data.get(list_key)
+        if isinstance(seq, list) and seq:
+            first = seq[0]
+            if isinstance(first, str) and first:
+                return _strip_data_uri(first)
+            if isinstance(first, dict):
+                b64 = first.get("b64_json") or first.get("base64") or first.get("image")
+                if isinstance(b64, str) and b64:
+                    return _strip_data_uri(b64)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provider
+# ---------------------------------------------------------------------------
+
+
+class NvidiaImageGenProvider(ImageGenProvider):
+    """NVIDIA NIM ``genai`` image backend — FLUX.1 + SDXL."""
+
+    @property
+    def name(self) -> str:
+        return "nvidia"
+
+    @property
+    def display_name(self) -> str:
+        return "NVIDIA NIM"
+
+    def is_available(self) -> bool:
+        return bool(os.environ.get("NVIDIA_API_KEY"))
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta["display"],
+                "speed": meta["speed"],
+                "strengths": meta["strengths"],
+                "price": "NVIDIA API credits",
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "NVIDIA NIM",
+            "badge": "api-key",
+            "tag": "FLUX.1 / SDXL via ai.api.nvidia.com",
+            "env_vars": [
+                {
+                    "key": "NVIDIA_API_KEY",
+                    "prompt": "NVIDIA API key (build.nvidia.com)",
+                    "url": "https://build.nvidia.com/",
+                },
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="nvidia",
+                aspect_ratio=aspect,
+            )
+
+        api_key = os.environ.get("NVIDIA_API_KEY")
+        if not api_key:
+            return error_response(
+                error=(
+                    "NVIDIA_API_KEY not set. The fleet plumbs this for chat "
+                    "routing; ensure it's present in the agent env and has "
+                    "image-NIM access at build.nvidia.com."
+                ),
+                error_type="auth_required",
+                provider="nvidia",
+                aspect_ratio=aspect,
+            )
+
+        model_id, meta = _resolve_model(kwargs.get("model"))
+        url = f"{_base_url()}/{meta['endpoint']}"
+        payload = _build_payload(meta, prompt, aspect)
+
+        try:
+            import requests
+
+            response = requests.post(
+                url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=120,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("NVIDIA image request failed", exc_info=True)
+            return error_response(
+                error=f"NVIDIA image request failed: {exc}",
+                error_type="api_error",
+                provider="nvidia",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if response.status_code != 200:
+            body = (response.text or "")[:500]
+            hint = ""
+            if response.status_code in (401, 403):
+                hint = (
+                    " — the NVIDIA_API_KEY may lack image-NIM access; enable "
+                    "the model at build.nvidia.com."
+                )
+            elif response.status_code == 404:
+                hint = f" — model endpoint '{meta['endpoint']}' not found/enabled for this key."
+            return error_response(
+                error=f"NVIDIA genai HTTP {response.status_code}: {body}{hint}",
+                error_type="api_error",
+                provider="nvidia",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            data = response.json()
+        except Exception as exc:  # noqa: BLE001
+            return error_response(
+                error=f"NVIDIA genai returned non-JSON response: {exc}",
+                error_type="empty_response",
+                provider="nvidia",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        b64 = _extract_b64(data)
+        if not b64:
+            return error_response(
+                error="NVIDIA genai response contained no recognizable image data",
+                error_type="empty_response",
+                provider="nvidia",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            saved_path = save_b64_image(b64, prefix=f"nvidia_{model_id}")
+        except Exception as exc:  # noqa: BLE001
+            return error_response(
+                error=f"Could not save image to cache: {exc}",
+                error_type="io_error",
+                provider="nvidia",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        return success_response(
+            image=str(saved_path),
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="nvidia",
+            extra={"endpoint": meta["endpoint"], "steps": meta["steps"]},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+
+def register(ctx) -> None:
+    """Plugin entry point — wire ``NvidiaImageGenProvider`` into the registry."""
+    ctx.register_image_gen_provider(NvidiaImageGenProvider())

--- a/src/mac/_hermes/plugins/image_gen/nvidia/plugin.yaml
+++ b/src/mac/_hermes/plugins/image_gen/nvidia/plugin.yaml
@@ -1,0 +1,7 @@
+name: nvidia
+version: 1.0.0
+description: "NVIDIA NIM image generation backend (FLUX.1, SDXL via ai.api.nvidia.com/v1/genai). Saves generated images to $HERMES_HOME/cache/images/."
+author: mac
+kind: backend
+requires_env:
+  - NVIDIA_API_KEY

--- a/tests/test_image_gen_nvidia.py
+++ b/tests/test_image_gen_nvidia.py
@@ -1,0 +1,169 @@
+"""Tests for the NVIDIA NIM image-generation backend plugin.
+
+The plugin lives in the vendored Hermes snapshot
+(``src/mac/_hermes/plugins/image_gen/nvidia/``). We load it by file path
+after putting the vendored runtime on sys.path, so the test exercises the
+exact module the agents load — without needing the plugin discovery system.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+from mac import hermes_vendor
+
+pytestmark = pytest.mark.skipif(
+    not hermes_vendor.is_vendored(), reason="no vendored Hermes snapshot present"
+)
+
+
+def _load_plugin():
+    """Put the vendored runtime on sys.path and load the nvidia plugin module."""
+    hermes_vendor.ensure_on_path()
+    plugin_path = (
+        Path(hermes_vendor.VENDOR_DIR)
+        / "plugins"
+        / "image_gen"
+        / "nvidia"
+        / "__init__.py"
+    )
+    spec = importlib.util.spec_from_file_location("mac_test_nvidia_imagegen", plugin_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+# 1x1 transparent PNG, base64 — a real decodable image so save_b64_image works.
+_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+)
+
+
+def test_extract_b64_handles_all_nvidia_shapes():
+    mod = _load_plugin()
+    assert mod._extract_b64({"artifacts": [{"base64": "AAAA"}]}) == "AAAA"
+    assert mod._extract_b64({"image": "BBBB"}) == "BBBB"
+    assert mod._extract_b64({"b64_json": "CCCC"}) == "CCCC"
+    assert mod._extract_b64({"data": [{"b64_json": "DDDD"}]}) == "DDDD"
+    assert mod._extract_b64({"images": ["EEEE"]}) == "EEEE"
+    # data: URI prefix is stripped
+    assert mod._extract_b64({"image": "data:image/png;base64,FFFF"}) == "FFFF"
+    # nothing recognizable
+    assert mod._extract_b64({"unexpected": 1}) is None
+    assert mod._extract_b64("not a dict") is None
+
+
+def test_build_payload_dialects_and_aspect():
+    mod = _load_plugin()
+    flux = mod._MODELS["flux.1-dev"]
+    body = mod._build_payload(flux, "a cat", "portrait")
+    assert body["prompt"] == "a cat"
+    assert (body["width"], body["height"]) == mod._FLUX_SIZES["portrait"]
+    assert body["steps"] == flux["steps"]
+    assert "text_prompts" not in body
+
+    sdxl = mod._MODELS["sdxl"]
+    sbody = mod._build_payload(sdxl, "a dog", "landscape")
+    assert sbody["text_prompts"][0]["text"] == "a dog"
+    assert "prompt" not in sbody
+
+
+def test_generate_requires_api_key(monkeypatch):
+    mod = _load_plugin()
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    result = mod.NvidiaImageGenProvider().generate("a fox", "square")
+    assert result["success"] is False
+    assert result["error_type"] == "auth_required"
+
+
+def test_generate_success_saves_image(monkeypatch, tmp_path):
+    mod = _load_plugin()
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["auth"] = headers.get("Authorization")
+        return _FakeResponse(200, {"artifacts": [{"base64": _PNG_B64}]})
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    provider = mod.NvidiaImageGenProvider()
+    result = provider.generate("a serene mountain lake at dawn", "landscape")
+
+    assert result["success"] is True, result
+    assert result["provider"] == "nvidia"
+    assert result["model"] == "flux.1-dev"
+    # The default model's endpoint was hit with a bearer token.
+    assert captured["url"].endswith("black-forest-labs/flux.1-dev")
+    assert captured["auth"] == "Bearer nvapi-test"
+    # A real file landed under the cache dir.
+    saved = Path(result["image"])
+    assert saved.exists()
+    assert saved.read_bytes() == base64.b64decode(_PNG_B64)
+
+
+def test_generate_honors_explicit_model_kwarg(monkeypatch, tmp_path):
+    mod = _load_plugin()
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        return _FakeResponse(200, {"image": _PNG_B64})
+
+    monkeypatch.setattr("requests.post", fake_post)
+    # The tool dispatcher passes image_gen.model through as a `model` kwarg.
+    result = mod.NvidiaImageGenProvider().generate(
+        "a galaxy", "square", model="flux.1-schnell"
+    )
+    assert result["success"] is True, result
+    assert result["model"] == "flux.1-schnell"
+    assert captured["url"].endswith("black-forest-labs/flux.1-schnell")
+
+
+def test_generate_surfaces_http_error_with_hint(monkeypatch, tmp_path):
+    mod = _load_plugin()
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-test")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        return _FakeResponse(403, payload=None, text="forbidden")
+
+    monkeypatch.setattr("requests.post", fake_post)
+    result = mod.NvidiaImageGenProvider().generate("anything", "square")
+    assert result["success"] is False
+    assert result["error_type"] == "api_error"
+    assert "403" in result["error"]
+    assert "image-NIM access" in result["error"]
+
+
+def test_provider_identity_and_models():
+    mod = _load_plugin()
+    provider = mod.NvidiaImageGenProvider()
+    assert provider.name == "nvidia"
+    assert provider.default_model() == "flux.1-dev"
+    ids = {m["id"] for m in provider.list_models()}
+    assert {"flux.1-dev", "flux.1-schnell", "sdxl"} <= ids


### PR DESCRIPTION
## Summary
Gives **rocky / natasha / bullwinkle** the ability to generate images. The hermes runtime already ships a core `image_generate` tool (in `_HERMES_CORE_TOOLS`, offered to every agent) gated by a provider `check_fn`; this adds an **NVIDIA NIM** backend so the tool becomes usable — using the `NVIDIA_API_KEY` the deploy already plumbs (no new external secret beyond an NVIDIA key with image-NIM access).

## Changes
- **`plugins/image_gen/nvidia/`** — FLUX.1-dev/schnell + SDXL backend. Handles both NVIDIA genai request dialects (flux flat body / stability `text_prompts`) and normalizes the `artifacts`/`image`/`b64_json`/`data` response shapes; saves to `$HERMES_HOME/cache/images/` (the gateway then delivers to Slack as a file).
- **`tests/test_image_gen_nvidia.py`** — 7 tests (response-shape parsing, dialects/aspect, explicit-model kwarg, success→saved file, missing-key, HTTP-error hinting). All pass.
- **Deploy plumbing** — `NVIDIA_API_KEY` is no longer stripped from the agent env (the NVIDIA *base URLs* still are, so chat stays pinned to TokenHub/`custom`). When the key is present the deploy writes `image_gen.provider: nvidia` (+ `model: flux.1-dev`) into `~/.hermes/config.yaml`.
- **`deploy/systemd/mac.env.example`** — documents the key + optional model override.

## Activation (operator)
Provide an NVIDIA key with image-NIM access (build.nvidia.com) in the fleet config — `NVIDIA_API_KEY` or per-agent `NVIDIA_API_KEY__ROCKY` etc. — then redeploy. E2E acceptance criteria tracked in `img-01`.

## Tests
`scripts/run-contract-tests.sh` — image-gen (7) + deploy/fleet (44) + evidence validators all green; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)