### PR TITLE
local-gen: catalog of locally-runnable models + reproducible image server, wired to media

### DIFF
--- a/deploy/local-gen/openai_image_server.py
+++ b/deploy/local-gen/openai_image_server.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Minimal OpenAI-images-compatible local image-gen server for a GPU agent.
+
+Loads a diffusers text-to-image pipeline on the local accelerator (CUDA / Apple
+MPS / CPU) and serves ``POST /v1/images/generations`` →
+``{"data":[{"b64_json": "<png base64>"}]}`` — exactly the shape the in-mac
+router's ``openai_images`` adapter consumes. So a GPU agent runs this, advertises
+a media route (MAC_AGENT_MEDIA_ROUTES, see mac.local_gen_catalog.media_route_for),
+and the hub routes ``/v1/media/image.generate`` to its GPU with cloud failover.
+
+stdlib HTTP server; torch/diffusers imported lazily (present only on GPU agents).
+Configure via env:
+    LOCAL_GEN_MODEL  HF repo or a mac.local_gen_catalog id (default stabilityai/sdxl-turbo)
+    LOCAL_GEN_PORT   listen port (default 8189)
+    LOCAL_GEN_HOST   bind host (default 0.0.0.0)
+
+Run (on the GPU agent):
+    LOCAL_GEN_MODEL=stabilityai/sdxl-turbo ~/gen/venv/bin/python openai_image_server.py
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+MODEL = os.environ.get("LOCAL_GEN_MODEL", "stabilityai/sdxl-turbo").strip()
+PORT = int(os.environ.get("LOCAL_GEN_PORT", "8189"))
+HOST = os.environ.get("LOCAL_GEN_HOST", "0.0.0.0")
+
+_pipe = None
+_pipe_lock = threading.Lock()
+_device = "cpu"
+
+
+def _resolve_repo(model: str) -> str:
+    """Accept either an HF repo id or a mac.local_gen_catalog short id."""
+    try:
+        from mac.local_gen_catalog import get_model
+
+        entry = get_model(model)
+        if entry is not None:
+            return entry.repo
+    except Exception:  # noqa: BLE001 - catalog is optional on the agent
+        pass
+    return model
+
+
+def _pipeline():
+    global _pipe, _device
+    if _pipe is not None:
+        return _pipe
+    with _pipe_lock:
+        if _pipe is not None:
+            return _pipe
+        import torch
+        from diffusers import AutoPipelineForText2Image
+
+        if torch.cuda.is_available():
+            _device = "cuda"
+        elif getattr(torch.backends, "mps", None) and torch.backends.mps.is_available():
+            _device = "mps"
+        else:
+            _device = "cpu"
+        dtype = torch.float16 if _device == "cuda" else torch.float32
+        repo = _resolve_repo(MODEL)
+        print("local-gen: loading %s on %s (%s)" % (repo, _device, dtype), flush=True)
+        pipe = AutoPipelineForText2Image.from_pretrained(repo, torch_dtype=dtype)
+        _pipe = pipe.to(_device)
+        return _pipe
+
+
+def _generate(prompt: str, steps: int, width: int, height: int, seed):
+    import torch
+
+    pipe = _pipeline()
+    kwargs = {"prompt": prompt, "num_inference_steps": max(1, steps)}
+    # Turbo/distilled models want guidance 0; others a sane default.
+    kwargs["guidance_scale"] = 0.0 if "turbo" in MODEL.lower() else 5.0
+    if width and height:
+        kwargs["width"], kwargs["height"] = width, height
+    if seed is not None:
+        kwargs["generator"] = torch.Generator(device=_device).manual_seed(int(seed))
+    image = pipe(**kwargs).images[0]
+    buf = io.BytesIO()
+    image.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def _send(self, code: int, obj: dict) -> None:
+        raw = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self) -> None:
+        if self.path.rstrip("/") in ("/health", "/healthz"):
+            self._send(200, {"ok": True, "model": MODEL, "device": _device})
+        else:
+            self._send(404, {"error": {"message": "not found"}})
+
+    def do_POST(self) -> None:
+        if self.path.rstrip("/") not in ("/v1/images/generations", "/images/generations"):
+            self._send(404, {"error": {"message": "unsupported path %r" % self.path}})
+            return
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+            body = json.loads(self.rfile.read(length) or b"{}")
+        except Exception as exc:  # noqa: BLE001
+            self._send(400, {"error": {"message": "bad request: %s" % exc}})
+            return
+        prompt = str(body.get("prompt") or "").strip()
+        if not prompt:
+            self._send(400, {"error": {"message": "prompt is required"}})
+            return
+        default_steps = 2 if "turbo" in MODEL.lower() else 25
+        try:
+            b64 = _generate(
+                prompt,
+                int(body.get("steps") or default_steps),
+                int(body.get("width") or 0),
+                int(body.get("height") or 0),
+                body.get("seed"),
+            )
+            self._send(200, {"data": [{"b64_json": b64}], "model": MODEL})
+        except Exception as exc:  # noqa: BLE001
+            self._send(500, {"error": {"message": "generation failed: %s" % exc}})
+
+    def log_message(self, *args) -> None:  # noqa: ANN002 - quiet
+        return
+
+
+def main() -> int:
+    print("local-gen server: model=%s host=%s port=%d" % (MODEL, HOST, PORT), flush=True)
+    try:
+        _pipeline()  # warm-load so the first request isn't a cold start
+        print("local-gen: pipeline ready on %s" % _device, flush=True)
+    except Exception as exc:  # noqa: BLE001
+        print("local-gen: WARNING failed to warm-load pipeline: %s" % exc, file=sys.stderr, flush=True)
+    ThreadingHTTPServer((HOST, PORT), _Handler).serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -471,6 +471,7 @@ def cmd_agent_hardware(args: argparse.Namespace) -> None:
     hub-derived gen capability (can this agent host media generation, and is it
     currently advertising a gen endpoint)."""
     from mac.hardware import summarize
+    from mac.local_gen_catalog import models_for_hardware
     from mac.media_routing import is_gen_capable
 
     rows = []
@@ -480,10 +481,13 @@ def cmd_agent_hardware(args: argparse.Namespace) -> None:
         hardware = resources.get("hardware") if isinstance(resources, dict) else None
         serving = bool(isinstance(resources, dict) and resources.get("media_routes"))
         capable = is_gen_capable(hardware) if isinstance(hardware, dict) else False
+        # Routable-today (image) catalog models this agent's hardware can run.
+        runnable = [m.id for m in models_for_hardware(hardware) if m.routable] if isinstance(hardware, dict) else []
         rows.append({
             "agent": data.get("name") or data.get("id"),
             "accelerator": (hardware or {}).get("accelerator", "unknown") if isinstance(hardware, dict) else "unreported",
             "gen": ("serving" if serving else "capable") if capable else ("serving(cpu)" if serving else "no"),
+            "runnable_models": runnable,
             "hardware": summarize(hardware) if isinstance(hardware, dict) else "(no hardware reported — agent predates self-reporting; redeploy to populate)",
         })
     _print(rows)

--- a/src/mac/local_gen_catalog.py
+++ b/src/mac/local_gen_catalog.py
@@ -1,0 +1,132 @@
+"""Catalog of generative models that run locally on a GPU agent, and which a
+given agent's reported hardware can actually serve.
+
+This turns "agent has a GPU" into a concrete model list, and ties the models to
+media-01 routing: each entry names the media ``op`` it serves and the router
+``adapter`` a local OpenAI-compatible server should be routed through. Used to
+(a) surface what each agent could run (`mac agent hardware`), and (b) pick a
+model + build the ``media_routes`` advertisement when standing a local gen
+server up (see ``deploy/local-gen/openai_image_server.py``).
+
+Pure data + filters (stdlib only). VRAM figures are approximate fp16 minimums;
+``vram_min_mb=0`` means "runs on CPU / no hard floor". Filtering uses the agent's
+reported GPU VRAM, falling back to system memory for unified-memory devices
+(Apple Metal, NVIDIA GB10) where ``nvidia-smi`` reports no discrete VRAM.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple
+
+
+class LocalGenModel(NamedTuple):
+    id: str  # short id used in media_routes/model selection
+    modality: str  # image | audio | video
+    op: str  # media-01 op: image.generate | audio.music | audio.tts | audio.asr | video.generate
+    repo: str  # HF repo / weights id the local server loads
+    vram_min_mb: int  # approximate fp16 minimum (0 = CPU-able / no floor)
+    accelerators: Tuple[str, ...]  # accelerators it runs on: cuda | metal | cpu
+    framework: str  # diffusers | transformers
+    adapter: str  # media-01 router adapter for the local OpenAI-compatible server
+    routable: bool  # True if media-01 can route this op end-to-end today
+    notes: str = ""
+
+
+# Curated, intentionally small. `routable=True` is image.generate (the op the
+# router + openai_images adapter serve today via a local diffusers server);
+# audio/video are enumerated for capability but need the audio/video transport
+# (binary/multipart/async) before they route end-to-end.
+LOCAL_GEN_MODELS: Tuple[LocalGenModel, ...] = (
+    # ---- image: text-to-image (routable today) ----
+    LocalGenModel("sd15", "image", "image.generate", "stable-diffusion-v1-5/stable-diffusion-v1-5",
+                  4000, ("cuda", "metal", "cpu"), "diffusers", "openai_images", True,
+                  "Stable Diffusion 1.5 — lightweight, runs almost anywhere"),
+    LocalGenModel("sdxl-turbo", "image", "image.generate", "stabilityai/sdxl-turbo",
+                  7000, ("cuda", "metal"), "diffusers", "openai_images", True,
+                  "SDXL-Turbo — 1-4 step, fast; great default"),
+    LocalGenModel("sdxl", "image", "image.generate", "stabilityai/stable-diffusion-xl-base-1.0",
+                  10000, ("cuda", "metal"), "diffusers", "openai_images", True,
+                  "SDXL base 1.0 — higher quality, ~25 steps"),
+    LocalGenModel("sd3.5-medium", "image", "image.generate", "stabilityai/stable-diffusion-3.5-medium",
+                  10000, ("cuda",), "diffusers", "openai_images", True,
+                  "Stable Diffusion 3.5 Medium"),
+    LocalGenModel("flux.1-schnell", "image", "image.generate", "black-forest-labs/FLUX.1-schnell",
+                  24000, ("cuda",), "diffusers", "openai_images", True,
+                  "FLUX.1 [schnell] — high quality few-step; large (fp16 ~24GB)"),
+    LocalGenModel("flux.1-dev", "image", "image.generate", "black-forest-labs/FLUX.1-dev",
+                  24000, ("cuda",), "diffusers", "openai_images", True,
+                  "FLUX.1 [dev] — highest quality; large"),
+    # ---- audio (enumerated; needs audio transport to route) ----
+    LocalGenModel("musicgen-small", "audio", "audio.music", "facebook/musicgen-small",
+                  3000, ("cuda", "metal"), "transformers", "passthrough", False,
+                  "MusicGen small — text-to-music"),
+    LocalGenModel("bark", "audio", "audio.tts", "suno/bark",
+                  4000, ("cuda", "metal"), "transformers", "passthrough", False,
+                  "Bark — text-to-speech (binary audio; needs TTS transport)"),
+    LocalGenModel("whisper-large-v3", "audio", "audio.asr", "openai/whisper-large-v3",
+                  10000, ("cuda",), "transformers", "passthrough", False,
+                  "Whisper large v3 — speech-to-text (multipart; needs ASR transport)"),
+    LocalGenModel("stable-audio-open", "audio", "audio.generate", "stabilityai/stable-audio-open-1.0",
+                  8000, ("cuda",), "diffusers", "passthrough", False,
+                  "Stable Audio Open — text-to-audio"),
+    # ---- video (enumerated; needs async video transport to route) ----
+    LocalGenModel("svd", "video", "video.generate", "stabilityai/stable-video-diffusion-img2vid-xt",
+                  15000, ("cuda",), "diffusers", "passthrough", False,
+                  "Stable Video Diffusion (image-to-video)"),
+    LocalGenModel("animatediff", "video", "video.generate", "guoyww/animatediff-motion-adapter-v1-5-2",
+                  12000, ("cuda",), "diffusers", "passthrough", False,
+                  "AnimateDiff — text-to-video"),
+)
+
+_BY_ID = {m.id: m for m in LOCAL_GEN_MODELS}
+
+
+def get_model(model_id: str) -> Optional[LocalGenModel]:
+    return _BY_ID.get((model_id or "").strip())
+
+
+def _memory_budget_mb(hardware: Mapping[str, Any]) -> int:
+    """The VRAM budget to filter on: discrete GPU VRAM if reported, else system
+    memory (unified-memory devices — Apple Metal, NVIDIA GB10 — report no
+    discrete VRAM via nvidia-smi but share the system RAM with the GPU)."""
+    gpu = hardware.get("gpu") if isinstance(hardware.get("gpu"), Mapping) else {}
+    vram = int(gpu.get("vram_mb") or 0)
+    if vram:
+        return vram
+    return int(hardware.get("memory_mb") or 0)
+
+
+def models_for_hardware(hardware: Optional[Mapping[str, Any]]) -> List[LocalGenModel]:
+    """Catalog models an agent's reported hardware can run: accelerator must
+    match, and (when the VRAM budget is known) it must clear the model's
+    minimum. Unknown budget (0) is permissive — list it, don't hide it."""
+    if not isinstance(hardware, Mapping):
+        return []
+    accel = str(hardware.get("accelerator") or "none").strip().lower()
+    if accel not in ("cuda", "rocm", "metal", "cpu"):
+        return []
+    budget = _memory_budget_mb(hardware)
+    out: List[LocalGenModel] = []
+    for model in LOCAL_GEN_MODELS:
+        if accel not in model.accelerators:
+            continue
+        if model.vram_min_mb and budget and budget < model.vram_min_mb:
+            continue
+        out.append(model)
+    return out
+
+
+def media_route_for(model_id: str, base_url: str, *, key_spec: str = "", auth_scheme: str = "Bearer") -> Dict[str, Any]:
+    """Build the ``media_routes`` advertisement dict for serving ``model_id`` at
+    ``base_url`` (what a GPU agent sets in MAC_AGENT_MEDIA_ROUTES). Raises on an
+    unknown model so a typo fails loudly rather than advertising nothing."""
+    model = get_model(model_id)
+    if model is None:
+        raise ValueError("unknown local gen model %r (see LOCAL_GEN_MODELS)" % model_id)
+    return {
+        "op": model.op,
+        "base_url": base_url.rstrip("/"),
+        "model": model.id,
+        "adapter": model.adapter,
+        "key": key_spec,
+        "auth_scheme": auth_scheme,
+    }

--- a/tests/test_local_gen_catalog.py
+++ b/tests/test_local_gen_catalog.py
@@ -1,0 +1,69 @@
+"""Catalog of locally-runnable gen models + hardware filtering + media wiring."""
+from __future__ import annotations
+
+import pytest
+
+from mac.local_gen_catalog import (
+    LOCAL_GEN_MODELS,
+    get_model,
+    media_route_for,
+    models_for_hardware,
+)
+
+
+def test_catalog_entries_well_formed():
+    for m in LOCAL_GEN_MODELS:
+        assert m.id and m.repo and m.op and m.modality in ("image", "audio", "video")
+        assert m.accelerators and all(a in ("cuda", "metal", "cpu") for a in m.accelerators)
+        # routable today == image.generate via the openai_images adapter
+        if m.routable:
+            assert m.op == "image.generate" and m.adapter == "openai_images"
+
+
+def test_cuda_big_vram_runs_flux_and_sdxl():
+    hw = {"accelerator": "cuda", "gpu": {"vram_mb": 49000}}
+    ids = {m.id for m in models_for_hardware(hw)}
+    assert {"sd15", "sdxl-turbo", "sdxl", "flux.1-schnell"} <= ids
+
+
+def test_metal_excludes_cuda_only_models():
+    hw = {"accelerator": "metal", "memory_mb": 64000}  # M-series unified mem
+    ids = {m.id for m in models_for_hardware(hw)}
+    assert "sdxl-turbo" in ids and "sd15" in ids
+    assert "flux.1-schnell" not in ids  # flux is cuda-only in the catalog
+
+
+def test_unified_memory_uses_system_ram_when_vram_unknown():
+    # GB10: nvidia-smi reports no discrete VRAM (vram_mb 0) but 122GB unified.
+    hw = {"accelerator": "cuda", "gpu": {"name": "NVIDIA GB10", "vram_mb": 0}, "memory_mb": 122000}
+    ids = {m.id for m in models_for_hardware(hw)}
+    assert "flux.1-schnell" in ids  # big model allowed via unified-memory budget
+
+
+def test_small_vram_excludes_large_models():
+    hw = {"accelerator": "cuda", "gpu": {"vram_mb": 6000}}
+    ids = {m.id for m in models_for_hardware(hw)}
+    assert "sd15" in ids and "flux.1-schnell" not in ids and "sdxl" not in ids
+
+
+def test_no_accelerator_runs_nothing_gpu():
+    assert models_for_hardware({"accelerator": "none", "memory_mb": 8000}) == []
+    assert models_for_hardware(None) == []
+
+
+def test_media_route_for_builds_advertisement():
+    route = media_route_for("sdxl-turbo", "http://natasha:8189/v1/")
+    assert route == {
+        "op": "image.generate", "base_url": "http://natasha:8189/v1",
+        "model": "sdxl-turbo", "adapter": "openai_images", "key": "", "auth_scheme": "Bearer",
+    }
+
+
+def test_media_route_for_unknown_model_raises():
+    with pytest.raises(ValueError):
+        media_route_for("not-a-real-model", "http://x")
+
+
+def test_get_model():
+    assert get_model("sdxl-turbo").repo == "stabilityai/sdxl-turbo"
+    assert get_model("nope") is None


### PR DESCRIPTION
Enumerates the gen models a GPU agent can run locally and wires them to media-01 routing — so "agent has a GPU" becomes a concrete, hardware-filtered model list, and standing up a local backend is reproducible.

- **`mac.local_gen_catalog`**: curated `LocalGenModel` catalog — image (sd15, sdxl-turbo, sdxl, sd3.5-medium, flux.1-schnell/dev), audio (musicgen/bark/whisper/stable-audio), video (svd/animatediff) — each with modality, media `op`, HF repo, approx VRAM floor, accelerators, framework, router `adapter`, and `routable` (image.generate via openai_images today; audio/video enumerated pending transport). `models_for_hardware()` filters by reported accelerator + VRAM (falls back to system RAM for unified-memory devices like GB10/Metal where nvidia-smi reports no VRAM). `media_route_for()` builds the `MAC_AGENT_MEDIA_ROUTES` advertisement.
- **`deploy/local-gen/openai_image_server.py`**: self-contained OpenAI-images server (stdlib HTTP + lazy diffusers) → `/v1/images/generations` → `{data:[{b64_json}]}`, exactly what the `openai_images` adapter consumes. Run it on a GPU agent + advertise → the hub routes `/v1/media/image.generate` to its GPU with cloud failover.
- **`mac agent hardware`** now lists each agent's `runnable_models`.

Tests (9): catalog well-formed; hardware filtering across cuda/metal/GB10-unified/small-vram/none; `media_route_for` build + unknown-model raise.

Next: run this on natasha's GB10 (SDXL-Turbo is staged) so `capable → serving` and the fleet generates on-prem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)