### PR TITLE
fix(deploy): make `python -m mac.deploy_env` import-light (no yaml on bootstrap)

### DIFF
--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -1,6 +1,30 @@
 """Multi-agent coordinator control plane."""
 
-from mac.services import ControlPlane
-from mac.store import SQLiteStore
+from typing import TYPE_CHECKING
 
 __all__ = ["ControlPlane", "SQLiteStore"]
+
+if TYPE_CHECKING:  # type-checkers / IDEs only — never imported at runtime
+    from mac.services import ControlPlane
+    from mac.store import SQLiteStore
+
+
+def __getattr__(name: str):
+    """Lazily re-export the heavy control-plane classes (PEP 562).
+
+    Keeps ``import mac`` import-light so dependency-free submodules — notably
+    ``mac.deploy_env``, which ``deploy/deploy-mac-fleet.sh`` runs via
+    ``python -m mac.deploy_env`` on the bootstrap python *before* the deploy venv
+    exists — don't transitively pull in ``mac.services`` and its third-party deps
+    (yaml, cryptography, …). ``from mac import ControlPlane`` still works; it just
+    imports ``mac.services`` on first access instead of at package import.
+    """
+    if name == "ControlPlane":
+        from mac.services import ControlPlane
+
+        return ControlPlane
+    if name == "SQLiteStore":
+        from mac.store import SQLiteStore
+
+        return SQLiteStore
+    raise AttributeError("module %r has no attribute %r" % (__name__, name))

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -132,6 +132,26 @@ def test_parse_env_text_trailing_unquoted_tokens_take_leading_assignment():
     assert parse_env_text("export RAW=plainvalue\n") == {"RAW": "plainvalue"}
 
 
+def test_deploy_env_import_is_dependency_light():
+    # Regression: deploy-mac-fleet.sh runs `python -m mac.deploy_env write-mac-env`
+    # on the bootstrap python BEFORE the deploy venv exists, so importing
+    # mac.deploy_env must NOT transitively pull in mac.services (which needs
+    # yaml, cryptography, …). A lazy mac/__init__ keeps the package import light.
+    # (A bullwinkle redeploy died with ModuleNotFoundError: 'yaml' before this.)
+    code = (
+        "import sys, mac.deploy_env\n"
+        "assert 'mac.services' not in sys.modules, "
+        "'mac.deploy_env import pulled in mac.services (heavy deps)'\n"
+        "from mac import ControlPlane\n"  # lazy re-export still resolves
+        "assert ControlPlane.__name__ == 'ControlPlane'\n"
+        "print('OK')\n"
+    )
+    env = {**os.environ, "PYTHONPATH": str(ROOT / "src") + os.pathsep + os.environ.get("PYTHONPATH", "")}
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
 def test_sample_fleet_config_is_generic_and_externalized():
     cfg = load_sample_fleet_config()
     gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem
`deploy/deploy-mac-fleet.sh` writes the env file by running `python -m mac.deploy_env write-mac-env` on the **bootstrap python, before the deploy venv exists**. Importing `mac.deploy_env` runs `mac/__init__.py`, which eagerly did `from mac.services import ControlPlane` → `import yaml` (+ `cryptography`, …). So the bootstrap python needed mac's *entire* dependency set, despite `deploy_env`'s "intentionally dependency-free" contract.

It worked on hosts whose bootstrap python happened to have those deps (rocky) and failed elsewhere: a **bullwinkle (macOS) redeploy died with `ModuleNotFoundError: No module named 'yaml'`** at the env-file step — after it had already stopped the agent's services for artifact replacement (recovered via the rollback script).

## Fix
Make the heavy re-exports lazy via PEP 562 `__getattr__` in `mac/__init__.py`:
- `import mac` (and therefore `python -m mac.deploy_env`) no longer imports `mac.services`.
- `from mac import ControlPlane` / `SQLiteStore` still resolve — they import `mac.services`/`mac.store` on first access.

`mac.deploy_env` only needs `mac.providers` (stdlib-only), so it now runs on a bare bootstrap python.

## Test
Adds `test_deploy_env_import_is_dependency_light`: a subprocess imports `mac.deploy_env` and asserts `mac.services` is **not** pulled into `sys.modules` (and that `from mac import ControlPlane` still resolves).

Verified: `import mac.deploy_env` → `mac.services` absent; lazy `ControlPlane`/`SQLiteStore` resolve on access. Full hermetic suite is green on the committed tree.

> Note: 4 `test_hermes_*` contract tests currently fail in a *working tree that has the in-flight hgmac-capability removal* (those tests aren't updated for it yet) — that's unrelated to this PR and not present in the committed tree this branch builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)