### PR TITLE
adopt low-risk fixes from Vikaspogu/mac fork (router, verdict, outbox, portability, UI)

### DIFF
--- a/src/mac/observability_service.py
+++ b/src/mac/observability_service.py
@@ -338,12 +338,19 @@ class ObservabilityService:
                     "_keys": list(ensure_json_object(detail).keys())[:50],
                 }
             )
-        cursor = conn.execute(
+        # RETURNING is supported by both SQLite (>=3.35, 2021) and Postgres.
+        # Replaces an earlier `cursor.lastrowid` read that worked under
+        # SQLite but broke on Postgres because the PostgresStore _Result
+        # adapter does not expose lastrowid (Postgres has no implicit
+        # last-row-id concept — the sequence value is only available via
+        # RETURNING or LASTVAL(), and RETURNING is portable).
+        result = conn.execute(
             """
             INSERT INTO observability_events (
                 id, kind, layer, source, level, name, subject_type, subject_id,
                 value, unit, detail, created_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            RETURNING sequence
             """,
             (
                 obs_id,
@@ -360,8 +367,12 @@ class ObservabilityService:
                 when,
             ),
         )
+        sequence_row = result.fetchone()
+        if sequence_row is None:
+            raise RuntimeError("INSERT ... RETURNING sequence yielded no row")
+        sequence_value = sequence_row[0] if not hasattr(sequence_row, "keys") else sequence_row["sequence"]
         return ObservabilityEvent(
-            int(cursor.lastrowid),
+            int(sequence_value),
             obs_id,
             kind_value,
             layer_value,

--- a/src/mac/provisioning_service.py
+++ b/src/mac/provisioning_service.py
@@ -85,27 +85,26 @@ class ProvisioningService:
         hardware_obj = ensure_json_object(hardware)
         detail_obj = ensure_json_object(detail)
 
+        # SQLite accepts ``col IS ?`` (matches NULL or value); Postgres
+        # rejects it ("syntax error at or near $N"). Split into IS NULL
+        # vs = ? branches so the SQL works on both backends.
+        clauses = ["status = ?", "reason = ?"]
+        params: List[Any] = [ProvisioningStatus.PENDING.value, reason_value]
+        for col, value in (
+            ("role_slug", role_slug),
+            ("task_id", task_id),
+            ("tenant_id", tenant_id),
+        ):
+            if value is None:
+                clauses.append("%s IS NULL" % col)
+            else:
+                clauses.append("%s = ?" % col)
+                params.append(value)
         existing = self.store.query_one(
-            """
-            SELECT * FROM agent_provisioning_requests
-            WHERE status = ?
-              AND reason = ?
-              AND (role_slug IS ? OR role_slug = ?)
-              AND (task_id IS ? OR task_id = ?)
-              AND (tenant_id IS ? OR tenant_id = ?)
-            ORDER BY created_at DESC, id DESC
-            LIMIT 1
-            """,
-            (
-                ProvisioningStatus.PENDING.value,
-                reason_value,
-                role_slug,
-                role_slug,
-                task_id,
-                task_id,
-                tenant_id,
-                tenant_id,
-            ),
+            "SELECT * FROM agent_provisioning_requests WHERE "
+            + " AND ".join(clauses)
+            + " ORDER BY created_at DESC, id DESC LIMIT 1",
+            tuple(params),
         )
         if existing is not None:
             # Refresh updated_at + detail so subsequent ticks show the

--- a/src/mac/roles_service.py
+++ b/src/mac/roles_service.py
@@ -115,10 +115,16 @@ class RolesService:
             # Resolve to confirm the parent exists in the same tenant.
             parent = self.get_role(reports_to, tenant_id=tenant_id)
             reports_to = parent.id
-        existing = self.store.query_one(
-            "SELECT id FROM agent_roles WHERE slug = ? AND (tenant_id IS ? OR tenant_id = ?)",
-            (slug_value, tenant_id, tenant_id),
-        )
+        if tenant_id is None:
+            existing = self.store.query_one(
+                "SELECT id FROM agent_roles WHERE slug = ? AND tenant_id IS NULL",
+                (slug_value,),
+            )
+        else:
+            existing = self.store.query_one(
+                "SELECT id FROM agent_roles WHERE slug = ? AND tenant_id = ?",
+                (slug_value, tenant_id),
+            )
         if existing is not None and role_id is None:
             role_id = existing["id"]
         rid = role_id or new_id("role")

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -163,6 +163,7 @@ class ProviderProxy:
         breaker. Returns ``(status, body_or_iterator)``."""
         candidates = self._candidate_models(payload)
         last: Optional[Tuple[int, Any]] = None
+        retried_401 = False  # per-request: at most one transient-401 retry
         for idx, model in enumerate(candidates):
             is_last = idx == len(candidates) - 1
             outgoing = {**payload, "model": model}
@@ -184,6 +185,15 @@ class ProviderProxy:
                 self._router.record_success(provider.name)
                 provider_answered = True
                 logger.info("route model=%s provider=%s status=%s", model, provider.name, status)
+                # A 401 from upstream is usually a real auth problem, but some
+                # gateways briefly mislabel a transient backend hiccup (e.g.
+                # "can't reach key-verification DB") as 401. One same-provider
+                # retry turns that seconds-long blip into a non-event; a genuine
+                # bad key 401s again and is returned. Bounded to a single retry.
+                if int(status) == 401 and not retried_401:
+                    retried_401 = True
+                    logger.info("route model=%s provider=%s status=401 transient-retry", model, provider.name)
+                    status, obj = forward(provider, path, outgoing, timeout=timeout)
                 if int(status) in _MODEL_RETRY_CODES and not is_last:
                     last = (int(status), obj)  # this model is unusable; substitute the next
                     break

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -119,6 +119,25 @@ def _is_provider_failure(status: Optional[int]) -> bool:
 _MODEL_RETRY_CODES = frozenset({404, 422})
 
 
+# th-merge: params some OpenAI-compatible upstreams reject with
+# 400 "unknown_parameter" (e.g. opencode sends `reasoningSummary` for GPT-5
+# reasoning models). The router is the single chokepoint that sanitizes the
+# request body, so no per-agent config has to know each upstream's quirks.
+# Overridable via MAC_ROUTER_DROP_PARAMS (comma-separated) at build time.
+_DEFAULT_DROP_PARAMS = ("reasoningSummary", "reasoning_summary")
+
+
+def _normalize_payload(payload: Dict[str, Any], drop_params: Tuple[str, ...]) -> Dict[str, Any]:
+    """Strip known-unsupported top-level params before forwarding upstream.
+    Leaves everything else untouched. Returns a new dict (does not mutate)."""
+    if not drop_params:
+        return payload
+    drop = set(drop_params)
+    if not any(k in payload for k in drop):
+        return payload
+    return {k: v for k, v in payload.items() if k not in drop}
+
+
 class ProviderProxy:
     def __init__(
         self,
@@ -130,6 +149,7 @@ class ProviderProxy:
         wildcard_models: Tuple[str, ...] = (),
         timeout: float = 60.0,
         stream_timeout: float = 300.0,
+        drop_params: Tuple[str, ...] = _DEFAULT_DROP_PARAMS,
     ) -> None:
         self._router = router
         self._forward = forward_fn
@@ -140,6 +160,7 @@ class ProviderProxy:
         self._wildcard_models = tuple(m for m in wildcard_models if m)
         self._timeout = timeout
         self._stream_timeout = stream_timeout
+        self._drop_params = tuple(drop_params)
 
     # -- model resolution ----------------------------------------------------
 
@@ -166,7 +187,7 @@ class ProviderProxy:
         retried_401 = False  # per-request: at most one transient-401 retry
         for idx, model in enumerate(candidates):
             is_last = idx == len(candidates) - 1
-            outgoing = {**payload, "model": model}
+            outgoing = {**_normalize_payload(payload, self._drop_params), "model": model}
             attempts = []
             provider_answered = False
             # Bounded: one try per provider (+1 so a half-open probe can be
@@ -354,6 +375,12 @@ def build_proxy_from_env(
     wildcard_models = tuple(
         m.strip() for m in (env.get("MAC_ROUTER_WILDCARD_MODELS") or "").split("|") if m.strip()
     )
+    drop_raw = env.get("MAC_ROUTER_DROP_PARAMS")
+    drop_params = (
+        tuple(p.strip() for p in drop_raw.split(",") if p.strip())
+        if drop_raw is not None
+        else _DEFAULT_DROP_PARAMS
+    )
     return ProviderProxy(
         router,
         _fwd,
@@ -362,6 +389,7 @@ def build_proxy_from_env(
         wildcard_models=wildcard_models,
         timeout=_f("MAC_ROUTER_TIMEOUT", 60.0),
         stream_timeout=_f("MAC_ROUTER_STREAM_TIMEOUT", 300.0),
+        drop_params=drop_params,
     )
 
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -12550,7 +12550,10 @@ class ControlPlane:
     def _verdict_value(self, evidence: Evidence) -> str:
         manifest = evidence.metadata.get("verification") or {}
         verdict = str(manifest.get("verdict") or "").strip().lower()
-        return verdict if verdict in {"approved", "rejected"} else "approved"
+        # Fail closed: an unknown/malformed verdict must NOT auto-approve.
+        # (Adopted from Vikaspogu/mac 7b02877; the rejected-requires-feedback
+        # validator from that commit is intentionally left out for now.)
+        return verdict if verdict in {"approved", "rejected"} else "rejected"
 
     def _retract_default_review(self, review: Review, actor: str, reason: str) -> None:
         now = utcnow()

--- a/src/mac/task_lifecycle.py
+++ b/src/mac/task_lifecycle.py
@@ -1,8 +1,26 @@
 from __future__ import annotations
 
+import itertools
+import threading
 from typing import Any, Dict, List, Optional
 
 from mac.models import JsonDict, TaskTransitionOutbox, json_dumps, json_loads, new_id, utcnow
+
+# Outbox rows from a single transition share an identical ``created_at``.
+# ``list_outbox`` orders by ``created_at, id``; if ``id`` is a random uuid
+# the secondary sort is non-deterministic and side effects (e.g. the beads
+# ledger note vs the reopen --status note) can fire out of enqueue order.
+# A process-wide monotonic counter baked into the id makes the id sort in
+# enqueue order, so the drain order is stable. Store-agnostic, no schema
+# change. The counter resets per process, which is fine because it only
+# acts as a tiebreaker within the same created_at timestamp.
+_outbox_seq = itertools.count()
+_outbox_seq_lock = threading.Lock()
+
+
+def _next_outbox_seq() -> int:
+    with _outbox_seq_lock:
+        return next(_outbox_seq)
 
 
 class TaskLedgerService:
@@ -16,6 +34,7 @@ class TaskLedgerService:
     def __init__(self, store: Any) -> None:
         self.store = store
 
+
     def enqueue_outbox(
         self,
         conn: Any,
@@ -28,7 +47,7 @@ class TaskLedgerService:
         detail: Optional[Dict[str, Any]] = None,
         created_at: Optional[str] = None,
     ) -> str:
-        outbox_id = new_id("tout")
+        outbox_id = "tout_%016x_%s" % (_next_outbox_seq(), new_id("").lstrip("_"))
         conn.execute(
             """
             INSERT INTO task_transition_outbox (

--- a/src/mac/ui/app.js
+++ b/src/mac/ui/app.js
@@ -6,6 +6,48 @@
 //   cp /tmp/uib/app.js app.js
 import { createDashboardApi } from "./dashboard_api.js";
 const TOKEN_KEY = "mac.dashboard.token";
+const THEME_KEY = "mac.dashboard.theme";
+function readStoredTheme() {
+    let stored = null;
+    try {
+        stored = localStorage.getItem(THEME_KEY);
+    }
+    catch {
+        stored = null;
+    }
+    if (stored === "light" || stored === "dark")
+        return stored;
+    if (typeof window !== "undefined" &&
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches) {
+        return "dark";
+    }
+    return "light";
+}
+function applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
+    const toggle = document.querySelector("#themeToggle");
+    if (toggle) {
+        const isDark = theme === "dark";
+        toggle.setAttribute("aria-pressed", String(isDark));
+        const label = toggle.querySelector(".theme-toggle-label");
+        if (label)
+            label.textContent = isDark ? "Light" : "Dark";
+    }
+}
+function setTheme(theme) {
+    applyTheme(theme);
+    try {
+        localStorage.setItem(THEME_KEY, theme);
+    }
+    catch {
+        /* storage unavailable — theme still applies for this session */
+    }
+}
+function toggleTheme() {
+    const current = document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
+    setTheme(current === "dark" ? "light" : "dark");
+}
 const TASK_STATES = [
     "open",
     "blocked",
@@ -117,8 +159,10 @@ const nodes = {
     loginForm: requiredElement("#loginForm"),
     loginTokenInput: requiredElement("#loginTokenInput"),
     serviceLinks: requiredElement("#serviceLinks"),
+    themeToggle: requiredElement("#themeToggle"),
 };
 const api = createDashboardApi(() => state.token);
+applyTheme(readStoredTheme());
 nodes.tokenInput.value = state.token;
 nodes.loginTokenInput.value = state.token;
 bindEvents();
@@ -140,6 +184,7 @@ function bindEvents() {
         render();
     });
     nodes.refresh.addEventListener("click", () => loadDashboard());
+    nodes.themeToggle.addEventListener("click", () => toggleTheme());
     nodes.content.addEventListener("click", handleContentClick);
     nodes.content.addEventListener("keydown", handleContentKeydown);
     nodes.content.addEventListener("submit", handleActionSubmit);
@@ -581,12 +626,12 @@ function renderProjects() {
     <section class="split">
       <div class="surface">
         <h2>Create Project</h2>
-        <form class="action-form aligned-form" data-action="projectCreate">
+        <form class="action-form aligned-form project-create-form" data-action="projectCreate">
           <label>Name <input name="name" required ${disabledAttr(!writable)}></label>
-          <label>Description <textarea name="description" ${disabledAttr(!writable)}></textarea></label>
           <label>Status ${select("status", ["active", "inactive", "archived"], "active", !writable)}</label>
-          <label>Metadata JSON <textarea name="metadata" placeholder="{}" ${disabledAttr(!writable)}></textarea></label>
-          <button type="submit" ${disabledAttr(!writable)}>Create</button>
+          <label class="field-full">Description <textarea name="description" ${disabledAttr(!writable)}></textarea></label>
+          <label class="field-full">Metadata JSON <textarea class="json-editor" name="metadata" placeholder="{}" spellcheck="false" autocomplete="off" autocapitalize="off" ${disabledAttr(!writable)}></textarea></label>
+          <div class="field-full form-actions"><button type="submit" ${disabledAttr(!writable)}>Create</button></div>
         </form>
       </div>
       <div class="surface">
@@ -2130,7 +2175,7 @@ function projectTableRow(project, data) {
     const description = String(project.description || "");
     const status = String(project.status || (durable ? "active" : "derived"));
     const statusValue = ["active", "inactive", "archived"].includes(status) ? status : "active";
-    const metadata = project.metadata && typeof project.metadata === "object" ? JSON.stringify(project.metadata) : "{}";
+    const metadata = project.metadata && typeof project.metadata === "object" ? JSON.stringify(project.metadata, null, 2) : "{}";
     const disabled = disabledAttr(!editable);
     return `
     <tr class="${state.projectFilter === project.project ? "is-selected" : ""}">
@@ -2144,7 +2189,7 @@ function projectTableRow(project, data) {
       </td>
       <td>${select("status", ["active", "inactive", "archived"], statusValue, !editable, formId)}</td>
       <td><textarea form="${escapeHtml(formId)}" name="description" ${disabled}>${escapeHtml(description)}</textarea></td>
-      <td><textarea form="${escapeHtml(formId)}" name="metadata" ${disabled}>${escapeHtml(metadata)}</textarea></td>
+      <td><textarea class="json-editor" form="${escapeHtml(formId)}" name="metadata" placeholder="{}" spellcheck="false" autocomplete="off" autocapitalize="off" rows="4" ${disabled}>${escapeHtml(metadata)}</textarea></td>
       <td>
         <span class="mono">${project.task_count}</span>
         <div class="chip-row">
@@ -2504,8 +2549,8 @@ function agentCard(item, data) {
 function taskLane(taskState, tasks, agents) {
     const laneTasks = tasks.filter((detail) => detail.task.state === taskState);
     return `
-    <div class="task-lane">
-      <h2><span>${escapeHtml(labelize(taskState))}</span><span class="pill">${laneTasks.length}</span></h2>
+    <div class="task-lane status-${escapeHtml(taskState)}">
+      <h2><span class="lane-title">${escapeHtml(labelize(taskState))}</span><span class="pill lane-count">${laneTasks.length}</span></h2>
       ${laneTasks.length ? laneTasks.map((detail) => taskCard(detail, agents)).join("") : `<div class="empty-state">Empty</div>`}
     </div>
   `;
@@ -2516,11 +2561,14 @@ function taskCard(detail, agents) {
     const origin = taskOrigin(task);
     const evidenceOptions = detail.evidence.map((item) => option(String(item.id), String(item.id), "")).join("");
     const pendingReviews = detail.reviews.filter((review) => review.status === "pending");
+    const isSelected = state.selectedId === task.id;
+    const recentHistory = detail.history.slice(-3);
+    const summaryText = String(detail.summary?.summary || "");
     return `
-    <article class="task-card ${selectedClass(task.id)}">
+    <article class="task-card status-${escapeHtml(task.state)} ${selectedClass(task.id)}">
       <div class="record-header">
-        <div><h3>${escapeHtml(task.title)}</h3><p class="muted small mono">${escapeHtml(task.id)}</p></div>
-        <button class="link-button" type="button" data-select-id="${escapeHtml(task.id)}">Select</button>
+        <div class="task-card-heading"><h3>${escapeHtml(task.title)}</h3><p class="muted small mono task-id" title="${escapeHtml(task.id)}">${escapeHtml(task.id)}</p></div>
+        <button class="select-button${isSelected ? " is-selected" : ""}" type="button" data-select-id="${escapeHtml(task.id)}" aria-pressed="${isSelected ? "true" : "false"}">${isSelected ? "Selected" : "Select"}</button>
       </div>
       <div class="chip-row">
         ${chip(`P${task.priority || 0}`, "info")}
@@ -2528,15 +2576,18 @@ function taskCard(detail, agents) {
         ${owner ? chip(owner.name, "info") : chip("unowned", "warn")}
         ${origin.hermes_instance_id ? chip("Hermes origin", "info") : ""}
       </div>
-      <div class="row-grid compact-fields">
-        ${field("Started", task.started_at ? formatAge(task.started_at) : "not started")}
-        ${field("Completed", task.completed_at ? formatAge(task.completed_at) : "not completed")}
-        ${field("Updated", formatAge(task.last_updated_at || task.updated_at))}
+      <div class="time-summary">
+        <span class="time-cell"><span class="time-label">Started</span><span class="time-value">${escapeHtml(task.started_at ? formatAge(task.started_at) : "not started")}</span></span>
+        <span class="time-cell"><span class="time-label">Completed</span><span class="time-value">${escapeHtml(task.completed_at ? formatAge(task.completed_at) : "not completed")}</span></span>
+        <span class="time-cell"><span class="time-label">Updated</span><span class="time-value">${escapeHtml(formatAge(task.last_updated_at || task.updated_at))}</span></span>
       </div>
-      <p class="small muted">${escapeHtml(String(detail.summary?.summary || ""))}</p>
-      <div class="timeline">
-        ${detail.history.slice(-3).map((event) => timelineItem(String(event.event_type), String(event.actor || ""), String(event.created_at || ""))).join("")}
-      </div>
+      ${summaryText ? `<p class="small muted">${escapeHtml(summaryText)}</p>` : ""}
+      ${recentHistory.length ? `<details class="activity-disclosure">
+        <summary><span class="activity-show">Show activity</span><span class="activity-hide">Hide activity</span></summary>
+        <div class="timeline">
+          ${recentHistory.map((event) => timelineItem(String(event.event_type), String(event.actor || ""), String(event.created_at || ""))).join("")}
+        </div>
+      </details>` : ""}
       <div class="record-actions">
         <details class="row-actions edit-disclosure">
           <summary>Edit</summary>
@@ -3874,9 +3925,16 @@ function parseJsonObject(value) {
     const text = String(value || "").trim();
     if (!text)
         return {};
-    const parsed = JSON.parse(text);
+    let parsed;
+    try {
+        parsed = JSON.parse(text);
+    }
+    catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        throw new Error(`invalid JSON: ${detail}`);
+    }
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        throw new Error("expected a JSON object");
+        throw new Error("metadata must be a JSON object, e.g. {\"key\": \"value\"}");
     }
     return parsed;
 }

--- a/src/mac/ui/app.ts
+++ b/src/mac/ui/app.ts
@@ -465,9 +465,55 @@ interface DashboardNodes {
   loginForm: HTMLFormElement;
   loginTokenInput: HTMLInputElement;
   serviceLinks: HTMLElement;
+  themeToggle: HTMLButtonElement;
 }
 
 const TOKEN_KEY = "mac.dashboard.token";
+const THEME_KEY = "mac.dashboard.theme";
+type ThemeName = "light" | "dark";
+
+function readStoredTheme(): ThemeName {
+  let stored: string | null = null;
+  try {
+    stored = localStorage.getItem(THEME_KEY);
+  } catch {
+    stored = null;
+  }
+  if (stored === "light" || stored === "dark") return stored;
+  if (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+    return "dark";
+  }
+  return "light";
+}
+
+function applyTheme(theme: ThemeName): void {
+  document.documentElement.setAttribute("data-theme", theme);
+  const toggle = document.querySelector<HTMLButtonElement>("#themeToggle");
+  if (toggle) {
+    const isDark = theme === "dark";
+    toggle.setAttribute("aria-pressed", String(isDark));
+    const label = toggle.querySelector<HTMLElement>(".theme-toggle-label");
+    if (label) label.textContent = isDark ? "Light" : "Dark";
+  }
+}
+
+function setTheme(theme: ThemeName): void {
+  applyTheme(theme);
+  try {
+    localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    /* storage unavailable — theme still applies for this session */
+  }
+}
+
+function toggleTheme(): void {
+  const current = document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
+  setTheme(current === "dark" ? "light" : "dark");
+}
 const TASK_STATES = [
   "open",
   "blocked",
@@ -582,9 +628,11 @@ const nodes: DashboardNodes = {
   loginForm: requiredElement<HTMLFormElement>("#loginForm"),
   loginTokenInput: requiredElement<HTMLInputElement>("#loginTokenInput"),
   serviceLinks: requiredElement("#serviceLinks"),
+  themeToggle: requiredElement<HTMLButtonElement>("#themeToggle"),
 };
 const api = createDashboardApi(() => state.token);
 
+applyTheme(readStoredTheme());
 nodes.tokenInput.value = state.token;
 nodes.loginTokenInput.value = state.token;
 bindEvents();
@@ -605,6 +653,7 @@ function bindEvents(): void {
     render();
   });
   nodes.refresh.addEventListener("click", () => loadDashboard());
+  nodes.themeToggle.addEventListener("click", () => toggleTheme());
   nodes.content.addEventListener("click", handleContentClick);
   nodes.content.addEventListener("keydown", handleContentKeydown);
   nodes.content.addEventListener("submit", handleActionSubmit);
@@ -1034,12 +1083,12 @@ function renderProjects(): string {
     <section class="split">
       <div class="surface">
         <h2>Create Project</h2>
-        <form class="action-form aligned-form" data-action="projectCreate">
+        <form class="action-form aligned-form project-create-form" data-action="projectCreate">
           <label>Name <input name="name" required ${disabledAttr(!writable)}></label>
-          <label>Description <textarea name="description" ${disabledAttr(!writable)}></textarea></label>
           <label>Status ${select("status", ["active", "inactive", "archived"], "active", !writable)}</label>
-          <label>Metadata JSON <textarea name="metadata" placeholder="{}" ${disabledAttr(!writable)}></textarea></label>
-          <button type="submit" ${disabledAttr(!writable)}>Create</button>
+          <label class="field-full">Description <textarea name="description" ${disabledAttr(!writable)}></textarea></label>
+          <label class="field-full">Metadata JSON <textarea class="json-editor" name="metadata" placeholder="{}" spellcheck="false" autocomplete="off" autocapitalize="off" ${disabledAttr(!writable)}></textarea></label>
+          <div class="field-full form-actions"><button type="submit" ${disabledAttr(!writable)}>Create</button></div>
         </form>
       </div>
       <div class="surface">
@@ -2619,7 +2668,7 @@ function projectTableRow(project: ProjectSummary, data: DashboardData): string {
   const description = String(project.description || "");
   const status = String(project.status || (durable ? "active" : "derived"));
   const statusValue = ["active", "inactive", "archived"].includes(status) ? status : "active";
-  const metadata = project.metadata && typeof project.metadata === "object" ? JSON.stringify(project.metadata) : "{}";
+  const metadata = project.metadata && typeof project.metadata === "object" ? JSON.stringify(project.metadata, null, 2) : "{}";
   const disabled = disabledAttr(!editable);
   return `
     <tr class="${state.projectFilter === project.project ? "is-selected" : ""}">
@@ -2633,7 +2682,7 @@ function projectTableRow(project: ProjectSummary, data: DashboardData): string {
       </td>
       <td>${select("status", ["active", "inactive", "archived"], statusValue, !editable, formId)}</td>
       <td><textarea form="${escapeHtml(formId)}" name="description" ${disabled}>${escapeHtml(description)}</textarea></td>
-      <td><textarea form="${escapeHtml(formId)}" name="metadata" ${disabled}>${escapeHtml(metadata)}</textarea></td>
+      <td><textarea class="json-editor" form="${escapeHtml(formId)}" name="metadata" placeholder="{}" spellcheck="false" autocomplete="off" autocapitalize="off" rows="4" ${disabled}>${escapeHtml(metadata)}</textarea></td>
       <td>
         <span class="mono">${project.task_count}</span>
         <div class="chip-row">
@@ -3003,8 +3052,8 @@ function agentCard(item: AgentItem, data: DashboardData): string {
 function taskLane(taskState: string, tasks: TaskDetail[], agents: AgentItem[]): string {
   const laneTasks = tasks.filter((detail) => detail.task.state === taskState);
   return `
-    <div class="task-lane">
-      <h2><span>${escapeHtml(labelize(taskState))}</span><span class="pill">${laneTasks.length}</span></h2>
+    <div class="task-lane status-${escapeHtml(taskState)}">
+      <h2><span class="lane-title">${escapeHtml(labelize(taskState))}</span><span class="pill lane-count">${laneTasks.length}</span></h2>
       ${laneTasks.length ? laneTasks.map((detail) => taskCard(detail, agents)).join("") : `<div class="empty-state">Empty</div>`}
     </div>
   `;
@@ -3016,11 +3065,14 @@ function taskCard(detail: TaskDetail, agents: AgentItem[]): string {
   const origin = taskOrigin(task);
   const evidenceOptions = detail.evidence.map((item) => option(String(item.id), String(item.id), "")).join("");
   const pendingReviews = detail.reviews.filter((review) => review.status === "pending");
+  const isSelected = state.selectedId === task.id;
+  const recentHistory = detail.history.slice(-3);
+  const summaryText = String(detail.summary?.summary || "");
   return `
-    <article class="task-card ${selectedClass(task.id)}">
+    <article class="task-card status-${escapeHtml(task.state)} ${selectedClass(task.id)}">
       <div class="record-header">
-        <div><h3>${escapeHtml(task.title)}</h3><p class="muted small mono">${escapeHtml(task.id)}</p></div>
-        <button class="link-button" type="button" data-select-id="${escapeHtml(task.id)}">Select</button>
+        <div class="task-card-heading"><h3>${escapeHtml(task.title)}</h3><p class="muted small mono task-id" title="${escapeHtml(task.id)}">${escapeHtml(task.id)}</p></div>
+        <button class="select-button${isSelected ? " is-selected" : ""}" type="button" data-select-id="${escapeHtml(task.id)}" aria-pressed="${isSelected ? "true" : "false"}">${isSelected ? "Selected" : "Select"}</button>
       </div>
       <div class="chip-row">
         ${chip(`P${task.priority || 0}`, "info")}
@@ -3028,15 +3080,18 @@ function taskCard(detail: TaskDetail, agents: AgentItem[]): string {
         ${owner ? chip(owner.name, "info") : chip("unowned", "warn")}
         ${origin.hermes_instance_id ? chip("Hermes origin", "info") : ""}
       </div>
-      <div class="row-grid compact-fields">
-        ${field("Started", task.started_at ? formatAge(task.started_at) : "not started")}
-        ${field("Completed", task.completed_at ? formatAge(task.completed_at) : "not completed")}
-        ${field("Updated", formatAge(task.last_updated_at || task.updated_at))}
+      <div class="time-summary">
+        <span class="time-cell"><span class="time-label">Started</span><span class="time-value">${escapeHtml(task.started_at ? formatAge(task.started_at) : "not started")}</span></span>
+        <span class="time-cell"><span class="time-label">Completed</span><span class="time-value">${escapeHtml(task.completed_at ? formatAge(task.completed_at) : "not completed")}</span></span>
+        <span class="time-cell"><span class="time-label">Updated</span><span class="time-value">${escapeHtml(formatAge(task.last_updated_at || task.updated_at))}</span></span>
       </div>
-      <p class="small muted">${escapeHtml(String(detail.summary?.summary || ""))}</p>
-      <div class="timeline">
-        ${detail.history.slice(-3).map((event) => timelineItem(String(event.event_type), String(event.actor || ""), String(event.created_at || ""))).join("")}
-      </div>
+      ${summaryText ? `<p class="small muted">${escapeHtml(summaryText)}</p>` : ""}
+      ${recentHistory.length ? `<details class="activity-disclosure">
+        <summary><span class="activity-show">Show activity</span><span class="activity-hide">Hide activity</span></summary>
+        <div class="timeline">
+          ${recentHistory.map((event) => timelineItem(String(event.event_type), String(event.actor || ""), String(event.created_at || ""))).join("")}
+        </div>
+      </details>` : ""}
       <div class="record-actions">
         <details class="row-actions edit-disclosure">
           <summary>Edit</summary>
@@ -4391,9 +4446,15 @@ function mustData(): DashboardData {
 function parseJsonObject(value: unknown): JsonObject {
   const text = String(value || "").trim();
   if (!text) return {};
-  const parsed = JSON.parse(text);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`invalid JSON: ${detail}`);
+  }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("expected a JSON object");
+    throw new Error("metadata must be a JSON object, e.g. {\"key\": \"value\"}");
   }
   return parsed as JsonObject;
 }

--- a/src/mac/ui/index.html
+++ b/src/mac/ui/index.html
@@ -4,7 +4,26 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>MAC Control Plane</title>
-    <link rel="stylesheet" href="/ui/assets/styles.css">
+    <link rel="stylesheet" href="/ui/assets/styles.css?v=20260602-theme-toggle">
+    <script>
+      // No-FOUC theme bootstrap: apply the stored/preferred theme before the
+      // first paint. app.js re-applies the same logic and wires the toggle.
+      (function () {
+        try {
+          var stored = localStorage.getItem("mac.dashboard.theme");
+          var theme =
+            stored === "light" || stored === "dark"
+              ? stored
+              : window.matchMedia &&
+                  window.matchMedia("(prefers-color-scheme: dark)").matches
+                ? "dark"
+                : "light";
+          document.documentElement.setAttribute("data-theme", theme);
+        } catch (e) {
+          document.documentElement.setAttribute("data-theme", "light");
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="loginScreen" class="login-screen" hidden>
@@ -79,6 +98,10 @@
           </div>
           <div class="topbar-actions">
             <span class="sync-state" id="syncState">Not loaded</span>
+            <button class="theme-toggle" type="button" id="themeToggle" aria-label="Toggle dark mode" aria-pressed="false" title="Toggle dark mode">
+              <span class="theme-toggle-icon" aria-hidden="true"></span>
+              <span class="theme-toggle-label">Dark</span>
+            </button>
             <button class="primary-button" type="button" id="refreshButton">Refresh</button>
           </div>
         </header>
@@ -87,6 +110,6 @@
       </main>
     </div>
     <!-- app.ts is the maintained source; app.js is checked-in browser output. -->
-    <script type="module" src="/ui/assets/app.js?v=20260527-agent-fleets"></script>
+    <script type="module" src="/ui/assets/app.js?v=20260602-theme-toggle"></script>
   </body>
 </html>

--- a/src/mac/ui/styles.css
+++ b/src/mac/ui/styles.css
@@ -2,17 +2,51 @@
   --page: #f5f7f8;
   --panel: #ffffff;
   --panel-soft: #f9fbfa;
+  --sidebar: #fbfcfd;
+  --topbar: rgba(255, 255, 255, 0.9);
+  --input-bg: #ffffff;
+  --on-accent: #ffffff;
   --ink: #202124;
   --muted: #667085;
   --line: #d8dee7;
   --accent: #2f6f63;
+  --accent-strong: #2f6f63;
+  --accent-ink: #174f45;
   --accent-soft: #e4f2ee;
+  --accent-line: #b8d8d0;
   --warning: #9a5b13;
   --warning-soft: #fff4df;
+  --warning-line: #ead09f;
   --danger: #b42318;
   --danger-soft: #fde8e4;
+  --danger-line: #efc3bb;
+  --danger-ink: #74231c;
   --blue: #245c8f;
   --blue-soft: #e6f0f8;
+  --blue-line: #bdd4e9;
+  /* Neutral raised surface (was hardcoded #ffffff across inputs/cards/pills) */
+  --surface: #ffffff;
+  /* Recessed neutral surface (was #fbfcfd / #f6f8fb / #f9fafc) */
+  --surface-sunken: #fbfcfd;
+  /* Brand mark badge */
+  --brand-bg: #233a35;
+  --brand-line: #28443d;
+  --brand-ink: #ffffff;
+  /* Progress / track */
+  --track: #e8edf2;
+  /* Relationship + workflow graph */
+  --graph-edge: #b8c5d2;
+  --graph-node-bg: #ffffff;
+  --graph-fleet-bg: #f4f1ff;
+  --graph-fleet-line: #cbc2f2;
+  --graph-task-bg: #eef2f8;
+  --graph-task-line: #bdd0e3;
+  --graph-plan-bg: #f4ecff;
+  --graph-plan-line: #c8b6f0;
+  --graph-commit-bg: #ecf7ef;
+  --graph-commit-line: #b5d8be;
+  --graph-verify-bg: #e7f1f6;
+  --graph-verify-line: #a7c8d8;
   --shadow: 0 18px 50px rgba(32, 33, 36, 0.08);
   color-scheme: light;
   font-family:
@@ -20,6 +54,54 @@
     sans-serif;
   font-size: 15px;
   letter-spacing: 0;
+}
+
+:root[data-theme="dark"] {
+  --page: #11151a;
+  --panel: #1a1f26;
+  --panel-soft: #1f2630;
+  --sidebar: #151a20;
+  --topbar: rgba(21, 26, 32, 0.9);
+  --input-bg: #11151a;
+  --on-accent: #f5f7f8;
+  --ink: #e6eaf0;
+  --muted: #9aa6b5;
+  --line: #2b333d;
+  --accent: #4fb3a1;
+  --accent-strong: #3f9686;
+  --accent-ink: #aee6da;
+  --accent-soft: #1d3631;
+  --accent-line: #2f5a51;
+  --warning: #f0b860;
+  --warning-soft: #3a2f1c;
+  --warning-line: #6e5630;
+  --danger: #f08376;
+  --danger-soft: #3a2320;
+  --danger-line: #5e3631;
+  --danger-ink: #f3aaa0;
+  --blue: #6aa6d8;
+  --blue-soft: #1d2c3a;
+  --blue-line: #2f4a63;
+  --surface: #1a1f26;
+  --surface-sunken: #161b21;
+  --brand-bg: #1d3631;
+  --brand-line: #2f5a51;
+  --brand-ink: #d7f1ea;
+  --track: #2b333d;
+  --graph-edge: #44515f;
+  --graph-node-bg: #1f2630;
+  --graph-fleet-bg: #25243a;
+  --graph-fleet-line: #4a4570;
+  --graph-task-bg: #1e2733;
+  --graph-task-line: #36506b;
+  --graph-plan-bg: #271f3a;
+  --graph-plan-line: #4f3f72;
+  --graph-commit-bg: #1c3025;
+  --graph-commit-line: #356a4a;
+  --graph-verify-bg: #18303a;
+  --graph-verify-line: #2d637c;
+  --shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+  color-scheme: dark;
 }
 
 * {
@@ -105,7 +187,7 @@ a:focus-visible,
   height: 44px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--input-bg);
   color: var(--ink);
   padding: 0 12px;
 }
@@ -130,7 +212,7 @@ a:focus-visible,
   max-height: 100vh;
   overflow-y: auto;
   border-right: 1px solid var(--line);
-  background: #fbfcfd;
+  background: var(--sidebar);
   padding: 24px 18px;
 }
 
@@ -145,10 +227,10 @@ a:focus-visible,
   min-width: 44px;
   height: 32px;
   place-items: center;
-  border: 1px solid #28443d;
+  border: 1px solid var(--brand-line);
   border-radius: 8px;
-  background: #233a35;
-  color: #ffffff;
+  background: var(--brand-bg);
+  color: var(--brand-ink);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.86rem;
   font-weight: 700;
@@ -192,9 +274,9 @@ a:focus-visible,
 }
 
 .nav-item.is-active {
-  border-color: #b8d8d0;
+  border-color: var(--accent-line);
   background: var(--accent-soft);
-  color: #174f45;
+  color: var(--accent-ink);
   font-weight: 700;
 }
 
@@ -231,7 +313,7 @@ a:focus-visible,
 }
 
 .service-link-btn:hover {
-  border-color: #b8d8d0;
+  border-color: var(--accent-line);
   background: var(--accent-soft);
 }
 
@@ -260,7 +342,7 @@ a:focus-visible,
   height: 44px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--input-bg);
   color: var(--ink);
   padding: 0 10px;
 }
@@ -278,7 +360,7 @@ a:focus-visible,
   height: 44px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--surface);
   color: var(--ink);
   padding: 0 12px;
   font-weight: 700;
@@ -286,15 +368,15 @@ a:focus-visible,
 
 .link-button {
   min-height: 30px;
-  background: #ffffff;
+  background: var(--surface);
   color: var(--blue);
   padding: 0 10px;
 }
 
 .primary-button {
-  border-color: #2f6f63;
+  border-color: var(--accent);
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent);
 }
 
 .main {
@@ -310,7 +392,7 @@ a:focus-visible,
   gap: 20px;
   min-height: 96px;
   border-bottom: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--topbar);
   padding: 22px 28px;
 }
 
@@ -358,12 +440,66 @@ h3 {
   text-align: right;
 }
 
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 38px;
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+  padding: 0 14px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.theme-toggle:hover {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+}
+
+.theme-toggle:hover .theme-toggle-icon {
+  background: var(--on-accent);
+  box-shadow: inset -4px -2px 0 0 var(--accent);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.theme-toggle-icon {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: inset -4px -2px 0 0 var(--accent-soft);
+}
+
+:root[data-theme="dark"] .theme-toggle-icon {
+  background: var(--warning);
+  box-shadow: none;
+}
+
+:root[data-theme="dark"] .theme-toggle:hover .theme-toggle-icon {
+  background: var(--warning);
+  box-shadow: none;
+}
+
 .banner {
   margin: 18px 28px 0;
-  border: 1px solid #f3c6bd;
+  border: 1px solid var(--danger-line);
   border-radius: 8px;
   background: var(--danger-soft);
-  color: #74231c;
+  color: var(--danger-ink);
   padding: 12px 14px;
 }
 
@@ -510,6 +646,30 @@ h3 {
   align-items: end;
 }
 
+/* Project create form: 2-column grid that fits inside the half-width card.
+   Single-line fields share a row; multi-line fields span both columns so the
+   JSON/description textareas never overflow the card boundary. */
+.action-form.project-create-form {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: 12px;
+}
+
+.action-form.project-create-form .field-full {
+  grid-column: 1 / -1;
+}
+
+.action-form.project-create-form .form-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.action-form.project-create-form .form-actions button {
+  width: auto;
+  min-width: 140px;
+}
+
 .action-form label {
   display: grid;
   gap: 5px;
@@ -526,7 +686,7 @@ h3 {
   height: 42px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--input-bg);
   color: var(--ink);
   padding: 0 10px;
   text-transform: none;
@@ -539,21 +699,36 @@ h3 {
   resize: vertical;
 }
 
+/* Keep both textareas in the project create form the same height so the
+   Description and Metadata JSON fields line up visually. */
+.action-form.project-create-form textarea {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+  min-height: 110px;
+}
+
+.action-form.project-create-form textarea.json-editor {
+  min-height: 110px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .action-form button,
 .action-strip button {
   width: 100%;
   min-height: 42px;
-  border: 1px solid #2f6f63;
+  border: 1px solid var(--accent-strong);
   border-radius: 8px;
   background: var(--accent);
-  color: #ffffff;
+  color: var(--on-accent);
   padding: 0 12px;
   font-weight: 800;
   align-self: end;
 }
 
 .action-status {
-  border: 1px solid #bdd4e9;
+  border: 1px solid var(--blue-line);
   border-radius: 8px;
   background: var(--blue-soft);
   color: var(--blue);
@@ -561,7 +736,7 @@ h3 {
 }
 
 .danger-action button {
-  border-color: #b42318;
+  border-color: var(--danger);
   background: var(--danger);
 }
 
@@ -586,10 +761,10 @@ h3 {
 .danger-button {
   min-width: 96px;
   min-height: 42px;
-  border: 1px solid #b42318;
+  border: 1px solid var(--danger);
   border-radius: 8px;
   background: var(--danger);
-  color: #ffffff;
+  color: var(--on-accent);
   padding: 0 14px;
   font-weight: 800;
 }
@@ -601,9 +776,9 @@ h3 {
 
 details.action-box {
   margin-top: 12px;
-  border: 1px solid #e5e9ef;
+  border: 1px solid var(--line);
   border-radius: 8px;
-  background: #fbfcfd;
+  background: var(--surface-sunken);
   padding: 10px 12px;
 }
 
@@ -612,9 +787,9 @@ details.row-actions {
 }
 
 details.row-actions.edit-disclosure {
-  border: 1px solid #e5e9ef;
+  border: 1px solid var(--line);
   border-radius: 8px;
-  background: #fbfcfd;
+  background: var(--surface-sunken);
   padding: 8px 10px;
 }
 
@@ -664,7 +839,7 @@ details.action-box summary {
   min-height: 44px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--surface);
   color: var(--ink);
   padding: 8px 10px;
   text-align: left;
@@ -724,7 +899,7 @@ details.action-box summary {
   min-width: 140px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--input-bg);
   color: var(--ink);
   padding: 8px 10px;
 }
@@ -734,12 +909,37 @@ details.action-box summary {
   resize: vertical;
 }
 
+/* JSON metadata editors: legible monospace, roomier, no autocorrect noise. */
+.json-editor {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  tab-size: 2;
+  white-space: pre;
+  overflow: auto;
+}
+
+.action-form textarea.json-editor {
+  min-height: 96px;
+}
+
+.data-table textarea.json-editor {
+  min-width: 220px;
+  min-height: 92px;
+}
+
 .project-table {
-  min-width: 1180px;
+  min-width: 1240px;
 }
 
 .project-table td:first-child {
   min-width: 190px;
+}
+
+/* Description + Metadata columns need room for multi-line JSON editing. */
+.project-table td:nth-child(3),
+.project-table td:nth-child(4) {
+  min-width: 240px;
 }
 
 .compact-table {
@@ -754,7 +954,7 @@ details.action-box summary {
   min-height: 36px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--surface);
   color: var(--blue);
   padding: 0 10px;
   font-weight: 700;
@@ -841,11 +1041,11 @@ details.action-box summary {
 }
 
 .agent-card.is-blocked {
-  border-color: #e7c4bd;
+  border-color: var(--danger-line);
 }
 
 .is-selected {
-  outline: 2px solid #245c8f;
+  outline: 2px solid var(--blue);
   outline-offset: 2px;
 }
 
@@ -854,7 +1054,7 @@ details.action-box summary {
 }
 
 .record-section {
-  border-top: 1px solid var(--border);
+  border-top: 1px solid var(--line);
   margin-top: 14px;
   padding-top: 12px;
 }
@@ -871,8 +1071,53 @@ details.action-box summary {
 }
 
 .timeline-item {
-  border-left: 3px solid #bdd4e9;
+  border-left: 3px solid var(--blue-line);
   padding: 2px 0 2px 10px;
+}
+
+/* Activity log collapses behind a chevron disclosure so cards stay compact. */
+.activity-disclosure {
+  margin-top: 12px;
+}
+
+.activity-disclosure > summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  list-style: none;
+  color: var(--blue);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.activity-disclosure > summary::-webkit-details-marker {
+  display: none;
+}
+
+.activity-disclosure > summary::after {
+  content: "\25be"; /* down chevron */
+  font-size: 0.8em;
+}
+
+.activity-disclosure[open] > summary::after {
+  content: "\25b4"; /* up chevron */
+}
+
+.activity-disclosure .activity-hide {
+  display: none;
+}
+
+.activity-disclosure[open] .activity-show {
+  display: none;
+}
+
+.activity-disclosure[open] .activity-hide {
+  display: inline;
+}
+
+.activity-disclosure .timeline {
+  margin-top: 10px;
 }
 
 .record-header,
@@ -910,7 +1155,7 @@ details.action-box summary {
 
 .field {
   min-height: 58px;
-  border: 1px solid #e5e9ef;
+  border: 1px solid var(--line);
   border-radius: 8px;
   background: var(--panel-soft);
   padding: 10px;
@@ -944,7 +1189,7 @@ details.action-box summary {
   min-height: 26px;
   border: 1px solid var(--line);
   border-radius: 999px;
-  background: #ffffff;
+  background: var(--surface);
   color: var(--muted);
   padding: 0 9px;
   font-size: 0.82rem;
@@ -954,25 +1199,25 @@ details.action-box summary {
 }
 
 .tone-good {
-  border-color: #b8d8d0;
+  border-color: var(--accent-line);
   background: var(--accent-soft);
-  color: #174f45;
+  color: var(--accent-ink);
 }
 
 .tone-warn {
-  border-color: #ead09f;
+  border-color: var(--warning-line);
   background: var(--warning-soft);
   color: var(--warning);
 }
 
 .tone-bad {
-  border-color: #efc3bb;
+  border-color: var(--danger-line);
   background: var(--danger-soft);
   color: var(--danger);
 }
 
 .tone-info {
-  border-color: #bdd4e9;
+  border-color: var(--blue-line);
   background: var(--blue-soft);
   color: var(--blue);
 }
@@ -989,23 +1234,176 @@ details.action-box summary {
   gap: 10px;
   min-height: 120px;
   border: 1px solid var(--line);
+  border-top: 3px solid var(--lane-accent, var(--line));
   border-radius: 8px;
-  background: #fbfcfd;
+  background: var(--surface-sunken);
   padding: 12px;
+}
+
+/* Per-status lane accent colours give an at-a-glance status cue. */
+.task-lane.status-completed {
+  --lane-accent: var(--accent);
+}
+
+.task-lane.status-failed,
+.task-lane.status-cancelled {
+  --lane-accent: var(--danger);
+}
+
+.task-lane.status-blocked {
+  --lane-accent: var(--warning);
+}
+
+.task-lane.status-running,
+.task-lane.status-claimed,
+.task-lane.status-reviewing,
+.task-lane.status-needs_review {
+  --lane-accent: var(--blue);
 }
 
 .task-lane h2 {
   display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: 10px;
   margin-bottom: 2px;
 }
 
+.task-lane h2 .lane-title {
+  text-transform: capitalize;
+}
+
+.task-lane h2 .lane-count {
+  min-height: 22px;
+  border-color: var(--lane-accent, var(--line));
+  background: var(--surface);
+  color: var(--ink);
+  padding: 0 8px;
+  font-size: 0.78rem;
+}
+
 .task-card {
-  border: 1px solid #e5e9ef;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--lane-accent, var(--line));
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--panel);
   padding: 12px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+/* Inherit the lane status accent on the card's left border. */
+.task-lane.status-completed .task-card {
+  --lane-accent: var(--accent);
+}
+
+.task-lane.status-failed .task-card,
+.task-lane.status-cancelled .task-card {
+  --lane-accent: var(--danger);
+}
+
+.task-lane.status-blocked .task-card {
+  --lane-accent: var(--warning);
+}
+
+.task-lane.status-running .task-card,
+.task-lane.status-claimed .task-card,
+.task-lane.status-reviewing .task-card,
+.task-lane.status-needs_review .task-card {
+  --lane-accent: var(--blue);
+}
+
+.task-card.is-selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.task-card .record-header {
+  min-width: 0;
+  align-items: center;
+}
+
+.task-card .task-card-heading {
+  min-width: 0;
+}
+
+.task-card .record-header h3,
+.task-card .record-header .mono {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+/* Long machine-generated task ids are low value when scanning: keep them to a
+   single truncated line with the full id available on hover. */
+.task-card .task-id {
+  margin: 2px 0 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Proper button affordance for selection instead of raw blue text. */
+.select-button {
+  flex: 0 0 auto;
+  min-height: 28px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--ink);
+  padding: 0 12px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.select-button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.select-button.is-selected {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--on-accent);
+}
+
+/* Compact single-line time summary (was a three-box grid). */
+.time-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 8px;
+  margin-top: 12px;
+  font-size: 0.8rem;
+}
+
+.time-summary .time-cell {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.time-summary .time-cell + .time-cell::before {
+  content: "\b7"; /* middot separator */
+  margin-right: 8px;
+  color: var(--muted);
+}
+
+.time-summary .time-label {
+  color: var(--muted);
+  font-size: 0.7rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.time-summary .time-value {
+  color: var(--ink);
+}
+
+.task-card .chip {
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .task-card p,
@@ -1031,7 +1429,7 @@ details.action-box summary {
   height: 10px;
   overflow: hidden;
   border-radius: 999px;
-  background: #e8edf2;
+  background: var(--track);
 }
 
 .bar-fill {
@@ -1052,9 +1450,9 @@ details.action-box summary {
   width: 100%;
   overflow-x: auto;
   margin-top: 12px;
-  border: 1px solid #e5e9ef;
+  border: 1px solid var(--line);
   border-radius: 8px;
-  background: linear-gradient(180deg, #ffffff 0%, #f9fbfa 100%);
+  background: linear-gradient(180deg, var(--panel) 0%, var(--panel-soft) 100%);
 }
 
 .relationship-graph {
@@ -1072,21 +1470,21 @@ details.action-box summary {
 
 .graph-edge {
   fill: none;
-  stroke: #b8c5d2;
+  stroke: var(--graph-edge);
   stroke-width: 2;
   opacity: 0.72;
 }
 
 .graph-edge-agent-task {
-  stroke: #2f6f63;
+  stroke: var(--accent);
 }
 
 .graph-edge-fleet-agent {
-  stroke: #5661a6;
+  stroke: var(--graph-fleet-line);
 }
 
 .graph-edge-dependency {
-  stroke: #9a5b13;
+  stroke: var(--warning);
   stroke-dasharray: 5 4;
 }
 
@@ -1095,24 +1493,24 @@ details.action-box summary {
 }
 
 .graph-node rect {
-  fill: #ffffff;
+  fill: var(--graph-node-bg);
   stroke: var(--line);
   stroke-width: 1.2;
 }
 
 .graph-node-machine rect {
   fill: var(--blue-soft);
-  stroke: #bdd4e9;
+  stroke: var(--blue-line);
 }
 
 .graph-node-fleet rect {
-  fill: #f4f1ff;
-  stroke: #cbc2f2;
+  fill: var(--graph-fleet-bg);
+  stroke: var(--graph-fleet-line);
 }
 
 .graph-node-agent rect {
   fill: var(--accent-soft);
-  stroke: #b8d8d0;
+  stroke: var(--accent-line);
 }
 
 /*
@@ -1125,45 +1523,45 @@ details.action-box summary {
  * own .graph-node-machine/fleet/agent rules above.
  */
 .graph-node-task rect {
-  fill: #eef2f8;
-  stroke: #bdd0e3;
+  fill: var(--graph-task-bg);
+  stroke: var(--graph-task-line);
 }
 
 .graph-node-approval rect {
   fill: var(--warning-soft);
-  stroke: #ead09f;
+  stroke: var(--warning-line);
   stroke-width: 2;
 }
 
 .graph-node-approval .graph-node-icon {
-  color: #9a5b13;
+  color: var(--warning);
 }
 
 .graph-node-plan rect {
-  fill: #f4ecff;
-  stroke: #c8b6f0;
+  fill: var(--graph-plan-bg);
+  stroke: var(--graph-plan-line);
 }
 
 .graph-node-plan .graph-node-icon {
-  color: #6e3fbb;
+  color: var(--graph-plan-line);
 }
 
 .graph-node-commit rect {
-  fill: #ecf7ef;
-  stroke: #b5d8be;
+  fill: var(--graph-commit-bg);
+  stroke: var(--graph-commit-line);
 }
 
 .graph-node-commit .graph-node-icon {
-  color: #2f6f4a;
+  color: var(--graph-commit-line);
 }
 
 .graph-node-verify rect {
-  fill: #e7f1f6;
-  stroke: #a7c8d8;
+  fill: var(--graph-verify-bg);
+  stroke: var(--graph-verify-line);
 }
 
 .graph-node-verify .graph-node-icon {
-  color: #2d637c;
+  color: var(--graph-verify-line);
 }
 
 .graph-node-icon {
@@ -1171,20 +1569,20 @@ details.action-box summary {
 }
 
 .graph-edge-approved {
-  stroke: #2f6f4a;
+  stroke: var(--accent);
 }
 
 .graph-edge-rejected {
-  stroke: #b6443c;
+  stroke: var(--danger);
   stroke-dasharray: 5 4;
 }
 
 .graph-edge-failure {
-  stroke: #b6443c;
+  stroke: var(--danger);
 }
 
 .graph-edge-success {
-  stroke: #2f6f63;
+  stroke: var(--accent);
 }
 
 /* Workflow stage: legend + selector + inspector */
@@ -1206,7 +1604,8 @@ details.action-box summary {
   padding: 4px 8px;
   border: 1px solid var(--line);
   border-radius: 6px;
-  background: #ffffff;
+  background: var(--input-bg);
+  color: var(--ink);
   font: inherit;
 }
 
@@ -1233,11 +1632,11 @@ details.action-box summary {
   border: 1px solid var(--line);
 }
 
-.workflow-legend-task .workflow-legend-swatch { background: #eef2f8; border-color: #bdd0e3; }
-.workflow-legend-approval .workflow-legend-swatch { background: var(--warning-soft); border-color: #ead09f; }
-.workflow-legend-plan .workflow-legend-swatch { background: #f4ecff; border-color: #c8b6f0; }
-.workflow-legend-commit .workflow-legend-swatch { background: #ecf7ef; border-color: #b5d8be; }
-.workflow-legend-verify .workflow-legend-swatch { background: #e7f1f6; border-color: #a7c8d8; }
+.workflow-legend-task .workflow-legend-swatch { background: var(--graph-task-bg); border-color: var(--graph-task-line); }
+.workflow-legend-approval .workflow-legend-swatch { background: var(--warning-soft); border-color: var(--warning-line); }
+.workflow-legend-plan .workflow-legend-swatch { background: var(--graph-plan-bg); border-color: var(--graph-plan-line); }
+.workflow-legend-commit .workflow-legend-swatch { background: var(--graph-commit-bg); border-color: var(--graph-commit-line); }
+.workflow-legend-verify .workflow-legend-swatch { background: var(--graph-verify-bg); border-color: var(--graph-verify-line); }
 
 .workflow-graph-wrap {
   overflow-x: auto;
@@ -1248,11 +1647,11 @@ details.action-box summary {
   padding: 14px 16px;
   border: 1px solid var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--surface);
 }
 
 .workflow-inspector-empty {
-  background: #f6f8fb;
+  background: var(--surface-sunken);
   color: var(--muted);
   text-align: center;
 }
@@ -1303,7 +1702,7 @@ details.action-box summary {
 .workflow-instructions {
   font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, monospace);
   font-size: 12px;
-  background: #f6f8fb;
+  background: var(--surface-sunken);
   border: 1px solid var(--line);
   border-radius: 6px;
   padding: 8px 10px;
@@ -1381,8 +1780,8 @@ details.action-box summary {
 }
 
 .workflow-draft-remove:hover {
-  color: #b6443c;
-  border-color: #e0b3ae;
+  color: var(--danger);
+  border-color: var(--danger-line);
 }
 
 .workflow-draft-add {
@@ -1391,7 +1790,7 @@ details.action-box summary {
 }
 
 .workflow-draft-add:hover {
-  background: #f6f8fb;
+  background: var(--surface-sunken);
 }
 
 .workflow-draft-answers {
@@ -1419,7 +1818,7 @@ details.action-box summary {
 }
 
 .workflow-draft-raw {
-  background: #f9fafc;
+  background: var(--surface-sunken);
   border: 1px solid var(--line);
   border-radius: 8px;
   padding: 10px 14px;
@@ -1446,9 +1845,9 @@ details.action-box summary {
 }
 
 .empty-state {
-  border: 1px dashed #c7d0dc;
+  border: 1px dashed var(--line);
   border-radius: 8px;
-  background: #ffffff;
+  background: var(--surface);
   color: var(--muted);
   padding: 24px;
   text-align: center;

--- a/src/mac/workflow_service.py
+++ b/src/mac/workflow_service.py
@@ -262,15 +262,20 @@ class WorkflowService:
         parsed_definition = self._validate_definition(definition, tenant_id=tenant_id)
         normalized_definition = parsed_definition.to_dict()
 
-        existing = self.store.query_all(
-            """
-            SELECT * FROM workflows
-            WHERE slug = ? AND (tenant_id IS ? OR tenant_id = ?)
-            ORDER BY version DESC
-            LIMIT 1
-            """,
-            (slug_value, tenant_id, tenant_id),
-        )
+        # ``tenant_id IS ?`` works on SQLite but errors on Postgres
+        # (``syntax error at or near $N``). Split into IS NULL / = ?.
+        if tenant_id is None:
+            existing = self.store.query_all(
+                "SELECT * FROM workflows WHERE slug = ? AND tenant_id IS NULL "
+                "ORDER BY version DESC LIMIT 1",
+                (slug_value,),
+            )
+        else:
+            existing = self.store.query_all(
+                "SELECT * FROM workflows WHERE slug = ? AND tenant_id = ? "
+                "ORDER BY version DESC LIMIT 1",
+                (slug_value, tenant_id),
+            )
         existing_row = existing[0] if existing else None
         version = 1
         if existing_row is not None:

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -3518,6 +3518,44 @@ def test_task_claim_records_history_and_outbox_in_same_transaction(cp):
     assert outbox[0].detail["lease_id"] == lease.id
 
 
+def test_outbox_drains_in_enqueue_order_with_identical_created_at(cp):
+    """mac: a single task transition enqueues several outbox rows
+    (task.lifecycle, beads.ledger, beads.reopen) sharing the exact same
+    created_at. list_outbox must return them in stable ENQUEUE order so
+    downstream side effects (e.g. the beads ledger note before the reopen
+    --status note) fire deterministically. Previously the secondary sort
+    key was a random uuid4 id, so the drain order was non-deterministic
+    and flaky."""
+    worker = register_agent(cp, "worker", ["python"])
+    task = cp.create_task("ordering", required_capabilities=["python"])
+    # Drain any rows from create so we isolate the enqueue below.
+    cp.drain_task_transition_outbox(task_id=task.id)
+
+    now = "2026-06-01T00:00:00.000000+00:00"
+    expected = []
+    with cp.store.transaction() as conn:
+        for event_type in (
+            "task.lifecycle",
+            "beads.ledger",
+            "beads.reopen",
+            "workflow.advance",
+        ):
+            cp.task_ledger.enqueue_outbox(
+                conn,
+                task_id=task.id,
+                event_type=event_type,
+                actor=worker.id,
+                from_state="running",
+                to_state="failed",
+                detail={"reason": "x"},
+                created_at=now,  # identical timestamp for all rows
+            )
+            expected.append(event_type)
+
+    pending = cp.list_task_transition_outbox(task_id=task.id)
+    assert [item.event_type for item in pending] == expected
+
+
 def test_beads_bridge_syncs_claim_and_failure_to_beads(cp, tmp_path, monkeypatch):
     monkeypatch.setenv("MAC_BEADS_BRIDGE_ENABLED", "1")
     repo = tmp_path / "repo"

--- a/tests/test_router_app.py
+++ b/tests/test_router_app.py
@@ -115,6 +115,43 @@ def test_all_providers_failing_returns_503_failfast():
     assert {a["provider"] for a in body["error"]["attempts"]} == {"primary", "secondary"}
 
 
+def test_strips_unsupported_reasoning_summary_param_before_forwarding():
+    """A client (opencode) may send `reasoningSummary` for an OpenAI reasoning
+    model; some upstreams reject it with 400 unknown_parameter. The router must
+    strip known-unsupported params before forwarding so the request succeeds,
+    while leaving normal params untouched."""
+    r = _router()
+    seen = {}
+
+    def fwd(provider, path, payload, *, timeout=60.0):
+        seen.update(payload)
+        return 200, {"ok": True}
+
+    proxy = ProviderProxy(r, fwd)
+    status, _ = proxy.complete(
+        "/chat/completions",
+        {"model": "gpt-5.5", "messages": [{"role": "user", "content": "hi"}], "reasoningSummary": "auto"},
+    )
+    assert status == 200
+    assert "reasoningSummary" not in seen  # stripped
+    assert seen["model"] == "gpt-5.5"  # normal params preserved
+    assert seen["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_build_proxy_drop_params_overridable_via_env():
+    """Operators can extend the stripped-param set declaratively via
+    MAC_ROUTER_DROP_PARAMS (comma-separated) without a code change."""
+    proxy = build_proxy_from_env(
+        env={
+            "MAC_ROUTER_PROVIDERS": "primary=http://p/v1,0",
+            "MAC_ROUTER_DROP_PARAMS": "reasoningSummary,foo_param",
+        }
+    )
+    assert proxy is not None
+    assert "reasoningSummary" in proxy._drop_params
+    assert "foo_param" in proxy._drop_params
+
+
 def test_mount_is_noop_unless_inproc(monkeypatch):
     from fastapi import FastAPI
 

--- a/tests/test_router_app.py
+++ b/tests/test_router_app.py
@@ -62,6 +62,39 @@ def test_network_error_status_none_fails_over():
     assert r.status()["primary"]["state"] == "open"
 
 
+def test_transient_401_is_retried_once_on_same_provider():
+    """A transient upstream 401 (e.g. NVIDIA gateway momentarily can't reach its
+    key-verification DB) must not kill a long agent session. The router retries
+    the SAME provider once; if the retry succeeds, the client never sees the
+    blip."""
+    r = _router()
+    seq = iter([(401, {"error": {"message": "Can't reach database server", "code": "401"}}),
+                (200, {"ok": True})])
+
+    def fwd(provider, path, payload, *, timeout=60.0):
+        return next(seq)
+
+    status, body = ProviderProxy(r, fwd).complete("/chat/completions", {"model": "primary-model"})
+    assert status == 200 and body == {"ok": True}
+
+
+def test_persistent_401_returned_after_bounded_retry():
+    """A genuine bad-key 401 keeps returning 401 on retry. The router must NOT
+    loop forever: it retries once, still gets 401, returns it to the client."""
+    r = _router()
+    calls = []
+
+    def fwd(provider, path, payload, *, timeout=60.0):
+        calls.append(provider.name)
+        return 401, {"error": {"message": "invalid api key"}}
+
+    status, body = ProviderProxy(r, fwd).complete("/chat/completions", {"model": "primary-model"})
+    assert status == 401
+    # bounded: the same provider is tried at most twice (initial + one retry),
+    # never an unbounded loop.
+    assert calls.count("primary") <= 2
+
+
 def test_4xx_is_returned_not_failed_over():
     # A 400 is a bad request, not a provider health problem: return it, keep the
     # provider healthy, and do NOT pointlessly retry the same bad request elsewhere.


### PR DESCRIPTION
Pulls in the **low-risk, independently-valuable** changes from the Vikaspogu/mac fork (review of the full fork done separately). Explicitly **excludes** the strategic tier (Postgres backend, K8s orchestration, OpenCode executors, capability/role policy) — that's a separate, bare-metal-verified integration.

### Included
- **Router** (`807fc13`, `5789852`): retry a transient upstream **401 once** on the same provider (bounded, fail-safe); **strip unsupported request params** (`reasoningSummary`) before forwarding, overridable via `MAC_ROUTER_DROP_PARAMS`. Cherry-picked clean onto our modality-proxy/route-logging router. +2 tests each.
- **Fail-closed verdict** (`7b02877`, services.py portion only): unknown/malformed review verdict now defaults to **`rejected`** instead of `approved`. The rejected-requires-feedback validator from that commit is **omitted** to avoid breaking bare rejections.
- **Deterministic outbox drain** (`563325a`): monotonic counter in the outbox id → stable drain order (fixes flaky ordering even on SQLite). +test.
- **Portability fixes** (no-ops on SQLite): `IS ?`→`IS NULL`/`= ?` in provisioning + workflow + roles services (`8e636b7`, roles_service); observability `INSERT ... RETURNING` instead of SQLite-only `lastrowid` (`977c1c2`, observability portion only).
- **UI**: dark/light theme toggle (CSS variables, no-FOUC), Kanban lane/card polish, Create-Project form reflow, card-overflow fixes.

### Verified
Full suite: **810 passed** (5 new). SQLite 3.50.4 supports `RETURNING`. No test relied on the old approve-default.

Credit: changes adopted from https://github.com/Vikaspogu/mac (cherry-picks recorded with `-x`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)