### PR TITLE
feat(agents): shared hub task ledger tool for chat personas (tasks-01)

### DIFF
--- a/src/mac/_hermes/tools/fleet_tool.py
+++ b/src/mac/_hermes/tools/fleet_tool.py
@@ -13,8 +13,16 @@ plumbing. Three actions behind one tool:
   fleet message <agent>   → send a quick message to another agent (agentbus)
   fleet inbox             → read recent messages addressed to me (agentbus)
 
-All hub I/O is best-effort + read-mostly; the only write is a point-to-point
-agentbus message the user/agent explicitly sends.
+This module ALSO registers a companion ``tasks`` tool (tasks-01) on the same hub
+plumbing. That one is the chat agent's read/write window onto the SHARED hub task
+ledger — the same durable store the autonomous worker and the ``mac task`` CLI
+use. It exists because the only other task tool a chat agent has is ``todo``,
+which is in-memory and per-session: when one agent "filed tasks for itself" via
+``todo`` the rest of the fleet couldn't see them. ``tasks`` fixes that — work
+filed/claimed/closed there is visible fleet-wide.
+
+The fleet actions are best-effort + read-mostly (the only write is an agentbus
+message); the ``tasks`` tool deliberately writes to the shared ledger.
 """
 
 from __future__ import annotations
@@ -244,4 +252,187 @@ registry.register(
     requires_env=[],
     is_async=False,
     emoji="🛰️",
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared task ledger (tasks-01)
+# ---------------------------------------------------------------------------
+# The chat agent's window onto the SAME hub task store the autonomous worker
+# and the `mac task` CLI use. Unlike `todo` (in-memory, per-session, invisible
+# to others), everything here is durable and visible fleet-wide — so when one
+# agent files or claims work, the rest of the fleet sees it. Reuses the fleet
+# tool's _hub_request / _self_agent_id (same hub URL + token in the agent env).
+
+
+def format_task_list(tasks: List[Dict[str, Any]], limit: int = 40) -> str:
+    """Render the shared backlog compactly (id / state / title / owner)."""
+    if not tasks:
+        return "No tasks on the shared ledger."
+    shown = tasks[:limit]
+    header = "Shared fleet tasks (%d shown%s):" % (
+        len(shown), "" if len(tasks) <= limit else " of %d" % len(tasks))
+    lines = [header]
+    for t in shown:
+        lines.append(
+            "- %s [%s] %s (owner: %s)"
+            % (
+                str(t.get("id") or "?")[:18],
+                t.get("state", "?"),
+                (t.get("title") or "")[:70],
+                t.get("owner_agent_id") or "-",
+            )
+        )
+    return "\n".join(lines)
+
+
+def _action_tasks_list(state: str) -> str:
+    path = "/tasks"
+    if state:
+        path += "?%s" % urlencode({"state": state})
+    tasks = _hub_request("GET", path) or []
+    if not isinstance(tasks, list):
+        tasks = []
+    return format_task_list(tasks)
+
+
+def _action_tasks_create(title: str, description: str, priority: int) -> str:
+    if not title:
+        return tool_error("tasks create requires a title")
+    me = _self_agent_id()
+    payload = {
+        "title": title,
+        "description": description or "",
+        "priority": int(priority or 0),
+        "actor": me or "agent",
+    }
+    t = _hub_request("POST", "/tasks", payload) or {}
+    return json.dumps({
+        "success": True,
+        "task_id": t.get("id"),
+        "state": t.get("state"),
+        "title": t.get("title"),
+        "note": "Filed on the shared fleet ledger — visible to every agent.",
+    })
+
+
+def _action_tasks_claim(task_id: str) -> str:
+    if not task_id:
+        return tool_error("tasks claim requires a task_id")
+    me = _self_agent_id()
+    if not me:
+        return tool_error("cannot determine my own agent id (MAC_AGENT_ID unset)")
+    res = _hub_request(
+        "POST",
+        "/tasks/%s/claim?%s" % (quote(task_id, safe=""), urlencode({"agent_id": me})),
+    ) or {}
+    task = res.get("task") if isinstance(res, dict) else None
+    return json.dumps({
+        "success": True,
+        "claimed": task_id,
+        "owner": me,
+        "state": (task or {}).get("state"),
+    })
+
+
+def _action_tasks_close(task_id: str, cancelled: bool, reason: str) -> str:
+    if not task_id:
+        return tool_error("tasks close requires a task_id")
+    me = _self_agent_id()
+    target = "cancelled" if cancelled else "completed"
+    payload = {
+        "target_state": target,
+        "actor": me or "agent",
+        "detail": {"reason": reason} if reason else {},
+    }
+    res = _hub_request("POST", "/tasks/%s/transition" % quote(task_id, safe=""), payload) or {}
+    return json.dumps({
+        "success": True,
+        "task_id": task_id,
+        "state": res.get("state") or target,
+    })
+
+
+def _action_tasks_show(task_id: str) -> str:
+    if not task_id:
+        return tool_error("tasks show requires a task_id")
+    return json.dumps(_hub_request("GET", "/tasks/%s" % quote(task_id, safe="")) or {})
+
+
+TASKS_SCHEMA = {
+    "name": "tasks",
+    "description": (
+        "The SHARED, fleet-wide task ledger — the same durable store the rest of the "
+        "fleet (and the autonomous worker) sees. Use this, NOT the session-local `todo` "
+        "tool, for any real work that should be tracked, handed off, or visible to other "
+        "agents. Anything you file here, the whole fleet can see and pick up.\n\n"
+        "Actions:\n"
+        "- list:   the shared backlog (optionally filter by state: open / claimed / "
+        "running / needs_review / completed / cancelled)\n"
+        "- create: file a new task (title required) — returns its task_id\n"
+        "- claim:  take ownership of a task so others know you're on it\n"
+        "- close:  finish a task (completed, or cancelled=true to abandon) with an "
+        "optional reason\n"
+        "- show:   full detail of one task\n\n"
+        "Reserve the `todo` tool for private, within-this-conversation scratch steps that "
+        "nobody else needs to see."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list", "create", "claim", "close", "show"],
+                "description": "what to do against the shared ledger",
+            },
+            "title": {"type": "string", "description": "for action=create: the task title"},
+            "description": {"type": "string", "description": "for action=create: longer detail (optional)"},
+            "priority": {"type": "integer", "description": "for action=create: higher = more urgent (default 0)"},
+            "task_id": {"type": "string", "description": "for claim/close/show: the task id"},
+            "state": {"type": "string", "description": "for action=list: optional state filter"},
+            "cancelled": {"type": "boolean", "description": "for action=close: true to cancel/abandon instead of completing (default false)"},
+            "reason": {"type": "string", "description": "for action=close: short reason / outcome note"},
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _handle_tasks(args, **kw):
+    action = str(args.get("action") or "").strip().lower()
+    try:
+        if action == "list":
+            return _action_tasks_list(str(args.get("state") or "").strip())
+        if action == "create":
+            return _action_tasks_create(
+                str(args.get("title") or "").strip(),
+                str(args.get("description") or "").strip(),
+                args.get("priority") or 0,
+            )
+        if action == "claim":
+            return _action_tasks_claim(str(args.get("task_id") or "").strip())
+        if action == "close":
+            return _action_tasks_close(
+                str(args.get("task_id") or "").strip(),
+                bool(args.get("cancelled")),
+                str(args.get("reason") or "").strip(),
+            )
+        if action == "show":
+            return _action_tasks_show(str(args.get("task_id") or "").strip())
+        return tool_error("unknown tasks action %r (use list/create/claim/close/show)" % action)
+    except RuntimeError as exc:
+        return tool_error(str(exc))
+    except Exception as exc:  # noqa: BLE001
+        return tool_error("tasks tool error: %s" % exc)
+
+
+registry.register(
+    name="tasks",
+    toolset="fleet",
+    schema=TASKS_SCHEMA,
+    handler=_handle_tasks,
+    check_fn=check_fleet_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🗂️",
 )

--- a/src/mac/_hermes/tools/todo_tool.py
+++ b/src/mac/_hermes/tools/todo_tool.py
@@ -209,8 +209,12 @@ def check_todo_requirements() -> bool:
 TODO_SCHEMA = {
     "name": "todo",
     "description": (
-        "Manage your task list for the current session. Use for complex tasks "
-        "with 3+ steps or when the user provides multiple tasks. "
+        "Manage your PRIVATE, session-local task list — in-memory scratch for "
+        "decomposing a complex request within THIS conversation. It is NOT shared: "
+        "other agents cannot see it and it is lost when the session ends. For work "
+        "that should be tracked, handed off, or visible to the rest of the fleet, use "
+        "the `tasks` tool (the shared hub ledger) instead. "
+        "Use for complex tasks with 3+ steps or when the user provides multiple tasks. "
         "Call with no parameters to read the current list.\n\n"
         "Writing:\n"
         "- Provide 'todos' array to create/update items\n"

--- a/tests/test_fleet_tasks_tool.py
+++ b/tests/test_fleet_tasks_tool.py
@@ -1,0 +1,111 @@
+"""The `tasks` tool gives a chat agent read/write access to the SHARED hub task
+ledger (so work is visible fleet-wide), unlike the session-local `todo` tool.
+
+These tests drive the tool's action router with a stubbed _hub_request and
+assert it builds the exact requests the hub /tasks API expects."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERMES = Path(__file__).resolve().parents[1] / "src" / "mac" / "_hermes"
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+from tools import fleet_tool  # noqa: E402
+
+
+@pytest.fixture
+def capture(monkeypatch):
+    """Capture (method, path, payload) and return a canned response per path."""
+    calls = []
+
+    def fake_hub_request(method, path, payload=None, **kw):
+        calls.append((method, path, payload))
+        if method == "GET" and (path == "/tasks" or path.startswith("/tasks?")):
+            return [
+                {"id": "task_aaa", "state": "open", "title": "embed API", "owner_agent_id": None},
+                {"id": "task_bbb", "state": "running", "title": "vector math", "owner_agent_id": "rocky"},
+            ]
+        if "/claim" in path:
+            return {"task": {"state": "claimed"}, "lease": {"id": "lease_1"}}
+        if "/transition" in path:
+            return {"state": (payload or {}).get("target_state")}
+        if method == "POST" and path == "/tasks":
+            return {"id": "task_new", "state": "open", "title": (payload or {}).get("title")}
+        return {"id": "task_aaa", "state": "open", "title": "embed API"}
+
+    monkeypatch.setattr(fleet_tool, "_hub_request", fake_hub_request)
+    return calls
+
+
+def test_create_posts_title_and_actor(capture, monkeypatch):
+    monkeypatch.setenv("MAC_AGENT_ID", "rocky")
+    out = json.loads(fleet_tool._handle_tasks(
+        {"action": "create", "title": "Add embedding API", "description": "for dreaming", "priority": 2}))
+    method, path, payload = capture[-1]
+    assert (method, path) == ("POST", "/tasks")
+    assert payload == {"title": "Add embedding API", "description": "for dreaming", "priority": 2, "actor": "rocky"}
+    assert out["success"] and out["task_id"] == "task_new"
+
+
+def test_claim_passes_agent_id_as_query(capture, monkeypatch):
+    monkeypatch.setenv("MAC_AGENT_ID", "natasha")
+    out = json.loads(fleet_tool._handle_tasks({"action": "claim", "task_id": "task_aaa"}))
+    method, path, _ = capture[-1]
+    assert method == "POST"
+    assert path == "/tasks/task_aaa/claim?agent_id=natasha"
+    assert out["owner"] == "natasha" and out["state"] == "claimed"
+
+
+def test_close_completed_vs_cancelled(capture, monkeypatch):
+    monkeypatch.setenv("MAC_AGENT_ID", "rocky")
+    json.loads(fleet_tool._handle_tasks({"action": "close", "task_id": "task_bbb", "reason": "done"}))
+    _, path, payload = capture[-1]
+    assert path == "/tasks/task_bbb/transition"
+    assert payload["target_state"] == "completed" and payload["detail"] == {"reason": "done"}
+
+    json.loads(fleet_tool._handle_tasks({"action": "close", "task_id": "task_bbb", "cancelled": True}))
+    _, _, payload2 = capture[-1]
+    assert payload2["target_state"] == "cancelled" and payload2["detail"] == {}
+
+
+def test_list_renders_shared_backlog(capture):
+    out = fleet_tool._handle_tasks({"action": "list"})
+    assert capture[-1][:2] == ("GET", "/tasks")
+    assert "task_aaa" in out and "[open]" in out and "owner: rocky" in out
+
+
+def test_list_state_filter_is_query(capture):
+    fleet_tool._handle_tasks({"action": "list", "state": "open"})
+    assert capture[-1][1] == "/tasks?state=open"
+
+
+def test_claim_without_agent_id_errors(capture, monkeypatch):
+    monkeypatch.delenv("MAC_AGENT_ID", raising=False)
+    monkeypatch.delenv("MAC_WORKER_AGENT_ID", raising=False)
+    out = fleet_tool._handle_tasks({"action": "claim", "task_id": "task_aaa"})
+    assert "agent id" in out.lower()
+
+
+def test_create_requires_title(capture):
+    out = fleet_tool._handle_tasks({"action": "create", "title": ""})
+    assert "title" in out.lower()
+
+
+def test_check_fn_gates_on_hub_env(monkeypatch):
+    monkeypatch.setenv("MAC_HUB_URL", "http://hub:8789")
+    monkeypatch.setenv("MAC_API_TOKEN", "tok")
+    assert fleet_tool.check_fleet_requirements() is True
+    monkeypatch.delenv("MAC_HUB_URL", raising=False)
+    monkeypatch.delenv("MAC_URL", raising=False)
+    assert fleet_tool.check_fleet_requirements() is False
+
+
+def test_tasks_tool_registered():
+    from tools.registry import registry
+    entry = registry._tools.get("tasks")
+    assert entry is not None and entry.toolset == "fleet"


### PR DESCRIPTION
### Problem
Fleet chat personas weren't working from a shared task list. Rocky "filed tasks for itself" on Slack, but Natasha/Bullwinkle couldn't see them. **Root cause:** the only task tool a chat agent had was `todo` (`tools/todo_tool.py`) — an **in-memory, per-session** `TodoStore`, invisible to other agents and lost at session end. The shared hub `/tasks` ledger (what the autonomous worker and `mac task` CLI use) had **no chat-agent-facing write tool** — the `fleet` tool could only *read* tasks.

### Fix
A new **`tasks`** tool built on the `fleet` tool's existing hub plumbing (`_hub_request` / `_self_agent_id` — same `MAC_HUB_URL` + token already in every agent's env):

| action | hub call |
|---|---|
| `list` | `GET /tasks` (optional `?state=`) |
| `create` | `POST /tasks` (title required; `actor` = agent's own id) |
| `claim` | `POST /tasks/{id}/claim?agent_id=<me>` |
| `close` | `POST /tasks/{id}/transition` → `completed` (or `cancelled=true`), `reason`→`detail` |
| `show` | `GET /tasks/{id}` |

Everything it writes is **durable and visible fleet-wide**.

Behavioural steering via tool descriptions: `tasks` = "shared, use instead of `todo` for anything others should see"; `todo` now explicitly says "private, session-local, not shared."

### Tests
Each action asserts the exact hub request the `/tasks` API expects (create posts title+actor; claim passes `agent_id` as a query param; close maps completed/cancelled + reason→detail; list renders the backlog), hub-env gating, and tool registration. Full suite: **805 passed**.

### Next
Deploy live to rocky/natasha/bullwinkle + verify cross-agent visibility (one agent creates, another lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)