### PR TITLE
fix(deploy): wire network=none reverse-tunnel spokes end-to-end (gketun-01/02)

### DIFF
--- a/.tickets/gketun-01.md
+++ b/.tickets/gketun-01.md
@@ -1,0 +1,46 @@
+---
+id: gketun-01
+status: open
+deps: []
+links: [gketun-02, gketun-03]
+created: 2026-06-03T00:00:00Z
+type: bug
+priority: 2
+audit: jordanh-GKE-supervisord-validation
+discovered_via: fresh-fleet-deploy
+---
+# network=none reverse tunnel goes FATAL on first deploy with no auto-recovery
+
+## Symptom
+
+Deploying a fresh `network: none` fleet (hub + spokes) leaves spokes
+unregistered after the first deploy: `WARNING: hub tunnel not reachable after
+first deploy; redeploy to complete setup`. The hub's reverse-tunnel program is
+`FATAL  Exited too quickly`.
+
+## Root cause
+
+`deploy/deploy-mac-fleet.sh`: in the per-spoke orchestration, `install_reverse_tunnel_on_hub`
+(~line 4945) runs **before** `deploy_host` (~4958), but `deploy_host` is what
+authorizes the hub's tunnel pubkey on the spoke (`install_hub_tunnel_pubkey`).
+So when the hub's tunnel program first starts, the spoke hasn't authorized the
+key yet → the `ssh -R …` exits immediately → supervisord exceeds `startretries`
+→ `FATAL`. `autorestart=true` does not recover a FATAL program, so even after
+`deploy_host` authorizes the key the tunnel never reconnects. The post-deploy
+"waiting for hub tunnel to auto-establish" loop therefore always times out on a
+first deploy.
+
+## Fix options
+
+- Install/start (or `supervisorctl restart`) the hub tunnel **after** the spoke
+  has authorized the pubkey (i.e. after `deploy_host`), not before; or
+- give the tunnel program effectively-unlimited retries (`startretries`) +
+  longer `startsecs` so it keeps retrying until the key lands; and/or
+- in the post-deploy step, explicitly `restart` the hub tunnel program (clears
+  FATAL) once the spoke key is in place, instead of relying on `autorestart`.
+
+## Validated workaround (manual)
+
+After the spoke authorized the key, `sudo supervisorctl restart
+<fleet>-tunnel-<worker>` on the hub brought both tunnels to RUNNING and the
+spokes reached the hub at `127.0.0.1:18789` (200).

--- a/.tickets/gketun-02.md
+++ b/.tickets/gketun-02.md
@@ -1,0 +1,47 @@
+---
+id: gketun-02
+status: open
+deps: []
+links: [gketun-01, gketun-03]
+created: 2026-06-03T00:00:00Z
+type: bug
+priority: 1
+audit: jordanh-GKE-supervisord-validation
+discovered_via: fresh-fleet-deploy
+---
+# network=none spokes get cluster-DNS shared-service URLs, not the tunnel ports
+
+## Symptom
+
+On a `network: none` spoke, the agent startup self-test reports Qdrant and
+Firecrawl unreachable (`URLError: timed out`) even though the hub's reverse
+tunnel is up and forwards those services:
+
+```
+checks: {qdrant_shared_memory: False, firecrawl_web_search: False, hermes_chat: True, ...}
+blocking: ['Qdrant ... unreachable: timed out', 'Firecrawl ... unreachable: timed out']
+```
+
+## Root cause
+
+The spoke's `MAC_QDRANT_URL` / firecrawl URL are derived from the **hub_url**
+(e.g. `http://jordanh-hub.ov-agent-farm.svc.cluster.local:6333` and `:3002`).
+In a cluster-pod environment those ports are blocked cross-pod (only port 22 is
+open between pods — which is exactly why the SSH reverse tunnel exists). The
+reverse tunnel forwards the hub's services to the spoke's localhost
+(`-R 127.0.0.1:16333:127.0.0.1:6333`, `-R 127.0.0.1:13002:127.0.0.1:3002`), so
+the spoke should reach Qdrant/Firecrawl at `127.0.0.1:16333` / `127.0.0.1:13002`,
+not the hub FQDN. Confirmed: from the spoke, `curl 127.0.0.1:16333` → 200 and
+`127.0.0.1:13002` → 200, while the FQDN ports time out.
+
+The control-plane/qdrant/firecrawl forward ports (18789/16333/13002) are already
+the tunnel convention (see `install_reverse_tunnel_on_hub`), and `MAC_HUB_URL`
+is correctly set to `http://127.0.0.1:18789` for spokes — but the shared-service
+URLs were not given the same tunnel-localhost treatment under `network=none`.
+
+## Fix
+
+Under `network: none` (reverse-tunnel topology), set the spoke's Qdrant and
+Firecrawl URLs to the tunnel-forwarded localhost ports
+(`127.0.0.1:16333` / `127.0.0.1:13002`) rather than the hub FQDN — mirroring how
+`MAC_HUB_URL` already uses `127.0.0.1:18789`.

--- a/.tickets/gketun-03.md
+++ b/.tickets/gketun-03.md
@@ -1,0 +1,34 @@
+---
+id: gketun-03
+status: open
+deps: [gketun-02]
+links: [gketun-01, gketun-02]
+created: 2026-06-03T00:00:00Z
+type: bug
+priority: 1
+audit: jordanh-GKE-supervisord-validation
+discovered_via: fresh-fleet-deploy
+---
+# network=none spokes don't register with the hub even with the tunnel up
+
+## Symptom
+
+After the reverse tunnel is established (spoke reaches `127.0.0.1:18789` → 200)
+and the spoke agent is RUNNING with `hermes_chat: True`, the spoke still does not
+appear in the hub's `/agents` list (only the hub is registered). The self-test
+logs `failed to report heartbeat: HTTP Error 404` (the agent id isn't registered,
+so `/agents/<id>/heartbeat` 404s).
+
+## Hypothesis / likely link to gketun-02
+
+The startup self-test still has blocking problems (Qdrant + Firecrawl unreachable
+— see [[gketun-02]]), which appears to prevent the agent from completing
+registration with the hub even though the process stays up and chat works. If so,
+fixing the spoke shared-service URLs (gketun-02) should clear the self-test and
+let registration proceed. Needs confirmation that registration is gated on a
+clean self-test (vs. a separate auth/endpoint problem in the register call).
+
+## Acceptance
+
+A fresh `network: none` spoke, after deploy, appears in the hub `/agents` list
+with a healthy status, without manual intervention.

--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -950,6 +950,16 @@ FIRECRAWL_REQUIRE="1"
 FIRECRAWL_BIND_ADDR_CONFIGURED="${MAC_DEPLOY_FIRECRAWL_BIND_ADDR:-}"
 FIRECRAWL_PORT_CONFIGURED="${MAC_DEPLOY_FIRECRAWL_PORT:-3002}"
 NETWORK_PROVIDER="${MAC_DEPLOY_NETWORK_PROVIDER:-tailscale}"
+# gketun-02: network=none spokes reach hub-managed shared services through the
+# reverse tunnel's localhost forwards (install_reverse_tunnel_on_hub:
+# -R 127.0.0.1:16333:hub:6333, -R 127.0.0.1:13002:hub:3002), NOT the hub FQDN —
+# cross-pod service ports are typically blocked (only port 22 is), which is the
+# whole reason the SSH tunnel exists. Mirror MAC_HUB_URL's 127.0.0.1:18789
+# convention so the agent self-test + runtime hit the tunnel-forwarded ports.
+if [ "$NETWORK_PROVIDER" = "none" ] && [ "$AGENT" != "$SHARED_SERVICES_MANAGER_AGENT" ]; then
+  QDRANT_URL_CONFIGURED="http://127.0.0.1:16333"
+  FIRECRAWL_URL_CONFIGURED="http://127.0.0.1:13002"
+fi
 NETWORK_INSTALL="${MAC_DEPLOY_NETWORK_INSTALL:-auto}"
 NETWORK_HOSTNAME_PREFIX="${MAC_DEPLOY_NETWORK_HOSTNAME_PREFIX:-}"
 TAILSCALE_AUTH_KEY_ENV="${MAC_DEPLOY_TAILSCALE_AUTH_KEY_ENV:-MAC_DEPLOY_TAILSCALE_AUTH_KEY}"
@@ -4843,6 +4853,11 @@ user=$(whoami)
 autostart=true
 autorestart=true
 startsecs=5
+; gketun-01: this program is (re)installed before the spoke authorizes the hub
+; tunnel key (install runs before deploy_host), so its first ssh attempts exit
+; immediately. Keep retrying instead of going FATAL after the default 3 tries, so
+; the tunnel auto-establishes once the spoke authorizes the key mid-deploy.
+startretries=1000
 stopwaitsecs=10
 stdout_logfile=$HOME/.mac/logs/tunnel-${worker_agent}.log
 stderr_logfile=$HOME/.mac/logs/tunnel-${worker_agent}.log

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -837,6 +837,28 @@ def test_hub_escrows_router_provider_keys_into_vault():
     assert script.count("\n  escrow_router_provider_keys\n") == 3
 
 
+def test_network_none_spoke_uses_tunnel_forwarded_service_ports():
+    # gketun-02: cross-pod service ports are blocked under network=none, so a spoke
+    # must reach hub Qdrant/Firecrawl via the reverse tunnel's localhost forwards
+    # (16333/13002), not the hub FQDN.
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    assert (
+        'if [ "$NETWORK_PROVIDER" = "none" ] && [ "$AGENT" != "$SHARED_SERVICES_MANAGER_AGENT" ]; then'
+        in script
+    )
+    assert 'QDRANT_URL_CONFIGURED="http://127.0.0.1:16333"' in script
+    assert 'FIRECRAWL_URL_CONFIGURED="http://127.0.0.1:13002"' in script
+
+
+def test_reverse_tunnel_program_keeps_retrying_until_key_authorized():
+    # gketun-01: install_reverse_tunnel_on_hub runs before the spoke authorizes the
+    # hub key, so the tunnel program must keep retrying instead of going FATAL after
+    # the default 3 attempts.
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    fn = script.split("install_reverse_tunnel_on_hub() {", 1)[1].split("\nuses_direct_mesh_hub", 1)[0]
+    assert "startretries=1000" in fn
+
+
 def test_setup_fleet_build_router_provider_spec():
     # The wizard wires the in-mac router from the providers it collects, using the
     # plain env-var key form the router resolves at use (no vault escrow needed).


### PR DESCRIPTION
Follows #58. The chat-path installer fixes in #58 got the jordanh-GKE **hub** healthy on supervisord; this PR fixes the `network: none` **reverse-tunnel topology** gaps that kept the two spokes from registering. Three tickets filed in `.tickets/` (`gketun-01/02/03`).

## gketun-02 — spoke shared-service URLs (priority fix)
network=none spokes were configured with hub-**FQDN** qdrant/firecrawl URLs (`http://<hub>:6333` / `:3002`). In a cluster-pod environment those ports are blocked cross-pod — only the SSH reverse tunnel's localhost forwards are reachable (`-R 127.0.0.1:16333:hub:6333`, `-R 127.0.0.1:13002:hub:3002`). The spoke's `QDRANT_URL_CONFIGURED`/`FIRECRAWL_URL_CONFIGURED` now point at `127.0.0.1:16333` / `127.0.0.1:13002` (mirroring how `MAC_HUB_URL` already uses `127.0.0.1:18789`). This was the `qdrant/firecrawl unreachable: timed out` self-test failure that also blocked spoke registration (gketun-03).

## gketun-01 — reverse tunnel went FATAL on first deploy
`install_reverse_tunnel_on_hub` runs *before* the spoke authorizes the hub key (install precedes `deploy_host`), so the supervisord tunnel program's first `ssh` attempts exit immediately and it hit FATAL after the default 3 retries — never recovering even after the key landed (the deploy's own "redeploy to complete setup"). `startretries=1000` lets it keep retrying and auto-establish once the spoke authorizes the key mid-deploy.

## Tests
- New: assert the network=none spoke service-port rewrite + the tunnel `startretries`.
- 47 deploy tests green.

Validated by hand on jordanh-GKE (restarting the FATAL tunnels with the key authorized brought both spokes' `:18789` to 200); a clean redeploy will confirm unaided. gketun-03 (spoke registration) is expected to clear once gketun-02 fixes the self-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)