### PR TITLE
deploy: pin source worktree to exact $DEPLOY_REV (not merge --ff-only)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -3374,8 +3374,17 @@ rm -rf "$SRC_DIR.new"
 if [ -n "$DEPLOY_GIT_URL" ] && git clone --quiet --branch "$DEPLOY_GIT_BRANCH" "$DEPLOY_GIT_URL" "$SRC_DIR.new"; then
   actual_rev="$(git -C "$SRC_DIR.new" rev-parse HEAD)"
   if [ "$actual_rev" != "$DEPLOY_REV" ]; then
-    git -C "$SRC_DIR.new" fetch --quiet origin "$DEPLOY_REV"
-    git -C "$SRC_DIR.new" merge --ff-only "$DEPLOY_REV"
+    # Pin the worktree to the operator's exact deploy revision. fetch + reset,
+    # NOT `merge --ff-only`: ff aborts with "Not possible to fast-forward"
+    # whenever $DEPLOY_REV isn't a descendant of the freshly-cloned branch HEAD
+    # — e.g. origin/$DEPLOY_GIT_BRANCH advanced past the operator's local HEAD
+    # (someone else merged mid-session), which leaves the spoke half-deployed.
+    # We want exactly $DEPLOY_REV regardless of how it relates to the branch tip.
+    if git -C "$SRC_DIR.new" fetch --quiet origin "$DEPLOY_REV"; then
+      git -C "$SRC_DIR.new" reset --hard --quiet "$DEPLOY_REV"
+    else
+      log "WARNING: could not fetch deploy rev $DEPLOY_REV from origin; using clone HEAD $actual_rev"
+    fi
   fi
 else
   log "WARNING: git clone failed or was not configured; installing archive without self-update worktree"

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -1422,3 +1422,14 @@ def test_mac_repository_contract_test_command_uses_hermetic_runner():
     text = runner.read_text(encoding="utf-8")
     assert 'unset "${!MAC_@}"' in text
     assert 'exec .venv/bin/python -m pytest "$@"' in text
+
+
+def test_source_install_pins_exact_rev_not_ff_only():
+    """The remote source install must pin the worktree to the operator's exact
+    $DEPLOY_REV via fetch+reset. `git merge --ff-only $DEPLOY_REV` aborts with
+    "Not possible to fast-forward" when origin/<branch> advanced past the
+    operator's local HEAD mid-session, leaving the spoke half-deployed."""
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    assert 'reset --hard --quiet "$DEPLOY_REV"' in script
+    # the ff-only merge *command* must be gone (a comment mentioning it is fine)
+    assert 'merge --ff-only "$DEPLOY_REV"' not in script


### PR DESCRIPTION
## Why
A spoke redeploy aborts at "installing mac source" with `fatal: Not possible to fast-forward` when `origin/<branch>` advanced past the operator's local HEAD mid-session (someone else merged). The source install does `git clone <branch>` then `git merge --ff-only $DEPLOY_REV`, which can't fast-forward to a $DEPLOY_REV that isn't a descendant of the fresh clone HEAD. By then the deploy has **stopped the agent's services and backed up its source**, so the node is left half-deployed (hit live on a rocky-fleet redeploy; recovered only by syncing the local checkout and re-running).

## Fix
Fetch the rev, then `git reset --hard $DEPLOY_REV` — pin the worktree to exactly that commit regardless of its relation to the branch tip; warn + fall back to the clone HEAD if the rev can't be fetched. Same successful-case result (worktree at $DEPLOY_REV) without the divergence abort.

## Test
Static assertion that the source install uses fetch+reset and no longer issues the ff-only merge command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)