### PR TITLE
fix(mood): fetch mood from the hub HTTP API, not local SQLite

### DIFF
--- a/deploy/systemd/mac-fleet-context.service
+++ b/deploy/systemd/mac-fleet-context.service
@@ -15,11 +15,11 @@ EnvironmentFile=-__MAC_HOME__/mac.env
 # session knows what teammates are doing and behaves in its current mood.
 # --agent excludes the caller from its own fleet view.
 #
-# Unset MAC_DB so the CLI resolves to the hub ($MAC_URL/$MAC_HUB_URL) rather than
-# this host's local SQLite — $MAC_DB outranks the hub URL in resolution, so a
-# spoke would otherwise refresh from an empty local db (members=0, no hub mood).
+# Runs against local SQLite (mac.env sets $MAC_DB): the fleet snapshot isn't
+# wrapped for hub mode, so on the hub agent (local db == hub db) it sees the live
+# fleet. The mood overlay is fetched straight from the hub's HTTP API inside the
+# command, so a spoke still picks up a hub-set mood regardless of $MAC_DB.
 ExecStart=/bin/bash -lc '\
-  unset MAC_DB; \
   exec __MAC_HOME__/venv/bin/mac fleet refresh-context \
     --agent "${MAC_AGENT_ID:-${MAC_WORKER_AGENT_ID:-}}"'
 

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -487,6 +487,33 @@ def cmd_fleet_snapshot(args: argparse.Namespace) -> None:
     _print(_plane(args).fleet_snapshot(exclude_agent_id=getattr(args, "agent", None)))
 
 
+def _hub_get_mood(agent_id: Optional[str]) -> Optional[Dict[str, Any]]:
+    """GET the agent's current mood overlay straight from the hub HTTP API.
+
+    The fleet-context refresh otherwise runs against local SQLite ($MAC_DB wins
+    in CLI resolution), so on a spoke a hub-set mood would never be seen. This
+    talks to the hub directly (same URL + token the worker uses). Returns the
+    overlay dict, or None on any error / no active mood."""
+    import json as _json
+    import os as _os
+    import urllib.request as _u
+
+    base = (_os.environ.get("MAC_HUB_URL") or _os.environ.get("MAC_URL") or "").rstrip("/")
+    token = (_os.environ.get("MAC_WORKER_TOKEN") or _os.environ.get("MAC_API_TOKEN") or "").strip()
+    if not (base and token and agent_id):
+        return None
+    req = _u.Request("%s/agents/%s/mood" % (base, agent_id), method="GET")
+    req.add_header("Authorization", "Bearer %s" % token)
+    req.add_header("Accept", "application/json")
+    try:
+        with _u.urlopen(req, timeout=10) as resp:  # noqa: S310 (operator-configured hub)
+            raw = resp.read().decode("utf-8", "replace")
+        data = _json.loads(raw) if raw.strip() else None
+        return data if isinstance(data, dict) else None
+    except Exception:  # noqa: BLE001 - mood is best-effort
+        return None
+
+
 def cmd_fleet_refresh_context(args: argparse.Namespace) -> None:
     """fleet-02 + mood-01: refresh the live Fleet section AND this agent's mood
     overlay in its runtime-context markdown, so its next session knows what
@@ -510,20 +537,10 @@ def cmd_fleet_refresh_context(args: argparse.Namespace) -> None:
     path = _Path(markdown)
     refresh_fleet_section(path, render_fleet_section(snapshot))
 
-    # mood-01: render this agent's current mood overlay into the same context so
-    # a set mood colors behaviour. Best-effort — never break the fleet refresh.
-    overlay = None
-    if agent:
-        try:
-            current = plane.get_current_mood(agent)
-            if current is None:
-                overlay = None
-            elif hasattr(current, "to_dict"):
-                overlay = current.to_dict()
-            elif isinstance(current, dict):
-                overlay = current
-        except Exception:  # noqa: BLE001
-            overlay = None
+    # mood-01: fetch this agent's mood straight from the hub HTTP API so a spoke
+    # picks it up even though $MAC_DB pins the rest of the CLI to local SQLite
+    # (fleet_snapshot above isn't wrapped in hub mode, so it stays local). Best-effort.
+    overlay = _hub_get_mood(agent) if agent else None
     refresh_mood_section(path, render_mood_section(overlay))
     _print(
         {

--- a/tests/test_mood_policy.py
+++ b/tests/test_mood_policy.py
@@ -67,3 +67,51 @@ def test_refresh_is_idempotent_replaces_and_clears(tmp_path):
     refresh_mood_section(md, render_mood_section(None))
     t3 = md.read_text()
     assert t3.count(MOOD_SECTION_BEGIN) == 1 and "Current mood" not in t3
+
+
+def test_hub_get_mood_fetches_from_hub(monkeypatch):
+    """The fleet-context refresh must pull mood from the hub (not local SQLite),
+    so a spoke sees a hub-set mood."""
+    import json as _json
+    import urllib.request as _u
+
+    from mac.cli import _hub_get_mood
+
+    monkeypatch.setenv("MAC_HUB_URL", "http://hub:8789")
+    monkeypatch.setenv("MAC_API_TOKEN", "tok")
+    captured = {}
+
+    class _R:
+        def __init__(self, payload):
+            self._b = _json.dumps(payload).encode()
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["auth"] = req.get_header("Authorization")
+        return _R({"mode": "warm", "reason": "good chat"})
+
+    monkeypatch.setattr(_u, "urlopen", fake)
+    out = _hub_get_mood("agent_rocky")
+    assert out == {"mode": "warm", "reason": "good chat"}
+    assert captured["url"] == "http://hub:8789/agents/agent_rocky/mood"
+    assert captured["auth"] == "Bearer tok"
+
+
+def test_hub_get_mood_none_without_env_or_agent(monkeypatch):
+    from mac.cli import _hub_get_mood
+
+    for k in ("MAC_HUB_URL", "MAC_URL", "MAC_WORKER_TOKEN", "MAC_API_TOKEN"):
+        monkeypatch.delenv(k, raising=False)
+    assert _hub_get_mood("agent_rocky") is None
+    monkeypatch.setenv("MAC_HUB_URL", "http://h")
+    monkeypatch.setenv("MAC_API_TOKEN", "t")
+    assert _hub_get_mood(None) is None


### PR DESCRIPTION
Installing the timer (and PR #77) revealed that `mac fleet refresh-context` can't run in hub mode — `fleet_snapshot` isn't wrapped in `RemoteDispatch`, so `unset MAC_DB` made the whole refresh raise `DispatchError` on spokes instead of just reading empty local data.

**Fix:**
- Revert the `unset MAC_DB` (refresh runs local again — fleet snapshot works on the hub agent where local db == hub db; no error on spokes).
- Add `_hub_get_mood()` — a direct `GET /agents/{id}/mood` to the hub with the agent's token (endpoint already exists) — so a **hub-set mood reaches a spoke's prompt regardless of `$MAC_DB`**, without needing RemoteDispatch wrapping.

Live fleet *awareness* on spokes (the `fleet_snapshot` half) stays hub-only — a separate follow-up (wrap `fleet_snapshot` for hub mode). Mood (the requested feature) now works fleet-wide.

Tests: `_hub_get_mood` hits the right URL + bearer, returns None without env/agent. Suite: **1206 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)