### PR TITLE
deploy: MAC_DEPLOY_GH_TOKEN -> GH_TOKEN passthrough (agents clone private repos)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -1023,6 +1023,8 @@ deploy_host() {
   add_remote_env MAC_DEPLOY_AGENT_MEDIA_ROUTES "${MAC_DEPLOY_AGENT_MEDIA_ROUTES:-}"
   # media-01 service-role election: ops the fleet wants held (hub seeds + reconciles).
   add_remote_env MAC_DEPLOY_SERVICE_ROLE_OPS "${MAC_DEPLOY_SERVICE_ROLE_OPS:-}"
+  # Git credential for cloning/pushing private repos (-> GH_TOKEN in mac.env).
+  add_remote_env MAC_DEPLOY_GH_TOKEN "${MAC_DEPLOY_GH_TOKEN:-}"
   local img_key="${NVIDIA_IMAGE_API_KEY:-}" aud_key="${NVIDIA_AUDIO_API_KEY:-}" vid_key="${NVIDIA_VIDEO_API_KEY:-}"
   if [ "$agent" != "$shared_services_manager" ] && [ "$router_backend_lc" = "inproc" ]; then
     img_key="" ; aud_key="" ; vid_key=""

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -568,6 +568,10 @@ def build_mac_env(
         ("MAC_DEPLOY_AGENT_MEDIA_ROUTES", "MAC_AGENT_MEDIA_ROUTES"),
         # media-01 service-role election: ops the fleet wants held (hub seeds these).
         ("MAC_DEPLOY_SERVICE_ROLE_OPS", "MAC_SERVICE_ROLE_OPS"),
+        # Git credential for agents to clone/push private repos (gitops reads
+        # GH_TOKEN; mac.env is sourced after the pod env so this overrides a stale
+        # platform-injected token). 600-perm file, same as MAC_API_TOKEN.
+        ("MAC_DEPLOY_GH_TOKEN", "GH_TOKEN"),
     ):
         _v = (env.get(_src) or "").strip()
         if _v:

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -1542,3 +1542,18 @@ def test_deploy_rehydrates_agent_footprint():
     # disable knob + npm bin on PATH for self-installed CLI tools
     assert "MAC_AGENT_FOOTPRINT_REINSTALL" in script
     assert "$HOME/.mac/node_modules/.bin" in script
+
+
+def test_build_mac_env_passes_through_gh_token(tmp_path):
+    """Agents get a git credential: MAC_DEPLOY_GH_TOKEN -> GH_TOKEN in mac.env
+    (overrides any stale platform-injected token, since the wrapper sources
+    mac.env after the pod env)."""
+    values = build_mac_env(
+        {}, deploy_env_config(tmp_path, fleet_name="gke"),
+        environ={"MAC_DEPLOY_GH_TOKEN": "ghp_test123"},
+    )
+    assert values["GH_TOKEN"] == "ghp_test123"
+    bare = build_mac_env({}, deploy_env_config(tmp_path, fleet_name="gke2"), environ={})
+    assert "GH_TOKEN" not in bare
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    assert "add_remote_env MAC_DEPLOY_GH_TOKEN" in script


### PR DESCRIPTION
Agents auth git over HTTPS via `GH_TOKEN` (`gitops.inject_git_remote_auth`), but fleets had no managed git credential — jordanh-gke pods inherited a stale/invalid `GH_TOKEN` from the platform and couldn't clone private repos. This adds a deploy passthrough: `MAC_DEPLOY_GH_TOKEN` → `GH_TOKEN` in `mac.env` (600-perm, like `MAC_API_TOKEN`); the agent wrapper sources `mac.env` after the pod env so it overrides the stale token. Repos must be https:// (not `git@`) for token injection. Test: build_mac_env passthrough + add_remote_env wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)