### PR TITLE
fix(setup): wire the in-mac router into the setup flow + honor degraded flag

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -1290,10 +1290,20 @@ install_github_review_key() {
   fi
 }
 
+# On a brand-new spoke the hub's Qdrant/Firecrawl are reached through a reverse
+# tunnel that is not fully established until this first deploy authorizes the
+# tunnel key. MAC_DEPLOY_ALLOW_DEGRADED_SERVICES=1 (set by main() for that first
+# deploy) lets the deploy proceed degraded so the tunnel gets set up; the
+# post-deploy path in main() then waits for the tunnel and restarts the agent,
+# and a subsequent deploy (flag unset) validates strictly.
 validate_qdrant_endpoint() {
-  local qdrant_url
+  local qdrant_url degraded="${MAC_DEPLOY_ALLOW_DEGRADED_SERVICES:-0}"
   qdrant_url="${QDRANT_URL:-${QDRANT_ADDRESS:-${QDRANT_FLEET_URL:-}}}"
   if [ -z "$qdrant_url" ]; then
+    if [ "$degraded" = "1" ]; then
+      log "WARNING: Qdrant endpoint not configured; proceeding degraded (first deploy)"
+      return
+    fi
     log "ERROR: Qdrant shared memory is required but no endpoint is configured"
     exit 1
   fi
@@ -1301,19 +1311,31 @@ validate_qdrant_endpoint() {
     log "Qdrant shared memory reachable at configured collections endpoint"
     return
   fi
+  if [ "$degraded" = "1" ]; then
+    log "WARNING: Qdrant unreachable at ${qdrant_url%/}/collections; proceeding degraded (first deploy — hub tunnel not yet established). Redeploy after it comes up to validate strictly."
+    return
+  fi
   log "ERROR: Qdrant shared memory is unreachable at ${qdrant_url%/}/collections"
   exit 1
 }
 
 validate_firecrawl_endpoint() {
-  local firecrawl_url
+  local firecrawl_url degraded="${MAC_DEPLOY_ALLOW_DEGRADED_SERVICES:-0}"
   firecrawl_url="${FIRECRAWL_API_URL:-${FIRECRAWL_GATEWAY_URL:-${FIRECRAWL_URL_CONFIGURED:-}}}"
   if [ -z "$firecrawl_url" ]; then
+    if [ "$degraded" = "1" ]; then
+      log "WARNING: Firecrawl endpoint not configured; proceeding degraded (first deploy)"
+      return
+    fi
     log "ERROR: Firecrawl web search is required but no endpoint is configured"
     exit 1
   fi
   if curl -fsS --connect-timeout 2 --max-time 5 "${firecrawl_url%/}/health" >/dev/null; then
     log "Firecrawl web search reachable at configured health endpoint"
+    return
+  fi
+  if [ "$degraded" = "1" ]; then
+    log "WARNING: Firecrawl unreachable at ${firecrawl_url%/}/health; proceeding degraded (first deploy — hub tunnel not yet established). Redeploy after it comes up to validate strictly."
     return
   fi
   log "ERROR: Firecrawl web search is unreachable at ${firecrawl_url%/}/health"

--- a/scripts/setup-fleet.py
+++ b/scripts/setup-fleet.py
@@ -254,6 +254,33 @@ def _default_worker_capabilities() -> List[str]:
     return ["ops", "python", "hermes", "review", "web_search", "web_extract", "web_crawl", "firecrawl"]
 
 
+# Known OpenAI-compatible upstreams the wizard can wire into the in-mac router.
+# provider id -> (key env var, base-url env var, default base url)
+_KNOWN_PROVIDERS: Dict[str, tuple] = {
+    "nvidia":     ("NVIDIA_API_KEY",     "NVIDIA_BASE_URL",     "https://inference-api.nvidia.com/v1"),
+    "openai":     ("OPENAI_API_KEY",     "OPENAI_BASE_URL",     "https://api.openai.com/v1"),
+    "anthropic":  ("ANTHROPIC_API_KEY",  "ANTHROPIC_BASE_URL",  "https://api.anthropic.com"),
+    "perplexity": ("PERPLEXITY_API_KEY", "PERPLEXITY_BASE_URL", "https://api.perplexity.ai"),
+}
+
+
+def build_router_provider_spec(provider_env_values: Dict[str, str]) -> str:
+    """Build MAC_ROUTER_PROVIDERS from the provider keys the wizard collected.
+
+    Format (mac.provider_router.providers_from_env): ``name=base_url,priority,
+    key=ENVVAR`` joined by ';'. ``key`` is the plain env-var NAME — router_app
+    resolves it from the agent env at use (the deploy plumbs these provider keys
+    through), so no vault escrow is needed to route. Emitted in _KNOWN_PROVIDERS
+    order (nvidia preferred, priority 0)."""
+    specs = []
+    for prio, (pid, (key_var, base_var, default_base)) in enumerate(_KNOWN_PROVIDERS.items()):
+        if key_var not in provider_env_values:
+            continue
+        base = provider_env_values.get(base_var) or default_base
+        specs.append("%s=%s,%d,key=%s" % (pid, base, prio, key_var))
+    return ";".join(specs)
+
+
 def _setup_hub(args: argparse.Namespace, fleets_config: Path, env_file: Path, running_locally: bool) -> int:
     fleet_name = prompt("Fleet name", default="my-fleet")
     hub_name = prompt("Hub node name", required=True)
@@ -480,12 +507,6 @@ def _setup_hub(args: argparse.Namespace, fleets_config: Path, env_file: Path, ru
     }
 
     # Provider credentials — at least one required for the in-mac router to route requests.
-    _KNOWN_PROVIDERS: Dict[str, tuple] = {
-        "nvidia":     ("NVIDIA_API_KEY",     "NVIDIA_BASE_URL",     "https://inference-api.nvidia.com/v1"),
-        "openai":     ("OPENAI_API_KEY",     "OPENAI_BASE_URL",     "https://api.openai.com/v1"),
-        "anthropic":  ("ANTHROPIC_API_KEY",  "ANTHROPIC_BASE_URL",  "https://api.anthropic.com"),
-        "perplexity": ("PERPLEXITY_API_KEY", "PERPLEXITY_BASE_URL", "https://api.perplexity.ai"),
-    }
     provider_env_values: Dict[str, str] = {}
     print("")
     print("The in-mac router requires at least one upstream LLM provider.")
@@ -521,6 +542,16 @@ def _setup_hub(args: argparse.Namespace, fleets_config: Path, env_file: Path, ru
         "MAC_DEPLOY_SHARED_SERVICES_MANAGER_AGENT": hub_name,
     }
     env_values.update(provider_env_values)
+    # Wire the in-mac router — the replacement for the retired TokenHub. With
+    # MAC_ROUTER_BACKEND=inproc + providers, the deploy mounts each agent's local
+    # /v1 front door and points its gateway there (see deploy-mac-fleet.sh router
+    # block). Without this a freshly-generated fleet would have no chat routing.
+    env_values["MAC_DEPLOY_ROUTER_BACKEND"] = "inproc"
+    env_values["MAC_DEPLOY_ROUTER_PROVIDERS"] = build_router_provider_spec(provider_env_values)
+    print("")
+    print("Wired in-mac router: MAC_ROUTER_BACKEND=inproc")
+    print("  providers: %s" % (env_values["MAC_DEPLOY_ROUTER_PROVIDERS"] or "(none)"))
+    print("  (set MAC_DEPLOY_ROUTER_DEFAULT_MODEL in %s if your gateway model is '*')" % env_file)
     if prompt_bool("Generate MAC_SECRET_KEY in %s?" % env_file, default=True):
         env_values["MAC_SECRET_KEY"] = secrets.token_urlsafe(48)
     if prompt_bool("Generate MAC_API_TOKEN in %s?" % env_file, default=True):
@@ -844,6 +875,11 @@ def main(argv: List[str]) -> int:
             "MAC_DEPLOY_SHARED_SERVICES_MANAGER_AGENT": hub_name,
             "MAC_SECRET_KEY": secrets.token_urlsafe(48),
             "MAC_API_TOKEN": secrets.token_urlsafe(32),
+            # Make the in-mac router the routing backend (mounts as a no-op until
+            # providers are added). --new-hub collects no provider keys, so set
+            # MAC_DEPLOY_ROUTER_PROVIDERS + the provider key(s) in the env file
+            # before deploy or chat will have no upstream.
+            "MAC_DEPLOY_ROUTER_BACKEND": "inproc",
         }
         if args.headscale_preauth_key:
             env_values[headscale_preauth_key_env] = args.headscale_preauth_key
@@ -859,7 +895,7 @@ def main(argv: List[str]) -> int:
 
     print("mac fleet setup wizard")
     print("Do not put provider API keys in the fleet config YAML. The wizard collects")
-    print("them into ~/.mac/.env (mode 0600); deploy escrows them into mac's vault.")
+    print("them into ~/.mac/.env (mode 0600) and wires the in-mac router to read them.")
     print("")
 
     running_locally = prompt_bool(

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -395,6 +395,58 @@ def test_fleet_deploy_routes_provider_secrets_through_in_mac_router():
     assert 'or os.environ.get("NVIDIA_API_BASE")' not in startup
 
 
+def test_first_deploy_validators_honor_allow_degraded_services_flag():
+    # A brand-new spoke reaches the hub's Qdrant/Firecrawl through a reverse
+    # tunnel that is not established until the first deploy authorizes the tunnel
+    # key. main() sets MAC_DEPLOY_ALLOW_DEGRADED_SERVICES=1 for that first deploy;
+    # the remote validators MUST honor it (warn + proceed) instead of hard-exiting,
+    # or the deploy dies before main()'s post-deploy tunnel-reconnect path runs.
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    qdrant_validator = script.split("validate_qdrant_endpoint() {", 1)[1].split("\n}", 1)[0]
+    firecrawl_validator = script.split("validate_firecrawl_endpoint() {", 1)[1].split("\n}", 1)[0]
+    for validator in (qdrant_validator, firecrawl_validator):
+        assert 'degraded="${MAC_DEPLOY_ALLOW_DEGRADED_SERVICES:-0}"' in validator
+        # Both the unreachable-endpoint and missing-endpoint branches must offer a
+        # degraded early-return guarded by the flag.
+        assert validator.count('if [ "$degraded" = "1" ]; then') == 2
+        assert "proceeding degraded (first deploy" in validator
+    # The flag is plumbed into the remote deploy env and consumed by the
+    # post-deploy reconnect path in main().
+    assert 'MAC_DEPLOY_ALLOW_DEGRADED_SERVICES=$(shell_quote "${allow_degraded_services:-0}")' in script
+    assert '[ "${allow_degraded_services:-0}" = "1" ]' in script
+
+
+def test_setup_fleet_build_router_provider_spec():
+    # The wizard wires the in-mac router from the providers it collects, using the
+    # plain env-var key form the router resolves at use (no vault escrow needed).
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "setup_fleet_mod", ROOT / "scripts" / "setup-fleet.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    build = mod.build_router_provider_spec
+
+    assert build({}) == ""
+    assert build({"OPENAI_API_KEY": "sk"}) == "openai=https://api.openai.com/v1,1,key=OPENAI_API_KEY"
+    # nvidia is preferred (priority 0); a custom base url is honored.
+    assert build(
+        {"NVIDIA_API_KEY": "k", "OPENAI_API_KEY": "sk", "OPENAI_BASE_URL": "https://x/v1"}
+    ) == (
+        "nvidia=https://inference-api.nvidia.com/v1,0,key=NVIDIA_API_KEY"
+        ";openai=https://x/v1,1,key=OPENAI_API_KEY"
+    )
+    # The spec round-trips through the router's own parser.
+    from mac.provider_router import providers_from_env
+
+    providers = providers_from_env(
+        {"MAC_ROUTER_PROVIDERS": build({"NVIDIA_API_KEY": "k"})}
+    )
+    assert [p.name for p in providers] == ["nvidia"]
+    assert providers[0].api_key_env == "NVIDIA_API_KEY"
+
+
 def test_fleet_deploy_uses_home_scoped_registry_not_legacy_site_config():
     script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
 
@@ -507,6 +559,12 @@ def test_setup_fleet_wizard_writes_fleet_registry_and_env(tmp_path):
     assert "MAC_DEPLOY_FLEET_SITE_CONFIG=" not in env
     assert "MAC_DEPLOY_HUB_URL=" not in env
     assert "MAC_SECRET_KEY" not in env
+    # KEY INSIGHT fix: the wizard must wire the in-mac router (TokenHub's
+    # replacement) from the collected providers, or a fresh fleet has no chat
+    # routing. The test adds the "openai" provider with key "sk-test".
+    assert "MAC_DEPLOY_ROUTER_BACKEND=inproc" in env
+    assert "MAC_DEPLOY_ROUTER_PROVIDERS=openai=https://api.openai.com/v1,1,key=OPENAI_API_KEY" in env
+    assert "OPENAI_API_KEY=sk-test" in env
     assert "MAC_API_TOKEN" not in env
 
 


### PR DESCRIPTION
## Summary

Two correctness gaps surfaced after the TokenHub retirement (#40) — both about the *replacement* path not actually being load-bearing:

### 1. The in-mac router was optional and never wired by setup (the real gap)
`scripts/setup-fleet.py` collected provider keys (`NVIDIA_API_KEY`, …) but **never emitted `MAC_ROUTER_BACKEND=inproc` / `MAC_ROUTER_PROVIDERS`** — even though `router_app.mount_router` only mounts the local `/v1` when `MAC_ROUTER_BACKEND=inproc` ([router_app.py:341](../blob/main/src/mac/router_app.py#L341)). So a freshly-generated fleet had TokenHub removed **and no replacement** → no chat routing at all. The wizard text even claimed "deploy escrows them into mac's vault" — which never happened.

**Fix:** `_setup_hub` now builds `MAC_DEPLOY_ROUTER_PROVIDERS` from the providers it collects via a new `build_router_provider_spec` helper (`name=base_url,priority,key=ENVVAR` — the plain env-var key form `router_app` resolves at use ([router_app.py:80](../blob/main/src/mac/router_app.py#L80)); the deploy already plumbs those provider keys, so **no vault escrow is needed to route**) and sets `MAC_DEPLOY_ROUTER_BACKEND=inproc`. `--new-hub` sets the backend too (a safe no-op until providers are added, with a note). The misleading wizard line is corrected.

### 2. First-deploy degraded override was plumbed but never honored
`main()` computes `MAC_DEPLOY_ALLOW_DEGRADED_SERVICES` and passes it into the remote env, but `validate_qdrant_endpoint` / `validate_firecrawl_endpoint` hard-exit on an unreachable service **regardless** ([deploy:1293/1308](../blob/main/deploy/deploy-mac-fleet.sh)). A brand-new reverse-tunnel spoke — whose hub Qdrant/Firecrawl aren't reachable until *this* first deploy authorizes the tunnel key — therefore died before `main()`'s post-deploy tunnel-reconnect path ever ran.

**Fix:** both validators now honor the flag — warn + proceed degraded on the first deploy so the tunnel gets established and the agent restarts; a subsequent deploy (flag unset) validates strictly.

## Tests
- Wizard test asserts the router env is wired (`MAC_DEPLOY_ROUTER_BACKEND=inproc` + `MAC_DEPLOY_ROUTER_PROVIDERS=openai=…,key=OPENAI_API_KEY`).
- New `test_first_deploy_validators_honor_allow_degraded_services_flag` locks the validator behavior.
- New `test_setup_fleet_build_router_provider_spec` covers the builder + a round-trip through `providers_from_env`.
- Full suite: **744 passed** (1 deselected — env-only `mac-agent` E2E precondition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)