### PR TITLE
feat(journal): daily agent soul + memory backups with off-host hook

### DIFF
--- a/deploy/install-agent-journal-service.sh
+++ b/deploy/install-agent-journal-service.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# install-agent-journal-service.sh - systemd timer that runs `mac journal
+# snapshot` once a day, capturing this agent's soul + memory state (SOUL.md,
+# USER.md, MEMORY.md, memories/, mood, config) into $HOME/.mac/journal/<date>/.
+#
+# An agent's evolved personality is irreplaceable; this keeps dated, restorable
+# backups so a wiped host or a bad redeploy can't silently erase it.
+#
+# To also ship copies off-host (e.g. a cloud blob store), set a backup hook in
+# /etc/mac/agent-journal.env — a shell command run after each snapshot with
+# MAC_JOURNAL_PATH / _DATE / _AGENT / _MANIFEST in the environment, e.g.:
+#   MAC_JOURNAL_BACKUP_HOOK='aws s3 cp --recursive "$MAC_JOURNAL_PATH" "s3://mac-agent-journals/$MAC_JOURNAL_AGENT/$MAC_JOURNAL_DATE/"'
+set -euo pipefail
+
+FLEET_NAME="${FLEET_NAME:-mac}"
+WORKSPACE="${WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+UNIT_DIR="${WORKSPACE}/deploy/systemd"
+SERVICE_TEMPLATE="${UNIT_DIR}/mac-agent-journal.service"
+TIMER_TEMPLATE="${UNIT_DIR}/mac-agent-journal.timer"
+SERVICE_DEST="/etc/systemd/system/${FLEET_NAME}-agent-journal.service"
+TIMER_DEST="/etc/systemd/system/${FLEET_NAME}-agent-journal.timer"
+ENV_DEST="/etc/${FLEET_NAME}/agent-journal.env"
+
+# Detect the user mac.service runs as and substitute into the unit template.
+MAC_USER="${MAC_USER:-}"
+MAC_HOME_DIR="${MAC_HOME_DIR:-}"
+if [ -z "$MAC_USER" ] && [ -f "/etc/systemd/system/${FLEET_NAME}.service" ]; then
+  MAC_USER="$(awk -F= '/^User=/{print $2; exit}' "/etc/systemd/system/${FLEET_NAME}.service" 2>/dev/null || true)"
+fi
+if [ -z "$MAC_USER" ]; then
+  echo "[agent-journal] ERROR: could not detect MAC_USER; set it explicitly." >&2
+  exit 1
+fi
+if [ -z "$MAC_HOME_DIR" ]; then
+  MAC_HOME_DIR="$(getent passwd "$MAC_USER" | cut -d: -f6)/.mac"
+fi
+
+if [ ! -f "$SERVICE_TEMPLATE" ] || [ ! -f "$TIMER_TEMPLATE" ]; then
+  echo "[agent-journal] ERROR: unit templates not found under $UNIT_DIR" >&2
+  exit 1
+fi
+if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
+  echo "[agent-journal] ERROR: systemd not detected; this installer is Linux-only." >&2
+  exit 1
+fi
+
+sudo install -d -m 0755 "$(dirname "$ENV_DEST")"
+if [ ! -f "$ENV_DEST" ]; then
+  sudo tee "$ENV_DEST" >/dev/null <<'ENV'
+# Optional off-host archival. MAC_JOURNAL_BACKUP_HOOK runs after each daily
+# snapshot with MAC_JOURNAL_PATH / MAC_JOURNAL_DATE / MAC_JOURNAL_AGENT /
+# MAC_JOURNAL_MANIFEST set. Leave unset to keep journals local only.
+#MAC_JOURNAL_BACKUP_HOOK='aws s3 cp --recursive "$MAC_JOURNAL_PATH" "s3://mac-agent-journals/$MAC_JOURNAL_AGENT/$MAC_JOURNAL_DATE/"'
+#MAC_JOURNAL_DIR=
+ENV
+  sudo chmod 0644 "$ENV_DEST"
+fi
+
+rendered="$(mktemp)"
+sed -e "s|__MAC_USER__|${MAC_USER}|g" -e "s|__MAC_HOME__|${MAC_HOME_DIR}|g" \
+    "$SERVICE_TEMPLATE" > "$rendered"
+sudo install -m 0644 "$rendered" "$SERVICE_DEST"
+rm -f "$rendered"
+sudo install -m 0644 "$TIMER_TEMPLATE" "$TIMER_DEST"
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now "$(basename "$TIMER_DEST")"
+
+echo "[agent-journal] installed (User=${MAC_USER}, mac home=${MAC_HOME_DIR}); next run:"
+sudo systemctl list-timers --no-pager "$(basename "$TIMER_DEST")" || true

--- a/deploy/systemd/mac-agent-journal.service
+++ b/deploy/systemd/mac-agent-journal.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=mac agent journal — daily snapshot of this agent's soul + memory state
+Documentation=https://github.com/jordanh/mac
+After=mac.service
+Wants=mac.service
+
+[Service]
+Type=oneshot
+User=__MAC_USER__
+WorkingDirectory=__MAC_HOME__
+
+# HERMES_HOME, MAC_AGENT_ID come from mac.env. Set MAC_JOURNAL_BACKUP_HOOK (a
+# shell command that archives the snapshot off-host — e.g. aws/gsutil/rclone)
+# and/or MAC_JOURNAL_DIR in /etc/mac/agent-journal.env to ship copies to durable
+# storage. Without a hook this just keeps local dated journals.
+EnvironmentFile=-__MAC_HOME__/mac.env
+EnvironmentFile=-/etc/mac/agent-journal.env
+
+# Snapshot SOUL.md / USER.md / MEMORY.md / memories/ / mood state / config into
+# $HOME/.mac/journal/<date>/ and run the backup hook if configured.
+ExecStart=__MAC_HOME__/venv/bin/mac journal snapshot
+
+StandardOutput=journal
+StandardError=journal

--- a/deploy/systemd/mac-agent-journal.timer
+++ b/deploy/systemd/mac-agent-journal.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Daily trigger for mac agent journal (soul + memory backup)
+Documentation=https://github.com/jordanh/mac
+
+[Timer]
+# Once a day. Persistent=true means a host that was off at the scheduled time
+# runs the snapshot on next boot rather than silently skipping a day — we never
+# want to miss capturing an agent's evolving state. The randomized delay spreads
+# the fleet's snapshots so they don't all hit the hub's backup hook at once.
+OnCalendar=daily
+RandomizedDelaySec=30min
+Persistent=true
+Unit=mac-agent-journal.service
+
+[Install]
+WantedBy=timers.target

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -502,6 +502,57 @@ def cmd_fleet_refresh_context(args: argparse.Namespace) -> None:
     _print({"status": "refreshed", "markdown": markdown, "members": len(snapshot.get("members", []))})
 
 
+def cmd_journal_snapshot(args: argparse.Namespace) -> None:
+    """journal-01: snapshot this agent's soul + memory state into
+    $HOME/.mac/journal/<date>/ and run the backup hook (unless --no-hook)."""
+    from pathlib import Path as _Path
+
+    from mac import journal as _journal
+
+    root = _Path(args.dir).expanduser() if getattr(args, "dir", None) else None
+    home = _Path(args.home).expanduser() if getattr(args, "home", None) else None
+    m = _journal.snapshot(
+        home=home,
+        root=root,
+        date=getattr(args, "date", None),
+        agent_id=getattr(args, "agent", None),
+        run_hook=not getattr(args, "no_hook", False),
+    )
+    _print(
+        {
+            "date": m["date"],
+            "agent_id": m["agent_id"],
+            "captured": m["captured"],
+            "files": len(m["files"]),
+            "path": str((root or _journal.journal_root()) / m["date"]),
+            "hook": m.get("hook"),
+        }
+    )
+
+
+def cmd_journal_list(args: argparse.Namespace) -> None:
+    from pathlib import Path as _Path
+
+    from mac import journal as _journal
+
+    root = _Path(args.dir).expanduser() if getattr(args, "dir", None) else None
+    _print(_journal.list_journals(root))
+
+
+def cmd_journal_restore(args: argparse.Namespace) -> None:
+    from pathlib import Path as _Path
+
+    from mac import journal as _journal
+
+    root = _Path(args.dir).expanduser() if getattr(args, "dir", None) else None
+    home = _Path(args.home).expanduser() if getattr(args, "home", None) else None
+    _print(
+        _journal.restore(
+            args.date, home=home, root=root, dry_run=getattr(args, "dry_run", False)
+        )
+    )
+
+
 def _fleet_setup_plan_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     from mac.fleet_setup import build_setup_plan, load_setup_spec, public_plan
 
@@ -1855,6 +1906,40 @@ def build_parser() -> argparse.ArgumentParser:
         default=str(Path.home() / ".mac" / ".env"),
     )
     _set(cmd_fleet_validate_setup, fleet_validate)
+
+    # journal-01: daily snapshots of an agent's soul + memory state so an
+    # evolved personality can be restored if its files are ever lost. Local
+    # file ops only — no hub/--db needed.
+    journal = sub.add_parser(
+        "journal",
+        help="snapshot / restore an agent's soul + memory state (guards against soul loss)",
+    ).add_subparsers(dest="journal_command", required=True)
+
+    journal_snap = journal.add_parser(
+        "snapshot",
+        help="snapshot SOUL/USER/MEMORY/memories/mood/config to $HOME/.mac/journal/<date>/ "
+        "and run MAC_JOURNAL_BACKUP_HOOK if set",
+    )
+    journal_snap.add_argument("--dir", help="journal root (default $MAC_JOURNAL_DIR or ~/.mac/journal)")
+    journal_snap.add_argument("--home", help="agent HERMES_HOME (default $HERMES_HOME or ~/.hermes)")
+    journal_snap.add_argument("--date", help="snapshot date label (default today, UTC)")
+    journal_snap.add_argument("--agent", help="agent id label (default $MAC_AGENT_ID)")
+    journal_snap.add_argument("--no-hook", action="store_true", help="skip the backup hook")
+    _set(cmd_journal_snapshot, journal_snap)
+
+    journal_list = journal.add_parser("list", help="list journaled snapshots")
+    journal_list.add_argument("--dir", help="journal root (default ~/.mac/journal)")
+    _set(cmd_journal_list, journal_list)
+
+    journal_restore = journal.add_parser(
+        "restore",
+        help="restore an agent's state from a journal date (snapshots current state first, so it's reversible)",
+    )
+    journal_restore.add_argument("date", help="journal date to restore (e.g. 2026-06-04)")
+    journal_restore.add_argument("--dir", help="journal root (default ~/.mac/journal)")
+    journal_restore.add_argument("--home", help="agent HERMES_HOME to restore into")
+    journal_restore.add_argument("--dry-run", action="store_true", help="show what would be restored, change nothing")
+    _set(cmd_journal_restore, journal_restore)
 
     fleet_doctor = fleet.add_parser(
         "doctor",

--- a/src/mac/journal.py
+++ b/src/mac/journal.py
@@ -1,0 +1,204 @@
+"""Agent memory journaling (journal-01).
+
+Daily snapshots of an agent's *emergent* state — SOUL.md, USER.md, MEMORY.md,
+the memories/ directory, mood state, and the persona config — into
+``$HOME/.mac/journal/<date>/``, each with a manifest, plus an optional backup
+hook so the snapshot can be archived off-host (e.g. to a cloud blob store).
+
+This exists because an agent's evolved personality is irreplaceable. If those
+files are lost (a bad redeploy, a wiped host, an over-eager seed of the generic
+default soul), there is no way to regenerate the accumulated state — and the
+people who work with that agent genuinely feel the loss. Journaling makes the
+state restorable, and the hook lets the hub ship copies to durable storage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# The files/dirs that together make up an agent's "soul + memory". Missing ones
+# are skipped — not every agent (or layout) has every file.
+STATE_ENTRIES: List[str] = [
+    "SOUL.md",            # identity / voice
+    "USER.md",            # what it knows about its human
+    "MEMORY.md",          # persistent notes
+    "memories",           # dir: daily memories (+ MEMORY.md/USER.md in newer layout)
+    "mood-overlay.json",  # active mood overlay (mood engine)
+    "mood-memory.json",   # per-actor warmth/anger memory (mood engine)
+    "config.yaml",        # persona / model config
+]
+
+
+def hermes_home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+
+
+def journal_root() -> Path:
+    return Path(os.environ.get("MAC_JOURNAL_DIR") or (Path.home() / ".mac" / "journal"))
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _agent_id() -> str:
+    return (
+        os.environ.get("MAC_AGENT_ID")
+        or os.environ.get("MAC_AGENT_NAME")
+        or os.environ.get("HERMES_INSTANCE_ID")
+        or "agent"
+    )
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def snapshot(
+    *,
+    home: Optional[Path] = None,
+    root: Optional[Path] = None,
+    date: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    run_hook: bool = True,
+) -> Dict[str, Any]:
+    """Copy the agent's soul+memory state into ``<root>/<date>/`` and write a
+    manifest (with per-file sha256). Runs the backup hook unless run_hook=False.
+    Idempotent for a given date (re-running refreshes that day's snapshot)."""
+    home = Path(home) if home else hermes_home()
+    root = Path(root) if root else journal_root()
+    date = date or _today()
+    agent_id = agent_id or _agent_id()
+    dest = root / date
+    dest.mkdir(parents=True, exist_ok=True)
+
+    captured: List[str] = []
+    for name in STATE_ENTRIES:
+        src = home / name
+        if not src.exists():
+            continue
+        target = dest / name
+        if src.is_dir():
+            shutil.copytree(src, target, dirs_exist_ok=True)
+        else:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, target)
+        captured.append(name)
+
+    files: Dict[str, str] = {}
+    for p in sorted(dest.rglob("*")):
+        if p.is_file() and p.name != "manifest.json":
+            files[str(p.relative_to(dest))] = _sha256(p)
+
+    manifest = {
+        "version": "mac.agent_journal.v1",
+        "date": date,
+        "agent_id": agent_id,
+        "hermes_home": str(home),
+        "captured": captured,
+        "files": files,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    (dest / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    manifest["hook"] = _run_backup_hook(dest, manifest) if run_hook else None
+    return manifest
+
+
+def _run_backup_hook(dest: Path, manifest: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Invoke ``MAC_JOURNAL_BACKUP_HOOK`` (a shell command) so an operator can
+    archive the snapshot off-host — e.g. ``aws s3 cp``, ``gsutil``, ``rclone``,
+    or a hub aggregator. The hook gets the snapshot location via env:
+    MAC_JOURNAL_PATH / _DATE / _AGENT / _MANIFEST. Best-effort: a hook failure is
+    recorded in the manifest but does NOT fail the snapshot (the local journal
+    is the source of truth; the hook is an extra copy)."""
+    hook = (os.environ.get("MAC_JOURNAL_BACKUP_HOOK") or "").strip()
+    if not hook:
+        return None
+    env = dict(os.environ)
+    env.update(
+        {
+            "MAC_JOURNAL_PATH": str(dest),
+            "MAC_JOURNAL_DATE": str(manifest.get("date")),
+            "MAC_JOURNAL_AGENT": str(manifest.get("agent_id")),
+            "MAC_JOURNAL_MANIFEST": str(dest / "manifest.json"),
+        }
+    )
+    try:
+        proc = subprocess.run(
+            ["/bin/sh", "-c", hook],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        result: Dict[str, Any] = {"ran": True, "exit_code": proc.returncode}
+        if proc.returncode != 0:
+            result["stderr"] = (proc.stderr or "")[-500:]
+        return result
+    except Exception as exc:  # noqa: BLE001 - hook is best-effort
+        return {"ran": True, "error": str(exc)[:200]}
+
+
+def list_journals(root: Optional[Path] = None) -> List[Dict[str, Any]]:
+    root = Path(root) if root else journal_root()
+    if not root.exists():
+        return []
+    out: List[Dict[str, Any]] = []
+    for d in sorted(p for p in root.iterdir() if p.is_dir()):
+        mf = d / "manifest.json"
+        if not mf.exists():
+            continue
+        try:
+            m = json.loads(mf.read_text())
+            out.append(
+                {
+                    "date": m.get("date") or d.name,
+                    "agent_id": m.get("agent_id"),
+                    "files": len(m.get("files") or {}),
+                    "path": str(d),
+                }
+            )
+        except Exception:  # noqa: BLE001
+            out.append({"date": d.name, "agent_id": None, "files": 0, "path": str(d)})
+    return out
+
+
+def restore(
+    date: str,
+    *,
+    home: Optional[Path] = None,
+    root: Optional[Path] = None,
+    dry_run: bool = False,
+) -> Dict[str, Any]:
+    """Restore an agent's state from a journal date back into HERMES_HOME. Always
+    snapshots the *current* state first (a ``pre-restore-*`` journal) so a
+    restore is itself reversible — restoring a soul should never destroy one."""
+    home = Path(home) if home else hermes_home()
+    root = Path(root) if root else journal_root()
+    src = root / date
+    mf = src / "manifest.json"
+    if not mf.exists():
+        raise FileNotFoundError("no journal for %s under %s" % (date, root))
+    manifest = json.loads(mf.read_text())
+    plan = sorted((manifest.get("files") or {}).keys())
+    if dry_run:
+        return {"dry_run": True, "date": date, "would_restore": plan, "into": str(home)}
+    safety = snapshot(home=home, root=root, date="pre-restore-%s" % _today(), run_hook=False)
+    for rel in plan:
+        sp = src / rel
+        dp = home / rel
+        dp.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(sp, dp)
+    return {"restored": plan, "from": date, "into": str(home), "safety_backup": safety.get("date")}

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,94 @@
+"""Agent memory journaling: snapshot soul+memory state, run a backup hook, and
+restore — the guard against irreversible soul loss."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from mac import journal
+
+
+def _make_agent_home(home: Path) -> None:
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "SOUL.md").write_text("# SOUL\nI'm Rocky.\n", encoding="utf-8")
+    (home / "USER.md").write_text("user likes terse replies\n", encoding="utf-8")
+    (home / "MEMORY.md").write_text("the deploy was flaky on 2026-06-01\n", encoding="utf-8")
+    (home / "config.yaml").write_text("model: {provider: custom}\n", encoding="utf-8")
+    mem = home / "memories"
+    mem.mkdir(exist_ok=True)
+    (mem / "2026-06-01.md").write_text("woke up, fixed a tunnel\n", encoding="utf-8")
+    # a STATE_ENTRY that does NOT exist (mood files) must be silently skipped
+
+
+def test_snapshot_captures_state_and_manifest(tmp_path):
+    home = tmp_path / ".hermes"
+    root = tmp_path / ".mac" / "journal"
+    _make_agent_home(home)
+
+    m = journal.snapshot(home=home, root=root, date="2026-06-04", agent_id="rocky", run_hook=False)
+
+    dest = root / "2026-06-04"
+    assert (dest / "SOUL.md").read_text().startswith("# SOUL")
+    assert (dest / "memories" / "2026-06-01.md").exists()
+    assert set(m["captured"]) == {"SOUL.md", "USER.md", "MEMORY.md", "memories", "config.yaml"}
+    # per-file checksums recorded for every file, manifest written
+    assert "SOUL.md" in m["files"] and "memories/2026-06-01.md" in m["files"]
+    assert m["agent_id"] == "rocky" and m["version"] == "mac.agent_journal.v1"
+    assert json.loads((dest / "manifest.json").read_text())["date"] == "2026-06-04"
+
+
+def test_backup_hook_runs_with_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    root = tmp_path / ".mac" / "journal"
+    _make_agent_home(home)
+    marker = tmp_path / "uploaded.txt"
+    monkeypatch.setenv("MAC_JOURNAL_BACKUP_HOOK", 'echo "$MAC_JOURNAL_AGENT $MAC_JOURNAL_DATE" > "%s"' % marker)
+
+    m = journal.snapshot(home=home, root=root, date="2026-06-04", agent_id="natasha")
+
+    assert m["hook"]["ran"] is True and m["hook"]["exit_code"] == 0
+    assert marker.read_text().strip() == "natasha 2026-06-04"
+
+
+def test_hook_failure_does_not_break_snapshot(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    root = tmp_path / ".mac" / "journal"
+    _make_agent_home(home)
+    monkeypatch.setenv("MAC_JOURNAL_BACKUP_HOOK", "exit 7")
+
+    m = journal.snapshot(home=home, root=root, date="2026-06-04", agent_id="rocky")
+    # the local journal is still written; the hook failure is just recorded
+    assert (root / "2026-06-04" / "SOUL.md").exists()
+    assert m["hook"]["exit_code"] == 7
+
+
+def test_list_journals(tmp_path):
+    home = tmp_path / ".hermes"
+    root = tmp_path / ".mac" / "journal"
+    _make_agent_home(home)
+    journal.snapshot(home=home, root=root, date="2026-06-03", agent_id="rocky", run_hook=False)
+    journal.snapshot(home=home, root=root, date="2026-06-04", agent_id="rocky", run_hook=False)
+
+    listed = journal.list_journals(root)
+    assert [j["date"] for j in listed] == ["2026-06-03", "2026-06-04"]
+    assert all(j["files"] >= 5 for j in listed)
+
+
+def test_restore_reverts_state_and_keeps_safety_backup(tmp_path):
+    home = tmp_path / ".hermes"
+    root = tmp_path / ".mac" / "journal"
+    _make_agent_home(home)
+    journal.snapshot(home=home, root=root, date="2026-06-04", agent_id="rocky", run_hook=False)
+
+    # the agent's soul gets wiped to a bland default (the regression we're guarding against)
+    (home / "SOUL.md").write_text("# SOUL\ngeneric default\n", encoding="utf-8")
+
+    # dry-run changes nothing
+    dry = journal.restore("2026-06-04", home=home, root=root, dry_run=True)
+    assert dry["dry_run"] and "SOUL.md" in dry["would_restore"]
+    assert "generic default" in (home / "SOUL.md").read_text()
+
+    res = journal.restore("2026-06-04", home=home, root=root)
+    assert "I'm Rocky." in (home / "SOUL.md").read_text()      # restored
+    assert res["safety_backup"].startswith("pre-restore-")     # current state saved first
+    assert (root / res["safety_backup"] / "SOUL.md").read_text().startswith("# SOUL\ngeneric default")


### PR DESCRIPTION
Losing an agent's emergent personality is irreversible — and we just watched a migration reset every agent to the generic default soul. This adds journaling so it can never silently happen again.

### What it does
- **`mac journal snapshot`** copies an agent's soul+memory state — `SOUL.md`, `USER.md`, `MEMORY.md`, `memories/`, mood state, persona `config.yaml` — into `$HOME/.mac/journal/<date>/` with a per-file-checksummed manifest. Dated, append-only → a history of the evolving personality.
- **Backup hook** (`MAC_JOURNAL_BACKUP_HOOK`): runs after each snapshot with `MAC_JOURNAL_PATH`/`_DATE`/`_AGENT`/`_MANIFEST` in the env, so the hub (or each host) can archive to a cloud blob store (`aws s3 cp`, `gsutil`, `rclone`, …). Best-effort — a hook failure is recorded but never fails the local journal.
- **`mac journal list`** / **`mac journal restore <date>`** — restore snapshots the *current* state first, so reverting a soul is itself reversible.
- **Daily timer**: `deploy/systemd/mac-agent-journal.{service,timer}` (`Persistent=true` so a host that was off catches up) + `install-agent-journal-service.sh`, mirroring the nap-tick installer. (launchd plist installed on the darwin node at deploy.)

### Tested
capture+manifest, hook env + failure isolation, list, restore-with-safety-backup; CLI smoke (snapshot/list/restore + hook firing). Full suite: **1192 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)