### PR TITLE
fix(deploy): make a fresh supervisord fleet's chat path work end-to-end

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -4354,6 +4354,18 @@ EOF
   run_supervisorctl update >/dev/null
   run_supervisorctl restart "$MAC_SUPERVISORD_PROG" >/dev/null 2>&1 || run_supervisorctl start "$MAC_SUPERVISORD_PROG" >/dev/null
   sleep 3
+  # Escrow the router upstream key + scrub spoke secrets + sync messaging BEFORE
+  # the gateway/agent start, mirroring the systemd (install_linux_hermes_service)
+  # and launchd paths. Without this the supervisord path left the hub vault empty,
+  # so the router forwarded keyless (upstream 401) and the agent self-test failed.
+  # Needs the control plane reachable, so wait briefly for it.
+  for _i in $(seq 1 30); do
+    curl -fsS -o /dev/null "http://127.0.0.1:${MAC_PORT:-8789}/ui" 2>/dev/null && break
+    sleep 1
+  done
+  escrow_router_provider_keys
+  scrub_spoke_provider_secrets
+  sync_messaging_config
   run_supervisorctl restart "$HERMES_SUPERVISORD_PROG" >/dev/null 2>&1 || run_supervisorctl start "$HERMES_SUPERVISORD_PROG" >/dev/null
   sleep 5
   run_supervisorctl restart "$AGENT_SUPERVISORD_PROG" >/dev/null 2>&1 || run_supervisorctl start "$AGENT_SUPERVISORD_PROG" >/dev/null

--- a/src/mac/fleet_setup.py
+++ b/src/mac/fleet_setup.py
@@ -410,6 +410,16 @@ def _router_env(
             provider_env_values[base_env] = base_url
     if router_specs:
         provider_env_values["MAC_ROUTER_PROVIDERS"] = ";".join(router_specs)
+    # Upstream keys are often scoped to a fixed model set, so the bare wildcard
+    # `*` a runtime emits must be substituted to a concrete allowed model. Carry
+    # the ladder + default from the spec; without it a fresh fleet's chat dies on
+    # "key can only access models=[...]. Tried to access *".
+    wildcard_models = _str(router.get("wildcard_models"))
+    if wildcard_models:
+        provider_env_values["MAC_ROUTER_WILDCARD_MODELS"] = wildcard_models
+    default_model = _str(router.get("default_model"))
+    if default_model:
+        provider_env_values["MAC_ROUTER_DEFAULT_MODEL"] = default_model
     backend = _str(router.get("backend")) or "inproc"
     return {"backend": backend, "providers": ";".join(router_specs)}, provider_env_values, required_env, warnings
 

--- a/src/mac/hermes_chat_config.py
+++ b/src/mac/hermes_chat_config.py
@@ -98,11 +98,26 @@ def sync_hermes_env(hermes_home: Path, mac_env: Dict[str, str]) -> List[str]:
 def sync_config_yaml(hermes_home: Path, base_url: str, api_key: str) -> bool:
     """Point model.{provider,base_url} at the router and (re)define a `custom`
     provider with the bearer in `api_key` (the schema field). Line-based to
-    preserve the rest of the file. Returns True if the custom provider was set."""
+    preserve the rest of the file. Returns True if the custom provider was set.
+
+    Robust to a freshly-initialized config.yaml that is only a stub (e.g. just a
+    `web:` block): when the `model:` block or the `providers:` section is absent
+    it is *created*, not just patched. The original patch-only version silently
+    no-op'd on such configs, leaving fresh nodes with no chat provider (HTTP 403
+    "unknown bearer token")."""
     cfg = hermes_home / "config.yaml"
     if not cfg.exists() or not base_url or not api_key:
         return False
     base = base_url.rstrip("/")
+
+    def custom_block() -> List[str]:
+        return [
+            "  custom:",
+            "    api: %s/" % base,
+            "    name: custom",
+            "    transport: chat_completions",
+            "    api_key: %s" % api_key,
+        ]
 
     # 1) drop any existing top-level `  custom:` provider block (idempotent).
     pruned: List[str] = []
@@ -117,15 +132,20 @@ def sync_config_yaml(hermes_home: Path, base_url: str, api_key: str) -> bool:
             skip = False
         pruned.append(ln)
 
-    # 2) fix the model: block, then insert providers.custom after `providers:`.
+    # 2) patch the model: block + insert providers.custom after `providers:`,
+    #    backfilling provider/base_url lines if the existing model block lacks them.
     res: List[str] = []
-    in_model = did_provider = did_base = did_custom = False
+    model_seen = in_model = did_provider = did_base = did_custom = False
     for ln in pruned:
         if re.match(r"^model:\s*$", ln):
-            in_model = True
+            model_seen = in_model = True
             res.append(ln)
             continue
         if in_model and re.match(r"^\S", ln):
+            if not did_provider:
+                res.append("  provider: custom"); did_provider = True
+            if not did_base:
+                res.append("  base_url: %s/" % base); did_base = True
             in_model = False
         if in_model and not did_provider and re.match(r"^\s+provider:\s", ln):
             res.append(re.sub(r"(provider:\s*).*", r"\g<1>custom", ln))
@@ -137,14 +157,23 @@ def sync_config_yaml(hermes_home: Path, base_url: str, api_key: str) -> bool:
             continue
         res.append(ln)
         if re.match(r"^providers:\s*$", ln) and not did_custom:
-            res += [
-                "  custom:",
-                "    api: %s/" % base,
-                "    name: custom",
-                "    transport: chat_completions",
-                "    api_key: %s" % api_key,
-            ]
+            res += custom_block()
             did_custom = True
+
+    # close an open model block at EOF
+    if in_model:
+        if not did_provider:
+            res.append("  provider: custom")
+        if not did_base:
+            res.append("  base_url: %s/" % base)
+
+    # 3) create whichever top-level structures were missing entirely.
+    if not model_seen:
+        res += ["model:", "  provider: custom", "  base_url: %s/" % base]
+    if not did_custom:
+        res += ["providers:"] + custom_block()
+        did_custom = True
+
     cfg.write_text("\n".join(res) + "\n", encoding="utf-8")
     _chmod_600(cfg)
     return did_custom

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -783,10 +783,11 @@ def test_scrub_spoke_provider_secrets_is_noop_on_hub(tmp_path):
     assert "NVIDIA_API_KEY" in keys and "OPENAI_API_KEY" in keys
 
 
-def test_scrub_called_for_both_os_flows():
+def test_scrub_called_for_all_service_flows():
     script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
-    # symmetric with the hub escrow: escrow (hub) then scrub (spoke) before messaging
-    assert script.count("\n  escrow_router_provider_keys\n  scrub_spoke_provider_secrets\n  sync_messaging_config\n") == 2
+    # symmetric with the hub escrow: escrow (hub) then scrub (spoke) before messaging,
+    # in each of the three service flows (systemd, launchd, supervisord)
+    assert script.count("\n  escrow_router_provider_keys\n  scrub_spoke_provider_secrets\n  sync_messaging_config\n") == 3
 
 
 def test_deploy_host_blanks_provider_keys_for_spokes():
@@ -831,8 +832,9 @@ def test_hub_escrows_router_provider_keys_into_vault():
     assert 'ivalue = (os.environ.get("NVIDIA_API_KEY")' in fn
     # failure is loud but non-fatal (chat won't route until the key is escrowed)
     assert "router provider key escrow failed" in fn
-    # invoked on the hub after the API is up, before the gateway, in both OS flows
-    assert script.count("\n  escrow_router_provider_keys\n") == 2
+    # invoked on the hub after the API is up, before the gateway, in all three
+    # service flows (systemd, launchd, supervisord)
+    assert script.count("\n  escrow_router_provider_keys\n") == 3
 
 
 def test_setup_fleet_build_router_provider_spec():

--- a/tests/test_hermes_chat_config.py
+++ b/tests/test_hermes_chat_config.py
@@ -105,3 +105,66 @@ def test_sync_migrates_tokenhub_runtime_config_to_router(tmp_path):
     cfg2 = (home / "config.yaml").read_text(encoding="utf-8")
     assert cfg2.count("  custom:\n") == 1
     assert cfg2.count("api_key: %s" % TOKEN) == 1
+
+
+def test_sync_creates_chat_config_on_stub_config(tmp_path):
+    # Regression: a freshly-initialized node's config.yaml is a stub with no
+    # `model:`/`providers:` scaffold. The patch-only version no-op'd, leaving the
+    # node with no chat provider (HTTP 403). sync must CREATE the structure.
+    import yaml
+
+    mac = _mac_env(tmp_path)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / ".env").write_text("SLACK_BOT_TOKEN=xoxb-keepme\n", encoding="utf-8")
+    (home / "config.yaml").write_text("web:\n  search_backend: firecrawl\n", encoding="utf-8")
+
+    result = sync(home, mac)
+    assert result["config_custom_provider"] is True
+
+    d = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
+    assert d["model"]["provider"] == "custom"
+    assert d["model"]["base_url"] == "http://127.0.0.1:8789/v1/"
+    assert d["providers"]["custom"]["api_key"] == TOKEN
+    assert d["providers"]["custom"]["api"] == "http://127.0.0.1:8789/v1/"
+    assert d["providers"]["custom"]["transport"] == "chat_completions"
+    # unrelated existing section preserved
+    assert d["web"]["search_backend"] == "firecrawl"
+
+    # idempotent: re-running keeps exactly one custom block
+    sync(home, mac)
+    cfg2 = (home / "config.yaml").read_text(encoding="utf-8")
+    assert cfg2.count("  custom:\n") == 1
+    assert cfg2.count("api_key: %s" % TOKEN) == 1
+
+
+def test_router_env_emits_wildcard_models_from_spec(tmp_path):
+    # Regression (#3): the spec's router.wildcard_models must flow to
+    # MAC_ROUTER_WILDCARD_MODELS so the router substitutes `*` for an allowed model.
+    from pathlib import Path
+
+    from mac.fleet_setup import build_setup_plan
+
+    spec = {
+        "schema": "mac.fleet_setup.v1",
+        "fleet": {"name": "gke", "hub": "gke-hub", "hub_url": "http://gke-hub:8789"},
+        "agents": [{"name": "gke-hub", "target": "horde@gke-hub", "os": "linux"}],
+        "router": {
+            "backend": "inproc",
+            "providers": [{"id": "nvidia", "key_env": "NVIDIA_API_KEY"}],
+            "wildcard_models": "us/azure/openai/gpt-4.1-mini|azure/openai/gpt-4.1-mini",
+            "default_model": "us/azure/openai/gpt-4.1-mini",
+        },
+        "network": {"provider": "none"},
+    }
+    plan = build_setup_plan(
+        spec,
+        root=Path(__file__).resolve().parents[1],
+        fleets_config=tmp_path / "fleets.yaml",
+        env_file=tmp_path / ".env",
+        env={"NVIDIA_API_KEY": "nv-secret"},
+    )
+    assert plan["status"] == "pass"
+    ev = plan["env_values"]
+    assert ev["MAC_ROUTER_WILDCARD_MODELS"] == "us/azure/openai/gpt-4.1-mini|azure/openai/gpt-4.1-mini"
+    assert ev["MAC_ROUTER_DEFAULT_MODEL"] == "us/azure/openai/gpt-4.1-mini"

--- a/tests/test_worker_process_e2e.py
+++ b/tests/test_worker_process_e2e.py
@@ -78,8 +78,11 @@ def test_real_hub_and_mac_agent_process_execute_canary_without_touching_normal_t
     tmp_path: Path,
 ):
     root = Path(__file__).resolve().parents[1]
-    mac_agent = shutil.which("mac-agent")
-    assert mac_agent is not None, "mac-agent console script must be installed for E2E"
+    # Prefer the installed console script; fall back to `python -m mac.worker`
+    # (the same `mac.worker:main` entry point) so the E2E runs in environments
+    # without an editable install on PATH. worker_env carries PYTHONPATH=src below.
+    mac_agent_bin = shutil.which("mac-agent")
+    mac_agent = [mac_agent_bin] if mac_agent_bin else [sys.executable, "-m", "mac.worker"]
 
     token = "worker-process-e2e-token-with-enough-entropy"
     port = _free_port()
@@ -152,7 +155,7 @@ def test_real_hub_and_mac_agent_process_execute_canary_without_touching_normal_t
         worker_env = hub_env.copy()
         workspace = tmp_path / "worker-workspaces"
         common = [
-            mac_agent,
+            *mac_agent,
             "--url",
             base_url,
             "--token",


### PR DESCRIPTION
## Why

Standing up a brand-new **supervisord**-managed fleet (jordanh-GKE: hub + 2 spokes on GKE pods) surfaced three installer defects that bare-metal/systemd fleets never hit. Each independently broke the hub agent's Hermes chat self-test → `agent did not register` → aborted deploy. Validated by hand-repairing the live hub (chat now returns `ping-ok`, agent registered `idle`); this PR fixes each at the source so a clean redeploy works unaided.

## Fixes

1. **`hermes_chat_config.sync_config_yaml` was patch-only.** It rewrote an *existing* `model:`/`providers:` block via regex but never created one. A freshly-initialized `config.yaml` that is just a stub (e.g. only `web:`) was a silent no-op (`config_custom_provider=False`) → no chat provider → `403 unknown bearer token`. Now it **creates** `model:` + `providers.custom` when absent (and backfills a partial `model:` block). systemd fleets only worked because their config already had the scaffold.

2. **`install_supervisord_service` never escrowed the upstream key.** `escrow_router_provider_keys` / `scrub_spoke_provider_secrets` / `sync_messaging_config` were only in the systemd and launchd paths. A supervisord hub left its vault empty → router forwarded keyless → upstream `401 No api key passed in`. The calls now run in the supervisord path too, after the control plane is reachable and before the gateway/agent start (so the agent self-test sees the escrowed key).

3. **`fleet_setup._router_env` never emitted `MAC_ROUTER_WILDCARD_MODELS`/`MAC_ROUTER_DEFAULT_MODEL`.** A runtime's bare `*` reached an upstream whose key is scoped to a fixed model set → `401 key can only access models=[...]. Tried to access *`. The spec's `router.wildcard_models`/`router.default_model` now flow to the generated env (the deploy already plumbs them onward).

## Also

- `test_worker_process_e2e` hard-asserted the `mac-agent` console script on PATH; it now falls back to `python -m mac.worker` (same entry point) so the E2E runs without an editable install instead of hard-failing.

## Tests

- New: stub-config creation + idempotency for `sync_config_yaml`; wildcard/default propagation for `_router_env`.
- Updated: escrow/scrub call-site counts 2 → 3 for the added supervisord flow.
- Full suite: **782 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)