### PR TITLE
fix(gateway): 'no home channel' prompt must respect a config-set home channel

### DIFF
--- a/src/mac/_hermes/gateway/run.py
+++ b/src/mac/_hermes/gateway/run.py
@@ -8988,7 +8988,13 @@ class GatewayRunner:
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
-            if not os.getenv(env_key):
+            # A home channel may be configured either via the legacy
+            # <PLATFORM>_HOME_CHANNEL env var OR via config (e.g. the mac deploy
+            # retires SLACK_HOME_CHANNEL in favour of slack_home_channels.json,
+            # which is applied to config.home_channel). Only prompt when neither
+            # is present, otherwise a correctly-configured fleet is told to run
+            # /sethome even though cron delivery already has a home channel.
+            if not os.getenv(env_key) and self.config.get_home_channel(source.platform) is None:
                 # Slack dispatches all Hermes commands through a single
                 # parent slash command `/hermes`; bare `/sethome` is not
                 # registered and would fail with "app did not respond".

--- a/tests/test_gateway_home_channel.py
+++ b/tests/test_gateway_home_channel.py
@@ -1,0 +1,50 @@
+"""The mac deploy retires the legacy <PLATFORM>_HOME_CHANNEL env var and instead
+resolves the fleet's configured home channel into slack_home_channels.json, which
+the gateway applies to config.home_channel. The "no home channel" prompt must
+therefore key off the resolved/config home channel, not just the legacy env var
+(see gateway/run.py). This guards the consumption path that populates it."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERMES = Path(__file__).resolve().parents[1] / "src" / "mac" / "_hermes"
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+
+def test_slack_home_resolved_from_file(tmp_path, monkeypatch):
+    from gateway.config import _slack_home_from_resolved_file
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "slack_home_channels.json").write_text(
+        json.dumps(
+            [
+                {
+                    "channel_id": "C0AMSBEU7CJ",
+                    "channel_name": "#rockyandfriends",
+                    "name": "offtera",
+                    "team_id": "THJ9A47K3",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    chan, name = _slack_home_from_resolved_file()
+    assert chan == "C0AMSBEU7CJ"
+    assert name == "rockyandfriends"  # leading '#' stripped
+
+
+def test_slack_home_absent_returns_empty(tmp_path, monkeypatch):
+    from gateway.config import _slack_home_from_resolved_file
+
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    chan, name = _slack_home_from_resolved_file("fallback")
+    assert chan == ""
+    assert name == "fallback"


### PR DESCRIPTION
## Symptom (reported on rocky)

> :mailbox_with_mail: No home channel is set for Slack. … Type `/hermes sethome` …

…even though the fleet's `slack_home_channel_name` (`rockyandfriends`) is configured in `fleets.yaml` and the deploy resolved it.

## Root cause

The deploy resolves the configured channel name into `slack_home_channels.json` and the gateway applies it to `config.platforms[SLACK].home_channel` (cron delivery correctly uses `get_home_channel()` at run.py:4628). But the one-time prompt at `run.py:8991` gated purely on `not os.getenv(_home_target_env_var(...))` — i.e. the **legacy `SLACK_HOME_CHANNEL` env var**, which the deploy deliberately **retires** (`slack_home_channels.json` replaces it; confirmed in the sync report: `legacy_env_removed_keys: [SLACK_HOME_CHANNEL_NAME]`). So a correctly-configured fleet — home channel set, cron delivery working — still nagged on every fresh thread.

## Fix

Only prompt when neither signal is present:
```python
if not os.getenv(env_key) and self.config.get_home_channel(source.platform) is None:
```

## Test

`tests/test_gateway_home_channel.py` covers the resolved-file consumption that populates `config.home_channel` (present → channel id/name with `#` stripped; absent → empty + fallback).

## Note (follow-up, not this PR)

`_slack_home_from_resolved_file` returns only `homes[0]`, so a multi-workspace Slack fleet (rocky has 2: offtera + omgjkh) applies a single home channel for cron delivery. The prompt is now correct for all workspaces; per-workspace cron delivery to the right team is a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)