### PR TITLE
Fix autonomous dev loop: fail closed on non-work, remove fabricated evidence (loop-01)

### DIFF
--- a/.tickets/loop-01.md
+++ b/.tickets/loop-01.md
@@ -1,0 +1,71 @@
+---
+id: loop-01
+status: open
+deps: []
+links: [mac-73cz, mem-08]
+created: 2026-05-31T00:00:00Z
+type: task
+priority: 2
+audit: autonomous-dev-loop-review
+discovered_via: architecture_review
+---
+# Autonomous dev loop: architecture review + fail-closed hardening
+
+End-to-end review of the autonomous dev loop and the fixes that make it stop
+producing non-work that jams.
+
+## Flow (as built)
+
+1. **Claim** — `worker.py` polls `/agents/{id}/claim-next` every `poll_interval`
+   (1s); gets a task + a 900s lease.
+2. **Lease/heartbeat** — `_execute_with_lease_renewal` renews every
+   `min(60, lease/2)`=60s. Hub lease TTL is also 900s (services.py:4498/6560) —
+   **no TTL mismatch**; the earlier "~10s expiry" was the executor subprocess
+   exiting fast on a provider 429, now bounded by [[mac-73cz]].
+3. **Execute** — `mac-hermes-task-executor.py` (a heredoc in
+   deploy-mac-fleet.sh) runs the vendored Hermes agent:
+   `hermes_cli.main chat --query <prompt> --quiet --accept-hooks --yolo`. This
+   IS agentic (max_turns=90, full toolset), so the agent can do multi-step dev
+   work in a git worktree.
+4. **Evidence** — for `publication_target=git://` tasks a deterministic git
+   finalizer commits/pushes/tests and writes `mac-evidence.json` from REAL git
+   state (honest). Otherwise the fallback writer ran.
+5. **Verify → review → publish** — worker pre-check + server
+   `_assess_default_review_evidence`/`validate_evidence_type` gate the evidence;
+   a signed reviewer verdict then publishes (merges + `verify_source_ancestor`).
+
+## Root causes fixed (this review)
+
+- **The fallback writer fabricated verified completion.** It turned the agent's
+  raw chat output (or its own "completed without textual output" placeholder)
+  into a `status=complete` manifest with a synthetic passing
+  `hermes_chat_query` check — so chatter ("hello hello hello") published as
+  done. Fixed: the fallback now emits only an UNVERIFIED `operator_result`
+  (never a fake repo_change/test) with no synthetic check.
+- **`operator_result` accepted any non-empty text.** Added a substance gate
+  (`_operator_result_is_substantive`) rejecting degenerate/placeholder text;
+  genuine planning summaries (several distinct tokens) and structured
+  findings/artifacts still pass.
+- **Worker/server validator divergence.** The worker had its own
+  `_worker_verification_contract_problems` whose operator_result branch lacked
+  the gate, so chatter passed the local pre-check, was submitted, and crashed on
+  the server's 400. Fixed by reusing the shared `_operator_result_is_substantive`
+  so the worker fails the task cleanly (status=failed).
+- Tests: `test_evidence_validators` (substance), `test_e2e_chatter_evidence_fails_closed`
+  (full loop fails closed on chatter, passes on a substantive result),
+  updated `test_deploy_agent_configs`.
+
+## Remaining architectural debt (follow-ups)
+
+- [ ] **Executor lives in a ~500-line bash heredoc** (deploy-mac-fleet.sh) —
+      untestable, easy to drift. Extract to a real `src/mac/task_executor.py`
+      module the deploy just invokes, with unit tests for the prompt builder,
+      git finalizer, and fallback.
+- [ ] **Full worker/server validator consolidation** — the worker still
+      reimplements most of `evidence_validators` (`_worker_*`). Have the worker
+      delegate to `validate_evidence_type` so the contract has ONE source of
+      truth and cannot drift again.
+- [ ] **Worker generic handler re-raises after marking failed** (worker.py:542)
+      — a server-only verification rejection that slips past the local pre-check
+      still escapes run_once. Consider returning a clean `failed` result for
+      verification rejections (4xx) and re-raising only on transient/5xx.

--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -5250,28 +5250,33 @@ def write_fallback_evidence_manifest(
         return
     stdout = (result.stdout or "").strip()
     stderr = (result.stderr or "").strip()
-    result_text = stdout or stderr or "Hermes executor completed without textual output."
+    # autonomy-loop fix: do NOT substitute a "completed without output" placeholder
+    # — leave the deliverable empty so the substance gate can fail it honestly.
+    result_text = stdout or stderr or ""
     summary = next((line.strip() for line in result_text.splitlines() if line.strip()), "")
     if len(summary) > 240:
         summary = summary[:237].rstrip() + "..."
+    # autonomy-loop fix: the fallback must never fabricate *verified* completion.
+    # The deterministic git finalizer already writes real repo_change evidence for
+    # git:// tasks (and short-circuits this via manifest_path.exists()). So the
+    # only thing left to record here is the agent's textual output as an
+    # UNVERIFIED operator_result — NOT a fake repo_change/test/deployment, and
+    # with NO synthetic passing "check" (the chat process exiting 0 is not proof
+    # of the work). A proof-requiring task with no real evidence then fails
+    # validation honestly instead of auto-publishing chatter (the "hello hello
+    # hello" jam). Repo-coupled tasks are additionally rejected by the
+    # operator_result repo-coupled gate (mem-11).
     manifest = {
         "schema": "mac.worker_evidence.v1",
         "status": "complete",
-        "evidence_type": task_evidence_type(task),
-        "summary": summary or "Hermes executor completed.",
+        "evidence_type": "operator_result",
+        "summary": summary,
         "result": result_text[-20000:],
         "task": {
             "id": task.get("id"),
             "title": task.get("title"),
             "project": task.get("project"),
         },
-        "checks": [
-            {
-                "name": "hermes_chat_query",
-                "returncode": result.returncode,
-                "status": "pass",
-            }
-        ],
     }
     manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 

--- a/src/mac/evidence_validators.py
+++ b/src/mac/evidence_validators.py
@@ -317,11 +317,25 @@ class OperatorResultValidator(EvidenceValidator):
                 "provide repo_change/test/no_change evidence with a pushed repo anchor "
                 "(repo.head_sha, repo.pushed=true, repo.remote_ref)"
             ]
-        if str(manifest.raw.get("summary") or manifest.raw.get("result") or "").strip():
-            return []
+        # Structured proof (findings/artifacts) is always sufficient.
         if _manifest_list(manifest.raw.get("artifacts")) or _manifest_list(manifest.raw.get("findings")):
             return []
-        return ["operator_result evidence requires summary, result, findings, or artifacts"]
+        combined = (
+            str(manifest.raw.get("summary") or "") + " " + str(manifest.raw.get("result") or "")
+        ).strip()
+        if not combined:
+            return ["operator_result evidence requires summary, result, findings, or artifacts"]
+        # autonomy-loop fix: reject degenerate / placeholder deliverable text so
+        # the executor's fallback writer can't turn agent chatter ("hello hello
+        # hello") or its own "completed without textual output" stub into a
+        # PUBLISHED task. Genuine planning summaries clear the distinct-token bar.
+        if not _operator_result_is_substantive(combined):
+            return [
+                "operator_result evidence is not substantive (degenerate or placeholder "
+                "text); provide a real summary/result describing the completed work, or "
+                "structured findings/artifacts"
+            ]
+        return []
 
 
 VALIDATORS: Dict[str, EvidenceValidator] = {
@@ -369,3 +383,33 @@ def validate_evidence_type(
 
 def _manifest_list(value: Any) -> List[Any]:
     return value if isinstance(value, list) else []
+
+
+# mem-11 / autonomy-loop fix: the executor's fallback evidence writer turns the
+# agent's raw chat output (or its own no-output placeholder) into an
+# operator_result. The verified jam was a task whose deliverable was literally
+# "hello hello hello". These markers + the distinct-token floor below let the
+# validator reject degenerate, non-substantive operator_result text without
+# over-rejecting genuine short planning summaries (which carry several distinct
+# words, or structured findings/artifacts).
+_OPERATOR_RESULT_PLACEHOLDERS = frozenset(
+    {
+        "hermes executor completed without textual output",
+        "hermes executor completed",
+    }
+)
+_OPERATOR_RESULT_MIN_DISTINCT_TOKENS = 3
+
+
+def _operator_result_is_substantive(text: str) -> bool:
+    """True when ``text`` reads like a real deliverable rather than degenerate
+    chatter ('hello hello hello') or the executor's own no-output placeholder."""
+    cleaned = " ".join((text or "").split())
+    if not cleaned:
+        return False
+    if cleaned.lower().rstrip(". ") in _OPERATOR_RESULT_PLACEHOLDERS:
+        return False
+    # Distinct, non-trivial word tokens. 'hello hello hello' collapses to one
+    # distinct token; a real summary carries several.
+    tokens = {t for t in re.findall(r"[a-z0-9]+", cleaned.lower()) if len(t) > 1}
+    return len(tokens) >= _OPERATOR_RESULT_MIN_DISTINCT_TOKENS

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -2474,9 +2474,26 @@ def _worker_verification_contract_problems(
     if evidence_type == "review_verdict":
         return []
     if evidence_type == "operator_result":
-        if not str(manifest.get("summary") or manifest.get("result") or "").strip():
-            if not _manifest_list(manifest.get("artifacts")) and not _manifest_list(manifest.get("findings")):
-                return ["operator_result evidence requires summary, result, findings, or artifacts"]
+        # autonomy-loop fix: mirror the server's substance gate so the worker
+        # pre-check fails chatter ("hello hello hello") / placeholder evidence
+        # locally and fails the task cleanly, instead of submitting it and
+        # crashing on the server's 400. One definition of "substantive" —
+        # reused from evidence_validators so worker and server can't drift.
+        from mac.evidence_validators import _operator_result_is_substantive
+
+        if _manifest_list(manifest.get("artifacts")) or _manifest_list(manifest.get("findings")):
+            return []
+        combined = (
+            str(manifest.get("summary") or "") + " " + str(manifest.get("result") or "")
+        ).strip()
+        if not combined:
+            return ["operator_result evidence requires summary, result, findings, or artifacts"]
+        if not _operator_result_is_substantive(combined):
+            return [
+                "operator_result evidence is not substantive (degenerate or placeholder "
+                "text); provide a real summary/result describing the completed work, or "
+                "structured findings/artifacts"
+            ]
         return []
     return ["unsupported verification.evidence_type: %s" % evidence_type]
 

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -407,7 +407,13 @@ def test_fleet_deploy_uses_tokenhub_instead_of_direct_provider_secret_paths():
     assert 'tokenhub_provider.pop("api_key", None)' in script
     assert '"chat", "--query", prompt, "--quiet", "--accept-hooks"' in script
     assert "write_fallback_evidence_manifest(task_workspace, task, result, review_context)" in script
-    assert '"evidence_type": task_evidence_type(task)' in script
+    # autonomy-loop fix: the fallback must never fabricate verified completion.
+    # It records the agent's output as an UNVERIFIED operator_result (never a
+    # fake repo_change/test) and without a synthetic passing check — so a
+    # proof-requiring task with no real evidence fails the verification gate
+    # instead of auto-publishing chatter.
+    assert '"evidence_type": "operator_result",' in script
+    assert '"name": "hermes_chat_query"' not in script
     # ADR 0001 hu-03: the gateway provider/model override is now owned, in-process
     # code (mac.agent_provider) routing through TokenHub — not runtime
     # string-surgery of an upstream checkout. Verify the owned mechanism.

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -211,6 +211,72 @@ def test_e2e_full_task_lifecycle_via_http_and_disk(tmp_path: Path):
     assert (tmp_path / "mac.db").stat().st_size > 0
 
 
+def _operator_execution(summary: str) -> WorkerExecution:
+    """A non-repo operator_result execution (the planning/directive path the
+    executor's fallback writer emits)."""
+    return WorkerExecution(
+        0,
+        summary,
+        stdout=summary + "\n",
+        metadata={
+            "verification": {
+                "schema": "mac.worker_evidence.v1",
+                "status": "complete",
+                "evidence_type": "operator_result",
+                "summary": summary,
+            }
+        },
+    )
+
+
+def test_e2e_chatter_evidence_fails_closed(tmp_path: Path):
+    """autonomy-loop fix: an executor that only chats ('hello hello hello') —
+    the exact jam shape — must fail closed at the verification gate, not get
+    submitted for review or published. A *substantive* operator_result on the
+    same kind of task still passes the gate, proving we didn't break the
+    legitimate planning/directive path."""
+    client = _disk_app(tmp_path)
+    machine = client.post("/machines", json={"hostname": "host-fc"}).json()
+    worker = client.post(
+        "/agents",
+        json={"machine_id": machine["id"], "name": "rocky", "capabilities": ["python"]},
+    ).json()
+    api = MacApiClient("http://mac.test", transport=_api_transport(client))
+
+    def _run(title: str, summary: str):
+        task = client.post(
+            "/tasks",
+            json={
+                "title": title,
+                "required_capabilities": ["python"],
+                "metadata": {"publication_target": "test://e2e"},
+            },
+        ).json()
+        macworker = MacWorker(
+            api,
+            worker["id"],
+            tmp_path / "workspaces",
+            lambda _t, _d: _operator_execution(summary),
+            attestation_key=worker["attestation_key"],
+        )
+        return task, macworker.run_once()
+
+    # Chatter → rejected at the gate, task fails closed, nothing published.
+    task, result = _run("E2E chatter task", "hello hello hello")
+    assert result.status == "failed", result
+    assert "substantive" in (result.error or "")
+    final = client.get("/tasks/%s" % task["id"]).json()
+    assert final["task"]["state"] == TaskState.FAILED.value
+    assert not final.get("publications")
+
+    # Substantive planning result → passes the gate (submitted for review).
+    task2, result2 = _run(
+        "E2E planning task",
+        "Produced the rollout plan and identified the three blocking dependencies.",
+    )
+    assert result2.status == "submitted_for_review", result2
+
+
 # ---------------------------------------------------------------------------
 # Test 2: two workers race for one task; exactly one wins
 # ---------------------------------------------------------------------------

--- a/tests/test_evidence_validators.py
+++ b/tests/test_evidence_validators.py
@@ -61,19 +61,62 @@ def test_evidence_validators_are_registry_backed_by_type():
 def test_operator_result_rejected_for_repo_coupled_task():
     # mem-11: a repo-coupled task must anchor on a pushed commit, not a free-text
     # operator_result (the verified task_d7c51a0b "hello hello…" jam).
+    # Use a substantive summary so this exercises the *repo-coupled* gate and not
+    # the separate substance gate (see test_operator_result_rejects_degenerate…).
     manifest = {
         "schema": "mac.verification.v1",
         "status": "complete",
         "evidence_type": "operator_result",
-        "summary": "hello hello hello",  # the literal incident payload shape
+        "summary": "Produced the rollout plan and identified the three blocking dependencies.",
     }
-    # Not repo-coupled (default): accepted as before.
+    # Not repo-coupled (default): a substantive planning result is accepted.
     assert validate_evidence_type("operator_result", manifest, passed_check_count=_passed_check_count) == []
     # Repo-coupled: rejected, with guidance to use a pushed repo anchor.
     problems = validate_evidence_type(
         "operator_result", manifest, passed_check_count=_passed_check_count, repo_coupled=True
     )
     assert problems and "not accepted for a repo-coupled task" in problems[0]
+
+
+def test_operator_result_rejects_degenerate_and_placeholder_text():
+    # autonomy-loop fix: the executor fallback turned agent chatter / its own
+    # no-output stub into a PUBLISHED operator_result. Both must now be rejected.
+    def _op(summary="", result=""):
+        return {
+            "schema": "mac.verification.v1",
+            "status": "complete",
+            "evidence_type": "operator_result",
+            "summary": summary,
+            "result": result,
+        }
+
+    # The literal jam payload.
+    bad = validate_evidence_type("operator_result", _op(summary="hello hello hello"),
+                                 passed_check_count=_passed_check_count)
+    assert bad and "not substantive" in bad[0]
+    # The fallback writer's own placeholder.
+    bad2 = validate_evidence_type(
+        "operator_result",
+        _op(summary="Hermes executor completed without textual output."),
+        passed_check_count=_passed_check_count,
+    )
+    assert bad2 and "not substantive" in bad2[0]
+    # A genuine planning summary clears the bar.
+    good = validate_evidence_type(
+        "operator_result",
+        _op(summary="Story graph produced", result="Mapped the milestones and owners."),
+        passed_check_count=_passed_check_count,
+    )
+    assert good == []
+    # Structured findings/artifacts always pass, regardless of summary text.
+    structured = {
+        "schema": "mac.verification.v1",
+        "status": "complete",
+        "evidence_type": "operator_result",
+        "summary": "ok",
+        "findings": [{"id": 1, "note": "x"}],
+    }
+    assert validate_evidence_type("operator_result", structured, passed_check_count=_passed_check_count) == []
 
 
 def test_repo_change_requires_tests_only_when_contract_demands():


### PR DESCRIPTION
## Architecture review
End-to-end review of the autonomous dev loop (`.tickets/loop-01.md`): claim → 900s lease (heartbeat 60s; hub TTL also 900s, **no mismatch**) → executor runs the vendored Hermes agent via `chat --query --yolo` (**agentic**, max_turns=90, full toolset, in a git worktree) → deterministic git finalizer writes honest `repo_change` evidence from real git state for `git://` tasks → worker + server verification gate → signed reviewer verdict → publish (merge + `verify_source_ancestor`).

## Root cause
The loop "produced non-work that jams" because **a task could reach `complete` without real, checkable work**:

1. **The fallback evidence writer fabricated verified completion** — it turned the agent's raw chat output (or its own "completed without textual output" placeholder) into `status=complete` with a synthetic passing `hermes_chat_query` check. So chatter ("hello hello hello") published as done.
2. **`operator_result` accepted any non-empty text** — no substance check.
3. **Worker/server validator divergence** — the worker reimplements the validator; its `operator_result` branch lacked the gate, so chatter passed the local pre-check, was submitted, and crashed on the server's 400.

## Fix (fail closed, one source of truth)
- Fallback writer now emits only an **unverified `operator_result`** (never a fake `repo_change`/`test`) with **no synthetic check** — proof-requiring tasks with no real evidence fail the gate honestly.
- Added `_operator_result_is_substantive` (rejects degenerate/placeholder text; passes genuine summaries + structured findings/artifacts).
- Worker reuses that shared helper, so it fails chatter **cleanly** (`status=failed`) instead of crashing — and worker/server can't drift on this rule.

The agent invocation and git finalizer were already sound; this makes the **system honest** about whether work happened.

## Tests
`test_e2e_chatter_evidence_fails_closed` (full loop: chatter → failed/not-published, substantive → submitted-for-review) + evidence-validator substance tests + updated `test_deploy_agent_configs`. **Full suite: 683 passed.**

Remaining debt tracked in `loop-01`: extract the executor from the bash heredoc into a tested module; fully consolidate the worker validator onto `validate_evidence_type`; return clean `failed` on server verification rejections instead of re-raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)