### PR TITLE
media-01 Part C (C1+C2): autonomous agent self-install + persistent footprint

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -594,6 +594,10 @@ class CommandAuditCreate(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
+class AgentInstalledPackagesUpdate(BaseModel):
+    installed_packages: Dict[str, Any] = Field(default_factory=dict)
+
+
 class MessageCreate(BaseModel):
     sender_agent_id: str
     recipient_agent_id: Optional[str] = None
@@ -3107,6 +3111,17 @@ def create_app(
     ) -> Dict[str, Any]:
         principal.assert_actor(agent_id)  # mac-wcfy
         return cp.record_command_audit(agent_id=agent_id, **_data(body)).to_dict()
+
+    @app.post("/agents/{agent_id}/installed-packages")
+    def update_agent_installed_packages(
+        agent_id: str,
+        body: AgentInstalledPackagesUpdate,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.assert_actor(agent_id)  # an agent reports only its OWN footprint
+        return cp.update_agent_installed_packages(
+            agent_id, body.installed_packages, actor=agent_id
+        ).to_dict()
 
     @app.get("/command-audit")
     def list_command_audit(

--- a/src/mac/models.py
+++ b/src/mac/models.py
@@ -545,6 +545,9 @@ class Agent:
     last_seen_at: str
     role_id: Optional[str] = None
     hermes_instance_id: Optional[str] = None
+    # Packages the agent has self-installed into its own environment (pip/npm),
+    # reported to the hub as its "default footprint" so redeploys re-hydrate it.
+    installed_packages: JsonDict = field(default_factory=dict)
 
     def to_dict(self) -> JsonDict:
         return asdict(self)

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6015,6 +6015,42 @@ class ControlPlane:
             )
         return self.get_agent(agent_id)
 
+    def update_agent_installed_packages(
+        self,
+        agent_id: str,
+        installed_packages: Dict[str, Any],
+        *,
+        actor: str = "agent",
+    ) -> Agent:
+        """Record the agent's self-installed pip/npm footprint (its persistent
+        "default footprint"). Kept separate from update_agent so a footprint
+        report can't clobber capabilities/status. Re-registration preserves it
+        (the register UPSERT does not touch this column)."""
+        agent_before = self.get_agent(agent_id)
+        payload = ensure_json_object(installed_packages)
+        now = utcnow()
+        pip = payload.get("pip")
+        npm = payload.get("npm")
+        with self.store.transaction() as conn:
+            conn.execute(
+                "UPDATE agents SET installed_packages = ?, updated_at = ? WHERE id = ?",
+                (json_dumps(payload), now, agent_id),
+            )
+            self._record_agent_lifecycle_event(
+                conn,
+                agent_id,
+                "agent.installed_packages_updated",
+                actor,
+                {
+                    "agent_id": agent_id,
+                    "agent_name": agent_before.name,
+                    "pip_count": len(pip) if isinstance(pip, list) else 0,
+                    "npm_count": len(npm) if isinstance(npm, list) else 0,
+                },
+                now,
+            )
+        return self.get_agent(agent_id)
+
     def disable_agent(self, agent_id: str, *, actor: str = "human") -> Agent:
         return self.update_agent(
             agent_id,
@@ -11797,6 +11833,11 @@ class ControlPlane:
         hermes_instance_id = (
             row["hermes_instance_id"] if "hermes_instance_id" in keys else None
         )
+        installed_packages = (
+            json_loads(row["installed_packages"], {})
+            if "installed_packages" in keys
+            else {}
+        )
         return Agent(
             row["id"],
             row["machine_id"],
@@ -11812,6 +11853,7 @@ class ControlPlane:
             row["last_seen_at"],
             role_id,
             hermes_instance_id,
+            installed_packages,
         )
 
     def _project_item_from_row(self, row: Any) -> ProjectItem:

--- a/src/mac/store.py
+++ b/src/mac/store.py
@@ -1253,6 +1253,9 @@ class SQLiteStore:
         self._ensure_column(
             "agents", "attestation_key_ciphertext", "attestation_key_ciphertext TEXT"
         )
+        self._ensure_column(
+            "agents", "installed_packages", "installed_packages TEXT NOT NULL DEFAULT '{}'"
+        )
         self._ensure_column("machines", "hardware", "hardware TEXT NOT NULL DEFAULT '{}'")
         self._ensure_column("tasks", "started_at", "started_at TEXT")
         self._ensure_column("tasks", "completed_at", "completed_at TEXT")

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -2073,6 +2073,182 @@ class MacWorker:
         except Exception:
             pass
 
+    # --- autonomous self-install (pip/npm into the agent's OWN environment) ----
+    # Fully unrestricted by decision: install only into the agent venv / local
+    # npm prefix (never the system), every install is audited via command_audit,
+    # and the resulting footprint is reported to the hub so redeploys re-hydrate
+    # it. This is what lets an agent provision its own tools for autonomous work.
+
+    def _mac_home(self) -> Path:
+        return Path(os.environ.get("MAC_HOME") or (Path.home() / ".mac"))
+
+    def _agent_venv_python(self) -> str:
+        py = self._mac_home() / "venv" / "bin" / "python"
+        return str(py) if py.exists() else sys.executable
+
+    def _footprint_path(self) -> Path:
+        return self._mac_home() / "agent-footprint.json"
+
+    def _load_footprint(self) -> JsonDict:
+        try:
+            return json.loads(self._footprint_path().read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+
+    def _write_footprint(self, footprint: JsonDict) -> None:
+        path = self._footprint_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(footprint, indent=2, sort_keys=True), encoding="utf-8")
+        tmp.replace(path)
+
+    def _report_footprint(self, footprint: JsonDict) -> None:
+        try:
+            self.client.post(
+                "/agents/%s/installed-packages" % quote(self.agent_id, safe=""),
+                {"installed_packages": footprint},
+            )
+        except Exception:
+            pass
+
+    @staticmethod
+    def _pip_base_name(spec: str) -> str:
+        return re.split(r"[\[<>=!~;\s]", spec.strip(), 1)[0].strip().lower().replace("_", "-")
+
+    @staticmethod
+    def _npm_base_name(spec: str) -> str:
+        spec = spec.strip()
+        if spec.startswith("@"):
+            parts = spec.split("@")  # ['', 'scope/name', 'ver'?]
+            return ("@" + parts[1]).lower() if len(parts) >= 2 else spec.lower()
+        return spec.split("@", 1)[0].lower()
+
+    def _pip_installed(self, py: str) -> set:
+        try:
+            out = subprocess.run(
+                [py, "-m", "pip", "list", "--format=json"],
+                capture_output=True, text=True, timeout=120, check=False,
+            ).stdout
+            return {str(p.get("name", "")).lower().replace("_", "-") for p in json.loads(out or "[]")}
+        except Exception:
+            return set()
+
+    def _npm_installed(self, prefix: str) -> set:
+        try:
+            out = subprocess.run(
+                ["npm", "ls", "--prefix", prefix, "--depth", "0", "--json"],
+                capture_output=True, text=True, timeout=120, check=False,
+            ).stdout
+            deps = (json.loads(out or "{}").get("dependencies") or {})
+            return {str(k).lower() for k in deps}
+        except Exception:
+            return set()
+
+    def _run_install(self, argv: List[str], *, manager: str, reason: str, specs: List[str]) -> JsonDict:
+        command_id = secrets.token_hex(8)
+        cwd = str(self._mac_home())
+        meta = {"self_install": True, "package_manager": manager, "reason": reason, "specs": specs}
+        started = datetime.now(timezone.utc).isoformat()
+        self._record_command_audit({
+            "command_id": command_id, "phase": "started", "argv": argv,
+            "cwd": cwd, "started_at": started, "metadata": meta,
+        })
+        t0 = time.monotonic()
+        try:
+            proc = subprocess.run(argv, cwd=cwd, capture_output=True, text=True, timeout=1800, check=False)
+            rc, out, err = proc.returncode, proc.stdout or "", proc.stderr or ""
+        except Exception as exc:  # noqa: BLE001 - install failures are reported, not raised.
+            self._record_command_audit({
+                "command_id": command_id, "phase": "failed", "argv": argv, "cwd": cwd,
+                "started_at": started, "completed_at": datetime.now(timezone.utc).isoformat(),
+                "returncode": -1, "metadata": {**meta, "error": str(exc)},
+            })
+            return {"ok": False, "error": str(exc), "specs": specs}
+        dur_ms = (time.monotonic() - t0) * 1000.0
+        self._record_command_audit({
+            "command_id": command_id, "phase": "completed" if rc == 0 else "failed",
+            "argv": argv, "cwd": cwd, "started_at": started,
+            "completed_at": datetime.now(timezone.utc).isoformat(), "duration_ms": dur_ms,
+            "returncode": rc,
+            "stdout_sha256": hashlib.sha256(out.encode("utf-8")).hexdigest(),
+            "stderr_sha256": hashlib.sha256(err.encode("utf-8")).hexdigest(),
+            "stdout_bytes": len(out.encode("utf-8")), "stderr_bytes": len(err.encode("utf-8")),
+            "metadata": meta,
+        })
+        return {"ok": rc == 0, "returncode": rc, "stdout": out[-4000:], "stderr": err[-4000:], "specs": specs}
+
+    def _update_footprint(self, manager: str, specs: List[str], *, index_url: Optional[str] = None) -> None:
+        fp = self._load_footprint()
+        entries = fp.get(manager) if isinstance(fp.get(manager), list) else []
+        by_name = {e.get("name"): dict(e) for e in entries if isinstance(e, dict) and e.get("name")}
+        now = datetime.now(timezone.utc).isoformat()
+        base = self._pip_base_name if manager == "pip" else self._npm_base_name
+        for spec in specs:
+            entry = {"name": base(spec), "spec": spec, "installed_at": now}
+            if index_url:
+                entry["index_url"] = index_url
+            by_name[entry["name"]] = entry
+        fp[manager] = [by_name[k] for k in sorted(by_name)]
+        fp["updated_at"] = now
+        self._write_footprint(fp)
+        self._report_footprint(fp)
+
+    def _install_lock(self):
+        lock_path = self._mac_home() / ".install.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        fh = open(lock_path, "w")  # noqa: SIM115 - held until caller closes
+        try:
+            import fcntl
+
+            fcntl.flock(fh, fcntl.LOCK_EX)
+        except Exception:
+            pass
+        return fh
+
+    def ensure_pip(self, specs: List[str], *, reason: str = "agent self-install",
+                   index_url: Optional[str] = None) -> JsonDict:
+        # reject flag-smuggling specs (e.g. "-rfile", "--upgrade"); only real pkgs.
+        specs = [s.strip() for s in (specs or []) if s and not s.strip().startswith("-")]
+        if not specs:
+            return {"ok": True, "skipped": "no specs"}
+        py = self._agent_venv_python()
+        installed = self._pip_installed(py)
+        pending = [s for s in specs if self._pip_base_name(s) not in installed]
+        if not pending:
+            self._update_footprint("pip", specs, index_url=index_url)
+            return {"ok": True, "skipped": "already satisfied", "specs": specs}
+        argv = [py, "-m", "pip", "install", *pending]
+        if index_url:
+            argv += ["--index-url", index_url]
+        lock = self._install_lock()
+        try:
+            result = self._run_install(argv, manager="pip", reason=reason, specs=pending)
+            if result.get("ok"):
+                self._update_footprint("pip", pending, index_url=index_url)
+        finally:
+            lock.close()
+        return result
+
+    def ensure_npm(self, packages: List[str], *, reason: str = "agent self-install") -> JsonDict:
+        packages = [p.strip() for p in (packages or []) if p and not p.strip().startswith("-")]
+        if not packages:
+            return {"ok": True, "skipped": "no packages"}
+        prefix = str(self._mac_home())
+        installed = self._npm_installed(prefix)
+        pending = [p for p in packages if self._npm_base_name(p) not in installed]
+        if not pending:
+            self._update_footprint("npm", packages)
+            return {"ok": True, "skipped": "already satisfied", "packages": packages}
+        argv = ["npm", "install", "--prefix", prefix, *pending]
+        lock = self._install_lock()
+        try:
+            result = self._run_install(argv, manager="npm", reason=reason, specs=pending)
+            if result.get("ok"):
+                self._update_footprint("npm", pending)
+        finally:
+            lock.close()
+        return result
+
     def _heartbeat(self) -> None:
         payload: JsonDict = {"status": "idle"}
         # Declare the build the agent is running. Send the digest at most once
@@ -3115,6 +3291,31 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("MAC_WORKER_RESOURCES"),
         help="JSON resource/capacity object to advertise when --register is used",
     )
+    parser.add_argument(
+        "--install-pip",
+        action="append",
+        default=[],
+        metavar="SPEC",
+        help="pip spec to self-install into the agent venv (repeatable); audited + "
+        "reported to the hub footprint, then exits.",
+    )
+    parser.add_argument(
+        "--install-npm",
+        action="append",
+        default=[],
+        metavar="PKG",
+        help="npm package to self-install under the agent's local prefix (repeatable).",
+    )
+    parser.add_argument(
+        "--install-index-url",
+        default=None,
+        help="optional pip --index-url for --install-pip (e.g. a CUDA wheel index).",
+    )
+    parser.add_argument(
+        "--install-reason",
+        default="agent self-install",
+        help="reason recorded in the command audit for --install-pip/--install-npm.",
+    )
     parser.add_argument("--workspace", default=".mac-agent-workspaces")
     parser.add_argument("--lease-seconds", type=int, default=900)
     # mac-ehch: hard-cap executor runtime so a wedged subprocess can't
@@ -3241,6 +3442,25 @@ def main(argv: Optional[List[str]] = None) -> int:
                     _write_env_value(attestation_env_path, "MAC_ATTESTATION_KEY", attestation_key)
         if not agent_id:
             raise MacApiError("--agent-id or --register is required")
+        if args.install_pip or args.install_npm:
+            # Autonomous self-install: provision tools into the agent's own
+            # environment, audit + report the footprint, then exit.
+            installer = MacWorker(
+                client, agent_id, Path(args.workspace), SubprocessExecutor(["true"])
+            )
+            results: JsonDict = {}
+            if args.install_pip:
+                results["pip"] = installer.ensure_pip(
+                    args.install_pip,
+                    reason=args.install_reason,
+                    index_url=args.install_index_url,
+                )
+            if args.install_npm:
+                results["npm"] = installer.ensure_npm(
+                    args.install_npm, reason=args.install_reason
+                )
+            print(json.dumps({"status": "self-install", "results": results}, indent=2, sort_keys=True))
+            return 0 if all(r.get("ok", True) for r in results.values()) else 1
         if not attestation_key and args.rotate_missing_attestation_key:
             rotated = client.post(
                 "/agents/%s/attestation-key/rotate" % quote(agent_id, safe=""),

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -8180,3 +8180,24 @@ def test_no_publication_target_is_silenced():
     from mac.observability_service import _VERBOSE_POLL_LOG_NAMES
 
     assert "workflow.default_review.no_publication_target" in _VERBOSE_POLL_LOG_NAMES
+
+
+def test_agent_installed_packages_footprint_persists_and_survives_register(cp):
+    """Part C: a self-installed footprint is recorded per-agent, returned by
+    get_agent, and survives re-registration (the register UPSERT must not clobber
+    it). This is the persistent 'default footprint' deploys re-hydrate."""
+    machine = cp.register_machine("gpu-host", resources={"cpu": 4})
+    agent = cp.register_agent(machine.id, "gpu-worker", capabilities=["python"], agent_id="agent_gpu1")
+    fp = {
+        "pip": [{"name": "diffusers", "spec": "diffusers==0.31", "installed_at": "t"}],
+        "npm": [{"name": "left-pad", "spec": "left-pad@1.0", "installed_at": "t"}],
+        "updated_at": "t",
+    }
+    updated = cp.update_agent_installed_packages(agent.id, fp, actor="agent_gpu1")
+    assert updated.installed_packages == fp
+    assert cp.get_agent(agent.id).installed_packages["pip"][0]["name"] == "diffusers"
+    # re-register the SAME agent with new capabilities -> footprint preserved.
+    again = cp.register_agent(machine.id, "gpu-worker", capabilities=["python", "gpu"], agent_id="agent_gpu1")
+    assert again.id == agent.id
+    assert cp.get_agent(agent.id).installed_packages == fp
+    assert "gpu" in cp.get_agent(agent.id).capabilities

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1905,3 +1905,58 @@ def test_mac_worker_completes_task_even_if_observability_writes_fail(tmp_path: P
     assert result.status == "submitted_for_review"
     assert result.task["id"] == task.id
     assert cp.get_task(task.id).state == TaskState.NEEDS_REVIEW.value
+
+
+def test_self_install_name_parsers():
+    assert MacWorker._pip_base_name("diffusers==0.31") == "diffusers"
+    assert MacWorker._pip_base_name("torch>=2 ; python_version>'3'") == "torch"
+    assert MacWorker._pip_base_name("Pillow_SIMD") == "pillow-simd"
+    assert MacWorker._npm_base_name("@scope/pkg@1.2.3") == "@scope/pkg"
+    assert MacWorker._npm_base_name("left-pad@1.0") == "left-pad"
+
+
+def test_mac_worker_self_install_pip_audits_and_reports_footprint(tmp_path: Path, monkeypatch):
+    """Part C1+C2 round-trip: ensure_pip rejects flag-smuggling, runs pip in the
+    agent venv, audits the command, reports the footprint to the hub, and is
+    idempotent (skips an already-satisfied spec)."""
+    cp = ControlPlane.in_memory()
+    agent = register_worker_fixture(cp)
+    client = TestClient(create_app(control_plane=cp))
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=api_transport(client)),
+        agent.id,
+        tmp_path,
+        lambda *a: None,
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "machome"))
+    monkeypatch.setattr(worker, "_pip_installed", lambda py: set())
+
+    calls: Dict[str, Any] = {}
+
+    class _Result:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    def fake_run(argv, **kwargs):
+        calls["argv"] = argv
+        return _Result()
+
+    monkeypatch.setattr("mac.worker.subprocess.run", fake_run)
+
+    result = worker.ensure_pip(["diffusers==0.31", "-rmalicious.txt"], reason="need diffusers")
+    assert result["ok"] is True
+    assert "diffusers==0.31" in calls["argv"]
+    assert "-rmalicious.txt" not in calls["argv"]  # flag-smuggling rejected
+
+    # footprint persisted on the hub (exercises the C2 endpoint + column)
+    footprint = cp.get_agent(agent.id).installed_packages
+    assert any(e["name"] == "diffusers" for e in footprint["pip"])
+
+    # idempotency: report it as already installed -> no subprocess invocation
+    monkeypatch.setattr(worker, "_pip_installed", lambda py: {"diffusers"})
+    calls.clear()
+    again = worker.ensure_pip(["diffusers==0.31"], reason="again")
+    assert again.get("skipped") == "already satisfied"
+    assert "argv" not in calls


### PR DESCRIPTION
Agents can install their own **pip/npm** dependencies into their **own environment with no user prompt** (required for autonomous work), audit every install, and report a persistent **"default footprint"** to the hub. Fully unrestricted per decision: own-venv/prefix only, never the system; the only guards are correctness ones (idempotency, flag-smuggling rejection, file lock, full audit).

## C1 — agent side (`worker.py`)
- `MacWorker.ensure_pip(specs, reason, index_url=None)` / `ensure_npm(packages, reason)`: install into `~/.mac/venv` (pip) / `~/.mac` local prefix (npm) — never bare `pip`, never `-g`. Idempotent (diff vs `pip list`/`npm ls`), rejects flag-smuggling specs, file-locked, audited via `record_command_audit` (`metadata.self_install=True`), writes `~/.mac/agent-footprint.json` and POSTs it to the hub.
- CLI: `mac-agent --install-pip SPEC --install-npm PKG [--install-index-url URL]` → installs, then exits.

## C2 — hub side (`store`/`models`/`services`/`api`)
- New `agents.installed_packages` JSON column (idempotent migration) + `Agent` field + `_agent_from_row` read.
- `update_agent_installed_packages()` persists it + emits an `agent.installed_packages_updated` lifecycle event; **re-registration preserves it** (the register UPSERT doesn't touch the column).
- `POST /agents/{id}/installed-packages` (self-auth via `assert_actor`); footprint flows out of `GET /agents`.

## Tests
Name parsers; `ensure_pip` flag-reject + audit + **hub footprint round-trip** + idempotency (C1→C2 integration); footprint persists + survives re-register. Full `test_control_plane` + `test_worker` suites green (286).

Part C3 (deploy re-hydrates the footprint) follows in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)