### PR TITLE
fix(home-channel): gateway resolves Slack home channel from slack_home_channels.json + silence retired-TokenHub warning

### DIFF
--- a/src/mac/_hermes/gateway/config.py
+++ b/src/mac/_hermes/gateway/config.py
@@ -1245,6 +1245,25 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
                 pconfig.enabled = False
 
 
+def _slack_home_from_resolved_file(default_name: str = "") -> "tuple[str, str]":
+    """th-merge-07: read the primary resolved Slack home channel from
+    ``<hermes_home>/slack_home_channels.json`` (written by the deploy's
+    home-channel sync from the fleet's configured channel name). Returns
+    ``(channel_id, name)`` or ``("", default_name)`` if unavailable."""
+    try:
+        path = os.path.join(str(get_hermes_home()), "slack_home_channels.json")
+        with open(path, "r", encoding="utf-8") as fh:
+            homes = json.load(fh)
+        if isinstance(homes, list) and homes:
+            entry = homes[0]
+            chan = str(entry.get("channel_id") or "")
+            name = str(entry.get("channel_name") or "").lstrip("#") or default_name
+            return chan, name
+    except Exception:
+        pass
+    return "", default_name
+
+
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
     
@@ -1346,11 +1365,19 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         # send Slack messages can use it without activating the gateway adapter.
         config.platforms[Platform.SLACK].token = slack_token
     slack_home = os.getenv("SLACK_HOME_CHANNEL")
+    slack_home_name = os.getenv("SLACK_HOME_CHANNEL_NAME", "")
+    if not slack_home:
+        # th-merge-07: the deploy retires the legacy SLACK_HOME_CHANNEL env in
+        # favour of the multi-account slack_home_channels.json (resolved from the
+        # fleet's configured home-channel name). Load the primary resolved channel
+        # so get_home_channel(SLACK) is populated and Hermes stops reporting
+        # "No home channel set".
+        slack_home, slack_home_name = _slack_home_from_resolved_file(slack_home_name)
     if slack_home and Platform.SLACK in config.platforms:
         config.platforms[Platform.SLACK].home_channel = HomeChannel(
             platform=Platform.SLACK,
             chat_id=slack_home,
-            name=os.getenv("SLACK_HOME_CHANNEL_NAME", ""),
+            name=slack_home_name,
             thread_id=os.getenv("SLACK_HOME_CHANNEL_THREAD_ID") or None,
         )
     

--- a/src/mac/hermes_startup.py
+++ b/src/mac/hermes_startup.py
@@ -925,6 +925,12 @@ def _tokenhub_report() -> Dict[str, Any]:
         "warning": "",
         "degradation_reason": "",
     }
+    if (os.environ.get("MAC_ROUTER_BACKEND") or "").strip().lower() == "inproc":
+        # th-merge-07: in router mode TokenHub is retired — its health endpoint
+        # being unreachable is expected, not a degradation. Report cleanly.
+        report["status"] = "retired"
+        report["ready"] = True
+        return report
     if not endpoint:
         if not required:
             return report


### PR DESCRIPTION
**Root cause** of "No home channel is set for Slack": the deploy sync resolves the fleet's home-channel name into the multi-account `slack_home_channels.json` and **retires** the legacy `SLACK_HOME_CHANNEL` env, but the gateway's `get_home_channel(SLACK)` only read that (now-deleted) env var → `home_channel` always None.

**Fix**: gateway falls back to the primary resolved channel in `slack_home_channels.json` when `SLACK_HOME_CHANNEL` is unset — so the fleet-metadata home channel is applied on startup as intended.

Also gates the cosmetic "TokenHub health endpoint unreachable" startup warning to a clean `retired` status in router mode. Full suite **761 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)