### PR TITLE
fix(api): /observability/logs 500 on silenced poll-log names

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -3099,7 +3099,12 @@ def create_app(
 
     @app.post("/observability/logs")
     def record_observability_log(body: ObservabilityLogCreate) -> Dict[str, Any]:
-        return cp.record_log(**_data(body)).to_dict()
+        # record_log returns None when the log name is a silenced high-volume
+        # idle-poll emitter (mem-04 dropped 1.83M/2.09M rows from these). That's
+        # an intentional drop, not an error — report it as filtered rather than
+        # calling .to_dict() on None, which 500'd on every silenced poll log.
+        event = cp.record_log(**_data(body))
+        return event.to_dict() if event is not None else {"filtered": True}
 
     @app.get("/observability/metrics")
     def list_observability_metrics(

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1709,6 +1709,28 @@ def test_observability_api_records_lists_and_streams_metrics_and_logs():
     assert [line["id"] for line in lines[:2]] == [metric["id"], log["id"]]
 
 
+def test_observability_logs_silenced_poll_name_is_filtered_not_500():
+    """mem-04 silences high-volume idle-poll log names (record_log -> None).
+    The endpoint must report that as filtered, not 500 on .to_dict() of None."""
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+
+    # a silenced idle-poll name is dropped: 200 + {"filtered": True}, never 500
+    dropped = client.post(
+        "/observability/logs",
+        json={"name": "worker.no_task", "level": "info", "layer": "worker", "source": "rocky"},
+    )
+    assert dropped.status_code == 200
+    assert dropped.json() == {"filtered": True}
+
+    # a normal log name still records and returns the event
+    kept = client.post(
+        "/observability/logs",
+        json={"name": "worker.dispatch.waiting", "level": "warning", "layer": "worker", "source": "rocky"},
+    )
+    assert kept.status_code == 200
+    assert kept.json()["name"] == "worker.dispatch.waiting"
+
+
 def test_http_observation_middleware_is_off_by_default_and_writes_one_row_when_on():
     off_cp = ControlPlane.in_memory()
     client = TestClient(create_app(control_plane=off_cp))


### PR DESCRIPTION
### Bug (pre-existing, found during the #71 redeploy)
The **mem-04** observability-bloat fix made `ObservabilityService.record_log` return `None` for high-volume idle-poll log names (it dropped 1.83M of 2.09M rows on rocky). But `POST /observability/logs` still did `cp.record_log(...).to_dict()` — so every silenced poll log (`worker.no_task`, `worker.routing.no_candidate`, `workflow.default_review.*`, …) raised `AttributeError: 'NoneType' object has no attribute 'to_dict'` → **500**. Agents emit these on every idle poll, so the control-plane log was a constant 500 stream.

### Fix
Handle the intentional drop: return `{"filtered": true}` when `record_log` returns `None`, else the event dict as before. `/observability/metrics` is unaffected (`record_metric` never returns `None`).

### Test
A silenced name (`worker.no_task`) now returns **200 + `{"filtered": true}`** (was 500); a normal name still records + returns the event. Full suite: **811 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)