### PR TITLE
th-merge-02: auth the in-mac router (/v1 agent scope) + gateway presents a mac token

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -3812,6 +3812,16 @@ if _router_backend.lower() == "inproc" and _router_providers:
     values["CUSTOM_BASE_URL"] = _local_router_v1
     values["MAC_HERMES_GATEWAY_BASE_URL"] = _local_router_v1
     values["ACC_HERMES_GATEWAY_BASE_URL"] = _local_router_v1
+    # The gateway now talks to its LOCAL mac /v1 router, which is auth-gated like
+    # the rest of the mac API. It must present a valid mac token (agent scope) as
+    # its bearer; the router then uses the provider's OWN key (MAC_ROUTER_PROVIDERS
+    # key=...) for the upstream. Without this the gateway would send the upstream
+    # key, which the mac API rejects as an unknown bearer token.
+    _local_tok = values.get("MAC_API_TOKEN") or ""
+    if _local_tok:
+        values["OPENAI_API_KEY"] = _local_tok
+        values["MAC_HERMES_GATEWAY_API_KEY"] = _local_tok
+        values["ACC_HERMES_GATEWAY_API_KEY"] = _local_tok
 home_channel = (
     configured_home_channel
     or values.get("MAC_HERMES_SLACK_HOME_CHANNEL_NAME", "").strip().lstrip("#")

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -926,6 +926,12 @@ def _required_scope(method: str, path: str) -> Optional[str]:
         return None
     if path == "/ui" or path.startswith("/ui/"):
         return None
+    if path == "/v1" or path.startswith("/v1/"):
+        # In-mac model router (th-merge-02): LLM inference is an agent action, so
+        # the OpenAI front door requires the agent scope (admin inherits it),
+        # regardless of method. This keeps the router from being an open proxy
+        # when the API is bound to a network interface (e.g. the hub node).
+        return "agent"
     if method == "GET":
         return "read"
     if path.startswith("/agents/") and (

--- a/tests/test_api_required_scope.py
+++ b/tests/test_api_required_scope.py
@@ -1,0 +1,22 @@
+"""th-merge-02: the in-mac router's /v1 surface is auth-gated as an agent action."""
+
+from __future__ import annotations
+
+from mac.api import _required_scope
+
+
+def test_v1_router_requires_agent_scope_any_method():
+    # Inference is an agent action: the OpenAI front door requires agent scope
+    # (not the broad `write`), regardless of HTTP method, so it is never an open
+    # proxy when the API is bound to a network interface.
+    assert _required_scope("POST", "/v1/chat/completions") == "agent"
+    assert _required_scope("POST", "/v1/embeddings") == "agent"
+    assert _required_scope("GET", "/v1/models") == "agent"
+    assert _required_scope("GET", "/v1") == "agent"
+
+
+def test_non_v1_paths_unchanged():
+    assert _required_scope("GET", "/health") is None
+    assert _required_scope("GET", "/tasks") == "read"
+    assert _required_scope("POST", "/tasks") == "write"
+    assert _required_scope("POST", "/agentbus") == "agent"


### PR DESCRIPTION
## What

Makes the agent gateway able to reach the in-mac router. The canary proved the router **mounts and forwards correctly** (a manual `POST /v1/chat/completions` with `model="*"` returned `200` "canary ok" through TokenHub), but the gateway's own calls 403'd.

Root cause: the mac API's global `authenticate` middleware gates every route via `_required_scope`; `/v1/chat/completions` fell through to the `write` scope, and the gateway presents the **upstream/TokenHub key** — an unknown bearer to the mac API.

## Fix

1. **`api.py` `_required_scope`** — `/v1[/...]` requires the `agent` scope (admin inherits it), for any method. Inference is an agent action, and this keeps the router from being an open proxy when the API binds a network interface (the hub node).
2. **deploy** — when an agent routes in-proc, its gateway bearer (`OPENAI_API_KEY` / `*_GATEWAY_API_KEY`) is set to the **local mac token** (`MAC_API_TOKEN`). The gateway authenticates to its own router as an agent; the router uses the provider's own key (`MAC_ROUTER_PROVIDERS key=...`) for the upstream. Caller-auth (mac token) is cleanly separate from upstream-auth (provider key).

## Tests

New `tests/test_api_required_scope.py` (`/v1`→`agent`, other paths unchanged). Full suite **750 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
