### PR TITLE
fix(image-gen): route the NVIDIA image backend through the in-mac router

### DIFF
--- a/src/mac/_hermes/plugins/image_gen/nvidia/__init__.py
+++ b/src/mac/_hermes/plugins/image_gen/nvidia/__init__.py
@@ -52,15 +52,38 @@ DEFAULT_BASE_URL = "https://ai.api.nvidia.com/v1/genai"
 
 
 def _base_url() -> str:
-    """Resolve the genai image base URL (env override, else the public host).
+    """Resolve the genai image base URL.
 
-    NVIDIA's *image* NIMs live under ``ai.api.nvidia.com/v1/genai`` — a
-    different host from the OpenAI-compatible chat base (``NVIDIA_BASE_URL`` /
-    ``integrate.api.nvidia.com``), so we don't reuse that. Override with
-    ``NVIDIA_IMAGE_BASE_URL`` for an on-prem NIM.
+    Default: route through the **in-mac router** like chat does. The agent's
+    gateway base is ``<hub>/v1`` and the router exposes the image proxy at
+    ``/v1/genai`` (``MAC_ROUTER_IMAGE_*``), so the hub's escrowed image key
+    (``secret:nvidia-image`` — distinct from the chat key) is used and spokes
+    route through the hub. ``NVIDIA_IMAGE_BASE_URL`` overrides (on-prem NIM /
+    direct host); falls back to NVIDIA's public host only if no gateway is set.
     """
     raw = (os.environ.get("NVIDIA_IMAGE_BASE_URL") or "").strip()
-    return (raw or DEFAULT_BASE_URL).rstrip("/")
+    if raw:
+        return raw.rstrip("/")
+    gw = (
+        os.environ.get("MAC_HERMES_GATEWAY_BASE_URL")
+        or os.environ.get("OPENAI_BASE_URL")
+        or ""
+    ).strip().rstrip("/")
+    if gw:
+        return gw + "/genai"  # <hub>/v1 -> <hub>/v1/genai (the router image proxy)
+    return DEFAULT_BASE_URL
+
+
+def _bearer() -> str:
+    """The bearer to present. Default to the agent's hub/gateway token (the same
+    one chat uses) so requests go through the router, which swaps in the vault
+    image key. Falls back to a raw NVIDIA key for the direct-host setup."""
+    return (
+        os.environ.get("MAC_HERMES_GATEWAY_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or os.environ.get("NVIDIA_API_KEY")
+        or ""
+    ).strip()
 
 
 # ``endpoint`` is the model path appended to the base URL. ``dialect`` selects
@@ -232,7 +255,10 @@ class NvidiaImageGenProvider(ImageGenProvider):
         return "NVIDIA NIM"
 
     def is_available(self) -> bool:
-        return bool(os.environ.get("NVIDIA_API_KEY"))
+        # Available whenever the agent has a hub/gateway bearer (it routes image-gen
+        # through the in-mac router, which holds the image key) — so it works on
+        # spokes too, where raw provider keys are intentionally absent.
+        return bool(_bearer())
 
     def list_models(self) -> List[Dict[str, Any]]:
         return [
@@ -280,13 +306,14 @@ class NvidiaImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        api_key = os.environ.get("NVIDIA_API_KEY")
+        api_key = _bearer()
         if not api_key:
             return error_response(
                 error=(
-                    "NVIDIA_API_KEY not set. The fleet plumbs this for chat "
-                    "routing; ensure it's present in the agent env and has "
-                    "image-NIM access at build.nvidia.com."
+                    "No gateway bearer available (MAC_HERMES_GATEWAY_API_KEY / "
+                    "OPENAI_API_KEY). Image-gen routes through the in-mac router, "
+                    "which holds the image key — ensure the agent's gateway env "
+                    "is configured (it is, wherever chat works)."
                 ),
                 error_type="auth_required",
                 provider="nvidia",

--- a/src/mac/_hermes/plugins/image_gen/nvidia/plugin.yaml
+++ b/src/mac/_hermes/plugins/image_gen/nvidia/plugin.yaml
@@ -1,7 +1,10 @@
 name: nvidia
 version: 1.0.0
-description: "NVIDIA NIM image generation backend (FLUX.1, SDXL via ai.api.nvidia.com/v1/genai). Saves generated images to $HERMES_HOME/cache/images/."
+description: "NVIDIA NIM image generation (FLUX.1, SDXL). Routes through the in-mac router's /v1/genai proxy by default (uses the hub's escrowed nvidia-image key; works on spokes too), or set NVIDIA_IMAGE_BASE_URL for a direct/on-prem endpoint. Saves images to $HERMES_HOME/cache/images/."
 author: mac
 kind: backend
-requires_env:
-  - NVIDIA_API_KEY
+# No requires_env: a bundled backend auto-loads and is_available() gates at
+# runtime on the gateway bearer (MAC_HERMES_GATEWAY_API_KEY / OPENAI_API_KEY),
+# present wherever chat works — including spokes, where raw provider keys are
+# intentionally absent. Falls back to a direct NVIDIA key if no gateway is set.
+requires_env: []

--- a/tests/test_nvidia_image_gen_plugin.py
+++ b/tests/test_nvidia_image_gen_plugin.py
@@ -1,0 +1,52 @@
+"""The NVIDIA image-gen backend must route through the in-mac router (like chat)
+so it uses the hub's escrowed image key and works on spokes — not hit
+ai.api.nvidia.com directly with the (blanked-on-spokes, image-401) chat key."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERMES = Path(__file__).resolve().parents[1] / "src" / "mac" / "_hermes"
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+
+def test_routes_through_router_with_gateway_bearer(monkeypatch):
+    from plugins.image_gen.nvidia import _base_url, _bearer
+
+    monkeypatch.delenv("NVIDIA_IMAGE_BASE_URL", raising=False)
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)  # blanked on spokes
+    monkeypatch.setenv("MAC_HERMES_GATEWAY_BASE_URL", "http://127.0.0.1:18789/v1")
+    monkeypatch.setenv("MAC_HERMES_GATEWAY_API_KEY", "hub-token")
+
+    # base URL is the router's image proxy (gateway base + /genai); bearer is the
+    # hub token — so the hub swaps in the vault image key.
+    assert _base_url() == "http://127.0.0.1:18789/v1/genai"
+    assert _bearer() == "hub-token"
+
+
+def test_available_on_spoke_without_provider_key(monkeypatch):
+    from plugins.image_gen.nvidia import ImageGenProvider  # type: ignore[attr-defined]
+
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    monkeypatch.setenv("MAC_HERMES_GATEWAY_API_KEY", "hub-token")
+    # provider is discoverable here as a class; instantiate the concrete one
+    import plugins.image_gen.nvidia as nv
+
+    provider = next(
+        obj() for obj in vars(nv).values()
+        if isinstance(obj, type) and getattr(obj, "name", None) is not None
+        and obj.__module__ == nv.__name__
+    )
+    assert provider.is_available() is True
+
+
+def test_direct_host_override_uses_nvidia_key(monkeypatch):
+    from plugins.image_gen.nvidia import _base_url, _bearer
+
+    for k in ("MAC_HERMES_GATEWAY_BASE_URL", "OPENAI_BASE_URL", "MAC_HERMES_GATEWAY_API_KEY", "OPENAI_API_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    monkeypatch.setenv("NVIDIA_IMAGE_BASE_URL", "https://nim.local/v1/genai")
+    monkeypatch.setenv("NVIDIA_API_KEY", "nvapi-direct")
+    assert _base_url() == "https://nim.local/v1/genai"
+    assert _bearer() == "nvapi-direct"


### PR DESCRIPTION
A fleet agent reported image generation "unavailable (no configured backend or API key)" — even though image-gen works at the router level. Root cause: the NVIDIA `image_gen` plugin gated on `NVIDIA_API_KEY` (intentionally **blanked on spokes**) and hit `ai.api.nvidia.com` **directly** with the chat key (401 for images; the image key lives in the **hub vault**, not the agent env).

## Fix — route through the in-mac router (like chat)
- `_base_url()`: default to `<gateway-base>/genai` (`MAC_HERMES_GATEWAY_BASE_URL`/`OPENAI_BASE_URL` → the hub's `/v1/genai` proxy), so the hub's escrowed `nvidia-image` key is used and spokes route through the hub. `NVIDIA_IMAGE_BASE_URL` still overrides for a direct/on-prem endpoint.
- `_bearer()`: present the gateway/hub token, falling back to `NVIDIA_API_KEY` for the direct case.
- `is_available()` gates on the bearer (present wherever chat works, incl. spokes); `plugin.yaml` `requires_env` emptied (bundled backend auto-loads, `is_available()` decides).

## Tests
Routes via gateway base + hub bearer; available on a spoke without a provider key; direct-host override still uses the NVIDIA key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)