### PR TITLE
Worker loop resilience: one task's error no longer crashes the worker (loop-01)

### DIFF
--- a/.tickets/loop-01.md
+++ b/.tickets/loop-01.md
@@ -65,7 +65,10 @@ producing non-work that jams.
       reimplements most of `evidence_validators` (`_worker_*`). Have the worker
       delegate to `validate_evidence_type` so the contract has ONE source of
       truth and cannot drift again.
-- [ ] **Worker generic handler re-raises after marking failed** (worker.py:542)
-      — a server-only verification rejection that slips past the local pre-check
-      still escapes run_once. Consider returning a clean `failed` result for
-      verification rejections (4xx) and re-raising only on transient/5xx.
+- [x] **Worker loop resilience** — `run_forever` had no per-iteration guard, so
+      a `run_once` re-raise (e.g. a server-only verification rejection past the
+      local pre-check) crashed the whole worker and halted all autonomous work.
+      Now `run_forever` catches it, records a `status=error` result, and keeps
+      polling (run_once still best-effort-fails the task first). Test:
+      `test_run_forever_survives_run_once_exception`. (A finer-grained
+      clean-`failed`-on-4xx vs re-raise-on-5xx remains a possible refinement.)

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -344,7 +344,25 @@ class MacWorker:
         try:
             while not self._stop and (max_iterations is None or iterations < max_iterations):
                 iterations += 1
-                outcome = self.run_once()
+                try:
+                    outcome = self.run_once()
+                except Exception as exc:  # noqa: BLE001
+                    # Loop resilience (loop-01): run_once best-effort-marks the
+                    # task failed before any re-raise, so one task's error must
+                    # not crash the worker and halt ALL autonomous work. Record
+                    # it and continue to the next poll. (SIGTERM/SIGINT set
+                    # self._stop via the handlers, not exceptions, so graceful
+                    # shutdown is unaffected; KeyboardInterrupt/SystemExit are
+                    # BaseException and still propagate.)
+                    self._observe_log(
+                        "worker.run_once.exception",
+                        level="error",
+                        detail={"error": str(exc), "iteration": iterations},
+                    )
+                    results.append(WorkerRunResult(status="error", error=str(exc)))
+                    if max_iterations is None:
+                        time.sleep(self.poll_interval_seconds)
+                    continue
                 if outcome.status == "no_task":
                     if max_iterations is None:
                         time.sleep(self.poll_interval_seconds)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -167,6 +167,34 @@ def _write_repo_worker_manifest(task_dir: Path, worktree: Path) -> Dict[str, Any
     )
 
 
+def test_run_forever_survives_run_once_exception(tmp_path: Path):
+    # loop-01: one task's error (here the executor raising) must NOT crash the
+    # worker loop and halt all autonomous work. run_once best-effort-fails the
+    # task and re-raises; run_forever must catch, record, and keep polling.
+    cp = ControlPlane.in_memory()
+    agent = register_worker_fixture(cp)
+    task = cp.create_task("Python task", required_capabilities=["python"])
+    client = TestClient(create_app(control_plane=cp))
+
+    def boom_executor(task_payload: Dict[str, Any], task_dir: Path) -> WorkerExecution:
+        raise RuntimeError("executor blew up")
+
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=api_transport(client)),
+        agent.id,
+        tmp_path,
+        boom_executor,
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+
+    # Does not raise: the loop absorbs the exception and returns a result.
+    results = worker.run_forever(max_iterations=1)
+    assert results and results[-1].status == "error"
+    assert "executor blew up" in (results[-1].error or "")
+    # The task was best-effort-marked failed before the re-raise.
+    assert cp.get_task(task.id).state == TaskState.FAILED.value
+
+
 def test_mac_worker_claims_for_specific_agent_and_submits_for_review(tmp_path: Path):
     cp = ControlPlane.in_memory()
     agent = register_worker_fixture(cp)


### PR DESCRIPTION
## Problem
`run_forever()` called `run_once()` with **no per-iteration guard**. A re-raise from `run_once` (a server-side verification rejection that slips past the local pre-check, or any transient API error) escaped the loop → hit `finally` → **the whole worker process exited**. One bad task halted *all* autonomous work for that agent.

## Fix
`run_forever` now catches the exception, records a `status=error` result, and keeps polling. `run_once` still best-effort-marks the task `failed` before any re-raise, so the task fails and the worker survives. Graceful shutdown is unaffected (SIGTERM/SIGINT set `self._stop`, not exceptions; `KeyboardInterrupt`/`SystemExit` are `BaseException` and still propagate).

## Test
`test_run_forever_survives_run_once_exception` — an executor that raises leaves the task `FAILED` and `run_forever` returns a `status=error` result without propagating. **Full suite: 684 passed.**

Completes the third follow-up in `loop-01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)