### PR TITLE
mac: Title: Add collapse toggle and per-lane sort to kanban lane headers on T

### DIFF
--- a/src/mac/ui/app.js
+++ b/src/mac/ui/app.js
@@ -51,6 +51,106 @@ function toggleTheme() {
     const current = document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
     setTheme(current === "dark" ? "light" : "dark");
 }
+// Per-lane collapse + sort persistence. Collapse state is keyed by lane name
+// so it survives refreshes; empty lanes auto-collapse on first load.
+const LANE_COLLAPSE_KEY = "mac.dashboard.laneCollapse";
+const LANE_SORT_KEY = "mac.dashboard.laneSort";
+const LANE_SORTS = ["updated", "priority", "title"];
+const LANE_SORT_LABELS = {
+    updated: "Recently updated",
+    priority: "Priority",
+    title: "Title",
+};
+function readLaneCollapse() {
+    try {
+        const raw = localStorage.getItem(LANE_COLLAPSE_KEY);
+        if (!raw)
+            return {};
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object") {
+            const out = {};
+            for (const [key, value] of Object.entries(parsed)) {
+                out[key] = Boolean(value);
+            }
+            return out;
+        }
+    }
+    catch {
+        /* ignore corrupt/unavailable storage */
+    }
+    return {};
+}
+function writeLaneCollapse(map) {
+    try {
+        localStorage.setItem(LANE_COLLAPSE_KEY, JSON.stringify(map));
+    }
+    catch {
+        /* storage unavailable — collapse still applies for this session */
+    }
+}
+function readLaneSort() {
+    try {
+        const raw = localStorage.getItem(LANE_SORT_KEY);
+        if (!raw)
+            return {};
+        const parsed = JSON.parse(raw);
+        if (parsed && typeof parsed === "object") {
+            const out = {};
+            for (const [key, value] of Object.entries(parsed)) {
+                if (LANE_SORTS.includes(String(value)))
+                    out[key] = value;
+            }
+            return out;
+        }
+    }
+    catch {
+        /* ignore */
+    }
+    return {};
+}
+function writeLaneSort(map) {
+    try {
+        localStorage.setItem(LANE_SORT_KEY, JSON.stringify(map));
+    }
+    catch {
+        /* storage unavailable */
+    }
+}
+function laneSortFor(taskState) {
+    const sort = state.laneSort[taskState];
+    return sort && LANE_SORTS.includes(sort) ? sort : "updated";
+}
+// Lanes the operator has explicitly toggled (so auto-collapse of empty lanes
+// only applies until the operator makes a choice for that lane).
+const laneCollapseExplicit = new Set();
+function isLaneCollapsed(taskState, laneCount) {
+    if (laneCollapseExplicit.has(taskState)) {
+        return Boolean(state.laneCollapse[taskState]);
+    }
+    if (Object.prototype.hasOwnProperty.call(state.laneCollapse, taskState)) {
+        return Boolean(state.laneCollapse[taskState]);
+    }
+    // Empty lanes auto-collapse on first load.
+    return laneCount === 0;
+}
+function sortLaneTasks(laneTasks, sort) {
+    const sorted = laneTasks.slice();
+    if (sort === "priority") {
+        sorted.sort((a, b) => (b.task.priority || 0) - (a.task.priority || 0));
+    }
+    else if (sort === "title") {
+        sorted.sort((a, b) => String(a.task.title || "").localeCompare(String(b.task.title || "")));
+    }
+    else {
+        // updated: most recently updated first.
+        sorted.sort((a, b) => {
+            const at = Date.parse(String(a.task.last_updated_at || a.task.updated_at || "")) || 0;
+            const bt = Date.parse(String(b.task.last_updated_at || b.task.updated_at || "")) || 0;
+            return bt - at;
+        });
+    }
+    return sorted;
+}
 const TASK_STATES = [
     "open",
     "blocked",
@@ -179,6 +279,8 @@ const state = {
     showDerivedProjects: DEFAULT_URL_STATE.showDerivedProjects,
     taskFilter: DEFAULT_URL_STATE.taskFilter,
     selectedId: DEFAULT_URL_STATE.selectedId,
+    laneCollapse: readLaneCollapse(),
+    laneSort: readLaneSort(),
     targets: [],
     selectedTargetId: readStoredTargetId(),
     selectedTokenSourceId: readStoredTokenSourceId(),
@@ -4071,10 +4173,25 @@ function agentCard(item, data) {
 }
 function taskLane(taskState, tasks, agents) {
     const laneTasks = tasks.filter((detail) => detail.task.state === taskState);
+    const collapsed = isLaneCollapsed(taskState, laneTasks.length);
+    const sort = laneSortFor(taskState);
+    const sortOptions = LANE_SORTS
+        .map((value) => `<option value="${escapeHtml(value)}"${value === sort ? " selected" : ""}>${escapeHtml(LANE_SORT_LABELS[value])}</option>`)
+        .join("");
+    const sortedTasks = sortLaneTasks(laneTasks, sort);
     return `
-    <div class="task-lane status-${escapeHtml(taskState)}">
-      <h2><span class="lane-title">${escapeHtml(labelize(taskState))}</span><span class="pill lane-count">${laneTasks.length}</span></h2>
-      ${laneTasks.length ? laneTasks.map((detail) => taskCard(detail, agents)).join("") : `<div class="empty-state">Empty</div>`}
+    <div class="task-lane status-${escapeHtml(taskState)}${collapsed ? " is-collapsed" : ""}" data-lane="${escapeHtml(taskState)}">
+      <h2>
+        <button class="lane-toggle" type="button" data-lane-toggle="${escapeHtml(taskState)}" aria-expanded="${collapsed ? "false" : "true"}" title="${collapsed ? "Expand" : "Collapse"} lane">
+          <span class="lane-chevron" aria-hidden="true">${collapsed ? "&#9656;" : "&#9662;"}</span>
+          <span class="lane-title">${escapeHtml(labelize(taskState))}</span>
+        </button>
+        <span class="lane-header-meta">
+          <select class="lane-sort" data-lane-sort="${escapeHtml(taskState)}" title="Sort lane" aria-label="Sort ${escapeHtml(labelize(taskState))} lane">${sortOptions}</select>
+          <span class="pill lane-count">${laneTasks.length}</span>
+        </span>
+      </h2>
+      ${collapsed ? "" : `<div class="lane-body">${sortedTasks.length ? sortedTasks.map((detail) => taskCard(detail, agents)).join("") : `<div class="empty-state">Empty</div>`}</div>`}
     </div>
   `;
 }
@@ -4952,6 +5069,17 @@ function handleContentChange(event) {
     const target = event.target;
     if (!target)
         return;
+    const laneSort = target.closest("select[data-lane-sort]");
+    if (laneSort) {
+        const lane = laneSort.dataset.laneSort || "";
+        const value = laneSort.value;
+        if (lane && LANE_SORTS.includes(value)) {
+            state.laneSort = { ...state.laneSort, [lane]: value };
+            writeLaneSort(state.laneSort);
+            render();
+        }
+        return;
+    }
     const planField = target.closest("[data-plan-field]");
     if (planField) {
         syncWorkflowPlanDraftFromDom();
@@ -5005,6 +5133,20 @@ function handleContentKeydown(event) {
     }
 }
 async function handleContentClick(event) {
+    const laneToggle = event.target?.closest("[data-lane-toggle]");
+    if (laneToggle) {
+        event.preventDefault();
+        const lane = laneToggle.dataset.laneToggle || "";
+        if (lane) {
+            const laneEl = laneToggle.closest(".task-lane");
+            const currentlyCollapsed = laneEl?.classList.contains("is-collapsed") ?? false;
+            laneCollapseExplicit.add(lane);
+            state.laneCollapse = { ...state.laneCollapse, [lane]: !currentlyCollapsed };
+            writeLaneCollapse(state.laneCollapse);
+            render();
+        }
+        return;
+    }
     const launchpad = event.target?.closest("[data-dashboard-go]");
     if (launchpad) {
         event.preventDefault();

--- a/src/mac/ui/app.ts
+++ b/src/mac/ui/app.ts
@@ -541,6 +541,8 @@ interface DashboardState {
   showDerivedProjects: boolean;
   taskFilter: string;
   selectedId: string;
+  laneCollapse: Record<string, boolean>;
+  laneSort: Record<string, LaneSort>;
   targets: DashboardTarget[];
   selectedTargetId: string;
   selectedTokenSourceId: string;
@@ -648,6 +650,108 @@ function toggleTheme(): void {
   const current = document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
   setTheme(current === "dark" ? "light" : "dark");
 }
+
+// Per-lane collapse + sort persistence. Collapse state is keyed by lane name
+// so it survives refreshes; empty lanes auto-collapse on first load.
+const LANE_COLLAPSE_KEY = "mac.dashboard.laneCollapse";
+const LANE_SORT_KEY = "mac.dashboard.laneSort";
+type LaneSort = "updated" | "priority" | "title";
+const LANE_SORTS: LaneSort[] = ["updated", "priority", "title"];
+const LANE_SORT_LABELS: Record<LaneSort, string> = {
+  updated: "Recently updated",
+  priority: "Priority",
+  title: "Title",
+};
+
+function readLaneCollapse(): Record<string, boolean> {
+  try {
+    const raw = localStorage.getItem(LANE_COLLAPSE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object") {
+      const out: Record<string, boolean> = {};
+      for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        out[key] = Boolean(value);
+      }
+      return out;
+    }
+  } catch {
+    /* ignore corrupt/unavailable storage */
+  }
+  return {};
+}
+
+function writeLaneCollapse(map: Record<string, boolean>): void {
+  try {
+    localStorage.setItem(LANE_COLLAPSE_KEY, JSON.stringify(map));
+  } catch {
+    /* storage unavailable — collapse still applies for this session */
+  }
+}
+
+function readLaneSort(): Record<string, LaneSort> {
+  try {
+    const raw = localStorage.getItem(LANE_SORT_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === "object") {
+      const out: Record<string, LaneSort> = {};
+      for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+        if ((LANE_SORTS as string[]).includes(String(value))) out[key] = value as LaneSort;
+      }
+      return out;
+    }
+  } catch {
+    /* ignore */
+  }
+  return {};
+}
+
+function writeLaneSort(map: Record<string, LaneSort>): void {
+  try {
+    localStorage.setItem(LANE_SORT_KEY, JSON.stringify(map));
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+function laneSortFor(taskState: string): LaneSort {
+  const sort = state.laneSort[taskState];
+  return sort && (LANE_SORTS as string[]).includes(sort) ? sort : "updated";
+}
+
+// Lanes the operator has explicitly toggled (so auto-collapse of empty lanes
+// only applies until the operator makes a choice for that lane).
+const laneCollapseExplicit = new Set<string>();
+
+function isLaneCollapsed(taskState: string, laneCount: number): boolean {
+  if (laneCollapseExplicit.has(taskState)) {
+    return Boolean(state.laneCollapse[taskState]);
+  }
+  if (Object.prototype.hasOwnProperty.call(state.laneCollapse, taskState)) {
+    return Boolean(state.laneCollapse[taskState]);
+  }
+  // Empty lanes auto-collapse on first load.
+  return laneCount === 0;
+}
+
+function sortLaneTasks(laneTasks: TaskDetail[], sort: LaneSort): TaskDetail[] {
+  const sorted = laneTasks.slice();
+  if (sort === "priority") {
+    sorted.sort((a, b) => (b.task.priority || 0) - (a.task.priority || 0));
+  } else if (sort === "title") {
+    sorted.sort((a, b) => String(a.task.title || "").localeCompare(String(b.task.title || "")));
+  } else {
+    // updated: most recently updated first.
+    sorted.sort((a, b) => {
+      const at = Date.parse(String(a.task.last_updated_at || a.task.updated_at || "")) || 0;
+      const bt = Date.parse(String(b.task.last_updated_at || b.task.updated_at || "")) || 0;
+      return bt - at;
+    });
+  }
+  return sorted;
+}
+
 const TASK_STATES = [
   "open",
   "blocked",
@@ -779,6 +883,8 @@ const state: DashboardState = {
   showDerivedProjects: DEFAULT_URL_STATE.showDerivedProjects,
   taskFilter: DEFAULT_URL_STATE.taskFilter,
   selectedId: DEFAULT_URL_STATE.selectedId,
+  laneCollapse: readLaneCollapse(),
+  laneSort: readLaneSort(),
   targets: [],
   selectedTargetId: readStoredTargetId(),
   selectedTokenSourceId: readStoredTokenSourceId(),
@@ -4737,10 +4843,25 @@ function agentCard(item: AgentItem, data: DashboardData): string {
 
 function taskLane(taskState: string, tasks: TaskDetail[], agents: AgentItem[]): string {
   const laneTasks = tasks.filter((detail) => detail.task.state === taskState);
+  const collapsed = isLaneCollapsed(taskState, laneTasks.length);
+  const sort = laneSortFor(taskState);
+  const sortOptions = LANE_SORTS
+    .map((value) => `<option value="${escapeHtml(value)}"${value === sort ? " selected" : ""}>${escapeHtml(LANE_SORT_LABELS[value])}</option>`)
+    .join("");
+  const sortedTasks = sortLaneTasks(laneTasks, sort);
   return `
-    <div class="task-lane status-${escapeHtml(taskState)}">
-      <h2><span class="lane-title">${escapeHtml(labelize(taskState))}</span><span class="pill lane-count">${laneTasks.length}</span></h2>
-      ${laneTasks.length ? laneTasks.map((detail) => taskCard(detail, agents)).join("") : `<div class="empty-state">Empty</div>`}
+    <div class="task-lane status-${escapeHtml(taskState)}${collapsed ? " is-collapsed" : ""}" data-lane="${escapeHtml(taskState)}">
+      <h2>
+        <button class="lane-toggle" type="button" data-lane-toggle="${escapeHtml(taskState)}" aria-expanded="${collapsed ? "false" : "true"}" title="${collapsed ? "Expand" : "Collapse"} lane">
+          <span class="lane-chevron" aria-hidden="true">${collapsed ? "&#9656;" : "&#9662;"}</span>
+          <span class="lane-title">${escapeHtml(labelize(taskState))}</span>
+        </button>
+        <span class="lane-header-meta">
+          <select class="lane-sort" data-lane-sort="${escapeHtml(taskState)}" title="Sort lane" aria-label="Sort ${escapeHtml(labelize(taskState))} lane">${sortOptions}</select>
+          <span class="pill lane-count">${laneTasks.length}</span>
+        </span>
+      </h2>
+      ${collapsed ? "" : `<div class="lane-body">${sortedTasks.length ? sortedTasks.map((detail) => taskCard(detail, agents)).join("") : `<div class="empty-state">Empty</div>`}</div>`}
     </div>
   `;
 }
@@ -5628,6 +5749,17 @@ function bindAuditControl(selector: string, key: keyof Pick<DashboardState, "aud
 function handleContentChange(event: Event): void {
   const target = event.target as HTMLElement | null;
   if (!target) return;
+  const laneSort = target.closest<HTMLSelectElement>("select[data-lane-sort]");
+  if (laneSort) {
+    const lane = laneSort.dataset.laneSort || "";
+    const value = laneSort.value;
+    if (lane && (LANE_SORTS as string[]).includes(value)) {
+      state.laneSort = { ...state.laneSort, [lane]: value as LaneSort };
+      writeLaneSort(state.laneSort);
+      render();
+    }
+    return;
+  }
   const planField = target.closest<HTMLElement>("[data-plan-field]");
   if (planField) {
     syncWorkflowPlanDraftFromDom();
@@ -5684,6 +5816,20 @@ function handleContentKeydown(event: KeyboardEvent): void {
 }
 
 async function handleContentClick(event: MouseEvent): Promise<void> {
+  const laneToggle = (event.target as Element | null)?.closest<HTMLElement>("[data-lane-toggle]");
+  if (laneToggle) {
+    event.preventDefault();
+    const lane = laneToggle.dataset.laneToggle || "";
+    if (lane) {
+      const laneEl = laneToggle.closest<HTMLElement>(".task-lane");
+      const currentlyCollapsed = laneEl?.classList.contains("is-collapsed") ?? false;
+      laneCollapseExplicit.add(lane);
+      state.laneCollapse = { ...state.laneCollapse, [lane]: !currentlyCollapsed };
+      writeLaneCollapse(state.laneCollapse);
+      render();
+    }
+    return;
+  }
   const launchpad = (event.target as Element | null)?.closest<HTMLElement>("[data-dashboard-go]");
   if (launchpad) {
     event.preventDefault();

--- a/src/mac/ui/styles.css
+++ b/src/mac/ui/styles.css
@@ -1624,7 +1624,9 @@ button.mobile-object-card {
   padding: 12px;
 }
 
-/* Per-status lane accent colours give an at-a-glance status cue. */
+/* Per-status lane accent colours give an at-a-glance status cue.
+ * Needs Review (amber) and Reviewing (blue) are intentionally distinct so the
+ * two review lanes are not confused with each other. */
 .task-lane.status-completed {
   --lane-accent: var(--accent);
 }
@@ -1634,14 +1636,14 @@ button.mobile-object-card {
   --lane-accent: var(--danger);
 }
 
-.task-lane.status-blocked {
+.task-lane.status-blocked,
+.task-lane.status-needs_review {
   --lane-accent: var(--warning);
 }
 
 .task-lane.status-running,
 .task-lane.status-claimed,
-.task-lane.status-reviewing,
-.task-lane.status-needs_review {
+.task-lane.status-reviewing {
   --lane-accent: var(--blue);
 }
 
@@ -1659,8 +1661,67 @@ button.mobile-object-card {
   padding: 12px;
 }
 
+/* Collapsed lanes shrink to just their header so empty/parked lanes get out
+ * of the way; the chevron in the header toggles this. */
+.task-lane.is-collapsed {
+  min-height: 0;
+  gap: 0;
+}
+
+.task-lane.is-collapsed h2 {
+  margin-bottom: -12px;
+  border-bottom: none;
+}
+
+.task-lane h2 .lane-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.task-lane h2 .lane-toggle:focus-visible {
+  outline: 2px solid var(--lane-accent, var(--blue));
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.task-lane h2 .lane-chevron {
+  display: inline-flex;
+  width: 0.9em;
+  justify-content: center;
+  color: var(--lane-accent, var(--muted));
+  font-size: 0.85em;
+}
+
+.task-lane h2 .lane-header-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.task-lane h2 .lane-sort {
+  min-height: 22px;
+  padding: 0 6px;
+  font-size: 0.74rem;
+}
+
 .task-lane h2 .lane-title {
   text-transform: capitalize;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .task-lane h2 .lane-count {
@@ -1670,6 +1731,11 @@ button.mobile-object-card {
   color: var(--ink);
   padding: 0 8px;
   font-size: 0.78rem;
+}
+
+.task-lane .lane-body {
+  display: grid;
+  gap: 10px;
 }
 
 .task-card {
@@ -1692,14 +1758,14 @@ button.mobile-object-card {
   --lane-accent: var(--danger);
 }
 
-.task-lane.status-blocked .task-card {
+.task-lane.status-blocked .task-card,
+.task-lane.status-needs_review .task-card {
   --lane-accent: var(--warning);
 }
 
 .task-lane.status-running .task-card,
 .task-lane.status-claimed .task-card,
-.task-lane.status-reviewing .task-card,
-.task-lane.status-needs_review .task-card {
+.task-lane.status-reviewing .task-card {
   --lane-accent: var(--blue);
 }
 


### PR DESCRIPTION
task=task_9ce412c4d8d048a89bdcbef772df3b30
agent=mac-worker-python-coder-opencode
role=python-coder-opencode

Title: Add collapse toggle and per-lane sort to kanban lane headers on Tasks page

Improve kanban lane headers on the MAC Tasks page with collapse/expand and distinct accent colors.

## Requirements
- Empty lanes (0 tasks) auto-collapse on page load
- Each lane header has a chevron toggle to expand/collapse; state persists in localStorage keyed by lane name
- Fix: Needs Review and Reviewing lanes get distinct accent colours (currently both same blue). Suggested: Needs Review -> amber/yellow, Reviewing -> blue, Completed -> green, Failed -> red
- Lane header shows task count badge

## Acceptance Criteria
- Empty lanes collapse automatically on load
- Chevron toggles work; state survives page refresh (localStorage)
- All 4 lanes have visually distinct accent colours in header and left border
- Run full test suite; all tests must pass before opening MR