### PR TITLE
fix: Slack tokens into ~/.hermes/.env so a restarted gateway enables Slack

### DIFF
--- a/scripts/mac-fetch-slack-secrets.py
+++ b/scripts/mac-fetch-slack-secrets.py
@@ -161,6 +161,49 @@ def write_slack_accounts(hermes_home: Path, accounts: list[dict]) -> None:
         pass
 
 
+def upsert_env_file(env_path: Path, kvs: dict[str, str]) -> bool:
+    """Idempotently set KEY=VALUE lines in a .env file, preserving everything
+    else. Returns True if the file changed.
+
+    This is the durable fix for the gateway coming up "No messaging platforms
+    enabled" after a restart: the gateway wrapper sources ~/.hermes/.env, so the
+    Slack tokens must live THERE (not only in config.yaml's env: block, which a
+    freshly systemd-launched gateway doesn't reliably load before deciding which
+    platforms to enable).
+    """
+    if not kvs:
+        return False
+    existing = ""
+    if env_path.exists():
+        existing = env_path.read_text(encoding="utf-8", errors="ignore")
+    lines = existing.splitlines()
+    out: list[str] = []
+    handled: set[str] = set()
+    changed = False
+    for line in lines:
+        key = line.split("=", 1)[0].strip() if ("=" in line and not line.lstrip().startswith("#")) else None
+        if key in kvs:
+            new_line = "%s=%s" % (key, kvs[key])
+            if new_line != line:
+                changed = True
+            out.append(new_line)
+            handled.add(key)
+        else:
+            out.append(line)
+    for key, value in kvs.items():
+        if key not in handled:
+            out.append("%s=%s" % (key, value))
+            changed = True
+    if changed:
+        env_path.parent.mkdir(parents=True, exist_ok=True)
+        env_path.write_text("\n".join(out) + "\n", encoding="utf-8")
+        try:
+            env_path.chmod(0o600)
+        except OSError:
+            pass
+    return changed
+
+
 def main() -> int:
     agent = (os.environ.get("MAC_AGENT_NAME") or "").strip().lower()
     if not agent:
@@ -280,12 +323,21 @@ def main() -> int:
     if config_path.exists() and env_updates:
         config_changed = update_yaml_env_block(config_path, env_updates)
 
+    # Durable fix: also write the primary tokens into ~/.hermes/.env, which the
+    # gateway wrapper sources at startup. Without this, a systemd-restarted
+    # gateway has no SLACK_BOT_TOKEN/SLACK_APP_TOKEN in its process env and comes
+    # up "No messaging platforms enabled" (Slack silent), even though the tokens
+    # are present in config.yaml.
+    env_file_changed = upsert_env_file(hermes_home / ".env", env_updates)
+
     print(json.dumps({
         "agent": agent,
         "workspaces": summary,
         "slack_accounts_path": str(hermes_home / "slack_accounts.json"),
         "config_yaml_path": str(config_path),
         "config_yaml_changed": config_changed,
+        "env_file_changed": env_file_changed,
+        "env_file_path": str(hermes_home / ".env"),
     }, indent=2))
     return 0
 

--- a/tests/test_slack_secrets_fetcher.py
+++ b/tests/test_slack_secrets_fetcher.py
@@ -1,0 +1,62 @@
+"""Tests for the Slack-secret fetcher's .env upsert (the gateway-Slack fix).
+
+A systemd-restarted gateway came up "No messaging platforms enabled" because
+the Slack tokens lived only in config.yaml's env: block, not in ~/.hermes/.env
+(which the gateway wrapper sources). The fetcher now writes the primary tokens
+into ~/.hermes/.env; these tests lock that behavior in.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_FETCHER = Path(__file__).resolve().parent.parent / "scripts" / "mac-fetch-slack-secrets.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("mac_fetch_slack_secrets", _FETCHER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.skipif(not _FETCHER.exists(), reason="fetcher script not present")
+def test_upsert_adds_tokens_preserving_other_lines(tmp_path):
+    m = _load()
+    env = tmp_path / ".env"
+    env.write_text("TOKENHUB_URL=http://hub:8090\n# comment\nOPENAI_API_KEY=x\n")
+    changed = m.upsert_env_file(env, {"SLACK_BOT_TOKEN": "xoxb-1", "SLACK_APP_TOKEN": "xapp-1"})
+    assert changed is True
+    text = env.read_text()
+    assert "SLACK_BOT_TOKEN=xoxb-1" in text
+    assert "SLACK_APP_TOKEN=xapp-1" in text
+    assert "TOKENHUB_URL=http://hub:8090" in text  # preserved
+    assert "# comment" in text                      # comment preserved
+    assert "OPENAI_API_KEY=x" in text
+
+
+@pytest.mark.skipif(not _FETCHER.exists(), reason="fetcher script not present")
+def test_upsert_is_idempotent_and_updates_in_place(tmp_path):
+    m = _load()
+    env = tmp_path / ".env"
+    m.upsert_env_file(env, {"SLACK_BOT_TOKEN": "xoxb-1"})
+    # same value → no change
+    assert m.upsert_env_file(env, {"SLACK_BOT_TOKEN": "xoxb-1"}) is False
+    # new value → in-place update, no duplicate line
+    assert m.upsert_env_file(env, {"SLACK_BOT_TOKEN": "xoxb-2"}) is True
+    text = env.read_text()
+    assert text.count("SLACK_BOT_TOKEN=") == 1
+    assert "xoxb-2" in text and "xoxb-1" not in text
+
+
+@pytest.mark.skipif(not _FETCHER.exists(), reason="fetcher script not present")
+def test_upsert_creates_file_and_noop_on_empty(tmp_path):
+    m = _load()
+    env = tmp_path / "sub" / ".env"  # parent doesn't exist yet
+    assert m.upsert_env_file(env, {}) is False         # nothing to write
+    assert not env.exists()
+    assert m.upsert_env_file(env, {"SLACK_BOT_TOKEN": "xoxb-9"}) is True
+    assert env.exists() and "xoxb-9" in env.read_text()


### PR DESCRIPTION
## Root cause
After a deploy/restart, rocky's and bullwinkle's gateways came up logging **`No messaging platforms enabled`** and never connected to Slack. The Slack tokens (`SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN`) lived **only** in `config.yaml`'s `env:` block, but the gateway wrapper sources `~/.hermes/.env` + `~/.mac/mac.env` — neither of which had them — and a freshly systemd-launched gateway doesn't reliably load `config.yaml` `env:` before deciding which platforms to enable. natasha's long-lived gateway (started *before* my deploys) still had the tokens in its process env, which is why only she kept responding. **The merger did not remove Slack capability** — natasha proves it works end to end.

## Fix
`scripts/mac-fetch-slack-secrets.py` now also upserts the primary `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN` into `~/.hermes/.env` (idempotent, `0600`, preserving other lines). The gateway wrapper already sources that file, and the later tokenhub env-sync merges (preserving unlisted keys), so the tokens reach the gateway process env on **every** start → Slack enables.

## Effect
Takes effect on the next deploy (the fetcher runs during deploy). Currently-stuck gateways recover on redeploy, or by adding the tokens to `~/.hermes/.env` + a gateway restart.

## Tests
`test_slack_secrets_fetcher.py` (3: add+preserve, idempotent+in-place update, create+empty). **Full suite: 718 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)