### PR TITLE
deploy: route spokes through the hub's /v1 — centralize keys on the hub

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -3357,39 +3357,83 @@ values.setdefault("MAC_REVIEW_TICK_HUB_AGENT", shared_services_manager)
 _mem_embed_model = (os.environ.get("MAC_DEPLOY_MEMORY_EMBED_MODEL") or "").strip()
 if _mem_embed_model:
     values["MAC_MEMORY_EMBED_MODEL"] = _mem_embed_model
-# th-merge-02 canary: optional in-mac model router. When this agent's
-# MAC_ROUTER_BACKEND=inproc and providers are configured, its mac API mounts the
-# /v1 OpenAI front door (streaming + failover + recovering breaker) and its own
-# gateway is cut over to that LOCAL router instead of a remote gateway base_url.
+# th-merge-02 / Stream B: the in-mac model router runs ONLY on the hub. Keys stay
+# centralized — only the hub holds the upstream provider keys (MAC_ROUTER_PROVIDERS
+# key=secret:<name>, resolved from the hub's encrypted vault at use) and mounts the
+# /v1 OpenAI front door (streaming + failover + recovering breaker). The hub's own
+# gateway talks to its LOCAL /v1 with the local mac token.
+#
+# A SPOKE never runs its own router — that would require an upstream key on the
+# spoke (defeating centralization). Instead each spoke's gateway routes through the
+# HUB's /v1, reachable via MAC_HUB_URL (the mesh hub URL, or the reverse tunnel at
+# 127.0.0.1:18789), authenticating with the spoke's hub-facing token
+# (MAC_WORKER_TOKEN, which has agent scope at the hub). Spokes carry no upstream
+# key, no MAC_ROUTER_PROVIDERS, and no local router.
+#
 # Additive + gated: with no MAC_ROUTER_* set, the fleet is unchanged.
 _router_backend = (os.environ.get("MAC_DEPLOY_ROUTER_BACKEND") or "").strip()
 _router_providers = (os.environ.get("MAC_DEPLOY_ROUTER_PROVIDERS") or "").strip()
 _router_default_model = (os.environ.get("MAC_DEPLOY_ROUTER_DEFAULT_MODEL") or "").strip()
 _router_wildcard_models = (os.environ.get("MAC_DEPLOY_ROUTER_WILDCARD_MODELS") or "").strip()
-if _router_backend:
+_router_inproc = _router_backend.lower() == "inproc"
+_is_hub = agent_name == shared_services_manager
+if _router_inproc and _is_hub:
+    # HUB: run the router with the upstream providers; cut its OWN gateway over to
+    # the LOCAL /v1 with the local mac token. The router uses each provider's own
+    # key (MAC_ROUTER_PROVIDERS key=..., e.g. secret:<name> from the vault) upstream.
     values["MAC_ROUTER_BACKEND"] = _router_backend
-if _router_providers:
-    values["MAC_ROUTER_PROVIDERS"] = _router_providers
-if _router_default_model:
-    values["MAC_ROUTER_DEFAULT_MODEL"] = _router_default_model
-if _router_wildcard_models:
-    values["MAC_ROUTER_WILDCARD_MODELS"] = _router_wildcard_models
-if _router_backend.lower() == "inproc" and _router_providers:
-    _local_router_v1 = "http://127.0.0.1:%s/v1" % port
-    values["OPENAI_BASE_URL"] = _local_router_v1
-    values["CUSTOM_BASE_URL"] = _local_router_v1
-    values["MAC_HERMES_GATEWAY_BASE_URL"] = _local_router_v1
-    values["ACC_HERMES_GATEWAY_BASE_URL"] = _local_router_v1
-    # The gateway now talks to its LOCAL mac /v1 router, which is auth-gated like
-    # the rest of the mac API. It must present a valid mac token (agent scope) as
-    # its bearer; the router then uses the provider's OWN key (MAC_ROUTER_PROVIDERS
-    # key=...) for the upstream. Without this the gateway would send the upstream
-    # key, which the mac API rejects as an unknown bearer token.
-    _local_tok = values.get("MAC_API_TOKEN") or ""
-    if _local_tok:
-        values["OPENAI_API_KEY"] = _local_tok
-        values["MAC_HERMES_GATEWAY_API_KEY"] = _local_tok
-        values["ACC_HERMES_GATEWAY_API_KEY"] = _local_tok
+    if _router_providers:
+        values["MAC_ROUTER_PROVIDERS"] = _router_providers
+    if _router_default_model:
+        values["MAC_ROUTER_DEFAULT_MODEL"] = _router_default_model
+    if _router_wildcard_models:
+        values["MAC_ROUTER_WILDCARD_MODELS"] = _router_wildcard_models
+    if _router_providers:
+        _local_router_v1 = "http://127.0.0.1:%s/v1" % port
+        values["OPENAI_BASE_URL"] = _local_router_v1
+        values["CUSTOM_BASE_URL"] = _local_router_v1
+        values["MAC_HERMES_GATEWAY_BASE_URL"] = _local_router_v1
+        values["ACC_HERMES_GATEWAY_BASE_URL"] = _local_router_v1
+        _local_tok = values.get("MAC_API_TOKEN") or ""
+        if _local_tok:
+            values["OPENAI_API_KEY"] = _local_tok
+            values["MAC_HERMES_GATEWAY_API_KEY"] = _local_tok
+            values["ACC_HERMES_GATEWAY_API_KEY"] = _local_tok
+elif _router_inproc:
+    # SPOKE: do NOT mount a local router or carry providers/upstream keys. Strip any
+    # router/provider config a fleet-wide MAC_DEPLOY_ROUTER_* introduced, and route
+    # the gateway through the HUB's /v1 with the spoke's hub-facing token.
+    for _k in ("MAC_ROUTER_BACKEND", "MAC_ROUTER_PROVIDERS",
+               "MAC_ROUTER_DEFAULT_MODEL", "MAC_ROUTER_WILDCARD_MODELS"):
+        values.pop(_k, None)
+    _hub_base = (values.get("MAC_HUB_URL") or configured_hub_url or "").rstrip("/")
+    if _hub_base:
+        _hub_v1 = "%s/v1" % _hub_base
+        values["OPENAI_BASE_URL"] = _hub_v1
+        values["CUSTOM_BASE_URL"] = _hub_v1
+        values["MAC_HERMES_GATEWAY_BASE_URL"] = _hub_v1
+        values["ACC_HERMES_GATEWAY_BASE_URL"] = _hub_v1
+        _hub_tok = (
+            values.get("MAC_WORKER_TOKEN")
+            or configured_hub_token
+            or values.get("MAC_API_TOKEN")
+            or ""
+        )
+        if _hub_tok:
+            values["OPENAI_API_KEY"] = _hub_tok
+            values["MAC_HERMES_GATEWAY_API_KEY"] = _hub_tok
+            values["ACC_HERMES_GATEWAY_API_KEY"] = _hub_tok
+else:
+    # Router backend not inproc → preserve prior pass-through of whatever
+    # MAC_ROUTER_* was configured (no /v1 cutover).
+    if _router_backend:
+        values["MAC_ROUTER_BACKEND"] = _router_backend
+    if _router_providers:
+        values["MAC_ROUTER_PROVIDERS"] = _router_providers
+    if _router_default_model:
+        values["MAC_ROUTER_DEFAULT_MODEL"] = _router_default_model
+    if _router_wildcard_models:
+        values["MAC_ROUTER_WILDCARD_MODELS"] = _router_wildcard_models
 home_channel = (
     configured_home_channel
     or values.get("MAC_HERMES_SLACK_HOME_CHANNEL_NAME", "").strip().lstrip("#")

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -356,15 +356,31 @@ def test_fleet_deploy_routes_provider_secrets_through_in_mac_router():
     assert 'values["TOKENHUB_URL"]' not in script
     assert "TOKENHUB_API_KEY" not in script
 
-    # Chat now routes through the agent's OWN local /v1 router (MAC_ROUTER_BACKEND
-    # =inproc). The router holds the upstream provider key; the gateway only
-    # presents this agent's local mac token (agent scope) to the local /v1.
-    assert 'if _router_backend.lower() == "inproc" and _router_providers:' in script
+    # Stream B: the in-mac router runs ONLY on the hub (keys centralized there);
+    # spokes route through the hub's /v1 with their hub-facing token.
+    assert '_router_inproc = _router_backend.lower() == "inproc"' in script
+    assert "_is_hub = agent_name == shared_services_manager" in script
+    assert "if _router_inproc and _is_hub:" in script
+    # hub branch: mount the router + cut its own gateway over to the LOCAL /v1
+    # with the local mac token.
     assert 'values["MAC_ROUTER_BACKEND"] = _router_backend' in script
     assert '_local_router_v1 = "http://127.0.0.1:%s/v1" % port' in script
     assert 'values["MAC_HERMES_GATEWAY_BASE_URL"] = _local_router_v1' in script
     assert 'values["OPENAI_API_KEY"] = _local_tok' in script
     assert 'values["MAC_HERMES_GATEWAY_API_KEY"] = _local_tok' in script
+    # spoke branch: NO local router/providers; route via the hub's /v1 (MAC_HUB_URL
+    # = mesh URL or the reverse tunnel) with MAC_WORKER_TOKEN. Keys never reach the
+    # spoke.
+    assert "elif _router_inproc:" in script
+    spoke_branch = script.split("elif _router_inproc:", 1)[1].split("\nelse:", 1)[0]
+    assert 'values.pop(_k, None)' in spoke_branch
+    assert '_hub_base = (values.get("MAC_HUB_URL") or configured_hub_url or "").rstrip("/")' in spoke_branch
+    assert '_hub_v1 = "%s/v1" % _hub_base' in spoke_branch
+    assert 'values["MAC_HERMES_GATEWAY_BASE_URL"] = _hub_v1' in spoke_branch
+    assert 'values.get("MAC_WORKER_TOKEN")' in spoke_branch
+    # the spoke branch only POPs router/provider keys, never assigns them
+    assert 'values["MAC_ROUTER_PROVIDERS"] =' not in spoke_branch
+    assert 'values["MAC_ROUTER_BACKEND"] =' not in spoke_branch
 
     # loop-01: the executor logic was extracted from a ~500-line bash heredoc
     # into the tested mac.task_executor module. The deploy now writes only a


### PR DESCRIPTION
## Summary

**Stream B (key-centralization re-architecture, step 1).** The audit found every spoke ran its *own* inproc router and therefore needed the upstream provider key locally — spreading keys across the fleet. Per the agreed principle: **agents hold only a hub-talking token; upstream keys live solely on the hub.**

The deploy's router block now splits **hub vs spoke**:

- **HUB** (`agent == shared_services_manager`): runs the router with the upstream providers (`MAC_ROUTER_PROVIDERS key=secret:<name>`, resolved from the hub's vault) and cuts its *own* gateway over to the local `/v1` with the local mac token. Unchanged.
- **SPOKE**: never mounts a local router and carries **no** `MAC_ROUTER_PROVIDERS` / upstream key. Any fleet-wide `MAC_DEPLOY_ROUTER_*` is stripped from its env; its gateway is pointed at the **hub's `/v1`** (`MAC_HUB_URL` — the mesh hub URL or the reverse tunnel `127.0.0.1:18789`), authenticating with the spoke's hub-facing token (`MAC_WORKER_TOKEN`, which has agent scope at the hub — confirmed `/v1` requires `agent` scope and that token carries it).

Result: upstream keys + the vault stay **centralized on the hub**; spokes hold only their hub token for chat. Additive + gated — no `MAC_ROUTER_*` ⇒ fleet unchanged; a non-inproc backend preserves the prior pass-through.

## Validation
- `bash -n` + `ast.parse` of all 30 deploy heredocs.
- Deploy-config tests extended to assert **both** branches (hub: local `/v1` + local token; spoke: hub `/v1` + `MAC_WORKER_TOKEN`, and crucially **no** router/provider assignment in the spoke branch).
- Full suite: **746 passed** (1 deselected — env-only `mac-agent` E2E precondition).

## Follow-ups (rest of the plan)
- **Wizard + deploy-time escrow** so fresh fleets put the hub's upstream key in the vault (`key=secret:<name>`) instead of plaintext env.
- **Strip `MAC_SECRET_KEY` / the local vault / plaintext Slack+Firecrawl keys from spokes** (they no longer need a vault).
- **Applying this to the live fleet is a separate, explicitly-approved deploy** — this PR is code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)