### PR TITLE
feat(skills): fleet-wide nvidia-inference-multimodal skill (vision + image-gen)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -2732,6 +2732,22 @@ sync_hermes_chat_config() {
     || log "WARNING: hermes chat config sync failed; agent chat self-test may stay degraded"
 }
 
+install_fleet_skills() {
+  # Fleet-wide (no GPU gate): these skills drive the hub's hosted models through
+  # the in-mac router (vision + image generation), so every agent benefits — no
+  # local GPU needed. Re-copied each deploy → durable + repeatable. Non-fatal.
+  local src="$SRC_DIR/deploy/skills/fleet"
+  local skills_dir="$HOME/.hermes/skills"
+  [ -d "$src" ] || return 0
+  mkdir -p "$skills_dir"
+  local n=0 d
+  for d in "$src"/*/; do
+    [ -f "$d/SKILL.md" ] || continue
+    cp -r "$d" "$skills_dir/" && n=$((n + 1))
+  done
+  log "fleet skills installed on $AGENT: $n skill(s) under $skills_dir"
+}
+
 install_omniverse_gpu_skills() {
   # GPU-only: the vendored NVIDIA Omniverse + physical-AI agent skills (and our
   # omniverse-kit-app build skill) are only useful where the Kit SDK / CUDA can
@@ -3336,6 +3352,7 @@ initialize_hermes_home
 ensure_hermes_identity_memory_continuity
 apply_hermes_gateway_runtime_shim
 sync_hermes_chat_config
+install_fleet_skills
 install_omniverse_gpu_skills
 install_hermes_web_deps
 install_hermes_messaging_deps

--- a/deploy/skills/README.md
+++ b/deploy/skills/README.md
@@ -31,3 +31,13 @@ done
 tar xzf deploy/skills/omniverse-skills.tar.gz -C /tmp/omv-stage omniverse-kit-app 2>/dev/null || true
 tar czf deploy/skills/omniverse-skills.tar.gz -C /tmp/omv-stage .
 ```
+
+## Fleet-wide skills (`fleet/`, no GPU gate)
+
+`deploy/skills/fleet/<skill>/` is installed into `$HOME/.hermes/skills` on **every**
+agent by `install_fleet_skills` — these drive the hub's hosted models via the
+in-mac router and need no local GPU:
+
+- `nvidia-inference-multimodal` — vision (send images in chat) + image generation
+  (`/v1/genai` proxy). Image-gen needs the hub's `nvidia-image` key to have public
+  image-API (`ai.api.nvidia.com`) access; the internal chat-gateway key returns 401.

--- a/deploy/skills/fleet/nvidia-inference-multimodal/SKILL.md
+++ b/deploy/skills/fleet/nvidia-inference-multimodal/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: nvidia-inference-multimodal
+description: "Go beyond text: understand images (vision) and generate images via the NVIDIA inference hub through the in-mac router. Use when a task involves looking at an image/screenshot or producing an image — no local GPU needed (routes to hosted models)."
+version: "0.1.0"
+license: Apache-2.0
+platforms: [linux, macos, windows]
+tools:
+  - Read
+  - Shell
+metadata:
+  author: mac fleet (jordanh)
+  tags: [nvidia, inference, multimodal, vision, vlm, image-generation, sdxl, flux, router]
+  hermes:
+    tags: [vision, image, multimodal, image-gen, nvidia, router]
+    related_skills: [omniverse-realtime-viewer]
+---
+
+# NVIDIA inference: vision + image generation (via the in-mac router)
+
+The fleet's chat already routes through the in-mac router (`/v1/chat/completions`)
+to the NVIDIA inference hub, and the hub hosts many model *types* (chat, vision,
+text-to-image, embeddings, …). This is a **routing** capability — you do **not**
+need a local GPU or a local Stable Diffusion install; you call the router and it
+forwards to NVIDIA's hosted models.
+
+Call the router at the hub URL with the mac bearer:
+- URL base: `${MAC_HUB_URL:-http://127.0.0.1:8789}`  (spokes reach the hub via this)
+- Auth header: `Authorization: Bearer $MAC_API_TOKEN`
+
+## 1) Understand an image (vision / VLM) — works today
+The routed chat model is multimodal, so send the image as message content. Use a
+`data:` URL (base64) for local files, or an `http(s)` URL the model can fetch.
+
+```bash
+B64=$(base64 -w0 path/to/image.png)
+curl -s -X POST "$MAC_HUB_URL/v1/chat/completions" \
+  -H "Authorization: Bearer $MAC_API_TOKEN" -H 'Content-Type: application/json' \
+  -d "{\"model\":\"*\",\"max_tokens\":300,\"messages\":[{\"role\":\"user\",\"content\":[
+        {\"type\":\"text\",\"text\":\"Describe this image.\"},
+        {\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,$B64\"}}]}]}"
+```
+`"model":"*"` lets the router pick the configured chat model (it's vision-capable).
+Verified: the chat path returns 200 and analyzes the image.
+
+## 2) Generate an image (text-to-image) — proxy wired; needs an image-capable key
+POST to the router's image proxy `POST /v1/genai/<model>`; it forwards to NVIDIA's
+hosted image models. Two common ones:
+
+```bash
+# SDXL-Turbo (fast)
+curl -s -X POST "$MAC_HUB_URL/v1/genai/stabilityai/sdxl-turbo" \
+  -H "Authorization: Bearer $MAC_API_TOKEN" -H 'Accept: application/json' -H 'Content-Type: application/json' \
+  -d '{"text_prompts":[{"text":"a red cube on a white table"}],"steps":2,"seed":0}' -o out.json
+
+# FLUX.1-schnell (higher quality)
+curl -s -X POST "$MAC_HUB_URL/v1/genai/black-forest-labs/flux.1-schnell" \
+  -H "Authorization: Bearer $MAC_API_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"prompt":"a red cube on a white table","steps":4,"seed":0}' -o out.json
+```
+The response carries the image as base64 (e.g. `artifacts[].base64` for SDXL, or an
+`image`/`b64_json` field); decode it to a `.png`:
+```bash
+python3 -c "import json,base64,sys; d=json.load(open('out.json'));
+import re; b=(d.get('artifacts') or [{}])[0].get('base64') or d.get('image') or d.get('b64_json');
+open('out.png','wb').write(base64.b64decode(b)) if b else sys.exit('no image in response: '+str(d)[:200])"
+```
+
+### If image-gen returns HTTP 401 "Authentication failed"
+The hub's **`nvidia-image`** vault key lacks access to the public image API
+(`ai.api.nvidia.com`). The internal chat-gateway key does **not** cover it. Fix:
+escrow a `build.nvidia.com` personal API key (`nvapi-…`) with image-model access
+as the `nvidia-image` secret on the hub (the deploy escrows `NVIDIA_API_KEY` →
+`nvidia-image`; provide an image-capable key, or `mac secret create nvidia-image`).
+No code change is needed — the proxy + format above are already correct.
+
+## When you'd run a model locally instead
+Only for models not on the hub, data that can't leave (privacy), very high
+throughput, or custom/fine-tuned models — then a GPU node can host a NIM / vLLM /
+diffusion service. For the standard set above, the router + hub cover it.

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -876,8 +876,8 @@ def test_omniverse_gpu_skills_installed_only_on_gpu_nodes():
     assert "nvidia-smi -L" in fn  # GPU gate
     assert 'deploy/skills/omniverse-skills.tar.gz' in fn
     assert '"$HOME/.hermes/skills"' in fn
-    # invoked in the agent setup flow
-    assert "\nsync_hermes_chat_config\ninstall_omniverse_gpu_skills\n" in script
+    # invoked in the agent setup flow (right after the fleet-wide skill install)
+    assert "\ninstall_fleet_skills\ninstall_omniverse_gpu_skills\n" in script
 
 
 def test_reverse_tunnel_program_keeps_retrying_until_key_authorized():

--- a/tests/test_fleet_skills.py
+++ b/tests/test_fleet_skills.py
@@ -1,0 +1,35 @@
+"""The nvidia-inference-multimodal skill ships fleet-wide (no GPU gate) via the
+deploy: vision + image generation route to the hub's hosted models through the
+in-mac router, so every agent gets it without a local GPU. install_fleet_skills
+copies deploy/skills/fleet/* into ~/.hermes/skills on every deploy."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "deploy" / "skills" / "fleet" / "nvidia-inference-multimodal" / "SKILL.md"
+
+
+def test_multimodal_skill_present_and_well_formed():
+    assert SKILL.exists(), "deploy/skills/fleet/nvidia-inference-multimodal/SKILL.md must exist"
+    text = SKILL.read_text(encoding="utf-8")
+    fm = yaml.safe_load(text.split("---\n", 2)[1])
+    assert fm["name"] == "nvidia-inference-multimodal"
+    assert "image" in fm["description"].lower() and "vision" in fm["description"].lower()
+    # the verified recipes + key caveat
+    assert "/v1/chat/completions" in text and "image_url" in text
+    assert "/v1/genai/" in text
+    assert "401" in text and "nvidia-image" in text
+
+
+def test_fleet_skills_installed_for_every_agent():
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    fn = script.split("install_fleet_skills() {", 1)[1].split("\ninstall_omniverse_gpu_skills() {", 1)[0]
+    # fleet-wide: must NOT be GPU-gated, copies the deploy/skills/fleet assets
+    assert "nvidia-smi" not in fn
+    assert 'deploy/skills/fleet' in fn
+    assert '"$HOME/.hermes/skills"' in fn
+    # invoked in the agent setup flow, before the GPU-only omniverse install
+    assert "\nsync_hermes_chat_config\ninstall_fleet_skills\ninstall_omniverse_gpu_skills\n" in script


### PR DESCRIPTION
Wires the "create images / handle more than text" capability into the agents.

## Findings (verified live on the hub)
- **Vision / VLM routing already works** — the routed chat model is multimodal; a `/v1/chat/completions` request with `image_url` content returned **200** and analyzed the image. No routing change needed.
- **Image generation is wired except the key** — the router's `/v1/genai` proxy + the correct NVIDIA format (`stabilityai/sdxl-turbo` with `text_prompts`, FLUX with `prompt`) reach NVIDIA, but the `nvidia-image` vault key (the *internal* `inference-api` gateway key) returns **401** at the public image API (`ai.api.nvidia.com`). Enabling image-gen is a **key/escrow** step (escrow a `build.nvidia.com` nvapi key as `nvidia-image`) — no code change.

## What ships
- `deploy/skills/fleet/nvidia-inference-multimodal/SKILL.md` — vision + image-gen recipes via the in-mac router, with the verified key caveat.
- `install_fleet_skills()` — copies `deploy/skills/fleet/*` into `$HOME/.hermes/skills` on **every** agent, every deploy (durable + repeatable, no GPU gate — these route to the hub). Distinct from the GPU-only `install_omniverse_gpu_skills`.

## Test
Skill frontmatter + recipes; `install_fleet_skills` is ungated, copies the fleet assets, runs before the GPU-only omniverse install. 50 deploy tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)