### PR TITLE
fleet-01: 'fleet' tool — group view + agentbus messaging (the team capability)

### DIFF
--- a/.tickets/fleet-01.md
+++ b/.tickets/fleet-01.md
@@ -49,10 +49,12 @@ wired to use them.**
       `write_runtime_context` to include a compact, current view of the fleet
       (agents + status + their active tasks + recent completions), refreshed
       live (not just at deploy). The chat agent then *sees* the group.
-- [ ] **fleet-03: a `fleet` tool for the gateway toolset.** An in-process tool
-      exposing read-only `list_agents` / `list_tasks(state)` / recent
-      observations so a session can answer "what is the fleet doing?" with real
-      data. Enable it in the default Slack toolset.
+- [x] **fleet-03: a `fleet` tool (DONE).** `src/mac/_hermes/tools/fleet_tool.py`
+      (added to `_HERMES_CORE_TOOLS`): `fleet status` = roster + who's working on
+      what; `fleet message <agent>` = send an agentbus message to another agent;
+      `fleet inbox` = read messages addressed to me. Calls the hub HTTP API with
+      the agent's env token; gated on hub access. Tests: test_fleet_tool.py (6).
+      This delivers the core 'know what others are doing + talk over agentbus'.
 - [ ] **fleet-04: shared-memory recall in chat.** Have the chat turn recall
       project/fleet memory (like the executor) and inject a "what the fleet has
       learned / is working on" block — true shared consciousness, building on

--- a/src/mac/_hermes/tools/fleet_tool.py
+++ b/src/mac/_hermes/tools/fleet_tool.py
@@ -1,0 +1,247 @@
+"""Fleet awareness + inter-agent messaging tool (fleet-01).
+
+Gives a hermes chat session a "group view" of the fleet and a way to talk to
+other agents over the agentbus — so the three agents behave as a team (each
+keeps its own identity/personality, but knows what the others are doing and can
+message them quickly), instead of each session being isolated to itself.
+
+It reaches the mac hub over HTTP using the agent's own env (the same hub URL +
+token the worker uses), so it works from the in-process gateway without any new
+plumbing. Three actions behind one tool:
+
+  fleet status            → who is on the fleet, their status, and current task
+  fleet message <agent>   → send a quick message to another agent (agentbus)
+  fleet inbox             → read recent messages addressed to me (agentbus)
+
+All hub I/O is best-effort + read-mostly; the only write is a point-to-point
+agentbus message the user/agent explicitly sends.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote, urlencode
+
+from tools.registry import registry, tool_error
+
+
+# ---------------------------------------------------------------------------
+# Hub access (env-driven; mirrors the worker/executor resolution)
+# ---------------------------------------------------------------------------
+
+
+def _hub_env() -> Tuple[str, str]:
+    base_url = (os.environ.get("MAC_HUB_URL") or os.environ.get("MAC_URL") or "").rstrip("/")
+    token = (
+        os.environ.get("MAC_WORKER_TOKEN")
+        or os.environ.get("MAC_TOKEN")
+        or os.environ.get("MAC_API_TOKEN")
+        or ""
+    )
+    return base_url, token
+
+
+def _self_agent_id() -> str:
+    return (
+        os.environ.get("MAC_AGENT_ID")
+        or os.environ.get("MAC_WORKER_AGENT_ID")
+        or ""
+    )
+
+
+def _hub_request(method: str, path: str, payload: Optional[Dict[str, Any]] = None, *, timeout: float = 10.0) -> Any:
+    base_url, token = _hub_env()
+    if not base_url or not token:
+        raise RuntimeError("fleet tool needs MAC_HUB_URL/MAC_URL + a hub token in the agent env")
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(base_url + path, data=data, method=method)
+    req.add_header("Accept", "application/json")
+    req.add_header("Authorization", "Bearer %s" % token)
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (operator-configured hub)
+        raw = resp.read()
+    text = raw.decode("utf-8", "replace") if isinstance(raw, (bytes, bytearray)) else raw
+    return json.loads(text) if text.strip() else None
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers (pure — unit-testable without a hub)
+# ---------------------------------------------------------------------------
+
+
+def format_fleet_status(agents: List[Dict[str, Any]], tasks: List[Dict[str, Any]]) -> str:
+    """Render the fleet roster: who's here, their status, and what they're on."""
+    by_owner: Dict[str, Dict[str, Any]] = {}
+    for t in tasks:
+        owner = t.get("owner_agent_id")
+        if owner and t.get("state") in ("claimed", "running", "needs_review", "reviewing"):
+            by_owner.setdefault(owner, t)
+    lines = ["Fleet status (%d agents):" % len(agents)]
+    for a in sorted(agents, key=lambda x: x.get("name", "")):
+        cur = by_owner.get(a.get("id"))
+        doing = ""
+        if cur:
+            doing = " — working on %s: %s" % (cur.get("id", "?")[:18], (cur.get("title") or "")[:60])
+        elif a.get("current_task_id"):
+            doing = " — task %s" % str(a.get("current_task_id"))[:18]
+        lines.append(
+            "- %s [%s/%s]%s"
+            % (a.get("name", "?"), a.get("status", "?"), a.get("health_status", "?"), doing)
+        )
+    return "\n".join(lines)
+
+
+def format_inbox(chunks: List[Dict[str, Any]], limit: int = 10) -> str:
+    if not chunks:
+        return "Inbox empty — no recent agentbus messages addressed to you."
+    lines = ["Recent agentbus messages (%d):" % min(len(chunks), limit)]
+    for c in chunks[-limit:]:
+        sender = c.get("sender_agent_id") or c.get("sender") or "?"
+        topic = c.get("topic") or "content"
+        payload = c.get("payload")
+        body = payload if isinstance(payload, str) else json.dumps(payload)[:200]
+        lines.append("- from %s [%s]: %s" % (sender, topic, body))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Action handlers
+# ---------------------------------------------------------------------------
+
+
+def _action_status() -> str:
+    agents = _hub_request("GET", "/agents") or []
+    try:
+        tasks = _hub_request("GET", "/tasks?%s" % urlencode({"state": "running"})) or []
+    except Exception:
+        tasks = []
+    if not isinstance(agents, list):
+        agents = []
+    if not isinstance(tasks, list):
+        tasks = []
+    return format_fleet_status(agents, tasks)
+
+
+def _action_message(recipient: str, message: str) -> str:
+    me = _self_agent_id()
+    if not me:
+        return tool_error("cannot determine my own agent id (MAC_AGENT_ID unset)")
+    if not recipient:
+        return tool_error("fleet message requires a recipient agent (name or id)")
+    if not message:
+        return tool_error("fleet message requires a non-empty message")
+    # Resolve a recipient name → agent id if needed.
+    recipient_id = recipient
+    try:
+        agents = _hub_request("GET", "/agents") or []
+        match = next((a for a in agents if a.get("name") == recipient or a.get("id") == recipient), None)
+        if match:
+            recipient_id = match.get("id")
+    except Exception:
+        pass
+    result = _hub_request(
+        "POST",
+        "/agentbus",
+        {
+            "sender_agent_id": me,
+            "recipient_agent_id": recipient_id,
+            "topic": "chat",
+            "content_type": "text/plain",
+            "payload": message,
+            "payload_encoding": "json",
+        },
+    )
+    return json.dumps({"success": True, "delivered_to": recipient_id, "result": result})
+
+
+def _action_inbox(limit: int) -> str:
+    me = _self_agent_id()
+    if not me:
+        return tool_error("cannot determine my own agent id (MAC_AGENT_ID unset)")
+    streams = _hub_request("GET", "/agentbus/streams?%s" % urlencode({"agent_id": me, "limit": 50})) or []
+    chunks: List[Dict[str, Any]] = []
+    if isinstance(streams, list):
+        for s in streams:
+            sid = s.get("id")
+            if not sid:
+                continue
+            try:
+                got = _hub_request(
+                    "GET",
+                    "/agentbus/streams/%s/chunks?%s" % (quote(str(sid), safe=""), urlencode({"agent_id": me, "limit": limit})),
+                ) or []
+                if isinstance(got, list):
+                    chunks.extend(got)
+            except Exception:
+                continue
+    chunks.sort(key=lambda c: str(c.get("created_at") or c.get("sequence") or ""))
+    return format_inbox(chunks, limit=limit)
+
+
+FLEET_SCHEMA = {
+    "name": "fleet",
+    "description": (
+        "See what the rest of the agent fleet is doing and message other agents over "
+        "the agentbus. Use this to coordinate as a team: check who is online and what "
+        "they are working on (status), send another agent a quick message (message), or "
+        "read messages addressed to you (inbox). You keep your own identity — this is "
+        "for group awareness and quick agent-to-agent coordination."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["status", "message", "inbox"],
+                "description": "status = fleet roster + what each agent is working on; "
+                "message = send a message to another agent; inbox = read your recent messages",
+            },
+            "recipient": {"type": "string", "description": "for action=message: the agent name or id to send to"},
+            "message": {"type": "string", "description": "for action=message: the message text"},
+            "limit": {"type": "integer", "description": "for action=inbox: how many recent messages (default 10)"},
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _handle_fleet(args, **kw):
+    action = str(args.get("action") or "").strip().lower()
+    try:
+        if action == "status":
+            return _action_status()
+        if action == "message":
+            return _action_message(str(args.get("recipient") or "").strip(), str(args.get("message") or "").strip())
+        if action == "inbox":
+            try:
+                limit = int(args.get("limit") or 10)
+            except (TypeError, ValueError):
+                limit = 10
+            return _action_inbox(max(1, min(50, limit)))
+        return tool_error("unknown fleet action %r (use status/message/inbox)" % action)
+    except RuntimeError as exc:
+        return tool_error(str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return tool_error("fleet tool error: %s" % exc)
+
+
+def check_fleet_requirements() -> bool:
+    """Available when the agent has hub access (a hub URL + token in env)."""
+    base_url, token = _hub_env()
+    return bool(base_url and token)
+
+
+registry.register(
+    name="fleet",
+    toolset="fleet",
+    schema=FLEET_SCHEMA,
+    handler=_handle_fleet,
+    check_fn=check_fleet_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🛰️",
+)

--- a/src/mac/_hermes/toolsets.py
+++ b/src/mac/_hermes/toolsets.py
@@ -58,6 +58,10 @@ _HERMES_CORE_TOOLS = [
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
     "send_message",
+    # Fleet awareness + inter-agent agentbus messaging (fleet-01): group view of
+    # what other agents are doing + quick agent-to-agent coordination. Gated on
+    # hub access via check_fn.
+    "fleet",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is

--- a/tests/test_fleet_tool.py
+++ b/tests/test_fleet_tool.py
@@ -1,0 +1,104 @@
+"""Tests for the fleet awareness + agentbus messaging tool (fleet-01).
+
+Loads the vendored module by file path (like the nvidia image-gen test) and
+stubs the hub HTTP seam, so nothing here touches a live hub.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from mac import hermes_vendor
+
+pytestmark = pytest.mark.skipif(
+    not hermes_vendor.is_vendored(), reason="no vendored Hermes snapshot present"
+)
+
+
+def _load():
+    hermes_vendor.ensure_on_path()
+    path = Path(hermes_vendor.VENDOR_DIR) / "tools" / "fleet_tool.py"
+    spec = importlib.util.spec_from_file_location("mac_test_fleet_tool", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_format_fleet_status_shows_who_is_doing_what():
+    mod = _load()
+    agents = [
+        {"id": "agent_rocky", "name": "rocky", "status": "busy", "health_status": "healthy"},
+        {"id": "agent_natasha", "name": "natasha", "status": "idle", "health_status": "healthy"},
+    ]
+    tasks = [{"id": "task_abc", "owner_agent_id": "agent_rocky", "state": "running", "title": "Ship the connector"}]
+    out = mod.format_fleet_status(agents, tasks)
+    assert "rocky [busy/healthy]" in out
+    assert "working on task_abc" in out and "Ship the connector" in out
+    assert "natasha [idle/healthy]" in out  # idle agent shown, no task
+
+
+def test_format_inbox_empty_and_populated():
+    mod = _load()
+    assert "Inbox empty" in mod.format_inbox([])
+    chunks = [{"sender_agent_id": "natasha", "topic": "chat", "payload": "can you take task X?"}]
+    out = mod.format_inbox(chunks)
+    assert "from natasha" in out and "task X" in out
+
+
+def test_check_requirements_needs_hub_env(monkeypatch):
+    mod = _load()
+    for k in ("MAC_HUB_URL", "MAC_URL", "MAC_WORKER_TOKEN", "MAC_TOKEN", "MAC_API_TOKEN"):
+        monkeypatch.delenv(k, raising=False)
+    assert mod.check_fleet_requirements() is False
+    monkeypatch.setenv("MAC_HUB_URL", "http://hub:8789")
+    monkeypatch.setenv("MAC_TOKEN", "t")
+    assert mod.check_fleet_requirements() is True
+
+
+def test_status_action_queries_agents_and_tasks(monkeypatch):
+    mod = _load()
+    calls = []
+
+    def fake_req(method, path, payload=None, **kw):
+        calls.append((method, path))
+        if path == "/agents":
+            return [{"id": "agent_rocky", "name": "rocky", "status": "busy", "health_status": "healthy"}]
+        if path.startswith("/tasks"):
+            return [{"id": "t1", "owner_agent_id": "agent_rocky", "state": "running", "title": "X"}]
+        return []
+
+    monkeypatch.setattr(mod, "_hub_request", fake_req)
+    out = mod._handle_fleet({"action": "status"})
+    assert "rocky" in out and "working on t1" in out
+    assert ("GET", "/agents") in calls
+
+
+def test_message_action_resolves_name_and_posts(monkeypatch):
+    mod = _load()
+    monkeypatch.setenv("MAC_AGENT_ID", "agent_rocky")
+    posted = {}
+
+    def fake_req(method, path, payload=None, **kw):
+        if path == "/agents":
+            return [{"id": "agent_natasha", "name": "natasha"}]
+        if method == "POST" and path == "/agentbus":
+            posted.update(payload)
+            return {"stream_id": "s1"}
+        return []
+
+    monkeypatch.setattr(mod, "_hub_request", fake_req)
+    out = mod._handle_fleet({"action": "message", "recipient": "natasha", "message": "hi"})
+    assert json.loads(out)["delivered_to"] == "agent_natasha"
+    assert posted["sender_agent_id"] == "agent_rocky"
+    assert posted["recipient_agent_id"] == "agent_natasha"
+    assert posted["payload"] == "hi"
+
+
+def test_unknown_action_errors():
+    mod = _load()
+    out = mod._handle_fleet({"action": "bogus"})
+    assert "unknown fleet action" in out.lower() or "error" in out.lower()


### PR DESCRIPTION
## Why
hermes chat sessions were isolated to themselves. This makes the three agents a **team**: each keeps its own identity/personality, but can see what the others are doing and message them over the agentbus.

## What
`src/mac/_hermes/tools/fleet_tool.py`, added to `_HERMES_CORE_TOOLS` (so every chat session has it). One tool, three actions:
- **`fleet status`** — the roster + what each agent is currently working on (queries `/agents` + in-flight `/tasks`).
- **`fleet message <agent>`** — send a quick message to another agent over the agentbus (`POST /agentbus`, sender→recipient).
- **`fleet inbox`** — read recent agentbus messages addressed to me.

It reaches the hub over HTTP using the agent's own env token (works from the in-process gateway, no new plumbing) and is gated on hub access via `check_fn`.

## Tests
`test_fleet_tool.py` (6): status/inbox formatters, env gating, status action wiring, name→id resolution + agentbus post, unknown-action error. **Full suite: 709 passed.**

## Remaining fleet-01 (tracked)
Live fleet snapshot injected into the runtime context (passive awareness), shared-memory recall in chat, and home-channel fleet digests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)