### PR TITLE
docs: scale specs — memory tier at scale (ADR 0002) + optional in-mac router (ADR 0003)

### DIFF
--- a/.tickets/mem-store-01.md
+++ b/.tickets/mem-store-01.md
@@ -1,0 +1,34 @@
+---
+id: mem-store-01
+status: open
+deps: []
+links: [dream-04, dream-06, mem-08, mem-09, th-merge-01]
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 1
+audit: memory-store-at-scale
+discovered_via: architecture_review
+---
+# EPIC: memory tier for 50–200 agents per hub (ADR 0002)
+
+Spec: `docs/adr/0002-memory-store-at-scale.md`. Qdrant stays the production
+default (not overkill at the target scale); the work is the abstraction + the
+gaps around it.
+
+## Work breakdown (by leverage)
+
+- [ ] **mem-store-02: real embeddings on by default.** Default a hub to a real
+      embedding model (batched, async, fixed model+dim per collection); hash
+      stub becomes offline/test-only. Biggest recall-quality win, store-agnostic.
+- [ ] **mem-store-03: `VectorStore` interface.** `ensure_collection/upsert/
+      query/delete` ABC; move Qdrant specifics behind it; `MAC_VECTOR_BACKEND`
+      = qdrant (prod) | sqlite-vec/lancedb (dev/single-agent). Test seam.
+- [ ] **mem-store-04: hard multi-tenant scoping.** Every point payload carries
+      tenant/agent/project/tier/record_type/salience/created_at; recall filters
+      by tenant + agent|project; explicit fleet/project-shared layer ([[dream-06]]).
+- [ ] **mem-store-05: bounded growth.** Wire [[dream-04]] decay per hub +
+      scalar/product quantization so the index stays bounded as agents/history
+      grow.
+- [ ] **mem-store-06: fail-soft recall.** Bounded timeout; Qdrant-unavailable →
+      empty result, never hang the agent (same lesson as [[loop-01]]); health
+      check + resource caps + monitoring on the Qdrant dependency.

--- a/.tickets/th-merge-01.md
+++ b/.tickets/th-merge-01.md
@@ -1,0 +1,40 @@
+---
+id: th-merge-01
+status: open
+deps: []
+links: [mac-nyx7, hu-05, mem-store-02]
+created: 2026-05-31T00:00:00Z
+type: feature
+priority: 1
+audit: tokenhub-core-into-mac
+discovered_via: architecture_review
+---
+# EPIC: optional in-mac model router + vault (ADR 0003)
+
+Spec: `docs/adr/0003-tokenhub-core-into-mac.md`. Subsume TokenHub's core
+leverage (provider routing + secret vault) into mac as an OPTION behind the
+OpenAI-compatible surface; drop the UI; keep standalone TokenHub as a backend.
+Motivated by the live wedge (single provider + stuck breaker + no fail-fast).
+
+## Work breakdown
+
+- [ ] **th-merge-02: OpenAI front door in mac.** `/v1/chat/completions` +
+      `/v1/embeddings` accepting `model="*"`; Hermes/executor point at it via the
+      same base_url contract (config flip). `MAC_ROUTER_BACKEND=inproc|tokenhub`.
+- [ ] **th-merge-03: multi-provider + recovering breaker.** >1 provider,
+      priority/Thompson selection, a circuit breaker that **half-opens + re-probes**
+      (the exact bug we hit), and fail-fast when all providers are down. Fixes
+      the SPOF + the hang.
+- [ ] **th-merge-04: secret vault.** Encrypted-at-rest provider keys
+      (`vault://`); EMBED TokenHub's vault lib or a minimal audited
+      envelope-encryption store — do NOT reinvent crypto. Gate behind review.
+- [ ] **th-merge-05: native decision telemetry.** Emit `mac.router.*`
+      observations in-process (reuse [[hu-05]] mapping); surface provider
+      decisions in the hub UI (replaces the dropped TokenHub admin UI).
+- [ ] **th-merge-06: weekly wildcard refresh wiring.** Fold [[mac-nyx7]] into the
+      in-proc router's model ladder when backend=inproc.
+
+## Guardrails (stay minimal)
+Port routing + vault + the OpenAI surface only. NOT the admin UI, NOT Temporal,
+NOT feature parity — that long tail stays behind the `tokenhub` backend option.
+This partially supersedes ADR 0001's "keep TokenHub separate".

--- a/docs/adr/0002-memory-store-at-scale.md
+++ b/docs/adr/0002-memory-store-at-scale.md
@@ -1,0 +1,79 @@
+# ADR 0002 — Memory store / vector tier at fleet scale (50–200 agents per hub)
+
+- Status: **Proposed**
+- Date: 2026-05-31
+- Decision owner: Jordan Hubbard
+- Context: the fleet today is 3 agents (the minimum), but the target is
+  **50–200 agents per user, each user starting with their own hub**. The
+  question "is Qdrant the best vector store for our purposes" has a different
+  answer at 3 agents than at 200. This ADR specs the memory tier for the
+  *target* scale, not the current minimum.
+
+## TL;DR verdict
+
+**At the target scale, Qdrant is the right default — not overkill.** The earlier
+"a separate vector service is a heavy moving part" concern holds for a 1–3 agent
+toy, but 50–200 agents per hub, each generating conversation/nap/deployment
+memories over time, is a **millions-of-vectors-per-hub** workload. That is
+exactly what a dedicated ANN store (HNSW + payload filtering + quantization) is
+for; brute-force SQLite would not keep up.
+
+The real work is **not** "pick a different store." It is the five things around
+the store that are currently missing or stubbed, plus an abstraction so the
+store is a config choice rather than a rewrite.
+
+| Concern | Today | At 50–200 agents |
+| --- | --- | --- |
+| Embeddings | **hash stub by default** (`MAC_MEMORY_EMBED_BACKEND=hash`) | real, batched, fixed model/dim per collection — **the dominant lever** |
+| Scoping | thin (subject_type/subject_id) | hard multi-tenant: every vector carries `{tenant, agent_id, project, tier, record_type}`; recall filters on them |
+| Growth | unbounded (observability bloat already seen) | salience + decay/forget ([[dream-04]]) + scalar/product quantization or it dies |
+| Store binding | `VectorWriterService` *is* the Qdrant client (`_VECTOR_DB_LABEL="qdrant"`) | a `VectorStore` interface; Qdrant prod, embedded (sqlite-vec/LanceDB) for dev/single-agent |
+| Failure mode | `recall_memory` hard-requires Qdrant; can hang | **fail-soft**: timeout → empty result, never hang the agent (same lesson as [[loop-01]]) |
+
+## Decision
+
+1. **Keep Qdrant as the default production backend.** One Qdrant per hub,
+   shared across that hub's agents (the existing hub-owns-the-tier model). It
+   scales to the target via HNSW + payload filters + quantization on a single
+   node; shard-by-tenant or cluster only if a single hub ever exceeds one node.
+2. **Introduce a `VectorStore` interface** (`ensure_collection / upsert / query /
+   delete`) and move the Qdrant specifics behind it. `MAC_VECTOR_BACKEND`
+   selects `qdrant` (default) or an embedded `sqlite-vec`/`lancedb` impl for
+   dev, CI, and single-agent installs. This is the same "make the backend a
+   connector" instinct as the ticketing connector — the store stops being a
+   rewrite and becomes a config choice + a test seam.
+3. **Make embeddings real and batched.** Default a hub to a real embedding model
+   (via the router — see [[th-merge-01]]/TokenHub), fixed model+dim per
+   collection, batched + async on the write path. The hash stub stays only as
+   an offline/test fallback. *This is the single biggest recall-quality win and
+   is independent of the store.*
+4. **Hard multi-tenant scoping.** Every point's payload carries
+   `tenant_id, agent_id, project, tier, record_type, salience, created_at`.
+   Recall always filters by tenant + (agent or project) so agent A never recalls
+   agent B's private memory, while the explicit fleet/project-shared layer
+   (deployment_learning, [[dream-06]]) is queryable across agents by design.
+5. **Bound growth with salience + decay.** [[dream-04]] decay runs per hub on a
+   schedule; promote high-salience to long, demote/forget stale low-salience,
+   and enable quantization so the resident index stays bounded as agent count
+   and history grow.
+6. **Fail-soft recall.** Recall gets a bounded timeout and returns empty on
+   Qdrant unavailability rather than raising/hanging — a wedged vector store
+   must degrade gracefully, exactly like the agent LLM-call bound in [[loop-01]]
+   after the TokenHub wedge.
+
+## Consequences
+
+- Qdrant stays; the work is the abstraction + the five gaps, tracked in
+  **mem-store-01**.
+- Small/dev/single-agent installs get an embedded backend with no separate
+  service — the "fewer moving parts" benefit is preserved where it actually
+  applies (not at production scale).
+- Operationally, Qdrant becomes a monitored, resource-capped, health-checked
+  dependency with a fail-soft client — it must not be able to wedge the fleet
+  the way TokenHub just did.
+
+## Non-goals
+
+- A vector-DB bake-off. Qdrant is decided for production; the interface keeps
+  the door open without blocking on a comparison.
+- Re-embedding history eagerly — backfill is a bounded background job.

--- a/docs/adr/0003-tokenhub-core-into-mac.md
+++ b/docs/adr/0003-tokenhub-core-into-mac.md
@@ -1,0 +1,87 @@
+# ADR 0003 — Optional in-mac model router + vault (revisiting TokenHub's boundary)
+
+- Status: **Proposed** (revisits the TokenHub decision in [[ADR 0001|0001-unify-hermes-runtime-into-mac]])
+- Date: 2026-05-31
+- Decision owner: Jordan Hubbard
+- Context: ADR 0001 chose to **keep TokenHub separate** ("mature Go infra;
+  the dark spot is observability, not a boundary problem"). Two things have
+  changed that judgment:
+  1. **Operational reality.** This session TokenHub wedged the entire fleet:
+     a single configured provider (`nvidia`), a circuit breaker that tripped
+     and never half-opened to recover, and no fast-fail — so completions hung
+     and every agent went silent. A separate service that can take down the
+     whole hub is exactly the failure-domain cost ADR 0001 under-weighted.
+  2. **Leverage reassessment (owner).** TokenHub's *actual* leverage is two
+     things — **provider routing** (`model="*"` → pick a provider, with
+     failover) and the **secret vault**. The rest (notably the admin **UI**) is
+     "probably most of the code, and is not necessarily used — or could be
+     re-imagined in the hub UI, which is still evolving."
+
+So the boundary question flips: if the UI is most of the code and isn't load-
+bearing, the *core* (routing + vault) is small enough to live in `mac` as an
+option — the same in-process win the Hermes merge delivered.
+
+## TL;DR
+
+Build an **optional, in-`mac` model router + vault** that subsumes TokenHub's
+core leverage behind the OpenAI-compatible surface `mac`/Hermes already speak
+(`/v1/chat/completions`, `/v1/embeddings`, `model="*"`). Standalone TokenHub
+becomes **one of two interchangeable backends**, selected by config. **Drop the
+admin UI** (re-imagine routing visibility in the evolving hub UI, fed by the
+[[hu-05]] decision feed → native observations). Keep it **minimal and optional**
+— this is explicitly *not* a feature-parity rewrite (that is the ACC/openclaw
+"too complicated" trap ADR 0001 warned about).
+
+## Decision
+
+Provide `mac.router` (optional, in-process on the hub):
+
+1. **OpenAI-compatible front door** — `/v1/chat/completions` + `/v1/embeddings`
+   served by mac, accepting `model="*"`. Hermes/the executor point at it
+   unchanged (same base_url contract), so adopting it is a config flip.
+2. **Multi-provider config + health-aware routing** — fixes the live SPOF:
+   more than one provider, priority + Thompson/round-robin selection, and a
+   **circuit breaker that half-opens and re-probes** (the exact bug we hit:
+   the breaker tripped on a transient and never recovered even though the
+   upstream was healthy). Plus **fail-fast** when all providers are down
+   (return "no provider available" immediately — never hang).
+3. **Secret vault** — an encrypted at-rest store for provider keys, addressed
+   the same way (`vault://...`). To avoid a risky crypto rewrite, prefer
+   **embedding TokenHub's existing vault library** or a minimal audited
+   envelope-encryption store; the vault is the one genuinely security-sensitive
+   piece and gets the most scrutiny.
+4. **Native decision telemetry** — emit `mac.router.*` observations directly
+   (no SSE bridge needed when in-process); reuse the [[hu-05]] mapping so the
+   hub UI can show per-turn provider decisions.
+5. **TokenHub stays an option** — `MAC_ROUTER_BACKEND = inproc | tokenhub`.
+   Existing deployments keep the Go service; new/simple ones use the in-mac
+   router and shed a service + a failure domain.
+
+## Explicitly out of scope (the "stay minimal" guardrails)
+
+- The TokenHub **admin UI** — dropped; visibility moves to the hub UI.
+- **Temporal workflows** — only if a concrete need appears; not ported wholesale.
+- **Feature-parity** with every TokenHub knob. Port the routing policy + vault +
+  the OpenAI surface; leave the long tail behind the `tokenhub` backend option
+  for anyone who needs it.
+
+## Consequences
+
+- When `inproc` is selected, the hub has **one fewer service that can wedge it**
+  (the session's recurring lesson), and provider config/secrets are managed in
+  the same place as everything else.
+- The live misconfig is fixed *by construction*: multi-provider + a recovering
+  breaker + fail-fast are requirements of the in-mac router, not afterthoughts.
+- This **partially supersedes ADR 0001's "keep TokenHub separate"** — narrowed
+  to: keep it separate *as an option*, but its core is no longer off-limits to
+  merge.
+
+## Risks
+
+- **Vault security** — reimplementing crypto is the trap; embed/reuse, don't
+  reinvent. Gate behind review.
+- **Scope creep** — the failure mode is rebuilding all of TokenHub. The
+  `inproc` router must stay small (routing + vault + OpenAI surface) or it
+  becomes the thing ADR 0001 warned against.
+
+Tracked in **th-merge-01**.


### PR DESCRIPTION
Specs for the **50–200 agents per hub** target (3 agents is the current minimum), plus epics.

## ADR 0002 — memory store at scale (`mem-store-01`)
At the target scale **Qdrant is the right default, not overkill** — that's a millions-of-vectors-per-hub workload. The work isn't picking a different store; it's the five gaps around it:
- real (non-hash) batched embeddings — the dominant recall lever, store-agnostic;
- a `VectorStore` interface so the backend is config (`qdrant` prod / `sqlite-vec`|`lancedb` for dev/single-agent), not a rewrite;
- hard multi-tenant payload scoping (tenant/agent/project/tier);
- salience + decay (`dream-04`) + quantization to bound growth;
- **fail-soft recall** so a wedged Qdrant degrades gracefully instead of hanging the fleet.

## ADR 0003 — optional in-mac model router + vault (`th-merge-01`)
Revisits ADR 0001's "keep TokenHub separate." The live wedge (single provider + a circuit breaker that tripped and never recovered + no fail-fast stranded the whole fleet) and your read that TokenHub's leverage is just **routing + the vault** (UI is most of the code, not load-bearing) flip the judgment. Spec: an **optional** in-`mac` router + vault behind the OpenAI surface (`model="*"`), **drop the UI** (re-imagine in the hub UI), keep standalone TokenHub as a selectable backend. Fixes the SPOF + stuck-breaker **by construction** (multi-provider + half-opening breaker + fail-fast). Explicitly minimal — not a feature-parity rewrite (the ACC trap).

Docs + epics only; no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)