### PR TITLE
tickets: media-routing design (media-01 epic + media-02 credential model)

### DIFF
--- a/.tickets/media-01.md
+++ b/.tickets/media-01.md
@@ -1,0 +1,107 @@
+---
+id: media-01
+status: open
+deps: []
+links: [in-mac-router-vault]
+created: 2026-06-04T00:00:00Z
+type: epic
+priority: 2
+audit: media-routing-architecture
+discovered_via: image-gen-fragmentation
+---
+# EPIC: unify media routing — operation → [provider binding] table + adapters
+
+## Why this exists
+
+Image/audio/video generation is wired three disjoint ways, and they don't
+agree, so "the backend works but the agent can't reach it" is a recurring bug
+(e.g. `/v1/genai` returns a real JPEG, yet agents report "no FAL_KEY"):
+
+1. **Chat router** — `MAC_ROUTER_PROVIDERS="nvidia=url,0,key=secret:nvidia-upstream;madmax=…"`.
+   Rich: ordered providers, priority, per-model routing, vault-ref keys. *This
+   is the model to copy.*
+2. **Media proxies** — `MAC_ROUTER_{IMAGE,AUDIO,VIDEO}_UPSTREAM` + one flat
+   `…_KEY` each (router_app.py `_MODALITY_PROXIES`). A **dumb pass-through**:
+   one upstream, one key, no model list, and the caller must speak the
+   upstream's dialect (`POST /v1/genai/black-forest-labs/flux.1-schnell`).
+3. **Agent tool** — the `ImageGenProvider` registry (`_hermes/agent/
+   image_gen_registry.py`), default-fallback `fal` (needs `FAL_KEY`), with no
+   wiring to #2. So #2 works, agents use #3, #3 is unkeyed → no image.
+
+A single key per modality can't express reality: a key belongs to a *provider*;
+a provider serves *many* operations; an operation has *many* candidate
+providers (many-to-many). And the providers don't share a wire format, so a
+generic proxy + single key can't translate requests.
+
+## Design
+
+Route on **`(modality, operation)`**; each route resolves to an **ordered list
+of provider bindings** (priority = fallback/robustness). Generalize the chat
+provider model to all modalities.
+
+```yaml
+router:
+  media:
+    image.generate:                 # text→image
+      - {provider: bullwinkle-local, base_url: http://bullwinkle:8189, model: sdxl-turbo,
+         key: "", adapter: openai_images, priority: 0, when: {agent_up: bullwinkle}}
+      - {provider: nvidia-nim, base_url: https://ai.api.nvidia.com/v1/genai,
+         model: black-forest-labs/flux.1-schnell, key: secret:nvidia-image, adapter: nvidia_genai, priority: 1}
+      - {provider: fal, base_url: https://fal.run, model: fal-ai/flux-2/klein/9b,
+         key: secret:fal, adapter: fal, priority: 2}
+    image.understand:               # vision/VLM → a CHAT model, not genai
+      - {provider: nvidia-chat, model: "*", adapter: openai_chat_vision, key: secret:nvidia-upstream}
+    audio.tts:   [...]
+    audio.asr:   [...]
+    video.generate: [...]
+```
+
+Each binding beyond `(operation, url, key)`:
+- **`model`** separate from `base_url` — one provider has many models; one op may try several.
+- **`key: secret:<name>`** — never inline; resolved by `SecretsService` (already
+  exists). Rotation is a vault op, no config edit (see media-02).
+- **`adapter`** — the missing piece. Translates a *canonical* request
+  (`{operation, prompt, image?, size, steps, …}`) ↔ each provider's schema
+  (NVIDIA genai's flux vs stability dialects, FAL, OpenAI-images, a local SDXL
+  server). Callers become provider-agnostic; providers are swappable.
+- **`priority` + `when`** — try local GPU first, fall back to cloud; **skip a
+  provider whose key is missing/invalid** (a 401 becomes graceful fallback, not
+  a hard failure).
+
+### Unify the code paths
+- Router: replace the three flat modality proxies with this table; expose a
+  canonical `POST /v1/media/{op}` (normalized body) that walks the bindings in
+  priority order, applies the adapter, falls back on failure. The current flat
+  `MAC_ROUTER_*_{UPSTREAM,KEY}` become the degenerate single-binding case
+  (back-compat).
+- Agents: the `ImageGenProvider` registry is the right seam — add ONE provider,
+  `mac-hub`, whose `generate()` calls `/v1/media/image.generate`; make it the
+  default. Agents then inherit the hub's vault keys and never need a local
+  `FAL_KEY`. The keyless `nvidia` provider already does ~this for image (routes
+  through `/v1/genai`); `mac-hub` is its generalization across modalities.
+- Register **bullwinkle-local** (and any GPU agent, e.g. natasha post-driver) as
+  a *binding*, not a separate code path, so the table can prefer on-box GPU.
+
+### Where it lives
+`fleets.yaml` `defaults.router.media` (+ per-agent overrides), materialized into
+the hub env, keys resolved via `SecretsService` — the same pattern chat uses.
+
+## Acceptance Criteria
+- A `(modality, operation) → [binding]` table parsed from fleets.yaml, with
+  ordered fallback and `secret:`-ref keys.
+- A per-provider adapter interface; adapters for nvidia_genai (flux + stability),
+  fal, openai_images, openai_chat_vision.
+- Canonical `POST /v1/media/{op}`; flat `MAC_ROUTER_*_{UPSTREAM,KEY}` still work
+  (degenerate single binding).
+- A `mac-hub` ImageGenProvider that routes via the canonical endpoint; default
+  for agents; no per-agent media keys required.
+- Fallback skips bindings with missing/invalid keys (verified: a bad key →
+  next provider, not a hard error).
+
+## Notes
+- Tactical precursor (shipped): default `image_gen.provider: nvidia` so agents
+  use the keyless hub-routed `/v1/genai` path (PR for hermes_chat_config). This
+  epic makes that the general mechanism instead of an image-only special case.
+- See media-02 for the credential model (per-provider vault secrets;
+  `nvidia-upstream` = chat, `nvidia-image` = genai are *distinct* entitlements —
+  conflating them is what 401'd image-gen on a fresh hub).

--- a/.tickets/media-02.md
+++ b/.tickets/media-02.md
@@ -1,0 +1,53 @@
+---
+id: media-02
+status: open
+deps: [media-01]
+links: [in-mac-router-vault, media-01]
+created: 2026-06-04T00:00:00Z
+type: feature
+priority: 2
+audit: media-routing-architecture
+discovered_via: jordanh-gke-image-401
+---
+# Media credential model: per-provider vault secrets, distinct entitlements
+
+## Why this exists
+
+Image-gen 401'd on a freshly-deployed hub (jordanh-gke) even though chat worked,
+because the deploy's modality escrow falls back to the **chat** key when the
+image key isn't supplied:
+
+```
+# deploy-mac-fleet.sh modality escrow
+("image", "MAC_ROUTER_IMAGE_KEY",
+ os.environ.get("NVIDIA_IMAGE_API_KEY") or os.environ.get("NVIDIA_API_KEY") or "")
+```
+
+So a fresh hub got `secret:nvidia-image` = the chat key, which NVIDIA's
+`ai.api.nvidia.com/v1/genai` rejects (`401 Authentication failed`). The chat
+NIM key and the genai/image key are **distinct entitlements** at build.nvidia.com
+— conflating them silently produces a working-chat / broken-image fleet.
+
+(Resolved operationally for jordanh-gke by rotating `nvidia-image` to a real
+build key via `DELETE`+`POST /secrets`; this ticket makes the model correct.)
+
+## What to fix
+
+- Keys are per-**provider/entitlement**, referenced by `secret:<name>` and
+  resolved from `SecretsService` (the vault already exists; rotation is a vault
+  op — no config edit, no redeploy).
+- Stop the chat-key fallback for media. If `NVIDIA_IMAGE_API_KEY` (and audio/
+  video) isn't supplied, escrow **nothing** for that modality and mark the
+  corresponding `media` bindings *unavailable* (media-01's fallback then skips
+  them gracefully) — never escrow the chat key under an image/audio/video name.
+- Surface missing media entitlements at deploy time (a clear "image-gen
+  disabled: no nvidia-image key" line) instead of a runtime 401.
+- A small `mac secret rotate <name>` CLI (today there's create/delete/resolve
+  but no HTTP rotate) so operators don't DELETE+POST by hand.
+
+## Acceptance Criteria
+- Per-provider `secret:` keys; no cross-entitlement fallback (chat key never
+  escrowed as a media key).
+- Deploy reports which media operations are enabled vs disabled (by key
+  presence), no hard failure when a media key is absent.
+- `mac secret rotate <name> --value-file <f>` (stdin `-` supported), audited.


### PR DESCRIPTION
Design tickets for unifying media (image/audio/video) routing, written while fixing fleet image generation (the duck problem).

- **media-01 (epic)**: collapse the three disjoint media paths into one `(modality, operation) → [provider binding]` table + per-provider adapters + canonical `POST /v1/media/{op}`; route the agent `ImageGenProvider` through a `mac-hub` provider (no per-agent `FAL_KEY`); register local GPUs (bullwinkle) as bindings.
- **media-02**: per-provider vault credentials; stop escrowing the chat key under `nvidia-image` (the fresh-hub 401 root cause); deploy-time enabled/disabled media-op reporting; `mac secret rotate`.

Tactical precursor merged in #83 (default `image_gen.provider=nvidia`). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)