### PR TITLE
fix(review): stop unbounded review loop — verdict-wait cap + mem-12 window fix

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -8057,18 +8057,16 @@ class ControlPlane:
                 retraction_cap = int(os.environ.get("MAC_REVIEW_RETRACTION_CAP", "3"))
             except ValueError:
                 retraction_cap = 3
-            evidence_threshold = self.store.query_one(
-                """
-                SELECT created_at FROM evidence
-                WHERE task_id = ?
-                ORDER BY created_at DESC, id DESC
-                LIMIT 1
-                """,
-                (task_id,),
-            )
-            threshold_at = (
-                evidence_threshold["created_at"] if evidence_threshold else ""
-            )
+            # mem-12 window fix: scope the retraction count to "retractions
+            # since the work under review was submitted" — i.e. the executor
+            # evidence we are actually reviewing (already resolved above as
+            # ``evidence``). The original query took the latest evidence of
+            # ANY kind, so the reviewer's own ``review``-kind attempt evidence
+            # advanced the window every cycle and the cap never tripped — the
+            # bug behind the 2026-06 review runaway. Genuine rework still
+            # resets the window because new executor evidence becomes the
+            # reviewed ``evidence`` on the next advance.
+            threshold_at = evidence.created_at or ""
             retracted_count_row = self.store.query_one(
                 """
                 SELECT COUNT(*) AS n FROM reviews
@@ -8177,6 +8175,75 @@ class ControlPlane:
                 not_before=review.created_at,
             )
             if verdict_evidence is None:
+                # Bound the verdict-wait loop. mem-12 only caps RETRACTION;
+                # a reviewer that keeps producing review-attempt evidence but
+                # never a valid signed verdict would otherwise spin here
+                # forever, re-nudging every tick (task_5de06b: 59 review-kind
+                # evidence rows, 0 verdict — the live half of the 2026-06
+                # runaway). Past a cap, fail the task instead of re-nudging.
+                try:
+                    verdict_wait_cap = int(
+                        os.environ.get("MAC_REVIEW_VERDICT_WAIT_CAP", "6")
+                    )
+                except ValueError:
+                    verdict_wait_cap = 6
+                wait_count_row = self.store.query_one(
+                    """
+                    SELECT COUNT(*) AS n FROM evidence
+                    WHERE task_id = ? AND kind = 'review'
+                      AND created_at >= ?
+                    """,
+                    (task_id, review.created_at),
+                )
+                wait_count = int(wait_count_row["n"]) if wait_count_row else 0
+                if verdict_wait_cap > 0 and wait_count >= verdict_wait_cap:
+                    self._record_default_review_observation(
+                        task_id,
+                        "workflow.default_review.exhausted",
+                        "error",
+                        {
+                            "reason": "review_verdict_wait_cap_hit",
+                            "cap": verdict_wait_cap,
+                            "wait_count": wait_count,
+                            "review_id": review.id,
+                            "reviewer_agent_id": review.reviewer_agent_id,
+                        },
+                        actor,
+                    )
+                    self._record_history(
+                        task_id,
+                        "task.review_exhausted",
+                        actor,
+                        None,
+                        None,
+                        {
+                            "reason": "review_verdict_wait_cap_hit",
+                            "cap": verdict_wait_cap,
+                            "wait_count": wait_count,
+                            "review_id": review.id,
+                        },
+                    )
+                    try:
+                        self.transition_task(
+                            task_id,
+                            TaskState.FAILED.value,
+                            actor,
+                            {
+                                "reason": "review_verdict_wait_cap_hit",
+                                "cap": verdict_wait_cap,
+                                "wait_count": wait_count,
+                                "review_id": review.id,
+                            },
+                        )
+                    except TransitionError:
+                        pass
+                    return {
+                        "task_id": task_id,
+                        "status": "review_verdict_wait_exhausted",
+                        "cap": verdict_wait_cap,
+                        "wait_count": wait_count,
+                        "review_id": review.id,
+                    }
                 self._record_default_review_observation(
                     task_id,
                     "workflow.default_review.waiting_for_verdict",

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -1055,6 +1055,114 @@ def test_default_review_retraction_cap_resets_on_new_evidence(cp, monkeypatch):
     assert cp.get_task(task.id).state != TaskState.FAILED.value
 
 
+def test_default_review_workflow_caps_verdict_wait(cp, monkeypatch):
+    """A reviewer that keeps producing review-attempt evidence but never a
+    valid signed verdict must not spin forever: past the verdict-wait cap the
+    task FAILS instead of re-nudging (the live half of the 2026-06 runaway)."""
+    monkeypatch.setenv("MAC_REVIEW_VERDICT_WAIT_CAP", "2")
+    worker = register_agent(cp, "worker", ["python"])
+    register_agent(cp, "reviewer-a", ["review"])
+    task = cp.create_task("Spinny", required_capabilities=["python"])
+    cp.claim_task(task.id, worker.id)
+    cp.start_task(task.id, worker.id)
+    cp.add_evidence(
+        task.id,
+        "test",
+        "file://repo",
+        "did the thing",
+        worker.id,
+        metadata=verified_repo_metadata(cp, worker.id),
+    )
+    cp.submit_for_review(task.id, worker.id)
+
+    # First advance opens a pending review (assigns a reviewer).
+    cp.advance_default_review_workflow(task.id)
+    from mac.models import ReviewStatus
+
+    pending = [
+        r for r in cp.list_reviews(task.id)
+        if r.status == ReviewStatus.PENDING.value
+    ]
+    assert pending, "expected a pending review after first advance"
+    review = pending[0]
+
+    # Reviewer produces N review-attempt evidence rows but no valid verdict.
+    for i in range(2):
+        cp.add_evidence(
+            task.id,
+            "review",
+            "file://review-%d" % i,
+            "looked, still unsure",
+            review.reviewer_agent_id,
+        )
+
+    result = cp.advance_default_review_workflow(task.id)
+    assert result["status"] == "review_verdict_wait_exhausted", result
+    assert result["cap"] == 2
+    assert result["wait_count"] >= 2
+    assert cp.get_task(task.id).state == TaskState.FAILED.value
+    names = {event.name for event in cp.list_observability(limit=50)}
+    assert "workflow.default_review.exhausted" in names
+
+
+def test_default_review_retraction_cap_not_reset_by_review_evidence(cp, monkeypatch):
+    """mem-12 window fix: the reviewer's OWN review-attempt evidence must not
+    reset the retraction window. Only genuine new executor work (the reviewed
+    evidence) does. With the pre-fix 'latest evidence of any kind' window this
+    looped forever."""
+    monkeypatch.setenv("MAC_REVIEW_RETRACTION_CAP", "2")
+    worker = register_agent(cp, "worker", ["python"])
+    register_agent(cp, "reviewer-a", ["review"])
+    task = cp.create_task("Loopy2", required_capabilities=["python"])
+    cp.claim_task(task.id, worker.id)
+    cp.start_task(task.id, worker.id)
+    cp.add_evidence(
+        task.id,
+        "test",
+        "file://repo",
+        "did the thing",
+        worker.id,
+        metadata=verified_repo_metadata(cp, worker.id),
+    )
+    cp.submit_for_review(task.id, worker.id)
+
+    from mac.models import ReviewStatus, new_id, utcnow
+
+    now = utcnow()
+    for label in ("a", "b"):
+        cp.store.execute(
+            """
+            INSERT INTO reviews (
+                id, task_id, reviewer_agent_id, status, reason, evidence_id,
+                created_at, completed_at
+            ) VALUES (?, ?, ?, ?, ?, NULL, ?, ?)
+            """,
+            (
+                new_id("review"),
+                task.id,
+                "agent_" + label,
+                ReviewStatus.RETRACTED.value,
+                "stale",
+                now,
+                now,
+            ),
+        )
+    # Reviewer churn AFTER the retractions: a 'review'-kind evidence row.
+    # Pre-fix this advanced the window and reset the count to 0; post-fix the
+    # window is anchored to the reviewed executor evidence, so the cap fires.
+    cp.add_evidence(
+        task.id,
+        "review",
+        "file://review-churn",
+        "still unsure",
+        "agent_reviewer-a",
+    )
+
+    result = cp.advance_default_review_workflow(task.id)
+    assert result["status"] == "review_retraction_exhausted", result
+    assert cp.get_task(task.id).state == TaskState.FAILED.value
+
+
 def test_default_review_workflow_approves_repo_less_operator_result(cp):
     from tests.conftest import submit_review_verdict
 


### PR DESCRIPTION
## The incident
The fleet's review system was looping, not resolving: **639/887 reviews (72%) `retracted`**, tasks stuck in `reviewing` for days, and agents spamming `review_evidence` on Slack every few seconds. (Stopped operationally by cancelling the 8 stuck tasks + pruning 34K obs events; this PR is the durable fix.)

## Why mem-12 didn't catch it
Two gaps, both verified in code + the live DB:

1. **mem-12's retraction window was self-defeating.** It counted retractions `created_at >= threshold`, where `threshold` = *latest evidence of any kind*. The review executor writes a fresh `review`-kind evidence row every cycle → the window advanced → the count reset to ~0 → the cap of 3 **never tripped**. Fix: anchor the window to the executor evidence under review (`evidence.created_at`). Genuine rework still resets it; reviewer churn no longer does.
2. **No cap on the verdict-wait path at all.** A pending review whose reviewer never emits a valid signed verdict re-nudged forever (`waiting_for_verdict`; `task_5de06b` had 59 review-kind evidence rows, 0 verdict). Fix: a verdict-wait circuit breaker (`MAC_REVIEW_VERDICT_WAIT_CAP`, default 6) that fails the task past the cap, mirroring mem-12's cap-or-fail.

The *rejected* path was already bounded by `attempt_count`; these two paths were not.

## Tests
- `test_default_review_workflow_caps_verdict_wait` — reviewer churn w/o verdict → task FAILED + `exhausted` observation.
- `test_default_review_retraction_cap_not_reset_by_review_evidence` — `review`-kind churn no longer resets the retraction cap.
- Existing `caps_retractions` + `resets_on_new_evidence` still pass (241 in `test_control_plane`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)