### PR TITLE
media-01: capability auto-registration — agents advertise media routes, hub composes the table

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -4190,7 +4190,22 @@ def create_app(
             except Exception:  # noqa: BLE001 - inference must not fail because telemetry failed
                 _log.warning("failed to record llm.route observation", exc_info=True)
 
-        if mount_router(app, secret_resolver=_router_secret_resolver, route_observer=_router_route_observer):
+        # media-01 capability auto-routing: compose media bindings from LIVE
+        # agents that self-advertised resources["media_routes"] (e.g. a GPU agent
+        # announcing image.generate). Queried per request so a GPU agent coming
+        # up/down is picked up without a hub restart; a registry hiccup degrades
+        # to the static/config table (mount_media_router guards the call).
+        def _media_agent_table_provider() -> Dict[str, Any]:
+            from mac.media_routing import media_bindings_from_agents
+
+            return media_bindings_from_agents(agent.to_dict() for agent in cp.list_agents())
+
+        if mount_router(
+            app,
+            secret_resolver=_router_secret_resolver,
+            route_observer=_router_route_observer,
+            media_agent_table_provider=_media_agent_table_provider,
+        ):
             _log.info("in-mac model router mounted (/v1/chat/completions, /v1/embeddings)")
     except Exception as exc:  # noqa: BLE001 - the router must never block app startup
         _log.warning("in-mac model router not mounted: %s", exc)

--- a/src/mac/media_routing.py
+++ b/src/mac/media_routing.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Mapping, NamedTuple, Optional, Tuple
 
 logger = logging.getLogger("mac.media_routing")
 
@@ -322,3 +322,82 @@ def build_media_table(env: Optional[Mapping[str, str]] = None) -> Dict[str, List
                 )
             ]
     return table
+
+
+# --- capability self-registration (agents advertise media routes) -----------
+# A GPU agent advertises what it serves in its registration
+# ``resources["media_routes"]`` (a list of route dicts); the hub composes the
+# routing table from LIVE agents instead of operator hand-config. So plugging in
+# a GPU agent that announces e.g. image.generate makes the fleet start using it
+# with zero per-caller knowledge — and it's dropped automatically when the agent
+# is offline. Route dict shape (all but op/base_url optional)::
+#
+#     {"op": "image.generate", "base_url": "http://bullwinkle:8189",
+#      "model": "sdxl-turbo", "adapter": "openai_images",
+#      "key": "secret:...", "auth_scheme": "Bearer", "priority": 0, "timeout": 180}
+
+_OFFLINE_STATUSES = {"offline", "draining", "drained", "retired", "decommissioned"}
+_UNHEALTHY = {"unhealthy", "dead", "degraded"}
+
+
+def _agent_is_routable(agent: Mapping[str, Any]) -> bool:
+    """Only route to agents that are up — a down GPU agent must not be a binding
+    (failover also covers transient errors, but skipping offline agents avoids a
+    guaranteed-failing first hop on every request)."""
+    status = str(agent.get("status") or "").strip().lower()
+    health = str(agent.get("health_status") or agent.get("health") or "").strip().lower()
+    if status in _OFFLINE_STATUSES:
+        return False
+    if health in _UNHEALTHY:
+        return False
+    return True
+
+
+def media_bindings_from_agents(agents: Iterable[Mapping[str, Any]]) -> Dict[str, List[MediaBinding]]:
+    """Compose ``{op: [MediaBinding]}`` from live agent registrations.
+
+    Each routable agent's ``resources["media_routes"]`` contributes bindings,
+    sorted by the route's ``priority`` (asc). Offline/unhealthy agents are
+    skipped. Returns ``{}`` when no agent advertises anything.
+    """
+    staged: Dict[str, List[Tuple[int, MediaBinding]]] = {}
+    for agent in agents:
+        if not isinstance(agent, Mapping) or not _agent_is_routable(agent):
+            continue
+        resources = agent.get("resources")
+        routes = resources.get("media_routes") if isinstance(resources, Mapping) else None
+        if not isinstance(routes, list):
+            continue
+        for route in routes:
+            if not isinstance(route, Mapping):
+                continue
+            op = str(route.get("op") or "").strip()
+            base = str(route.get("base_url") or "").strip().rstrip("/")
+            if not op or not base:
+                continue
+            binding = MediaBinding(
+                provider=str(route.get("provider") or agent.get("name") or agent.get("id") or "agent"),
+                base_url=base,
+                key_spec=str(route.get("key") or ""),
+                model=str(route.get("model") or ""),
+                adapter=str(route.get("adapter") or "passthrough"),
+                timeout=_float(route.get("timeout"), 180.0),
+                auth_scheme=str(route.get("auth_scheme") or "Bearer"),
+            )
+            staged.setdefault(op, []).append((_int(route.get("priority"), 0), binding))
+    return {op: [b for _, b in sorted(items, key=lambda pb: pb[0])] for op, items in staged.items()}
+
+
+def compose_media_table(
+    static_table: Mapping[str, List[MediaBinding]],
+    agent_table: Optional[Mapping[str, List[MediaBinding]]],
+    op: str,
+) -> List[MediaBinding]:
+    """Bindings for ``op``: live agent-advertised first (prefer on-prem GPU),
+    then the operator's static/config bindings (cloud fallback). Either side may
+    be empty."""
+    bindings: List[MediaBinding] = []
+    if agent_table:
+        bindings.extend(agent_table.get(op, []))
+    bindings.extend(static_table.get(op, []))
+    return bindings

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -830,26 +830,39 @@ def mount_media_router(
     *,
     env: Optional[Dict[str, str]] = None,
     secret_resolver: Optional[SecretResolver] = None,
+    agent_table_provider: Optional[Callable[[], Dict[str, Any]]] = None,
 ) -> bool:
     """media-01: mount the canonical ``POST /v1/media/{op}`` endpoint.
 
-    Resolves an ordered list of provider bindings for the operation
-    (:func:`mac.media_routing.build_media_table`), adapts the single canonical
-    request to each provider's wire format, forwards, and falls back to the next
-    binding on failure (missing key → 401 → next, non-2xx, or unreachable). The
-    flat ``/v1/genai`` etc. proxies stay mounted for back-compat; this is the
-    operation-keyed layer above them. No-op when no media op is bound."""
-    from mac.media_routing import ADAPTERS, build_media_table
+    Resolves an ordered list of provider bindings for the operation, adapts the
+    single canonical request to each provider's wire format, forwards, and falls
+    back to the next binding on failure (missing key → 401 → next, non-2xx, or
+    unreachable). The flat ``/v1/genai`` etc. proxies stay mounted for
+    back-compat; this is the operation-keyed layer above them.
+
+    Bindings are composed per request: ``agent_table_provider`` (live GPU agents
+    that self-advertised ``resources["media_routes"]``) is consulted FIRST so the
+    fleet prefers an on-prem GPU when one is up, then the static config table
+    (:func:`mac.media_routing.build_media_table`) as cloud fallback. So a GPU
+    agent that announces a capability is used with zero operator config, and a
+    down one falls over automatically. No-op when neither side can bind anything."""
+    from mac.media_routing import ADAPTERS, build_media_table, compose_media_table
 
     env = os.environ if env is None else env
-    table = build_media_table(env)
-    if not table:
+    static_table = build_media_table(env)
+    if not static_table and agent_table_provider is None:
         return False
     from fastapi.responses import JSONResponse
 
     @app.post("/v1/media/{op}")
     def _media(op: str, body: Dict[str, Any] = Body(...)) -> Any:  # noqa: ANN401
-        bindings = table.get(op)
+        agent_table: Dict[str, Any] = {}
+        if agent_table_provider is not None:
+            try:
+                agent_table = agent_table_provider() or {}
+            except Exception:  # noqa: BLE001 - never let registry hiccups break routing
+                agent_table = {}
+        bindings = compose_media_table(static_table, agent_table, op)
         if not bindings:
             return JSONResponse(
                 {"error": {"message": "no provider bound for media op %r" % op,
@@ -894,11 +907,13 @@ def mount_router(
     proxy: Optional[ProviderProxy] = None,
     secret_resolver: Optional[SecretResolver] = None,
     route_observer: Optional[RouteObserver] = None,
+    media_agent_table_provider: Optional[Callable[[], Dict[str, Any]]] = None,
 ) -> bool:
     """Mount /v1/chat/completions + /v1/embeddings (+ /v1/genai image proxy) on
     ``app`` when MAC_ROUTER_BACKEND=inproc. Returns True if anything mounted.
     Default backend is 'tokenhub' → no-op, so an existing fleet is unchanged until
-    flipped."""
+    flipped. ``media_agent_table_provider`` (optional) lets the media router
+    compose bindings from live self-advertising agents (capability auto-routing)."""
     env = os.environ if env is None else env
     if (env.get("MAC_ROUTER_BACKEND") or "tokenhub").strip().lower() != "inproc":
         return False
@@ -908,7 +923,10 @@ def mount_router(
     mounted = mount_image_proxy(app, env=env, secret_resolver=secret_resolver)
     # media-01: operation-keyed canonical media routing (POST /v1/media/{op}),
     # layered above the flat /v1/genai proxy. Independent of chat providers.
-    if mount_media_router(app, env=env, secret_resolver=secret_resolver):
+    if mount_media_router(
+        app, env=env, secret_resolver=secret_resolver,
+        agent_table_provider=media_agent_table_provider,
+    ):
         mounted = True
     proxy = proxy or build_proxy_from_env(env, secret_resolver=secret_resolver, route_observer=route_observer)
     if proxy is None:

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -238,6 +238,20 @@ def register_worker(
         raise MacApiError("agent_name is required for worker registration")
     resolved_machine_id = machine_id or _stable_id("machine", host)
     resolved_agent_id = agent_id or _stable_id("agent", name)
+    # media-01 capability self-advertisement: a GPU agent announces the media ops
+    # it serves via MAC_AGENT_MEDIA_ROUTES (JSON list of route dicts, e.g.
+    # [{"op":"image.generate","base_url":"http://host:8189","adapter":"openai_images"}]).
+    # The hub composes its /v1/media routing table from live agents'
+    # resources["media_routes"], so the fleet uses this agent with zero operator
+    # config. Merged into the registration resources here.
+    _media_routes = (os.environ.get("MAC_AGENT_MEDIA_ROUTES") or "").strip()
+    if _media_routes:
+        try:
+            _parsed_routes = json.loads(_media_routes)
+        except ValueError:
+            _parsed_routes = None
+        if isinstance(_parsed_routes, list):
+            resources = {**(resources or {}), "media_routes": _parsed_routes}
     machine = client.post(
         "/machines",
         {

--- a/tests/test_media_routing.py
+++ b/tests/test_media_routing.py
@@ -8,10 +8,13 @@ import urllib.error
 
 from mac.media_routing import (
     DEFAULT_IMAGE_MODEL,
+    MediaBinding,
     build_media_table,
+    compose_media_table,
     extract_b64,
     fal_request,
     fal_response,
+    media_bindings_from_agents,
     nvidia_genai_request,
     nvidia_genai_response,
     openai_images_request,
@@ -310,3 +313,62 @@ def test_mount_forwards_with_binding_auth_scheme(monkeypatch):
     assert r.status_code == 200
     assert r.json()["artifacts"] == [{"url": "https://cdn/x.png"}]
     assert captured["auths"][0] == "Key FALKEY"  # Key scheme, not Bearer
+
+
+# --- capability auto-registration (live agents advertise media routes) ------
+
+def test_media_bindings_from_agents_priority_and_offline_skip():
+    agents = [
+        {"name": "bullwinkle", "status": "idle", "health_status": "healthy",
+         "resources": {"media_routes": [
+             {"op": "image.generate", "base_url": "http://bw:8189", "adapter": "openai_images", "priority": 1},
+             {"op": "image.generate", "base_url": "http://bw:8190", "adapter": "passthrough", "priority": 0}]}},
+        {"name": "down-gpu", "status": "offline",
+         "resources": {"media_routes": [{"op": "image.generate", "base_url": "http://down:9"}]}},
+        {"name": "cpu", "status": "idle", "resources": {}},
+    ]
+    table = media_bindings_from_agents(agents)
+    assert [b.base_url for b in table["image.generate"]] == ["http://bw:8190", "http://bw:8189"]  # priority asc; offline dropped
+
+
+def test_media_bindings_from_agents_skips_unhealthy():
+    agents = [{"name": "x", "status": "idle", "health_status": "unhealthy",
+               "resources": {"media_routes": [{"op": "image.generate", "base_url": "http://x:1"}]}}]
+    assert media_bindings_from_agents(agents) == {}
+
+
+def test_compose_prefers_live_agent_then_static():
+    static = {"image.generate": [MediaBinding("nvidia", "https://nv", "secret:k", "m", "nvidia_genai", 180.0)]}
+    agent = {"image.generate": [MediaBinding("bw", "http://bw:8189", "", "sdxl", "openai_images", 180.0)]}
+    assert [b.provider for b in compose_media_table(static, agent, "image.generate")] == ["bw", "nvidia"]
+
+
+def test_media_endpoint_prefers_live_agent_over_static(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from mac import router_app
+
+    captured = {}
+    monkeypatch.setattr(
+        router_app.urllib.request, "urlopen",
+        _fake_urlopen_factory(captured, {"bw:8189": (200, b'{"data":[{"b64_json":"GPU"}]}')}),
+    )
+    app = FastAPI()
+    env = {  # static config = cloud fallback
+        "MAC_ROUTER_BACKEND": "inproc",
+        "MAC_ROUTER_IMAGE_UPSTREAM": "https://ai.api.nvidia.com/v1/genai",
+        "MAC_ROUTER_IMAGE_KEY": "secret:nvidia-image",
+    }
+
+    def agent_table():
+        return media_bindings_from_agents([
+            {"name": "bw", "status": "idle", "health_status": "healthy",
+             "resources": {"media_routes": [{"op": "image.generate", "base_url": "http://bw:8189",
+                                             "model": "sdxl", "adapter": "openai_images"}]}}])
+
+    assert router_app.mount_router(app, env=env, secret_resolver={}.get,
+                                   media_agent_table_provider=agent_table) is True
+    r = TestClient(app).post("/v1/media/image.generate", json={"prompt": "x"})
+    assert r.status_code == 200
+    assert r.json()["provider"] == "bw"  # routed to the live GPU agent, not cloud
+    assert "bw:8189" in captured["urls"][0]


### PR DESCRIPTION
Makes **"plug in a GPU agent and the fleet starts using it"** require zero per-caller or per-operator knowledge — the media routing table is composed from **live agent registrations** instead of hand config. (Answers the "wouldn't the user have to know which agent has the capability?" — no, they don't.)

**Agent side**: a GPU agent advertises via `MAC_AGENT_MEDIA_ROUTES` (JSON), merged into its registration `resources["media_routes"]`:
```
[{"op":"image.generate","base_url":"http://bullwinkle:8189","adapter":"openai_images"}]
```

**Hub side**:
- `media_bindings_from_agents(agents)`: pure resolver → `{op:[MediaBinding]}`, priority-sorted, **skips offline/unhealthy** agents.
- `compose_media_table`: live agent bindings **first** (prefer on-prem GPU), then the static/config table (cloud fallback).
- `mount_media_router(..., agent_table_provider)`: composes **per request** (an agent coming up/down is picked up with no hub restart; a registry hiccup degrades to static). Threaded through `mount_router`; `api.py` wires the provider from `cp.list_agents()`.

Net: any agent that announces `image.generate` is used fleet-wide and transparently fails over to cloud when down — no caller knows which agent has the GPU. The capstone for media-01 + the GPU-capability work.

Tests: resolver priority + offline/unhealthy skip; compose agent-before-static; mounted endpoint prefers a live agent over the static cloud binding. (api + worker suites green: 100 passed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)