### PR TITLE
feat(stream-b): Phase 1 — route image generation through the hub

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -3408,6 +3408,17 @@ if _router_inproc and _is_hub:
             values["OPENAI_API_KEY"] = _local_tok
             values["MAC_HERMES_GATEWAY_API_KEY"] = _local_tok
             values["ACC_HERMES_GATEWAY_API_KEY"] = _local_tok
+    # Image generation (Stream B "hub serves them"): the hub mounts the /v1/genai
+    # image proxy (router_app.mount_image_proxy) so spokes route NIM image-gen
+    # through the hub instead of holding the image key. Only when the hub actually
+    # has an image key to escrow — the escrow step puts NVIDIA_API_KEY into the
+    # vault as secret:nvidia-image, which the proxy resolves at use.
+    if (os.environ.get("NVIDIA_API_KEY") or "").strip():
+        values["MAC_ROUTER_IMAGE_UPSTREAM"] = (
+            os.environ.get("MAC_DEPLOY_ROUTER_IMAGE_UPSTREAM")
+            or "https://ai.api.nvidia.com/v1/genai"
+        )
+        values["MAC_ROUTER_IMAGE_KEY"] = "secret:nvidia-image"
 elif _router_inproc:
     # SPOKE: do NOT mount a local router or carry providers/upstream keys. Strip any
     # router/provider config a fleet-wide MAC_DEPLOY_ROUTER_* introduced, and route
@@ -3435,6 +3446,12 @@ elif _router_inproc:
         values["OPENAI_API_KEY"] = _hub_tok
         values["MAC_HERMES_GATEWAY_API_KEY"] = _hub_tok
         values["ACC_HERMES_GATEWAY_API_KEY"] = _hub_tok
+        # Image generation routes through the hub too: the NIM image tool sends
+        # NVIDIA_API_KEY as its bearer to NVIDIA_IMAGE_BASE_URL, so point both at
+        # the hub's /v1/genai image proxy with the spoke's hub token. The hub swaps
+        # in the vault image key; the spoke holds NO upstream image key.
+        values["NVIDIA_API_KEY"] = _hub_tok
+        values["NVIDIA_IMAGE_BASE_URL"] = "%s/v1/genai" % _hub_base
 else:
     # Router backend not inproc → preserve prior pass-through of whatever
     # MAC_ROUTER_* was configured (no /v1 cutover).
@@ -3710,6 +3727,35 @@ for chunk in providers.split(";"):
     resp = urllib.request.urlopen(req, timeout=15)
     print("escrowed %r (HTTP %s, %d-char value)" % (name, resp.status, len(value)))
     escrowed += 1
+# Image-gen key: the hub /v1/genai proxy resolves MAC_ROUTER_IMAGE_KEY
+# (secret:<name>) from the vault. Escrow NVIDIA_API_KEY there (the same NVIDIA
+# account key, which must have image-NIM access). MAC_ROUTER_IMAGE_KEY is read
+# from the freshly written mac.env (reload_mac_env ran before this step).
+image_key_spec = (os.environ.get("MAC_ROUTER_IMAGE_KEY") or "").strip()
+if image_key_spec.startswith("secret:"):
+    iname = image_key_spec[len("secret:"):]
+    ivalue = (os.environ.get("NVIDIA_API_KEY") or "").strip()
+    if iname in have:
+        print("escrow: %r already in vault; skip" % iname)
+        skipped += 1
+    elif not ivalue:
+        print("escrow: NVIDIA_API_KEY empty/unset for image secret %r; skip" % iname)
+        skipped += 1
+    else:
+        body = json.dumps({
+            "name": iname,
+            "value": ivalue,
+            "scopes": {"capabilities": ["router-upstream", "image"]},
+            "created_by": "deploy",
+        }).encode()
+        req = urllib.request.Request(
+            "http://127.0.0.1:%s/secrets" % port, data=body,
+            headers={"Authorization": "Bearer " + tok, "Content-Type": "application/json"},
+            method="POST",
+        )
+        resp = urllib.request.urlopen(req, timeout=15)
+        print("escrowed %r (HTTP %s, %d-char value)" % (iname, resp.status, len(ivalue)))
+        escrowed += 1
 print("router key escrow: %d escrowed, %d skipped" % (escrowed, skipped))
 PY
   then

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -327,6 +327,43 @@ def build_proxy_from_env(
     )
 
 
+def mount_image_proxy(
+    app: Any,
+    *,
+    env: Optional[Dict[str, str]] = None,
+    secret_resolver: Optional[SecretResolver] = None,
+) -> bool:
+    """Mount ``POST /v1/genai/{path}`` forwarding to an external image backend
+    (e.g. NVIDIA NIM) with a vault-resolved key, so spokes route image generation
+    through the HUB instead of holding the image key locally (Stream B "hub serves
+    them"). Gated on MAC_ROUTER_IMAGE_UPSTREAM + MAC_ROUTER_IMAGE_KEY; no-op
+    otherwise. NIM image-gen is a synchronous POST returning base64 inline, so a
+    transparent reverse-proxy suffices — no async/polling/URL-rewrite. The /v1/*
+    prefix is agent-scoped (api._required_scope), so a spoke presents its hub
+    token and the hub swaps in the vault key (MAC_ROUTER_IMAGE_KEY=secret:<name>)
+    on the way upstream."""
+    env = env or os.environ
+    upstream = (env.get("MAC_ROUTER_IMAGE_UPSTREAM") or "").strip().rstrip("/")
+    key_spec = (env.get("MAC_ROUTER_IMAGE_KEY") or "").strip()
+    if not upstream or not key_spec:
+        return False
+    try:
+        timeout = float(env.get("MAC_ROUTER_IMAGE_TIMEOUT") or 180.0)
+    except ValueError:
+        timeout = 180.0
+    image_provider = Provider(name="image", base_url=upstream, api_key_env=key_spec)
+    from fastapi.responses import JSONResponse
+
+    @app.post("/v1/genai/{path:path}")
+    def _genai(path: str, body: Dict[str, Any]) -> Any:  # noqa: ANN401
+        status, out = urllib_forwarder(
+            image_provider, "/" + path, body, timeout=timeout, secret_resolver=secret_resolver
+        )
+        return JSONResponse(out if isinstance(out, dict) else {}, status_code=status or 502)
+
+    return True
+
+
 def mount_router(
     app: Any,
     *,
@@ -334,15 +371,19 @@ def mount_router(
     proxy: Optional[ProviderProxy] = None,
     secret_resolver: Optional[SecretResolver] = None,
 ) -> bool:
-    """Mount /v1/chat/completions + /v1/embeddings on ``app`` when
-    MAC_ROUTER_BACKEND=inproc. Returns True if mounted. Default backend is
-    'tokenhub' → no-op, so an existing fleet is unchanged until flipped."""
+    """Mount /v1/chat/completions + /v1/embeddings (+ /v1/genai image proxy) on
+    ``app`` when MAC_ROUTER_BACKEND=inproc. Returns True if anything mounted.
+    Default backend is 'tokenhub' → no-op, so an existing fleet is unchanged until
+    flipped."""
     env = env or os.environ
     if (env.get("MAC_ROUTER_BACKEND") or "tokenhub").strip().lower() != "inproc":
         return False
+    # The image proxy is independent of the chat providers (a fixed upstream, no
+    # failover), so mount it even when no chat providers are configured.
+    mounted = mount_image_proxy(app, env=env, secret_resolver=secret_resolver)
     proxy = proxy or build_proxy_from_env(env, secret_resolver=secret_resolver)
     if proxy is None:
-        return False
+        return mounted
     from fastapi.responses import JSONResponse, StreamingResponse
 
     @app.post("/v1/chat/completions")

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -488,6 +488,9 @@ def test_env_writer_hub_runs_router_locally(tmp_path):
     assert out.get("MAC_HERMES_GATEWAY_BASE_URL") == "http://127.0.0.1:8789/v1"
     # the hub's own gateway presents the hub's LOCAL mac token to its local /v1
     assert out.get("OPENAI_API_KEY") == out.get("MAC_API_TOKEN")
+    # the hub mounts the image proxy (it has an image key, NVIDIA_API_KEY, to escrow)
+    assert out.get("MAC_ROUTER_IMAGE_UPSTREAM") == "https://ai.api.nvidia.com/v1/genai"
+    assert out.get("MAC_ROUTER_IMAGE_KEY") == "secret:nvidia-image"
 
 
 def test_env_writer_spoke_routes_via_hub_with_no_provider_keys(tmp_path):
@@ -506,8 +509,11 @@ def test_env_writer_spoke_routes_via_hub_with_no_provider_keys(tmp_path):
     assert out.get("MAC_HERMES_GATEWAY_BASE_URL") == "http://hub.example:8789/v1"
     assert out.get("OPENAI_API_KEY") == "HUBTOK"
     assert out.get("OPENAI_API_KEY") != out.get("MAC_API_TOKEN")
-    # the upstream provider key never lands in a spoke's env file
-    assert "NVIDIA_API_KEY" not in out
+    # image-gen routes via the hub too: NVIDIA_API_KEY is the HUB TOKEN (the bearer
+    # the NIM tool sends to the hub image proxy), NVIDIA_IMAGE_BASE_URL points at
+    # the hub's /v1/genai — the real upstream image key never reaches the spoke.
+    assert out.get("NVIDIA_API_KEY") == "HUBTOK"
+    assert out.get("NVIDIA_IMAGE_BASE_URL") == "http://hub.example:8789/v1/genai"
     assert "nvapi-SECRET" not in "\n".join(out.values())
 
 
@@ -630,6 +636,10 @@ def test_hub_escrows_router_provider_keys_into_vault():
     assert "WARNING no source env var mapped for provider" in fn
     assert '"http://127.0.0.1:%s/secrets" % port' in fn
     assert '"created_by": "deploy"' in fn
+    # also escrows the image-gen key (NVIDIA_API_KEY -> secret:nvidia-image) so the
+    # hub /v1/genai proxy can resolve it (Phase 1, image-gen via the hub)
+    assert 'image_key_spec = (os.environ.get("MAC_ROUTER_IMAGE_KEY")' in fn
+    assert 'ivalue = (os.environ.get("NVIDIA_API_KEY")' in fn
     # failure is loud but non-fatal (chat won't route until the key is escrowed)
     assert "router provider key escrow failed" in fn
     # invoked on the hub after the API is up, before the gateway, in both OS flows

--- a/tests/test_router_app.py
+++ b/tests/test_router_app.py
@@ -262,6 +262,63 @@ def test_urllib_forwarder_uses_secret_resolver(monkeypatch):
     assert captured["auth"] == "Bearer escrowed-key"
 
 
+def test_image_proxy_forwards_to_upstream_with_vault_key(monkeypatch):
+    # Stream B "hub serves them": a spoke POSTs image-gen to the hub's /v1/genai
+    # with its hub token; the hub swaps in the vault image key and forwards to NIM.
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from mac import router_app
+
+    captured = {}
+
+    class _Resp:
+        status = 200
+
+        def read(self):
+            return b'{"artifacts":[{"base64":"IMG"}]}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=60.0):
+        captured["url"] = req.full_url
+        captured["auth"] = req.headers.get("Authorization")
+        return _Resp()
+
+    monkeypatch.setattr(router_app.urllib.request, "urlopen", fake_urlopen)
+
+    app = FastAPI()
+    env = {
+        "MAC_ROUTER_BACKEND": "inproc",
+        "MAC_ROUTER_IMAGE_UPSTREAM": "https://ai.api.nvidia.com/v1/genai",
+        "MAC_ROUTER_IMAGE_KEY": "secret:nvidia-image",
+    }
+    # image proxy mounts even with NO chat providers configured
+    assert mount_router(app, env=env, secret_resolver={"nvidia-image": "escrowed-image-key"}.get) is True
+
+    client = TestClient(app)
+    r = client.post("/v1/genai/black-forest-labs/flux.1-dev", json={"prompt": "a cat"})
+    assert r.status_code == 200
+    assert r.json() == {"artifacts": [{"base64": "IMG"}]}
+    # forwarded to <upstream>/<path>, with the spoke's token swapped for the vault key
+    assert captured["url"] == "https://ai.api.nvidia.com/v1/genai/black-forest-labs/flux.1-dev"
+    assert captured["auth"] == "Bearer escrowed-image-key"
+
+
+def test_image_proxy_noop_without_config():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    # inproc but no MAC_ROUTER_IMAGE_* and no chat providers -> nothing mounted
+    assert mount_router(app, env={"MAC_ROUTER_BACKEND": "inproc"}) is False
+    r = TestClient(app).post("/v1/genai/x/y", json={})
+    assert r.status_code == 404
+
+
 def test_mount_streams_through_fastapi():
     from fastapi import FastAPI
     from fastapi.testclient import TestClient


### PR DESCRIPTION
## Summary

**"Hub serves them" Phase 1.** Image generation (NVIDIA NIM) now routes through the hub like chat, so spokes hold **no** image key. NIM image-gen is a *synchronous* POST returning base64 inline, so a transparent reverse-proxy suffices (no async/polling/URL-rewrite — scoped via an investigation of the plugin).

### `router_app.py`
- `mount_image_proxy()` mounts `POST /v1/genai/{path}` when `MAC_ROUTER_IMAGE_UPSTREAM` + `MAC_ROUTER_IMAGE_KEY` are set. It forwards the same path/body to the upstream (`ai.api.nvidia.com/v1/genai`), **swapping the caller's bearer for the vault-resolved key** (`key=secret:<name>` via the existing `SecretsService` resolver — same path the chat router uses). The `/v1/*` prefix is agent-scoped, so a spoke presents its hub token. Mounted by `mount_router` independently of chat providers; gated/no-op otherwise.

### `deploy-mac-fleet.sh`
- **HUB** (inproc, has `NVIDIA_API_KEY`): sets `MAC_ROUTER_IMAGE_UPSTREAM` + `MAC_ROUTER_IMAGE_KEY=secret:nvidia-image`; the escrow step escrows `NVIDIA_API_KEY` into the vault as `secret:nvidia-image`.
- **SPOKE** (inproc, has a hub token): sets `NVIDIA_API_KEY=<hub token>` + `NVIDIA_IMAGE_BASE_URL=<hub>/v1/genai`, so the NIM image tool POSTs to the hub proxy with the hub token — **no upstream image key on the spoke**. The clean-invariant scrub keeps stripping the `~/.hermes/.env` copies; mac.env supplies the hub-token versions (sourced last), exactly like `OPENAI_API_KEY`.

## Tests
- Router behavior tests run the **real** proxy: forwards to `<upstream>/<path>`, swaps in the vault key; no-op without config.
- Env-writer behavior tests: hub gets the image-proxy config; a spoke gets `NVIDIA_API_KEY`=hub token + `NVIDIA_IMAGE_BASE_URL`=hub/v1/genai, and the real upstream key never appears.
- Escrow test covers the `nvidia-image` escrow.
- Full suite: **756 passed** (1 deselected — env-only E2E precondition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)