### PR TITLE
deploy: escrow router provider keys into the hub vault; wizard uses key=secret:

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -3622,6 +3622,77 @@ EOF
   chmod 700 "$wrapper"
 }
 
+escrow_router_provider_keys() {
+  # Stream B (B2): on the HUB, escrow each router provider's upstream key into the
+  # local encrypted vault under the secret:<name> the provider spec references, so
+  # the in-mac router resolves it from secure storage rather than a plaintext env
+  # var. Keys stay centralized on the hub; spokes hold none and never run a router.
+  # HUB-only, idempotent (skips names already in the vault), best-effort with a
+  # loud warning on failure (chat will not route until the key is in the vault).
+  # The provider key values + MAC_DEPLOY_ROUTER_PROVIDERS arrive in the deploy env;
+  # the per-provider source var is <PROVIDER>_API_KEY (e.g. nvidia -> NVIDIA_API_KEY).
+  [ "$WORKER_MODE" = "loop" ] && [ "$AGENT" = "$SHARED_SERVICES_MANAGER_AGENT" ] || return 0
+  case "${MAC_DEPLOY_ROUTER_PROVIDERS:-}" in *key=secret:*) ;; *) return 0 ;; esac
+  reload_mac_env
+  log "escrowing router provider keys into the hub vault"
+  if "$PY" - >> "$DEPLOY_LOG" 2>&1 <<'PY'
+import json, os, re, urllib.request, urllib.error
+providers = os.environ.get("MAC_DEPLOY_ROUTER_PROVIDERS", "")
+port = os.environ.get("MAC_PORT", "8789")
+tok = os.environ.get("MAC_API_TOKEN", "")
+
+def existing_names():
+    req = urllib.request.Request(
+        "http://127.0.0.1:%s/secrets" % port,
+        headers={"Authorization": "Bearer " + tok},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return {s.get("name") for s in json.load(resp)}
+
+have = existing_names()
+escrowed = skipped = 0
+for chunk in providers.split(";"):
+    chunk = chunk.strip()
+    if not chunk:
+        continue
+    pid = chunk.split("=", 1)[0].strip()
+    m = re.search(r"key=secret:([^,;]+)", chunk)
+    if not m:
+        continue
+    name = m.group(1).strip()
+    if name in have:
+        print("escrow: %r already in vault; skip" % name)
+        skipped += 1
+        continue
+    env_var = pid.upper() + "_API_KEY"
+    value = (os.environ.get(env_var) or "").strip()
+    if not value:
+        print("escrow: %s empty/unset for secret %r; skip" % (env_var, name))
+        skipped += 1
+        continue
+    body = json.dumps({
+        "name": name,
+        "value": value,
+        "scopes": {"capabilities": ["router-upstream"]},
+        "created_by": "deploy",
+    }).encode()
+    req = urllib.request.Request(
+        "http://127.0.0.1:%s/secrets" % port, data=body,
+        headers={"Authorization": "Bearer " + tok, "Content-Type": "application/json"},
+        method="POST",
+    )
+    resp = urllib.request.urlopen(req, timeout=15)
+    print("escrowed %r (HTTP %s, %d-char value)" % (name, resp.status, len(value)))
+    escrowed += 1
+print("router key escrow: %d escrowed, %d skipped" % (escrowed, skipped))
+PY
+  then
+    :
+  else
+    log "WARNING: router provider key escrow failed; chat will not route until the upstream key(s) are escrowed into the hub vault (mac secret create)"
+  fi
+}
+
 sync_messaging_config() {
   # th-merge-07: fetch Slack secrets + resolve the home channel AFTER the mac API
   # is (re)started, so the hub reads its OWN freshly-up /v1 vault instead of
@@ -3674,6 +3745,7 @@ EOF
   sleep 3
   sudo systemctl --no-pager -l status "$MAC_SERVICE_NAME" || true
   sudo journalctl -u "$MAC_SERVICE_NAME" --since "$restart_since" --no-pager > "$LOG_DIR/mac-service-journal.txt" || true
+  escrow_router_provider_keys
   sync_messaging_config
   install_linux_hermes_service
 }
@@ -4478,6 +4550,7 @@ EOF
   launchctl kickstart -k "gui/$uid/$MAC_LAUNCHD_LABEL"
   sleep 3
   launchctl list "$MAC_LAUNCHD_LABEL" || true
+  escrow_router_provider_keys
   sync_messaging_config
   install_darwin_hermes_service "$uid"
   install_darwin_agent_service "$uid"

--- a/scripts/setup-fleet.py
+++ b/scripts/setup-fleet.py
@@ -264,20 +264,27 @@ _KNOWN_PROVIDERS: Dict[str, tuple] = {
 }
 
 
+def router_secret_name(provider_id: str) -> str:
+    """Vault secret name the router resolves a provider's upstream key from."""
+    return "%s-upstream" % provider_id
+
+
 def build_router_provider_spec(provider_env_values: Dict[str, str]) -> str:
     """Build MAC_ROUTER_PROVIDERS from the provider keys the wizard collected.
 
     Format (mac.provider_router.providers_from_env): ``name=base_url,priority,
-    key=ENVVAR`` joined by ';'. ``key`` is the plain env-var NAME — router_app
-    resolves it from the agent env at use (the deploy plumbs these provider keys
-    through), so no vault escrow is needed to route. Emitted in _KNOWN_PROVIDERS
-    order (nvidia preferred, priority 0)."""
+    key=secret:<name>`` joined by ';'. The key is referenced as ``secret:<name>``
+    so the (hub-only) router resolves it from the encrypted vault at use — keys
+    stay in secure storage on the hub, never plaintext-spread to spokes. The
+    deploy escrows each provider's <PROVIDER>_API_KEY into the vault under
+    router_secret_name(provider) before the router needs it. Emitted in
+    _KNOWN_PROVIDERS order (nvidia preferred, priority 0)."""
     specs = []
     for prio, (pid, (key_var, base_var, default_base)) in enumerate(_KNOWN_PROVIDERS.items()):
         if key_var not in provider_env_values:
             continue
         base = provider_env_values.get(base_var) or default_base
-        specs.append("%s=%s,%d,key=%s" % (pid, base, prio, key_var))
+        specs.append("%s=%s,%d,key=secret:%s" % (pid, base, prio, router_secret_name(pid)))
     return ";".join(specs)
 
 
@@ -542,14 +549,17 @@ def _setup_hub(args: argparse.Namespace, fleets_config: Path, env_file: Path, ru
         "MAC_DEPLOY_SHARED_SERVICES_MANAGER_AGENT": hub_name,
     }
     env_values.update(provider_env_values)
-    # Wire the in-mac router — the replacement for the retired TokenHub. With
-    # MAC_ROUTER_BACKEND=inproc + providers, the deploy mounts each agent's local
-    # /v1 front door and points its gateway there (see deploy-mac-fleet.sh router
-    # block). Without this a freshly-generated fleet would have no chat routing.
+    # Wire the in-mac router — the replacement for the retired TokenHub. Keys stay
+    # centralized: only the HUB runs the router (MAC_ROUTER_BACKEND=inproc), and it
+    # references each provider's upstream key as secret:<name>, which the deploy
+    # escrows into the hub's encrypted vault. SPOKES route through the hub's /v1
+    # and carry no upstream key (see deploy-mac-fleet.sh router block). Without this
+    # a freshly-generated fleet would have no chat routing.
     env_values["MAC_DEPLOY_ROUTER_BACKEND"] = "inproc"
     env_values["MAC_DEPLOY_ROUTER_PROVIDERS"] = build_router_provider_spec(provider_env_values)
     print("")
-    print("Wired in-mac router: MAC_ROUTER_BACKEND=inproc")
+    print("Wired in-mac router (hub-only; keys escrowed to the hub vault on deploy):")
+    print("  MAC_ROUTER_BACKEND=inproc")
     print("  providers: %s" % (env_values["MAC_DEPLOY_ROUTER_PROVIDERS"] or "(none)"))
     print("  (set MAC_DEPLOY_ROUTER_DEFAULT_MODEL in %s if your gateway model is '*')" % env_file)
     if prompt_bool("Generate MAC_SECRET_KEY in %s?" % env_file, default=True):

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -432,6 +432,30 @@ def test_first_deploy_validators_honor_allow_degraded_services_flag():
     assert '[ "${allow_degraded_services:-0}" = "1" ]' in script
 
 
+def test_hub_escrows_router_provider_keys_into_vault():
+    # Stream B (B2): the hub escrows each router provider's upstream key into its
+    # encrypted vault under the secret:<name> the provider spec references, so the
+    # router resolves it from secure storage — keys never plaintext-spread to spokes.
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    assert "escrow_router_provider_keys() {" in script
+    fn = script.split("escrow_router_provider_keys() {", 1)[1].split(
+        "\nsync_messaging_config() {", 1
+    )[0]
+    # HUB-only, and only when a provider references a vault secret
+    assert '[ "$WORKER_MODE" = "loop" ] && [ "$AGENT" = "$SHARED_SERVICES_MANAGER_AGENT" ] || return 0' in fn
+    assert 'case "${MAC_DEPLOY_ROUTER_PROVIDERS:-}" in *key=secret:*)' in fn
+    # idempotent: skip names already in the vault
+    assert "already in vault; skip" in fn
+    # derive <PROVIDER>_API_KEY from the provider id and POST to the LOCAL /secrets
+    assert 'env_var = pid.upper() + "_API_KEY"' in fn
+    assert '"http://127.0.0.1:%s/secrets" % port' in fn
+    assert '"created_by": "deploy"' in fn
+    # failure is loud but non-fatal (chat won't route until the key is escrowed)
+    assert "router provider key escrow failed" in fn
+    # invoked on the hub after the API is up, before the gateway, in both OS flows
+    assert script.count("\n  escrow_router_provider_keys\n") == 2
+
+
 def test_setup_fleet_build_router_provider_spec():
     # The wizard wires the in-mac router from the providers it collects, using the
     # plain env-var key form the router resolves at use (no vault escrow needed).
@@ -444,14 +468,17 @@ def test_setup_fleet_build_router_provider_spec():
     spec.loader.exec_module(mod)
     build = mod.build_router_provider_spec
 
+    # Stream B (B2): keys are referenced as secret:<name> (resolved from the hub
+    # vault, escrowed by the deploy), never plaintext-spread as env-var names.
+    assert mod.router_secret_name("nvidia") == "nvidia-upstream"
     assert build({}) == ""
-    assert build({"OPENAI_API_KEY": "sk"}) == "openai=https://api.openai.com/v1,1,key=OPENAI_API_KEY"
+    assert build({"OPENAI_API_KEY": "sk"}) == "openai=https://api.openai.com/v1,1,key=secret:openai-upstream"
     # nvidia is preferred (priority 0); a custom base url is honored.
     assert build(
         {"NVIDIA_API_KEY": "k", "OPENAI_API_KEY": "sk", "OPENAI_BASE_URL": "https://x/v1"}
     ) == (
-        "nvidia=https://inference-api.nvidia.com/v1,0,key=NVIDIA_API_KEY"
-        ";openai=https://x/v1,1,key=OPENAI_API_KEY"
+        "nvidia=https://inference-api.nvidia.com/v1,0,key=secret:nvidia-upstream"
+        ";openai=https://x/v1,1,key=secret:openai-upstream"
     )
     # The spec round-trips through the router's own parser.
     from mac.provider_router import providers_from_env
@@ -460,7 +487,7 @@ def test_setup_fleet_build_router_provider_spec():
         {"MAC_ROUTER_PROVIDERS": build({"NVIDIA_API_KEY": "k"})}
     )
     assert [p.name for p in providers] == ["nvidia"]
-    assert providers[0].api_key_env == "NVIDIA_API_KEY"
+    assert providers[0].api_key_env == "secret:nvidia-upstream"
 
 
 def test_fleet_deploy_uses_home_scoped_registry_not_legacy_site_config():
@@ -579,7 +606,7 @@ def test_setup_fleet_wizard_writes_fleet_registry_and_env(tmp_path):
     # replacement) from the collected providers, or a fresh fleet has no chat
     # routing. The test adds the "openai" provider with key "sk-test".
     assert "MAC_DEPLOY_ROUTER_BACKEND=inproc" in env
-    assert "MAC_DEPLOY_ROUTER_PROVIDERS=openai=https://api.openai.com/v1,1,key=OPENAI_API_KEY" in env
+    assert "MAC_DEPLOY_ROUTER_PROVIDERS=openai=https://api.openai.com/v1,1,key=secret:openai-upstream" in env
     assert "OPENAI_API_KEY=sk-test" in env
     assert "MAC_API_TOKEN" not in env
 


### PR DESCRIPTION
## Summary

**Stream B (key-centralization, step 2).** The hub holds the upstream provider keys, but the wizard (#41) wired them as plaintext env-var references (`key=NVIDIA_API_KEY`). Per the agreed principle, those keys belong in **secure storage** (the encrypted vault) on the hub, not plaintext.

- **Wizard** (`setup-fleet.py`): `build_router_provider_spec` now emits `key=secret:<provider>-upstream` (via `router_secret_name`) instead of `key=<ENVVAR>`, so the hub router resolves each upstream key from the vault at use.
- **Deploy** (`deploy-mac-fleet.sh`): a new **HUB-only** `escrow_router_provider_keys()` runs after the mac API is up and before the gateway, in **both** the systemd and launchd flows. It parses `MAC_DEPLOY_ROUTER_PROVIDERS`, and for every `key=secret:<name>` escrows the value of the provider's `<PROVIDER>_API_KEY` (already in the deploy env) into the local `/secrets` vault under `<name>`. **Idempotent** (skips names already present), **HUB-gated**, **best-effort with a loud warning** on failure (chat won't route until the key is in the vault). The provider key never leaves the hub.

Together with #43 (spokes route via the hub's `/v1`), a freshly-generated fleet now keeps **every upstream key in the hub's encrypted vault** — spokes carry only their hub token.

**Additive / safe for the live fleet:** with no `key=secret:` providers configured the escrow is a no-op, so the existing live fleet (already hand-escrowed to `secret:nvidia-upstream`) is unaffected.

## Validation
- `bash -n` + `ast.parse` of all **31** deploy heredocs; `ast.parse` of `setup-fleet.py`.
- Wizard tests updated to the `secret:` form (+ round-trip through `providers_from_env`).
- New `test_hub_escrows_router_provider_keys_into_vault` locks the hub-gating, idempotency, `<PROVIDER>_API_KEY` derivation, the local `/secrets` POST, and **both** call sites.
- Full suite: **747 passed** (1 deselected — env-only `mac-agent` E2E precondition).

## Follow-up
- Strip `MAC_SECRET_KEY` / the local vault / plaintext Slack+Firecrawl keys from spokes (they no longer need a vault).
- Apply to the live fleet via an explicitly-approved deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)