### PR TITLE
chore(tickets): close gketun-01/02/03; file slackhome-01 (multi-workspace home channels)

### DIFF
--- a/.tickets/gketun-01.md
+++ b/.tickets/gketun-01.md
@@ -1,6 +1,7 @@
 ---
 id: gketun-01
-status: open
+status: closed
+resolved_by: "#59"
 deps: []
 links: [gketun-02, gketun-03]
 created: 2026-06-03T00:00:00Z
@@ -44,3 +45,7 @@ first deploy.
 After the spoke authorized the key, `sudo supervisorctl restart
 <fleet>-tunnel-<worker>` on the hub brought both tunnels to RUNNING and the
 spokes reached the hub at `127.0.0.1:18789` (200).
+
+## Resolution
+
+Resolved by #59 (`startretries=1000` on the supervisord tunnel program). Validated 2026-06-03: both jordanh-GKE worker tunnels reachable in 5s on a clean redeploy — no FATAL, no second deploy needed.

--- a/.tickets/gketun-02.md
+++ b/.tickets/gketun-02.md
@@ -1,6 +1,7 @@
 ---
 id: gketun-02
-status: open
+status: closed
+resolved_by: "#59"
 deps: []
 links: [gketun-01, gketun-03]
 created: 2026-06-03T00:00:00Z
@@ -45,3 +46,7 @@ Under `network: none` (reverse-tunnel topology), set the spoke's Qdrant and
 Firecrawl URLs to the tunnel-forwarded localhost ports
 (`127.0.0.1:16333` / `127.0.0.1:13002`) rather than the hub FQDN — mirroring how
 `MAC_HUB_URL` already uses `127.0.0.1:18789`.
+
+## Resolution
+
+Resolved by #59 (network=none spokes use the tunnel-forwarded `127.0.0.1:16333`/`:13002` instead of the hub FQDN). Validated: the worker agent self-test's qdrant/firecrawl checks pass through the tunnel.

--- a/.tickets/gketun-03.md
+++ b/.tickets/gketun-03.md
@@ -1,6 +1,7 @@
 ---
 id: gketun-03
-status: open
+status: closed
+resolved_by: "#59"
 deps: [gketun-02]
 links: [gketun-01, gketun-02]
 created: 2026-06-03T00:00:00Z
@@ -32,3 +33,7 @@ clean self-test (vs. a separate auth/endpoint problem in the register call).
 
 A fresh `network: none` spoke, after deploy, appears in the hub `/agents` list
 with a healthy status, without manual intervention.
+
+## Resolution
+
+Resolved by #59 via [[gketun-02]]. Validated: all three jordanh-GKE agents (jordanh-hub, jordanh-worker1, jordanh-worker2) registered `idle` from a clean redeploy, unaided.

--- a/.tickets/slackhome-01.md
+++ b/.tickets/slackhome-01.md
@@ -1,0 +1,41 @@
+---
+id: slackhome-01
+status: open
+deps: []
+links: [gketun-03]
+created: 2026-06-03T00:00:00Z
+type: enhancement
+priority: 3
+audit: rocky-home-channel-regression
+discovered_via: rocky-home-channel-fix
+---
+# Slack home-channel delivery is single-workspace (only homes[0] is applied)
+
+## Context
+
+#60 fixed the *false* "No home channel is set" prompt — it now respects a
+config-set home channel rather than the retired `SLACK_HOME_CHANNEL` env var. But
+the underlying home-channel **application** is still single-workspace:
+`src/mac/_hermes/gateway/config.py` `_slack_home_from_resolved_file` returns only
+`homes[0]` and sets a single `config.platforms[Platform.SLACK].home_channel`, and
+`get_home_channel(SLACK)` returns that one channel.
+
+The deploy resolves a home channel **per workspace** into
+`slack_home_channels.json` (e.g. rocky has two: `offtera` team `THJ9A47K3` and
+`omgjkh` team `TE0V8MBEJ`, both `#rockyandfriends`). With a single applied home
+channel, cron-job results and cross-platform messages are delivered to the first
+workspace's channel only; the second workspace's resolved home channel is never
+used for delivery.
+
+## Proposed fix
+
+Make Slack home-channel resolution per-workspace (keyed by `team_id`): the
+gateway should consult `slack_home_channels.json` (which already carries
+`team_id` per entry) for the relevant workspace when delivering, instead of a
+single global `home_channel`. Likely needs per-account home channels on the Slack
+`PlatformConfig` (or a `team_id -> channel` map consulted at send time).
+
+## Acceptance
+
+Cron / cross-platform delivery reaches the configured home channel in **each**
+connected Slack workspace, not just the first one in `slack_home_channels.json`.


### PR DESCRIPTION
Tickets-only housekeeping.

- **Close `gketun-01/02/03`** — the network=none reverse-tunnel fixes landed in #59 and were validated by a clean jordanh-GKE redeploy: all three agents (`jordanh-hub`, `jordanh-worker1`, `jordanh-worker2`) registered `idle`, unaided. Each gets a `## Resolution` note + `resolved_by: "#59"`.
- **File `slackhome-01`** (enhancement) — #60 fixed the false "No home channel is set" prompt, but Slack home-channel *delivery* is still single-workspace (`_slack_home_from_resolved_file` applies only `homes[0]`). Per-workspace cron/cross-platform delivery (keyed by `team_id`) is tracked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)