### PR TITLE
fix(setup): materialize the resolved model into fleets.yaml (never blank)

### DIFF
--- a/scripts/setup-fleet.py
+++ b/scripts/setup-fleet.py
@@ -155,6 +155,23 @@ def load_fleet_registry(path: Path) -> Dict[str, Any]:
     return data
 
 
+# The fleet's default chat model, materialized into fleets.yaml so the picked
+# model is ALWAYS visible there. A blank gateway_model silently fell through to
+# the router's wildcard ladder — which is exactly how the whole fleet ended up
+# running on gpt-4.1-mini unnoticed. Writing the resolved model into the config
+# would have made that regression obvious on sight.
+DEFAULT_GATEWAY_MODEL = "azure/anthropic/claude-sonnet-4-6"
+
+
+def resolve_gateway_model(model: str) -> str:
+    """Never persist a blank/'*' model: fall back to the explicit default so the
+    config file records the model that will actually be used."""
+    value = (model or "").strip()
+    if not value or value == "*":
+        return DEFAULT_GATEWAY_MODEL
+    return value
+
+
 def build_agent(
     *,
     name: str,
@@ -175,7 +192,7 @@ def build_agent(
     }
     if control_bind_host:
         agent["control_bind_host"] = control_bind_host
-    agent["hermes"] = {"gateway_model": model}
+    agent["hermes"] = {"gateway_model": resolve_gateway_model(model)}
     agent["worker"] = {"mode": mode, "require_canary": require_canary}
     return agent
 
@@ -290,7 +307,7 @@ def _setup_hub(args: argparse.Namespace, fleets_config: Path, env_file: Path, ru
     )
     supervisor = prompt("Default supervisor", default="auto", choices=["auto", "systemd", "launchd", "supervisord"])
     home_channel = prompt("Slack home channel name without # (blank to skip)", default="")
-    hub_model = prompt("Hub Hermes model selector (blank to configure later)", default="")
+    hub_model = prompt("Hub Hermes model selector", default=DEFAULT_GATEWAY_MODEL)
     hub_worker_mode = prompt("Hub worker mode", default="loop", choices=["heartbeat", "dry-run", "loop"])
     hub_require_canary = prompt_bool("Require canary metadata on hub tasks?", default=False)
     qdrant_required = True
@@ -412,7 +429,7 @@ def _setup_hub(args: argparse.Namespace, fleets_config: Path, env_file: Path, ru
         name = prompt("Agent name", required=True)
         target = prompt("Agent SSH target", required=True)
         os_kind = prompt("Agent OS", default="linux", choices=["linux", "darwin"])
-        model = prompt("Agent Hermes model selector (blank to configure later)", default="")
+        model = prompt("Agent Hermes model selector", default=DEFAULT_GATEWAY_MODEL)
         agent_supervisor = prompt("Agent supervisor", default=supervisor, choices=["auto", "systemd", "launchd", "supervisord"])
         mode = prompt("Agent worker mode", default="loop", choices=["heartbeat", "dry-run", "loop"])
         require_canary = prompt_bool("Require canary metadata on this agent?", default=False)
@@ -644,7 +661,7 @@ def _setup_worker(args: argparse.Namespace, fleets_config: Path, env_file: Path,
         default=supervisor,
         choices=["auto", "systemd", "launchd", "supervisord"],
     )
-    agent_model = prompt("Worker Hermes model selector (blank to configure later)", default="")
+    agent_model = prompt("Worker Hermes model selector", default=DEFAULT_GATEWAY_MODEL)
     agent_mode = prompt("Worker mode", default="loop", choices=["heartbeat", "dry-run", "loop"])
     require_canary = prompt_bool("Require canary metadata on this worker?", default=False)
 

--- a/tests/test_setup_fleet_model.py
+++ b/tests/test_setup_fleet_model.py
@@ -1,0 +1,35 @@
+"""The fleet setup wizard must never persist a blank gateway_model — a blank
+silently fell through to the router wildcard, which is how the fleet ran on
+gpt-4.1-mini unnoticed. The picked model must be materialized into fleets.yaml."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "setup-fleet.py"
+    spec = importlib.util.spec_from_file_location("setup_fleet_script", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_resolve_gateway_model_materializes_default():
+    m = _load()
+    assert m.resolve_gateway_model("") == m.DEFAULT_GATEWAY_MODEL
+    assert m.resolve_gateway_model("   ") == m.DEFAULT_GATEWAY_MODEL
+    assert m.resolve_gateway_model("*") == m.DEFAULT_GATEWAY_MODEL
+    assert m.resolve_gateway_model("custom/x") == "custom/x"
+    # the default itself is a real, explicit model — not blank/wildcard
+    assert m.DEFAULT_GATEWAY_MODEL and m.DEFAULT_GATEWAY_MODEL != "*"
+
+
+def test_build_agent_never_writes_blank_model():
+    m = _load()
+    blank = m.build_agent(name="rocky", target="jkh@h", os_kind="linux", model="",
+                          supervisor="systemd", mode="loop", require_canary=False)
+    assert blank["hermes"]["gateway_model"] == m.DEFAULT_GATEWAY_MODEL
+    explicit = m.build_agent(name="x", target="t", os_kind="linux", model="custom/y",
+                             supervisor="systemd", mode="loop", require_canary=False)
+    assert explicit["hermes"]["gateway_model"] == "custom/y"


### PR DESCRIPTION
The lesson from the gpt-4.1-mini regression: a **blank `gateway_model` in `fleets.yaml` silently fell through to the router's wildcard ladder**, so the model the fleet actually ran on was never recorded in the config the operator reviews — making the regression invisible. (Falling back to a default was reasonable; leaving the config blank instead of recording the resolved choice was not.)

This makes the setup wizard **always write the picked model** into `fleets.yaml`:
- `resolve_gateway_model()` — a blank/`*` model resolves to an explicit `DEFAULT_GATEWAY_MODEL` (`azure/anthropic/claude-sonnet-4-6`).
- `build_agent()` persists the resolved value; the hub/agent/worker model prompts now default to the real model, not blank.

So a future regression would be obvious on sight in `fleets.yaml`. (Companion change: the live `~/.mac/fleets.yaml` is updated to record `claude-sonnet-4-6` explicitly.)

Tests: a blank model materializes the default; an explicit choice is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)