### PR TITLE
feat(router): speech (ASR/TTS) + video proxies; cluster-init for per-modality URL+key

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -896,6 +896,20 @@ deploy_host() {
   add_remote_env MAC_DEPLOY_ROUTER_PROVIDERS "$router_providers"
   add_remote_env MAC_DEPLOY_ROUTER_DEFAULT_MODEL "$router_default_model"
   add_remote_env MAC_DEPLOY_ROUTER_WILDCARD_MODELS "$router_wildcard_models"
+  # Modality reverse-proxy upstreams + keys (image/audio/video), supplied at
+  # cluster init and DISTINCT from the chat key. The image upstream defaults in
+  # deploy_env; audio/video are wired only when an upstream is configured. Keys
+  # are escrowed on the HUB only — blank for inproc spokes (they route via the hub).
+  add_remote_env MAC_DEPLOY_ROUTER_IMAGE_UPSTREAM "${MAC_DEPLOY_ROUTER_IMAGE_UPSTREAM:-}"
+  add_remote_env MAC_DEPLOY_ROUTER_AUDIO_UPSTREAM "${MAC_DEPLOY_ROUTER_AUDIO_UPSTREAM:-}"
+  add_remote_env MAC_DEPLOY_ROUTER_VIDEO_UPSTREAM "${MAC_DEPLOY_ROUTER_VIDEO_UPSTREAM:-}"
+  local img_key="${NVIDIA_IMAGE_API_KEY:-}" aud_key="${NVIDIA_AUDIO_API_KEY:-}" vid_key="${NVIDIA_VIDEO_API_KEY:-}"
+  if [ "$agent" != "$shared_services_manager" ] && [ "$router_backend_lc" = "inproc" ]; then
+    img_key="" ; aud_key="" ; vid_key=""
+  fi
+  add_remote_env NVIDIA_IMAGE_API_KEY "$img_key"
+  add_remote_env NVIDIA_AUDIO_API_KEY "$aud_key"
+  add_remote_env NVIDIA_VIDEO_API_KEY "$vid_key"
   add_remote_env NVIDIA_API_KEY "$nvidia_api_key"
   add_remote_env NVIDIA_API_BASE "$nvidia_api_base"
   add_remote_env NVIDIA_BASE_URL "$nvidia_base_url"
@@ -3547,23 +3561,28 @@ for chunk in providers.split(";"):
         continue
     post_secret(name, value, ["router-upstream"])
     escrowed += 1
-# Image-gen key: the hub /v1/genai proxy resolves MAC_ROUTER_IMAGE_KEY
-# (secret:<name>) from the vault. Escrow NVIDIA_API_KEY there (the same NVIDIA
-# account key, which must have image-NIM access). MAC_ROUTER_IMAGE_KEY is read
-# from the freshly written mac.env (reload_mac_env ran before this step).
-image_key_spec = (os.environ.get("MAC_ROUTER_IMAGE_KEY") or "").strip()
-if image_key_spec.startswith("secret:"):
-    iname = image_key_spec[len("secret:"):]
-    ivalue = (os.environ.get("NVIDIA_API_KEY") or "").strip()
-    if iname in have:
-        print("escrow: %r already in vault; skip" % iname)
-        skipped += 1
-    elif not ivalue:
-        print("escrow: NVIDIA_API_KEY empty/unset for image secret %r; skip" % iname)
-        skipped += 1
+# Modality upstream keys: the hub's /v1/{genai,audio,video} proxies resolve
+# MAC_ROUTER_<M>_KEY (secret:<name>) from the vault. The IMAGE key is DISTINCT from
+# the chat key — prefer NVIDIA_IMAGE_API_KEY (supplied at cluster init), fall back
+# to NVIDIA_API_KEY for back-compat; audio/video use their own keys. MAC_ROUTER_<M>_KEY
+# is read from the freshly written mac.env (reload_mac_env ran before this step).
+for _modality, _spec_env, _src in (
+    ("image", "MAC_ROUTER_IMAGE_KEY",
+     os.environ.get("NVIDIA_IMAGE_API_KEY") or os.environ.get("NVIDIA_API_KEY") or ""),
+    ("audio", "MAC_ROUTER_AUDIO_KEY", os.environ.get("NVIDIA_AUDIO_API_KEY") or ""),
+    ("video", "MAC_ROUTER_VIDEO_KEY", os.environ.get("NVIDIA_VIDEO_API_KEY") or ""),
+):
+    _spec = (os.environ.get(_spec_env) or "").strip()
+    if not _spec.startswith("secret:"):
+        continue
+    _name = _spec[len("secret:"):]
+    _value = _src.strip()
+    if _name in have:
+        print("escrow: %r already in vault; skip" % _name); skipped += 1
+    elif not _value:
+        print("escrow: no source key for %s secret %r; skip" % (_modality, _name)); skipped += 1
     else:
-        post_secret(iname, ivalue, ["router-upstream", "image"])
-        escrowed += 1
+        post_secret(_name, _value, ["router-upstream", _modality]); escrowed += 1
 print("router key escrow: %d escrowed, %d skipped" % (escrowed, skipped))
 PY
   then

--- a/deploy/skills/fleet/nvidia-inference-multimodal/SKILL.md
+++ b/deploy/skills/fleet/nvidia-inference-multimodal/SKILL.md
@@ -70,6 +70,26 @@ Notes:
   a `build.nvidia.com` image key. It is set on this fleet; if it regresses,
   re-escrow a `build.nvidia.com` `nvapi-…` key as the `nvidia-image` secret.
 
+## 3) Speech (ASR/TTS) and video — when configured
+The hub also proxies `POST /v1/audio/{path}` and `POST /v1/video/{path}` to
+configurable upstreams, wired only when the operator set them at cluster init
+(separate URL + key per modality). If configured:
+```bash
+# Speech-to-text (ASR)
+curl -s -X POST "$MAC_HUB_URL/v1/audio/transcriptions" \
+  -H "Authorization: Bearer $MAC_API_TOKEN" -F file=@clip.wav -F model=<asr-model>
+# Text-to-speech (TTS)
+curl -s -X POST "$MAC_HUB_URL/v1/audio/synthesize" \
+  -H "Authorization: Bearer $MAC_API_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"text":"hello","voice":"<voice>"}' -o speech.wav
+# Video generation
+curl -s -X POST "$MAC_HUB_URL/v1/video/<org>/<model>" \
+  -H "Authorization: Bearer $MAC_API_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"prompt":"a drone shot over a forest","seed":0}' -o out.json
+```
+A **404** on these means the modality isn't configured on this hub yet — the
+operator sets `router.audio` / `router.video` (URL + key) at init.
+
 ## When you'd run a model locally instead
 Only for models not on the hub, data that can't leave (privacy), very high
 throughput, or custom/fine-tuned models — then a GPU node can host a NIM / vLLM /

--- a/scripts/setup-fleet.py
+++ b/scripts/setup-fleet.py
@@ -543,6 +543,33 @@ def _setup_hub(args: argparse.Namespace, fleets_config: Path, env_file: Path, ru
     print("  MAC_ROUTER_BACKEND=inproc")
     print("  providers: %s" % (env_values["MAC_ROUTER_PROVIDERS"] or "(none)"))
     print("  (set MAC_ROUTER_DEFAULT_MODEL in %s if your gateway model is '*')" % env_file)
+    # Optional modality reverse-proxies: image generation (+ speech ASR/TTS, video).
+    # These use an endpoint + key DISTINCT from the chat/OpenAI key (hosted image/
+    # speech/video NIMs have separate endpoints + keys). All optional — blank to
+    # skip. The hub escrows the key as secret:nvidia-<m>; spokes route via the hub.
+    # Interactive-only (a tty); automation should set router.{image,audio,video} in
+    # the --spec so input alignment can't drift.
+    if sys.stdin.isatty():
+        print("")
+        print("Optional generative modalities (separate URL + key from the chat key):")
+        for modality, default_url in (
+            ("image", "https://ai.api.nvidia.com/v1/genai"),
+            ("audio", ""),
+            ("video", ""),
+        ):
+            try:
+                key = input("  %s-gen API key (build.nvidia.com nvapi-… ; blank to skip): " % modality).strip()
+            except EOFError:
+                break
+            if not key:
+                continue
+            url = input("  %s-gen upstream URL [%s]: " % (modality, default_url or "(required)")).strip() or default_url
+            if not url:
+                print("  Skipped %s — no URL." % modality)
+                continue
+            env_values["NVIDIA_%s_API_KEY" % modality.upper()] = key
+            env_values["MAC_DEPLOY_ROUTER_%s_UPSTREAM" % modality.upper()] = url
+            print("  Wired %s-gen → %s (key escrowed as secret:nvidia-%s on the hub)." % (modality, url, modality))
     if prompt_bool("Generate MAC_SECRET_KEY in %s?" % env_file, default=True):
         env_values["MAC_SECRET_KEY"] = secrets.token_urlsafe(48)
     if prompt_bool("Generate MAC_API_TOKEN in %s?" % env_file, default=True):

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -36,6 +36,10 @@ ROUTER_KEYS = (
     "MAC_ROUTER_IMAGE_UPSTREAM",
     "MAC_ROUTER_IMAGE_KEY",
     "MAC_ROUTER_IMAGE_TIMEOUT",
+    "MAC_ROUTER_AUDIO_UPSTREAM",
+    "MAC_ROUTER_AUDIO_KEY",
+    "MAC_ROUTER_VIDEO_UPSTREAM",
+    "MAC_ROUTER_VIDEO_KEY",
 )
 
 GATEWAY_ROUTING_KEYS = (
@@ -435,11 +439,24 @@ def _apply_inproc_router_hub(
             values["OPENAI_API_KEY"] = local_token
             values["MAC_HERMES_GATEWAY_API_KEY"] = local_token
             values["ACC_HERMES_GATEWAY_API_KEY"] = local_token
-    if (env.get("NVIDIA_API_KEY") or "").strip():
-        values["MAC_ROUTER_IMAGE_UPSTREAM"] = (
-            env.get("MAC_DEPLOY_ROUTER_IMAGE_UPSTREAM") or "https://ai.api.nvidia.com/v1/genai"
-        )
-        values["MAC_ROUTER_IMAGE_KEY"] = "secret:nvidia-image"
+    # Modality reverse-proxies (image/audio/video): set the upstream + vault key
+    # ref when a key for that modality is available. The image key is DISTINCT
+    # from the chat key — prefer NVIDIA_IMAGE_API_KEY (set at cluster init), fall
+    # back to NVIDIA_API_KEY for back-compat. Audio/video have no default upstream
+    # (hosted paths vary) — wired only when configured at init via
+    # MAC_DEPLOY_ROUTER_<M>_UPSTREAM. The key VALUE is escrowed separately
+    # (deploy escrow → secret:nvidia-<m>).
+    _modalities = (
+        ("image", "https://ai.api.nvidia.com/v1/genai",
+         (env.get("NVIDIA_IMAGE_API_KEY") or env.get("NVIDIA_API_KEY") or "").strip()),
+        ("audio", "", (env.get("NVIDIA_AUDIO_API_KEY") or "").strip()),
+        ("video", "", (env.get("NVIDIA_VIDEO_API_KEY") or "").strip()),
+    )
+    for _m, _default_upstream, _key_present in _modalities:
+        _up = (env.get("MAC_DEPLOY_ROUTER_%s_UPSTREAM" % _m.upper()) or _default_upstream).strip()
+        if _up and _key_present:
+            values["MAC_ROUTER_%s_UPSTREAM" % _m.upper()] = _up
+            values["MAC_ROUTER_%s_KEY" % _m.upper()] = "secret:nvidia-%s" % _m
 
 
 def _apply_inproc_router_spoke(values: MutableMapping[str, str], cfg: DeployEnvConfig) -> None:

--- a/src/mac/fleet_setup.py
+++ b/src/mac/fleet_setup.py
@@ -420,6 +420,23 @@ def _router_env(
     default_model = _str(router.get("default_model"))
     if default_model:
         provider_env_values["MAC_ROUTER_DEFAULT_MODEL"] = default_model
+    # Modality reverse-proxies (image/audio/video): each takes an optional upstream
+    # URL + a key DISTINCT from the chat/OpenAI key (hosted image/speech/video NIMs
+    # use separate endpoints + keys). The url -> MAC_DEPLOY_ROUTER_<M>_UPSTREAM; the
+    # key -> NVIDIA_<M>_API_KEY (inline, else read from the environment). The hub
+    # escrows it as secret:nvidia-<m>; spokes route through the hub.
+    for modality in ("image", "audio", "video"):
+        block = _mapping(router.get(modality))
+        if not block:
+            continue
+        url = _str(block.get("url") or block.get("upstream"))
+        if url:
+            provider_env_values["MAC_DEPLOY_ROUTER_%s_UPSTREAM" % modality.upper()] = url
+        key_env = _str(block.get("key_env")) or "NVIDIA_%s_API_KEY" % modality.upper()
+        if _str(block.get("key")):
+            provider_env_values[key_env] = _str(block["key"])
+        elif _str(env.get(key_env)):
+            provider_env_values[key_env] = _str(env[key_env])
     backend = _str(router.get("backend")) or "inproc"
     return {"backend": backend, "providers": ";".join(router_specs)}, provider_env_values, required_env, warnings
 

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -355,41 +355,83 @@ def build_proxy_from_env(
     )
 
 
+# Modality reverse-proxies the hub exposes beyond chat/embeddings. Each is a
+# transparent ``POST <prefix>/{path}`` forwarder to a configurable upstream with a
+# vault-resolved key, so spokes route through the HUB and never hold the upstream
+# key locally (Stream B "hub serves them"). Each is INDEPENDENT and gated on its
+# own UPSTREAM+KEY (no-op otherwise) — the upstream URL + key are supplied at
+# cluster init (distinct from the chat/OpenAI key), since hosted paths differ by
+# account/NIM. (name, route_prefix, upstream_env, key_env, timeout_env, default_timeout)
+_MODALITY_PROXIES = (
+    ("image", "/v1/genai", "MAC_ROUTER_IMAGE_UPSTREAM", "MAC_ROUTER_IMAGE_KEY", "MAC_ROUTER_IMAGE_TIMEOUT", 180.0),
+    ("audio", "/v1/audio", "MAC_ROUTER_AUDIO_UPSTREAM", "MAC_ROUTER_AUDIO_KEY", "MAC_ROUTER_AUDIO_TIMEOUT", 120.0),
+    ("video", "/v1/video", "MAC_ROUTER_VIDEO_UPSTREAM", "MAC_ROUTER_VIDEO_KEY", "MAC_ROUTER_VIDEO_TIMEOUT", 600.0),
+)
+
+
+def _mount_one_modality_proxy(
+    app: Any,
+    *,
+    name: str,
+    route_prefix: str,
+    upstream_env: str,
+    key_env: str,
+    timeout_env: str,
+    default_timeout: float,
+    env: Dict[str, str],
+    secret_resolver: Optional[SecretResolver],
+) -> bool:
+    """Mount ``POST {route_prefix}/{path}`` → ``env[upstream_env]`` with the
+    vault key ``env[key_env]`` (``secret:<name>``). The /v1/* prefix is
+    agent-scoped (api._required_scope), so a spoke presents its hub token and the
+    hub swaps in the vault key on the way upstream. No-op if either is unset."""
+    upstream = (env.get(upstream_env) or "").strip().rstrip("/")
+    key_spec = (env.get(key_env) or "").strip()
+    if not upstream or not key_spec:
+        return False
+    try:
+        timeout = float(env.get(timeout_env) or default_timeout)
+    except ValueError:
+        timeout = default_timeout
+    provider = Provider(name=name, base_url=upstream, api_key_env=key_spec)
+    from fastapi.responses import JSONResponse
+
+    @app.post(route_prefix + "/{path:path}")
+    def _proxy(path: str, body: Dict[str, Any]) -> Any:  # noqa: ANN401
+        status, out = urllib_forwarder(
+            provider, "/" + path, body, timeout=timeout, secret_resolver=secret_resolver
+        )
+        return JSONResponse(out if isinstance(out, dict) else {}, status_code=status or 502)
+
+    return True
+
+
 def mount_image_proxy(
     app: Any,
     *,
     env: Optional[Dict[str, str]] = None,
     secret_resolver: Optional[SecretResolver] = None,
 ) -> bool:
-    """Mount ``POST /v1/genai/{path}`` forwarding to an external image backend
-    (e.g. NVIDIA NIM) with a vault-resolved key, so spokes route image generation
-    through the HUB instead of holding the image key locally (Stream B "hub serves
-    them"). Gated on MAC_ROUTER_IMAGE_UPSTREAM + MAC_ROUTER_IMAGE_KEY; no-op
-    otherwise. NIM image-gen is a synchronous POST returning base64 inline, so a
-    transparent reverse-proxy suffices — no async/polling/URL-rewrite. The /v1/*
-    prefix is agent-scoped (api._required_scope), so a spoke presents its hub
-    token and the hub swaps in the vault key (MAC_ROUTER_IMAGE_KEY=secret:<name>)
-    on the way upstream."""
+    """Mount the hub's modality reverse-proxies (image `/v1/genai`, speech
+    `/v1/audio` for ASR/TTS, and video `/v1/video`). Synchronous POSTs returning
+    inline payloads, so transparent reverse-proxies suffice. Returns True if any
+    mounted. Kept named for back-compat; each modality is independently gated."""
     env = env or os.environ
-    upstream = (env.get("MAC_ROUTER_IMAGE_UPSTREAM") or "").strip().rstrip("/")
-    key_spec = (env.get("MAC_ROUTER_IMAGE_KEY") or "").strip()
-    if not upstream or not key_spec:
-        return False
-    try:
-        timeout = float(env.get("MAC_ROUTER_IMAGE_TIMEOUT") or 180.0)
-    except ValueError:
-        timeout = 180.0
-    image_provider = Provider(name="image", base_url=upstream, api_key_env=key_spec)
-    from fastapi.responses import JSONResponse
-
-    @app.post("/v1/genai/{path:path}")
-    def _genai(path: str, body: Dict[str, Any]) -> Any:  # noqa: ANN401
-        status, out = urllib_forwarder(
-            image_provider, "/" + path, body, timeout=timeout, secret_resolver=secret_resolver
-        )
-        return JSONResponse(out if isinstance(out, dict) else {}, status_code=status or 502)
-
-    return True
+    mounted = False
+    for name, route_prefix, upstream_env, key_env, timeout_env, default_timeout in _MODALITY_PROXIES:
+        if _mount_one_modality_proxy(
+            app,
+            name=name,
+            route_prefix=route_prefix,
+            upstream_env=upstream_env,
+            key_env=key_env,
+            timeout_env=timeout_env,
+            default_timeout=default_timeout,
+            env=env,
+            secret_resolver=secret_resolver,
+        ):
+            mounted = True
+    return mounted
 
 
 def mount_router(

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -826,10 +826,12 @@ def test_hub_escrows_router_provider_keys_into_vault():
     assert "WARNING no source env var mapped for provider" in fn
     assert '"http://127.0.0.1:%s/secrets" % port' in fn
     assert '"created_by": "deploy"' in fn
-    # also escrows the image-gen key (NVIDIA_API_KEY -> secret:nvidia-image) so the
-    # hub /v1/genai proxy can resolve it (Phase 1, image-gen via the hub)
-    assert 'image_key_spec = (os.environ.get("MAC_ROUTER_IMAGE_KEY")' in fn
-    assert 'ivalue = (os.environ.get("NVIDIA_API_KEY")' in fn
+    # also escrows the modality-proxy keys (image/audio/video) so the hub's
+    # /v1/{genai,audio,video} proxies can resolve them. The IMAGE key is DISTINCT
+    # from the chat key (NVIDIA_IMAGE_API_KEY, falling back to NVIDIA_API_KEY).
+    assert '"MAC_ROUTER_IMAGE_KEY"' in fn and '"MAC_ROUTER_AUDIO_KEY"' in fn and '"MAC_ROUTER_VIDEO_KEY"' in fn
+    assert 'NVIDIA_IMAGE_API_KEY' in fn and 'NVIDIA_AUDIO_API_KEY' in fn and 'NVIDIA_VIDEO_API_KEY' in fn
+    assert 'post_secret(_name, _value, ["router-upstream", _modality])' in fn
     # failure is loud but non-fatal (chat won't route until the key is escrowed)
     assert "router provider key escrow failed" in fn
     # invoked on the hub after the API is up, before the gateway, in all three

--- a/tests/test_hermes_chat_config.py
+++ b/tests/test_hermes_chat_config.py
@@ -168,3 +168,41 @@ def test_router_env_emits_wildcard_models_from_spec(tmp_path):
     ev = plan["env_values"]
     assert ev["MAC_ROUTER_WILDCARD_MODELS"] == "us/azure/openai/gpt-4.1-mini|azure/openai/gpt-4.1-mini"
     assert ev["MAC_ROUTER_DEFAULT_MODEL"] == "us/azure/openai/gpt-4.1-mini"
+
+
+def test_router_env_emits_modality_upstreams_and_keys_from_spec(tmp_path):
+    # Cluster-init: optional image/audio/video URL + key (DISTINCT from the chat
+    # key) flow to MAC_DEPLOY_ROUTER_<M>_UPSTREAM + NVIDIA_<M>_API_KEY for the
+    # deploy to wire the router proxies + escrow as secret:nvidia-<m>.
+    from pathlib import Path
+
+    from mac.fleet_setup import build_setup_plan
+
+    spec = {
+        "schema": "mac.fleet_setup.v1",
+        "fleet": {"name": "gke", "hub": "gke-hub", "hub_url": "http://gke-hub:8789"},
+        "agents": [{"name": "gke-hub", "target": "horde@gke-hub", "os": "linux"}],
+        "router": {
+            "backend": "inproc",
+            "providers": [{"id": "nvidia", "key_env": "NVIDIA_API_KEY"}],
+            "image": {"url": "https://ai.api.nvidia.com/v1/genai", "key": "nvapi-img"},
+            "audio": {"url": "https://ai.api.nvidia.com/v1/audio", "key": "nvapi-aud"},
+            "video": {"url": "https://video.example/v1/video", "key_env": "MY_VIDEO_KEY"},
+        },
+        "network": {"provider": "none"},
+    }
+    plan = build_setup_plan(
+        spec,
+        root=Path(__file__).resolve().parents[1],
+        fleets_config=tmp_path / "fleets.yaml",
+        env_file=tmp_path / ".env",
+        env={"NVIDIA_API_KEY": "nv-secret", "MY_VIDEO_KEY": "vid-secret"},
+    )
+    assert plan["status"] == "pass"
+    ev = plan["env_values"]
+    assert ev["MAC_DEPLOY_ROUTER_IMAGE_UPSTREAM"] == "https://ai.api.nvidia.com/v1/genai"
+    assert ev["NVIDIA_IMAGE_API_KEY"] == "nvapi-img"  # inline key, distinct from chat key
+    assert ev["MAC_DEPLOY_ROUTER_AUDIO_UPSTREAM"] == "https://ai.api.nvidia.com/v1/audio"
+    assert ev["NVIDIA_AUDIO_API_KEY"] == "nvapi-aud"
+    assert ev["MAC_DEPLOY_ROUTER_VIDEO_UPSTREAM"] == "https://video.example/v1/video"
+    assert ev["MY_VIDEO_KEY"] == "vid-secret"  # key_env read from the environment

--- a/tests/test_router_app.py
+++ b/tests/test_router_app.py
@@ -348,6 +348,52 @@ def test_image_proxy_forwards_to_upstream_with_vault_key(monkeypatch):
     assert captured["auth"] == "Bearer escrowed-image-key"
 
 
+def test_audio_and_video_proxies_forward_to_their_upstreams(monkeypatch):
+    # Speech (ASR/TTS) and video-gen are independent modality proxies, each gated
+    # on its own upstream+key and routing through the hub with a vault key.
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from mac import router_app
+
+    captured = []
+
+    class _Resp:
+        status = 200
+
+        def read(self):
+            return b'{"ok":true}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(
+        router_app.urllib.request, "urlopen",
+        lambda req, timeout=60.0: captured.append((req.full_url, req.headers.get("Authorization"))) or _Resp(),
+    )
+
+    app = FastAPI()
+    env = {
+        "MAC_ROUTER_BACKEND": "inproc",
+        "MAC_ROUTER_AUDIO_UPSTREAM": "https://ai.api.nvidia.com/v1/audio",
+        "MAC_ROUTER_AUDIO_KEY": "secret:nvidia-audio",
+        "MAC_ROUTER_VIDEO_UPSTREAM": "https://ai.api.nvidia.com/v1/video",
+        "MAC_ROUTER_VIDEO_KEY": "secret:nvidia-video",
+    }
+    resolver = {"nvidia-audio": "audio-key", "nvidia-video": "video-key"}.get
+    assert mount_router(app, env=env, secret_resolver=resolver) is True
+
+    client = TestClient(app)
+    assert client.post("/v1/audio/transcriptions", json={"x": 1}).status_code == 200
+    assert client.post("/v1/video/nvidia/cosmos-predict", json={"prompt": "x"}).status_code == 200
+
+    urls = dict(captured)
+    assert urls["https://ai.api.nvidia.com/v1/audio/transcriptions"] == "Bearer audio-key"
+    assert urls["https://ai.api.nvidia.com/v1/video/nvidia/cosmos-predict"] == "Bearer video-key"
+
+
 def test_image_proxy_noop_without_config():
     from fastapi import FastAPI
     from fastapi.testclient import TestClient


### PR DESCRIPTION
Adds the speech + video modality proxies and a cluster-init step that requests the optional per-modality URL + key (distinct from the chat/OpenAI key).

## Router (`router_app.py`)
Generalized the image proxy into three independent modality reverse-proxies, each a transparent `POST` forwarder gated on its own `MAC_ROUTER_<M>_UPSTREAM` + `MAC_ROUTER_<M>_KEY` (no-op otherwise); spokes route through the hub, which swaps in the vault key:
- **image** → `/v1/genai` (FLUX/SDXL)
- **speech** → `/v1/audio` (ASR `/transcriptions`, TTS `/synthesize`)
- **video** → `/v1/video` (e.g. Cosmos)

## Cluster-init: per-modality URL + key (distinct from the chat key)
- `deploy_env.py`: wires image/audio/video upstream+key refs. The **image key is now distinct** from the chat key (`NVIDIA_IMAGE_API_KEY`, falling back to `NVIDIA_API_KEY` for back-compat). Audio/video have no default upstream — wired only when configured.
- **escrow**: escrows `nvidia-image`/`-audio`/`-video` from their own source env vars; upstreams+keys forwarded to the **hub only** (spokes route via the hub).
- `fleet_setup.py`: spec `router.{image,audio,video}: {url, key|key_env}` → the generated env. (Spec/automation path.)
- `setup-fleet.py`: interactive prompts for the optional per-modality URL + key (tty-gated; automation uses the spec).
- skill: documents `/v1/audio` + `/v1/video` usage (404 until configured).

## Tests
Audio/video proxies forward with vault keys; spec modality URL+key flow to the env; escrow covers all three modality keys. **Full suite: 793 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)