### PR TITLE
feat(agents): bundle embeddings + vector math for memory/dream review

### DIFF
--- a/src/mac/_hermes/tools/code_execution_tool.py
+++ b/src/mac/_hermes/tools/code_execution_tool.py
@@ -66,6 +66,7 @@ SANDBOX_ALLOWED_TOOLS = frozenset([
     "search_files",
     "patch",
     "terminal",
+    "embed",
 ])
 
 # Resource limit defaults (overridable via config.yaml → code_execution.*)
@@ -253,6 +254,12 @@ _TOOL_STUBS = {
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
         '{"command": command, "timeout": timeout, "workdir": workdir}',
     ),
+    "embed": (
+        "embed",
+        "text, model: str = None",
+        '"""Embed a string or list of strings via the fleet embedding model. Returns dict {model, dim, count, embeddings:[[float,...],...]}. Pair with centroid()/cosine_similarity()/nearest_neighbors() for memory/dream review."""',
+        '{"input": text, "model": model}',
+    ),
 }
 
 
@@ -328,6 +335,51 @@ def retry(fn, max_attempts=3, delay=2):
             if attempt < max_attempts - 1:
                 time.sleep(delay * (2 ** attempt))
     raise last_err
+
+
+# --- Vector math (numpy) for embeddings: review memories/dreams/concepts ------
+# Typical flow:
+#   e = embed(["concept a", "concept b", ...]); V = e["embeddings"]
+#   c = centroid(V); ranked = nearest_neighbors(c, V, k=3)
+# numpy is imported lazily so importing hermes_tools never fails without it.
+
+def _np():
+    try:
+        import numpy as _n
+    except ImportError as exc:  # pragma: no cover - guidance only
+        raise RuntimeError("numpy is required for vector math (pip install numpy)") from exc
+    return _n
+
+
+def centroid(vectors):
+    """Mean (centroid) of a list of embedding vectors. Returns a list of floats."""
+    return _np().asarray(vectors, dtype=float).mean(axis=0).tolist()
+
+
+def cosine_similarity(a, b):
+    """Cosine similarity of two vectors, a float in [-1, 1]."""
+    np = _np()
+    a = np.asarray(a, dtype=float)
+    b = np.asarray(b, dtype=float)
+    na = np.linalg.norm(a)
+    nb = np.linalg.norm(b)
+    if na == 0 or nb == 0:
+        return 0.0
+    return float(a.dot(b) / (na * nb))
+
+
+def nearest_neighbors(query, candidates, k=5):
+    """Rank candidate vectors by cosine similarity to query (highest first).
+    Returns [{"index": i, "score": float}, ...]; k<=0 returns all."""
+    np = _np()
+    q = np.asarray(query, dtype=float)
+    C = np.asarray(candidates, dtype=float)
+    denom = np.linalg.norm(q) * np.linalg.norm(C, axis=1)
+    sims = np.divide(C.dot(q), denom, out=np.zeros(C.shape[0]), where=denom > 0)
+    order = np.argsort(-sims)
+    if k and k > 0:
+        order = order[:k]
+    return [{"index": int(i), "score": float(sims[i])} for i in order]
 
 '''
 

--- a/src/mac/_hermes/tools/embedding_tool.py
+++ b/src/mac/_hermes/tools/embedding_tool.py
@@ -1,0 +1,135 @@
+"""Embedding tool (embed-01).
+
+Gives an agent vector embeddings via the in-mac router's ``/v1/embeddings``
+proxy, so it can embed text — its own memories, dreams, or arbitrary concepts —
+and do vector math (centroid, nearest-neighbour) on them inside ``execute_code``
+(``from hermes_tools import embed``; the sandbox also ships ``centroid()`` /
+``cosine_similarity()`` / ``nearest_neighbors()`` numpy helpers).
+
+It routes through the gateway exactly like chat does: the agent presents its hub
+token and the hub swaps in the upstream key — so it works on the hub and on
+spokes with no extra plumbing. The default model is the verified-working
+``us/azure/openai/text-embedding-3-small`` (1536-dim); override per call with
+``model=`` or fleet-wide with ``MAC_HERMES_EMBED_MODEL``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List, Optional, Tuple
+
+from tools.registry import registry, tool_error
+
+DEFAULT_EMBED_MODEL = "us/azure/openai/text-embedding-3-small"
+
+
+def _gateway() -> Tuple[str, str]:
+    base = (
+        os.environ.get("MAC_HERMES_GATEWAY_BASE_URL")
+        or os.environ.get("OPENAI_BASE_URL")
+        or ""
+    ).strip().rstrip("/")
+    token = (
+        os.environ.get("MAC_HERMES_GATEWAY_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or os.environ.get("MAC_API_TOKEN")
+        or ""
+    ).strip()
+    return base, token
+
+
+def _default_model() -> str:
+    return (os.environ.get("MAC_HERMES_EMBED_MODEL") or "").strip() or DEFAULT_EMBED_MODEL
+
+
+def embed(text: Any, model: Optional[str] = None) -> Dict[str, Any]:
+    """Embed one string or a list of strings through the gateway /embeddings
+    proxy. Returns {"model", "dim", "count", "embeddings": [[float, ...], ...]}.
+    On failure returns a tool_error string."""
+    base, token = _gateway()
+    if not base or not token:
+        return tool_error("embed needs MAC_HERMES_GATEWAY_BASE_URL + a gateway token in the agent env")
+    inputs: List[str] = [text] if isinstance(text, str) else [str(t) for t in (text or [])]
+    if not inputs:
+        return tool_error("embed requires at least one input string")
+    payload = {"model": (model or _default_model()), "input": inputs}
+    req = urllib.request.Request(
+        base + "/embeddings",
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+    )
+    req.add_header("Authorization", "Bearer %s" % token)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:  # noqa: S310 (operator-configured hub)
+            out = json.loads(resp.read().decode("utf-8", "replace"))
+    except urllib.error.HTTPError as exc:
+        return tool_error("embeddings upstream HTTP %s: %s" % (exc.code, exc.read().decode("utf-8", "replace")[:200]))
+    except Exception as exc:  # noqa: BLE001
+        return tool_error("embed failed: %s" % exc)
+    rows = sorted(out.get("data") or [], key=lambda d: d.get("index", 0))
+    vectors = [r.get("embedding") for r in rows if r.get("embedding") is not None]
+    return {
+        "model": out.get("model") or payload["model"],
+        "count": len(vectors),
+        "dim": len(vectors[0]) if vectors else 0,
+        "embeddings": vectors,
+    }
+
+
+EMBED_SCHEMA = {
+    "name": "embed",
+    "description": (
+        "Get vector embeddings for text via the fleet's shared embedding model. Best "
+        "used inside execute_code (`from hermes_tools import embed`) so you can embed "
+        "your memories, dreams, or concepts and do vector math on them — the sandbox "
+        "also exposes `centroid()`, `cosine_similarity()` and `nearest_neighbors()` "
+        "(numpy). Pass a string or a list of strings; returns "
+        "{model, dim, count, embeddings:[[float,...],...]}. Default model: "
+        "us/azure/openai/text-embedding-3-small (1536-dim)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "input": {
+                "description": "a string, or a list of strings, to embed",
+                "oneOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}},
+                ],
+            },
+            "model": {"type": "string", "description": "optional embedding model override"},
+        },
+        "required": ["input"],
+    },
+}
+
+
+def _handle_embed(args, **kw):
+    try:
+        result = embed(args.get("input"), model=args.get("model"))
+    except Exception as exc:  # noqa: BLE001
+        return tool_error("embed tool error: %s" % exc)
+    return result if isinstance(result, str) else json.dumps(result)
+
+
+def check_embed_requirements() -> bool:
+    """Available when the agent has gateway access (base URL + token in env)."""
+    base, token = _gateway()
+    return bool(base and token)
+
+
+registry.register(
+    name="embed",
+    toolset="embed",
+    schema=EMBED_SCHEMA,
+    handler=_handle_embed,
+    check_fn=check_embed_requirements,
+    requires_env=[],
+    is_async=False,
+    emoji="🧮",
+)

--- a/tests/test_embedding_tool.py
+++ b/tests/test_embedding_tool.py
@@ -1,0 +1,107 @@
+"""The embed tool routes through the gateway /embeddings proxy and is exposed to
+the code sandbox (from hermes_tools import embed) alongside numpy vector-math
+helpers, so an agent can review its memories/dreams: embed -> centroid ->
+nearest_neighbors."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+HERMES = Path(__file__).resolve().parents[1] / "src" / "mac" / "_hermes"
+if str(HERMES) not in sys.path:
+    sys.path.insert(0, str(HERMES))
+
+from tools import embedding_tool  # noqa: E402
+from tools.code_execution_tool import generate_hermes_tools_module  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._b = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+@pytest.fixture
+def gateway_env(monkeypatch):
+    monkeypatch.setenv("MAC_HERMES_GATEWAY_BASE_URL", "http://127.0.0.1:18789/v1")
+    monkeypatch.setenv("MAC_HERMES_GATEWAY_API_KEY", "hub-token")
+    monkeypatch.delenv("MAC_HERMES_EMBED_MODEL", raising=False)
+
+
+def test_embed_posts_to_gateway_embeddings(gateway_env, monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["auth"] = req.get_header("Authorization")
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _Resp({
+            "model": "us/azure/openai/text-embedding-3-small",
+            "data": [
+                {"index": 1, "embedding": [0.4, 0.5, 0.6]},
+                {"index": 0, "embedding": [0.1, 0.2, 0.3]},
+            ],
+        })
+
+    monkeypatch.setattr(embedding_tool.urllib.request, "urlopen", fake_urlopen)
+    out = embedding_tool.embed(["alpha", "beta"])
+
+    assert captured["url"] == "http://127.0.0.1:18789/v1/embeddings"
+    assert captured["auth"] == "Bearer hub-token"
+    assert captured["body"] == {"model": "us/azure/openai/text-embedding-3-small", "input": ["alpha", "beta"]}
+    # results sorted by index; dim/count populated
+    assert out["count"] == 2 and out["dim"] == 3
+    assert out["embeddings"][0] == [0.1, 0.2, 0.3]
+
+
+def test_embed_default_model_overridable(gateway_env, monkeypatch):
+    monkeypatch.setenv("MAC_HERMES_EMBED_MODEL", "custom/embed-v2")
+    captured = {}
+    monkeypatch.setattr(
+        embedding_tool.urllib.request, "urlopen",
+        lambda req, timeout=None: captured.update(json.loads(req.data.decode())) or _Resp({"data": []}),
+    )
+    embedding_tool.embed("x")
+    assert captured["model"] == "custom/embed-v2"
+    assert captured["input"] == ["x"]
+
+
+def test_embed_requires_gateway(monkeypatch):
+    for k in ("MAC_HERMES_GATEWAY_BASE_URL", "OPENAI_BASE_URL", "MAC_HERMES_GATEWAY_API_KEY", "OPENAI_API_KEY", "MAC_API_TOKEN"):
+        monkeypatch.delenv(k, raising=False)
+    assert embedding_tool.check_embed_requirements() is False
+    assert "gateway" in embedding_tool.embed("x").lower()
+
+
+def test_embed_tool_registered():
+    from tools.registry import registry
+    assert "embed" in registry._tools
+
+
+def test_sandbox_exposes_embed_and_vector_helpers():
+    src = generate_hermes_tools_module(["embed", "web_search"], transport="uds")
+    assert "def embed(" in src
+    # the generated module is self-contained python: exec it and exercise the
+    # numpy helpers exactly as an agent would in the sandbox.
+    ns: dict = {}
+    exec(compile(src, "hermes_tools_generated", "exec"), ns)
+    assert {"centroid", "cosine_similarity", "nearest_neighbors"} <= ns.keys()
+
+    assert ns["centroid"]([[0, 0, 2], [0, 0, 4]]) == [0.0, 0.0, 3.0]
+    assert ns["cosine_similarity"]([1, 0], [1, 0]) == pytest.approx(1.0)
+    assert ns["cosine_similarity"]([1, 0], [0, 1]) == pytest.approx(0.0)
+
+    ranked = ns["nearest_neighbors"]([1, 0, 0], [[1, 0, 0], [0, 1, 0], [0.9, 0.1, 0.0]], k=2)
+    assert [r["index"] for r in ranked] == [0, 2]
+    assert ranked[0]["score"] == pytest.approx(1.0)


### PR DESCRIPTION
A fleet agent tried to `from hermes_tools import embed` (to do embed → centroid → nearest-neighbour over its memories/dreams) and it failed — there was **no embedding function**, and **numpy wasn't installed** on the agents, so vector math was impossible.

### What this adds
- **`embed` tool** (`tools/embedding_tool.py`) — routes through the in-mac router's `/v1/embeddings` proxy using the gateway base URL + hub token (works on hub *and* spokes, same pattern as the image-gen plugin). Default model `us/azure/openai/text-embedding-3-small` (verified live: 200, 1536-dim); override with `model=` or `MAC_HERMES_EMBED_MODEL`. Returns `{model, dim, count, embeddings:[[float,...],...]}`.
- **Code-sandbox exposure** — `embed` added to `SANDBOX_ALLOWED_TOOLS` + `_TOOL_STUBS`, so `from hermes_tools import embed` works in `execute_code` (auto-registered via `discover_builtin_tools`).
- **Vector math** — `centroid()`, `cosine_similarity()`, `nearest_neighbors()` added to the sandbox's `_COMMON_HELPERS` (lazy numpy import, so `hermes_tools` still imports without numpy). numpy is already a pinned dependency.

### Tests
embed POSTs to `<gateway>/embeddings` with bearer + index-sorted results; model override; gateway gating; tool registered; and the **generated `hermes_tools` module is exec'd** to exercise the numpy helpers end-to-end. Full suite: **818 passed**.

### Deploy note
numpy must be installed into the agent venvs (they predate the dependency) — handled at deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)