### PR TITLE
th-merge-04: router resolves upstream provider keys from the in-mac encrypted escrow

### DIFF
--- a/docs/adr/0003-tokenhub-core-into-mac.md
+++ b/docs/adr/0003-tokenhub-core-into-mac.md
@@ -85,3 +85,49 @@ Provide `mac.router` (optional, in-process on the hub):
   becomes the thing ADR 0001 warned against.
 
 Tracked in **th-merge-01**.
+
+## Update (2026-05-31): the vault already exists; the topology is centralized
+
+Two clarifications from building this out:
+
+1. **The "Vault security" risk is already retired — don't reinvent it.** mac
+   already ships a Python encrypted key escrow: `SecretsService`
+   (`src/mac/secrets_service.py`) — Fernet at-rest (`MAC_SECRET_KEY`), scoped
+   access, single-use time-limited reveal handles, rotation, and a full audit
+   trail, behind `/secrets` + the `secret` scope. So "build a key store in
+   Python" is **done**; the only wiring needed was letting the router resolve an
+   upstream provider key *from* it. **th-merge-04** adds exactly that: a
+   provider's `key=` may be `secret:<name>`, resolved at use via
+   `SecretsService.resolve_secret_value` (audited, decrypt-at-use). The upstream
+   credential is therefore escrowed encrypted, never in plaintext env — which is
+   also how the direct-to-upstream cutover crosses the credential boundary
+   without an agent ever scraping a key.
+
+2. **The router + vault are centralized on the hub node; spokes point at it.**
+   This is the same topology as standalone TokenHub (one place holds the keys +
+   the wildcard ladder), but in-process in mac. The auth work in th-merge-02
+   (the `/v1` surface requires the `agent` scope) is what makes this safe over
+   the network: a spoke presents its agent token to the hub's `/v1`, the router
+   authenticates it, then uses the escrowed provider key for the upstream —
+   caller-auth and upstream-auth cleanly separated. Per-agent local routers
+   (the canary form) remain valid for isolation but are not the end-state.
+
+### Validated (2026-05-31)
+
+A **wrap-TokenHub canary** on `natasha` is live: its gateway is cut over to its
+local in-mac router (recovering breaker + fail-fast + streaming passthrough),
+which forwards through TokenHub using natasha's own key. Streaming chat verified
+end-to-end (real SSE deltas, `"*"`→`azure/openai/gpt-4.1-mini`); rest of the
+fleet untouched. This proved the router code carries live agent traffic before
+any upstream credential is moved into the vault.
+
+### Remaining to fully retire standalone TokenHub
+
+- **th-merge-04** (this) — router resolves `secret:<name>` provider keys from
+  the escrow. ✅
+- **th-merge-06** — the wildcard *ladder* (rank-0 → rank-1 model failover +
+  on-the-fly substitution) inside the router, so it resolves `"*"` itself
+  instead of leaning on TokenHub.
+- **Networked-hub rollout** — bind the hub's mac `/v1` on the tailnet, store the
+  upstream key in the escrow (`secret:nvidia-upstream`), point spokes at the hub
+  router, and drop the per-spoke TokenHub dependency.

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -3904,7 +3904,19 @@ def create_app(
     try:
         from mac.router_app import mount_router
 
-        if mount_router(app):
+        # th-merge-04: let a provider key be `secret:<name>`, resolved (audited,
+        # decrypt-at-use) from the in-mac encrypted key store so upstream
+        # credentials are never stored in plaintext env on the hub.
+        def _router_secret_resolver(name: str) -> Optional[str]:
+            secrets = getattr(cp, "secrets", None)
+            if secrets is None:
+                return None
+            try:
+                return secrets.resolve_secret_value(name, purpose="router-upstream")
+            except Exception:  # noqa: BLE001 - a missing/disabled secret must not break routing
+                return None
+
+        if mount_router(app, secret_resolver=_router_secret_resolver):
             _log.info("in-mac model router mounted (/v1/chat/completions, /v1/embeddings)")
     except Exception as exc:  # noqa: BLE001 - the router must never block app startup
         _log.warning("in-mac model router not mounted: %s", exc)

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -47,6 +47,7 @@ from mac.provider_router import Provider, ProviderRouter, providers_from_env
 
 __all__ = [
     "ProviderProxy",
+    "resolve_provider_key",
     "urllib_forwarder",
     "urllib_stream_forwarder",
     "build_proxy_from_env",
@@ -57,6 +58,26 @@ __all__ = [
 ForwardFn = Callable[..., Tuple[Optional[int], Any]]
 # stream_forward_fn(provider, path, payload, *, timeout) -> (status|None, iter[bytes] | error-body)
 StreamForwardFn = Callable[..., Tuple[Optional[int], Any]]
+# secret_resolver(name) -> plaintext | None  (th-merge-04: audited hub key escrow)
+SecretResolver = Callable[[str], Optional[str]]
+
+_SECRET_PREFIX = "secret:"
+
+
+def resolve_provider_key(provider: Provider, secret_resolver: Optional[SecretResolver] = None) -> str:
+    """Resolve a provider's bearer key. ``provider.api_key_env`` is either an env
+    var name (``NVIDIA_API_KEY``) or, for escrowed upstream keys, ``secret:<name>``
+    which is fetched from the in-mac encrypted key store (SecretsService) via the
+    injected ``secret_resolver`` — so the upstream credential is never stored in
+    plaintext env. Returns "" when unresolved (forwarder sends no Authorization)."""
+    spec = (provider.api_key_env or "").strip()
+    if not spec:
+        return ""
+    if spec.startswith(_SECRET_PREFIX):
+        if secret_resolver is None:
+            return ""
+        return secret_resolver(spec[len(_SECRET_PREFIX):]) or ""
+    return os.environ.get(spec, "")
 
 
 def _is_provider_failure(status: Optional[int]) -> bool:
@@ -156,15 +177,21 @@ class ProviderProxy:
         }
 
 
-def urllib_forwarder(provider: Provider, path: str, payload: Dict[str, Any], *, timeout: float = 60.0):
+def urllib_forwarder(
+    provider: Provider,
+    path: str,
+    payload: Dict[str, Any],
+    *,
+    timeout: float = 60.0,
+    secret_resolver: Optional[SecretResolver] = None,
+):
     """Real HTTP forward to ``provider.base_url + path`` with its bearer key.
     Returns ``(status_code|None, body)``; status None means unreachable/timeout."""
     url = provider.base_url.rstrip("/") + path
     headers = {"Content-Type": "application/json", "Accept": "application/json"}
-    if provider.api_key_env:
-        key = os.environ.get(provider.api_key_env, "")
-        if key:
-            headers["Authorization"] = "Bearer %s" % key
+    key = resolve_provider_key(provider, secret_resolver)
+    if key:
+        headers["Authorization"] = "Bearer %s" % key
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
@@ -198,7 +225,14 @@ def _drain_chunks(resp: Any, chunk_size: int = 8192) -> Iterator[bytes]:
             pass
 
 
-def urllib_stream_forwarder(provider: Provider, path: str, payload: Dict[str, Any], *, timeout: float = 300.0):
+def urllib_stream_forwarder(
+    provider: Provider,
+    path: str,
+    payload: Dict[str, Any],
+    *,
+    timeout: float = 300.0,
+    secret_resolver: Optional[SecretResolver] = None,
+):
     """Streaming HTTP forward. On a 2xx status line returns
     ``(status, iterator_of_bytes)`` with the connection held open; on an HTTP
     error returns ``(code, body)``; on a transport failure ``(None, body)``.
@@ -208,10 +242,9 @@ def urllib_stream_forwarder(provider: Provider, path: str, payload: Dict[str, An
     — before the client sees any bytes."""
     url = provider.base_url.rstrip("/") + path
     headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
-    if provider.api_key_env:
-        key = os.environ.get(provider.api_key_env, "")
-        if key:
-            headers["Authorization"] = "Bearer %s" % key
+    key = resolve_provider_key(provider, secret_resolver)
+    if key:
+        headers["Authorization"] = "Bearer %s" % key
     data = json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
@@ -228,9 +261,14 @@ def urllib_stream_forwarder(provider: Provider, path: str, payload: Dict[str, An
         return None, {"error": {"message": str(exc), "type": "upstream_unreachable"}}
 
 
-def build_proxy_from_env(env: Optional[Dict[str, str]] = None) -> Optional[ProviderProxy]:
+def build_proxy_from_env(
+    env: Optional[Dict[str, str]] = None,
+    *,
+    secret_resolver: Optional[SecretResolver] = None,
+) -> Optional[ProviderProxy]:
     """Build a ProviderProxy from MAC_ROUTER_* env; None when no providers are
-    configured."""
+    configured. ``secret_resolver`` (th-merge-04) lets a provider's ``key=`` be
+    ``secret:<name>``, resolved from the in-mac encrypted key store at use."""
     env = env or os.environ
     providers = providers_from_env(env)
     if not providers:
@@ -242,6 +280,12 @@ def build_proxy_from_env(env: Optional[Dict[str, str]] = None) -> Optional[Provi
         except ValueError:
             return default
 
+    def _fwd(provider, path, payload, *, timeout=60.0):
+        return urllib_forwarder(provider, path, payload, timeout=timeout, secret_resolver=secret_resolver)
+
+    def _sfwd(provider, path, payload, *, timeout=300.0):
+        return urllib_stream_forwarder(provider, path, payload, timeout=timeout, secret_resolver=secret_resolver)
+
     router = ProviderRouter(
         providers,
         failure_threshold=int(_f("MAC_ROUTER_FAILURE_THRESHOLD", 3)),
@@ -249,22 +293,28 @@ def build_proxy_from_env(env: Optional[Dict[str, str]] = None) -> Optional[Provi
     )
     return ProviderProxy(
         router,
-        urllib_forwarder,
-        stream_forward_fn=urllib_stream_forwarder,
+        _fwd,
+        stream_forward_fn=_sfwd,
         default_model=(env.get("MAC_ROUTER_DEFAULT_MODEL") or "").strip(),
         timeout=_f("MAC_ROUTER_TIMEOUT", 60.0),
         stream_timeout=_f("MAC_ROUTER_STREAM_TIMEOUT", 300.0),
     )
 
 
-def mount_router(app: Any, *, env: Optional[Dict[str, str]] = None, proxy: Optional[ProviderProxy] = None) -> bool:
+def mount_router(
+    app: Any,
+    *,
+    env: Optional[Dict[str, str]] = None,
+    proxy: Optional[ProviderProxy] = None,
+    secret_resolver: Optional[SecretResolver] = None,
+) -> bool:
     """Mount /v1/chat/completions + /v1/embeddings on ``app`` when
     MAC_ROUTER_BACKEND=inproc. Returns True if mounted. Default backend is
     'tokenhub' → no-op, so an existing fleet is unchanged until flipped."""
     env = env or os.environ
     if (env.get("MAC_ROUTER_BACKEND") or "tokenhub").strip().lower() != "inproc":
         return False
-    proxy = proxy or build_proxy_from_env(env)
+    proxy = proxy or build_proxy_from_env(env, secret_resolver=secret_resolver)
     if proxy is None:
         return False
     from fastapi.responses import JSONResponse, StreamingResponse

--- a/src/mac/secrets_service.py
+++ b/src/mac/secrets_service.py
@@ -209,6 +209,38 @@ class SecretsService:
             raise NotFoundError("secret not found or disabled: %s" % secret_id)
         return self._decrypt(row["ciphertext"])
 
+    def resolve_secret_value(
+        self,
+        name: str,
+        *,
+        purpose: str = "router",
+        accessor: str = "router",
+    ) -> Optional[str]:
+        """Audited, in-process resolution of a secret's plaintext for a consumer
+        co-located with the control plane on the hub — specifically the model
+        router (th-merge-04) fetching an upstream provider key.
+
+        ``request_secret``/``reveal_secret`` gate *remote* agents behind a
+        single-use, time-limited handle. This is different: the hub is
+        decrypting a secret it already owns, so there is no handle dance — but it
+        is still audited (every upstream-key use is traceable) and respects the
+        ``enabled`` flag. Returns ``None`` when the secret is absent or disabled
+        so the caller can fall back to env or fail the provider, rather than
+        raising into the request path."""
+        try:
+            secret = self.get_secret(name)
+        except NotFoundError:
+            return None
+        if not secret.enabled:
+            return None
+        self.record_access(secret.id, accessor, purpose, SecretAuditResult.GRANTED.value)
+        row = self.store.query_one(
+            "SELECT ciphertext FROM secrets WHERE id = ? AND enabled = 1", (secret.id,)
+        )
+        if row is None:
+            return None
+        return self._decrypt(row["ciphertext"])
+
     # Audit + scope helpers ---------------------------------------------
 
     def record_access(

--- a/tests/test_router_app.py
+++ b/tests/test_router_app.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from mac.provider_router import Provider, ProviderRouter
-from mac.router_app import ProviderProxy, build_proxy_from_env, mount_router
+from mac.router_app import ProviderProxy, build_proxy_from_env, mount_router, resolve_provider_key
 
 
 def _router():
@@ -205,6 +205,61 @@ def test_stream_without_transport_degrades_to_buffered_completion():
     status, body = proxy.stream_complete("/chat/completions", {"model": "*", "stream": True})
     assert status == 200 and body == {"ok": True}
     assert calls == [("primary", "/chat/completions")]
+
+
+# -- th-merge-04: provider key from the encrypted secret store ---------------
+
+
+def test_resolve_provider_key_from_env(monkeypatch):
+    monkeypatch.setenv("MY_UPSTREAM_KEY", "env-secret-123")
+    p = Provider("nvidia", "http://u/v1", api_key_env="MY_UPSTREAM_KEY")
+    assert resolve_provider_key(p) == "env-secret-123"
+
+
+def test_resolve_provider_key_from_secret_store():
+    # key=secret:<name> is resolved via the injected escrow resolver, NOT env.
+    p = Provider("nvidia", "http://u/v1", api_key_env="secret:nvidia-upstream")
+    resolver = {"nvidia-upstream": "escrowed-nvapi-key"}.get
+    assert resolve_provider_key(p, resolver) == "escrowed-nvapi-key"
+
+
+def test_resolve_provider_key_secret_missing_resolver_or_value():
+    p = Provider("nvidia", "http://u/v1", api_key_env="secret:absent")
+    assert resolve_provider_key(p, None) == ""              # no resolver wired
+    assert resolve_provider_key(p, {}.get) == ""            # resolver returns None
+    p2 = Provider("nvidia", "http://u/v1", api_key_env="")
+    assert resolve_provider_key(p2) == ""                   # no key spec
+
+
+def test_urllib_forwarder_uses_secret_resolver(monkeypatch):
+    # The real forwarder builds an Authorization header from the resolved key.
+    captured = {}
+
+    class _Resp:
+        status = 200
+
+        def read(self):
+            return b'{"ok": true}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=60.0):
+        captured["auth"] = req.headers.get("Authorization")
+        return _Resp()
+
+    from mac import router_app
+
+    monkeypatch.setattr(router_app.urllib.request, "urlopen", fake_urlopen)
+    p = Provider("nvidia", "http://u/v1", api_key_env="secret:nvidia-upstream")
+    status, body = router_app.urllib_forwarder(
+        p, "/chat/completions", {"model": "x"}, secret_resolver={"nvidia-upstream": "escrowed-key"}.get
+    )
+    assert status == 200 and body == {"ok": True}
+    assert captured["auth"] == "Bearer escrowed-key"
 
 
 def test_mount_streams_through_fastapi():


### PR DESCRIPTION
## What

Wires the in-mac router to fetch upstream provider keys from mac's **existing** encrypted key escrow, so the upstream credential is never stored in plaintext env.

## Why this is the linchpin

The direct-to-upstream cutover ("retire TokenHub") was blocked on the upstream credential: it lives only in TokenHub's key store, and an agent scraping it is (rightly) gated. The answer isn't to scrape it — it's to **escrow** it. And mac already ships a Python encrypted key store: `SecretsService` (`secrets_service.py`) — Fernet at-rest (`MAC_SECRET_KEY`), scoped access, single-use time-limited reveal, rotation, full audit trail, `/secrets` + `secret` scope. So the "build a key store in Python on the hub" idea is **already done**; this PR is just the wiring.

## Changes

- **`SecretsService.resolve_secret_value(name, purpose, accessor)`** — audited, in-process, decrypt-at-use resolution for hub-co-located consumers (the router). Distinct from `request_secret`/`reveal_secret`, which gate *remote* agents behind a single-use handle. Returns `None` for absent/disabled secrets, so a missing key degrades rather than raising into the request path.
- **`router_app.resolve_provider_key` + `secret_resolver` plumbing** — a provider's `key=` may be `secret:<name>` (resolved from the escrow) instead of an env-var name. Threaded through `urllib_forwarder` / `urllib_stream_forwarder` / `build_proxy_from_env` / `mount_router`.
- **`api.py`** — `mount_router` is handed a resolver backed by `cp.secrets`, best-effort (a missing/disabled secret never breaks routing).
- **ADR 0003 update** — the vault already exists; end-state is a *centralized hub* router+escrow with spokes presenting agent tokens to the hub `/v1`.

## Result

The direct cutover becomes a clean operator action with no plaintext key and no scraping: store `secret:nvidia-upstream` in the escrow, set the provider `key=secret:nvidia-upstream`. Upstream-auth (escrowed provider key) stays cleanly separate from caller-auth (agent token).

## Tests

4 new in `tests/test_router_app.py` (env key, secret-store key, missing-resolver/value fallback, real forwarder building the `Bearer` from the resolved escrow key). Full suite **754 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
