### PR TITLE
fix(stream-b): scrub stale upstream provider keys from spoke gateway env

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -3719,6 +3719,37 @@ PY
   fi
 }
 
+scrub_spoke_provider_secrets() {
+  # Clean invariant (NOT mutate-in-place): a spoke routes every provider call
+  # through the hub, so its gateway env (~/.hermes/.env) must hold NO upstream
+  # provider/API keys — only messaging connection tokens (SLACK_*/MATTERMOST_*,
+  # which the gateway needs to connect directly) and the hub-token gateway creds
+  # mac.env supplies. The Slack/identity sync upserts specific keys and PRESERVES
+  # the rest, so a pre-centralization deploy's provider secrets would otherwise
+  # survive re-deploy forever. Strip the known upstream-provider secrets every
+  # deploy so re-deploy converges to the clean invariant. HUB keeps its keys (it
+  # runs the router + escrows them). Spoke-only, idempotent, backs up first.
+  [ "$AGENT" != "$SHARED_SERVICES_MANAGER_AGENT" ] || return 0
+  local henv="$HOME/.hermes/.env"
+  [ -f "$henv" ] || return 0
+  # Upstream provider/API keys + their base-url companions (the spoke gets these
+  # from the hub now). Messaging tokens (SLACK_*, MATTERMOST_*) and MAC_*/gateway
+  # creds are intentionally NOT listed — the gateway needs them locally.
+  local strip='NVIDIA_API_KEY|NVIDIA_API_BASE|NVIDIA_BASE_URL|NVIDIA_IMAGE_BASE_URL|OPENAI_API_KEY|OPENAI_BASE_URL|ANTHROPIC_API_KEY|ANTHROPIC_BASE_URL|PERPLEXITY_API_KEY|PERPLEXITY_BASE_URL|PERPLEXITY_API_BASE|FAL_KEY|VLLM_API_KEY|HAIMAKER_API_KEY|QDRANT_API_KEY|FIRECRAWL_API_KEY'
+  local hits
+  hits="$(grep -cE "^(export )?($strip)=" "$henv" 2>/dev/null || true)"
+  if [ "${hits:-0}" -eq 0 ]; then
+    log "spoke gateway env already clean of upstream provider keys"
+    return 0
+  fi
+  log "scrubbing ${hits} stale upstream provider key(s) from spoke gateway env (clean invariant)"
+  grep -nE "^(export )?($strip)=" "$henv" | sed -E 's/=.*/=<redacted>/' | sed 's/^/      /' >> "$DEPLOY_LOG" 2>&1 || true
+  cp -pf "$henv" "$henv.bak-scrub-${DEPLOY_TS}"
+  awk -v p="^(export )?($strip)=" '$0 !~ p' "$henv" > "$henv.scrub.$$"
+  chmod 600 "$henv.scrub.$$"
+  mv -f "$henv.scrub.$$" "$henv"
+}
+
 sync_messaging_config() {
   # th-merge-07: fetch Slack secrets + resolve the home channel AFTER the mac API
   # is (re)started, so the hub reads its OWN freshly-up /v1 vault instead of
@@ -3772,6 +3803,7 @@ EOF
   sudo systemctl --no-pager -l status "$MAC_SERVICE_NAME" || true
   sudo journalctl -u "$MAC_SERVICE_NAME" --since "$restart_since" --no-pager > "$LOG_DIR/mac-service-journal.txt" || true
   escrow_router_provider_keys
+  scrub_spoke_provider_secrets
   sync_messaging_config
   install_linux_hermes_service
 }
@@ -4577,6 +4609,7 @@ EOF
   sleep 3
   launchctl list "$MAC_LAUNCHD_LABEL" || true
   escrow_router_provider_keys
+  scrub_spoke_provider_secrets
   sync_messaging_config
   install_darwin_hermes_service "$uid"
   install_darwin_agent_service "$uid"

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -525,6 +525,78 @@ def test_env_writer_spoke_without_hub_token_leaves_gateway_unconfigured(tmp_path
     assert out.get("MAC_HERMES_GATEWAY_API_KEY") != local
 
 
+def _extract_bash_fn(name):
+    import re as _re
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    m = _re.search(r"\n%s\(\) \{\n(.*?)\n\}\n" % _re.escape(name), script, _re.S)
+    assert m, "function %s not found" % name
+    return "%s() {\n%s\n}\n" % (name, m.group(1))
+
+
+def _run_scrub(tmp_path, *, agent, hub_agent, hermes_env_text):
+    import subprocess as _sp
+    (tmp_path / ".hermes").mkdir(parents=True, exist_ok=True)
+    henv = tmp_path / ".hermes" / ".env"
+    henv.write_text(hermes_env_text, encoding="utf-8")
+    fn = _extract_bash_fn("scrub_spoke_provider_secrets")
+    script = (
+        "set -euo pipefail\n"
+        "log() { :; }\n"
+        'DEPLOY_TS=test; DEPLOY_LOG=/dev/null\n'
+        'HOME=%r; AGENT=%r; SHARED_SERVICES_MANAGER_AGENT=%r\n' % (str(tmp_path), agent, hub_agent)
+        + fn
+        + "scrub_spoke_provider_secrets\n"
+    )
+    r = _sp.run(["bash", "-c", script], text=True, capture_output=True)
+    assert r.returncode == 0, r.stderr
+    keys = set()
+    for line in henv.read_text(encoding="utf-8").splitlines():
+        if "=" in line and not line.startswith("#"):
+            keys.add(line.split("=", 1)[0].replace("export ", "").strip())
+    return keys
+
+
+_HERMES_ENV = (
+    "SLACK_BOT_TOKEN=xoxb-real\n"
+    "SLACK_APP_TOKEN=xapp-real\n"
+    "MATTERMOST_BOT_TOKEN=mm-real\n"
+    "OPENAI_API_KEY=sk-stale-provider\n"
+    "NVIDIA_API_KEY=nvapi-stale\n"
+    "FAL_KEY=fal-stale\n"
+    "ANTHROPIC_API_KEY=sk-ant-stale\n"
+    "PERPLEXITY_API_KEY=pplx-stale\n"
+    "FIRECRAWL_API_KEY=none\n"
+    "MESSAGING_CWD=/home/jkh/.mac/src/mac\n"
+    "MAC_HERMES_GATEWAY_API_KEY=hub-token\n"
+)
+
+
+def test_scrub_spoke_provider_secrets_clean_invariant(tmp_path):
+    # Re-deploy must converge a spoke's gateway env to a clean invariant: NO
+    # upstream provider keys, but messaging tokens + gateway creds preserved.
+    keys = _run_scrub(tmp_path, agent="natasha", hub_agent="rocky", hermes_env_text=_HERMES_ENV)
+    # upstream provider keys stripped
+    for gone in ("OPENAI_API_KEY", "NVIDIA_API_KEY", "FAL_KEY", "ANTHROPIC_API_KEY",
+                 "PERPLEXITY_API_KEY", "FIRECRAWL_API_KEY"):
+        assert gone not in keys, "%s should be scrubbed from a spoke gateway env" % gone
+    # messaging connections + gateway creds + config preserved
+    for kept in ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "MATTERMOST_BOT_TOKEN",
+                 "MESSAGING_CWD", "MAC_HERMES_GATEWAY_API_KEY"):
+        assert kept in keys, "%s must be preserved" % kept
+
+
+def test_scrub_spoke_provider_secrets_is_noop_on_hub(tmp_path):
+    # The hub legitimately holds provider keys (it runs the router) — never scrub it.
+    keys = _run_scrub(tmp_path, agent="rocky", hub_agent="rocky", hermes_env_text=_HERMES_ENV)
+    assert "NVIDIA_API_KEY" in keys and "OPENAI_API_KEY" in keys
+
+
+def test_scrub_called_for_both_os_flows():
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    # symmetric with the hub escrow: escrow (hub) then scrub (spoke) before messaging
+    assert script.count("\n  escrow_router_provider_keys\n  scrub_spoke_provider_secrets\n  sync_messaging_config\n") == 2
+
+
 def test_deploy_host_blanks_provider_keys_for_spokes():
     # Stream B: deploy_host must NOT ship upstream provider keys to spokes (only
     # the hub keeps them). It blanks them before building the remote SSH command.


### PR DESCRIPTION
## Summary

Review caught that the **upgrade path preserves old secrets**. Precise diagnosis:

- **`mac.env` is rebuilt clean** — the env-writer starts `values = {}`, so its router/gateway section is deterministic (its `FIRECRAWL_API_KEY` is the literal `"none"` placeholder; `NVIDIA_API_KEY` absent). Not the culprit.
- **`~/.hermes/.env` (the gateway env) is the carry-forward** — the Slack/identity sync *upserts* specific keys and **preserves the rest**. So a spoke upgraded into the key-centralized fleet still carried stale upstream provider secrets. Verified live on natasha: a real 73-char `OPENAI_API_KEY` + `FAL_KEY` survived in `~/.hermes/.env`. (The gateway uses mac.env's hub token because mac.env is sourced last, but the stale key sat in plaintext on disk regardless.)

## Fix

`scrub_spoke_provider_secrets` — a deterministic **clean-invariant** scrub of the spoke gateway env on every deploy, **symmetric with the hub escrow** (hub escrows provider keys into its vault; spoke removes them from its gateway env):
- **strips** the upstream-provider key set (`NVIDIA`/`OPENAI`/`ANTHROPIC`/`PERPLEXITY`/`FAL`/`VLLM`/`HAIMAKER`/`QDRANT`/`FIRECRAWL` + base-url companions);
- **keeps** messaging connection tokens (`SLACK_*`, `MATTERMOST_*`) and `MAC_*`/gateway creds — the gateway needs those locally;
- **HUB-exempt** (it legitimately holds provider keys), idempotent, backs up first.

So a re-deploy now converges to "spoke holds only its hub token + messaging tokens," instead of accreting whatever a prior deploy left behind.

## Tests (behavior, not substring)
- Run the **actual** scrub function over a temp gateway env → provider keys stripped, messaging/creds/config preserved.
- No-op on the hub.
- Both OS flows call it in the right order (`escrow → scrub → messaging`).
- Full suite: **754 passed** (1 deselected — env-only E2E precondition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)