### PR TITLE
mac: Title: Collapse connection config header into a settings drawer on Tasks

### DIFF
--- a/src/mac/ui/app.js
+++ b/src/mac/ui/app.js
@@ -271,6 +271,7 @@ const state = {
     data: null,
     error: null,
     actionMessage: null,
+    configCollapsed: false,
     agentQuery: DEFAULT_URL_STATE.agentQuery,
     agentFilter: DEFAULT_URL_STATE.agentFilter,
     agentSort: DEFAULT_URL_STATE.agentSort,
@@ -334,6 +335,8 @@ const nodes = {
     serviceLinks: requiredElement("#serviceLinks"),
     connectionBadge: requiredElement("#connectionBadge"),
     themeToggle: requiredElement("#themeToggle"),
+    topbar: requiredElement("#topbar"),
+    configToggle: requiredElement("#configToggle"),
 };
 const api = createDashboardApi(() => state.token, () => state.apiBaseUrl);
 applyTheme(readStoredTheme());
@@ -366,6 +369,7 @@ function bindEvents() {
     });
     nodes.refresh.addEventListener("click", () => loadDashboard());
     nodes.themeToggle.addEventListener("click", () => toggleTheme());
+    nodes.configToggle.addEventListener("click", () => toggleConfigCollapsed());
     nodes.viewSelect.addEventListener("change", () => {
         navigateDashboardView(nodes.viewSelect.value);
     });
@@ -461,6 +465,7 @@ async function loadDashboard() {
     try {
         applyDashboardData((await requestJSON("/dashboard/state")));
         state.connection = { ...state.connection, connected: true };
+        state.configCollapsed = true;
         syncDashboardSubscription();
     }
     catch (error) {
@@ -614,6 +619,7 @@ async function disconnectFromControls() {
     else {
         state.connection = { ...api.connection(), connected: false };
     }
+    state.configCollapsed = false;
     render();
 }
 async function applySelectedTarget(targetId, testingUrl, tokenSourceId = "", manualToken = "") {
@@ -824,6 +830,25 @@ function renderSyncState() {
             : connected
                 ? "Not updated"
                 : "Not connected";
+    renderConfigVisibility();
+}
+function renderConfigVisibility() {
+    const connected = isConnectionLive();
+    const collapsed = connected && state.configCollapsed;
+    nodes.topbar.classList.toggle("config-collapsed", collapsed);
+    nodes.connectionForm.hidden = collapsed;
+    nodes.configToggle.hidden = !connected;
+    nodes.configToggle.setAttribute("aria-expanded", String(!collapsed));
+    nodes.configToggle.setAttribute("aria-label", collapsed ? "Show connection settings" : "Hide connection settings");
+    nodes.configToggle.title = collapsed ? "Show connection settings" : "Hide connection settings";
+    nodes.configToggle.classList.toggle("is-active", !collapsed);
+}
+function setConfigCollapsed(collapsed) {
+    state.configCollapsed = collapsed;
+    renderConfigVisibility();
+}
+function toggleConfigCollapsed() {
+    setConfigCollapsed(!state.configCollapsed);
 }
 function renderBanner() {
     if (!state.error) {

--- a/src/mac/ui/app.ts
+++ b/src/mac/ui/app.ts
@@ -533,6 +533,7 @@ interface DashboardState {
   data: DashboardData | null;
   error: string | null;
   actionMessage: string | null;
+  configCollapsed: boolean;
   agentQuery: string;
   agentFilter: string;
   agentSort: string;
@@ -599,6 +600,8 @@ interface DashboardNodes {
   serviceLinks: HTMLElement;
   connectionBadge: HTMLElement;
   themeToggle: HTMLButtonElement;
+  topbar: HTMLElement;
+  configToggle: HTMLButtonElement;
 }
 
 const TOKEN_KEY = "mac.dashboard.token";
@@ -875,6 +878,7 @@ const state: DashboardState = {
   data: null,
   error: null,
   actionMessage: null,
+  configCollapsed: false,
   agentQuery: DEFAULT_URL_STATE.agentQuery,
   agentFilter: DEFAULT_URL_STATE.agentFilter,
   agentSort: DEFAULT_URL_STATE.agentSort,
@@ -939,6 +943,8 @@ const nodes: DashboardNodes = {
   serviceLinks: requiredElement("#serviceLinks"),
   connectionBadge: requiredElement("#connectionBadge"),
   themeToggle: requiredElement<HTMLButtonElement>("#themeToggle"),
+  topbar: requiredElement("#topbar"),
+  configToggle: requiredElement<HTMLButtonElement>("#configToggle"),
 };
 const api = createDashboardApi(() => state.token, () => state.apiBaseUrl);
 
@@ -971,6 +977,7 @@ function bindEvents(): void {
   });
   nodes.refresh.addEventListener("click", () => loadDashboard());
   nodes.themeToggle.addEventListener("click", () => toggleTheme());
+  nodes.configToggle.addEventListener("click", () => toggleConfigCollapsed());
   nodes.viewSelect.addEventListener("change", () => {
     navigateDashboardView(nodes.viewSelect.value as ViewKey);
   });
@@ -1054,6 +1061,9 @@ async function loadDashboard(): Promise<void> {
   try {
     applyDashboardData((await requestJSON("/dashboard/state")) as DashboardData);
     state.connection = { ...state.connection, connected: true };
+    // First successful connection collapses the config row so the board gets
+    // the vertical space back; the gear toggle re-opens it on demand.
+    state.configCollapsed = true;
     syncDashboardSubscription();
   } catch (error) {
     state.error = error instanceof Error ? error.message : String(error);
@@ -1209,6 +1219,9 @@ async function disconnectFromControls(): Promise<void> {
   } else {
     state.connection = { ...api.connection(), connected: false };
   }
+  // Re-expand the config row on disconnect so the inputs are immediately
+  // available for reconnecting.
+  state.configCollapsed = false;
   render();
 }
 
@@ -1420,7 +1433,39 @@ function renderSyncState(): void {
       : connected
         ? "Not updated"
         : "Not connected";
+  renderConfigVisibility();
 }
+
+// Connection config drawer. When a connection is live the config row collapses
+// behind a gear toggle so the kanban board gains the freed vertical space; when
+// disconnected the row stays visible by default so users can connect.
+function renderConfigVisibility(): void {
+  const connected = isConnectionLive();
+  // Force the config open whenever we are disconnected — there is nothing to
+  // collapse into and the user needs the inputs to establish a connection.
+  const collapsed = connected && state.configCollapsed;
+  nodes.topbar.classList.toggle("config-collapsed", collapsed);
+  nodes.connectionForm.hidden = collapsed;
+  // The gear toggle is only useful once a connection exists.
+  nodes.configToggle.hidden = !connected;
+  nodes.configToggle.setAttribute("aria-expanded", String(!collapsed));
+  nodes.configToggle.setAttribute(
+    "aria-label",
+    collapsed ? "Show connection settings" : "Hide connection settings",
+  );
+  nodes.configToggle.title = collapsed ? "Show connection settings" : "Hide connection settings";
+  nodes.configToggle.classList.toggle("is-active", !collapsed);
+}
+
+function setConfigCollapsed(collapsed: boolean): void {
+  state.configCollapsed = collapsed;
+  renderConfigVisibility();
+}
+
+function toggleConfigCollapsed(): void {
+  setConfigCollapsed(!state.configCollapsed);
+}
+
 
 function renderBanner(): void {
   if (!state.error) {

--- a/src/mac/ui/index.html
+++ b/src/mac/ui/index.html
@@ -99,7 +99,7 @@
         </form>
       </aside>
       <main class="main">
-        <header class="topbar">
+        <header class="topbar" id="topbar">
           <div>
             <p class="eyebrow">MAC</p>
             <h1 id="viewTitle">Overview</h1>
@@ -152,6 +152,9 @@
             </form>
             <span class="connection-badge" id="connectionBadge">Same origin</span>
             <span class="sync-state" id="syncState">Not loaded</span>
+            <button class="config-toggle" type="button" id="configToggle" aria-label="Connection settings" aria-expanded="true" aria-controls="connectionForm" title="Connection settings" hidden>
+              <span class="config-toggle-icon" aria-hidden="true">&#9881;</span>
+            </button>
             <button class="theme-toggle" type="button" id="themeToggle" aria-label="Toggle dark mode" aria-pressed="false" title="Toggle dark mode">
               <span class="theme-toggle-icon" aria-hidden="true"></span>
               <span class="theme-toggle-label">Dark</span>

--- a/src/mac/ui/styles.css
+++ b/src/mac/ui/styles.css
@@ -505,6 +505,55 @@ h3 {
   display: none;
 }
 
+/* Connection config drawer: once connected, the config row collapses behind
+   the gear toggle and the freed vertical space is returned to the board. */
+.topbar.config-collapsed .connection-form {
+  display: none;
+}
+
+.config-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.config-toggle[hidden] {
+  display: none;
+}
+
+.config-toggle:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+
+.config-toggle.is-active {
+  border-color: var(--accent);
+  color: var(--accent-ink);
+}
+
+.config-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.config-toggle-icon {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
 .sync-state {
   min-width: 120px;
   color: var(--muted);


### PR DESCRIPTION
task=task_326b96d76fb54aa4a0409d29c9ddcd9b
agent=mac-worker-python-coder-opencode
role=python-coder-opencode

Title: Collapse connection config header into a settings drawer on Tasks page

De-clutter the Tasks page header by collapsing the 4-input connection config into a settings drawer.

## Requirements
- The config row (Fleet Hub dropdown, Bearer Token dropdown, Manual Token field, Testing URL field + Connect button) auto-collapses once a successful connection is established
- A gear icon in the main header re-opens the config panel (collapsible section or sidebar drawer)
- When collapsed: only show Status badge + Refresh button + Theme toggle in the header
- When disconnected / no connection: config row remains visible by default
- Freed vertical space (~30% above the fold) is given back to the kanban board

## Acceptance Criteria
- Config row hides automatically after successful connection
- Gear icon re-expands the config row
- Header with config collapsed is clean: status badge + refresh + theme toggle only
- No regression: config inputs still functional when expanded
- Run full test suite; all tests must pass before opening MR