### PR TITLE
deploy: fix two bastion-fleet init bugs found deploying jordanh-gke

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -746,7 +746,11 @@ load_ssh_jump_config() {
   [ "$SSH_STRICT" = "0" ] && SSH_CONN_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
   [ -n "$SSH_JUMP" ] && SSH_CONN_OPTS="${SSH_CONN_OPTS:+$SSH_CONN_OPTS }-o ProxyJump=$SSH_JUMP"
   if [ -n "$SSH_JUMP" ]; then
-    log "ssh: operator->node via -o ProxyJump=${SSH_JUMP} (strict host-key checking: $([ "$SSH_STRICT" = "0" ] && echo off || echo on))"
+    # Operator-side message: log() is defined only inside the remote node
+    # payload (the <<'REMOTE' heredoc), so on the operator it resolves to the
+    # macOS /usr/bin/log binary and would abort under set -e. Use the same
+    # echo "==> ..." convention as the rest of main()'s operator-side output.
+    echo "==> ssh: operator->node via -o ProxyJump=${SSH_JUMP} (strict host-key checking: $([ "$SSH_STRICT" = "0" ] && echo off || echo on))"
   fi
 }
 
@@ -1858,15 +1862,27 @@ cp.register_hermes_instance(
 )
 if agent == shared_services_manager:
     fleet_metadata = {"source": "mac-deploy", "fleet": fleet, "hub_agent": agent}
-    try:
-        existing_fleet = cp.get_fleet(fleet)
-    except NotFoundError:
+    # Idempotent get-or-create. create_fleet derives the id via
+    # stable_id("fleet", fleet), which lowercases the name — so a prior deploy of
+    # the same fleet under different case (e.g. "jordanh-GKE" vs "jordanh-gke")
+    # shares the id but NOT the case-sensitive name. Look up by the stable id as
+    # well as the name, or a re-deploy hits a fleets.id UNIQUE collision instead
+    # of reconciling the fleet that is already there.
+    fleet_fid = stable_id("fleet", fleet)
+    existing_fleet = None
+    for _key in (fleet, fleet_fid):
+        try:
+            existing_fleet = cp.get_fleet(_key)
+            break
+        except NotFoundError:
+            continue
+    if existing_fleet is None:
         cp.create_fleet(
             fleet,
             description="Auto-registered deployment fleet",
             metadata=fleet_metadata,
             tenant_id=tenant_id,
-            fleet_id=stable_id("fleet", fleet),
+            fleet_id=fleet_fid,
             actor="mac-deploy",
         )
     else:

--- a/deploy/jordanh-gke.fleet.yaml
+++ b/deploy/jordanh-gke.fleet.yaml
@@ -1,0 +1,95 @@
+# Declarative fleet setup for the `jordanh-gke` fleet (GKE pods behind a
+# bastion). Fed to `scripts/setup-fleet.py --spec` which writes the fleet into
+# ~/.mac/fleets.yaml; nothing here is hand-patched into the registry.
+#
+#   NVIDIA_API_KEY=<key> python3 scripts/setup-fleet.py \
+#       --spec deploy/jordanh-gke.fleet.yaml --force
+#   make deploy HUB=jordanh-gke ARGS="jordanh-gke jordanh-worker1 jordanh-worker2"
+#
+# The pods are reachable only via the horde bastion, so ssh_jump/ssh_strict are
+# recorded fleet-wide and the stock deploy injects -o ProxyJump for every
+# operator->node hop (the in-cluster hub->spoke tunnels stay jump-free).
+schema: mac.fleet_setup.v1
+
+fleet_name: jordanh-gke
+# Hub agent name == fleet registry key (deploy --hub / mac --fleet both select by
+# key), exactly as the `rocky` fleet's hub agent is named `rocky` though it runs
+# on host do-host1. Here the agent `jordanh-gke` runs on the jordanh-hub pod.
+hub: jordanh-gke
+hub_url: http://jordanh-hub.ov-agent-farm.svc.cluster.local:8789
+control_port: 8789
+supervisor: supervisord
+
+# Operator -> node bastion. GKE pods resolve only inside the cluster, so every
+# ssh/scp ProxyJumps through the horde bastion; host keys are ephemeral per pod.
+ssh_jump: horde@bastion.horde-gke.nvidia.com:2222
+ssh_strict_host_key_checking: false
+
+defaults:
+  hermes:
+    gateway_provider: custom
+    gateway_base_url: ""
+    # Materialized model: never blank (a blank model is how a fleet silently
+    # fell through to gpt-4.1-mini). resolve_gateway_model enforces this too.
+    gateway_model: azure/anthropic/claude-sonnet-4-6
+  worker:
+    mode: loop
+    require_canary: false
+
+# In-cluster DNS only; no overlay network. The hub is reached over the stock
+# hub->spoke reverse tunnels rather than tailscale/headscale.
+network:
+  provider: none
+
+# The hub is the shared-services manager and has no degraded path: qdrant and
+# firecrawl are mandatory (the deploy hardcodes QDRANT_REQUIRE/FIRECRAWL_REQUIRE
+# =1), so the hub installs both via docker. Bind + URL are loopback so the hub's
+# own deploy-time validation hits 127.0.0.1 and the reverse tunnel's hub
+# endpoint (-R 127.0.0.1:16333:127.0.0.1:6333) forwards to them; network=none
+# spokes auto-rewrite their URLs to the tunnel-forwarded 127.0.0.1:16333/13002.
+qdrant:
+  install: auto
+  bind_addr: "127.0.0.1"
+  url: http://127.0.0.1:6333
+firecrawl:
+  install: auto
+  bind_addr: "127.0.0.1"
+  url: http://127.0.0.1:3002
+
+router:
+  backend: inproc
+  # Only nvidia: madmax's vLLM is tailscale-internal and unreachable from GKE.
+  # The deploy escrows NVIDIA_API_KEY into the hub vault as `nvidia-upstream`;
+  # the hub-only router resolves key=secret:nvidia-upstream from there.
+  providers:
+    - id: nvidia
+      key_env: NVIDIA_API_KEY
+  default_model: azure/anthropic/claude-sonnet-4-6
+
+agents:
+  - name: jordanh-gke
+    target: horde@jordanh-hub.ov-agent-farm.svc.cluster.local
+    os: linux
+    supervisor: supervisord
+    control_bind_host: "0.0.0.0"
+    worker:
+      mode: loop
+
+  - name: jordanh-worker1
+    target: horde@jordanh-worker1.ov-agent-farm.svc.cluster.local
+    os: linux
+    supervisor: supervisord
+    worker:
+      mode: loop
+
+  - name: jordanh-worker2
+    target: horde@jordanh-worker2.ov-agent-farm.svc.cluster.local
+    os: linux
+    supervisor: supervisord
+    worker:
+      mode: loop
+
+deploy_agents:
+  - jordanh-gke
+  - jordanh-worker1
+  - jordanh-worker2

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -272,7 +272,12 @@ def test_fleet_deploy_bootstraps_hub_fleet_record(tmp_path):
     assert values["MAC_FLEET_TENANT_ID"] == "tenant_test-fleet"
     assert "if agent == shared_services_manager:" in script
     assert "cp.create_fleet(" in script
-    assert 'fleet_id=stable_id("fleet", fleet)' in script
+    # Idempotent get-or-create: the id is derived once via stable_id (which
+    # lowercases the name) and the fleet is looked up by both name and that id,
+    # so a re-deploy under different name case reconciles instead of colliding.
+    assert 'fleet_fid = stable_id("fleet", fleet)' in script
+    assert "fleet_id=fleet_fid" in script
+    assert "for _key in (fleet, fleet_fid):" in script
     assert 'description="Auto-registered deployment fleet"' in script
 
 

--- a/tests/test_deploy_ssh_jump.py
+++ b/tests/test_deploy_ssh_jump.py
@@ -73,3 +73,13 @@ def test_ssh_conn_opts_emits_proxyjump_dynamically():
         capture_output=True, text=True,
     ).stdout
     assert none.strip() == ""
+
+
+def test_load_ssh_jump_config_is_operator_side_safe():
+    """load_ssh_jump_config runs on the operator, where the script's log() is
+    NOT defined (it lives only inside the remote <<'REMOTE' node payload, so on
+    macOS `log` resolves to /usr/bin/log and aborts under set -e). It must use
+    the operator-side echo "==>" convention instead."""
+    fn = _extract("load_ssh_jump_config")
+    assert 'log "' not in fn, "operator-side function must not call the remote-only log()"
+    assert 'echo "==>' in fn


### PR DESCRIPTION
Both bugs surfaced bringing up a brand-new GKE fleet (hub + 2 workers) behind a bastion via the stock `setup.py` + `deploy/deploy-mac-fleet.sh` (follow-up to #81).

## 1. Operator-side `log()` crash
`load_ssh_jump_config()` runs on the **operator**, but `log()` is defined only inside the remote `<<'REMOTE'` node payload. On macOS `log "..."` resolved to `/usr/bin/log` ("Unknown subcommand") and, under `set -e`, **aborted the whole deploy before any node work**. Now uses the operator-side `echo "==> ..."` convention. Adds a regression test asserting `load_ssh_jump_config` doesn't call the remote-only `log()`.

## 2. Fleet registration not idempotent across name case
`create_fleet` derives the id via `stable_id("fleet", name)` (which **lowercases** the name), but the deploy looked the fleet up by its **case-sensitive name**. A prior deploy of the same fleet under different case (`jordanh-GKE` vs `jordanh-gke`) shared the id but not the name → `get_fleet(name)` raised `NotFound` and `create_fleet` then hit a `fleets.id` UNIQUE collision instead of reconciling. Now looks up by the stable id as well as the name, so re-deploys update the existing fleet.

## Plus
`deploy/jordanh-gke.fleet.yaml` — a reproducible `mac.fleet_setup.v1` spec for a bastion-only (ProxyJump) GKE fleet: hub installs qdrant/firecrawl on loopback; `network=none` spokes reach them over the reverse tunnel's `127.0.0.1:16333/13002` forwards.

## Verification
Deployed live to `jordanh-gke` (GKE, bastion-only): all 3 agents register healthy, hub runs control-plane + qdrant + firecrawl + hermes-gateway + agent + both reverse tunnels, fleet created with the correct lowercase name. ssh-jump + fleet-setup suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)