### PR TITLE
media-01: hub derives gen routing preference + capability from reported hardware

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -467,17 +467,23 @@ def cmd_agent_list(args: argparse.Namespace) -> None:
 
 
 def cmd_agent_hardware(args: argparse.Namespace) -> None:
-    """Fleet hardware inventory from self-reported resources["hardware"]."""
+    """Fleet hardware inventory from self-reported resources["hardware"], with the
+    hub-derived gen capability (can this agent host media generation, and is it
+    currently advertising a gen endpoint)."""
     from mac.hardware import summarize
+    from mac.media_routing import is_gen_capable
 
     rows = []
     for agent in _plane(args).list_agents():
         data = agent.to_dict() if hasattr(agent, "to_dict") else agent
         resources = data.get("resources") if isinstance(data.get("resources"), dict) else {}
         hardware = resources.get("hardware") if isinstance(resources, dict) else None
+        serving = bool(isinstance(resources, dict) and resources.get("media_routes"))
+        capable = is_gen_capable(hardware) if isinstance(hardware, dict) else False
         rows.append({
             "agent": data.get("name") or data.get("id"),
             "accelerator": (hardware or {}).get("accelerator", "unknown") if isinstance(hardware, dict) else "unreported",
+            "gen": ("serving" if serving else "capable") if capable else ("serving(cpu)" if serving else "no"),
             "hardware": summarize(hardware) if isinstance(hardware, dict) else "(no hardware reported — agent predates self-reporting; redeploy to populate)",
         })
     _print(rows)

--- a/src/mac/media_routing.py
+++ b/src/mac/media_routing.py
@@ -353,14 +353,48 @@ def _agent_is_routable(agent: Mapping[str, Any]) -> bool:
     return True
 
 
+# Gen-routing preference derived from REPORTED hardware: lower rank = preferred.
+# The hub uses resources.hardware.accelerator to pick the best gen agent
+# automatically — CUDA/ROCm outrank Metal outrank CPU/unknown — so no operator
+# has to know which agent has the beefier silicon. (Hardware presence is not a
+# running gen server; this orders/qualifies advertised endpoints, it doesn't
+# invent one.)
+_ACCEL_RANK = {"cuda": 0, "rocm": 0, "metal": 1}
+_GEN_CAPABLE_ACCELERATORS = frozenset({"cuda", "rocm", "metal"})
+
+
+def hardware_gen_rank(accelerator: Optional[str]) -> int:
+    """Lower = preferred for gen routing. CUDA/ROCm best, Metal next, CPU/unknown last."""
+    return _ACCEL_RANK.get((accelerator or "").strip().lower(), 9)
+
+
+def is_gen_capable(hardware: Optional[Mapping[str, Any]]) -> bool:
+    """Whether an agent's reported hardware can plausibly host media generation
+    (a usable accelerator). Candidacy only — hardware presence is NOT a running
+    gen server, so this never by itself produces a routable binding."""
+    if not isinstance(hardware, Mapping):
+        return False
+    return str(hardware.get("accelerator") or "none").strip().lower() in _GEN_CAPABLE_ACCELERATORS
+
+
+def _agent_accelerator(agent: Mapping[str, Any]) -> str:
+    resources = agent.get("resources")
+    hardware = resources.get("hardware") if isinstance(resources, Mapping) else None
+    if isinstance(hardware, Mapping):
+        return str(hardware.get("accelerator") or "none").strip().lower()
+    return "unknown"
+
+
 def media_bindings_from_agents(agents: Iterable[Mapping[str, Any]]) -> Dict[str, List[MediaBinding]]:
     """Compose ``{op: [MediaBinding]}`` from live agent registrations.
 
-    Each routable agent's ``resources["media_routes"]`` contributes bindings,
-    sorted by the route's ``priority`` (asc). Offline/unhealthy agents are
-    skipped. Returns ``{}`` when no agent advertises anything.
+    Each routable agent's ``resources["media_routes"]`` contributes bindings.
+    They are ordered by **reported hardware first** (CUDA/ROCm → Metal → CPU/
+    unknown), then by the route's declared ``priority`` — so the hub prefers the
+    agent with the best accelerator without any operator config. Offline/
+    unhealthy agents are skipped. Returns ``{}`` when no agent advertises.
     """
-    staged: Dict[str, List[Tuple[int, MediaBinding]]] = {}
+    staged: Dict[str, List[Tuple[int, int, MediaBinding]]] = {}
     for agent in agents:
         if not isinstance(agent, Mapping) or not _agent_is_routable(agent):
             continue
@@ -368,6 +402,7 @@ def media_bindings_from_agents(agents: Iterable[Mapping[str, Any]]) -> Dict[str,
         routes = resources.get("media_routes") if isinstance(resources, Mapping) else None
         if not isinstance(routes, list):
             continue
+        accel_rank = hardware_gen_rank(_agent_accelerator(agent))
         for route in routes:
             if not isinstance(route, Mapping):
                 continue
@@ -384,8 +419,35 @@ def media_bindings_from_agents(agents: Iterable[Mapping[str, Any]]) -> Dict[str,
                 timeout=_float(route.get("timeout"), 180.0),
                 auth_scheme=str(route.get("auth_scheme") or "Bearer"),
             )
-            staged.setdefault(op, []).append((_int(route.get("priority"), 0), binding))
-    return {op: [b for _, b in sorted(items, key=lambda pb: pb[0])] for op, items in staged.items()}
+            staged.setdefault(op, []).append((accel_rank, _int(route.get("priority"), 0), binding))
+    return {
+        op: [b for _, _, b in sorted(items, key=lambda r: (r[0], r[1]))]
+        for op, items in staged.items()
+    }
+
+
+def gen_capable_agents(agents: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    """Derive, from reported hardware, which agents COULD host media generation
+    (a usable accelerator) — independent of whether they currently advertise a
+    gen endpoint. For visibility (`mac agent hardware`) and picking where to
+    stand a gen server up. Sorted best-accelerator-first."""
+    out: List[Dict[str, Any]] = []
+    for agent in agents:
+        if not isinstance(agent, Mapping):
+            continue
+        resources = agent.get("resources")
+        hardware = resources.get("hardware") if isinstance(resources, Mapping) else None
+        if not is_gen_capable(hardware):
+            continue
+        gpu = hardware.get("gpu") if isinstance(hardware.get("gpu"), Mapping) else {}
+        out.append({
+            "agent": agent.get("name") or agent.get("id"),
+            "accelerator": hardware.get("accelerator"),
+            "gpu": gpu.get("name"),
+            "rank": hardware_gen_rank(hardware.get("accelerator")),
+            "serving": bool(isinstance(resources, Mapping) and resources.get("media_routes")),
+        })
+    return sorted(out, key=lambda a: a["rank"])
 
 
 def compose_media_table(

--- a/tests/test_media_routing.py
+++ b/tests/test_media_routing.py
@@ -14,6 +14,9 @@ from mac.media_routing import (
     extract_b64,
     fal_request,
     fal_response,
+    gen_capable_agents,
+    hardware_gen_rank,
+    is_gen_capable,
     media_bindings_from_agents,
     nvidia_genai_request,
     nvidia_genai_response,
@@ -372,3 +375,47 @@ def test_media_endpoint_prefers_live_agent_over_static(monkeypatch):
     assert r.status_code == 200
     assert r.json()["provider"] == "bw"  # routed to the live GPU agent, not cloud
     assert "bw:8189" in captured["urls"][0]
+
+
+# --- hardware-derived gen routing -------------------------------------------
+
+def _gpu_agent(name, accel, gpu_name, op_url="http://h:8189"):
+    return {"name": name, "status": "idle", "health_status": "healthy",
+            "resources": {"hardware": {"accelerator": accel, "gpu": {"name": gpu_name}},
+                          "media_routes": [{"op": "image.generate", "base_url": op_url, "adapter": "openai_images"}]}}
+
+
+def test_hardware_gen_rank_orders_accelerators():
+    assert hardware_gen_rank("cuda") < hardware_gen_rank("metal") < hardware_gen_rank("none")
+    assert hardware_gen_rank("rocm") == hardware_gen_rank("cuda")
+    assert hardware_gen_rank(None) == hardware_gen_rank("none")
+
+
+def test_is_gen_capable():
+    assert is_gen_capable({"accelerator": "cuda"}) is True
+    assert is_gen_capable({"accelerator": "metal"}) is True
+    assert is_gen_capable({"accelerator": "none"}) is False
+    assert is_gen_capable(None) is False
+
+
+def test_media_bindings_ranked_by_reported_hardware():
+    # three agents advertise the same op; the hub must prefer the best accelerator
+    agents = [
+        _gpu_agent("cpu-box", "none", None, "http://cpu:8189"),
+        _gpu_agent("mac", "metal", "Apple M4 Pro", "http://mac:8189"),
+        _gpu_agent("natasha", "cuda", "NVIDIA GB10", "http://natasha:8189"),
+    ]
+    urls = [b.base_url for b in media_bindings_from_agents(agents)["image.generate"]]
+    assert urls == ["http://natasha:8189", "http://mac:8189", "http://cpu:8189"]  # cuda > metal > cpu
+
+
+def test_gen_capable_agents_lists_accelerated_only_sorted():
+    agents = [
+        _gpu_agent("natasha", "cuda", "NVIDIA GB10"),
+        _gpu_agent("mac", "metal", "Apple M4 Pro"),
+        {"name": "rocky", "status": "idle", "resources": {"hardware": {"accelerator": "none"}}},
+        {"name": "stale", "status": "idle", "resources": {}},
+    ]
+    caps = gen_capable_agents(agents)
+    assert [c["agent"] for c in caps] == ["natasha", "mac"]  # cuda first; none/stale excluded
+    assert caps[0]["gpu"] == "NVIDIA GB10" and caps[0]["serving"] is True


### PR DESCRIPTION
Now that agents self-report hardware (#96), the hub **uses** it instead of trusting advertisements blindly or making the operator know which box is beefier.

- `media_bindings_from_agents` orders advertised gen bindings by **reported accelerator first** (cuda/rocm → metal → cpu/unknown), then declared priority. So when several agents advertise `image.generate`, the hub auto-prefers the best GPU (natasha's GB10 > a Mac's Metal > a CPU box) with **zero config**.
- `is_gen_capable` / `hardware_gen_rank`: derive gen candidacy + ordering from the accelerator.
- `gen_capable_agents`: which agents *could* host gen (visibility / where to stand a server up), best-first.
- `mac agent hardware` gains a `gen` column: `serving | capable | no`.

**Honest boundary:** an agent still needs a *running gen server* (advertised via `resources.media_routes`) to be routable — hardware drives the **preference/gating** and the **capability view**, not endpoint invention. (That's why #2, standing up natasha's GB10 server, is the remaining last mile.)

Tests: accelerator rank ordering; `is_gen_capable`; bindings ranked cuda>metal>cpu across agents; `gen_capable_agents` accelerated-only + sorted. (media_routing + router_app + hardware suites green: 88.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)