### PR TITLE
th-merge-02: in-mac OpenAI front door (provider router + recovering breaker, opt-in)

### DIFF
--- a/.tickets/th-merge-01.md
+++ b/.tickets/th-merge-01.md
@@ -18,7 +18,7 @@ Motivated by the live wedge (single provider + stuck breaker + no fail-fast).
 
 ## Work breakdown
 
-- [ ] **th-merge-02: OpenAI front door in mac.** `/v1/chat/completions` +
+- [x] **th-merge-02: OpenAI front door in mac.** `/v1/chat/completions` +
       `/v1/embeddings` accepting `model="*"`; Hermes/executor point at it via the
       same base_url contract (config flip). `MAC_ROUTER_BACKEND=inproc|tokenhub`.
 - [x] **th-merge-03: multi-provider + recovering breaker.** >1 provider,

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -3892,6 +3892,17 @@ def create_app(
         rollout, task = cp.rescue_rollout(rollout_id, body.actor, body.reason, body.detail)
         return {"rollout": rollout.to_dict(), "task": task.to_dict()}
 
+    # th-merge-02: optional in-mac OpenAI front door (provider router + recovering
+    # breaker). No-op unless MAC_ROUTER_BACKEND=inproc, so the standalone TokenHub
+    # path is unchanged by default.
+    try:
+        from mac.router_app import mount_router
+
+        if mount_router(app):
+            _log.info("in-mac model router mounted (/v1/chat/completions, /v1/embeddings)")
+    except Exception as exc:  # noqa: BLE001 - the router must never block app startup
+        _log.warning("in-mac model router not mounted: %s", exc)
+
     return app
 
 

--- a/src/mac/provider_router.py
+++ b/src/mac/provider_router.py
@@ -52,6 +52,7 @@ class Provider:
     priority: int = 0                 # lower is preferred
     models: Tuple[str, ...] = ("*",)  # which model ids it serves; "*" = any
     enabled: bool = True
+    api_key_env: str = ""             # env var holding this provider's bearer key
 
 
 @dataclass
@@ -184,6 +185,9 @@ class ProviderRouter:
     def any_available(self, model: str = "*") -> bool:
         return self.select(model) is not None
 
+    def provider_names(self) -> List[str]:
+        return [p.name for p in self._order]
+
 
 # ---------------------------------------------------------------------------
 # Config loader
@@ -194,9 +198,9 @@ def providers_from_env(env: Optional[Dict[str, str]] = None) -> List[Provider]:
     """Parse ``MAC_ROUTER_PROVIDERS`` into Providers.
 
     Format (semicolon-separated providers, comma-separated fields):
-      ``name=base_url[,priority][,models=a|b|*]``
-    e.g. ``nvidia=https://inference-api.nvidia.com/v1,0,models=*;`` +
-           ``openai=https://api.openai.com/v1,1,models=*``
+      ``name=base_url[,priority][,models=a|b|*][,key=ENV_VAR]``
+    e.g. ``nvidia=https://inference-api.nvidia.com/v1,0,key=NVIDIA_API_KEY;`` +
+           ``openai=https://api.openai.com/v1,1,models=*,key=OPENAI_API_KEY``
     """
     env = env or os.environ
     raw = (env.get("MAC_ROUTER_PROVIDERS") or "").strip()
@@ -212,10 +216,15 @@ def providers_from_env(env: Optional[Dict[str, str]] = None) -> List[Provider]:
         base_url = fields[0]
         priority = 0
         models: Tuple[str, ...] = ("*",)
+        api_key_env = ""
         for f in fields[1:]:
             if f.startswith("models="):
                 models = tuple(m for m in f[len("models="):].split("|") if m) or ("*",)
+            elif f.startswith("key="):
+                api_key_env = f[len("key="):].strip()
             elif f.isdigit():
                 priority = int(f)
-        providers.append(Provider(name=name.strip(), base_url=base_url, priority=priority, models=models))
+        providers.append(
+            Provider(name=name.strip(), base_url=base_url, priority=priority, models=models, api_key_env=api_key_env)
+        )
     return providers

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -1,0 +1,148 @@
+"""th-merge-02: the in-mac OpenAI-compatible front door.
+
+Makes the routing brain (th-merge-03 `ProviderRouter`) load-bearing: a
+`/v1/chat/completions` + `/v1/embeddings` surface that selects a provider,
+forwards the request, **fails over** to the next provider on a provider-side
+failure, **fails fast** when every provider is down, and feeds success/failure
+back into the recovering circuit breaker.
+
+It is **opt-in**: mounted only when `MAC_ROUTER_BACKEND=inproc` (default
+`tokenhub`, so an existing fleet routes through the standalone service unchanged
+until this is validated and flipped). Provider keys come from env for now; the
+encrypted vault is th-merge-04.
+
+Failure semantics (what trips the breaker / triggers failover):
+* network error / timeout (status ``None``), HTTP 429, or HTTP >= 500 → the
+  provider failed: record_failure + try the next one.
+* 2xx or other 4xx → the provider *answered* (a 4xx is a bad request, not a
+  health problem): record_success and return it as-is (no pointless failover).
+
+The transport is injected (`forward_fn`) so the proxy logic is unit-testable
+without a live provider.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Dict, Optional, Tuple
+
+from mac.provider_router import Provider, ProviderRouter, providers_from_env
+
+__all__ = ["ProviderProxy", "urllib_forwarder", "build_proxy_from_env", "mount_router"]
+
+# forward_fn(provider, path, payload, *, timeout) -> (status_code|None, body)
+ForwardFn = Callable[..., Tuple[Optional[int], Any]]
+
+
+def _is_provider_failure(status: Optional[int]) -> bool:
+    """A provider-health failure (failover + breaker) vs. a request the provider
+    answered. None = unreachable/timeout; 429 = rate-limited; >=500 = upstream."""
+    return status is None or status == 429 or status >= 500
+
+
+class ProviderProxy:
+    def __init__(self, router: ProviderRouter, forward_fn: ForwardFn, *, timeout: float = 60.0) -> None:
+        self._router = router
+        self._forward = forward_fn
+        self._timeout = timeout
+
+    def complete(self, path: str, payload: Dict[str, Any]) -> Tuple[int, Any]:
+        """Route one request. ``path`` is the suffix after the provider base_url
+        (e.g. ``/chat/completions``). Returns ``(status_code, body)``."""
+        model = str(payload.get("model") or "*")
+        attempts = []
+        # Bounded: at most one try per provider (+1 to allow a half-open probe
+        # to be re-selected after another provider is tried).
+        for _ in range(len(self._router.provider_names()) + 1):
+            provider = self._router.select(model)
+            if provider is None:
+                break
+            status, body = self._forward(provider, path, payload, timeout=self._timeout)
+            if not _is_provider_failure(status):
+                self._router.record_success(provider.name)
+                return int(status), body
+            self._router.record_failure(provider.name)
+            attempts.append({"provider": provider.name, "status": status})
+        return 503, {
+            "error": {
+                "message": "no provider could serve model=%s" % model,
+                "type": "all_providers_unavailable",
+                "attempts": attempts,
+            }
+        }
+
+
+def urllib_forwarder(provider: Provider, path: str, payload: Dict[str, Any], *, timeout: float = 60.0):
+    """Real HTTP forward to ``provider.base_url + path`` with its bearer key.
+    Returns ``(status_code|None, body)``; status None means unreachable/timeout."""
+    url = provider.base_url.rstrip("/") + path
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if provider.api_key_env:
+        key = os.environ.get(provider.api_key_env, "")
+        if key:
+            headers["Authorization"] = "Bearer %s" % key
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (operator-configured upstream)
+            raw = resp.read().decode("utf-8", "replace")
+            return resp.status, (json.loads(raw) if raw.strip() else {})
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        try:
+            body = json.loads(detail) if detail.strip() else {"error": {"message": exc.reason}}
+        except Exception:
+            body = {"error": {"message": detail[:500] or exc.reason}}
+        return exc.code, body
+    except Exception as exc:  # noqa: BLE001 - connection/timeout -> treat as provider failure
+        return None, {"error": {"message": str(exc), "type": "upstream_unreachable"}}
+
+
+def build_proxy_from_env(env: Optional[Dict[str, str]] = None) -> Optional[ProviderProxy]:
+    """Build a ProviderProxy from MAC_ROUTER_* env; None when no providers are
+    configured."""
+    env = env or os.environ
+    providers = providers_from_env(env)
+    if not providers:
+        return None
+
+    def _f(name: str, default: float) -> float:
+        try:
+            return float(env.get(name) or default)
+        except ValueError:
+            return default
+
+    router = ProviderRouter(
+        providers,
+        failure_threshold=int(_f("MAC_ROUTER_FAILURE_THRESHOLD", 3)),
+        cooldown_seconds=_f("MAC_ROUTER_COOLDOWN_SECONDS", 30.0),
+    )
+    return ProviderProxy(router, urllib_forwarder, timeout=_f("MAC_ROUTER_TIMEOUT", 60.0))
+
+
+def mount_router(app: Any, *, env: Optional[Dict[str, str]] = None, proxy: Optional[ProviderProxy] = None) -> bool:
+    """Mount /v1/chat/completions + /v1/embeddings on ``app`` when
+    MAC_ROUTER_BACKEND=inproc. Returns True if mounted. Default backend is
+    'tokenhub' → no-op, so an existing fleet is unchanged until flipped."""
+    env = env or os.environ
+    if (env.get("MAC_ROUTER_BACKEND") or "tokenhub").strip().lower() != "inproc":
+        return False
+    proxy = proxy or build_proxy_from_env(env)
+    if proxy is None:
+        return False
+    from fastapi.responses import JSONResponse
+
+    @app.post("/v1/chat/completions")
+    def _chat(body: Dict[str, Any]) -> Any:  # noqa: ANN401
+        status, out = proxy.complete("/chat/completions", body)
+        return JSONResponse(out, status_code=status)
+
+    @app.post("/v1/embeddings")
+    def _embeddings(body: Dict[str, Any]) -> Any:  # noqa: ANN401
+        status, out = proxy.complete("/embeddings", body)
+        return JSONResponse(out, status_code=status)
+
+    return True

--- a/tests/test_router_app.py
+++ b/tests/test_router_app.py
@@ -1,0 +1,109 @@
+"""th-merge-02: the in-mac OpenAI front door (ProviderProxy + gated mount)."""
+
+from __future__ import annotations
+
+from mac.provider_router import Provider, ProviderRouter
+from mac.router_app import ProviderProxy, build_proxy_from_env, mount_router
+
+
+def _router():
+    return ProviderRouter(
+        [Provider("primary", "http://p/v1", priority=0), Provider("secondary", "http://s/v1", priority=1)],
+        failure_threshold=1,
+        cooldown_seconds=1000.0,
+    )
+
+
+def _fake_forward(responses):
+    """responses: dict provider_name -> (status, body) or a callable(payload)."""
+    calls = []
+
+    def fwd(provider, path, payload, *, timeout=60.0):
+        calls.append((provider.name, path))
+        r = responses[provider.name]
+        return r(payload) if callable(r) else r
+
+    return fwd, calls
+
+
+def test_routes_to_primary_on_success_and_records():
+    r = _router()
+    fwd, calls = _fake_forward({"primary": (200, {"ok": True})})
+    proxy = ProviderProxy(r, fwd)
+    status, body = proxy.complete("/chat/completions", {"model": "*"})
+    assert status == 200 and body == {"ok": True}
+    assert calls == [("primary", "/chat/completions")]
+    assert r.status()["primary"]["state"] == "closed"
+
+
+def test_fails_over_to_secondary_on_5xx():
+    r = _router()
+    fwd, calls = _fake_forward({"primary": (503, {"error": "down"}), "secondary": (200, {"ok": True})})
+    proxy = ProviderProxy(r, fwd)
+    status, body = proxy.complete("/chat/completions", {"model": "*"})
+    assert status == 200 and body == {"ok": True}
+    assert [c[0] for c in calls] == ["primary", "secondary"]   # tried primary, failed over
+    assert r.status()["primary"]["state"] == "open"            # breaker tripped on primary
+
+
+def test_429_is_treated_as_failure_and_fails_over():
+    r = _router()
+    fwd, _ = _fake_forward({"primary": (429, {"error": "rate"}), "secondary": (200, {"ok": 1})})
+    status, _ = ProviderProxy(r, fwd).complete("/chat/completions", {"model": "*"})
+    assert status == 200
+    assert r.status()["primary"]["state"] == "open"
+
+
+def test_network_error_status_none_fails_over():
+    r = _router()
+    fwd, _ = _fake_forward({"primary": (None, {"error": "timeout"}), "secondary": (200, {"ok": 1})})
+    status, _ = ProviderProxy(r, fwd).complete("/chat/completions", {"model": "*"})
+    assert status == 200
+    assert r.status()["primary"]["state"] == "open"
+
+
+def test_4xx_is_returned_not_failed_over():
+    # A 400 is a bad request, not a provider health problem: return it, keep the
+    # provider healthy, and do NOT pointlessly retry the same bad request elsewhere.
+    r = _router()
+    fwd, calls = _fake_forward({"primary": (400, {"error": "bad request"})})
+    status, body = ProviderProxy(r, fwd).complete("/chat/completions", {"model": "*"})
+    assert status == 400 and body == {"error": "bad request"}
+    assert [c[0] for c in calls] == ["primary"]                # no failover
+    assert r.status()["primary"]["state"] == "closed"          # provider stays healthy
+
+
+def test_all_providers_failing_returns_503_failfast():
+    r = _router()
+    fwd, _ = _fake_forward({"primary": (500, {}), "secondary": (500, {})})
+    status, body = ProviderProxy(r, fwd).complete("/chat/completions", {"model": "*"})
+    assert status == 503
+    assert body["error"]["type"] == "all_providers_unavailable"
+    assert {a["provider"] for a in body["error"]["attempts"]} == {"primary", "secondary"}
+
+
+def test_mount_is_noop_unless_inproc(monkeypatch):
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    # default backend (tokenhub) -> not mounted
+    assert mount_router(app, env={}) is False
+    # inproc but no providers -> still not mounted (nothing to route to)
+    assert mount_router(app, env={"MAC_ROUTER_BACKEND": "inproc"}) is False
+
+
+def test_mount_adds_routes_when_inproc_with_providers():
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    proxy = ProviderProxy(_router(), _fake_forward({"primary": (200, {"ok": True})})[0])
+    assert mount_router(app, env={"MAC_ROUTER_BACKEND": "inproc"}, proxy=proxy) is True
+    paths = {r.path for r in app.routes}
+    assert "/v1/chat/completions" in paths and "/v1/embeddings" in paths
+
+
+def test_build_proxy_from_env_reads_providers():
+    env = {"MAC_ROUTER_PROVIDERS": "p=http://p/v1,0,key=P_KEY;s=http://s/v1,1", "MAC_ROUTER_BACKEND": "inproc"}
+    proxy = build_proxy_from_env(env)
+    assert proxy is not None
+    assert build_proxy_from_env({}) is None  # no providers configured


### PR DESCRIPTION
Makes the `th-merge-03` routing brain **load-bearing**. `src/mac/router_app.py`:
- `ProviderProxy` selects a provider, forwards `/chat/completions` + `/embeddings`, **fails over** on a provider-side failure (network/timeout, 429, or ≥500), returns **4xx as-is** (a bad request isn't a health problem — no pointless retry), and **fails fast** (503) when every provider is down — feeding each outcome into the recovering breaker.
- Mounted on the mac hub **only when `MAC_ROUTER_BACKEND=inproc`** (default `tokenhub`), so the live fleet is unchanged until this is validated and flipped. Keys from env (vault = `th-merge-04`); tuning via `MAC_ROUTER_*`. `create_app` mounts best-effort (never blocks startup).

This is the piece that lets the recovering breaker protect real traffic instead of being a tested-but-unwired brain.

Tests: `test_router_app.py` (9). **Full suite: 740 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)