### PR TITLE
deploy: SSH ProxyJump (bastion) support + non-blank model in --spec setup

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -551,6 +551,14 @@ if mode == "hub-target":
     print("ERROR: hub_agent %s is not an enabled agent" % hub_agent, file=sys.stderr)
     raise SystemExit(2)
 
+if mode == "ssh-jump":
+    # Operator->node bastion ProxyJump + host-key strictness, fleet-wide.
+    # Emits "<jump>|<strict01>"; both empty/1 by default (no jump, strict on).
+    jump = text_field(defaults.get("ssh_jump"))
+    strict = "0" if defaults.get("ssh_strict_host_key_checking", True) is False else "1"
+    print("%s|%s" % (jump, strict))
+    raise SystemExit(0)
+
 by_name = {text_field(agent.get("name")): agent for agent in agents}
 selected = requested or list(by_name)
 unknown = [name for name in selected if name not in by_name]
@@ -681,9 +689,26 @@ print("%s|%s" % (user_host, parsed_port or ""))
 PY
 }
 
+# Operator->node connection options injected from the fleet config (SSH_JUMP /
+# SSH_STRICT are set once in main() from defaults.ssh_jump /
+# defaults.ssh_strict_host_key_checking in fleets.yaml). This is the single
+# chokepoint every operator->node ssh/scp flows through, so a bastion fleet (e.g.
+# GKE pods reachable only via a jump host) works without any ~/.ssh/config edits.
+# NOTE: these are operator-side only — they are never interpolated into the
+# hub->spoke reverse-tunnel heredocs, which run in-cluster without the bastion.
+ssh_conn_opts() {
+  if [ "${SSH_STRICT:-1}" = "0" ]; then
+    printf '%s\0%s\0%s\0%s\0' "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null"
+  fi
+  if [ -n "${SSH_JUMP:-}" ]; then
+    printf '%s\0%s\0' "-o" "ProxyJump=${SSH_JUMP}"
+  fi
+}
+
 ssh_target_args() {
   local raw_target="$1" ssh_target ssh_port
   IFS='|' read -r ssh_target ssh_port < <(parse_ssh_target_fields "$raw_target")
+  ssh_conn_opts
   if [ -n "$ssh_port" ]; then
     printf '%s\0%s\0%s\0' "-p" "$ssh_port" "$ssh_target"
   else
@@ -694,10 +719,34 @@ ssh_target_args() {
 scp_target_args() {
   local raw_target="$1" ssh_target ssh_port
   IFS='|' read -r ssh_target ssh_port < <(parse_ssh_target_fields "$raw_target")
+  ssh_conn_opts
   if [ -n "$ssh_port" ]; then
     printf '%s\0%s\0%s\0' "-P" "$ssh_port" "$ssh_target"
   else
     printf '%s\0' "$ssh_target"
+  fi
+}
+
+# Populate SSH_JUMP / SSH_STRICT globals from the fleet's
+# defaults.ssh_jump / defaults.ssh_strict_host_key_checking (fleets.yaml).
+# Called once in main() before any operator->node ssh/scp.
+SSH_JUMP="${SSH_JUMP:-}"
+SSH_STRICT="${SSH_STRICT:-1}"
+# Space-joined ssh opts (no spaces within any token, so it's safe to expand
+# unquoted) for the few bare-target ssh calls that don't flow through
+# ssh_target_args (health/tunnel probes, post-deploy restarts).
+SSH_CONN_OPTS=""
+load_ssh_jump_config() {
+  local out
+  out="$(fleet_config_query ssh-jump 2>/dev/null || true)"
+  [ -n "$out" ] || return 0
+  SSH_JUMP="${out%%|*}"
+  if [ "${out##*|}" = "0" ]; then SSH_STRICT="0"; else SSH_STRICT="1"; fi
+  SSH_CONN_OPTS=""
+  [ "$SSH_STRICT" = "0" ] && SSH_CONN_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  [ -n "$SSH_JUMP" ] && SSH_CONN_OPTS="${SSH_CONN_OPTS:+$SSH_CONN_OPTS }-o ProxyJump=$SSH_JUMP"
+  if [ -n "$SSH_JUMP" ]; then
+    log "ssh: operator->node via -o ProxyJump=${SSH_JUMP} (strict host-key checking: $([ "$SSH_STRICT" = "0" ] && echo off || echo on))"
   fi
 }
 
@@ -1052,14 +1101,17 @@ python_bin() {
     candidate="$(command -v "$candidate")"
     if "$candidate" - <<'PY' >/dev/null 2>&1
 import sys
-raise SystemExit(0 if sys.version_info >= (3, 10) else 1)
+# Must match pyproject.toml requires-python (>=3.11); a 3.10 interpreter would
+# fail `pip install -e .` partway through the remote deploy. Skip it so we pick
+# a real 3.11+ (e.g. python3.12) instead of dying mid-install.
+raise SystemExit(0 if sys.version_info >= (3, 11) else 1)
 PY
     then
       printf '%s\n' "$candidate"
       return
     fi
   done
-  log "ERROR: no Python >= 3.10 found"
+  log "ERROR: no Python >= 3.11 found (mac requires-python >=3.11)"
   exit 1
 }
 
@@ -4974,6 +5026,8 @@ worker_can_reach_hub_url() {
 
 main() {
   make_archive
+  # Operator->node ssh/scp options (bastion ProxyJump etc.) from fleets.yaml.
+  load_ssh_jump_config
   local spec agent hub_agent hub_token hub_token_key hub_target_str hub_tunnel_pubkey github_review_key_b64 local_target fleet_name_field network_provider_field hub_url_field direct_mesh_hub deployed_count
   hub_agent="$(fleet_hub_agent)"
   hub_target_str="$(fleet_hub_target)"
@@ -5009,7 +5063,7 @@ main() {
       # the hub tunnel key has not been authorized yet. Allow Qdrant and Firecrawl
       # to be degraded for this first deploy; they are re-checked after the tunnel
       # is established below.
-      if ! ssh -n -o BatchMode=yes -o ConnectTimeout=5 "$local_target" \
+      if ! ssh -n -o BatchMode=yes -o ConnectTimeout=5 $SSH_CONN_OPTS "$local_target" \
         "curl -fsS --max-time 3 http://127.0.0.1:8789/health >/dev/null 2>&1" 2>/dev/null; then
         allow_degraded_services=1
         echo "==> ${agent}: first deploy (no existing mac API); shared-services degraded override active"
@@ -5023,7 +5077,7 @@ main() {
       local attempt tunnel_ok=0
       for attempt in $(seq 1 6); do
         sleep 5
-        if ssh -n -o BatchMode=yes -o ConnectTimeout=5 "$local_target" \
+        if ssh -n -o BatchMode=yes -o ConnectTimeout=5 $SSH_CONN_OPTS "$local_target" \
           "curl -fsS --max-time 3 http://127.0.0.1:18789/health >/dev/null 2>&1" 2>/dev/null; then
           echo "==> ${agent}: hub tunnel reachable after $((attempt * 5))s"
           tunnel_ok=1
@@ -5047,7 +5101,7 @@ main() {
         echo "==> ${agent}: using ${network_provider_field} hub URL ${hub_url_field}; skipping reverse tunnel"
       elif [ "${tunnel_ok:-0}" = "1" ]; then
         local agent_prog="${fleet_name_field}-agent"
-        ssh -n -o BatchMode=yes -o ConnectTimeout=10 "$local_target" \
+        ssh -n -o BatchMode=yes -o ConnectTimeout=10 $SSH_CONN_OPTS "$local_target" \
           "sudo supervisorctl restart '$agent_prog' >/dev/null 2>&1 || sudo supervisorctl start '$agent_prog' >/dev/null 2>&1 || true" 2>/dev/null || true
         echo "==> ${agent}: restarted mac-agent with tunnel now available"
       elif [ "${allow_degraded_services:-0}" = "1" ]; then
@@ -5057,7 +5111,7 @@ main() {
         local attempt first_tunnel_ok=0
         for attempt in $(seq 1 12); do
           sleep 5
-          if ssh -n -o BatchMode=yes -o ConnectTimeout=5 "$local_target" \
+          if ssh -n -o BatchMode=yes -o ConnectTimeout=5 $SSH_CONN_OPTS "$local_target" \
             "curl -fsS --max-time 3 http://127.0.0.1:18789/health >/dev/null 2>&1" 2>/dev/null; then
             echo "==> ${agent}: hub tunnel reachable after $((attempt * 5))s"
             first_tunnel_ok=1
@@ -5066,7 +5120,7 @@ main() {
         done
         local agent_prog="${fleet_name_field}-agent"
         if [ "$first_tunnel_ok" = "1" ]; then
-          ssh -n -o BatchMode=yes -o ConnectTimeout=10 "$local_target" \
+          ssh -n -o BatchMode=yes -o ConnectTimeout=10 $SSH_CONN_OPTS "$local_target" \
             "sudo supervisorctl restart '$agent_prog' >/dev/null 2>&1 || sudo supervisorctl start '$agent_prog' >/dev/null 2>&1 || true" 2>/dev/null || true
           echo "==> ${agent}: restarted mac-agent with tunnel now available"
         else

--- a/scripts/setup-fleet.py
+++ b/scripts/setup-fleet.py
@@ -23,7 +23,13 @@ sys.path.insert(0, str(ROOT / "src"))
 
 from mac.fleet_deploy import normalize_ssh_target, parse_ssh_target  # noqa: E402
 from mac.deploy_env import build_router_provider_spec  # noqa: E402
-from mac.fleet_setup import build_setup_plan, load_setup_spec, public_plan  # noqa: E402
+from mac.fleet_setup import (  # noqa: E402
+    DEFAULT_GATEWAY_MODEL,
+    build_setup_plan,
+    load_setup_spec,
+    public_plan,
+    resolve_gateway_model,
+)
 from mac.providers import ROUTER_PROVIDERS, router_secret_name  # noqa: E402
 
 
@@ -153,23 +159,6 @@ def load_fleet_registry(path: Path) -> Dict[str, Any]:
     data.setdefault("version", 1)
     data["fleets"] = {}
     return data
-
-
-# The fleet's default chat model, materialized into fleets.yaml so the picked
-# model is ALWAYS visible there. A blank gateway_model silently fell through to
-# the router's wildcard ladder — which is exactly how the whole fleet ended up
-# running on gpt-4.1-mini unnoticed. Writing the resolved model into the config
-# would have made that regression obvious on sight.
-DEFAULT_GATEWAY_MODEL = "azure/anthropic/claude-sonnet-4-6"
-
-
-def resolve_gateway_model(model: str) -> str:
-    """Never persist a blank/'*' model: fall back to the explicit default so the
-    config file records the model that will actually be used."""
-    value = (model or "").strip()
-    if not value or value == "*":
-        return DEFAULT_GATEWAY_MODEL
-    return value
 
 
 def build_agent(

--- a/src/mac/fleet_setup.py
+++ b/src/mac/fleet_setup.py
@@ -22,6 +22,23 @@ DEFAULT_CONTROL_PORT = 8789
 DEFAULT_QDRANT_PORT = 6333
 DEFAULT_FIRECRAWL_PORT = 3002
 
+# The fleet's default chat model, materialized into fleets.yaml so the picked
+# model is ALWAYS visible there. A blank gateway_model silently fell through to
+# the router's wildcard ladder — which is exactly how the whole fleet ended up
+# running on gpt-4.1-mini unnoticed. Both setup paths (interactive wizard and
+# this declarative --spec planner) resolve through here so neither can persist a
+# blank model that hides which model the fleet actually runs.
+DEFAULT_GATEWAY_MODEL = "azure/anthropic/claude-sonnet-4-6"
+
+
+def resolve_gateway_model(model: str) -> str:
+    """Never persist a blank/'*' model: fall back to the explicit default so the
+    config file records the model that will actually be used."""
+    value = (model or "").strip()
+    if not value or value == "*":
+        return DEFAULT_GATEWAY_MODEL
+    return value
+
 
 def default_worker_capabilities() -> List[str]:
     return [
@@ -106,6 +123,22 @@ def build_setup_plan(
     if supervisor not in {"auto", "systemd", "launchd", "supervisord"}:
         errors.append("supervisor must be one of auto/systemd/launchd/supervisord")
 
+    # Operator->node SSH ProxyJump (bastion) + host-key strictness, fleet-wide.
+    # Persisting these into fleets.yaml lets the deploy reach bastion-only nodes
+    # (e.g. GKE pods behind a jump host) with no ~/.ssh/config edits.
+    ssh_jump = _str(
+        spec.get("ssh_jump")
+        or defaults_block.get("ssh_jump")
+        or fleet_block.get("ssh_jump")
+    )
+    ssh_strict = (
+        defaults_block.get(
+            "ssh_strict_host_key_checking",
+            spec.get("ssh_strict_host_key_checking", True),
+        )
+        is not False
+    )
+
     network = _network_config(spec, defaults_block, errors)
     qdrant = _qdrant_config(spec, defaults_block, hub_url)
     firecrawl = _firecrawl_config(spec, defaults_block, hub_url)
@@ -170,6 +203,8 @@ def build_setup_plan(
         "shared_services_manager_agent": hub_name,
         "defaults": {
             "supervisor": supervisor,
+            "ssh_jump": ssh_jump,
+            "ssh_strict_host_key_checking": ssh_strict,
             "hermes": {
                 "slack_home_channel_name": _str(
                     hermes_defaults.get("slack_home_channel_name")
@@ -352,10 +387,12 @@ def _agent_configs(
             "os": os_kind,
             "supervisor": agent_supervisor,
             "hermes": {
-                "gateway_model": _str(
-                    item.get("model")
-                    or hermes.get("gateway_model")
-                    or hermes_defaults.get("gateway_model")
+                "gateway_model": resolve_gateway_model(
+                    _str(
+                        item.get("model")
+                        or hermes.get("gateway_model")
+                        or hermes_defaults.get("gateway_model")
+                    )
                 ),
             },
             "worker": {

--- a/tests/test_deploy_ssh_jump.py
+++ b/tests/test_deploy_ssh_jump.py
@@ -1,0 +1,75 @@
+"""SSH ProxyJump (bastion) support: the setup writes ssh_jump into fleets.yaml,
+and the deploy injects -o ProxyJump=/StrictHostKeyChecking into every
+operator->node ssh/scp — so a bastion-only fleet (e.g. GKE pods) deploys with no
+~/.ssh/config edits, while the in-cluster hub->spoke tunnels stay jump-free."""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+SCRIPT = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+
+
+def test_fleet_setup_persists_ssh_jump_into_defaults():
+    from mac.fleet_setup import build_setup_plan
+
+    spec = {
+        "schema": "mac.fleet_setup.v1", "fleet_name": "jordanh-gke", "hub": "jordanh-hub",
+        "hub_url": "http://jordanh-hub:8789", "supervisor": "supervisord",
+        "ssh_jump": "horde@bastion.horde-gke.nvidia.com:2222",
+        "ssh_strict_host_key_checking": False,
+        "router": {"backend": "inproc", "providers": [{"id": "nvidia"}]},
+        "agents": [{"name": "jordanh-hub", "target": "horde@jordanh-hub", "os": "linux", "supervisor": "supervisord"}],
+        "deploy_agents": ["jordanh-hub"],
+    }
+    plan = build_setup_plan(spec, root=ROOT, fleets_config=Path("/tmp/_x.yaml"), env_file=Path("/tmp/_x.env"))
+    d = plan["fleet_config"]["defaults"]
+    assert plan["errors"] == []
+    assert d["ssh_jump"] == "horde@bastion.horde-gke.nvidia.com:2222"
+    assert d["ssh_strict_host_key_checking"] is False
+
+
+def test_default_setup_keeps_strict_on_and_jump_empty():
+    from mac.fleet_setup import build_setup_plan
+
+    spec = {
+        "schema": "mac.fleet_setup.v1", "fleet_name": "f", "hub": "h", "hub_url": "http://h:8789",
+        "router": {"backend": "inproc", "providers": [{"id": "nvidia"}]},
+        "agents": [{"name": "h", "target": "u@h", "os": "linux"}], "deploy_agents": ["h"],
+    }
+    d = build_setup_plan(spec, root=ROOT, fleets_config=Path("/tmp/_y.yaml"), env_file=Path("/tmp/_y.env"))["fleet_config"]["defaults"]
+    assert d["ssh_jump"] == "" and d["ssh_strict_host_key_checking"] is True
+
+
+def test_deploy_script_wires_proxyjump():
+    assert "ssh_conn_opts" in SCRIPT and "ProxyJump=" in SCRIPT and "load_ssh_jump_config" in SCRIPT
+    # both arg builders call the injector
+    assert SCRIPT.count("\n  ssh_conn_opts\n") >= 2
+    # the bare-target ssh calls carry the opts string
+    assert "$SSH_CONN_OPTS" in SCRIPT
+
+
+def _extract(func: str) -> str:
+    m = re.search(r"^%s\(\) \{\n.*?^\}$" % re.escape(func), SCRIPT, re.S | re.M)
+    assert m, "could not extract %s" % func
+    return m.group(0)
+
+
+def test_ssh_conn_opts_emits_proxyjump_dynamically():
+    fn = _extract("ssh_conn_opts")
+    with_jump = subprocess.run(
+        ["bash", "-c", fn + '\nSSH_JUMP="horde@bastion:2222"; SSH_STRICT=0; ssh_conn_opts | tr "\\0" "\\n"'],
+        capture_output=True, text=True,
+    ).stdout
+    assert "ProxyJump=horde@bastion:2222" in with_jump
+    assert "StrictHostKeyChecking=no" in with_jump
+    # no jump configured -> emits nothing (default non-bastion fleet)
+    none = subprocess.run(
+        ["bash", "-c", fn + '\nSSH_JUMP=""; SSH_STRICT=1; ssh_conn_opts | tr "\\0" "\\n"'],
+        capture_output=True, text=True,
+    ).stdout
+    assert none.strip() == ""

--- a/tests/test_fleet_setup.py
+++ b/tests/test_fleet_setup.py
@@ -158,3 +158,22 @@ def test_mac_fleet_doctor_prints_llm_setup_report(tmp_path):
     assert report["status"] == "pass"
     assert report["hub"] == "horde-hub"
     assert any(check["name"] == "router.providers" for check in report["checks"])
+
+
+def test_spec_path_materializes_default_model_never_blank(tmp_path):
+    """The --spec planner must record a concrete gateway_model for every agent:
+    an agent with an explicit model keeps it; one with none gets the default.
+    A blank model is what silently sent the fleet to gpt-4.1-mini."""
+    from mac.fleet_setup import DEFAULT_GATEWAY_MODEL
+
+    plan = build_setup_plan(
+        _spec(),
+        root=ROOT,
+        fleets_config=tmp_path / "fleets.yaml",
+        env_file=tmp_path / ".env",
+        env={"NVIDIA_API_KEY": "nv-secret"},
+    )
+    models = {a["name"]: a["hermes"]["gateway_model"] for a in plan["fleet_config"]["agents"]}
+    assert models["horde-hub"] == "nvidia/test-model"  # explicit model preserved
+    assert models["horde-worker"] == DEFAULT_GATEWAY_MODEL  # blank -> default, not ""
+    assert all(v for v in models.values())  # nothing blank


### PR DESCRIPTION
## Why

Deploy a fleet whose nodes are reachable **only through a jump host** (e.g. GKE pods behind a bastion) using the **stock** `scripts/setup-fleet.py` + `deploy/deploy-mac-fleet.sh`, with **no `~/.ssh/config` edits**. The bastion + host-key policy is recorded in `fleets.yaml` so it travels with the registry.

## What

**setup (fleets.yaml is the source of truth)**
- `fleet_setup.build_setup_plan` reads `ssh_jump` + `ssh_strict_host_key_checking` (spec / `defaults` / `fleet` block) and persists them into the fleet's `defaults`.

**deploy**
- `ssh_conn_opts()` injects `-o ProxyJump=<jump>` (+ optional `StrictHostKeyChecking=no`/`UserKnownHostsFile=/dev/null`) into the single `ssh_target_args`/`scp_target_args` chokepoint and the few bare-target ssh probes/restarts. `load_ssh_jump_config()` hydrates it once in `main()` from `fleet_config_query ssh-jump`.
- **Operator-side only:** the jump is never interpolated into the hub→spoke reverse-tunnel heredocs, which run in-cluster without the bastion.
- `python_bin()` floor `3.10 → 3.11` to match `pyproject` `requires-python`, so a 3.10 interpreter isn't selected only to fail `pip install -e .` mid-deploy.

**model regression guard**
- `DEFAULT_GATEWAY_MODEL`/`resolve_gateway_model` move into `fleet_setup` (single source of truth; `setup-fleet.py` imports them). The `--spec` planner resolves a blank/`*` `gateway_model` to the default instead of persisting `""` — the exact gap that let the fleet silently run on `gpt-4.1-mini`.

## Tests
`ssh_jump` round-trips into `defaults`; default keeps strict on / jump empty; `ssh_conn_opts` emits ProxyJump dynamically; `--spec` materializes a concrete model for every agent, never blank. Full fleet/deploy/setup/router suite green (171 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)