### PR TITLE
media-01: multi-GPU load balancing + durable GPU-gated advertisement

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -956,6 +956,12 @@ deploy_host() {
   add_remote_env MAC_DEPLOY_ROUTER_IMAGE_UPSTREAM "${MAC_DEPLOY_ROUTER_IMAGE_UPSTREAM:-}"
   add_remote_env MAC_DEPLOY_ROUTER_AUDIO_UPSTREAM "${MAC_DEPLOY_ROUTER_AUDIO_UPSTREAM:-}"
   add_remote_env MAC_DEPLOY_ROUTER_VIDEO_UPSTREAM "${MAC_DEPLOY_ROUTER_VIDEO_UPSTREAM:-}"
+  # media-01 durable local-gen advertisement (GPU-gated in the agent on register).
+  add_remote_env MAC_DEPLOY_AGENT_GEN_MODEL "${MAC_DEPLOY_AGENT_GEN_MODEL:-}"
+  add_remote_env MAC_DEPLOY_AGENT_GEN_PORT "${MAC_DEPLOY_AGENT_GEN_PORT:-}"
+  add_remote_env MAC_DEPLOY_AGENT_GEN_HOST "${MAC_DEPLOY_AGENT_GEN_HOST:-}"
+  add_remote_env MAC_DEPLOY_AGENT_GEN_BASE_URL "${MAC_DEPLOY_AGENT_GEN_BASE_URL:-}"
+  add_remote_env MAC_DEPLOY_AGENT_MEDIA_ROUTES "${MAC_DEPLOY_AGENT_MEDIA_ROUTES:-}"
   local img_key="${NVIDIA_IMAGE_API_KEY:-}" aud_key="${NVIDIA_AUDIO_API_KEY:-}" vid_key="${NVIDIA_VIDEO_API_KEY:-}"
   if [ "$agent" != "$shared_services_manager" ] && [ "$router_backend_lc" = "inproc" ]; then
     img_key="" ; aud_key="" ; vid_key=""

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -550,6 +550,20 @@ def build_mac_env(
     memory_model = (env.get("MAC_DEPLOY_MEMORY_EMBED_MODEL") or "").strip()
     if memory_model:
         values["MAC_MEMORY_EMBED_MODEL"] = memory_model
+    # media-01 durable advertisement: carry the deploy-supplied local-gen config
+    # into mac.env so a GPU agent self-advertises a media route on registration
+    # (GPU-gated in worker.register_worker) — no hand-patched env, no per-agent
+    # JSON. A global MAC_DEPLOY_AGENT_GEN_MODEL only lights up actual GPU agents.
+    for _src, _dst in (
+        ("MAC_DEPLOY_AGENT_GEN_MODEL", "MAC_AGENT_GEN_MODEL"),
+        ("MAC_DEPLOY_AGENT_GEN_PORT", "MAC_AGENT_GEN_PORT"),
+        ("MAC_DEPLOY_AGENT_GEN_HOST", "MAC_AGENT_GEN_HOST"),
+        ("MAC_DEPLOY_AGENT_GEN_BASE_URL", "MAC_AGENT_GEN_BASE_URL"),
+        ("MAC_DEPLOY_AGENT_MEDIA_ROUTES", "MAC_AGENT_MEDIA_ROUTES"),
+    ):
+        _v = (env.get(_src) or "").strip()
+        if _v:
+            values[_dst] = _v
     values.setdefault("MAC_REQUIRE_HERMES_STARTUP_READY", "0")
     values.setdefault("MAC_WORKER_WORKSPACE", str(cfg.paths.mac_home / "agent-workspaces"))
     values.setdefault("MAC_WORKER_HEARTBEAT_INTERVAL", "30")

--- a/src/mac/local_gen_catalog.py
+++ b/src/mac/local_gen_catalog.py
@@ -115,6 +115,35 @@ def models_for_hardware(hardware: Optional[Mapping[str, Any]]) -> List[LocalGenM
     return out
 
 
+_GEN_ACCELERATORS = frozenset({"cuda", "rocm", "metal"})
+
+
+def advertised_media_routes(
+    gen_model: str,
+    base_url: str,
+    hardware: Optional[Mapping[str, Any]],
+) -> List[Dict[str, Any]]:
+    """The media_routes an agent should advertise for a configured local gen
+    model — catalog-driven and **GPU-gated**: returns ``[]`` unless the agent has
+    a usable accelerator (cuda/rocm/metal), a base_url, and the model is in the
+    catalog and runnable on this hardware. So a single global ``MAC_AGENT_GEN_MODEL``
+    can be set fleet-wide and only actual GPU agents self-advertise; CPU agents
+    return nothing."""
+    gen_model = (gen_model or "").strip()
+    base_url = (base_url or "").strip()
+    if not gen_model or not base_url or not isinstance(hardware, Mapping):
+        return []
+    accel = str(hardware.get("accelerator") or "none").strip().lower()
+    if accel not in _GEN_ACCELERATORS:
+        return []
+    model = get_model(gen_model)
+    if model is None or not model.routable:
+        return []
+    if model not in models_for_hardware(hardware):
+        return []  # accelerator/VRAM can't run it
+    return [media_route_for(model.id, base_url)]
+
+
 def media_route_for(model_id: str, base_url: str, *, key_spec: str = "", auth_scheme: str = "Bearer") -> Dict[str, Any]:
     """Build the ``media_routes`` advertisement dict for serving ``model_id`` at
     ``base_url`` (what a GPU agent sets in MAC_AGENT_MEDIA_ROUTES). Raises on an

--- a/src/mac/media_routing.py
+++ b/src/mac/media_routing.py
@@ -52,6 +52,7 @@ class MediaBinding(NamedTuple):
     adapter: str  # adapter id (see ADAPTERS)
     timeout: float
     auth_scheme: str = "Bearer"  # Authorization scheme; FAL uses "Key", OpenAI/NVIDIA "Bearer"
+    rank: int = 9  # accelerator tier for load-balancing (0=cuda/rocm, 1=metal, 9=cpu/cloud)
 
 
 # An adapter is a (to_provider, from_provider) pair:
@@ -385,16 +386,27 @@ def _agent_accelerator(agent: Mapping[str, Any]) -> str:
     return "unknown"
 
 
+def _agent_vram_budget(agent: Mapping[str, Any]) -> int:
+    """VRAM budget for tie-breaking same-tier GPUs: discrete VRAM if reported,
+    else system RAM (unified-memory devices report no discrete VRAM)."""
+    resources = agent.get("resources")
+    hardware = resources.get("hardware") if isinstance(resources, Mapping) else {}
+    if not isinstance(hardware, Mapping):
+        return 0
+    gpu = hardware.get("gpu") if isinstance(hardware.get("gpu"), Mapping) else {}
+    return int(gpu.get("vram_mb") or 0) or int(hardware.get("memory_mb") or 0)
+
+
 def media_bindings_from_agents(agents: Iterable[Mapping[str, Any]]) -> Dict[str, List[MediaBinding]]:
     """Compose ``{op: [MediaBinding]}`` from live agent registrations.
 
-    Each routable agent's ``resources["media_routes"]`` contributes bindings.
-    They are ordered by **reported hardware first** (CUDA/ROCm → Metal → CPU/
-    unknown), then by the route's declared ``priority`` — so the hub prefers the
-    agent with the best accelerator without any operator config. Offline/
-    unhealthy agents are skipped. Returns ``{}`` when no agent advertises.
+    Each routable agent's ``resources["media_routes"]`` contributes bindings,
+    ordered by **reported hardware**: accelerator tier first (CUDA/ROCm → Metal →
+    CPU/unknown), then **VRAM** (bigger GPU first), then the route's declared
+    ``priority``. Each binding carries its accelerator ``rank`` so the dispatcher
+    can load-balance within a tier. Offline/unhealthy agents are skipped.
     """
-    staged: Dict[str, List[Tuple[int, int, MediaBinding]]] = {}
+    staged: Dict[str, List[Tuple[int, int, int, MediaBinding]]] = {}
     for agent in agents:
         if not isinstance(agent, Mapping) or not _agent_is_routable(agent):
             continue
@@ -403,6 +415,7 @@ def media_bindings_from_agents(agents: Iterable[Mapping[str, Any]]) -> Dict[str,
         if not isinstance(routes, list):
             continue
         accel_rank = hardware_gen_rank(_agent_accelerator(agent))
+        vram = _agent_vram_budget(agent)
         for route in routes:
             if not isinstance(route, Mapping):
                 continue
@@ -418,12 +431,36 @@ def media_bindings_from_agents(agents: Iterable[Mapping[str, Any]]) -> Dict[str,
                 adapter=str(route.get("adapter") or "passthrough"),
                 timeout=_float(route.get("timeout"), 180.0),
                 auth_scheme=str(route.get("auth_scheme") or "Bearer"),
+                rank=accel_rank,
             )
-            staged.setdefault(op, []).append((accel_rank, _int(route.get("priority"), 0), binding))
+            staged.setdefault(op, []).append((accel_rank, -vram, _int(route.get("priority"), 0), binding))
+    # rank asc, VRAM desc (note -vram), priority asc
     return {
-        op: [b for _, _, b in sorted(items, key=lambda r: (r[0], r[1]))]
+        op: [b for _, _, _, b in sorted(items, key=lambda r: (r[0], r[1], r[2]))]
         for op, items in staged.items()
     }
+
+
+def dispatch_order(bindings: List[MediaBinding], inflight: Optional[Mapping[str, int]] = None) -> List[MediaBinding]:
+    """Order bindings for a single request with **least-loaded load balancing**
+    within the top accelerator tier.
+
+    The leading bindings sharing the best (lowest) ``rank`` are a pool of
+    equivalent GPUs; among them the one with the fewest in-flight requests is
+    tried first (ties keep the VRAM/priority order from the resolver), so
+    concurrent requests spread across same-tier GPUs instead of hammering one.
+    Lower tiers (and the static cloud fallback) keep their order and follow as
+    failover. ``inflight`` maps ``base_url`` → current in-flight count.
+    """
+    if not bindings:
+        return []
+    inflight = inflight or {}
+    top_rank = min(b.rank for b in bindings)
+    top = [b for b in bindings if b.rank == top_rank]
+    rest = [b for b in bindings if b.rank != top_rank]
+    # stable sort by in-flight → preserves resolver order (vram/priority) on ties
+    top_balanced = sorted(top, key=lambda b: inflight.get(b.base_url, 0))
+    return top_balanced + rest
 
 
 def gen_capable_agents(agents: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -846,13 +847,18 @@ def mount_media_router(
     (:func:`mac.media_routing.build_media_table`) as cloud fallback. So a GPU
     agent that announces a capability is used with zero operator config, and a
     down one falls over automatically. No-op when neither side can bind anything."""
-    from mac.media_routing import ADAPTERS, build_media_table, compose_media_table
+    from mac.media_routing import ADAPTERS, build_media_table, compose_media_table, dispatch_order
 
     env = os.environ if env is None else env
     static_table = build_media_table(env)
     if not static_table and agent_table_provider is None:
         return False
     from fastapi.responses import JSONResponse
+
+    # In-flight request counts per upstream (base_url), for least-loaded balancing
+    # across same-tier GPUs. Process-local (the single hub router process).
+    inflight: Dict[str, int] = {}
+    inflight_lock = threading.Lock()
 
     @app.post("/v1/media/{op}")
     def _media(op: str, body: Dict[str, Any] = Body(...)) -> Any:  # noqa: ANN401
@@ -869,6 +875,10 @@ def mount_media_router(
                            "type": "not_configured"}},
                 status_code=404,
             )
+        # Least-loaded across the top accelerator tier (snapshot in-flight under
+        # the lock), then VRAM/priority order, then lower tiers + cloud failover.
+        with inflight_lock:
+            ordered = dispatch_order(bindings, dict(inflight))
         # A caller may request a specific model; it overrides the binding's
         # default but stays confined to the binding's fixed upstream host — it's
         # a model id, never a path (`..`/leading-slash rejected so it can't
@@ -878,15 +888,21 @@ def mount_media_router(
             requested_model = ""
         last_status: int = 502
         last_body: Dict[str, Any] = {"error": {"message": "no binding produced a response"}}
-        for binding in bindings:
+        for binding in ordered:
             to_provider, from_provider = ADAPTERS.get(binding.adapter, ADAPTERS["passthrough"])
             model = requested_model or binding.model
             path, provider_body = to_provider(op, body, model)
             provider = Provider(name=binding.provider, base_url=binding.base_url, api_key_env=binding.key_spec)
-            status, resp = urllib_forwarder(
-                provider, path, provider_body, timeout=binding.timeout,
-                secret_resolver=secret_resolver, auth_scheme=binding.auth_scheme,
-            )
+            with inflight_lock:
+                inflight[binding.base_url] = inflight.get(binding.base_url, 0) + 1
+            try:
+                status, resp = urllib_forwarder(
+                    provider, path, provider_body, timeout=binding.timeout,
+                    secret_resolver=secret_resolver, auth_scheme=binding.auth_scheme,
+                )
+            finally:
+                with inflight_lock:
+                    inflight[binding.base_url] = max(0, inflight.get(binding.base_url, 0) - 1)
             canonical = from_provider(status, resp)
             if status and 200 <= status < 300:
                 return JSONResponse(

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -249,19 +249,42 @@ def register_worker(
     except Exception:  # noqa: BLE001 - hardware probe must never fail registration
         pass
     # media-01 capability self-advertisement: a GPU agent announces the media ops
-    # it serves via MAC_AGENT_MEDIA_ROUTES (JSON list of route dicts, e.g.
-    # [{"op":"image.generate","base_url":"http://host:8189","adapter":"openai_images"}]).
-    # The hub composes its /v1/media routing table from live agents'
-    # resources["media_routes"], so the fleet uses this agent with zero operator
-    # config. Merged into the registration resources here.
-    _media_routes = (os.environ.get("MAC_AGENT_MEDIA_ROUTES") or "").strip()
-    if _media_routes:
+    # it serves in resources["media_routes"]; the hub composes its /v1/media
+    # routing table from live agents, so the fleet uses this agent with zero
+    # operator config. Two ways to set it, both honored here:
+    #   1. MAC_AGENT_MEDIA_ROUTES — explicit JSON list of route dicts (override).
+    #   2. MAC_AGENT_GEN_MODEL — a catalog model id; the route is derived from the
+    #      catalog + this agent's detected hardware (GPU-GATED: a CPU agent with
+    #      the var set advertises nothing), self-addressed via MAC_AGENT_GEN_BASE_URL
+    #      (or MAC_AGENT_GEN_HOST:MAC_AGENT_GEN_PORT). So a single global
+    #      MAC_AGENT_GEN_MODEL can be set fleet-wide and only real GPU agents serve.
+    _media_routes_env = (os.environ.get("MAC_AGENT_MEDIA_ROUTES") or "").strip()
+    _gen_model = (os.environ.get("MAC_AGENT_GEN_MODEL") or "").strip()
+    _routes = None
+    if _media_routes_env:
         try:
-            _parsed_routes = json.loads(_media_routes)
+            parsed = json.loads(_media_routes_env)
+            if isinstance(parsed, list):
+                _routes = parsed
         except ValueError:
-            _parsed_routes = None
-        if isinstance(_parsed_routes, list):
-            resources = {**(resources or {}), "media_routes": _parsed_routes}
+            _routes = None
+    elif _gen_model:
+        try:
+            from mac.local_gen_catalog import advertised_media_routes
+
+            base = (os.environ.get("MAC_AGENT_GEN_BASE_URL") or "").strip()
+            if not base:
+                gen_host = (os.environ.get("MAC_AGENT_GEN_HOST") or host).strip()
+                gen_port = (os.environ.get("MAC_AGENT_GEN_PORT") or "8189").strip()
+                base = "http://%s:%s/v1" % (gen_host, gen_port)
+            hw = resources.get("hardware") if isinstance(resources, dict) else None
+            derived = advertised_media_routes(_gen_model, base, hw)
+            if derived:
+                _routes = derived
+        except Exception:  # noqa: BLE001 - advertisement is best-effort
+            _routes = None
+    if _routes:
+        resources = {**(resources or {}), "media_routes": _routes}
     machine = client.post(
         "/machines",
         {

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -1447,3 +1447,29 @@ def test_media_key_escrow_has_no_chat_key_fallback():
     # and the deploy reports which media ops are enabled vs disabled
     assert "media ops:" in script
     assert "DISABLED: set" in script
+
+
+def test_build_mac_env_passes_through_local_gen_advertisement(tmp_path):
+    """media-01 durable advertisement: deploy-supplied MAC_DEPLOY_AGENT_GEN_*
+    flow into mac.env as MAC_AGENT_GEN_* (the agent self-advertises, GPU-gated)."""
+    values = build_mac_env(
+        {},
+        deploy_env_config(tmp_path, fleet_name="test-fleet"),
+        environ={
+            "MAC_DEPLOY_AGENT_GEN_MODEL": "sdxl-turbo",
+            "MAC_DEPLOY_AGENT_GEN_PORT": "8189",
+            "MAC_DEPLOY_AGENT_GEN_BASE_URL": "http://100.87.229.125:8189/v1",
+        },
+    )
+    assert values["MAC_AGENT_GEN_MODEL"] == "sdxl-turbo"
+    assert values["MAC_AGENT_GEN_PORT"] == "8189"
+    assert values["MAC_AGENT_GEN_BASE_URL"] == "http://100.87.229.125:8189/v1"
+    # absent when not supplied
+    bare = build_mac_env({}, deploy_env_config(tmp_path, fleet_name="t2"), environ={})
+    assert "MAC_AGENT_GEN_MODEL" not in bare
+
+
+def test_deploy_passes_local_gen_env_to_agent():
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    assert 'add_remote_env MAC_DEPLOY_AGENT_GEN_MODEL' in script
+    assert 'add_remote_env MAC_DEPLOY_AGENT_GEN_BASE_URL' in script

--- a/tests/test_local_gen_catalog.py
+++ b/tests/test_local_gen_catalog.py
@@ -5,6 +5,7 @@ import pytest
 
 from mac.local_gen_catalog import (
     LOCAL_GEN_MODELS,
+    advertised_media_routes,
     get_model,
     media_route_for,
     models_for_hardware,
@@ -67,3 +68,25 @@ def test_media_route_for_unknown_model_raises():
 def test_get_model():
     assert get_model("sdxl-turbo").repo == "stabilityai/sdxl-turbo"
     assert get_model("nope") is None
+
+
+# --- durable self-advertisement (catalog-driven, GPU-gated) -----------------
+
+def test_advertised_routes_gpu_agent():
+    routes = advertised_media_routes("sdxl-turbo", "http://natasha:8189/v1",
+                                     {"accelerator": "cuda", "gpu": {"vram_mb": 0}, "memory_mb": 122000})
+    assert routes == [{"op": "image.generate", "base_url": "http://natasha:8189/v1",
+                       "model": "sdxl-turbo", "adapter": "openai_images", "key": "", "auth_scheme": "Bearer"}]
+
+
+def test_advertised_routes_cpu_agent_is_empty():
+    # GPU-gating: a CPU agent with MAC_AGENT_GEN_MODEL set advertises nothing.
+    assert advertised_media_routes("sdxl-turbo", "http://x:8189/v1", {"accelerator": "none", "memory_mb": 8000}) == []
+
+
+def test_advertised_routes_requires_model_base_and_runnable():
+    hw = {"accelerator": "cuda", "gpu": {"vram_mb": 6000}}  # small VRAM
+    assert advertised_media_routes("", "http://x/v1", hw) == []         # no model
+    assert advertised_media_routes("sdxl-turbo", "", hw) == []          # no base_url
+    assert advertised_media_routes("nope", "http://x/v1", hw) == []     # unknown model
+    assert advertised_media_routes("flux.1-schnell", "http://x/v1", hw) == []  # 24GB model, 6GB GPU

--- a/tests/test_media_routing.py
+++ b/tests/test_media_routing.py
@@ -11,6 +11,7 @@ from mac.media_routing import (
     MediaBinding,
     build_media_table,
     compose_media_table,
+    dispatch_order,
     extract_b64,
     fal_request,
     fal_response,
@@ -419,3 +420,81 @@ def test_gen_capable_agents_lists_accelerated_only_sorted():
     caps = gen_capable_agents(agents)
     assert [c["agent"] for c in caps] == ["natasha", "mac"]  # cuda first; none/stale excluded
     assert caps[0]["gpu"] == "NVIDIA GB10" and caps[0]["serving"] is True
+
+
+# --- multi-GPU load balancing (VRAM tie-break + least-loaded dispatch) -------
+
+def _gpu_agent_vram(name, accel, vram_mb, url):
+    return {"name": name, "status": "idle", "health_status": "healthy",
+            "resources": {"hardware": {"accelerator": accel, "gpu": {"name": name, "vram_mb": vram_mb}},
+                          "media_routes": [{"op": "image.generate", "base_url": url, "adapter": "openai_images"}]}}
+
+
+def test_same_tier_ordered_by_vram_descending():
+    agents = [
+        _gpu_agent_vram("small", "cuda", 12000, "http://small:8189"),
+        _gpu_agent_vram("big", "cuda", 49000, "http://big:8189"),
+    ]
+    urls = [b.base_url for b in media_bindings_from_agents(agents)["image.generate"]]
+    assert urls == ["http://big:8189", "http://small:8189"]  # bigger VRAM first within the cuda tier
+
+
+def test_binding_carries_accelerator_rank():
+    agents = [_gpu_agent_vram("natasha", "cuda", 0, "http://natasha:8189"),
+              {"name": "mac", "status": "idle", "health_status": "healthy",
+               "resources": {"hardware": {"accelerator": "metal", "memory_mb": 64000},
+                             "media_routes": [{"op": "image.generate", "base_url": "http://mac:8189", "adapter": "openai_images"}]}}]
+    table = media_bindings_from_agents(agents)["image.generate"]
+    ranks = {b.base_url: b.rank for b in table}
+    assert ranks["http://natasha:8189"] == 0 and ranks["http://mac:8189"] == 1  # cuda tier 0, metal tier 1
+
+
+def test_dispatch_order_least_loaded_within_top_tier():
+    bindings = media_bindings_from_agents([
+        _gpu_agent_vram("a", "cuda", 40000, "http://a:8189"),
+        _gpu_agent_vram("b", "cuda", 40000, "http://b:8189"),
+    ])["image.generate"]
+    # no load -> resolver order (a before b by stable VRAM tie)
+    assert [b.base_url for b in dispatch_order(bindings, {})][0] in ("http://a:8189", "http://b:8189")
+    # a is busy -> b is tried first
+    order = dispatch_order(bindings, {"http://a:8189": 2})
+    assert order[0].base_url == "http://b:8189"
+
+
+def test_dispatch_order_keeps_lower_tiers_as_failover():
+    cuda = MediaBinding("gpu", "http://gpu:8189", "", "", "openai_images", 180.0, rank=0)
+    cloud = MediaBinding("nvidia", "https://cloud", "secret:k", "m", "nvidia_genai", 180.0, rank=9)
+    # even if the cuda agent is "loaded", cloud (lower tier) never jumps ahead of it
+    order = dispatch_order([cuda, cloud], {"http://gpu:8189": 99})
+    assert [b.provider for b in order] == ["gpu", "nvidia"]
+
+
+def test_mount_balances_across_two_gpu_agents(monkeypatch):
+    """Concurrent-ish requests spread across two same-tier GPU agents."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from mac import router_app
+
+    captured = {}
+    monkeypatch.setattr(
+        router_app.urllib.request, "urlopen",
+        _fake_urlopen_factory(captured, {
+            "a:8189": (200, b'{"data":[{"b64_json":"A"}]}'),
+            "b:8189": (200, b'{"data":[{"b64_json":"B"}]}'),
+        }),
+    )
+    app = FastAPI()
+
+    def agent_table():
+        return media_bindings_from_agents([
+            _gpu_agent_vram("a", "cuda", 40000, "http://a:8189"),
+            _gpu_agent_vram("b", "cuda", 40000, "http://b:8189"),
+        ])
+
+    assert router_app.mount_router(app, env={"MAC_ROUTER_BACKEND": "inproc"},
+                                   secret_resolver={}.get, media_agent_table_provider=agent_table) is True
+    client = TestClient(app)
+    # sequential requests: in-flight returns to 0 between them, so order is stable
+    # (the point is both are reachable + chosen, not strict alternation under serial calls)
+    providers = {client.post("/v1/media/image.generate", json={"prompt": "x"}).json()["provider"] for _ in range(2)}
+    assert providers <= {"a", "b"} and len(providers) >= 1


### PR DESCRIPTION
Two related media-01 GPU-routing pieces:

**Multi-GPU load balancing (#2):**
- `media_bindings_from_agents` orders within an accelerator tier by VRAM (bigger first), then priority, stamping each binding's accelerator `rank`.
- `dispatch_order(bindings, inflight)`: least-loaded within the top tier; lower tiers + cloud stay as failover.
- `mount_media_router` tracks per-upstream in-flight counts and dispatches least-loaded — concurrent requests spread across same-tier GPUs.

**Durable GPU-gated advertisement (#1 — finishes Part B without a hand-patch):**
- `local_gen_catalog.advertised_media_routes(model, base_url, hardware)`: catalog-driven + **GPU-gated** (CPU agents advertise nothing).
- `worker.register_worker`: builds `resources["media_routes"]` from `MAC_AGENT_GEN_MODEL` (self-addressed), gated on detected hardware; explicit `MAC_AGENT_MEDIA_ROUTES` still overrides.
- `build_mac_env` + deploy carry `MAC_DEPLOY_AGENT_GEN_*` into mac.env, so a single global `MAC_DEPLOY_AGENT_GEN_MODEL=sdxl-turbo` lights up only real GPU agents, durably, set by the deploy.

Tests cover VRAM ordering, least-loaded dispatch, failover, GPU-gated advertisement, env passthrough. (media_routing + router_app + catalog + deploy + worker suites green.)