### PR TITLE
secrets: add `mac secret rotate` (media-02)

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -738,6 +738,11 @@ class SecretRevealRequest(BaseModel):
     accessor_agent_id: str
 
 
+class SecretRotate(BaseModel):
+    value: str
+    actor: str = "operator"
+
+
 class ArtifactRegister(BaseModel):
     kind: str
     digest: str
@@ -3817,6 +3822,21 @@ def create_app(
             raise NotFoundError("secret store unavailable")
         actor = getattr(principal, "agent_id", None) or "operator"
         return cp.delete_secret(name, actor=actor)
+
+    @app.post("/secrets/{name}/rotate")
+    def rotate_secret(
+        name: str,
+        body: SecretRotate,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        # Rotate a secret's value in place, audited as a rotation — vs the
+        # DELETE + re-POST dance an operator otherwise has to do (and which loses
+        # the secret's id/scopes). Requires the `secret` scope (admin inherits
+        # it; covered by _required_scope for /secrets*). Used to swap an upstream
+        # provider key in the hub vault, e.g. correcting a media key that was
+        # escrowed from the wrong source (nvidia-image vs the chat key).
+        actor = getattr(principal, "agent_id", None) or body.actor or "operator"
+        return cp.rotate_secret(name, body.value, actor).to_dict()
 
     @app.get("/secret-audits")
     def list_secret_audits(secret_id: Optional[str] = Query(default=None)) -> List[Dict[str, Any]]:

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -960,6 +960,11 @@ def cmd_secret_delete(args: argparse.Namespace) -> None:
     _print(_plane(args).delete_secret(args.secret, actor=args.actor))
 
 
+def cmd_secret_rotate(args: argparse.Namespace) -> None:
+    value = _resolve_secret_value(args)
+    _print(_plane(args).rotate_secret(args.name, value, actor=args.actor))
+
+
 def cmd_secret_access(args: argparse.Namespace) -> None:
     _print(_plane(args).request_secret(args.secret, args.agent_id, args.purpose))
 
@@ -2361,6 +2366,13 @@ def build_parser() -> argparse.ArgumentParser:
     secret_delete.add_argument("secret", help="secret id or name")
     secret_delete.add_argument("--actor", default="operator")
     _set(cmd_secret_delete, secret_delete)
+    secret_rotate = secret.add_parser("rotate", help="rotate a secret's value in place (audited)")
+    secret_rotate.add_argument("name", help="secret id or name")
+    secret_rotate.add_argument("value", nargs="?", default=None, help="new value (avoid; prefer --from-stdin / --from-file)")
+    secret_rotate.add_argument("--from-stdin", action="store_true", help="read the new value from stdin")
+    secret_rotate.add_argument("--from-file", help="read the new value from a file path")
+    secret_rotate.add_argument("--actor", default="operator")
+    _set(cmd_secret_rotate, secret_rotate)
     secret_access = secret.add_parser("access")
     secret_access.add_argument("secret")
     secret_access.add_argument("agent_id")

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -635,6 +635,14 @@ class RemoteDispatch:
             )
         )
 
+    def rotate_secret(self, name: str, value: str, actor: str = "operator") -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/secrets/%s/rotate" % quote(name, safe=""),
+                {"value": value, "actor": actor},
+            )
+        )
+
     def list_secrets(self) -> List[_Dictish]:
         return _wrap_list(self._get("/secrets"))
 

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -2662,6 +2662,19 @@ def test_secrets_are_scoped_redacted_audited_and_not_stored_plaintext(cp):
     assert [audit.result for audit in audits] == ["granted", "denied"]
 
 
+def test_rotate_secret_updates_value_in_place_and_audits(cp):
+    deployer = register_agent(cp, "rotdep", ["deploy"])
+    secret = cp.create_secret(
+        "img-key", "old-value", {"capabilities": ["deploy"]}, "human"
+    )
+    rotated = cp.rotate_secret("img-key", "new-value", "operator")
+    assert rotated.id == secret.id  # same row — id + scopes preserved, not a new secret
+    handle = cp.request_secret(secret.id, deployer.id, "use")
+    assert cp.reveal_secret(secret.id, handle.audit_id, deployer.id) == "new-value"
+    # the rotation is audited (not stored plaintext, like every other access)
+    assert any(audit.result == "rotated" for audit in cp.list_secret_audits(secret.id))
+
+
 def test_delete_secret_scrubs_value_and_allows_name_reuse(cp):
     secret = cp.create_secret(
         "stale-router-key", "old-upstream-value", {"capabilities": ["router-upstream"]}, "deploy"


### PR DESCRIPTION
Part of [[media-02]]. There was `create`/`list`/`delete`/`access`/`resolve` but **no rotate**, so swapping an upstream key meant `DELETE` + re-`POST` by hand (losing the secret's id + scopes) — exactly what correcting jordanh-gke's miswired `nvidia-image` key took. `SecretsService.rotate_secret` already existed but wasn't reachable.

Wires it end to end:
- `POST /secrets/{name}/rotate` (secret-scoped, audited as a rotation)
- dispatch HTTP wrapper (hub mode)
- `mac secret rotate <name>` with the same value sources as `set` (`--from-stdin` / `--from-file` / positional)

Test: rotate preserves the secret id + scopes, reveal returns the new value, the rotation is audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)