### PR TITLE
th-merge-07: Slack fetcher reads from mac's vault (admin reveal-by-name endpoint)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -2844,17 +2844,29 @@ fetch_slack_secrets_from_vault() {
   # writes ~/.hermes/slack_accounts.json and updates SLACK_BOT_TOKEN /
   # SLACK_APP_TOKEN in ~/.hermes/config.yaml's env block.
   #
-  # th-merge-07: when the in-mac router is the backend, TokenHub is retired, so
-  # this TokenHub-reading fetch is skipped. The Slack secrets have been migrated
-  # into mac's own vault (scripts/migrate-tokenhub-vault.sh) and each agent's
-  # existing ~/.hermes/slack_accounts.json is preserved, so Slack keeps working.
-  # (A mac-vault-sourced fetcher is the follow-up; the secrets are already there.)
-  case "$(printf '%s' "${MAC_DEPLOY_ROUTER_BACKEND:-}" | tr 'A-Z' 'a-z')" in
-    inproc) log "skipping TokenHub Slack vault fetch (in-mac router active; secrets migrated to mac vault, existing slack config preserved)"; return 0 ;;
-  esac
+  # th-merge-07: in router mode TokenHub is retired, so read this agent's Slack
+  # secrets from mac's OWN vault (the hub's SecretsService, via /secrets +
+  # /secrets/<name>/resolve) instead of TokenHub. Secrets were migrated by
+  # scripts/migrate-tokenhub-vault.sh.
   local fetcher="$SRC_DIR/scripts/mac-fetch-slack-secrets.py"
   if [ ! -f "$fetcher" ]; then
     log "skipping Slack vault fetch: $fetcher not present (older mac source?)"
+    return 0
+  fi
+  if [ "$(printf '%s' "${MAC_DEPLOY_ROUTER_BACKEND:-}" | tr 'A-Z' 'a-z')" = inproc ]; then
+    local mac_vault_url="${MAC_HUB_URL:-http://127.0.0.1:${MAC_PORT:-8789}}"
+    local mac_vault_token="${MAC_WORKER_TOKEN:-${MAC_API_TOKEN:-}}"
+    if [ -z "$mac_vault_token" ]; then
+      log "skipping mac-vault Slack fetch: MAC_WORKER_TOKEN/MAC_API_TOKEN unavailable"
+      return 0
+    fi
+    log "fetching Slack secrets for ${AGENT} from mac vault ($mac_vault_url)"
+    MAC_AGENT_NAME="$AGENT" \
+      MAC_SECRET_VAULT_URL="$mac_vault_url" \
+      MAC_SECRET_VAULT_TOKEN="$mac_vault_token" \
+      HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}" \
+      "$PY" "$fetcher" >> "$DEPLOY_LOG" 2>&1 || \
+        log "WARNING: mac-vault Slack fetch failed for ${AGENT}; existing slack config preserved"
     return 0
   fi
   local th_env="$HOME/.tokenhub/env"

--- a/scripts/mac-fetch-slack-secrets.py
+++ b/scripts/mac-fetch-slack-secrets.py
@@ -49,6 +49,33 @@ def vault_get(base: str, token: str, key: str) -> str:
         return json.loads(resp.read()).get("value") or ""
 
 
+# th-merge-07: read Slack secrets from mac's OWN encrypted vault (SecretsService)
+# instead of TokenHub. list = GET /secrets (names only); get = POST
+# /secrets/<name>/resolve (audited reveal-by-name, `secret` scope). Used when
+# MAC_SECRET_VAULT_URL/TOKEN are set (router mode); TokenHub is retired.
+def mac_vault_list(base: str, token: str) -> list[str]:
+    req = urllib.request.Request(
+        "%s/secrets" % base.rstrip("/"),
+        headers={"Authorization": "Bearer %s" % token},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        data = json.loads(resp.read())
+    rows = data if isinstance(data, list) else data.get("secrets") or data.get("items") or []
+    return [r.get("name") for r in rows if isinstance(r, dict) and r.get("name")]
+
+
+def mac_vault_get(base: str, token: str, key: str) -> str:
+    safe = urllib.parse.quote(key, safe="")
+    req = urllib.request.Request(
+        "%s/secrets/%s/resolve" % (base.rstrip("/"), safe),
+        method="POST",
+        headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"},
+        data=b"{}",
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return json.loads(resp.read()).get("value") or ""
+
+
 def auth_test(token: str) -> tuple[bool, dict]:
     """Optional last-mile verification before applying. Returns
     (ok, response). Network failures count as ok=False so we don't
@@ -209,19 +236,28 @@ def main() -> int:
     if not agent:
         print("MAC_AGENT_NAME is required", file=sys.stderr)
         return 2
-    base = os.environ.get("TOKENHUB_URL", "http://127.0.0.1:8090")
-    token = os.environ.get("TOKENHUB_ADMIN_TOKEN", "")
-    if not token:
-        print("TOKENHUB_ADMIN_TOKEN is required", file=sys.stderr)
-        return 2
+    # th-merge-07: prefer mac's own vault (SecretsService) when configured;
+    # fall back to TokenHub for backward compat.
+    mac_url = (os.environ.get("MAC_SECRET_VAULT_URL") or "").strip()
+    mac_token = (os.environ.get("MAC_SECRET_VAULT_TOKEN") or "").strip()
+    if mac_url and mac_token:
+        base, token, source = mac_url, mac_token, "mac-vault"
+        list_fn, get_fn = mac_vault_list, mac_vault_get
+    else:
+        base = os.environ.get("TOKENHUB_URL", "http://127.0.0.1:8090")
+        token = os.environ.get("TOKENHUB_ADMIN_TOKEN", "")
+        source, list_fn, get_fn = "tokenhub", vault_list, vault_get
+        if not token:
+            print("TOKENHUB_ADMIN_TOKEN is required (or set MAC_SECRET_VAULT_URL/TOKEN)", file=sys.stderr)
+            return 2
     hermes_home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
     hermes_home.mkdir(parents=True, exist_ok=True)
     config_path = hermes_home / "config.yaml"
 
     try:
-        all_secrets = vault_list(base, token)
+        all_secrets = list_fn(base, token)
     except Exception as exc:
-        print("vault_list failed:", exc, file=sys.stderr)
+        print("vault_list (%s) failed:" % source, exc, file=sys.stderr)
         return 3
 
     # Find secrets for this agent
@@ -239,9 +275,9 @@ def main() -> int:
             continue
         _, _, workspace, kind = parts[0], parts[1], parts[2], parts[3]
         try:
-            value = vault_get(base, token, key)
+            value = get_fn(base, token, key)
         except Exception as exc:
-            print("vault_get %s failed: %s" % (key, exc), file=sys.stderr)
+            print("vault_get (%s) %s failed: %s" % (source, key, exc), file=sys.stderr)
             continue
         if not value:
             continue

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -3677,6 +3677,26 @@ def create_app(
             "value": cp.reveal_secret(secret_id, body.audit_id, body.accessor_agent_id),
         }
 
+    @app.post("/secrets/{name}/resolve")
+    def resolve_secret(
+        name: str,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        # th-merge-07: audited admin reveal-by-name for in-fleet consumers — the
+        # Slack fetcher reads slack.<agent>.* from mac's vault now that TokenHub is
+        # retired. Requires the `secret` scope (admin inherits it); decrypt-at-use
+        # and access-audited via SecretsService.resolve_secret_value. Distinct from
+        # the request/reveal handle flow (which is for per-agent scoped access).
+        _enforce_secret_rate_limit(principal, "resolve")  # mac-xc8u
+        secrets = getattr(cp, "secrets", None)
+        if secrets is None:
+            raise NotFoundError("secret store unavailable")
+        accessor = getattr(principal, "agent_id", None) or "fleet-fetch"
+        value = secrets.resolve_secret_value(name, purpose="fleet-fetch", accessor=accessor)
+        if value is None:
+            raise NotFoundError("secret not found or disabled: %s" % name)
+        return {"name": name, "value": value}
+
     @app.get("/secret-audits")
     def list_secret_audits(secret_id: Optional[str] = Query(default=None)) -> List[Dict[str, Any]]:
         return [audit.to_dict() for audit in cp.list_secret_audits(secret_id)]

--- a/tests/test_api_required_scope.py
+++ b/tests/test_api_required_scope.py
@@ -20,3 +20,9 @@ def test_non_v1_paths_unchanged():
     assert _required_scope("GET", "/tasks") == "read"
     assert _required_scope("POST", "/tasks") == "write"
     assert _required_scope("POST", "/agentbus") == "agent"
+
+
+def test_secret_resolve_requires_secret_scope():
+    # th-merge-07: audited reveal-by-name (Slack fetcher) is gated on `secret`.
+    assert _required_scope("POST", "/secrets/slack.rocky.omgjkh.bot/resolve") == "secret"
+    assert _required_scope("POST", "/secrets/github.token/resolve") == "secret"


### PR DESCRIPTION
Finishes the Slack-fetcher repoint so TokenHub retirement has no functional gap.

- **api.py**: `POST /secrets/{name}/resolve` — audited admin reveal-by-name (`secret` scope), via `SecretsService.resolve_secret_value` (decrypt-at-use + access-audited).
- **mac-fetch-slack-secrets.py**: source-agnostic — reads from mac's vault (`GET /secrets` + `POST /secrets/<name>/resolve`) when `MAC_SECRET_VAULT_URL/TOKEN` are set, else legacy TokenHub. Verification/dedupe/write unchanged.
- **deploy**: in router mode runs the fetcher in mac-vault mode (`MAC_HUB_URL` + `MAC_WORKER_TOKEN`) instead of skipping.

Tests: scope test + full suite **761 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)