### PR TITLE
fix: sync Slack tokens from config.yaml into ~/.hermes/.env (spokes without admin token)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -2884,6 +2884,32 @@ def write_env(path: Path, updates: dict[str, str | None]) -> None:
     path.chmod(0o600)
 
 
+def read_config_env_slack_tokens(config_path: Path) -> dict[str, str]:
+    """Extract SLACK_BOT_TOKEN/SLACK_APP_TOKEN from the top-level env: block of
+    config.yaml. This covers spokes whose Slack *vault fetch* is skipped (no
+    TOKENHUB_ADMIN_TOKEN) but whose config.yaml already carries the tokens: the
+    gateway wrapper sources ~/.hermes/.env, so the tokens must live there too or
+    a restarted gateway comes up "No messaging platforms enabled"."""
+    out: dict[str, str] = {}
+    if not config_path.exists():
+        return out
+    in_env = False
+    for line in config_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        if not in_env:
+            if line.rstrip() == "env:":
+                in_env = True
+            continue
+        if line.strip() and line[:1] not in {" ", "\t", "#"}:
+            break  # left the env: block
+        stripped = line.strip()
+        for k in ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"):
+            if stripped.startswith(k + ":"):
+                v = stripped.split(":", 1)[1].strip().strip("'\"")
+                if v:
+                    out[k] = v
+    return out
+
+
 source = read_env(source_path)
 keys = (
     "MAC_HERMES_SLACK_HOME_CHANNEL_NAME",
@@ -2899,6 +2925,10 @@ for key in keys:
     value = source.get(key, "").strip()
     if value:
         updates[key] = value
+# Ensure the gateway-sourced .env has the Slack tokens even when the vault fetch
+# was skipped (spokes without the admin token) — read them from config.yaml.
+for tk, tv in read_config_env_slack_tokens(target_path.parent / "config.yaml").items():
+    updates.setdefault(tk, tv)
 if updates:
     write_env(target_path, updates)
 print("Slack identity env: synced %d value(s) to %s" % (len(updates), target_path))


### PR DESCRIPTION
Follow-up to #16. The fetcher-side `.env` write only fires when the Slack vault fetch runs, but spokes without a `TOKENHUB_ADMIN_TOKEN` (e.g. bullwinkle) **skip the fetch** entirely — so their `~/.hermes/.env` never got the tokens even though `config.yaml` already has them, and a restarted gateway came up `No messaging platforms enabled`.

`sync_hermes_slack_identity_env` (runs every deploy, independent of the fetch) now also reads `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN` from `config.yaml`'s `env:` block and writes them into `~/.hermes/.env` (the gateway-sourced file). Covers every agent that has the tokens in config.yaml, fetch or not.

Verified live: after the redeploy, **rocky reconnected** (`[Slack] Socket Mode connected: 2 account(s)`) via #16's fetcher-side fix; this closes the remaining gap for bullwinkle.

Tests: deploy + fetcher suites green. **Full suite: 718 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)