### PR TITLE
security: purge dead retired-TokenHub env keys from agents + operator

### DIFF
--- a/scripts/purge-dead-tokenhub-keys.sh
+++ b/scripts/purge-dead-tokenhub-keys.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# purge-dead-tokenhub-keys.sh — remove retired-TokenHub env leftovers from the
+# env files on THIS machine (agent and/or operator).
+#
+# TokenHub was retired (th-merge-07: the in-mac router replaced it). These vars
+# are dead plaintext liabilities that nothing in the current code writes; only
+# the retirement-handling/compat paths read them, and they resolve correctly to
+# empty once removed. Carrying them — especially a TokenHub admin token or the
+# root URL that still influences provider/runtime resolution — is pure attack
+# surface for zero function.
+#
+# Cleans, when present:
+#   - $HOME/.mac/mac.env                          (agent systemd EnvironmentFile)
+#   - ${MAC_DEPLOY_ENV_FILE:-$HOME/.mac/.env}     (operator deploy env)
+#   - $HOME/.hermes/.env                          (gateway env)
+#
+# Idempotent; backs up each modified file (cp -pf) before rewriting (awk so an
+# all-dead file is emptied, not aborted under set -e); prints only key NAMES.
+#
+# Run locally:  bash purge-dead-tokenhub-keys.sh [--dry-run]
+# NOTE: a TokenHub *admin* token exposed here must ALSO be rotated/revoked at the
+# source — deleting the local copy does not invalidate the token itself.
+set -euo pipefail
+
+DRY=0
+[ "${1:-}" = "--dry-run" ] && DRY=1
+
+# Dead retired-TokenHub vars. The regex also matches an optional `export ` prefix
+# and an optional fleet-scoped `__SUFFIX` (e.g. MAC_DEPLOY_TOKENHUB_API_KEY__ROCKY).
+PAT='^(export )?(TOKENHUB_API_KEY|TOKENHUB_ADMIN_TOKEN|TOKENHUB_AGENT_KEY|TOKENHUB_URL|MAC_REQUIRE_TOKENHUB|MAC_TOKENHUB_PORT|MAC_TOKENHUB_URL|MAC_DEPLOY_TOKENHUB_API_KEY|MAC_DEPLOY_TOKENHUB_URL|MAC_DEPLOY_TOKENHUB_PORT|MAC_DEPLOY_TOKENHUB_INSTALL|MAC_DEPLOY_TOKENHUB_REF)(__[A-Za-z0-9_]+)?='
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+changed=0
+processed=""
+
+for f in "$HOME/.mac/mac.env" "${MAC_DEPLOY_ENV_FILE:-$HOME/.mac/.env}" "$HOME/.hermes/.env"; do
+  # Skip a path we've already handled (e.g. MAC_DEPLOY_ENV_FILE == mac.env).
+  case " $processed " in *" $f "*) continue ;; esac
+  processed="$processed $f"
+  if [ ! -f "$f" ]; then
+    echo "  $f: absent"
+    continue
+  fi
+  hits="$(grep -cE "$PAT" "$f" 2>/dev/null || true)"
+  if [ "${hits:-0}" -eq 0 ]; then
+    echo "  $f: clean"
+    continue
+  fi
+  echo "  $f: removing $hits dead TokenHub line(s):"
+  grep -nE "$PAT" "$f" | sed -E 's/=.*/=<redacted>/' | sed 's/^/      /'
+  [ "$DRY" = "1" ] && continue
+  cp -pf "$f" "$f.bak-tokenhub-$TS"
+  # awk (not grep -v): always exits 0, so a file of ONLY dead lines is emptied
+  # rather than aborting the script after the backup.
+  awk -v p="$PAT" '$0 !~ p' "$f" > "$f.purge.$$"
+  chmod 600 "$f.purge.$$"
+  mv -f "$f.purge.$$" "$f"
+  changed=1
+done
+
+echo "PURGE_CHANGED=$changed"
+[ "$DRY" = "1" ] && echo "(dry-run; no files modified)"
+exit 0

--- a/tests/test_purge_dead_tokenhub_keys.py
+++ b/tests/test_purge_dead_tokenhub_keys.py
@@ -1,0 +1,106 @@
+"""Tests for scripts/purge-dead-tokenhub-keys.sh.
+
+The purge must clean every env file it claims to (agent mac.env, the operator
+deploy env, and the gateway ~/.hermes/.env), keep live vars, handle fleet-scoped
+__SUFFIX variants, and survive a file that is ENTIRELY dead lines (the awk-vs-
+grep -e exit-1 edge case) without aborting under set -e.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "purge-dead-tokenhub-keys.sh"
+
+
+def _run(home: Path, extra_env=None):
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)], env=env, text=True, capture_output=True
+    )
+
+
+def test_purge_cleans_all_three_env_files(tmp_path):
+    home = tmp_path
+    (home / ".mac").mkdir(parents=True)
+    (home / ".hermes").mkdir(parents=True)
+    mac_env = home / ".mac" / "mac.env"
+    deploy_env = home / ".mac" / ".env"
+    hermes_env = home / ".hermes" / ".env"
+
+    # agent env: dead vars (incl the root URL) mixed with live config
+    mac_env.write_text(
+        "MAC_API_TOKEN=keepme\n"
+        "TOKENHUB_API_KEY=dead\n"
+        "MAC_REQUIRE_TOKENHUB=1\n"
+        "TOKENHUB_URL=http://hub:8090\n"
+        "MAC_TOKENHUB_PORT=8090\n"
+        "MAC_ROUTER_BACKEND=inproc\n"
+    )
+    # operator deploy env: bare + fleet-scoped dead variants + a live provider key
+    deploy_env.write_text(
+        "MAC_DEPLOY_HUB_AGENT=rocky\n"
+        "MAC_DEPLOY_TOKENHUB_API_KEY=dead\n"
+        "MAC_DEPLOY_TOKENHUB_API_KEY__ROCKY=dead\n"
+        "MAC_DEPLOY_TOKENHUB_URL=http://hub:8090\n"
+        "NVIDIA_API_KEY__ROCKY=keep\n"
+    )
+    # gateway env: ENTIRELY dead lines (would make `grep -v` exit 1 and, under
+    # set -e, abort after the backup — awk must emit empty output and exit 0).
+    hermes_env.write_text(
+        "TOKENHUB_API_KEY=dead\n"
+        "export TOKENHUB_ADMIN_TOKEN=dead\n"
+        "MAC_TOKENHUB_PORT=8090\n"
+    )
+
+    result = _run(home)
+    assert result.returncode == 0, result.stderr + result.stdout
+
+    mac_txt = mac_env.read_text()
+    assert "TOKENHUB" not in mac_txt
+    assert "MAC_REQUIRE_TOKENHUB" not in mac_txt
+    assert "MAC_API_TOKEN=keepme" in mac_txt
+    assert "MAC_ROUTER_BACKEND=inproc" in mac_txt
+
+    deploy_txt = deploy_env.read_text()
+    assert "MAC_DEPLOY_TOKENHUB_API_KEY" not in deploy_txt  # bare + __ROCKY both gone
+    assert "MAC_DEPLOY_TOKENHUB_URL" not in deploy_txt
+    assert "NVIDIA_API_KEY__ROCKY=keep" in deploy_txt
+    assert "MAC_DEPLOY_HUB_AGENT=rocky" in deploy_txt
+
+    # all-dead file: emptied (no dead vars), NOT aborted, backup written
+    hermes_txt = hermes_env.read_text()
+    assert "TOKENHUB" not in hermes_txt
+    assert hermes_txt.strip() == ""
+    assert list((home / ".hermes").glob(".env.bak-tokenhub-*")), "backup must exist"
+    assert list((home / ".mac").glob("mac.env.bak-tokenhub-*"))
+    assert "PURGE_CHANGED=1" in result.stdout
+
+
+def test_purge_is_idempotent_and_dry_run_makes_no_changes(tmp_path):
+    home = tmp_path
+    (home / ".mac").mkdir(parents=True)
+    mac_env = home / ".mac" / "mac.env"
+    mac_env.write_text("MAC_API_TOKEN=keepme\nTOKENHUB_API_KEY=dead\n")
+
+    # dry-run: reports the hit but writes nothing
+    dry = subprocess.run(
+        ["bash", str(SCRIPT), "--dry-run"],
+        env={**os.environ, "HOME": str(home)},
+        text=True,
+        capture_output=True,
+    )
+    assert dry.returncode == 0
+    assert "TOKENHUB_API_KEY" in mac_env.read_text()  # untouched
+    assert not list((home / ".mac").glob("mac.env.bak-tokenhub-*"))
+
+    # real run, then a second run is a clean no-op
+    first = _run(home)
+    assert first.returncode == 0
+    assert "TOKENHUB_API_KEY" not in mac_env.read_text()
+    second = _run(home)
+    assert second.returncode == 0
+    assert "PURGE_CHANGED=0" in second.stdout


### PR DESCRIPTION
## Summary

A key audit of the `rocky` fleet found **retired-TokenHub vars sitting in plaintext** on every agent and in the operator deploy env — pure attack surface for zero function (nothing in current code writes them; only retirement/compat paths read them, and they resolve correctly to empty once gone). Notably:
- a TokenHub **admin** token (`TOKENHUB_ADMIN_TOKEN`) on bullwinkle's `~/.hermes/.env`;
- `MAC_DEPLOY_TOKENHUB_API_KEY` + **3 fleet-scoped variants** in the operator's `~/.mac/.env`;
- `TOKENHUB_API_KEY` / `MAC_REQUIRE_TOKENHUB` / `MAC_TOKENHUB_PORT` / `TOKENHUB_URL` across all three agents' `mac.env` + `~/.hermes/.env`.

`scripts/purge-dead-tokenhub-keys.sh` removes them, run locally on each machine.

## Addresses the review of the first draft
- **Cleans all three places these vars live** — agent `$HOME/.mac/mac.env`, operator `${MAC_DEPLOY_ENV_FILE:-$HOME/.mac/.env}`, and gateway `$HOME/.hermes/.env` (the first draft scanned only two, leaving the operator env dirty while reporting success).
- **Includes the root `TOKENHUB_URL` / `MAC_TOKENHUB_URL`** (still read by compat resolution) and matches fleet-scoped `__SUFFIX` variants.
- **Uses `awk`, not `grep -v`** — a file of only-dead lines is emptied rather than aborting after the backup under `set -e`.
- `cp -pf` / `mv -f` per repo convention; `--dry-run`; prints only key NAMES.

## Applied
Run on the live rocky fleet (rocky/natasha/bullwinkle) + the operator host; all env files now verify clean (idempotent re-run reports `clean`/`absent` everywhere).

⚠️ **Follow-ups (not done here):**
- The affected services were **not** bounced (a live-service restart was out of scope / denied), so the dead vars persist in running process *memory* until the next restart/deploy. The on-disk plaintext exposure is eliminated.
- The bullwinkle TokenHub **admin token must be rotated/revoked at the source** — deleting the local copy does not invalidate the token.

## Test
`tests/test_purge_dead_tokenhub_keys.py` covers all three files, fleet-scoped variants, the all-dead-file edge case, idempotency, and `--dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)