### PR TITLE
fix(deploy): sync Hermes runtime chat config from mac.env (kill stale TokenHub :8090)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -2689,6 +2689,18 @@ if configured and (patch.get("error") or not report.get("gateway_runtime_shim_pr
 PY
 }
 
+sync_hermes_chat_config() {
+  # The Hermes runtime reads ~/.hermes/.env + config.yaml (+ auth.json pool) for
+  # its chat provider, NOT mac.env — and those retained stale TokenHub state
+  # (:8090 / provider: tokenhub / custom:* pool) across the retirement, so the
+  # agent self-test + task execution dialed the dead endpoint or sent a rejected
+  # bearer (403). Mirror mac.env's router endpoint + token into the runtime
+  # config. Non-fatal: a failure leaves chat degraded but doesn't abort deploy.
+  log "syncing Hermes chat config (in-mac-router endpoint + provider) from mac.env"
+  "$VENV/bin/python" -m mac.hermes_chat_config --hermes-home "$HOME/.hermes" --mac-env "$ENV_FILE" \
+    || log "WARNING: hermes chat config sync failed; agent chat self-test may stay degraded"
+}
+
 initialize_hermes_home() {
   log "initializing Hermes home with upstream Hermes defaults"
   "$VENV/bin/python" - <<'PY'
@@ -3268,6 +3280,7 @@ cat "$HERMES_VENDORED/SNAPSHOT_PIN" > "$LOG_DIR/hermes-vendored-pin.txt" 2>/dev/
 initialize_hermes_home
 ensure_hermes_identity_memory_continuity
 apply_hermes_gateway_runtime_shim
+sync_hermes_chat_config
 install_hermes_web_deps
 install_hermes_messaging_deps
 repair_hermes_kanban_schema

--- a/src/mac/hermes_chat_config.py
+++ b/src/mac/hermes_chat_config.py
@@ -1,0 +1,221 @@
+"""Sync the Hermes runtime's chat config from the deploy-authoritative mac.env.
+
+The vendored Hermes runtime resolves its chat provider from ``~/.hermes/.env`` +
+``~/.hermes/config.yaml`` (and an ``auth.json`` credential pool) — NOT from
+``mac.env``. After the TokenHub retirement those retained stale TokenHub state —
+the ``:8090`` endpoint, ``model.provider: tokenhub``, and ``custom:*`` pool
+entries — so the agent startup self-test (and task execution, same
+``hermes_cli chat`` path) dialed the dead endpoint or sent a rejected bearer
+(HTTP 403 "unknown bearer token"). ``write-mac-env`` fixes ``mac.env`` but never
+touched these, so every redeploy left the agents degraded.
+
+This module makes the runtime config mirror ``mac.env``'s in-mac-router endpoint
++ token:
+
+1. ``~/.hermes/.env``: chat endpoint/key vars copied from ``mac.env``.
+2. ``~/.hermes/config.yaml``: ``model.provider``/``base_url`` set to the router,
+   plus a ``providers.custom`` entry carrying the bearer in the schema's
+   ``api_key`` field (a bare ``key:`` is silently ignored by the provider
+   normalizer, which was the bug that left a bogus bearer in play).
+3. ``~/.hermes/auth.json``: stale ``custom:*`` credential-pool entries removed so
+   ``resolve_runtime_provider`` falls through to the synced key.
+
+Dependency-free (stdlib only) like ``mac.deploy_env``; the deploy runs it via the
+mac venv after ``write-mac-env`` + ``ensure_hermes_home``, before the gateway and
+agent start.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+from pathlib import Path
+from typing import Dict, List
+
+# Chat endpoint/credential vars the Hermes runtime reads; mirrored from mac.env.
+CHAT_ENV_KEYS = (
+    "OPENAI_BASE_URL",
+    "CUSTOM_BASE_URL",
+    "MAC_HERMES_GATEWAY_BASE_URL",
+    "ACC_HERMES_GATEWAY_BASE_URL",
+    "OPENAI_API_KEY",
+    "MAC_HERMES_GATEWAY_API_KEY",
+    "ACC_HERMES_GATEWAY_API_KEY",
+    "MAC_HERMES_GATEWAY_PROVIDER",
+    "ACC_HERMES_GATEWAY_PROVIDER",
+    "HERMES_INFERENCE_PROVIDER",
+)
+
+
+def parse_env_file(path: Path) -> Dict[str, str]:
+    out: Dict[str, str] = {}
+    if not path.exists():
+        return out
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        s = raw.strip()
+        if not s or s.startswith("#") or "=" not in s:
+            continue
+        key, value = s.split("=", 1)
+        key = key.replace("export ", "").strip()
+        try:
+            tokens = shlex.split(value)
+            value = tokens[0] if tokens else ""
+        except ValueError:
+            value = value.strip()
+        out[key] = value
+    return out
+
+
+def sync_hermes_env(hermes_home: Path, mac_env: Dict[str, str]) -> List[str]:
+    """Overwrite the chat endpoint/key vars in ~/.hermes/.env with mac.env's."""
+    henv = hermes_home / ".env"
+    lines = henv.read_text(encoding="utf-8").splitlines() if henv.exists() else []
+    out: List[str] = []
+    seen, changed = set(), []
+    for ln in lines:
+        if "=" in ln and not ln.lstrip().startswith("#"):
+            key = ln.split("=", 1)[0].strip()
+            if key in CHAT_ENV_KEYS and key in mac_env:
+                desired = "%s=%s" % (key, mac_env[key])
+                if ln != desired:
+                    changed.append(key)
+                out.append(desired)
+                seen.add(key)
+                continue
+        out.append(ln)
+    for key in CHAT_ENV_KEYS:
+        if key in mac_env and key not in seen:
+            out.append("%s=%s" % (key, mac_env[key]))
+            changed.append(key)
+    henv.parent.mkdir(parents=True, exist_ok=True)
+    henv.write_text("\n".join(out) + "\n", encoding="utf-8")
+    _chmod_600(henv)
+    return changed
+
+
+def sync_config_yaml(hermes_home: Path, base_url: str, api_key: str) -> bool:
+    """Point model.{provider,base_url} at the router and (re)define a `custom`
+    provider with the bearer in `api_key` (the schema field). Line-based to
+    preserve the rest of the file. Returns True if the custom provider was set."""
+    cfg = hermes_home / "config.yaml"
+    if not cfg.exists() or not base_url or not api_key:
+        return False
+    base = base_url.rstrip("/")
+
+    # 1) drop any existing top-level `  custom:` provider block (idempotent).
+    pruned: List[str] = []
+    skip = False
+    for ln in cfg.read_text(encoding="utf-8").splitlines():
+        if re.match(r"^  custom:\s*$", ln):
+            skip = True
+            continue
+        if skip:
+            if re.match(r"^    \S", ln) or ln.strip() == "":
+                continue
+            skip = False
+        pruned.append(ln)
+
+    # 2) fix the model: block, then insert providers.custom after `providers:`.
+    res: List[str] = []
+    in_model = did_provider = did_base = did_custom = False
+    for ln in pruned:
+        if re.match(r"^model:\s*$", ln):
+            in_model = True
+            res.append(ln)
+            continue
+        if in_model and re.match(r"^\S", ln):
+            in_model = False
+        if in_model and not did_provider and re.match(r"^\s+provider:\s", ln):
+            res.append(re.sub(r"(provider:\s*).*", r"\g<1>custom", ln))
+            did_provider = True
+            continue
+        if in_model and not did_base and re.match(r"^\s+base_url:\s", ln):
+            res.append(re.sub(r"(base_url:\s*).*", r"\g<1>%s/" % base, ln))
+            did_base = True
+            continue
+        res.append(ln)
+        if re.match(r"^providers:\s*$", ln) and not did_custom:
+            res += [
+                "  custom:",
+                "    api: %s/" % base,
+                "    name: custom",
+                "    transport: chat_completions",
+                "    api_key: %s" % api_key,
+            ]
+            did_custom = True
+    cfg.write_text("\n".join(res) + "\n", encoding="utf-8")
+    _chmod_600(cfg)
+    return did_custom
+
+
+def clear_stale_custom_pool(hermes_home: Path) -> List[str]:
+    """Remove `custom:*` credential-pool entries from auth.json so resolution
+    falls through to the synced key (they repopulate from config on next use)."""
+    authj = hermes_home / "auth.json"
+    if not authj.exists():
+        return []
+    try:
+        data = json.loads(authj.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    removed: List[str] = []
+
+    def scrub(obj: object) -> None:
+        if isinstance(obj, dict):
+            for k in list(obj.keys()):
+                if isinstance(k, str) and k.startswith("custom:"):
+                    removed.append(k)
+                    del obj[k]
+                else:
+                    scrub(obj[k])
+        elif isinstance(obj, list):
+            for item in obj:
+                scrub(item)
+
+    scrub(data)
+    if removed:
+        authj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        _chmod_600(authj)
+    return removed
+
+
+def _chmod_600(path: Path) -> None:
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+
+
+def sync(hermes_home: Path, mac_env_path: Path) -> Dict[str, object]:
+    mac_env = parse_env_file(mac_env_path)
+    base_url = (mac_env.get("MAC_HERMES_GATEWAY_BASE_URL") or mac_env.get("OPENAI_BASE_URL") or "").strip()
+    api_key = (mac_env.get("MAC_HERMES_GATEWAY_API_KEY") or mac_env.get("OPENAI_API_KEY") or "").strip()
+    return {
+        "base_url": base_url,
+        "key_present": bool(api_key),
+        "env_synced": sync_hermes_env(hermes_home, mac_env),
+        "config_custom_provider": sync_config_yaml(hermes_home, base_url, api_key),
+        "pool_cleared": clear_stale_custom_pool(hermes_home),
+    }
+
+
+def main(argv: object = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m mac.hermes_chat_config")
+    parser.add_argument(
+        "--hermes-home",
+        default=os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes"),
+    )
+    parser.add_argument("--mac-env", default=str(Path.home() / ".mac" / "mac.env"))
+    ns = parser.parse_args(argv)
+    result = sync(Path(ns.hermes_home), Path(ns.mac_env))
+    # Never print key material — only booleans/keys/counts.
+    printable = dict(result)
+    printable["pool_cleared"] = len(result["pool_cleared"])  # type: ignore[arg-type]
+    print("hermes chat config synced:", printable)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -152,6 +152,18 @@ def test_deploy_env_import_is_dependency_light():
     assert "OK" in result.stdout
 
 
+def test_fleet_deploy_syncs_hermes_chat_config_from_mac_env():
+    # The Hermes runtime reads ~/.hermes/.env + config.yaml (not mac.env) for its
+    # chat provider; the deploy must sync those from mac.env or agents dial the
+    # retired TokenHub :8090 / send a stale bearer (403) and self-test degrades.
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    assert "sync_hermes_chat_config()" in script
+    assert "-m mac.hermes_chat_config" in script
+    assert '--mac-env "$ENV_FILE"' in script
+    # runs in the main flow right after the gateway runtime shim, before services
+    assert "apply_hermes_gateway_runtime_shim\nsync_hermes_chat_config\n" in script
+
+
 def test_sample_fleet_config_is_generic_and_externalized():
     cfg = load_sample_fleet_config()
     gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")

--- a/tests/test_hermes_chat_config.py
+++ b/tests/test_hermes_chat_config.py
@@ -1,0 +1,107 @@
+import json
+
+from mac.hermes_chat_config import parse_env_file, sync
+
+TOKEN = "validtok_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+STALE = "stale_tokenhub_bearer_zzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+
+
+def _mac_env(tmp_path):
+    p = tmp_path / "mac.env"
+    p.write_text(
+        "\n".join(
+            [
+                "MAC_HERMES_GATEWAY_BASE_URL=http://127.0.0.1:8789/v1",
+                "OPENAI_BASE_URL=http://127.0.0.1:8789/v1",
+                "CUSTOM_BASE_URL=http://127.0.0.1:8789/v1",
+                "MAC_HERMES_GATEWAY_API_KEY=%s" % TOKEN,
+                "OPENAI_API_KEY=%s" % TOKEN,
+                "MAC_HERMES_GATEWAY_PROVIDER=custom",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _stale_hermes_home(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text(
+        "\n".join(
+            [
+                "OPENAI_BASE_URL=http://100.125.137.89:8090/v1",
+                "CUSTOM_BASE_URL=http://100.125.137.89:8090/v1",
+                "MAC_HERMES_GATEWAY_BASE_URL=http://100.125.137.89:8090/v1",
+                "MAC_HERMES_GATEWAY_API_KEY=%s" % STALE,
+                "SLACK_BOT_TOKEN=xoxb-keepme",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (home / "config.yaml").write_text(
+        "\n".join(
+            [
+                "model:",
+                "  provider: tokenhub",
+                "  base_url: http://100.125.137.89:8090/v1/",
+                "providers:",
+                "  tokenhub:",
+                "    api: http://100.125.137.89:8090/v1/",
+                "    name: tokenhub",
+                "    key: %s" % STALE,
+                "fallback_providers: []",
+                "agent:",
+                "  max_turns: 90",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (home / "auth.json").write_text(
+        json.dumps(
+            {
+                "credential_pool": {"custom:tokenhub": {"k": 1}, "anthropic": {"k": 2}},
+                "providers": {},
+                "version": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return home
+
+
+def test_sync_migrates_tokenhub_runtime_config_to_router(tmp_path):
+    mac = _mac_env(tmp_path)
+    home = _stale_hermes_home(tmp_path)
+
+    result = sync(home, mac)
+
+    # ~/.hermes/.env: chat vars repointed; unrelated tokens preserved
+    henv = parse_env_file(home / ".env")
+    assert henv["OPENAI_BASE_URL"] == "http://127.0.0.1:8789/v1"
+    assert henv["MAC_HERMES_GATEWAY_BASE_URL"] == "http://127.0.0.1:8789/v1"
+    assert henv["MAC_HERMES_GATEWAY_API_KEY"] == TOKEN
+    assert henv["SLACK_BOT_TOKEN"] == "xoxb-keepme"
+
+    # config.yaml: model points at the router; a custom provider with api_key (NOT key)
+    cfg = (home / "config.yaml").read_text(encoding="utf-8")
+    assert "provider: custom" in cfg
+    assert "base_url: http://127.0.0.1:8789/v1/" in cfg
+    assert "  custom:" in cfg
+    assert "api_key: %s" % TOKEN in cfg
+    assert result["config_custom_provider"] is True
+
+    # auth.json: stale custom:* pool entry gone, others kept
+    auth = json.loads((home / "auth.json").read_text(encoding="utf-8"))
+    assert "custom:tokenhub" not in auth["credential_pool"]
+    assert "anthropic" in auth["credential_pool"]
+    assert "custom:tokenhub" in result["pool_cleared"]
+
+    # idempotent: a second run doesn't duplicate the custom provider block
+    sync(home, mac)
+    cfg2 = (home / "config.yaml").read_text(encoding="utf-8")
+    assert cfg2.count("  custom:\n") == 1
+    assert cfg2.count("api_key: %s" % TOKEN) == 1


### PR DESCRIPTION
## Problem (root cause of the fleet-wide `degraded`)
The Hermes runtime resolves its chat provider from **`~/.hermes/.env` + `~/.hermes/config.yaml`** (and an `auth.json` credential pool) — **not** `mac.env`. After the TokenHub retirement those files retained stale state: the **`:8090`** endpoint, `model.provider: tokenhub`, and `custom:*` pool entries. So every agent's chat **self-test** (and task execution — same `hermes_cli chat` path) dialed the dead endpoint or sent a rejected bearer → **HTTP 403 "unknown bearer token"** → `health=degraded` (bullwinkle, which hard-gates the self-test, stayed offline). `write-mac-env` fixed `mac.env` correctly but never touched these — so **every redeploy re-broke the agents.**

A subtle second bug: the provider-config schema (`_normalize_custom_provider_entry`) accepts **`api_key`**/`key_env` but silently **ignores `key:`** — so a custom provider defined with `key:` left a bogus 15-char bearer in play (this is what made the first hand-fix attempts still 403).

## Fix
New stdlib-only `mac.hermes_chat_config` mirrors `mac.env`'s in-mac-router endpoint + token into the runtime config:
1. **`~/.hermes/.env`** — chat endpoint/key vars copied from `mac.env`.
2. **`config.yaml`** — `model.provider`/`base_url` → router; a `providers.custom` entry with the bearer in **`api_key`** (the schema field).
3. **`auth.json`** — stale `custom:*` pool entries removed so `resolve_runtime_provider` falls through to the synced key.

`deploy-mac-fleet.sh` runs it (mac venv) **right after `apply_hermes_gateway_runtime_shim`** — after `write-mac-env` + `ensure_hermes_home`, before the gateway/agent start. Non-fatal on error.

## Verification
This exact sequence, applied live, brought **rocky + natasha + bullwinkle** to `status=idle health=healthy hermes_chat=True`. New unit test exercises the tokenhub→router migration (env + config.yaml + pool, idempotent); deploy-wiring test asserts the step runs after the shim. Full hermetic suite: **769 passed, 1 deselected.**

## Follow-up (not in this PR)
#53's router route-logging is `logger.info`, but the mac service doesn't emit INFO — raise the `mac.router` logger level so `journalctl -u mac | grep 'router: route'` surfaces the per-route madmax-usage signal. (vLLM `/metrics` already works for that.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)