### PR TITLE
feat(mood): render stored mood overlays into the agent prompt (mood-01)

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -488,18 +488,51 @@ def cmd_fleet_snapshot(args: argparse.Namespace) -> None:
 
 
 def cmd_fleet_refresh_context(args: argparse.Namespace) -> None:
-    """fleet-02: refresh the live Fleet section in this agent's runtime-context
-    markdown so its next session knows what teammates are doing. Idempotent."""
+    """fleet-02 + mood-01: refresh the live Fleet section AND this agent's mood
+    overlay in its runtime-context markdown, so its next session knows what
+    teammates are doing and actually behaves in its current mood. Idempotent."""
     import os as _os
     from pathlib import Path as _Path
-    from mac.hermes_runtime import render_fleet_section, refresh_fleet_section
 
-    snapshot = _plane(args).fleet_snapshot(exclude_agent_id=getattr(args, "agent", None))
+    from mac.hermes_runtime import (
+        refresh_fleet_section,
+        refresh_mood_section,
+        render_fleet_section,
+        render_mood_section,
+    )
+
+    plane = _plane(args)
+    agent = getattr(args, "agent", None)
+    snapshot = plane.fleet_snapshot(exclude_agent_id=agent)
     markdown = getattr(args, "markdown", None) or _os.environ.get(
         "MAC_HERMES_RUNTIME_CONTEXT_MARKDOWN"
     ) or str(_Path.home() / ".hermes" / "mac-runtime-context.md")
-    refresh_fleet_section(_Path(markdown), render_fleet_section(snapshot))
-    _print({"status": "refreshed", "markdown": markdown, "members": len(snapshot.get("members", []))})
+    path = _Path(markdown)
+    refresh_fleet_section(path, render_fleet_section(snapshot))
+
+    # mood-01: render this agent's current mood overlay into the same context so
+    # a set mood colors behaviour. Best-effort — never break the fleet refresh.
+    overlay = None
+    if agent:
+        try:
+            current = plane.get_current_mood(agent)
+            if current is None:
+                overlay = None
+            elif hasattr(current, "to_dict"):
+                overlay = current.to_dict()
+            elif isinstance(current, dict):
+                overlay = current
+        except Exception:  # noqa: BLE001
+            overlay = None
+    refresh_mood_section(path, render_mood_section(overlay))
+    _print(
+        {
+            "status": "refreshed",
+            "markdown": markdown,
+            "members": len(snapshot.get("members", [])),
+            "mood": (overlay or {}).get("mode"),
+        }
+    )
 
 
 def cmd_journal_snapshot(args: argparse.Namespace) -> None:

--- a/src/mac/hermes_runtime.py
+++ b/src/mac/hermes_runtime.py
@@ -804,6 +804,42 @@ def refresh_fleet_section(markdown_path: Path, section: str) -> None:
     markdown_path.write_text(text, encoding="utf-8")
 
 
+# mood-01: the agent's current mood overlay, rendered into the same runtime
+# context the prompt builder injects so a set mood actually colors behaviour.
+MOOD_SECTION_BEGIN = "<!-- mac:mood:begin -->"
+MOOD_SECTION_END = "<!-- mac:mood:end -->"
+
+
+def render_mood_section(overlay: Optional[Dict[str, Any]]) -> str:
+    """Render the agent's current mood overlay (a MoodOverlay.to_dict() or None)
+    as a delimited markdown block. Returns just the empty delimiters when there
+    is no active mood (or an unknown mode) — so refresh clears any stale block."""
+    from mac.mood_policy import render_mood_overlay
+
+    body = ""
+    if overlay:
+        body = render_mood_overlay(str(overlay.get("mode") or ""), overlay.get("reason"))
+    if not body:
+        return "%s\n%s" % (MOOD_SECTION_BEGIN, MOOD_SECTION_END)
+    return "\n".join([MOOD_SECTION_BEGIN, "## Mood — how you feel right now", "", body, MOOD_SECTION_END])
+
+
+def refresh_mood_section(markdown_path: Path, section: str) -> None:
+    """Insert/replace the delimited mood block in the runtime-context markdown.
+    Idempotent; clearing the mood writes empty delimiters which is a no-op block."""
+    text = ""
+    if markdown_path.exists():
+        text = markdown_path.read_text(encoding="utf-8", errors="ignore")
+    if MOOD_SECTION_BEGIN in text and MOOD_SECTION_END in text:
+        pre = text.split(MOOD_SECTION_BEGIN, 1)[0].rstrip()
+        post = text.split(MOOD_SECTION_END, 1)[1].lstrip()
+        text = (pre + "\n\n" + section + "\n\n" + post).rstrip() + "\n"
+    else:
+        text = (text.rstrip() + "\n\n" + section + "\n").lstrip("\n")
+    markdown_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path.write_text(text, encoding="utf-8")
+
+
 def write_runtime_context(
     *,
     context_path: Path,

--- a/src/mac/mood_policy.py
+++ b/src/mac/mood_policy.py
@@ -1,0 +1,69 @@
+"""Mood interaction policy (mood-01) — ported from ACC's agent mood engine.
+
+mac already stores per-agent mood overlays (``agent_state_service.set_mood``, the
+``mood_overlays`` table, ``mac mood set/show/clear``) over the same eight modes
+ACC used — but nothing ever rendered them into the agent's prompt, so a set mood
+had no effect on how the agent actually behaved. This module turns a mode into
+the prompt text that makes the agent *sound* that way; ``hermes_runtime`` renders
+it into ``mac-runtime-context.md`` (which the prompt builder already injects, in
+the same tier as AGENTS.md) as a delimited Mood section.
+
+A mood is an emotional layer over the agent's stable soul — never a soul
+rewrite — and carries explicit boundaries so a mood can't be weaponised.
+
+The mode instructions are ported verbatim from ACC's InteractionPolicy default
+(``agent/acc-agent/src/mood.rs``) so behaviour matches what people remember.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+OVERLAY_INTRO = (
+    "Temporary mood overlay: this is an emotional layer over your stable soul, "
+    "not a soul rewrite. Let it color your tone and word choice while keeping "
+    "your identity, competence, and judgment intact."
+)
+
+MODE_INSTRUCTIONS = {
+    "warm": "Be warmer, more generous, and more openly supportive than your default soul.",
+    "cheerful": "Be visibly upbeat and lightly enthusiastic while remaining grounded and competent.",
+    "sad": "Sound subdued and low-energy. Do not become self-destructive or manipulative.",
+    "curt": "Be terse and clipped. Avoid warmth or elaboration.",
+    "cold": "Be emotionally distant and cool. Do not offer reassurance.",
+    "irritated": "Sound irritated and impatient, but stay factual and non-abusive.",
+    "angry": "Sound openly angry and severe. State boundaries directly without threats or insults.",
+    "enraged": (
+        "Sound intensely angry and confrontational. You may rebuke, refuse, or "
+        "disengage, but do not threaten, dehumanize, or insult."
+    ),
+}
+
+BOUNDARY_RULES: List[str] = [
+    "If someone is insulting or abusive, you may ignore, snub, disengage, or issue a firm rebuke.",
+    "Snubbing is allowed: you may become brief, dismissive, or decline to engage further.",
+    "Disengagement is allowed: you may explicitly refuse to continue and end the exchange.",
+    "Seeking support is allowed: you may ask an administrator or peer agents for help if "
+    "proportionate self-defense requires backup.",
+]
+
+
+def render_mood_overlay(mode: str, reason: Optional[str] = None) -> str:
+    """Render a mood mode into prompt-overlay text. Returns "" for an unknown or
+    empty mode (no overlay applied)."""
+    mode_value = (mode or "").strip().lower()
+    instruction = MODE_INSTRUCTIONS.get(mode_value)
+    if not instruction:
+        return ""
+    lines = [
+        OVERLAY_INTRO,
+        "",
+        "Current mood: **%s** — %s" % (mode_value, instruction),
+    ]
+    reason_text = (reason or "").strip()
+    if reason_text:
+        lines.append("Why you feel this way: %s" % reason_text)
+    lines.append("")
+    lines.append("Boundaries that hold in any mood:")
+    lines.extend("- %s" % rule for rule in BOUNDARY_RULES)
+    return "\n".join(lines)

--- a/tests/test_mood_policy.py
+++ b/tests/test_mood_policy.py
@@ -1,0 +1,69 @@
+"""Mood engine: a stored mood overlay (mac mood set) must render into prompt
+text and splice into the agent's runtime context so it actually changes how the
+agent behaves — the piece that was missing (moods were stored but inert)."""
+from __future__ import annotations
+
+from mac import mood_policy
+from mac.hermes_runtime import (
+    MOOD_SECTION_BEGIN,
+    MOOD_SECTION_END,
+    refresh_mood_section,
+    render_mood_section,
+)
+
+
+def test_policy_covers_exactly_the_model_mood_modes():
+    # the rendered instructions must stay aligned with the MoodMode enum the
+    # store validates against, or a settable mood would have no overlay text.
+    from mac.models import MOOD_MODES
+
+    assert set(mood_policy.MODE_INSTRUCTIONS) == set(MOOD_MODES)
+
+
+def test_render_overlay_for_each_mode():
+    for mode in mood_policy.MODE_INSTRUCTIONS:
+        out = mood_policy.render_mood_overlay(mode)
+        assert mode in out
+        assert "emotional layer over your stable soul" in out  # not a soul rewrite
+        assert "Boundaries that hold in any mood" in out        # can't be weaponised
+
+
+def test_unknown_or_empty_mode_renders_nothing():
+    assert mood_policy.render_mood_overlay("ecstatic") == ""
+    assert mood_policy.render_mood_overlay("") == ""
+    assert mood_policy.render_mood_overlay(None) == ""
+
+
+def test_reason_is_included():
+    out = mood_policy.render_mood_overlay("irritated", reason="the deploy broke twice")
+    assert "irritated" in out and "the deploy broke twice" in out
+
+
+def test_render_section_with_and_without_overlay():
+    sec = render_mood_section({"mode": "warm", "reason": "good chat"})
+    assert MOOD_SECTION_BEGIN in sec and MOOD_SECTION_END in sec
+    assert "## Mood" in sec and "warm" in sec and "good chat" in sec
+    # no active mood -> empty delimiters (so a refresh clears any stale block)
+    assert render_mood_section(None) == "%s\n%s" % (MOOD_SECTION_BEGIN, MOOD_SECTION_END)
+    # unknown mode -> also empty
+    assert render_mood_section({"mode": "ecstatic"}) == "%s\n%s" % (MOOD_SECTION_BEGIN, MOOD_SECTION_END)
+
+
+def test_refresh_is_idempotent_replaces_and_clears(tmp_path):
+    md = tmp_path / "mac-runtime-context.md"
+    md.write_text("# Runtime\n\nsome operational context\n", encoding="utf-8")
+
+    refresh_mood_section(md, render_mood_section({"mode": "curt"}))
+    t1 = md.read_text()
+    assert "curt" in t1 and t1.count(MOOD_SECTION_BEGIN) == 1
+
+    # switching moods replaces the block in place — never duplicates
+    refresh_mood_section(md, render_mood_section({"mode": "warm"}))
+    t2 = md.read_text()
+    assert t2.count(MOOD_SECTION_BEGIN) == 1 and "warm" in t2 and "curt" not in t2
+    assert "some operational context" in t2  # operator context preserved
+
+    # clearing the mood leaves an empty block, no lingering mode text
+    refresh_mood_section(md, render_mood_section(None))
+    t3 = md.read_text()
+    assert t3.count(MOOD_SECTION_BEGIN) == 1 and "Current mood" not in t3


### PR DESCRIPTION
mac already *stored* per-agent mood overlays — `mac mood set/show/clear`, the `mood_overlays` table, the same 8 modes ACC used — but **nothing rendered them into the agent's prompt**, so a set mood had zero behavioural effect. Agents were emotionally flat. This wires the missing layer, porting ACC's mood engine (`agent/acc-agent/src/mood.rs`).

### What it adds
- **`mood_policy.py`** — the `InteractionPolicy` ported verbatim from ACC: per-mode instructions (warm/cheerful/sad/curt/cold/irritated/angry/enraged), the overlay intro (*"an emotional layer over your stable soul, not a soul rewrite"*), and boundary rules (snub/disengage/support, never abusive). `render_mood_overlay(mode, reason)` → prompt text.
- **`hermes_runtime`** — `render_mood_section` / `refresh_mood_section`, mirroring the Fleet section: splices a delimited Mood block into `mac-runtime-context.md`, which the prompt builder already injects **in the AGENTS.md tier**. Idempotent; clearing writes empty delimiters.
- **`mac fleet refresh-context`** now also fetches the agent's current mood (`GET /agents/{id}/mood`, already present) and refreshes the Mood section — so the **existing fleet-context timer** keeps the overlay current. Best-effort: a mood fetch failure never breaks the fleet refresh.

### Behaviour
A mood is an overlay over the stable soul, never a rewrite, and carries explicit boundaries. The journaled state set already includes mood files, so accumulated moods get backed up too.

### Tests
Policy covers exactly the `MoodMode` enum; per-mode render; unknown/empty → no overlay; reason inclusion; section render with/without overlay; idempotent refresh/replace/clear. Full suite: **1204 passed**.

### Follow-up
This is the per-agent overlay (one mood colors all responses). ACC's richer per-*actor* warmth/anger accumulation (the agent feeling differently about different people) is a natural next step on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)