### PR TITLE
deploy: default image_gen.provider to the hub-routed nvidia backend

### DIFF
--- a/src/mac/hermes_chat_config.py
+++ b/src/mac/hermes_chat_config.py
@@ -217,6 +217,55 @@ def _chmod_600(path: Path) -> None:
         pass
 
 
+def ensure_image_gen_provider(hermes_home: Path, default: str = "nvidia") -> str:
+    """Default image generation to the hub-routed ``nvidia`` provider when the
+    operator hasn't picked one.
+
+    That backend routes text-to-image through the in-mac router's ``/v1/genai``
+    proxy (using the hub's escrowed image key), so agents render images with NO
+    per-agent ``FAL_KEY`` — and it works on spokes, which carry no raw provider
+    keys. Without this default, the registry's legacy fallback prefers ``fal``
+    (which reports available via the managed gateway but has no usable key here),
+    so image generation fails fleet-wide even though ``/v1/genai`` works.
+
+    Respects an explicit ``image_gen.provider`` (never overrides it). Line-based
+    to preserve the rest of the file. Returns the provider now in effect (``""``
+    when there is no config.yaml).
+    """
+    cfg = hermes_home / "config.yaml"
+    if not cfg.exists():
+        return ""
+    lines = cfg.read_text(encoding="utf-8").splitlines()
+
+    # Already chosen? Find the top-level `image_gen:` block and look for a
+    # `provider:` line within it; respect any explicit value.
+    n = len(lines)
+    for i, ln in enumerate(lines):
+        if re.match(r"^image_gen:\s*$", ln):
+            j = i + 1
+            while j < n and (not lines[j].strip() or lines[j].startswith((" ", "\t"))):
+                m = re.match(r"^\s+provider:\s*(\S.*?)\s*$", lines[j])
+                if m:
+                    return m.group(1).strip().strip("'\"")
+                j += 1
+            break
+
+    # Not set: insert `provider:` under an existing `image_gen:` block, else
+    # append a fresh block at EOF.
+    res: List[str] = []
+    inserted = False
+    for ln in lines:
+        res.append(ln)
+        if not inserted and re.match(r"^image_gen:\s*$", ln):
+            res.append("  provider: %s" % default)
+            inserted = True
+    if not inserted:
+        res += ["image_gen:", "  provider: %s" % default]
+    cfg.write_text("\n".join(res) + "\n", encoding="utf-8")
+    _chmod_600(cfg)
+    return default
+
+
 def sync(hermes_home: Path, mac_env_path: Path) -> Dict[str, object]:
     mac_env = parse_env_file(mac_env_path)
     base_url = (mac_env.get("MAC_HERMES_GATEWAY_BASE_URL") or mac_env.get("OPENAI_BASE_URL") or "").strip()
@@ -227,6 +276,7 @@ def sync(hermes_home: Path, mac_env_path: Path) -> Dict[str, object]:
         "env_synced": sync_hermes_env(hermes_home, mac_env),
         "config_custom_provider": sync_config_yaml(hermes_home, base_url, api_key),
         "pool_cleared": clear_stale_custom_pool(hermes_home),
+        "image_gen_provider": ensure_image_gen_provider(hermes_home),
     }
 
 

--- a/tests/test_hermes_chat_config.py
+++ b/tests/test_hermes_chat_config.py
@@ -206,3 +206,51 @@ def test_router_env_emits_modality_upstreams_and_keys_from_spec(tmp_path):
     assert ev["NVIDIA_AUDIO_API_KEY"] == "nvapi-aud"
     assert ev["MAC_DEPLOY_ROUTER_VIDEO_UPSTREAM"] == "https://video.example/v1/video"
     assert ev["MY_VIDEO_KEY"] == "vid-secret"  # key_env read from the environment
+
+
+# --- image_gen provider default (hub-routed nvidia) -------------------------
+from pathlib import Path  # noqa: E402
+
+from mac.hermes_chat_config import ensure_image_gen_provider  # noqa: E402
+
+
+def _home_with_config(tmp_path, body: str) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+    return home
+
+
+def test_image_gen_defaults_to_nvidia_when_unset(tmp_path):
+    # Fresh config with no image_gen block -> default to the hub-routed provider.
+    home = _home_with_config(tmp_path, "model:\n  provider: custom\n  base_url: http://x/v1/\n")
+    assert ensure_image_gen_provider(home) == "nvidia"
+    text = (home / "config.yaml").read_text(encoding="utf-8")
+    assert "image_gen:" in text and "provider: nvidia" in text
+    # idempotent: re-running respects the value just written
+    assert ensure_image_gen_provider(home) == "nvidia"
+
+
+def test_image_gen_respects_explicit_provider(tmp_path):
+    home = _home_with_config(tmp_path, "image_gen:\n  provider: fal\n")
+    assert ensure_image_gen_provider(home) == "fal"  # never override an explicit choice
+    assert (home / "config.yaml").read_text(encoding="utf-8").count("provider:") == 1
+
+
+def test_image_gen_inserts_provider_into_existing_block(tmp_path):
+    home = _home_with_config(tmp_path, "image_gen:\n  model: flux.1-schnell\n")
+    assert ensure_image_gen_provider(home) == "nvidia"
+    text = (home / "config.yaml").read_text(encoding="utf-8")
+    assert "provider: nvidia" in text and "model: flux.1-schnell" in text
+
+
+def test_image_gen_noop_without_config(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    assert ensure_image_gen_provider(home) == ""  # no config.yaml -> nothing to do
+
+
+def test_sync_reports_image_gen_provider(tmp_path):
+    home = _stale_hermes_home(tmp_path)
+    result = sync(home, _mac_env(tmp_path))
+    assert result["image_gen_provider"] == "nvidia"


### PR DESCRIPTION
## Why
Agents (Rocky, Bullwinkle) can't generate images **even though the hub's `/v1/genai` proxy works** (verified: FLUX → 200 → JPEG). Root cause is **provider selection**, not credentials: with `image_gen.provider` unset, the registry's legacy fallback prefers **`fal`**, which reports `is_available()` via the managed Nous gateway but has no usable key on the fleet → generation fails. Meanwhile the keyless, hub-routed **`nvidia`** provider (already shipped — routes text-to-image through the in-mac router's `/v1/genai`, works on spokes) sits unused.

## Fix
In the **mac-managed** hermes config sync (`hermes_chat_config.py`) — *not* the vendored `_hermes` registry — add `ensure_image_gen_provider()` that writes `image_gen.provider: nvidia` into `~/.hermes/config.yaml` when the operator hasn't chosen one. Selection becomes explicit/deterministic (registry rule 1 wins, independent of FAL's availability quirks). It:
- **Respects** an explicit `image_gen.provider` (never overrides).
- Is line-based (preserves the rest of config.yaml).
- Runs inside the existing `python -m mac.hermes_chat_config` deploy step → **propagates on redeploy with no deploy-script change.**

## Tests
Defaults to `nvidia` when unset (idempotent), respects an explicit provider, inserts into an existing `image_gen:` block, no-ops without a config, and `sync()` reports the resolved provider. (`tests/test_hermes_chat_config.py`, 9 passed.)

## Rollout
Lands the durable default; agents pick it up on next redeploy. Fleet image-gen then routes through the hub's escrowed NVIDIA key — no per-agent `FAL_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)