### PR TITLE
test: de-flake test_controller_daemon_failure_does_not_kill_runner

### DIFF
--- a/tests/test_k8s_orchestrator.py
+++ b/tests/test_k8s_orchestrator.py
@@ -249,8 +249,21 @@ def test_controller_daemon_failure_does_not_kill_runner(
 
     sleep_calls = {"n": 0}
     real_sleep = time.sleep
+    # The controller daemon runs in this named thread (orchestrator.main).
+    controller_thread_name = "mac-orchestrator-controller"
 
     def _bounded_sleep(seconds: float) -> None:
+        # Bound ONLY the controller daemon's own sleeps. `orchestrator.time` is
+        # the shared `time` module, so patching it also intercepts the runner's
+        # time.sleep(0.05) on the MAIN thread; counting those let the "stop
+        # daemon" raise fire inside the runner once the controller's two fast
+        # sleeps pushed the shared counter to >=2 first — which is exactly what
+        # happens on a loaded CI host, making main() return 1 (flaky). Scoping
+        # the bound to the controller thread makes the outcome deterministic
+        # regardless of how the threads interleave.
+        if threading.current_thread().name != controller_thread_name:
+            real_sleep(0)
+            return
         sleep_calls["n"] += 1
         if sleep_calls["n"] >= 2:
             # Kill the inner loop via outer-except path.


### PR DESCRIPTION
## Why
This test has been **failing most 3.11 CI runs** (passing 3.12 + locally) and blocking every PR's merge — including a docs-only PR.

## Root cause
It patches `orchestrator.time.sleep` to bound the controller daemon loop, but `orchestrator.time` **is the shared `time` module**, so the patch also intercepts the runner's own `time.sleep(0.05)` on the **main thread**. One shared, non-thread-safe counter bounds *all* sleeps and raises `"test bound: stop daemon"` at count ≥2. When the controller's two fast (0.01s) sleeps reach the counter first — the common case on a loaded runner — the **runner's** sleep then raises, `main()` catches it and returns 1, failing `assert rc == 0`. Fast machines sleep the runner first → passes. Hence the flake.

## Fix
Scope the bound to the controller daemon thread (`mac-orchestrator-controller`); sleeps on any other thread pass through. Deterministic regardless of thread interleaving. **0 failures in 30 local runs** (was intermittent).

No production code change — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)