### PR TITLE
media-01: agent mac-hub provider — route image-gen through /v1/media

### DIFF
--- a/src/mac/_hermes/plugins/image_gen/mac-hub/__init__.py
+++ b/src/mac/_hermes/plugins/image_gen/mac-hub/__init__.py
@@ -1,0 +1,184 @@
+"""MAC hub image generation backend (media-01).
+
+Routes text-to-image through the in-mac router's **canonical** operation
+endpoint ``POST <gateway>/v1/media/image.generate`` (router_app.mount_media_router)
+rather than a provider-specific path. The agent sends ONE provider-agnostic
+request ``{prompt, width, height, steps, seed, model}``; the hub resolves the
+operation's provider binding(s), applies the per-provider adapter, forwards, and
+fails over to the next binding on failure — so the dialect + key live on the hub
+and the agent needs no per-modality credential (works on spokes too).
+
+This is the agent-side half of media-01: it generalizes the ``nvidia`` plugin
+(which posts the NVIDIA flux/stability dialect to ``/v1/genai`` directly) onto
+the unified router seam. ``nvidia`` remains available for a direct/on-prem NIM.
+
+Models are passed straight through as the canonical ``model`` (the hub's adapter
+maps it to the provider path); the friendly ids below mirror the ``nvidia``
+catalog so ``image_gen.model`` behaves the same.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+# Friendly id -> the provider model id the hub's adapter forwards (mirrors the
+# `nvidia` plugin so image_gen.model is interchangeable between the two).
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "flux.1-schnell": {"endpoint": "black-forest-labs/flux.1-schnell", "display": "FLUX.1 [schnell]",
+                        "speed": "~5s", "strengths": "Fast few-step distillation — default"},
+    "flux.1-dev": {"endpoint": "black-forest-labs/flux.1-dev", "display": "FLUX.1 [dev]",
+                   "speed": "~15s", "strengths": "High-quality general text-to-image"},
+    "sdxl": {"endpoint": "stabilityai/stable-diffusion-xl", "display": "Stable Diffusion XL",
+             "speed": "~10s", "strengths": "Classic SDXL"},
+}
+DEFAULT_MODEL = "flux.1-schnell"
+
+# FLUX accepts explicit width/height; map the canonical aspect to a size.
+_SIZES = {"landscape": (1344, 768), "square": (1024, 1024), "portrait": (768, 1344)}
+
+
+def _base_url() -> str:
+    """The router's /v1 base (the agent's gateway base, same one chat uses).
+    The canonical media endpoint is ``<base>/media/<op>``."""
+    return (
+        os.environ.get("MAC_HERMES_GATEWAY_BASE_URL")
+        or os.environ.get("OPENAI_BASE_URL")
+        or ""
+    ).strip().rstrip("/")
+
+
+def _bearer() -> str:
+    return (
+        os.environ.get("MAC_HERMES_GATEWAY_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or ""
+    ).strip()
+
+
+def _resolve_model(explicit: Optional[str]) -> str:
+    env_override = os.environ.get("MAC_HUB_IMAGE_MODEL")
+    for candidate in (env_override, explicit):
+        if isinstance(candidate, str) and candidate.strip():
+            value = candidate.strip()
+            if value in _MODELS:
+                return _MODELS[value]["endpoint"]
+            return value  # already a provider model id (e.g. black-forest-labs/...)
+    return _MODELS[DEFAULT_MODEL]["endpoint"]
+
+
+class MacHubImageGenProvider(ImageGenProvider):
+    """Image gen via the in-mac router's canonical /v1/media/image.generate."""
+
+    @property
+    def name(self) -> str:
+        return "mac-hub"
+
+    @property
+    def display_name(self) -> str:
+        return "MAC hub (router /v1/media)"
+
+    def is_available(self) -> bool:
+        # Available wherever the agent has a gateway bearer + base (the router
+        # holds the provider key) — i.e. wherever chat works, spokes included.
+        return bool(_bearer() and _base_url())
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {"id": mid, "display": m["display"], "speed": m["speed"],
+             "strengths": m["strengths"], "price": "routed via hub"}
+            for mid, m in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "MAC hub (router)",
+            "badge": "routed",
+            "tag": "image gen via the in-mac router /v1/media (no per-agent key)",
+            "env_vars": [],
+        }
+
+    def generate(self, prompt: str, aspect_ratio: str = DEFAULT_ASPECT_RATIO, **kwargs: Any) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        if not prompt:
+            return error_response(error="Prompt is required and must be a non-empty string",
+                                  error_type="invalid_argument", provider="mac-hub", aspect_ratio=aspect)
+        base, key = _base_url(), _bearer()
+        if not base or not key:
+            return error_response(
+                error=("No gateway base/bearer (MAC_HERMES_GATEWAY_BASE_URL / "
+                       "MAC_HERMES_GATEWAY_API_KEY). Image-gen routes through the in-mac "
+                       "router; ensure the agent's gateway env is configured (it is wherever chat works)."),
+                error_type="auth_required", provider="mac-hub", aspect_ratio=aspect)
+
+        model = _resolve_model(kwargs.get("model"))
+        width, height = _SIZES.get(aspect, _SIZES["square"])
+        payload = {"prompt": prompt, "width": width, "height": height, "model": model}
+        if kwargs.get("seed") is not None:
+            payload["seed"] = kwargs["seed"]
+        if kwargs.get("steps") is not None:
+            payload["steps"] = kwargs["steps"]
+        url = "%s/media/image.generate" % base
+
+        try:
+            import requests
+
+            response = requests.post(
+                url,
+                headers={"Authorization": "Bearer %s" % key, "Accept": "application/json",
+                         "Content-Type": "application/json"},
+                json=payload,
+                timeout=180,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("mac-hub media request failed", exc_info=True)
+            return error_response(error="mac-hub media request failed: %s" % exc, error_type="api_error",
+                                  provider="mac-hub", model=model, prompt=prompt, aspect_ratio=aspect)
+
+        if response.status_code != 200:
+            body = (response.text or "")[:500]
+            return error_response(error="router /v1/media HTTP %s: %s" % (response.status_code, body),
+                                  error_type="api_error", provider="mac-hub", model=model,
+                                  prompt=prompt, aspect_ratio=aspect)
+        try:
+            data = response.json()
+        except Exception as exc:  # noqa: BLE001
+            return error_response(error="router /v1/media returned non-JSON: %s" % exc,
+                                  error_type="empty_response", provider="mac-hub", model=model,
+                                  prompt=prompt, aspect_ratio=aspect)
+
+        artifacts = data.get("artifacts") if isinstance(data, dict) else None
+        b64 = artifacts[0].get("base64") if isinstance(artifacts, list) and artifacts and isinstance(artifacts[0], dict) else None
+        if not b64:
+            return error_response(error="router /v1/media response had no image artifact",
+                                  error_type="empty_response", provider="mac-hub", model=model,
+                                  prompt=prompt, aspect_ratio=aspect)
+        try:
+            saved_path = save_b64_image(b64, prefix="machub_%s" % model.replace("/", "_"))
+        except Exception as exc:  # noqa: BLE001
+            return error_response(error="Could not save image to cache: %s" % exc, error_type="io_error",
+                                  provider="mac-hub", model=model, prompt=prompt, aspect_ratio=aspect)
+
+        return success_response(image=str(saved_path), model=model, prompt=prompt,
+                                aspect_ratio=aspect, provider="mac-hub",
+                                extra={"endpoint": "/v1/media/image.generate"})
+
+
+def register(ctx) -> None:
+    """Plugin entry point — wire MacHubImageGenProvider into the registry."""
+    ctx.register_image_gen_provider(MacHubImageGenProvider())

--- a/src/mac/_hermes/plugins/image_gen/mac-hub/plugin.yaml
+++ b/src/mac/_hermes/plugins/image_gen/mac-hub/plugin.yaml
@@ -1,0 +1,9 @@
+name: mac-hub
+version: 1.0.0
+description: "Image generation via the in-mac router's canonical /v1/media/image.generate endpoint (media-01). Sends one provider-agnostic request; the hub resolves the provider binding(s), adapts the request, and fails over — so agents need no per-modality key and the dialect lives server-side. Routes through the agent's gateway bearer; works on spokes. Saves images to $HERMES_HOME/cache/images/."
+author: mac
+kind: backend
+# No requires_env: bundled backend, is_available() gates on the gateway bearer
+# (MAC_HERMES_GATEWAY_API_KEY / OPENAI_API_KEY) — present wherever chat works,
+# including spokes (which carry no raw provider keys).
+requires_env: []

--- a/src/mac/hermes_chat_config.py
+++ b/src/mac/hermes_chat_config.py
@@ -217,16 +217,18 @@ def _chmod_600(path: Path) -> None:
         pass
 
 
-def ensure_image_gen_provider(hermes_home: Path, default: str = "nvidia") -> str:
-    """Default image generation to the hub-routed ``nvidia`` provider when the
+def ensure_image_gen_provider(hermes_home: Path, default: str = "mac-hub") -> str:
+    """Default image generation to the hub-routed ``mac-hub`` provider when the
     operator hasn't picked one.
 
-    That backend routes text-to-image through the in-mac router's ``/v1/genai``
-    proxy (using the hub's escrowed image key), so agents render images with NO
-    per-agent ``FAL_KEY`` — and it works on spokes, which carry no raw provider
+    ``mac-hub`` (media-01) routes text-to-image through the in-mac router's
+    canonical ``/v1/media/image.generate`` endpoint, which resolves the provider
+    binding(s), adapts the request, and fails over — so agents render images with
+    NO per-agent ``FAL_KEY``, and it works on spokes, which carry no raw provider
     keys. Without this default, the registry's legacy fallback prefers ``fal``
     (which reports available via the managed gateway but has no usable key here),
-    so image generation fails fleet-wide even though ``/v1/genai`` works.
+    so image generation fails fleet-wide even though the router works. (The older
+    ``nvidia`` provider, which posts straight to ``/v1/genai``, stays available.)
 
     Respects an explicit ``image_gen.provider`` (never overrides it). Line-based
     to preserve the rest of the file. Returns the provider now in effect (``""``

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -853,11 +853,19 @@ def mount_media_router(
                            "type": "not_configured"}},
                 status_code=404,
             )
+        # A caller may request a specific model; it overrides the binding's
+        # default but stays confined to the binding's fixed upstream host — it's
+        # a model id, never a path (`..`/leading-slash rejected so it can't
+        # escape /v1/genai/<model>).
+        requested_model = str(body.get("model") or "").strip()
+        if ".." in requested_model or requested_model.startswith("/"):
+            requested_model = ""
         last_status: int = 502
         last_body: Dict[str, Any] = {"error": {"message": "no binding produced a response"}}
         for binding in bindings:
             to_provider, from_provider = ADAPTERS.get(binding.adapter, ADAPTERS["passthrough"])
-            path, provider_body = to_provider(op, body, binding.model)
+            model = requested_model or binding.model
+            path, provider_body = to_provider(op, body, model)
             provider = Provider(name=binding.provider, base_url=binding.base_url, api_key_env=binding.key_spec)
             status, resp = urllib_forwarder(
                 provider, path, provider_body, timeout=binding.timeout, secret_resolver=secret_resolver
@@ -865,7 +873,7 @@ def mount_media_router(
             canonical = from_provider(status, resp)
             if status and 200 <= status < 300:
                 return JSONResponse(
-                    {**canonical, "provider": binding.provider, "model": binding.model},
+                    {**canonical, "provider": binding.provider, "model": model},
                     status_code=status,
                 )
             last_status, last_body = (status or 502), (canonical if isinstance(canonical, dict) else {})

--- a/tests/test_hermes_chat_config.py
+++ b/tests/test_hermes_chat_config.py
@@ -208,7 +208,7 @@ def test_router_env_emits_modality_upstreams_and_keys_from_spec(tmp_path):
     assert ev["MY_VIDEO_KEY"] == "vid-secret"  # key_env read from the environment
 
 
-# --- image_gen provider default (hub-routed nvidia) -------------------------
+# --- image_gen provider default (hub-routed mac-hub /v1/media) --------------
 from pathlib import Path  # noqa: E402
 
 from mac.hermes_chat_config import ensure_image_gen_provider  # noqa: E402
@@ -221,14 +221,14 @@ def _home_with_config(tmp_path, body: str) -> Path:
     return home
 
 
-def test_image_gen_defaults_to_nvidia_when_unset(tmp_path):
+def test_image_gen_defaults_to_mac_hub_when_unset(tmp_path):
     # Fresh config with no image_gen block -> default to the hub-routed provider.
     home = _home_with_config(tmp_path, "model:\n  provider: custom\n  base_url: http://x/v1/\n")
-    assert ensure_image_gen_provider(home) == "nvidia"
+    assert ensure_image_gen_provider(home) == "mac-hub"
     text = (home / "config.yaml").read_text(encoding="utf-8")
-    assert "image_gen:" in text and "provider: nvidia" in text
+    assert "image_gen:" in text and "provider: mac-hub" in text
     # idempotent: re-running respects the value just written
-    assert ensure_image_gen_provider(home) == "nvidia"
+    assert ensure_image_gen_provider(home) == "mac-hub"
 
 
 def test_image_gen_respects_explicit_provider(tmp_path):
@@ -239,9 +239,9 @@ def test_image_gen_respects_explicit_provider(tmp_path):
 
 def test_image_gen_inserts_provider_into_existing_block(tmp_path):
     home = _home_with_config(tmp_path, "image_gen:\n  model: flux.1-schnell\n")
-    assert ensure_image_gen_provider(home) == "nvidia"
+    assert ensure_image_gen_provider(home) == "mac-hub"
     text = (home / "config.yaml").read_text(encoding="utf-8")
-    assert "provider: nvidia" in text and "model: flux.1-schnell" in text
+    assert "provider: mac-hub" in text and "model: flux.1-schnell" in text
 
 
 def test_image_gen_noop_without_config(tmp_path):
@@ -253,4 +253,4 @@ def test_image_gen_noop_without_config(tmp_path):
 def test_sync_reports_image_gen_provider(tmp_path):
     home = _stale_hermes_home(tmp_path)
     result = sync(home, _mac_env(tmp_path))
-    assert result["image_gen_provider"] == "nvidia"
+    assert result["image_gen_provider"] == "mac-hub"

--- a/tests/test_media_routing.py
+++ b/tests/test_media_routing.py
@@ -191,3 +191,55 @@ def test_media_endpoint_fails_over_to_next_binding(monkeypatch):
     assert r.json()["artifacts"] == [{"base64": "OK"}]
     assert r.json()["provider"] == "s"  # failed over to the secondary binding
     assert len(captured["urls"]) == 2  # tried primary, then secondary
+
+
+def test_media_endpoint_honors_caller_model(monkeypatch):
+    """A caller may request a model; it overrides the binding default but stays
+    on the binding's upstream (path traversal rejected)."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from mac import router_app
+
+    captured = {}
+    monkeypatch.setattr(
+        router_app.urllib.request,
+        "urlopen",
+        _fake_urlopen_factory(captured, {"flux.1-dev": (200, b'{"artifacts":[{"base64":"X"}]}')}),
+    )
+    app = FastAPI()
+    env = {
+        "MAC_ROUTER_BACKEND": "inproc",
+        "MAC_ROUTER_IMAGE_UPSTREAM": "https://ai.api.nvidia.com/v1/genai",
+        "MAC_ROUTER_IMAGE_KEY": "secret:nvidia-image",
+    }
+    assert router_app.mount_router(app, env=env, secret_resolver={"nvidia-image": "K"}.get) is True
+    r = TestClient(app).post(
+        "/v1/media/image.generate",
+        json={"prompt": "x", "model": "black-forest-labs/flux.1-dev"},
+    )
+    assert r.status_code == 200
+    assert r.json()["model"] == "black-forest-labs/flux.1-dev"  # caller model honored
+    assert captured["urls"][0].endswith("/v1/genai/black-forest-labs/flux.1-dev")
+
+
+def test_media_endpoint_rejects_path_traversal_model(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from mac import router_app
+
+    captured = {}
+    monkeypatch.setattr(
+        router_app.urllib.request,
+        "urlopen",
+        _fake_urlopen_factory(captured, {"flux.1-schnell": (200, b'{"artifacts":[{"base64":"X"}]}')}),
+    )
+    app = FastAPI()
+    env = {
+        "MAC_ROUTER_BACKEND": "inproc",
+        "MAC_ROUTER_IMAGE_UPSTREAM": "https://ai.api.nvidia.com/v1/genai",
+        "MAC_ROUTER_IMAGE_KEY": "secret:nvidia-image",
+    }
+    assert router_app.mount_router(app, env=env, secret_resolver={"nvidia-image": "K"}.get) is True
+    r = TestClient(app).post("/v1/media/image.generate", json={"prompt": "x", "model": "../../etc/passwd"})
+    assert r.status_code == 200  # fell back to the binding default model
+    assert captured["urls"][0].endswith("/v1/genai/" + DEFAULT_IMAGE_MODEL)


### PR DESCRIPTION
The **agent-side half of media-01** (follow-up to #89). Adds a `mac-hub` `ImageGenProvider` that sends one provider-agnostic request to the router's canonical `POST <gateway>/v1/media/image.generate` — the hub resolves the binding, adapts to the provider dialect, and fails over — instead of the `nvidia` plugin's direct NVIDIA-specific POST to `/v1/genai/<model>`. The dialect + key now live on the hub, agents need **no per-modality credential**, and it works on spokes.

- New bundled plugin `_hermes/plugins/image_gen/mac-hub` (mirrors the nvidia model catalog so `image_gen.model` is interchangeable; default `flux.1-schnell`).
- `hermes_chat_config` now defaults `image_gen.provider` to **`mac-hub`** (was `nvidia`); `nvidia` stays available for a direct/on-prem NIM. Respects an explicit choice.
- `mount_media_router` honors a caller-supplied `model` (overrides the binding default) but confines it to the binding's upstream — `..`/leading-slash rejected so it can't escape `/v1/genai/<model>`.

Tests: chat-config defaults/reports `mac-hub`; canonical endpoint honors a caller model + rejects path-traversal ids.

This is what makes agents actually route through the media-01 endpoint; will verify a duck via `mac-hub` end-to-end after deploy. Remaining media-01: fal + openai_images adapters, audio/video ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)