### PR TITLE
mac: Title: Improve task card quick-actions, density, and timestamp display o

### DIFF
--- a/src/mac/ui/app.js
+++ b/src/mac/ui/app.js
@@ -4084,11 +4084,13 @@ function taskCard(detail, agents) {
     const origin = taskOrigin(task);
     const isSelected = state.selectedId === task.id;
     const recentHistory = detail.history.slice(-3);
-    const summaryText = String(detail.summary?.summary || "");
+    const summaryText = String(task.description || detail.summary?.summary || "");
+    const isFailed = task.state === "failed";
+    const isActive = !TERMINAL_TASK_STATES.has(task.state);
     return `
     <article class="task-card status-${escapeHtml(task.state)} ${selectedClass(task.id)}">
       <div class="record-header">
-        <div class="task-card-heading"><h3>${escapeHtml(task.title)}</h3><p class="muted small mono task-id" title="${escapeHtml(task.id)}">${escapeHtml(task.id)}</p></div>
+        <div class="task-card-heading"><h3>${escapeHtml(task.title)}</h3><button class="task-id-copy muted small mono task-id" type="button" data-copy-id="${escapeHtml(task.id)}" title="Click to copy: ${escapeHtml(task.id)}" aria-label="Copy task id ${escapeHtml(task.id)}"><span class="task-id-text">${escapeHtml(task.id)}</span><span class="task-id-copied" aria-hidden="true">Copied!</span></button></div>
         <button class="select-button${isSelected ? " is-selected" : ""}" type="button" data-select-id="${escapeHtml(task.id)}" aria-pressed="${isSelected ? "true" : "false"}">${isSelected ? "Selected" : "Inspect"}</button>
       </div>
       <div class="chip-row">
@@ -4098,11 +4100,14 @@ function taskCard(detail, agents) {
         ${origin.hermes_instance_id ? chip("Hermes origin", "info") : ""}
       </div>
       <div class="time-summary">
-        <span class="time-cell"><span class="time-label">Started</span><span class="time-value">${escapeHtml(task.started_at ? formatAge(task.started_at) : "not started")}</span></span>
-        <span class="time-cell"><span class="time-label">Completed</span><span class="time-value">${escapeHtml(task.completed_at ? formatAge(task.completed_at) : "not completed")}</span></span>
-        <span class="time-cell"><span class="time-label">Updated</span><span class="time-value">${escapeHtml(formatAge(task.last_updated_at || task.updated_at))}</span></span>
+        <span class="time-cell"><span class="time-label">Started</span><span class="time-value" title="${escapeHtml(formatIso(task.started_at))}">${escapeHtml(task.started_at ? formatAge(task.started_at) : "not started")}</span></span>
+        <span class="time-cell"><span class="time-label">Completed</span><span class="time-value" title="${escapeHtml(formatIso(task.completed_at))}">${escapeHtml(task.completed_at ? formatAge(task.completed_at) : "not completed")}</span></span>
+        <span class="time-cell"><span class="time-label">Updated</span><span class="time-value" title="${escapeHtml(formatIso(task.last_updated_at || task.updated_at))}">${escapeHtml(formatAge(task.last_updated_at || task.updated_at))}</span></span>
       </div>
-      ${summaryText ? `<p class="small muted">${escapeHtml(summaryText)}</p>` : ""}
+      ${summaryText ? `<div class="task-summary is-clamped" data-task-summary>
+        <p class="small muted task-summary-text">${escapeHtml(summaryText)}</p>
+        <button class="link-button task-summary-toggle" type="button" data-summary-toggle><span class="summary-show">Show more</span><span class="summary-hide">Show less</span></button>
+      </div>` : ""}
       ${recentHistory.length ? `<details class="activity-disclosure">
         <summary><span class="activity-show">Show activity</span><span class="activity-hide">Hide activity</span></summary>
         <div class="timeline">
@@ -4111,6 +4116,10 @@ function taskCard(detail, agents) {
       </details>` : ""}
       <div class="record-actions">
         <button class="link-button" type="button" data-select-id="${escapeHtml(task.id)}">Inspect</button>
+      </div>
+      <div class="quick-actions" role="group" aria-label="Quick actions">
+        ${isFailed ? `<button class="link-button quick-action quick-action-retry" type="button" data-quick-action="retry" data-task-id="${escapeHtml(task.id)}">Retry</button>` : ""}
+        ${isActive ? `<button class="danger-button quick-action quick-action-cancel" type="button" data-quick-action="cancel" data-task-id="${escapeHtml(task.id)}">Cancel</button>` : ""}
       </div>
     </article>
   `;
@@ -5148,6 +5157,26 @@ async function handleContentClick(event) {
         render();
         return;
     }
+    const copyTarget = event.target?.closest("[data-copy-id]");
+    if (copyTarget) {
+        event.preventDefault();
+        await copyTaskId(copyTarget);
+        return;
+    }
+    const summaryToggle = event.target?.closest("[data-summary-toggle]");
+    if (summaryToggle) {
+        event.preventDefault();
+        const block = summaryToggle.closest("[data-task-summary]");
+        if (block)
+            block.classList.toggle("is-clamped");
+        return;
+    }
+    const quickAction = event.target?.closest("[data-quick-action]");
+    if (quickAction) {
+        event.preventDefault();
+        await runQuickAction(quickAction);
+        return;
+    }
     const target = event.target?.closest("[data-select-id]");
     if (!target)
         return;
@@ -5157,6 +5186,69 @@ async function handleContentClick(event) {
     state.selectedId = state.selectedId === selectedId ? "" : selectedId;
     updateUrlState();
     render();
+}
+async function copyTaskId(button) {
+    const id = button.dataset.copyId || "";
+    if (!id)
+        return;
+    let copied = false;
+    try {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            await navigator.clipboard.writeText(id);
+            copied = true;
+        }
+    }
+    catch {
+        copied = false;
+    }
+    if (!copied) {
+        try {
+            const helper = document.createElement("textarea");
+            helper.value = id;
+            helper.setAttribute("readonly", "");
+            helper.style.position = "absolute";
+            helper.style.left = "-9999px";
+            document.body.appendChild(helper);
+            helper.select();
+            document.execCommand("copy");
+            document.body.removeChild(helper);
+            copied = true;
+        }
+        catch {
+            copied = false;
+        }
+    }
+    if (copied) {
+        button.classList.add("is-copied");
+        window.setTimeout(() => button.classList.remove("is-copied"), 1200);
+    }
+}
+async function runQuickAction(button) {
+    const taskId = button.dataset.taskId || "";
+    const action = button.dataset.quickAction || "";
+    if (!taskId || !action)
+        return;
+    const targetState = action === "retry" ? "open" : "cancelled";
+    const label = action === "retry" ? "Retry" : "Cancel";
+    if (action === "cancel" && !window.confirm("Cancel this task?"))
+        return;
+    button.disabled = true;
+    try {
+        const result = await postJSON(`/tasks/${encodeURIComponent(taskId)}/transition`, {
+            target_state: targetState,
+            actor: "human",
+            detail: {},
+        });
+        state.actionMessage = `${label} ok: ${redactedJson(result)}`;
+        await loadDashboard();
+    }
+    catch (error) {
+        state.actionMessage = `${label} failed: ${error instanceof Error ? error.message : String(error)}`;
+        render();
+    }
+    finally {
+        button.disabled = false;
+    }
 }
 function navigateDashboardView(view) {
     if (!view || !VIEW_KEYS.has(view))
@@ -6431,6 +6523,12 @@ function formatAge(value) {
 }
 function formatTime(value) {
     return new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit", second: "2-digit" }).format(value);
+}
+function formatIso(value) {
+    const date = value ? new Date(value) : null;
+    if (!date || Number.isNaN(date.getTime()))
+        return "unknown";
+    return date.toISOString();
 }
 function labelize(value) {
     return String(value == null || value === "" ? "none" : value).replaceAll("_", " ");

--- a/src/mac/ui/app.ts
+++ b/src/mac/ui/app.ts
@@ -4751,11 +4751,13 @@ function taskCard(detail: TaskDetail, agents: AgentItem[]): string {
   const origin = taskOrigin(task);
   const isSelected = state.selectedId === task.id;
   const recentHistory = detail.history.slice(-3);
-  const summaryText = String(detail.summary?.summary || "");
+  const summaryText = String(task.description || detail.summary?.summary || "");
+  const isFailed = task.state === "failed";
+  const isActive = !TERMINAL_TASK_STATES.has(task.state);
   return `
     <article class="task-card status-${escapeHtml(task.state)} ${selectedClass(task.id)}">
       <div class="record-header">
-        <div class="task-card-heading"><h3>${escapeHtml(task.title)}</h3><p class="muted small mono task-id" title="${escapeHtml(task.id)}">${escapeHtml(task.id)}</p></div>
+        <div class="task-card-heading"><h3>${escapeHtml(task.title)}</h3><button class="task-id-copy muted small mono task-id" type="button" data-copy-id="${escapeHtml(task.id)}" title="Click to copy: ${escapeHtml(task.id)}" aria-label="Copy task id ${escapeHtml(task.id)}"><span class="task-id-text">${escapeHtml(task.id)}</span><span class="task-id-copied" aria-hidden="true">Copied!</span></button></div>
         <button class="select-button${isSelected ? " is-selected" : ""}" type="button" data-select-id="${escapeHtml(task.id)}" aria-pressed="${isSelected ? "true" : "false"}">${isSelected ? "Selected" : "Inspect"}</button>
       </div>
       <div class="chip-row">
@@ -4765,11 +4767,14 @@ function taskCard(detail: TaskDetail, agents: AgentItem[]): string {
         ${origin.hermes_instance_id ? chip("Hermes origin", "info") : ""}
       </div>
       <div class="time-summary">
-        <span class="time-cell"><span class="time-label">Started</span><span class="time-value">${escapeHtml(task.started_at ? formatAge(task.started_at) : "not started")}</span></span>
-        <span class="time-cell"><span class="time-label">Completed</span><span class="time-value">${escapeHtml(task.completed_at ? formatAge(task.completed_at) : "not completed")}</span></span>
-        <span class="time-cell"><span class="time-label">Updated</span><span class="time-value">${escapeHtml(formatAge(task.last_updated_at || task.updated_at))}</span></span>
+        <span class="time-cell"><span class="time-label">Started</span><span class="time-value" title="${escapeHtml(formatIso(task.started_at))}">${escapeHtml(task.started_at ? formatAge(task.started_at) : "not started")}</span></span>
+        <span class="time-cell"><span class="time-label">Completed</span><span class="time-value" title="${escapeHtml(formatIso(task.completed_at))}">${escapeHtml(task.completed_at ? formatAge(task.completed_at) : "not completed")}</span></span>
+        <span class="time-cell"><span class="time-label">Updated</span><span class="time-value" title="${escapeHtml(formatIso(task.last_updated_at || task.updated_at))}">${escapeHtml(formatAge(task.last_updated_at || task.updated_at))}</span></span>
       </div>
-      ${summaryText ? `<p class="small muted">${escapeHtml(summaryText)}</p>` : ""}
+      ${summaryText ? `<div class="task-summary is-clamped" data-task-summary>
+        <p class="small muted task-summary-text">${escapeHtml(summaryText)}</p>
+        <button class="link-button task-summary-toggle" type="button" data-summary-toggle><span class="summary-show">Show more</span><span class="summary-hide">Show less</span></button>
+      </div>` : ""}
       ${recentHistory.length ? `<details class="activity-disclosure">
         <summary><span class="activity-show">Show activity</span><span class="activity-hide">Hide activity</span></summary>
         <div class="timeline">
@@ -4778,6 +4783,10 @@ function taskCard(detail: TaskDetail, agents: AgentItem[]): string {
       </details>` : ""}
       <div class="record-actions">
         <button class="link-button" type="button" data-select-id="${escapeHtml(task.id)}">Inspect</button>
+      </div>
+      <div class="quick-actions" role="group" aria-label="Quick actions">
+        ${isFailed ? `<button class="link-button quick-action quick-action-retry" type="button" data-quick-action="retry" data-task-id="${escapeHtml(task.id)}">Retry</button>` : ""}
+        ${isActive ? `<button class="danger-button quick-action quick-action-cancel" type="button" data-quick-action="cancel" data-task-id="${escapeHtml(task.id)}">Cancel</button>` : ""}
       </div>
     </article>
   `;
@@ -5825,6 +5834,25 @@ async function handleContentClick(event: MouseEvent): Promise<void> {
     render();
     return;
   }
+  const copyTarget = (event.target as Element | null)?.closest<HTMLElement>("[data-copy-id]");
+  if (copyTarget) {
+    event.preventDefault();
+    await copyTaskId(copyTarget);
+    return;
+  }
+  const summaryToggle = (event.target as Element | null)?.closest<HTMLElement>("[data-summary-toggle]");
+  if (summaryToggle) {
+    event.preventDefault();
+    const block = summaryToggle.closest<HTMLElement>("[data-task-summary]");
+    if (block) block.classList.toggle("is-clamped");
+    return;
+  }
+  const quickAction = (event.target as Element | null)?.closest<HTMLButtonElement>("[data-quick-action]");
+  if (quickAction) {
+    event.preventDefault();
+    await runQuickAction(quickAction);
+    return;
+  }
   const target = (event.target as Element | null)?.closest<HTMLElement>("[data-select-id]");
   if (!target) return;
   const selectedId = target.dataset.selectId || "";
@@ -5832,6 +5860,64 @@ async function handleContentClick(event: MouseEvent): Promise<void> {
   state.selectedId = state.selectedId === selectedId ? "" : selectedId;
   updateUrlState();
   render();
+}
+
+async function copyTaskId(button: HTMLElement): Promise<void> {
+  const id = button.dataset.copyId || "";
+  if (!id) return;
+  let copied = false;
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(id);
+      copied = true;
+    }
+  } catch {
+    copied = false;
+  }
+  if (!copied) {
+    try {
+      const helper = document.createElement("textarea");
+      helper.value = id;
+      helper.setAttribute("readonly", "");
+      helper.style.position = "absolute";
+      helper.style.left = "-9999px";
+      document.body.appendChild(helper);
+      helper.select();
+      document.execCommand("copy");
+      document.body.removeChild(helper);
+      copied = true;
+    } catch {
+      copied = false;
+    }
+  }
+  if (copied) {
+    button.classList.add("is-copied");
+    window.setTimeout(() => button.classList.remove("is-copied"), 1200);
+  }
+}
+
+async function runQuickAction(button: HTMLButtonElement): Promise<void> {
+  const taskId = button.dataset.taskId || "";
+  const action = button.dataset.quickAction || "";
+  if (!taskId || !action) return;
+  const targetState = action === "retry" ? "open" : "cancelled";
+  const label = action === "retry" ? "Retry" : "Cancel";
+  if (action === "cancel" && !window.confirm("Cancel this task?")) return;
+  button.disabled = true;
+  try {
+    const result = await postJSON(`/tasks/${encodeURIComponent(taskId)}/transition`, {
+      target_state: targetState,
+      actor: "human",
+      detail: {},
+    });
+    state.actionMessage = `${label} ok: ${redactedJson(result)}`;
+    await loadDashboard();
+  } catch (error) {
+    state.actionMessage = `${label} failed: ${error instanceof Error ? error.message : String(error)}`;
+    render();
+  } finally {
+    button.disabled = false;
+  }
 }
 
 function navigateDashboardView(view: ViewKey | undefined): void {
@@ -7111,6 +7197,12 @@ function formatAge(value: string | null | undefined): string {
 
 function formatTime(value: Date): string {
   return new Intl.DateTimeFormat(undefined, { hour: "numeric", minute: "2-digit", second: "2-digit" }).format(value);
+}
+
+function formatIso(value: string | null | undefined): string {
+  const date = value ? new Date(value) : null;
+  if (!date || Number.isNaN(date.getTime())) return "unknown";
+  return date.toISOString();
 }
 
 function labelize(value: unknown): string {

--- a/src/mac/ui/styles.css
+++ b/src/mac/ui/styles.css
@@ -1796,6 +1796,113 @@ button.mobile-object-card {
   overflow-wrap: anywhere;
 }
 
+/* Click-to-copy task id chip. */
+.task-id-copy {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  max-width: 100%;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  padding: 1px 6px 1px 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.task-id-copy:hover {
+  border-color: var(--line);
+  color: var(--accent);
+}
+
+.task-id-copy .task-id-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-id-copy .task-id-copied {
+  display: none;
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-weight: 800;
+}
+
+.task-id-copy.is-copied .task-id-text {
+  display: none;
+}
+
+.task-id-copy.is-copied .task-id-copied {
+  display: inline;
+}
+
+/* Collapsible description/summary clamped to 2 lines with a Show more toggle. */
+.task-summary {
+  margin-top: 8px;
+}
+
+.task-summary .task-summary-text {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.task-summary.is-clamped .task-summary-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.task-summary .task-summary-toggle {
+  margin-top: 2px;
+  padding: 0;
+  font-size: 0.75rem;
+}
+
+.task-summary .summary-hide {
+  display: inline;
+}
+
+.task-summary .summary-show {
+  display: none;
+}
+
+.task-summary.is-clamped .summary-show {
+  display: inline;
+}
+
+.task-summary.is-clamped .summary-hide {
+  display: none;
+}
+
+/* Hover-revealed quick-action bar (Retry / Cancel). */
+.task-card .quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+  max-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition: opacity 0.12s ease, max-height 0.12s ease;
+}
+
+.task-card .quick-actions:empty {
+  display: none;
+}
+
+.task-card:hover .quick-actions,
+.task-card:focus-within .quick-actions {
+  max-height: 60px;
+  opacity: 1;
+}
+
+.task-card .quick-action {
+  flex: 0 0 auto;
+}
+
 .task-card p,
 .record p,
 .runtime-record p,

--- a/tests/ui/test_ui_shell.py
+++ b/tests/ui/test_ui_shell.py
@@ -297,6 +297,46 @@ def test_app_js_has_object_inspector_mobile_runtime_secret_surfaces():
 
 
 # ---------------------------------------------------------------------------
+# JS — task card quick-actions, density, and timestamp display
+# ---------------------------------------------------------------------------
+
+
+def test_app_ts_and_app_js_have_task_card_quick_actions_and_copy():
+    """Task card improvements must exist in both the TS source and compiled JS."""
+    ts = (_UI_ROOT / "app.ts").read_text(encoding="utf-8")
+    js = (_UI_ROOT / "app.js").read_text(encoding="utf-8")
+    for source in (ts, js):
+        # Relative timestamps with ISO tooltip
+        assert "formatIso" in source
+        assert "toISOString" in source
+        # Click-to-copy task id chip with feedback
+        assert "data-copy-id" in source
+        assert "copyTaskId" in source
+        assert "writeText" in source
+        assert "is-copied" in source
+        # Hover-revealed quick actions: Retry (failed) / Cancel (active)
+        assert "data-quick-action" in source
+        assert "runQuickAction" in source
+        assert 'data-quick-action="retry"' in source
+        assert 'data-quick-action="cancel"' in source
+        assert "/transition" in source
+        # Collapsible description/summary block with Show more toggle
+        assert "data-summary-toggle" in source
+        assert "data-task-summary" in source
+        assert "is-clamped" in source
+
+
+def test_css_contains_task_card_density_styles():
+    css = (_UI_ROOT / "styles.css").read_text(encoding="utf-8")
+    assert ".task-id-copy" in css
+    assert ".task-id-copied" in css
+    assert ".task-summary" in css
+    assert "line-clamp" in css
+    assert ".quick-actions" in css
+    assert ".task-card:hover .quick-actions" in css
+
+
+# ---------------------------------------------------------------------------
 # TS/JS source consistency
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
task=task_78f793ae763044d0a12f96dd7edbeb79
agent=mac-worker-python-coder-opencode
role=python-coder-opencode

Title: Improve task card quick-actions, density, and timestamp display on Tasks page

Improve individual task cards on the MAC Tasks page for better UX and scannability.

## Requirements
1. Relative timestamps - show 2 hours ago style; full ISO datetime on hover tooltip
2. Click-to-copy task ID - chip copies to clipboard on click; brief visual feedback
3. Hover-revealed quick-action bar on card hover: Failed cards get Retry button; Open/running cards get Cancel button; actions call appropriate MAC API endpoints
4. Collapsible description/summary block - clamp to 2 lines with Show more toggle

## Acceptance Criteria
- All card timestamps render as relative strings with ISO tooltip on hover
- Task ID chip copies to clipboard; feedback shown
- Retry button visible on hover for Failed cards; Cancel for open/running cards
- Description blocks clamp to 2 lines with working Show more toggle
- Run full test suite; all tests must pass before opening MR