### PR TITLE
hardware: first-class self-reporting — agents detect + register their hardware

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -466,6 +466,23 @@ def cmd_agent_list(args: argparse.Namespace) -> None:
     _print([agent.to_dict() for agent in _plane(args).list_agents()])
 
 
+def cmd_agent_hardware(args: argparse.Namespace) -> None:
+    """Fleet hardware inventory from self-reported resources["hardware"]."""
+    from mac.hardware import summarize
+
+    rows = []
+    for agent in _plane(args).list_agents():
+        data = agent.to_dict() if hasattr(agent, "to_dict") else agent
+        resources = data.get("resources") if isinstance(data.get("resources"), dict) else {}
+        hardware = resources.get("hardware") if isinstance(resources, dict) else None
+        rows.append({
+            "agent": data.get("name") or data.get("id"),
+            "accelerator": (hardware or {}).get("accelerator", "unknown") if isinstance(hardware, dict) else "unreported",
+            "hardware": summarize(hardware) if isinstance(hardware, dict) else "(no hardware reported — agent predates self-reporting; redeploy to populate)",
+        })
+    _print(rows)
+
+
 def cmd_agent_heartbeat(args: argparse.Namespace) -> None:
     _print(
         _plane(args).heartbeat_agent(
@@ -1960,6 +1977,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     agent_list = agent.add_parser("list")
     _set(cmd_agent_list, agent_list)
+
+    agent_hardware = agent.add_parser(
+        "hardware", help="fleet hardware inventory from self-reported resources.hardware"
+    )
+    _set(cmd_agent_hardware, agent_hardware)
 
     heartbeat = agent.add_parser("heartbeat")
     heartbeat.add_argument("agent_id")

--- a/src/mac/hardware.py
+++ b/src/mac/hardware.py
@@ -1,0 +1,126 @@
+"""First-class hardware self-reporting.
+
+Agents detect their local accelerator + CPU/memory and report it into the
+registry (``resources["hardware"]``) at registration, so the fleet OWNS a
+hardware inventory instead of relying on hand-maintained notes (which drift and
+get an agent's silicon wrong). The hub can then derive compute/gen capability
+from facts — e.g. "which agent has a CUDA GPU" — and operators query it with
+``mac agent hardware``.
+
+Pure stdlib + best-effort subprocess probes. Detection NEVER raises: a probe
+failure yields ``accelerator: "none"`` / omitted fields, never a failed
+registration. The snapshot shape::
+
+    {"os": "linux", "arch": "aarch64", "cpu_count": 20, "memory_mb": 122000,
+     "accelerator": "cuda",                       # cuda | metal | none
+     "gpu": {"accelerator": "cuda", "name": "NVIDIA GB10", "vram_mb": 0, "count": 1}}
+"""
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+from typing import Any, Dict, Optional
+
+SCHEMA = "mac.hardware.v1"
+
+
+def _run(cmd: list, timeout: float = 5.0) -> Optional[str]:
+    """Run a probe command, returning stdout on success or None on any failure
+    (missing binary, non-zero exit, timeout). Never raises."""
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except Exception:  # noqa: BLE001 - probe is best-effort
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _memory_mb() -> int:
+    system = platform.system()
+    try:
+        if system == "Linux":
+            with open("/proc/meminfo", encoding="utf-8") as handle:
+                for line in handle:
+                    if line.startswith("MemTotal:"):
+                        return int(int(line.split()[1]) / 1024)  # kB -> MB
+        elif system == "Darwin":
+            out = _run(["sysctl", "-n", "hw.memsize"])
+            if out:
+                return int(int(out) / (1024 * 1024))  # bytes -> MB
+    except Exception:  # noqa: BLE001
+        pass
+    return 0
+
+
+def detect_nvidia() -> Optional[Dict[str, Any]]:
+    """CUDA GPU via nvidia-smi. One CSV row per GPU: ``name, memory.total``.
+    GB10 (unified memory) reports memory.total as ``[N/A]`` → vram_mb 0."""
+    out = _run([
+        "nvidia-smi",
+        "--query-gpu=name,memory.total",
+        "--format=csv,noheader,nounits",
+    ])
+    rows = [r.strip() for r in (out or "").splitlines() if r.strip()]
+    if not rows:
+        return None
+    fields = [c.strip() for c in rows[0].split(",")]
+    name = fields[0] if fields else "NVIDIA GPU"
+    vram_mb = 0
+    if len(fields) > 1:
+        try:
+            vram_mb = int(float(fields[1]))
+        except ValueError:
+            vram_mb = 0
+    return {"accelerator": "cuda", "name": name, "vram_mb": vram_mb, "count": len(rows)}
+
+
+def detect_apple_metal() -> Optional[Dict[str, Any]]:
+    """Apple Silicon integrated GPU (Metal). Present on every arm64 Mac."""
+    if platform.system() != "Darwin" or platform.machine() != "arm64":
+        return None
+    chip = _run(["sysctl", "-n", "machdep.cpu.brand_string"]) or "Apple Silicon"
+    return {"accelerator": "metal", "name": chip, "vram_mb": 0, "count": 1}
+
+
+def detect_hardware() -> Dict[str, Any]:
+    """Best-effort local hardware snapshot for the agent registry. Never raises."""
+    info: Dict[str, Any] = {
+        "schema": SCHEMA,
+        "os": platform.system().lower(),
+        "arch": platform.machine(),
+        "cpu_count": os.cpu_count() or 0,
+        "memory_mb": _memory_mb(),
+        "accelerator": "none",
+    }
+    try:
+        gpu = detect_nvidia() or detect_apple_metal()
+    except Exception:  # noqa: BLE001 - detection must never break registration
+        gpu = None
+    if gpu:
+        info["gpu"] = gpu
+        info["accelerator"] = gpu.get("accelerator", "none")
+    return info
+
+
+def summarize(hardware: Optional[Dict[str, Any]]) -> str:
+    """One-line human summary for `mac agent hardware`."""
+    if not isinstance(hardware, dict):
+        return "(no hardware reported)"
+    accel = hardware.get("accelerator", "none")
+    gpu = hardware.get("gpu") if isinstance(hardware.get("gpu"), dict) else None
+    parts = []
+    if gpu:
+        vram = gpu.get("vram_mb") or 0
+        count = gpu.get("count") or 1
+        label = "%s x%d" % (gpu.get("name", "GPU"), count) if count > 1 else str(gpu.get("name", "GPU"))
+        parts.append("%s [%s%s]" % (label, accel, (" %dGB" % (vram / 1024)) if vram else ""))
+    else:
+        parts.append("accelerator=%s" % accel)
+    parts.append("%s/%s" % (hardware.get("os", "?"), hardware.get("arch", "?")))
+    if hardware.get("cpu_count"):
+        parts.append("%dcpu" % hardware["cpu_count"])
+    if hardware.get("memory_mb"):
+        parts.append("%dGB" % (hardware["memory_mb"] / 1024))
+    return " · ".join(parts)

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -238,6 +238,16 @@ def register_worker(
         raise MacApiError("agent_name is required for worker registration")
     resolved_machine_id = machine_id or _stable_id("machine", host)
     resolved_agent_id = agent_id or _stable_id("agent", name)
+    # Hardware self-reporting: detect the local accelerator/CPU/memory and record
+    # it in the registry so the fleet OWNS a hardware inventory (vs hand notes
+    # that drift and get an agent's silicon wrong). Best-effort — the probe never
+    # blocks registration.
+    try:
+        from mac.hardware import detect_hardware
+
+        resources = {**(resources or {}), "hardware": detect_hardware()}
+    except Exception:  # noqa: BLE001 - hardware probe must never fail registration
+        pass
     # media-01 capability self-advertisement: a GPU agent announces the media ops
     # it serves via MAC_AGENT_MEDIA_ROUTES (JSON list of route dicts, e.g.
     # [{"op":"image.generate","base_url":"http://host:8189","adapter":"openai_images"}]).

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -1,0 +1,65 @@
+"""First-class hardware self-reporting: detection (best-effort, never raises) +
+summary. Subprocess probes are monkeypatched so tests are host-independent."""
+from __future__ import annotations
+
+import mac.hardware as hw
+
+
+def test_detect_nvidia_parses_csv(monkeypatch):
+    monkeypatch.setattr(hw, "_run", lambda cmd, timeout=5.0: "NVIDIA GB10, [N/A]")
+    gpu = hw.detect_nvidia()
+    assert gpu == {"accelerator": "cuda", "name": "NVIDIA GB10", "vram_mb": 0, "count": 1}
+
+
+def test_detect_nvidia_multi_gpu_with_vram(monkeypatch):
+    monkeypatch.setattr(hw, "_run", lambda cmd, timeout=5.0: "NVIDIA RTX 6000 Ada, 49140\nNVIDIA RTX 6000 Ada, 49140")
+    gpu = hw.detect_nvidia()
+    assert gpu["count"] == 2 and gpu["vram_mb"] == 49140 and gpu["accelerator"] == "cuda"
+
+
+def test_detect_nvidia_absent_returns_none(monkeypatch):
+    monkeypatch.setattr(hw, "_run", lambda cmd, timeout=5.0: None)  # nvidia-smi missing
+    assert hw.detect_nvidia() is None
+
+
+def test_detect_apple_metal_only_on_arm_darwin(monkeypatch):
+    monkeypatch.setattr(hw.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(hw.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(hw, "_run", lambda cmd, timeout=5.0: "Apple M4 Pro")
+    assert hw.detect_apple_metal() == {"accelerator": "metal", "name": "Apple M4 Pro", "vram_mb": 0, "count": 1}
+    monkeypatch.setattr(hw.platform, "system", lambda: "Linux")
+    assert hw.detect_apple_metal() is None
+
+
+def test_detect_hardware_composes_and_never_raises(monkeypatch):
+    monkeypatch.setattr(hw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(hw.platform, "machine", lambda: "aarch64")
+    monkeypatch.setattr(hw.os, "cpu_count", lambda: 20)
+    monkeypatch.setattr(hw, "_memory_mb", lambda: 122000)
+    monkeypatch.setattr(hw, "detect_nvidia", lambda: {"accelerator": "cuda", "name": "NVIDIA GB10", "vram_mb": 0, "count": 1})
+    info = hw.detect_hardware()
+    assert info["accelerator"] == "cuda" and info["gpu"]["name"] == "NVIDIA GB10"
+    assert info["cpu_count"] == 20 and info["memory_mb"] == 122000 and info["arch"] == "aarch64"
+
+
+def test_detect_hardware_no_accelerator(monkeypatch):
+    monkeypatch.setattr(hw, "detect_nvidia", lambda: None)
+    monkeypatch.setattr(hw, "detect_apple_metal", lambda: None)
+    info = hw.detect_hardware()
+    assert info["accelerator"] == "none" and "gpu" not in info
+
+
+def test_detect_hardware_survives_probe_exception(monkeypatch):
+    def _boom():
+        raise RuntimeError("nvidia-smi exploded")
+
+    monkeypatch.setattr(hw, "detect_nvidia", _boom)
+    monkeypatch.setattr(hw, "detect_apple_metal", lambda: None)
+    info = hw.detect_hardware()  # must not raise
+    assert info["accelerator"] == "none"
+
+
+def test_summarize():
+    assert "NVIDIA GB10" in hw.summarize({"accelerator": "cuda", "gpu": {"name": "NVIDIA GB10", "count": 1}, "os": "linux", "arch": "aarch64", "cpu_count": 20})
+    assert hw.summarize(None) == "(no hardware reported)"
+    assert "accelerator=none" in hw.summarize({"accelerator": "none", "os": "linux", "arch": "x86_64"})


### PR DESCRIPTION
The fleet recorded **zero hardware**, so every "which agent has a GPU" call was a guess from hand notes that drift — which is how I mistook bullwinkle's M4 Pro for the gen target when the real GPU is **natasha's NVIDIA GB10**. This makes hardware a fact the system owns.

- **`mac.hardware.detect_hardware()`**: best-effort, stdlib-only → `{os, arch, cpu_count, memory_mb, accelerator: cuda|metal|none, gpu:{name,vram_mb,count}}`. `nvidia-smi` for CUDA, `sysctl` for Apple Metal. **Never raises** (a probe failure yields `accelerator:"none"`, never a failed registration).
- **worker** records it in `resources["hardware"]` at registration → the agent registry holds a live hardware inventory (re-populated on redeploy/restart).
- **`mac agent hardware`**: fleet inventory from the self-reported data (per-agent accelerator + one-line summary; flags agents that predate self-reporting).

Tests (8): cuda/metal/none detection, multi-GPU vram parse, probe-exception survival, summary.

Follow-ups: heartbeat refresh; hub-derived gen capability/media bindings from `resources.hardware` (so a GPU agent that also runs a gen server is wired automatically — ties into the media-01 auto-registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)