### PR TITLE
fix(hub): stop the two runaway emitters bloating the control-plane db

### DIFF
--- a/src/mac/observability_service.py
+++ b/src/mac/observability_service.py
@@ -49,6 +49,10 @@ _VERBOSE_POLL_LOG_NAMES = frozenset(
         "workflow.default_review.waiting_for_verdict",
         "workflow.default_review.heartbeat_tick",
         "workflow.default_review.heartbeat_tick_failed",
+        # Re-emitted every review tick for a task stuck waiting on an operator to
+        # set metadata.publication_target — a steady-state condition, not an
+        # event. It alone wrote 262K rows in ~4 days on rocky.
+        "workflow.default_review.no_publication_target",
     }
 )
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6141,9 +6141,16 @@ class ControlPlane:
         if status_value in {AgentStatus.IDLE.value, AgentStatus.OFFLINE.value}:
             updates.append("current_task_id = NULL")
         params.append(agent_id)
+        # Only log a lifecycle/observability event when something MEANINGFUL
+        # changed (status / health / running_digest) — not on resource jitter,
+        # which differs on essentially every heartbeat. Writing a durable
+        # agent_lifecycle_events row (+ mirrored observability_event) on every
+        # beat was the dominant source of hub-db bloat: ~527K lifecycle + ~228K
+        # obs rows in ~4 days on rocky, almost all just CPU/mem jitter.
+        meaningful_changes = [f for f in changed_fields if f != "resources"]
         with self.store.transaction() as conn:
             conn.execute("UPDATE agents SET %s WHERE id = ?" % ", ".join(updates), tuple(params))
-            if status is not None or health_status is not None or resources is not None or running_digest is not None:
+            if meaningful_changes:
                 self._record_agent_lifecycle_event(
                     conn,
                     agent_id,
@@ -6152,7 +6159,7 @@ class ControlPlane:
                     {
                         "agent_id": agent_id,
                         "agent_name": agent_before.name,
-                        "changed_fields": sorted(set(changed_fields)),
+                        "changed_fields": sorted(set(meaningful_changes)),
                         "previous_status": agent_before.status,
                         "status": status_value or agent_before.status,
                         "previous_health_status": agent_before.health_status,

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -1876,8 +1876,12 @@ def test_default_review_workflow_refuses_without_publication_target(cp):
     # Task remains in REVIEWING — the review approval landed but
     # publication is held until a target is configured.
     assert cp.get_task(task.id).state == TaskState.REVIEWING.value
+    # The waiting condition is asserted via result["status"] above. The
+    # 'no_publication_target' log is silenced (mem-04): the review tick re-emits
+    # it every cycle for a stuck task — 262K durable rows in ~4 days on rocky —
+    # so it must NOT land as an observability event.
     names = {event.name for event in cp.list_observability(limit=50)}
-    assert "workflow.default_review.no_publication_target" in names
+    assert "workflow.default_review.no_publication_target" not in names
 
 
 def test_default_review_rejects_alias_evidence_taxonomy(cp):
@@ -7881,3 +7885,39 @@ def test_update_task_filters_disallowed_capabilities(cp):
 
     assert updated.required_capabilities == ["ops"]
     assert updated.metadata["domain_capabilities"] == ["typescript"]
+
+
+def test_heartbeat_only_logs_meaningful_changes():
+    """Hub-db bloat fix: a heartbeat must not write a durable lifecycle/obs row
+    on resource jitter — only on a meaningful change (status/health/digest).
+    Resource churn on every beat was ~527K+228K rows in ~4 days on rocky."""
+    cp = ControlPlane.in_memory()
+    agent = register_agent(cp, "worker", ["python"])
+
+    def hb_events():
+        return cp.store.query_one(
+            "SELECT COUNT(*) AS c FROM agent_lifecycle_events "
+            "WHERE event_type = 'agent.heartbeat_updated'"
+        )["c"]
+
+    before = hb_events()
+    # resource-only heartbeats (CPU/mem jitter) must NOT create lifecycle events
+    cp.heartbeat_agent(agent.id, resources={"cpu_percent": 12.3})
+    cp.heartbeat_agent(agent.id, resources={"cpu_percent": 88.0})
+    assert hb_events() == before, "resource jitter must not log heartbeat events"
+
+    # a meaningful status change DOES log exactly one event
+    cp.heartbeat_agent(agent.id, status="draining")
+    assert hb_events() == before + 1
+
+    # repeating the same status (with more jitter) is a no-op
+    cp.heartbeat_agent(agent.id, status="draining", resources={"cpu_percent": 5.0})
+    assert hb_events() == before + 1
+
+
+def test_no_publication_target_is_silenced():
+    """The review-tick 'no_publication_target' steady-state log is silenced
+    (mem-04) so it can't re-bloat the db every tick."""
+    from mac.observability_service import _VERBOSE_POLL_LOG_NAMES
+
+    assert "workflow.default_review.no_publication_target" in _VERBOSE_POLL_LOG_NAMES


### PR DESCRIPTION
rocky's `mac.db` reached **3.0GB in ~4 days**. Two emitters wrote ~1M of the rows and caused the SQLite `cannot commit transaction - SQL statements in progress` stalls that hung the hub HTTP:

1. **`agent.heartbeat_updated`** (527K `agent_lifecycle_events` + 228K mirrored obs) — `heartbeat_agent` logged a durable event whenever any field was *present*, and `resources` (CPU/mem) jitters every beat, so **every heartbeat wrote two rows**. Now gated on a *meaningful* change (status/health/running_digest); resources are still persisted, just not logged as an event per beat.
2. **`workflow.default_review.no_publication_target`** (262K obs) — re-emitted every review tick for a task stuck waiting on an operator-set publication target (a steady state). Added to mem-04's `_VERBOSE_POLL_LOG_NAMES` so `record_log` drops it; the waiting state is still surfaced via the workflow's return status + task state.

Removes ~1M rows / 4 days of growth. A prune + VACUUM reclaims the existing file separately (follow-up deploy step).

**Tests:** resource-jitter heartbeats log no event; a status change logs exactly one; `no_publication_target` silenced; refuse-without-target workflow contract still holds. Suite: **1208 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)