### PR TITLE
Pick a default fleet + load token from ~/.mac/.env without flags

### DIFF
--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -1042,7 +1042,7 @@ def _resolve_hub_url(args: Any, env: Dict[str, str]) -> Optional[str]:
         value = env.get(name)
         if value:
             return value
-    fleet = getattr(args, "fleet", None) or env.get("MAC_FLEET")
+    fleet = _effective_fleet(args, env)
     if fleet:
         url = _fleet_url_from_yaml(fleet)
         if url:
@@ -1054,7 +1054,7 @@ def _resolve_hub_token(args: Any, env: Dict[str, str]) -> Optional[str]:
     explicit = getattr(args, "token", None)
     if explicit:
         return explicit
-    fleet = getattr(args, "fleet", None) or env.get("MAC_FLEET")
+    fleet = _effective_fleet(args, env)
     token = resolve_env_var("MAC_API_TOKEN", fleet=fleet, env=env)
     if token:
         return token
@@ -1064,22 +1064,30 @@ def _resolve_hub_token(args: Any, env: Dict[str, str]) -> Optional[str]:
     return env.get("MAC_WORKER_TOKEN") or None
 
 
-def _fleet_url_from_yaml(fleet: str) -> Optional[str]:
-    """Look up hub_url for a named fleet in ~/.mac/fleets.yaml."""
-    candidate = Path(os.environ.get("MAC_FLEETS_CONFIG", "")) if os.environ.get("MAC_FLEETS_CONFIG") else (
-        Path.home() / ".mac" / "fleets.yaml"
-    )
-    if not candidate.is_file():
-        return None
+def _fleets_config_path() -> Path:
+    override = os.environ.get("MAC_FLEETS_CONFIG")
+    return Path(override) if override else (Path.home() / ".mac" / "fleets.yaml")
+
+
+def _load_fleets_yaml() -> Dict[str, Any]:
+    """Parse ~/.mac/fleets.yaml (or $MAC_FLEETS_CONFIG); {} on any problem."""
+    path = _fleets_config_path()
+    if not path.is_file():
+        return {}
     try:
         import yaml  # type: ignore
     except ImportError:
-        return None
+        return {}
     try:
-        data = yaml.safe_load(candidate.read_text()) or {}
+        data = yaml.safe_load(path.read_text()) or {}
     except Exception:
-        return None
-    fleets = (data or {}).get("fleets") or {}
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _fleet_url_from_yaml(fleet: str) -> Optional[str]:
+    """Look up hub_url for a named fleet in ~/.mac/fleets.yaml."""
+    fleets = _load_fleets_yaml().get("fleets") or {}
     entry = fleets.get(fleet)
     if not isinstance(entry, dict):
         return None
@@ -1087,23 +1095,54 @@ def _fleet_url_from_yaml(fleet: str) -> Optional[str]:
     return str(url) if url else None
 
 
+def _default_fleet_from_yaml() -> Optional[str]:
+    """Pick the default fleet when --fleet / $MAC_FLEET are unset.
+
+    A fleet entry in ~/.mac/fleets.yaml may set ``default: true``.
+    Resolution:
+      * exactly one fleet marked ``default: true`` -> that fleet;
+      * none marked but exactly one fleet defined -> that lone fleet;
+      * otherwise (none/several marked among multiple fleets) -> None,
+        leaving the choice to an explicit --fleet so we never guess.
+    """
+    fleets = _load_fleets_yaml().get("fleets") or {}
+    if not isinstance(fleets, dict) or not fleets:
+        return None
+    marked = [
+        name
+        for name, entry in fleets.items()
+        if isinstance(entry, dict) and entry.get("default") is True
+    ]
+    if len(marked) == 1:
+        return marked[0]
+    if not marked and len(fleets) == 1:
+        return next(iter(fleets))
+    return None
+
+
+def _effective_fleet(args: Any, env: Dict[str, str]) -> Optional[str]:
+    """The fleet to use: explicit --fleet, then $MAC_FLEET, then the
+    fleets.yaml default (the lone fleet, or the one marked ``default: true``)."""
+    return getattr(args, "fleet", None) or env.get("MAC_FLEET") or _default_fleet_from_yaml()
+
+
 def _load_dotenv_into(env: Dict[str, str]) -> None:
-    """Merge ~/.mac/.env into the env dict without clobbering live env."""
+    """Merge ~/.mac/.env into the env dict without clobbering live env.
+
+    Uses :func:`mac.fleet_env.parse_env_file` so ``export``-prefixed lines and
+    quoted values (e.g. a JSON ``MAC_API_TOKENS=...``) are handled the same way
+    a shell would, rather than landing as a bogus ``export MAC_API_TOKEN`` key
+    or a value with stray quotes.
+    """
     path = Path(os.environ.get("MAC_DEPLOY_ENV_FILE") or (Path.home() / ".mac" / ".env"))
     if not path.is_file():
         return
     try:
-        for line in path.read_text().splitlines():
-            stripped = line.strip()
-            if not stripped or stripped.startswith("#") or "=" not in stripped:
-                continue
-            key, _, value = stripped.partition("=")
-            key = key.strip()
-            value = value.strip()
-            if not key:
-                continue
+        from mac.fleet_env import parse_env_file
+
+        for key, value in parse_env_file(path).items():
             env.setdefault(key, value)
-    except OSError:
+    except Exception:
         return
 
 
@@ -1139,7 +1178,9 @@ def resolve_dispatch(args: Any) -> Union[LocalDispatch, RemoteDispatch]:
         "mac: no hub configured and no --db specified.\n"
         "  Set MAC_API_URL (or pass --hub-url <URL>) to target a hub, or\n"
         "  pass --db <path> to use a local SQLite database.\n"
-        "  For a named fleet: --fleet <name> reads ~/.mac/fleets.yaml.",
+        "  For a named fleet: --fleet <name> reads ~/.mac/fleets.yaml.\n"
+        "  With multiple fleets, mark one `default: true` in fleets.yaml to\n"
+        "  make it the flagless default (a lone fleet is the default already).",
         file=sys.stderr,
     )
     raise SystemExit(2)

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -17,13 +17,16 @@ A ``Dispatch`` is a transport-flavored facade. Two flavors exist:
    with a stderr banner so silent local writes can't happen.
 2. ``--hub-url URL`` (with optional ``--token``) → remote HTTP.
 3. ``MAC_API_URL`` / ``MAC_URL`` / ``MAC_HUB_URL`` env → remote HTTP.
-4. ``~/.mac/config.yaml`` ``default_fleet`` + ``~/.mac/fleets.yaml``
-   ``hub_url`` → remote HTTP.
+4. A fleet → its ``hub_url`` in ``~/.mac/fleets.yaml`` → remote HTTP. The
+   fleet is ``--fleet`` / ``MAC_FLEET`` if set, else the default fleet:
+   the lone fleet, or the one marked ``default: true`` in fleets.yaml.
 5. Nothing configured → error with help text. No silent fallback.
 
-When ``args.fleet`` is set (or ``MAC_FLEET`` env), the token resolution
-goes through :func:`mac.fleet_env.resolve` so ``MAC_API_TOKEN__<FLEET>``
-takes precedence over the flat ``MAC_API_TOKEN``.
+The effective fleet (explicit, env, or default) also scopes the token via
+:func:`mac.fleet_env.resolve` so ``MAC_API_TOKEN__<FLEET>`` takes precedence
+over the flat ``MAC_API_TOKEN``. Token values missing from the live
+environment are filled from ``~/.mac/.env`` (see :func:`_load_dotenv_into`),
+so a configured fleet needs no manual ``source``.
 
 Mirroring ControlPlane's surface
 --------------------------------

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -180,13 +180,17 @@ def test_resolve_dispatch_explicit_db_wins_over_hub(tmp_path, monkeypatch):
     assert isinstance(disp, LocalDispatch)
 
 
-def test_resolve_dispatch_errors_when_nothing_configured(monkeypatch, capsys):
+def test_resolve_dispatch_errors_when_nothing_configured(tmp_path, monkeypatch, capsys):
     monkeypatch.delenv("MAC_API_URL", raising=False)
     monkeypatch.delenv("MAC_URL", raising=False)
     monkeypatch.delenv("MAC_HUB_URL", raising=False)
     monkeypatch.delenv("HGMAC_URL", raising=False)
     monkeypatch.delenv("MAC_DB", raising=False)
+    monkeypatch.delenv("MAC_FLEET", raising=False)
     monkeypatch.setenv("MAC_DEPLOY_ENV_FILE", "/dev/null")
+    # Isolate from the dev machine's real ~/.mac/fleets.yaml: point the loader
+    # at a path that doesn't exist so no default fleet is inferred.
+    monkeypatch.setenv("MAC_FLEETS_CONFIG", str(tmp_path / "absent.yaml"))
     with pytest.raises(SystemExit) as excinfo:
         resolve_dispatch(_ns())
     assert excinfo.value.code == 2
@@ -194,6 +198,68 @@ def test_resolve_dispatch_errors_when_nothing_configured(monkeypatch, capsys):
     assert "no hub configured" in captured.err
     assert "--db" in captured.err
     assert "MAC_API_URL" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# default-fleet selection + ~/.mac/.env auto-loading (flagless usability)
+# ---------------------------------------------------------------------------
+
+
+def _write_fleets(tmp_path, monkeypatch, body: str):
+    path = tmp_path / "fleets.yaml"
+    path.write_text(body)
+    monkeypatch.setenv("MAC_FLEETS_CONFIG", str(path))
+    return path
+
+
+def _clear_hub_env(monkeypatch):
+    for name in ("MAC_API_URL", "MAC_URL", "MAC_HUB_URL", "HGMAC_URL", "MAC_DB", "MAC_FLEET"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("MAC_DEPLOY_ENV_FILE", "/dev/null")
+
+
+def test_default_fleet_lone_fleet_is_default(tmp_path, monkeypatch):
+    import mac.dispatch as d
+
+    _write_fleets(tmp_path, monkeypatch, "fleets:\n  only:\n    hub_url: http://only:8789\n")
+    assert d._default_fleet_from_yaml() == "only"
+
+
+def test_default_fleet_marked_wins_among_many(tmp_path, monkeypatch):
+    import mac.dispatch as d
+
+    _write_fleets(
+        tmp_path,
+        monkeypatch,
+        "fleets:\n"
+        "  a:\n    hub_url: http://a:8789\n"
+        "  b:\n    hub_url: http://b:8789\n    default: true\n",
+    )
+    assert d._default_fleet_from_yaml() == "b"
+
+
+def test_default_fleet_ambiguous_returns_none(tmp_path, monkeypatch):
+    import mac.dispatch as d
+
+    _write_fleets(
+        tmp_path,
+        monkeypatch,
+        "fleets:\n  a:\n    hub_url: http://a:8789\n  b:\n    hub_url: http://b:8789\n",
+    )
+    assert d._default_fleet_from_yaml() is None
+
+
+def test_resolve_dispatch_uses_default_fleet_url_and_dotenv_token(tmp_path, monkeypatch):
+    """Flagless `mac`: lone fleet -> hub_url, token pulled from ~/.mac/.env."""
+    _clear_hub_env(monkeypatch)
+    _write_fleets(tmp_path, monkeypatch, "fleets:\n  only:\n    hub_url: http://only:8789\n")
+    env_file = tmp_path / ".env"
+    env_file.write_text("export MAC_API_TOKEN__ONLY=sekret\n")
+    monkeypatch.setenv("MAC_DEPLOY_ENV_FILE", str(env_file))
+    disp = resolve_dispatch(_ns())  # no --fleet, no --hub-url, no --token
+    assert isinstance(disp, RemoteDispatch)
+    assert disp._client.base_url == "http://only:8789"
+    assert disp._client.token == "sekret"
 
 
 class _FakeTransport:


### PR DESCRIPTION
## Why

`mac` was less usable than the old `bd`: it required `--fleet` on every call and only found the bearer token if you had already `source`d `~/.mac/.env`. With nothing exported, flagless `mac task ...` fell straight through to "no hub configured."

## What

**Default fleet selection.** A fleet in `~/.mac/fleets.yaml` may now be marked `default: true`. When `--fleet` and `$MAC_FLEET` are unset, the effective fleet is:
- the one marked `default: true`, else
- the lone fleet when only one is defined, else
- *none* — multiple unmarked fleets stay ambiguous and still require an explicit `--fleet` (we never guess between peers).

This effective fleet drives **both** the hub URL (`fleets.yaml` `hub_url`) and the scoped token (`MAC_API_TOKEN__<FLEET>`).

**Robust `~/.mac/.env` token loading.** `resolve_dispatch` already merged `~/.mac/.env`, but via an inline parser that mishandled `export `-prefixed and quoted lines (a JSON `MAC_API_TOKENS=...` came through with stray quotes; `export MAC_API_TOKEN=x` became a key literally named `export MAC_API_TOKEN`). It now uses `fleet_env.parse_env_file`, matching shell semantics.

## Result

With one fleet (or one marked `default: true`) and `~/.mac/.env` present, `mac task ...` / `mac fleet ...` work with **no flags and no manual `source`**.

## Tests

New `tests/test_dispatch.py` cases cover lone-fleet default, `default: true` precedence, ambiguous→None, and end-to-end flagless resolution (hub URL from fleets.yaml + token from `~/.mac/.env`). Hardened the nothing-configured test to isolate the real `fleets.yaml`. Full pre-push (api/cli/ui) green.

## Follow-up

The `default:` key is read by the client here; the deploy-side `fleets.yaml` generator doesn't emit it yet, so a redeploy won't preserve a hand-set default — worth wiring into the generator separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)