### PR TITLE
fix(stream-b): close the key-centralization gaps from review

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -786,6 +786,15 @@ deploy_host() {
   perplexity_api_key="$(fleet_scoped_env PERPLEXITY_API_KEY "$agent")"
   perplexity_base_url="$(fleet_scoped_env PERPLEXITY_BASE_URL "$agent")"
   perplexity_api_base="$(fleet_scoped_env PERPLEXITY_API_BASE "$agent")"
+  # Stream B: upstream provider keys are CENTRALIZED on the hub. Only the hub runs
+  # the router (and escrows these into its vault); a spoke routes chat through the
+  # hub's /v1 and must never receive an upstream key in its deploy process env.
+  # Blank them for spokes so they are not embedded in the remote SSH command below.
+  # ($shared_services_manager is the hub agent, parsed from the spec above.)
+  if [ "$agent" != "$shared_services_manager" ]; then
+    nvidia_api_key="" ; openai_api_key="" ; anthropic_api_key="" ; perplexity_api_key=""
+    router_providers="" ; router_default_model="" ; router_wildcard_models=""
+  fi
   remote_archive="/tmp/mac-${agent}-${TS}.tar.gz"
   local ssh_parts=() scp_parts=() last_index
   while IFS= read -r -d '' item; do ssh_parts+=("$item"); done < <(ssh_target_args "$target")
@@ -3406,23 +3415,26 @@ elif _router_inproc:
     for _k in ("MAC_ROUTER_BACKEND", "MAC_ROUTER_PROVIDERS",
                "MAC_ROUTER_DEFAULT_MODEL", "MAC_ROUTER_WILDCARD_MODELS"):
         values.pop(_k, None)
+    # The spoke must present a token valid AT THE HUB (agent scope) on the hub's
+    # /v1 — the configured hub token (== MAC_WORKER_TOKEN in the normal case).
+    # NEVER the spoke's LOCAL MAC_API_TOKEN: the hub would reject it. If
+    # MAC_WORKER_TOKEN degenerated to the local token (no hub token was provisioned)
+    # or no hub token is available, leave the gateway UNCONFIGURED (a loud runtime
+    # failure) rather than write a plausible-looking broken credential.
     _hub_base = (values.get("MAC_HUB_URL") or configured_hub_url or "").rstrip("/")
-    if _hub_base:
+    _local_tok = values.get("MAC_API_TOKEN") or ""
+    _hub_tok = configured_hub_token or values.get("MAC_WORKER_TOKEN") or ""
+    if _hub_tok and _hub_tok == _local_tok:
+        _hub_tok = ""
+    if _hub_base and _hub_tok:
         _hub_v1 = "%s/v1" % _hub_base
         values["OPENAI_BASE_URL"] = _hub_v1
         values["CUSTOM_BASE_URL"] = _hub_v1
         values["MAC_HERMES_GATEWAY_BASE_URL"] = _hub_v1
         values["ACC_HERMES_GATEWAY_BASE_URL"] = _hub_v1
-        _hub_tok = (
-            values.get("MAC_WORKER_TOKEN")
-            or configured_hub_token
-            or values.get("MAC_API_TOKEN")
-            or ""
-        )
-        if _hub_tok:
-            values["OPENAI_API_KEY"] = _hub_tok
-            values["MAC_HERMES_GATEWAY_API_KEY"] = _hub_tok
-            values["ACC_HERMES_GATEWAY_API_KEY"] = _hub_tok
+        values["OPENAI_API_KEY"] = _hub_tok
+        values["MAC_HERMES_GATEWAY_API_KEY"] = _hub_tok
+        values["ACC_HERMES_GATEWAY_API_KEY"] = _hub_tok
 else:
     # Router backend not inproc → preserve prior pass-through of whatever
     # MAC_ROUTER_* was configured (no /v1 cutover).
@@ -3649,6 +3661,15 @@ def existing_names():
     with urllib.request.urlopen(req, timeout=15) as resp:
         return {s.get("name") for s in json.load(resp)}
 
+# Explicit provider -> source-env-var map (mirrors setup-fleet.py _KNOWN_PROVIDERS).
+# NOT derived from the provider id: a provider whose key env var isn't exactly
+# <ID>_API_KEY would otherwise be skipped silently. An unmapped provider warns loudly.
+PROVIDER_KEY_ENV = {
+    "nvidia": "NVIDIA_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "perplexity": "PERPLEXITY_API_KEY",
+}
 have = existing_names()
 escrowed = skipped = 0
 for chunk in providers.split(";"):
@@ -3664,7 +3685,12 @@ for chunk in providers.split(";"):
         print("escrow: %r already in vault; skip" % name)
         skipped += 1
         continue
-    env_var = pid.upper() + "_API_KEY"
+    env_var = PROVIDER_KEY_ENV.get(pid)
+    if not env_var:
+        print("escrow: WARNING no source env var mapped for provider %r (secret %r); "
+              "skip — add %r to PROVIDER_KEY_ENV" % (pid, name, pid))
+        skipped += 1
+        continue
     value = (os.environ.get(env_var) or "").strip()
     if not value:
         print("escrow: %s empty/unset for secret %r; skip" % (env_var, name))

--- a/scripts/setup-fleet.py
+++ b/scripts/setup-fleet.py
@@ -555,13 +555,18 @@ def _setup_hub(args: argparse.Namespace, fleets_config: Path, env_file: Path, ru
     # escrows into the hub's encrypted vault. SPOKES route through the hub's /v1
     # and carry no upstream key (see deploy-mac-fleet.sh router block). Without this
     # a freshly-generated fleet would have no chat routing.
-    env_values["MAC_DEPLOY_ROUTER_BACKEND"] = "inproc"
-    env_values["MAC_DEPLOY_ROUTER_PROVIDERS"] = build_router_provider_spec(provider_env_values)
+    # NOTE: these are the RUNTIME names the deploy reads via fleet_scoped_env
+    # (deploy-mac-fleet.sh: `fleet_scoped_env MAC_ROUTER_BACKEND`), exactly like the
+    # provider keys (NVIDIA_API_KEY, ...). They are NOT MAC_DEPLOY_*-prefixed —
+    # deploy_host re-exports them as MAC_DEPLOY_ROUTER_* into the remote env itself.
+    # Writing MAC_DEPLOY_ROUTER_* here would be inert (the deploy never reads it).
+    env_values["MAC_ROUTER_BACKEND"] = "inproc"
+    env_values["MAC_ROUTER_PROVIDERS"] = build_router_provider_spec(provider_env_values)
     print("")
     print("Wired in-mac router (hub-only; keys escrowed to the hub vault on deploy):")
     print("  MAC_ROUTER_BACKEND=inproc")
-    print("  providers: %s" % (env_values["MAC_DEPLOY_ROUTER_PROVIDERS"] or "(none)"))
-    print("  (set MAC_DEPLOY_ROUTER_DEFAULT_MODEL in %s if your gateway model is '*')" % env_file)
+    print("  providers: %s" % (env_values["MAC_ROUTER_PROVIDERS"] or "(none)"))
+    print("  (set MAC_ROUTER_DEFAULT_MODEL in %s if your gateway model is '*')" % env_file)
     if prompt_bool("Generate MAC_SECRET_KEY in %s?" % env_file, default=True):
         env_values["MAC_SECRET_KEY"] = secrets.token_urlsafe(48)
     if prompt_bool("Generate MAC_API_TOKEN in %s?" % env_file, default=True):
@@ -887,9 +892,10 @@ def main(argv: List[str]) -> int:
             "MAC_API_TOKEN": secrets.token_urlsafe(32),
             # Make the in-mac router the routing backend (mounts as a no-op until
             # providers are added). --new-hub collects no provider keys, so set
-            # MAC_DEPLOY_ROUTER_PROVIDERS + the provider key(s) in the env file
-            # before deploy or chat will have no upstream.
-            "MAC_DEPLOY_ROUTER_BACKEND": "inproc",
+            # MAC_ROUTER_PROVIDERS + the provider key(s) in the env file before
+            # deploy or chat will have no upstream. Runtime name (fleet_scoped_env),
+            # NOT MAC_DEPLOY_*-prefixed — see _setup_hub.
+            "MAC_ROUTER_BACKEND": "inproc",
         }
         if args.headscale_preauth_key:
             env_values[headscale_preauth_key_env] = args.headscale_preauth_key

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+import os
 import subprocess
 import sys
 
@@ -432,6 +433,109 @@ def test_first_deploy_validators_honor_allow_degraded_services_flag():
     assert '[ "${allow_degraded_services:-0}" = "1" ]' in script
 
 
+def _run_env_writer(tmp_path, *, agent, hub_agent, hub_url, hub_token, extra_env):
+    """Run the deploy's actual env-writer heredoc and return the mac.env it writes.
+
+    This exercises real behavior — the hub/spoke router split + token selection —
+    instead of asserting source substrings.
+    """
+    import re as _re
+    import subprocess as _sp
+
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    body = next(
+        m.group(1)
+        for m in _re.finditer(r"<<'PY'\n(.*?)\n[ \t]*PY$", script, _re.S | _re.M)
+        if "_router_inproc" in m.group(1) and "env_path = Path(sys.argv[1])" in m.group(1)
+    )
+    env_path = tmp_path / "mac.env"
+    mac_home = tmp_path / ".mac"
+    mac_home.mkdir(parents=True, exist_ok=True)
+    # argv[1..25] per the env-writer's sys.argv contract.
+    argv = [
+        str(env_path), str(mac_home), str(tmp_path), "8789", "home", "", "custom",
+        "", hub_url, hub_token, "127.0.0.1", "loop", "ops", "", "", "1",
+        agent, "systemd", hub_agent, "", "1", "6333", "", "1", "3002",
+    ]
+    env = {"PATH": os.environ["PATH"], "HOME": str(tmp_path), "MAC_SECRET_KEY": "x" * 40}
+    env.update(extra_env)
+    result = _sp.run([sys.executable, "-c", body, *argv], env=env, text=True, capture_output=True)
+    assert result.returncode == 0, result.stderr[-1000:]
+    out = {}
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        if "=" in line and not line.startswith("#"):
+            k, v = line.split("=", 1)
+            out[k] = v
+    return out
+
+
+_ROUTER_ENV = {
+    "MAC_DEPLOY_ROUTER_BACKEND": "inproc",
+    "MAC_DEPLOY_ROUTER_PROVIDERS": "nvidia=https://inference-api.nvidia.com/v1,0,key=secret:nvidia-upstream",
+    "MAC_DEPLOY_NETWORK_PROVIDER": "tailscale",
+}
+
+
+def test_env_writer_hub_runs_router_locally(tmp_path):
+    out = _run_env_writer(
+        tmp_path, agent="rocky", hub_agent="rocky",
+        hub_url="http://127.0.0.1:8789", hub_token="HUBTOK",
+        extra_env={**_ROUTER_ENV, "NVIDIA_API_KEY": "nvapi-SECRET"},
+    )
+    assert out.get("MAC_ROUTER_BACKEND") == "inproc"
+    assert "key=secret:nvidia-upstream" in out.get("MAC_ROUTER_PROVIDERS", "")
+    assert out.get("OPENAI_BASE_URL") == "http://127.0.0.1:8789/v1"
+    assert out.get("MAC_HERMES_GATEWAY_BASE_URL") == "http://127.0.0.1:8789/v1"
+    # the hub's own gateway presents the hub's LOCAL mac token to its local /v1
+    assert out.get("OPENAI_API_KEY") == out.get("MAC_API_TOKEN")
+
+
+def test_env_writer_spoke_routes_via_hub_with_no_provider_keys(tmp_path):
+    out = _run_env_writer(
+        tmp_path, agent="natasha", hub_agent="rocky",
+        hub_url="http://hub.example:8789", hub_token="HUBTOK",
+        # provider key passed UNBLANKED to prove the env-writer never persists it
+        # for a spoke (defense-in-depth on top of deploy_host's hub-only gating).
+        extra_env={**_ROUTER_ENV, "NVIDIA_API_KEY": "nvapi-SECRET"},
+    )
+    # no local router / providers on the spoke
+    assert "MAC_ROUTER_PROVIDERS" not in out
+    assert "MAC_ROUTER_BACKEND" not in out
+    # gateway routes through the HUB's /v1 with the HUB token (never the local one)
+    assert out.get("OPENAI_BASE_URL") == "http://hub.example:8789/v1"
+    assert out.get("MAC_HERMES_GATEWAY_BASE_URL") == "http://hub.example:8789/v1"
+    assert out.get("OPENAI_API_KEY") == "HUBTOK"
+    assert out.get("OPENAI_API_KEY") != out.get("MAC_API_TOKEN")
+    # the upstream provider key never lands in a spoke's env file
+    assert "NVIDIA_API_KEY" not in out
+    assert "nvapi-SECRET" not in "\n".join(out.values())
+
+
+def test_env_writer_spoke_without_hub_token_leaves_gateway_unconfigured(tmp_path):
+    # No configured hub token → MAC_WORKER_TOKEN degenerates to the local token.
+    out = _run_env_writer(
+        tmp_path, agent="natasha", hub_agent="rocky",
+        hub_url="http://hub.example:8789", hub_token="",
+        extra_env={**_ROUTER_ENV, "NVIDIA_API_KEY": ""},
+    )
+    # do NOT point the gateway at the hub with a broken local-token credential
+    assert out.get("OPENAI_BASE_URL") != "http://hub.example:8789/v1"
+    local = out.get("MAC_API_TOKEN")
+    assert out.get("OPENAI_API_KEY") != local  # never the local token
+    assert out.get("MAC_HERMES_GATEWAY_API_KEY") != local
+
+
+def test_deploy_host_blanks_provider_keys_for_spokes():
+    # Stream B: deploy_host must NOT ship upstream provider keys to spokes (only
+    # the hub keeps them). It blanks them before building the remote SSH command.
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    deploy_host = script.split("deploy_host() {", 1)[1].split("\nmain() {", 1)[0]
+    assert 'if [ "$agent" != "$shared_services_manager" ]; then' in deploy_host
+    gate = deploy_host.split('if [ "$agent" != "$shared_services_manager" ]; then', 1)[1].split("fi", 1)[0]
+    for var in ("nvidia_api_key", "openai_api_key", "anthropic_api_key", "perplexity_api_key"):
+        assert ('%s=""' % var) in gate
+
+
 def test_hub_escrows_router_provider_keys_into_vault():
     # Stream B (B2): the hub escrows each router provider's upstream key into its
     # encrypted vault under the secret:<name> the provider spec references, so the
@@ -446,8 +550,12 @@ def test_hub_escrows_router_provider_keys_into_vault():
     assert 'case "${MAC_DEPLOY_ROUTER_PROVIDERS:-}" in *key=secret:*)' in fn
     # idempotent: skip names already in the vault
     assert "already in vault; skip" in fn
-    # derive <PROVIDER>_API_KEY from the provider id and POST to the LOCAL /secrets
-    assert 'env_var = pid.upper() + "_API_KEY"' in fn
+    # explicit provider -> env-var map (not a brittle derivation); warns loudly on
+    # an unmapped provider rather than skipping silently
+    assert "PROVIDER_KEY_ENV = {" in fn
+    assert '"nvidia": "NVIDIA_API_KEY"' in fn
+    assert "env_var = PROVIDER_KEY_ENV.get(pid)" in fn
+    assert "WARNING no source env var mapped for provider" in fn
     assert '"http://127.0.0.1:%s/secrets" % port' in fn
     assert '"created_by": "deploy"' in fn
     # failure is loud but non-fatal (chat won't route until the key is escrowed)
@@ -605,9 +713,17 @@ def test_setup_fleet_wizard_writes_fleet_registry_and_env(tmp_path):
     # KEY INSIGHT fix: the wizard must wire the in-mac router (TokenHub's
     # replacement) from the collected providers, or a fresh fleet has no chat
     # routing. The test adds the "openai" provider with key "sk-test".
-    assert "MAC_DEPLOY_ROUTER_BACKEND=inproc" in env
-    assert "MAC_DEPLOY_ROUTER_PROVIDERS=openai=https://api.openai.com/v1,1,key=secret:openai-upstream" in env
+    # The wizard writes the RUNTIME names the deploy reads via fleet_scoped_env —
+    # NOT the MAC_DEPLOY_*-prefixed names (those would be inert; the deploy never
+    # reads them on the operator side). Cross-check both ends so the names can't
+    # silently diverge again.
+    assert "MAC_ROUTER_BACKEND=inproc" in env
+    assert "MAC_ROUTER_PROVIDERS=openai=https://api.openai.com/v1,1,key=secret:openai-upstream" in env
     assert "OPENAI_API_KEY=sk-test" in env
+    assert "MAC_DEPLOY_ROUTER_BACKEND=" not in env and "MAC_DEPLOY_ROUTER_PROVIDERS=" not in env
+    deploy = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    assert 'fleet_scoped_env MAC_ROUTER_BACKEND' in deploy
+    assert 'fleet_scoped_env MAC_ROUTER_PROVIDERS' in deploy
     assert "MAC_API_TOKEN" not in env
 
 


### PR DESCRIPTION
## Summary

Review of #41/#43/#44 found four spots where Stream B *looked* centralized but wasn't, plus a test-quality gap. All fixed in one corrective PR.

### 1. Provider keys were still shipped to spokes 🔴
`deploy_host()` read `NVIDIA_API_KEY`/`OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/`PERPLEXITY_API_KEY` for **every** agent and embedded them in the remote SSH command — so spokes received upstream keys in their deploy process env. That's "send secrets everywhere, hope for cleanup," not centralization. Now **blanked for spokes** (`agent != shared_services_manager`); only the hub gets them.

### 2. Name mismatch made wizard routing inert 🔴
The wizard wrote `MAC_DEPLOY_ROUTER_*`, but `deploy_host` reads `MAC_ROUTER_*` via `fleet_scoped_env` (no `MAC_DEPLOY_` bridge). So fresh wizard fleets passed **empty** router config → the escrow no-op'd and hub/spoke routing never activated. The wizard now writes the **runtime names** (`MAC_ROUTER_*`), exactly as it already does for `NVIDIA_API_KEY`. (This means #41 never actually wired fresh-fleet routing.)

### 3. Spoke `/v1` token fell back to the local `MAC_API_TOKEN` 🔴
The hub rejects the spoke's local token. The spoke branch now uses the **configured hub token** (`== MAC_WORKER_TOKEN`), never the local token (including when `MAC_WORKER_TOKEN` degenerated to it), and **leaves the gateway unconfigured** when no hub token is available — rather than writing a plausible-looking broken credential.

### 4. Brittle key-env derivation 🟡
The escrow derived the source var as `pid.upper()+"_API_KEY"` — a provider not matching that broke silently. Replaced with an explicit `PROVIDER_KEY_ENV` map (mirrors the wizard) that **warns loudly** on an unmapped provider.

### 5. Substring tests weren't behavior tests 🟡
Added tests that **run the actual env-writer**:
- **hub** → `MAC_ROUTER_*` + local `/v1` + local-token bearer;
- **spoke** → no router/providers, routes via the hub `/v1` with the **hub** token (≠ local), and **no provider key** in its env file (asserted by value);
- **spoke without a hub token** → gateway left unconfigured (never the local token).

Plus a wizard↔deploy **name cross-check** and a `deploy_host` spoke-key-blanking assertion.

## Validation
`bash -n` + `ast.parse` of all 31 deploy heredocs; `ast.parse` setup-fleet; full suite **751 passed** (1 deselected — env-only `mac-agent` E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)