### PR TITLE
feat(media): service-role election — hardware- + load-aware media distribution

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -1021,6 +1021,8 @@ deploy_host() {
   add_remote_env MAC_DEPLOY_AGENT_GEN_VIDEO_MODELS "${MAC_DEPLOY_AGENT_GEN_VIDEO_MODELS:-}"
   add_remote_env MAC_DEPLOY_AGENT_GEN_VIDEO_PORT "${MAC_DEPLOY_AGENT_GEN_VIDEO_PORT:-}"
   add_remote_env MAC_DEPLOY_AGENT_MEDIA_ROUTES "${MAC_DEPLOY_AGENT_MEDIA_ROUTES:-}"
+  # media-01 service-role election: ops the fleet wants held (hub seeds + reconciles).
+  add_remote_env MAC_DEPLOY_SERVICE_ROLE_OPS "${MAC_DEPLOY_SERVICE_ROLE_OPS:-}"
   local img_key="${NVIDIA_IMAGE_API_KEY:-}" aud_key="${NVIDIA_AUDIO_API_KEY:-}" vid_key="${NVIDIA_VIDEO_API_KEY:-}"
   if [ "$agent" != "$shared_services_manager" ] && [ "$router_backend_lc" = "inproc" ]; then
     img_key="" ; aud_key="" ; vid_key=""

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -583,6 +583,11 @@ class AgentClaimNextRequest(BaseModel):
     capabilities: List[str] = Field(default_factory=list)
 
 
+class ServiceClaimsSyncRequest(BaseModel):
+    willing_ops: List[str] = Field(default_factory=list)
+    lease_seconds: int = 1800
+
+
 class CommandAuditCreate(BaseModel):
     command_id: Optional[str] = None
     phase: str
@@ -3120,6 +3125,31 @@ def create_app(
                 lease["expires_at"],
             )
         return assignment
+
+    @app.post("/agents/{agent_id}/service-claims/sync")
+    def sync_agent_service_claims(
+        agent_id: str,
+        body: ServiceClaimsSyncRequest,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.assert_actor(agent_id)  # an agent syncs only its OWN service claims
+        return cp.sync_agent_service_claims(
+            agent_id, body.willing_ops, lease_seconds=body.lease_seconds
+        )
+
+    @app.get("/service-roles")
+    def list_service_roles() -> List[Dict[str, Any]]:
+        return [r.to_dict() for r in cp.service_roles.desired_services()]
+
+    @app.get("/service-claims")
+    def list_service_claims(op: Optional[str] = Query(default=None)) -> List[Dict[str, Any]]:
+        role_id = None
+        if op:
+            try:
+                role_id = cp.service_roles.get_role_by_slug("media:%s" % op).id
+            except Exception:  # noqa: BLE001
+                return []
+        return [c.to_dict() for c in cp.service_roles.list_active_claims(role_id=role_id)]
 
     @app.post("/agents/{agent_id}/command-audit")
     def record_agent_command_audit(

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -566,6 +566,8 @@ def build_mac_env(
         ("MAC_DEPLOY_AGENT_GEN_VIDEO_MODELS", "MAC_AGENT_GEN_VIDEO_MODELS"),
         ("MAC_DEPLOY_AGENT_GEN_VIDEO_PORT", "MAC_AGENT_GEN_VIDEO_PORT"),
         ("MAC_DEPLOY_AGENT_MEDIA_ROUTES", "MAC_AGENT_MEDIA_ROUTES"),
+        # media-01 service-role election: ops the fleet wants held (hub seeds these).
+        ("MAC_DEPLOY_SERVICE_ROLE_OPS", "MAC_SERVICE_ROLE_OPS"),
     ):
         _v = (env.get(_src) or "").strip()
         if _v:

--- a/src/mac/models.py
+++ b/src/mac/models.py
@@ -146,6 +146,12 @@ class LeaseStatus(StrEnum):
     RENEWED = "renewed"
 
 
+class ServiceClaimStatus(StrEnum):
+    ACTIVE = "active"
+    EXPIRED = "expired"
+    RELEASED = "released"
+
+
 class ReviewStatus(StrEnum):
     PENDING = "pending"
     APPROVED = "approved"
@@ -492,6 +498,43 @@ class Lease:
     # evidence on the lease's task. The lease owner (``agent_id``) still
     # owns renewal and release.
     delegated_agent_id: Optional[str] = None
+
+    def to_dict(self) -> JsonDict:
+        return asdict(self)
+
+
+@dataclass
+class ServiceRole:
+    """A media service the cluster wants held by some capable host (media-01
+    role-claims). The op is served by a catalog model; required_capabilities +
+    hardware_requirements gate which agents are eligible to claim it."""
+    id: str
+    op: str
+    slug: str
+    model_id: Optional[str]
+    required_capabilities: List[str]
+    hardware_requirements: JsonDict
+    enabled: bool
+    tenant_id: Optional[str]
+    metadata: JsonDict
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> JsonDict:
+        return asdict(self)
+
+
+@dataclass
+class ServiceClaim:
+    """A capable host's leased hold on a service_role (mirrors Lease). Renewed by
+    the holder's worker loop; expires on silence/overload; reopened for reclaim."""
+    id: str
+    service_role_id: str
+    agent_id: str
+    status: str
+    expires_at: str
+    created_at: str
+    updated_at: str
 
     def to_dict(self) -> JsonDict:
         return asdict(self)

--- a/src/mac/service_role_service.py
+++ b/src/mac/service_role_service.py
@@ -1,0 +1,248 @@
+"""Service-role election: media services as leased role-claims (media-01).
+
+A SERVICE (image/audio/video/ASR generation) is a leased role a capable host
+CLAIMS — the same sticky-until-timeout-then-reclaimable lifecycle a task lease
+has. ``service_roles`` is the desired state (what ops the cluster wants served);
+``service_claims`` is the leased holder (mirrors ``leases``). Pool model: many
+hosts may hold the same op; the DB unique-active index only stops one host from
+double-holding it. Eligibility + capacity policy lives in the control plane
+(services.py); this module is the pure CRUD + the atomic claim/renew/expire that
+mirrors claim_task/renew_lease/expire_leases.
+"""
+from __future__ import annotations
+
+import sqlite3
+from datetime import timedelta
+from typing import Any, List, Optional
+
+from mac.models import (
+    JsonDict,
+    NotFoundError,
+    ServiceClaim,
+    ServiceClaimStatus,
+    ServiceRole,
+    coerce_list,
+    ensure_json_object,
+    json_dumps,
+    json_loads,
+    new_id,
+    parse_time,
+    utcnow,
+)
+from mac.observability_service import ObservabilityService
+
+
+class ServiceRoleService:
+    def __init__(self, store: Any, observability: ObservabilityService) -> None:
+        self.store = store
+        self.observability = observability
+
+    # --- roles (desired services) --------------------------------------
+
+    def upsert_role(
+        self,
+        op: str,
+        *,
+        slug: Optional[str] = None,
+        model_id: Optional[str] = None,
+        required_capabilities: Optional[List[str]] = None,
+        hardware_requirements: Optional[JsonDict] = None,
+        enabled: bool = True,
+        tenant_id: Optional[str] = None,
+        metadata: Optional[JsonDict] = None,
+    ) -> ServiceRole:
+        op = (op or "").strip()
+        if not op:
+            raise ValueError("service role op is required")
+        slug = (slug or ("media:%s" % op)).strip()
+        now = utcnow()
+        rid = new_id("srole")
+        self.store.execute(
+            """
+            INSERT INTO service_roles (
+                id, op, slug, model_id, required_capabilities, hardware_requirements,
+                enabled, tenant_id, metadata, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(slug, tenant_id) DO UPDATE SET
+                op = excluded.op,
+                model_id = excluded.model_id,
+                required_capabilities = excluded.required_capabilities,
+                hardware_requirements = excluded.hardware_requirements,
+                enabled = excluded.enabled,
+                metadata = excluded.metadata,
+                updated_at = excluded.updated_at
+            """,
+            (
+                rid, op, slug, model_id,
+                json_dumps(coerce_list(required_capabilities or [])),
+                json_dumps(ensure_json_object(hardware_requirements or {})),
+                1 if enabled else 0, tenant_id,
+                json_dumps(ensure_json_object(metadata or {})), now, now,
+            ),
+        )
+        return self.get_role_by_slug(slug, tenant_id=tenant_id)
+
+    def get_role(self, role_id: str) -> ServiceRole:
+        row = self.store.query_one("SELECT * FROM service_roles WHERE id = ?", (role_id,))
+        if row is None:
+            raise NotFoundError("service role %r not found" % role_id)
+        return self._role_from_row(row)
+
+    def get_role_by_slug(self, slug: str, *, tenant_id: Optional[str] = None) -> ServiceRole:
+        row = self.store.query_one(
+            "SELECT * FROM service_roles WHERE slug = ? AND tenant_id IS ?",
+            (slug, tenant_id),
+        )
+        if row is None:
+            raise NotFoundError("service role %r not found" % slug)
+        return self._role_from_row(row)
+
+    def desired_services(self, *, tenant_id: Optional[str] = None) -> List[ServiceRole]:
+        rows = self.store.query_all(
+            "SELECT * FROM service_roles WHERE enabled = 1 AND (tenant_id IS ? OR tenant_id IS NULL)",
+            (tenant_id,),
+        )
+        return [self._role_from_row(r) for r in rows]
+
+    # --- claims (leased holders) ---------------------------------------
+
+    def claim_service(self, role_id: str, agent_id: str, lease_seconds: int = 1800) -> ServiceClaim:
+        """Atomically claim (or renew) a host's hold on a service role. The
+        unique-active index makes the INSERT the split-brain guard: a second
+        active claim by the SAME agent for the SAME role is rejected (and renewed
+        instead). Other agents may hold the same role (pool model)."""
+        existing = self._active_claim(role_id, agent_id)
+        if existing is not None:
+            return self.renew_service_claim(existing.id, agent_id, lease_seconds)
+        now = utcnow()
+        expires_at = (parse_time(now) + timedelta(seconds=int(lease_seconds))).isoformat()
+        cid = new_id("sclaim")
+        try:
+            self.store.execute(
+                """
+                INSERT INTO service_claims (
+                    id, service_role_id, agent_id, status, expires_at, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (cid, role_id, agent_id, ServiceClaimStatus.ACTIVE.value, expires_at, now, now),
+            )
+        except sqlite3.IntegrityError:
+            existing = self._active_claim(role_id, agent_id)
+            if existing is not None:
+                return existing
+            raise
+        return self._claim(cid)
+
+    def renew_service_claim(self, claim_id: str, agent_id: str, lease_seconds: int = 1800) -> ServiceClaim:
+        now = utcnow()
+        expires_at = (parse_time(now) + timedelta(seconds=int(lease_seconds))).isoformat()
+        self.store.execute(
+            "UPDATE service_claims SET expires_at = ?, updated_at = ? "
+            "WHERE id = ? AND agent_id = ? AND status = ?",
+            (expires_at, now, claim_id, agent_id, ServiceClaimStatus.ACTIVE.value),
+        )
+        return self._claim(claim_id)
+
+    def release_service_claim(self, claim_id: str, agent_id: Optional[str] = None, *, reason: str = "released") -> None:
+        now = utcnow()
+        if agent_id is None:
+            self.store.execute(
+                "UPDATE service_claims SET status = ?, updated_at = ? WHERE id = ? AND status = ?",
+                (ServiceClaimStatus.RELEASED.value, now, claim_id, ServiceClaimStatus.ACTIVE.value),
+            )
+        else:
+            self.store.execute(
+                "UPDATE service_claims SET status = ?, updated_at = ? "
+                "WHERE id = ? AND agent_id = ? AND status = ?",
+                (ServiceClaimStatus.RELEASED.value, now, claim_id, agent_id, ServiceClaimStatus.ACTIVE.value),
+            )
+
+    def expire_service_claims(self, now: Optional[str] = None, *, grace_seconds: int = 60) -> List[ServiceClaim]:
+        """Sweep active claims past expiry (holder stopped renewing = silent or
+        overloaded) → status=expired, slot reopens. Race-guarded on status."""
+        cutoff = (parse_time(utcnow()) - timedelta(seconds=int(grace_seconds))).isoformat()
+        rows = self.store.query_all(
+            "SELECT * FROM service_claims WHERE status = ? AND expires_at <= ?",
+            (ServiceClaimStatus.ACTIVE.value, cutoff),
+        )
+        expired: List[ServiceClaim] = []
+        stamp = utcnow()
+        for row in rows:
+            claim = self._claim_from_row(row)
+            self.store.execute(
+                "UPDATE service_claims SET status = ?, updated_at = ? WHERE id = ? AND status = ?",
+                (ServiceClaimStatus.EXPIRED.value, stamp, claim.id, ServiceClaimStatus.ACTIVE.value),
+            )
+            expired.append(claim)
+        return expired
+
+    def expire_agent_claims(self, agent_id: str, *, reason: str = "agent_offline") -> List[ServiceClaim]:
+        """Expire all of an agent's active service claims (e.g. it went offline)."""
+        rows = self.store.query_all(
+            "SELECT * FROM service_claims WHERE agent_id = ? AND status = ?",
+            (agent_id, ServiceClaimStatus.ACTIVE.value),
+        )
+        now = utcnow()
+        out: List[ServiceClaim] = []
+        for row in rows:
+            claim = self._claim_from_row(row)
+            self.store.execute(
+                "UPDATE service_claims SET status = ?, updated_at = ? WHERE id = ? AND status = ?",
+                (ServiceClaimStatus.EXPIRED.value, now, claim.id, ServiceClaimStatus.ACTIVE.value),
+            )
+            out.append(claim)
+        return out
+
+    def list_active_claims(self, *, role_id: Optional[str] = None, agent_id: Optional[str] = None) -> List[ServiceClaim]:
+        sql = "SELECT * FROM service_claims WHERE status = ?"
+        params: List[Any] = [ServiceClaimStatus.ACTIVE.value]
+        if role_id is not None:
+            sql += " AND service_role_id = ?"
+            params.append(role_id)
+        if agent_id is not None:
+            sql += " AND agent_id = ?"
+            params.append(agent_id)
+        return [self._claim_from_row(r) for r in self.store.query_all(sql, tuple(params))]
+
+    def held_ops_for_agent(self, agent_id: str) -> List[str]:
+        rows = self.store.query_all(
+            """
+            SELECT r.op AS op FROM service_claims c
+            JOIN service_roles r ON r.id = c.service_role_id
+            WHERE c.agent_id = ? AND c.status = ?
+            """,
+            (agent_id, ServiceClaimStatus.ACTIVE.value),
+        )
+        return [str(r["op"]) for r in rows]
+
+    # --- row mappers ---------------------------------------------------
+
+    def _active_claim(self, role_id: str, agent_id: str) -> Optional[ServiceClaim]:
+        row = self.store.query_one(
+            "SELECT * FROM service_claims WHERE service_role_id = ? AND agent_id = ? AND status = ?",
+            (role_id, agent_id, ServiceClaimStatus.ACTIVE.value),
+        )
+        return self._claim_from_row(row) if row is not None else None
+
+    def _claim(self, claim_id: str) -> ServiceClaim:
+        row = self.store.query_one("SELECT * FROM service_claims WHERE id = ?", (claim_id,))
+        if row is None:
+            raise NotFoundError("service claim %r not found" % claim_id)
+        return self._claim_from_row(row)
+
+    def _role_from_row(self, row: Any) -> ServiceRole:
+        return ServiceRole(
+            id=row["id"], op=row["op"], slug=row["slug"], model_id=row["model_id"],
+            required_capabilities=json_loads(row["required_capabilities"], []),
+            hardware_requirements=json_loads(row["hardware_requirements"], {}),
+            enabled=bool(row["enabled"]), tenant_id=row["tenant_id"],
+            metadata=json_loads(row["metadata"], {}),
+            created_at=row["created_at"], updated_at=row["updated_at"],
+        )
+
+    def _claim_from_row(self, row: Any) -> ServiceClaim:
+        return ServiceClaim(
+            id=row["id"], service_role_id=row["service_role_id"], agent_id=row["agent_id"],
+            status=row["status"], expires_at=row["expires_at"],
+            created_at=row["created_at"], updated_at=row["updated_at"],
+        )

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -117,6 +117,7 @@ from mac.messaging_service import MessagingService
 from mac.notifier_service import NotifierService
 from mac.observability_service import ObservabilityService
 from mac.provisioning_service import ProvisioningService
+from mac.service_role_service import ServiceRoleService
 from mac.review_service import ReviewService
 from mac.roles_service import RolesService
 from mac.rollout_service import RolloutService
@@ -588,6 +589,7 @@ class ControlPlane:
         self.observability = ObservabilityService(self.store)
         self.agentbus = AgentBusService(self.store, self.observability)
         self.provisioning = ProvisioningService(self.store, self.observability)
+        self.service_roles = ServiceRoleService(self.store, self.observability)
         self.roles = RolesService(
             self.store,
             self.observability,
@@ -6271,6 +6273,10 @@ class ControlPlane:
             updates.append("current_task_id = NULL")
         if status_value == AgentStatus.OFFLINE.value:
             self._expire_agent_active_leases(agent_id, now, "heartbeat_offline")
+            try:
+                self.service_roles.expire_agent_claims(agent_id, reason="heartbeat_offline")
+            except Exception:  # noqa: BLE001 - best-effort service-claim cleanup
+                pass
         if status_value in {AgentStatus.IDLE.value, AgentStatus.OFFLINE.value}:
             updates.append("current_task_id = NULL")
         params.append(agent_id)
@@ -7358,6 +7364,10 @@ class ControlPlane:
                 for agent in self.mark_stale_agents_offline(stale_after_seconds)
             ]
         expired = [task.to_dict() for task in self.expire_leases()]
+        try:
+            self.reconcile_service_roles()  # media-01: reap stale claims + signal zero-holder ops
+        except Exception:  # noqa: BLE001 - reconcile must never break the tick
+            pass
         self._unblock_ready_tasks()
         review_workflows = self.advance_default_review_workflows(limit=limit)
         assignments = []
@@ -13537,6 +13547,159 @@ class ControlPlane:
             if value is not None:
                 return max(1, int(value))
         return 1
+
+    # --- service-role election (media-01) -------------------------------
+
+    def _agent_eligible_for_service(self, agent: Agent, role: ServiceRole) -> bool:
+        """Capability + hardware fit (uses reported GPU hw + the catalog VRAM
+        floor). Capacity is checked separately in the sync loop."""
+        if not set(role.required_capabilities).issubset(set(agent.capabilities or [])):
+            return False
+        hw = agent.resources.get("hardware") if isinstance(agent.resources, dict) else None
+        if role.hardware_requirements:
+            from mac.roles_service import machine_hardware_satisfies
+
+            ok, _reasons = machine_hardware_satisfies(role.hardware_requirements, hw or {})
+            if not ok:
+                return False
+        if role.model_id:
+            try:
+                from mac.local_gen_catalog import get_model, models_for_hardware
+
+                model = get_model(role.model_id)
+                if model is not None and model not in models_for_hardware(hw):
+                    return False
+            except Exception:  # noqa: BLE001 - catalog is optional
+                pass
+        return True
+
+    def _service_holder_live(self, agent_id: str) -> bool:
+        try:
+            agent = self.get_agent(agent_id)
+        except Exception:  # noqa: BLE001
+            return False
+        return agent.status != AgentStatus.OFFLINE.value
+
+    def sync_agent_service_claims(
+        self, agent_id: str, willing_ops: Iterable[str], *, lease_seconds: int = 1800
+    ) -> JsonDict:
+        """A capable host declares the ops it's willing+able to run; the hub
+        renews its still-willing held ops, releases ones it no longer wants, and
+        claims new eligible ops up to the agent's capacity (so ops spread to
+        hosts with headroom). Returns the authoritative held-op set."""
+        agent = self.get_agent(agent_id)
+        willing = {str(op).strip() for op in (willing_ops or []) if str(op).strip()}
+        capacity = self._agent_capacity(agent)
+        roles_by_op = {r.op: r for r in self.service_roles.desired_services(tenant_id=None)}
+        held_ops: Dict[str, Any] = {}
+        for claim in self.service_roles.list_active_claims(agent_id=agent_id):
+            try:
+                op = self.service_roles.get_role(claim.service_role_id).op
+            except Exception:  # noqa: BLE001
+                continue
+            held_ops[op] = claim
+        # release held ops no longer willing/desired
+        for op, claim in list(held_ops.items()):
+            if op not in willing or op not in roles_by_op:
+                self.service_roles.release_service_claim(claim.id, agent_id, reason="not_willing")
+                del held_ops[op]
+        # renew still-held
+        for claim in held_ops.values():
+            self.service_roles.renew_service_claim(claim.id, agent_id, lease_seconds)
+        # claim new eligible willing ops, capacity-bounded. Prefer the LEAST-served
+        # ops (fewest current live holders) so the pool spreads to cover every op
+        # instead of every host piling onto the same one.
+        load = len(held_ops) + self._agent_active_lease_count(agent_id)
+        candidates = [
+            op for op in willing
+            if op not in held_ops and op in roles_by_op and roles_by_op[op].enabled
+        ]
+
+        def _holder_count(op: str) -> int:
+            return len(self.service_roles.list_active_claims(role_id=roles_by_op[op].id))
+
+        for op in sorted(candidates, key=lambda o: (_holder_count(o), o)):
+            if load >= capacity:
+                break  # at capacity -> leave the op for a host with headroom (spread)
+            role = roles_by_op[op]
+            if not self._agent_eligible_for_service(agent, role):
+                continue
+            try:
+                self.service_roles.claim_service(role.id, agent_id, lease_seconds)
+            except Exception:  # noqa: BLE001
+                continue
+            held_ops[op] = True
+            load += 1
+        # "managed" = ops that have a service_role (election active). Ops NOT managed
+        # are advertised unconditionally by the worker (back-compat: a fleet that
+        # seeds no service_roles keeps today's advertise-all behavior).
+        return {
+            "held": sorted(held_ops.keys()),
+            "managed": sorted(roles_by_op.keys()),
+            "capacity": capacity,
+        }
+
+    def reconcile_service_roles(self) -> JsonDict:
+        """Periodic (called from tick): seed desired ops from MAC_SERVICE_ROLE_OPS
+        (opt-in; unset = no election, agents advertise as before), expire silent/
+        overloaded holders, drop offline holders, and emit a provisioning demand
+        signal for any desired op with zero live holders ("the cluster needs a
+        <op> agent")."""
+        ops_env = (os.environ.get("MAC_SERVICE_ROLE_OPS") or "").strip()
+        if ops_env:
+            wanted = [o.strip() for o in ops_env.split(",") if o.strip()]
+            existing = {r.op for r in self.service_roles.desired_services(tenant_id=None)}
+            if any(o not in existing for o in wanted):
+                self.seed_service_roles(wanted)
+        expired = self.service_roles.expire_service_claims()
+        requested: List[str] = []
+        for role in self.service_roles.desired_services(tenant_id=None):
+            live = [
+                c for c in self.service_roles.list_active_claims(role_id=role.id)
+                if self._service_holder_live(c.agent_id)
+            ]
+            for claim in self.service_roles.list_active_claims(role_id=role.id):
+                if not self._service_holder_live(claim.agent_id):
+                    self.service_roles.release_service_claim(claim.id, reason="holder_offline")
+            if not live:
+                try:
+                    self.provisioning.request_agent(
+                        reason="service_role:%s" % role.slug,
+                        capabilities=role.required_capabilities,
+                        hardware=role.hardware_requirements,
+                        detail={"op": role.op, "model_id": role.model_id},
+                        requested_by="service-role-reconciler",
+                    )
+                    requested.append(role.op)
+                except Exception:  # noqa: BLE001 - demand signal is best-effort
+                    pass
+        return {"expired": len(expired), "requested": requested}
+
+    def seed_service_roles(self, ops: Iterable[Any]) -> int:
+        """Idempotently seed/enable a desired service_role per op. Each op is a
+        dict {op, model_id, capabilities?} or a bare op string (model from the
+        catalog)."""
+        from mac.local_gen_catalog import LOCAL_GEN_MODELS
+
+        by_op_default = {}
+        for m in LOCAL_GEN_MODELS:
+            if m.routable:
+                by_op_default.setdefault(m.op, m.id)
+        count = 0
+        for spec in ops:
+            if isinstance(spec, dict):
+                op = str(spec.get("op") or "").strip()
+                model_id = spec.get("model_id") or by_op_default.get(op)
+                caps = spec.get("capabilities") or ["gpu"]
+            else:
+                op = str(spec).strip()
+                model_id = by_op_default.get(op)
+                caps = ["gpu"]
+            if not op:
+                continue
+            self.service_roles.upsert_role(op, model_id=model_id, required_capabilities=caps)
+            count += 1
+        return count
 
     def _task_tenant_id(self, task: Task) -> Optional[str]:
         origin = task.metadata.get("origin")

--- a/src/mac/store.py
+++ b/src/mac/store.py
@@ -352,6 +352,40 @@ class SQLiteStore:
                 CREATE UNIQUE INDEX IF NOT EXISTS uniq_leases_active_per_task
                     ON leases (task_id) WHERE status = 'active';
 
+                -- media-01 service-role election: desired media services + the
+                -- leased holds capable hosts claim (mirrors tasks+leases).
+                CREATE TABLE IF NOT EXISTS service_roles (
+                    id TEXT PRIMARY KEY,
+                    op TEXT NOT NULL,
+                    slug TEXT NOT NULL,
+                    model_id TEXT,
+                    required_capabilities TEXT NOT NULL DEFAULT '[]',
+                    hardware_requirements TEXT NOT NULL DEFAULT '{}',
+                    enabled INTEGER NOT NULL DEFAULT 1,
+                    tenant_id TEXT REFERENCES tenants(id) ON DELETE CASCADE,
+                    metadata TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    UNIQUE(slug, tenant_id)
+                );
+                CREATE TABLE IF NOT EXISTS service_claims (
+                    id TEXT PRIMARY KEY,
+                    service_role_id TEXT NOT NULL REFERENCES service_roles(id) ON DELETE CASCADE,
+                    agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+                    status TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_service_claims_role_status
+                    ON service_claims (service_role_id, status);
+                CREATE INDEX IF NOT EXISTS idx_service_claims_agent_status
+                    ON service_claims (agent_id, status);
+                -- Pool model: a host holds an op at most once; multiple hosts may
+                -- hold the same op. Split-brain guard at the DB layer.
+                CREATE UNIQUE INDEX IF NOT EXISTS uniq_service_claims_active_per_role_agent
+                    ON service_claims (service_role_id, agent_id) WHERE status = 'active';
+
                 CREATE TABLE IF NOT EXISTS machines (
                     id TEXT PRIMARY KEY,
                     hostname TEXT NOT NULL,

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -219,6 +219,41 @@ class SubprocessExecutor:
             pass
 
 
+def _build_willing_media_routes(host: str, hardware: Optional[JsonDict]) -> List[JsonDict]:
+    """All media routes this host is configured (willing) to serve: catalog-
+    derived + GPU-gated (advertised_media_routes returns [] off-GPU). One server
+    per modality — image :8189, audio :8190, video :8191. Shared by registration
+    and the service-claim sync (advertise-on-hold)."""
+    try:
+        from mac.local_gen_catalog import advertised_media_routes
+    except Exception:  # noqa: BLE001
+        return []
+    gen_host = (os.environ.get("MAC_AGENT_GEN_HOST") or host).strip()
+
+    def _base(base_env: str, port_env: str, default_port: str) -> str:
+        explicit = (os.environ.get(base_env) or "").strip()
+        if explicit:
+            return explicit
+        port = (os.environ.get(port_env) or default_port).strip()
+        return "http://%s:%s/v1" % (gen_host, port)
+
+    routes: List[JsonDict] = []
+    img = (os.environ.get("MAC_AGENT_GEN_MODEL") or "").strip()
+    if img:
+        routes.extend(advertised_media_routes(
+            img, _base("MAC_AGENT_GEN_BASE_URL", "MAC_AGENT_GEN_PORT", "8189"), hardware))
+    for models_env, base_env, port_env, default_port in (
+        ("MAC_AGENT_GEN_AUDIO_MODELS", "MAC_AGENT_GEN_AUDIO_BASE_URL", "MAC_AGENT_GEN_AUDIO_PORT", "8190"),
+        ("MAC_AGENT_GEN_VIDEO_MODELS", "MAC_AGENT_GEN_VIDEO_BASE_URL", "MAC_AGENT_GEN_VIDEO_PORT", "8191"),
+    ):
+        base = _base(base_env, port_env, default_port)
+        for model_id in (os.environ.get(models_env) or "").split(","):
+            model_id = model_id.strip()
+            if model_id:
+                routes.extend(advertised_media_routes(model_id, base, hardware))
+    return routes
+
+
 def register_worker(
     client: MacApiClient,
     hostname: Optional[str] = None,
@@ -268,42 +303,13 @@ def register_worker(
         except ValueError:
             _routes = None
     else:
-        # Catalog-derived, GPU-gated routes for each configured local gen server:
-        # image (MAC_AGENT_GEN_MODEL @ :8189), and CSV model lists for audio
-        # (MAC_AGENT_GEN_AUDIO_MODELS @ :8190) + video (MAC_AGENT_GEN_VIDEO_MODELS
-        # @ :8191), all on one server per modality. advertised_media_routes
-        # self-gates on hardware, so a CPU agent advertises nothing.
-        try:
-            from mac.local_gen_catalog import advertised_media_routes
-
-            hw = resources.get("hardware") if isinstance(resources, dict) else None
-            gen_host = (os.environ.get("MAC_AGENT_GEN_HOST") or host).strip()
-
-            def _base(base_env: str, port_env: str, default_port: str) -> str:
-                explicit = (os.environ.get(base_env) or "").strip()
-                if explicit:
-                    return explicit
-                port = (os.environ.get(port_env) or default_port).strip()
-                return "http://%s:%s/v1" % (gen_host, port)
-
-            derived: List[JsonDict] = []
-            _img = (os.environ.get("MAC_AGENT_GEN_MODEL") or "").strip()
-            if _img:
-                derived.extend(advertised_media_routes(
-                    _img, _base("MAC_AGENT_GEN_BASE_URL", "MAC_AGENT_GEN_PORT", "8189"), hw))
-            for models_env, base_env, port_env, default_port in (
-                ("MAC_AGENT_GEN_AUDIO_MODELS", "MAC_AGENT_GEN_AUDIO_BASE_URL", "MAC_AGENT_GEN_AUDIO_PORT", "8190"),
-                ("MAC_AGENT_GEN_VIDEO_MODELS", "MAC_AGENT_GEN_VIDEO_BASE_URL", "MAC_AGENT_GEN_VIDEO_PORT", "8191"),
-            ):
-                base = _base(base_env, port_env, default_port)
-                for model_id in (os.environ.get(models_env) or "").split(","):
-                    model_id = model_id.strip()
-                    if model_id:
-                        derived.extend(advertised_media_routes(model_id, base, hw))
-            if derived:
-                _routes = derived
-        except Exception:  # noqa: BLE001 - advertisement is best-effort
-            _routes = None
+        # Catalog-derived, GPU-gated routes for each configured local gen server.
+        # The worker's service-claim sync (advertise-on-hold) narrows this to the
+        # ops the agent actually HOLDS; here we stamp the willing set initially.
+        hw = resources.get("hardware") if isinstance(resources, dict) else None
+        derived = _build_willing_media_routes(host, hw)
+        if derived:
+            _routes = derived
     if _routes:
         resources = {**(resources or {}), "media_routes": _routes}
     machine = client.post(
@@ -475,6 +481,7 @@ class MacWorker:
 
     def run_once(self) -> WorkerRunResult:
         self._heartbeat()
+        self._maybe_sync_service_claims()
         control_result = self._process_agentbus_control()
         if control_result and control_result.get("restart_requested"):
             self.stop()
@@ -2269,6 +2276,56 @@ class MacWorker:
         finally:
             lock.close()
         return result
+
+    def _maybe_sync_service_claims(self) -> None:
+        # media-01: claim/renew the media service-roles this host is willing to
+        # run, and advertise only the ops it currently HOLDS. Throttled + fully
+        # best-effort (never breaks the run loop).
+        import time as _t
+
+        now = _t.monotonic()
+        last = getattr(self, "_last_service_sync", None)
+        if last is not None and (now - last) < 30.0:
+            return
+        self._last_service_sync = now
+        try:
+            self._sync_service_claims()
+        except Exception:  # noqa: BLE001 - service sync must never break the loop
+            pass
+
+    def _sync_service_claims(self) -> None:
+        host = (os.environ.get("MAC_AGENT_GEN_HOST") or socket.gethostname()).strip()
+        try:
+            agent = self.client.get("/agents/%s" % quote(self.agent_id, safe=""))
+        except Exception:  # noqa: BLE001
+            return
+        base = dict((agent or {}).get("resources") or {})
+        all_routes = _build_willing_media_routes(host, base.get("hardware"))
+        willing_ops = sorted({str(r.get("op")) for r in all_routes if r.get("op")})
+        if not willing_ops:
+            return
+        try:
+            res = self.client.post(
+                "/agents/%s/service-claims/sync" % quote(self.agent_id, safe=""),
+                {"willing_ops": willing_ops},
+            )
+        except Exception:  # noqa: BLE001
+            return
+        held = set((res or {}).get("held") or [])
+        managed = set((res or {}).get("managed") or [])
+        # advertise-on-hold: advertise an op if we HOLD its claim, OR if it isn't
+        # managed by a service_role at all (back-compat: no roles seeded -> advertise
+        # everything we're willing+able to serve, as before).
+        base["media_routes"] = [
+            r for r in all_routes if r.get("op") in held or r.get("op") not in managed
+        ]
+        try:
+            self.client.post(
+                "/agents/%s/heartbeat" % quote(self.agent_id, safe=""),
+                {"status": "idle", "resources": base},
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
     def _heartbeat(self) -> None:
         payload: JsonDict = {"status": "idle"}

--- a/tests/test_service_role_service.py
+++ b/tests/test_service_role_service.py
@@ -1,0 +1,121 @@
+"""media-01 service-role election: claim/sync/reconcile lifecycle."""
+from __future__ import annotations
+
+from mac.services import ControlPlane
+
+GPU_HW = {"accelerator": "cuda", "gpu": {"name": "X", "vram_mb": 48000}, "memory_mb": 120000}
+OPS = ["image.generate", "audio.tts", "audio.music", "audio.asr", "video.generate"]
+
+
+def _gpu_agent(cp, name, capacity=3):
+    m = cp.register_machine("%s-host" % name, resources={})
+    return cp.register_agent(
+        m.id, name, capabilities=["gpu", "cuda"],
+        resources={"hardware": GPU_HW, "capacity": capacity},
+    )
+
+
+def _seed(cp):
+    cp.seed_service_roles(OPS)
+
+
+def test_sync_claims_eligible_ops_up_to_capacity():
+    cp = ControlPlane.in_memory()
+    _seed(cp)
+    a = _gpu_agent(cp, "natasha", capacity=2)
+    res = cp.sync_agent_service_claims(a.id, ["image.generate", "audio.tts", "video.generate"])
+    assert res["capacity"] == 2
+    assert len(res["held"]) == 2  # capacity-bounded
+    assert set(res["held"]).issubset({"image.generate", "audio.tts", "video.generate"})
+
+
+def test_pool_spreads_across_hosts():
+    cp = ControlPlane.in_memory()
+    _seed(cp)
+    a = _gpu_agent(cp, "natasha", capacity=2)
+    b = _gpu_agent(cp, "madmax", capacity=2)
+    willing = ["image.generate", "audio.tts", "audio.music", "video.generate"]
+    held_a = set(cp.sync_agent_service_claims(a.id, willing)["held"])
+    held_b = set(cp.sync_agent_service_claims(b.id, willing)["held"])
+    assert len(held_a) == 2 and len(held_b) == 2
+    # pool model: together they cover more ops than any one host (spread)
+    assert len(held_a | held_b) >= 3
+
+
+def test_cpu_agent_is_ineligible():
+    cp = ControlPlane.in_memory()
+    _seed(cp)
+    m = cp.register_machine("rocky-host", resources={})
+    a = cp.register_agent(
+        m.id, "rocky", capabilities=["python"],
+        resources={"hardware": {"accelerator": "none"}, "capacity": 5},
+    )
+    res = cp.sync_agent_service_claims(a.id, ["image.generate", "audio.tts"])
+    assert res["held"] == []  # no gpu capability + no accelerator
+
+
+def test_under_vram_hardware_is_ineligible():
+    cp = ControlPlane.in_memory()
+    _seed(cp)
+    m = cp.register_machine("small-host", resources={})
+    a = cp.register_agent(
+        m.id, "small", capabilities=["gpu", "cuda"],
+        resources={"hardware": {"accelerator": "cuda", "gpu": {"vram_mb": 5000}}, "capacity": 5},
+    )
+    res = cp.sync_agent_service_claims(a.id, ["video.generate"])  # svd needs 15GB
+    assert "video.generate" not in res["held"]
+
+
+def test_release_on_unwilling_then_renew():
+    cp = ControlPlane.in_memory()
+    _seed(cp)
+    a = _gpu_agent(cp, "natasha", capacity=5)
+    cp.sync_agent_service_claims(a.id, ["image.generate", "audio.tts"])
+    assert set(cp.service_roles.held_ops_for_agent(a.id)) == {"image.generate", "audio.tts"}
+    cp.sync_agent_service_claims(a.id, ["image.generate"])  # drop audio.tts
+    assert set(cp.service_roles.held_ops_for_agent(a.id)) == {"image.generate"}
+
+
+def test_expire_reopens_and_reconcile_signals_zero_holders():
+    cp = ControlPlane.in_memory()
+    _seed(cp)
+    a = _gpu_agent(cp, "natasha", capacity=5)
+    cp.sync_agent_service_claims(a.id, ["image.generate"])
+    role = cp.service_roles.get_role_by_slug("media:image.generate")
+    # renew into the past, then sweep with no grace -> expired, slot reopens
+    cp.service_roles.claim_service(role.id, a.id, lease_seconds=-100)
+    expired = cp.service_roles.expire_service_claims(grace_seconds=0)
+    assert any(c.agent_id == a.id for c in expired)
+    assert cp.service_roles.list_active_claims(role_id=role.id) == []
+    out = cp.reconcile_service_roles()
+    assert "image.generate" in out["requested"]  # cluster needs an image agent
+
+
+def test_one_agent_cannot_double_hold_an_op():
+    cp = ControlPlane.in_memory()
+    _seed(cp)
+    a = _gpu_agent(cp, "natasha", capacity=5)
+    role = cp.service_roles.get_role_by_slug("media:image.generate")
+    c1 = cp.service_roles.claim_service(role.id, a.id)
+    c2 = cp.service_roles.claim_service(role.id, a.id)  # same agent+op -> renew, not duplicate
+    assert c1.id == c2.id
+    assert len(cp.service_roles.list_active_claims(role_id=role.id)) == 1
+
+
+def test_reconcile_auto_seeds_from_env_and_signals_zero_holders(monkeypatch):
+    cp = ControlPlane.in_memory()
+    monkeypatch.setenv("MAC_SERVICE_ROLE_OPS", "image.generate, video.generate")
+    out = cp.reconcile_service_roles()
+    ops = {r.op for r in cp.service_roles.desired_services()}
+    assert {"image.generate", "video.generate"} <= ops  # auto-seeded
+    assert set(out["requested"]) == {"image.generate", "video.generate"}  # zero holders
+
+
+def test_offline_holder_is_reaped_by_reconcile():
+    cp = ControlPlane.in_memory()
+    _seed(cp)
+    a = _gpu_agent(cp, "natasha", capacity=5)
+    cp.sync_agent_service_claims(a.id, ["image.generate"])
+    assert cp.service_roles.held_ops_for_agent(a.id) == ["image.generate"]
+    cp.heartbeat_agent(a.id, status="offline")  # agent goes offline -> claims expired
+    assert cp.service_roles.held_ops_for_agent(a.id) == []

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2032,3 +2032,52 @@ def test_register_worker_advertises_multi_modality_routes(monkeypatch):
     assert ":8190/" in by_op["audio.tts"]["base_url"]
     assert ":8190/" in by_op["audio.music"]["base_url"]
     assert ":8191/" in by_op["video.generate"]["base_url"]
+
+
+def test_worker_advertises_only_held_service_ops(tmp_path: Path, monkeypatch):
+    """media-01 advertise-on-hold: the worker claims service-roles up to capacity
+    and re-stamps media_routes to ONLY the ops it currently holds."""
+    cp = ControlPlane.in_memory()
+    cp.seed_service_roles(["image.generate", "audio.tts", "video.generate"])
+    api = MacApiClient("http://mac.test", transport=api_transport(TestClient(create_app(control_plane=cp))))
+    monkeypatch.setattr(
+        "mac.hardware.detect_hardware",
+        lambda: {"accelerator": "cuda", "gpu": {"vram_mb": 48000}, "memory_mb": 120000},
+    )
+    monkeypatch.delenv("MAC_AGENT_MEDIA_ROUTES", raising=False)
+    monkeypatch.setenv("MAC_AGENT_GEN_MODEL", "sdxl-turbo")
+    monkeypatch.setenv("MAC_AGENT_GEN_AUDIO_MODELS", "bark")
+    monkeypatch.setenv("MAC_AGENT_GEN_HOST", "natasha")
+    registered = register_worker(
+        api, hostname="natasha", agent_name="natasha",
+        capabilities=["gpu", "cuda"], resources={"capacity": 1},
+    )
+    worker = MacWorker(api, registered["id"], tmp_path, lambda *a: None,
+                       attestation_key=registered.get("attestation_key"))
+    worker._sync_service_claims()
+    held = set(cp.service_roles.held_ops_for_agent(registered["id"]))
+    routes_ops = {r["op"] for r in cp.get_agent(registered["id"]).resources.get("media_routes", [])}
+    assert len(held) == 1  # capacity 1 -> holds exactly one op
+    assert routes_ops == held  # advertises only the held op
+    assert routes_ops <= {"image.generate", "audio.tts"}
+
+
+def test_worker_advertises_all_willing_when_no_service_roles(tmp_path: Path, monkeypatch):
+    """Back-compat: a fleet that seeds NO service_roles keeps advertise-all (the
+    sync's 'managed' set is empty, so every willing op is advertised)."""
+    cp = ControlPlane.in_memory()  # no seed_service_roles
+    api = MacApiClient("http://mac.test", transport=api_transport(TestClient(create_app(control_plane=cp))))
+    monkeypatch.setattr(
+        "mac.hardware.detect_hardware",
+        lambda: {"accelerator": "cuda", "gpu": {"vram_mb": 48000}, "memory_mb": 120000},
+    )
+    monkeypatch.delenv("MAC_AGENT_MEDIA_ROUTES", raising=False)
+    monkeypatch.setenv("MAC_AGENT_GEN_MODEL", "sdxl-turbo")
+    monkeypatch.setenv("MAC_AGENT_GEN_AUDIO_MODELS", "bark")
+    monkeypatch.setenv("MAC_AGENT_GEN_HOST", "natasha")
+    registered = register_worker(api, hostname="natasha", agent_name="natasha", capabilities=["gpu", "cuda"])
+    worker = MacWorker(api, registered["id"], tmp_path, lambda *a: None,
+                       attestation_key=registered.get("attestation_key"))
+    worker._sync_service_claims()
+    routes_ops = {r["op"] for r in cp.get_agent(registered["id"]).resources.get("media_routes", [])}
+    assert routes_ops == {"image.generate", "audio.tts"}  # all willing (unmanaged)


### PR DESCRIPTION
Answers "are services just another form of tasking?" — **yes**. A media service is now a **leased role-claim**: "the cluster needs a video agent, who claims it?" A capable, not-overloaded host claims the role (renewable lease), holds + advertises it, and it **times out + re-files** if the host overloads or goes silent — reusing the task lease lifecycle.

**Model (your two decisions):** *pool* + capacity-bounded. All capable, not-overloaded hosts can hold each op; the capacity gate spreads ops so one host doesn't get all; `dispatch_order` still balances requests across holders (keeps #99 multi-GPU throughput). Load = held service-claims + task-leases vs `resources.capacity`. Hardware-aware eligibility via the reported GPU VRAM + the catalog floor.

## Pieces
- **`service_roles` + `service_claims`** tables — mirror `tasks`+`leases` (unique-active partial index = split-brain guard, per (role, agent) for the pool).
- **`service_role_service.py`** — claim/renew/release/expire/list lease lifecycle.
- **`services.py`** — eligibility (VRAM + `machine_hardware_satisfies` + capability + capacity); `sync_agent_service_claims` (claims **least-served** eligible ops up to capacity → spread); `reconcile_service_roles` in `tick()` (auto-seed from `MAC_SERVICE_ROLE_OPS`, reap offline/expired, signal zero-holder ops via `request_agent`); offline → claims expire.
- **API**: `POST /agents/{id}/service-claims/sync`, `GET /service-roles`, `GET /service-claims`.
- **worker**: `_sync_service_claims` on the loop advertises **only held** ops (or unmanaged → **back-compat**: no roles seeded keeps advertise-all).
- **deploy**: `MAC_DEPLOY_SERVICE_ROLE_OPS` → hub seeds + reconciles.

## Tests
Capacity-bounded spread, least-served preference, VRAM/capacity eligibility, claim exclusivity, expire→reopen + zero-holder signal, offline reap, advertise-on-hold, and no-roles back-compat. Full control_plane/media/api/worker/deploy suites green.

Rollout (natasha + madmax with `MAC_DEPLOY_SERVICE_ROLE_OPS`) follows on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)