### PR TITLE
th-merge-02b: streaming passthrough + wildcard model resolution for the in-mac router

### DIFF
--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -11,14 +11,28 @@ It is **opt-in**: mounted only when `MAC_ROUTER_BACKEND=inproc` (default
 until this is validated and flipped). Provider keys come from env for now; the
 encrypted vault is th-merge-04.
 
+Two things make it a genuine TokenHub replacement (not just a proxy), both
+required because the real upstream — unlike TokenHub — does NOT accept
+`model="*"` and the agent loop streams:
+
+* **Wildcard resolution.** The agent sends `model="*"`; the upstream rejects it
+  (401). `default_model` (`MAC_ROUTER_DEFAULT_MODEL`) resolves `"*"`/empty to a
+  concrete model id the provider serves before forwarding. Provider *selection*
+  still uses the requested model string. (Full per-model ladder failover —
+  rank-0 down → rank-1 — is th-merge-06; this resolves to rank-0.)
+* **Streaming passthrough.** The interactive gateway runs the agent loop through
+  `responses.stream()` → SSE. `stream_complete` opens the upstream as a stream,
+  applies failover/breaker on the *status line* (before any bytes flow), then
+  passes the `text/event-stream` chunks straight through.
+
 Failure semantics (what trips the breaker / triggers failover):
 * network error / timeout (status ``None``), HTTP 429, or HTTP >= 500 → the
   provider failed: record_failure + try the next one.
 * 2xx or other 4xx → the provider *answered* (a 4xx is a bad request, not a
   health problem): record_success and return it as-is (no pointless failover).
 
-The transport is injected (`forward_fn`) so the proxy logic is unit-testable
-without a live provider.
+The transport is injected (`forward_fn` / `stream_forward_fn`) so the proxy
+logic is unit-testable without a live provider.
 """
 
 from __future__ import annotations
@@ -27,14 +41,22 @@ import json
 import os
 import urllib.error
 import urllib.request
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple
 
 from mac.provider_router import Provider, ProviderRouter, providers_from_env
 
-__all__ = ["ProviderProxy", "urllib_forwarder", "build_proxy_from_env", "mount_router"]
+__all__ = [
+    "ProviderProxy",
+    "urllib_forwarder",
+    "urllib_stream_forwarder",
+    "build_proxy_from_env",
+    "mount_router",
+]
 
 # forward_fn(provider, path, payload, *, timeout) -> (status_code|None, body)
 ForwardFn = Callable[..., Tuple[Optional[int], Any]]
+# stream_forward_fn(provider, path, payload, *, timeout) -> (status|None, iter[bytes] | error-body)
+StreamForwardFn = Callable[..., Tuple[Optional[int], Any]]
 
 
 def _is_provider_failure(status: Optional[int]) -> bool:
@@ -44,29 +66,88 @@ def _is_provider_failure(status: Optional[int]) -> bool:
 
 
 class ProviderProxy:
-    def __init__(self, router: ProviderRouter, forward_fn: ForwardFn, *, timeout: float = 60.0) -> None:
+    def __init__(
+        self,
+        router: ProviderRouter,
+        forward_fn: ForwardFn,
+        *,
+        stream_forward_fn: Optional[StreamForwardFn] = None,
+        default_model: str = "",
+        timeout: float = 60.0,
+        stream_timeout: float = 300.0,
+    ) -> None:
         self._router = router
         self._forward = forward_fn
+        self._stream_forward = stream_forward_fn
+        self._default_model = (default_model or "").strip()
         self._timeout = timeout
+        self._stream_timeout = stream_timeout
+
+    # -- model resolution ----------------------------------------------------
+
+    def _resolve_payload(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve a wildcard/empty model to the configured concrete model so
+        the upstream (which rejects ``model="*"``) accepts it. A concrete model
+        is forwarded untouched."""
+        model = str(payload.get("model") or "").strip()
+        if model in ("", "*") and self._default_model:
+            return {**payload, "model": self._default_model}
+        return payload
+
+    # -- non-streaming -------------------------------------------------------
 
     def complete(self, path: str, payload: Dict[str, Any]) -> Tuple[int, Any]:
         """Route one request. ``path`` is the suffix after the provider base_url
         (e.g. ``/chat/completions``). Returns ``(status_code, body)``."""
-        model = str(payload.get("model") or "*")
+        select_model = str(payload.get("model") or "*")
+        outgoing = self._resolve_payload(payload)
         attempts = []
         # Bounded: at most one try per provider (+1 to allow a half-open probe
         # to be re-selected after another provider is tried).
         for _ in range(len(self._router.provider_names()) + 1):
-            provider = self._router.select(model)
+            provider = self._router.select(select_model)
             if provider is None:
                 break
-            status, body = self._forward(provider, path, payload, timeout=self._timeout)
+            status, body = self._forward(provider, path, outgoing, timeout=self._timeout)
             if not _is_provider_failure(status):
                 self._router.record_success(provider.name)
                 return int(status), body
             self._router.record_failure(provider.name)
             attempts.append({"provider": provider.name, "status": status})
-        return 503, {
+        return 503, self._failfast_body(select_model, attempts)
+
+    # -- streaming -----------------------------------------------------------
+
+    def stream_complete(self, path: str, payload: Dict[str, Any]) -> Tuple[int, Any]:
+        """Route one streaming request. On 2xx the second element is an iterator
+        of raw upstream byte chunks (pass straight to the client as
+        ``text/event-stream``); otherwise it is an error/body dict.
+
+        Failover + breaker decisions are made on the *status line* — before any
+        bytes are streamed to the client. Once a 2xx stream has started we are
+        committed to it (the client is already receiving bytes)."""
+        if self._stream_forward is None:
+            # No streaming transport wired: degrade to a buffered completion so a
+            # stream=true request still gets an answer rather than failing.
+            return self.complete(path, {**payload, "stream": False})
+        select_model = str(payload.get("model") or "*")
+        outgoing = self._resolve_payload({**payload, "stream": True})
+        attempts = []
+        for _ in range(len(self._router.provider_names()) + 1):
+            provider = self._router.select(select_model)
+            if provider is None:
+                break
+            status, obj = self._stream_forward(provider, path, outgoing, timeout=self._stream_timeout)
+            if not _is_provider_failure(status):
+                self._router.record_success(provider.name)
+                return int(status), obj
+            self._router.record_failure(provider.name)
+            attempts.append({"provider": provider.name, "status": status})
+        return 503, self._failfast_body(select_model, attempts)
+
+    @staticmethod
+    def _failfast_body(model: str, attempts) -> Dict[str, Any]:
+        return {
             "error": {
                 "message": "no provider could serve model=%s" % model,
                 "type": "all_providers_unavailable",
@@ -101,6 +182,52 @@ def urllib_forwarder(provider: Provider, path: str, payload: Dict[str, Any], *, 
         return None, {"error": {"message": str(exc), "type": "upstream_unreachable"}}
 
 
+def _drain_chunks(resp: Any, chunk_size: int = 8192) -> Iterator[bytes]:
+    """Yield raw bytes from an open urllib response, then close it. Kept as a
+    generator so the connection stays open for the lifetime of the stream."""
+    try:
+        while True:
+            chunk = resp.read(chunk_size)
+            if not chunk:
+                break
+            yield chunk
+    finally:
+        try:
+            resp.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def urllib_stream_forwarder(provider: Provider, path: str, payload: Dict[str, Any], *, timeout: float = 300.0):
+    """Streaming HTTP forward. On a 2xx status line returns
+    ``(status, iterator_of_bytes)`` with the connection held open; on an HTTP
+    error returns ``(code, body)``; on a transport failure ``(None, body)``.
+
+    The status line is available as soon as ``urlopen`` returns (headers
+    received), which is exactly where the breaker/failover decision must be made
+    — before the client sees any bytes."""
+    url = provider.base_url.rstrip("/") + path
+    headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
+    if provider.api_key_env:
+        key = os.environ.get(provider.api_key_env, "")
+        if key:
+            headers["Authorization"] = "Bearer %s" % key
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        resp = urllib.request.urlopen(req, timeout=timeout)  # noqa: S310 (operator-configured upstream); not `with` — stream stays open
+        return resp.status, _drain_chunks(resp)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")
+        try:
+            body = json.loads(detail) if detail.strip() else {"error": {"message": exc.reason}}
+        except Exception:
+            body = {"error": {"message": detail[:500] or exc.reason}}
+        return exc.code, body
+    except Exception as exc:  # noqa: BLE001 - connection/timeout -> treat as provider failure
+        return None, {"error": {"message": str(exc), "type": "upstream_unreachable"}}
+
+
 def build_proxy_from_env(env: Optional[Dict[str, str]] = None) -> Optional[ProviderProxy]:
     """Build a ProviderProxy from MAC_ROUTER_* env; None when no providers are
     configured."""
@@ -120,7 +247,14 @@ def build_proxy_from_env(env: Optional[Dict[str, str]] = None) -> Optional[Provi
         failure_threshold=int(_f("MAC_ROUTER_FAILURE_THRESHOLD", 3)),
         cooldown_seconds=_f("MAC_ROUTER_COOLDOWN_SECONDS", 30.0),
     )
-    return ProviderProxy(router, urllib_forwarder, timeout=_f("MAC_ROUTER_TIMEOUT", 60.0))
+    return ProviderProxy(
+        router,
+        urllib_forwarder,
+        stream_forward_fn=urllib_stream_forwarder,
+        default_model=(env.get("MAC_ROUTER_DEFAULT_MODEL") or "").strip(),
+        timeout=_f("MAC_ROUTER_TIMEOUT", 60.0),
+        stream_timeout=_f("MAC_ROUTER_STREAM_TIMEOUT", 300.0),
+    )
 
 
 def mount_router(app: Any, *, env: Optional[Dict[str, str]] = None, proxy: Optional[ProviderProxy] = None) -> bool:
@@ -133,10 +267,15 @@ def mount_router(app: Any, *, env: Optional[Dict[str, str]] = None, proxy: Optio
     proxy = proxy or build_proxy_from_env(env)
     if proxy is None:
         return False
-    from fastapi.responses import JSONResponse
+    from fastapi.responses import JSONResponse, StreamingResponse
 
     @app.post("/v1/chat/completions")
     def _chat(body: Dict[str, Any]) -> Any:  # noqa: ANN401
+        if body.get("stream"):
+            status, obj = proxy.stream_complete("/chat/completions", body)
+            if status == 200 and not isinstance(obj, dict):
+                return StreamingResponse(obj, media_type="text/event-stream")
+            return JSONResponse(obj if isinstance(obj, dict) else {}, status_code=status)
         status, out = proxy.complete("/chat/completions", body)
         return JSONResponse(out, status_code=status)
 

--- a/tests/test_router_app.py
+++ b/tests/test_router_app.py
@@ -107,3 +107,117 @@ def test_build_proxy_from_env_reads_providers():
     proxy = build_proxy_from_env(env)
     assert proxy is not None
     assert build_proxy_from_env({}) is None  # no providers configured
+
+
+# -- wildcard -> concrete model resolution (th-merge-02b) --------------------
+
+
+def _capturing_forward(status, body):
+    """Forward that records the exact payload it was handed."""
+    seen = []
+
+    def fwd(provider, path, payload, *, timeout=60.0):
+        seen.append(payload)
+        return status, body
+
+    return fwd, seen
+
+
+def test_wildcard_model_resolves_to_default_before_forward():
+    # The real upstream rejects model="*"; the proxy must substitute the
+    # configured concrete model before forwarding.
+    r = _router()
+    fwd, seen = _capturing_forward(200, {"ok": True})
+    proxy = ProviderProxy(r, fwd, default_model="meta/llama-3.3-70b-instruct")
+    status, _ = proxy.complete("/chat/completions", {"model": "*", "messages": []})
+    assert status == 200
+    assert seen[0]["model"] == "meta/llama-3.3-70b-instruct"
+
+
+def test_empty_model_resolves_and_concrete_model_passes_through():
+    r = _router()
+    fwd, seen = _capturing_forward(200, {"ok": True})
+    proxy = ProviderProxy(r, fwd, default_model="meta/llama-3.3-70b-instruct")
+    proxy.complete("/chat/completions", {})                       # missing model -> default
+    proxy.complete("/chat/completions", {"model": "azure/openai/o4-mini"})  # concrete -> untouched
+    assert seen[0]["model"] == "meta/llama-3.3-70b-instruct"
+    assert seen[1]["model"] == "azure/openai/o4-mini"
+
+
+def test_no_default_model_leaves_wildcard_untouched():
+    r = _router()
+    fwd, seen = _capturing_forward(200, {"ok": True})
+    ProviderProxy(r, fwd).complete("/chat/completions", {"model": "*"})
+    assert seen[0]["model"] == "*"   # no default configured -> unchanged (back-compat)
+
+
+# -- streaming passthrough (th-merge-02b) ------------------------------------
+
+
+def _fake_stream(responses):
+    """responses: dict provider_name -> (status, iterator|body)."""
+    calls = []
+
+    def fwd(provider, path, payload, *, timeout=300.0):
+        calls.append((provider.name, payload.get("model"), payload.get("stream")))
+        return responses[provider.name]
+
+    return fwd, calls
+
+
+def test_stream_returns_iterator_on_2xx_and_records_success():
+    r = _router()
+    chunks = iter([b"data: {\"x\":1}\n\n", b"data: [DONE]\n\n"])
+    sfwd, calls = _fake_stream({"primary": (200, chunks)})
+    proxy = ProviderProxy(r, _fake_forward({})[0], stream_forward_fn=sfwd,
+                          default_model="meta/llama-3.3-70b-instruct")
+    status, obj = proxy.stream_complete("/chat/completions", {"model": "*"})
+    assert status == 200
+    assert b"".join(obj) == b"data: {\"x\":1}\n\ndata: [DONE]\n\n"
+    assert calls[0][1] == "meta/llama-3.3-70b-instruct"   # wildcard resolved
+    assert calls[0][2] is True                            # stream forced on
+    assert r.status()["primary"]["state"] == "closed"
+
+
+def test_stream_fails_over_to_secondary_on_5xx_before_bytes():
+    r = _router()
+    good = iter([b"data: ok\n\n"])
+    sfwd, calls = _fake_stream({"primary": (503, {"error": "down"}), "secondary": (200, good)})
+    proxy = ProviderProxy(r, _fake_forward({})[0], stream_forward_fn=sfwd)
+    status, obj = proxy.stream_complete("/chat/completions", {"model": "*"})
+    assert status == 200 and b"".join(obj) == b"data: ok\n\n"
+    assert [c[0] for c in calls] == ["primary", "secondary"]
+    assert r.status()["primary"]["state"] == "open"
+
+
+def test_stream_failfast_when_all_providers_down():
+    r = _router()
+    sfwd, _ = _fake_stream({"primary": (500, {}), "secondary": (None, {"error": "timeout"})})
+    proxy = ProviderProxy(r, _fake_forward({})[0], stream_forward_fn=sfwd)
+    status, body = proxy.stream_complete("/chat/completions", {"model": "*"})
+    assert status == 503 and body["error"]["type"] == "all_providers_unavailable"
+
+
+def test_stream_without_transport_degrades_to_buffered_completion():
+    r = _router()
+    fwd, calls = _fake_forward({"primary": (200, {"ok": True})})
+    proxy = ProviderProxy(r, fwd)   # no stream_forward_fn
+    status, body = proxy.stream_complete("/chat/completions", {"model": "*", "stream": True})
+    assert status == 200 and body == {"ok": True}
+    assert calls == [("primary", "/chat/completions")]
+
+
+def test_mount_streams_through_fastapi():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    sse = [b"data: {\"delta\":\"hi\"}\n\n", b"data: [DONE]\n\n"]
+    sfwd, _ = _fake_stream({"primary": (200, iter(sse))})
+    proxy = ProviderProxy(_router(), _fake_forward({"primary": (200, {})})[0], stream_forward_fn=sfwd)
+    app = FastAPI()
+    assert mount_router(app, env={"MAC_ROUTER_BACKEND": "inproc"}, proxy=proxy) is True
+    client = TestClient(app)
+    resp = client.post("/v1/chat/completions", json={"model": "*", "stream": True})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    assert resp.content == b"".join(sse)


### PR DESCRIPTION
## What

Makes the in-mac model router (th-merge-02/03) a genuine TokenHub replacement instead of a buffered proxy, so it can actually carry live agent traffic. Two gaps were found by a pre-cutover pre-flight against the live upstream:

1. **Wildcard resolution.** `inference-api.nvidia.com` returns **401 for `model="*"`** — only TokenHub resolves the wildcard. The proxy now resolves `"*"`/empty → a configured concrete model (`MAC_ROUTER_DEFAULT_MODEL`, e.g. the wildcard ladder's rank-0 `meta/llama-3.3-70b-instruct`) before forwarding. Provider *selection* still uses the requested model string; concrete models pass through untouched.
2. **Streaming passthrough.** The interactive gateway runs the agent loop through `responses.stream()` (SSE). The old proxy buffered the full body, which breaks streaming chat. `stream_complete` + `urllib_stream_forwarder` make the failover/breaker decision on the **status line** (before any bytes flow), then pass `text/event-stream` chunks straight through. Degrades to a buffered completion if no streaming transport is wired.

## Why

These are the two blockers to flipping `MAC_ROUTER_BACKEND=inproc` without taking the fleet down. With them in, a canary cutover (one agent → in-mac router → upstream, recovering breaker, instant rollback) is safe.

## Scope / follow-ups

- Per-model ladder failover (rank-0 down → rank-1) is **th-merge-06**; this resolves to rank-0 only.
- Router stays **opt-in** (`MAC_ROUTER_BACKEND` default `tokenhub`) — no behaviour change to the live fleet from this PR.

## Tests

8 new (`tests/test_router_app.py`): wildcard→concrete resolution, concrete pass-through, no-default back-compat, streaming iterator + record_success, stream failover on 5xx, stream fail-fast, degrade-without-transport, and a FastAPI `StreamingResponse` end-to-end. Full suite **748 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
