### PR TITLE
fix(fleet-context): refresh from the hub, not the spoke's local SQLite

### DIFF
--- a/deploy/systemd/mac-fleet-context.service
+++ b/deploy/systemd/mac-fleet-context.service
@@ -10,11 +10,17 @@ User=__MAC_USER__
 WorkingDirectory=__MAC_HOME__
 EnvironmentFile=-__MAC_HOME__/mac.env
 
-# fleet-02: refresh the live "Fleet — your teammates" block in this agent's
-# runtime-context markdown, so each new hermes session always knows what the
-# other agents are doing. --agent excludes the caller from its own view.
+# fleet-02 + mood-01: refresh the live "Fleet — your teammates" block AND the
+# agent's mood overlay in its runtime-context markdown, so each new hermes
+# session knows what teammates are doing and behaves in its current mood.
+# --agent excludes the caller from its own fleet view.
+#
+# Unset MAC_DB so the CLI resolves to the hub ($MAC_URL/$MAC_HUB_URL) rather than
+# this host's local SQLite — $MAC_DB outranks the hub URL in resolution, so a
+# spoke would otherwise refresh from an empty local db (members=0, no hub mood).
 ExecStart=/bin/bash -lc '\
-  __MAC_HOME__/venv/bin/mac fleet refresh-context \
+  unset MAC_DB; \
+  exec __MAC_HOME__/venv/bin/mac fleet refresh-context \
     --agent "${MAC_AGENT_ID:-${MAC_WORKER_AGENT_ID:-}}"'
 
 StandardOutput=journal


### PR DESCRIPTION
Installing the fleet-context timer surfaced a pre-existing bug: the refresh ran against the **spoke's local SQLite** (`mac: writing LOCAL db`), not the hub — because `mac fleet refresh-context` sources `mac.env` (`MAC_DB` set), and `$MAC_DB` outranks the hub URL in CLI resolution. Result on every non-hub agent: `members=0` (no live fleet awareness) and no hub-set mood — both the fleet teammate view **and** the new mood overlay were silently inert on spokes.

**Fix:** `unset MAC_DB` in the service `ExecStart` so the CLI resolves to the hub (`$MAC_URL`/`$MAC_HUB_URL`) with the agent's token. The hub agent is unaffected (its local db *is* the hub db).

🤖 Generated with [Claude Code](https://claude.com/claude-code)