### PR TITLE
fix(startup): stop mistaking the hub router /v1 for a TokenHub on spokes

### DIFF
--- a/src/mac/hermes_startup.py
+++ b/src/mac/hermes_startup.py
@@ -878,15 +878,14 @@ def _firecrawl_web_search_report() -> Dict[str, Any]:
 
 
 def _tokenhub_endpoint_from_env() -> Tuple[Optional[str], Optional[str]]:
+    # th-merge-07: TokenHub is retired. Only an EXPLICIT TokenHub URL counts — do
+    # NOT fall back to CUSTOM_BASE_URL/OPENAI_BASE_URL: on a spoke that is the hub's
+    # in-mac router /v1, and health-checking it as a "TokenHub" yields a spurious
+    # 403 + degraded status. With no explicit endpoint the report is "retired".
     for name in ("TOKENHUB_URL", "MAC_TOKENHUB_URL"):
         value = os.environ.get(name)
         if value and value.strip():
             return value.strip().rstrip("/"), name
-    custom = os.environ.get("CUSTOM_BASE_URL") or os.environ.get("OPENAI_BASE_URL")
-    if custom and custom.strip():
-        value = custom.strip().rstrip("/")
-        if value.endswith("/v1"):
-            return value[:-3].rstrip("/"), "CUSTOM_BASE_URL" if os.environ.get("CUSTOM_BASE_URL") else "OPENAI_BASE_URL"
     return None, None
 
 
@@ -933,6 +932,10 @@ def _tokenhub_report() -> Dict[str, Any]:
         return report
     if not endpoint:
         if not required:
+            # No explicit TokenHub endpoint + not required = the retired state
+            # (e.g. a spoke routing chat through the hub). Report it as such so the
+            # operator sees "retired", not a vague "disabled".
+            report["status"] = "retired"
             return report
         report["ready"] = bool(degraded_allowed)
         report["status"] = "degraded_allowed" if degraded_allowed else "missing_endpoint"

--- a/tests/test_hermes_startup.py
+++ b/tests/test_hermes_startup.py
@@ -241,6 +241,27 @@ def test_startup_reports_tokenhub_readiness_without_leaking_key(monkeypatch, tmp
     assert "secret-tokenhub-key" not in str(report)
 
 
+def test_spoke_router_v1_not_mistaken_for_tokenhub(monkeypatch):
+    # th-merge-07 / Stream B: a spoke's OPENAI_BASE_URL is the HUB's router /v1, not
+    # a TokenHub. The startup report must NOT health-check it as a TokenHub (doing so
+    # produced a spurious "403 Forbidden" + degraded operator status). With no
+    # explicit TOKENHUB_URL the report is "retired", ready, no warning.
+    for var in ("TOKENHUB_URL", "MAC_TOKENHUB_URL", "MAC_ROUTER_BACKEND",
+                "MAC_REQUIRE_TOKENHUB", "CUSTOM_BASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://100.125.137.89:8789/v1")
+    assert hermes_startup._tokenhub_endpoint_from_env() == (None, None)
+
+    def _boom(*a, **k):
+        raise AssertionError("must not health-check a TokenHub endpoint on a spoke")
+
+    monkeypatch.setattr(hermes_startup, "_fetch_tokenhub_json", _boom)
+    report = hermes_startup._tokenhub_report()
+    assert report["status"] == "retired"
+    assert report["ready"] is True
+    assert not report["warning"]
+
+
 def test_slack_bot_token_satisfies_upstream_slack_activation(monkeypatch, tmp_path):
     _clear_startup_env(monkeypatch)
     hermes_home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary

Phase 4 cleanup. Every spoke deploy logged `TokenHub health endpoint is unreachable: HTTP Error 403: Forbidden` and reported `operator_status=degraded`.

**Root cause:** `_tokenhub_endpoint_from_env` fell back to `CUSTOM_BASE_URL`/`OPENAI_BASE_URL` when no explicit TokenHub URL was set. On a Stream B spoke that value is the **hub's in-mac router `/v1`**, so startup health-checked the hub as if it were a TokenHub → 403. The hub avoided this via the `MAC_ROUTER_BACKEND=inproc` retired short-circuit, which spokes no longer have.

**Fix:** TokenHub is retired — only an **explicit** `TOKENHUB_URL`/`MAC_TOKENHUB_URL` counts; drop the base-url fallback so the router's own `/v1` is never probed as a TokenHub. With no explicit endpoint the report is **`retired` + ready** (not a vague `disabled`, no spurious warning), clearing the false degraded status on spokes.

## Test
A spoke env (`OPENAI_BASE_URL` = hub `/v1`, no `TOKENHUB_URL`, not inproc) resolves no TokenHub endpoint and reports `retired`/ready without health-checking anything. Full suite **757 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)