### PR TITLE
Preserve New Task drawer + in-progress prompt across stream refreshes

### DIFF
--- a/src/mac/ui/app.js
+++ b/src/mac/ui/app.js
@@ -872,11 +872,34 @@ function render() {
     syncObservabilitySubscription();
 }
 function renderPreservingFocusedControl() {
+    // A streamed refresh re-renders the active view via innerHTML, which would
+    // otherwise collapse open drawers and wipe whatever the user is mid-typing
+    // (e.g. a half-composed New Task prompt — see kanban-adopt-01 interim fix).
+    // Snapshot the open <details> (by id), the values of fields marked
+    // `data-preserve`, and the focused control's selection; restore them after
+    // the re-render so a background tick never discards in-progress work.
+    const openDrawers = Array.from(document.querySelectorAll("details[id][open]")).map((el) => el.id);
+    const drafts = new Map();
+    document
+        .querySelectorAll("[data-preserve][id]")
+        .forEach((el) => drafts.set(el.id, el.value));
     const active = document.activeElement;
     const id = active?.id || "";
     const selectionStart = active && "selectionStart" in active ? active.selectionStart : null;
     const selectionEnd = active && "selectionEnd" in active ? active.selectionEnd : null;
     render();
+    for (const drawerId of openDrawers) {
+        const drawer = document.getElementById(drawerId);
+        if (drawer)
+            drawer.open = true;
+    }
+    // Restore in-progress edits the re-render discarded — only when they differ,
+    // so a value the new render legitimately set is never clobbered.
+    drafts.forEach((value, draftId) => {
+        const el = document.getElementById(draftId);
+        if (el && "value" in el && el.value !== value)
+            el.value = value;
+    });
     if (!id)
         return;
     const next = document.getElementById(id);
@@ -886,8 +909,13 @@ function renderPreservingFocusedControl() {
     if (selectionStart !== null
         && selectionEnd !== null
         && "setSelectionRange" in next
-        && next instanceof HTMLInputElement) {
-        next.setSelectionRange(selectionStart, selectionEnd);
+        && (next instanceof HTMLInputElement || next instanceof HTMLTextAreaElement)) {
+        try {
+            next.setSelectionRange(selectionStart, selectionEnd);
+        }
+        catch {
+            /* number/email inputs reject setSelectionRange — caret restore is best-effort */
+        }
     }
 }
 function isConnectionLive() {
@@ -1509,24 +1537,24 @@ function renderTasks() {
       <input id="taskSearch" type="search" placeholder="Search tasks by title, id, project, capability" value="${escapeHtml(state.taskQuery)}">
       <button type="button" id="clearTaskFilter">Clear</button>
     </section>
-    <details class="surface action-drawer">
+    <details id="newTaskDrawer" class="surface action-drawer">
       <summary>
         <span>New Task</span>
         <span class="muted small">CEO mode: just describe the task — first line becomes the title, the full text the description. Open Advanced for full control.</span>
       </summary>
       <form class="action-form" data-action="taskCreate">
         <label class="field-full">Task
-          <textarea name="prompt" rows="4" required placeholder="Describe the task in plain language. The first line becomes the title; the whole thing becomes the description."></textarea>
+          <textarea id="newTaskPrompt" name="prompt" rows="4" required data-preserve placeholder="Describe the task in plain language. The first line becomes the title; the whole thing becomes the description."></textarea>
         </label>
-        <details class="field-full advanced-options">
+        <details id="newTaskAdvanced" class="field-full advanced-options">
           <summary>Advanced options</summary>
           <div class="advanced-grid">
-            <label>Title override <input name="title" placeholder="defaults to the first line above"></label>
-            <label>Project <input name="project" value="${escapeHtml(state.projectFilter === "all" ? "" : state.projectFilter)}"></label>
-            <label>Priority <input name="priority" type="number" value="0"></label>
-            <label>Capabilities <input name="required_capabilities" placeholder="python,deploy"></label>
-            <label>Dependencies <input name="dependencies" placeholder="task_a,task_b"></label>
-            <label class="field-full">Metadata JSON <textarea name="metadata" placeholder="{}"></textarea></label>
+            <label>Title override <input id="newTaskTitle" name="title" data-preserve placeholder="defaults to the first line above"></label>
+            <label>Project <input id="newTaskProject" name="project" data-preserve value="${escapeHtml(state.projectFilter === "all" ? "" : state.projectFilter)}"></label>
+            <label>Priority <input id="newTaskPriority" name="priority" type="number" data-preserve value="0"></label>
+            <label>Capabilities <input id="newTaskCaps" name="required_capabilities" data-preserve placeholder="python,deploy"></label>
+            <label>Dependencies <input id="newTaskDeps" name="dependencies" data-preserve placeholder="task_a,task_b"></label>
+            <label class="field-full">Metadata JSON <textarea id="newTaskMetadata" name="metadata" data-preserve placeholder="{}"></textarea></label>
           </div>
         </details>
         <div class="field-full form-actions"><button type="submit">Create</button></div>

--- a/src/mac/ui/app.ts
+++ b/src/mac/ui/app.ts
@@ -1551,11 +1551,34 @@ function render(): void {
 }
 
 function renderPreservingFocusedControl(): void {
+  // A streamed refresh re-renders the active view via innerHTML, which would
+  // otherwise collapse open drawers and wipe whatever the user is mid-typing
+  // (e.g. a half-composed New Task prompt — see kanban-adopt-01 interim fix).
+  // Snapshot the open <details> (by id), the values of fields marked
+  // `data-preserve`, and the focused control's selection; restore them after
+  // the re-render so a background tick never discards in-progress work.
+  const openDrawers = Array.from(
+    document.querySelectorAll<HTMLDetailsElement>("details[id][open]"),
+  ).map((el) => el.id);
+  const drafts = new Map<string, string>();
+  document
+    .querySelectorAll<HTMLInputElement | HTMLTextAreaElement>("[data-preserve][id]")
+    .forEach((el) => drafts.set(el.id, el.value));
   const active = document.activeElement as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null;
   const id = active?.id || "";
   const selectionStart = active && "selectionStart" in active ? active.selectionStart : null;
   const selectionEnd = active && "selectionEnd" in active ? active.selectionEnd : null;
   render();
+  for (const drawerId of openDrawers) {
+    const drawer = document.getElementById(drawerId) as HTMLDetailsElement | null;
+    if (drawer) drawer.open = true;
+  }
+  // Restore in-progress edits the re-render discarded — only when they differ,
+  // so a value the new render legitimately set is never clobbered.
+  drafts.forEach((value, draftId) => {
+    const el = document.getElementById(draftId) as HTMLInputElement | HTMLTextAreaElement | null;
+    if (el && "value" in el && el.value !== value) el.value = value;
+  });
   if (!id) return;
   const next = document.getElementById(id) as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement | null;
   if (!next) return;
@@ -1564,9 +1587,13 @@ function renderPreservingFocusedControl(): void {
     selectionStart !== null
     && selectionEnd !== null
     && "setSelectionRange" in next
-    && next instanceof HTMLInputElement
+    && (next instanceof HTMLInputElement || next instanceof HTMLTextAreaElement)
   ) {
-    next.setSelectionRange(selectionStart, selectionEnd);
+    try {
+      next.setSelectionRange(selectionStart, selectionEnd);
+    } catch {
+      /* number/email inputs reject setSelectionRange — caret restore is best-effort */
+    }
   }
 }
 
@@ -2194,24 +2221,24 @@ function renderTasks(): string {
       <input id="taskSearch" type="search" placeholder="Search tasks by title, id, project, capability" value="${escapeHtml(state.taskQuery)}">
       <button type="button" id="clearTaskFilter">Clear</button>
     </section>
-    <details class="surface action-drawer">
+    <details id="newTaskDrawer" class="surface action-drawer">
       <summary>
         <span>New Task</span>
         <span class="muted small">CEO mode: just describe the task — first line becomes the title, the full text the description. Open Advanced for full control.</span>
       </summary>
       <form class="action-form" data-action="taskCreate">
         <label class="field-full">Task
-          <textarea name="prompt" rows="4" required placeholder="Describe the task in plain language. The first line becomes the title; the whole thing becomes the description."></textarea>
+          <textarea id="newTaskPrompt" name="prompt" rows="4" required data-preserve placeholder="Describe the task in plain language. The first line becomes the title; the whole thing becomes the description."></textarea>
         </label>
-        <details class="field-full advanced-options">
+        <details id="newTaskAdvanced" class="field-full advanced-options">
           <summary>Advanced options</summary>
           <div class="advanced-grid">
-            <label>Title override <input name="title" placeholder="defaults to the first line above"></label>
-            <label>Project <input name="project" value="${escapeHtml(state.projectFilter === "all" ? "" : state.projectFilter)}"></label>
-            <label>Priority <input name="priority" type="number" value="0"></label>
-            <label>Capabilities <input name="required_capabilities" placeholder="python,deploy"></label>
-            <label>Dependencies <input name="dependencies" placeholder="task_a,task_b"></label>
-            <label class="field-full">Metadata JSON <textarea name="metadata" placeholder="{}"></textarea></label>
+            <label>Title override <input id="newTaskTitle" name="title" data-preserve placeholder="defaults to the first line above"></label>
+            <label>Project <input id="newTaskProject" name="project" data-preserve value="${escapeHtml(state.projectFilter === "all" ? "" : state.projectFilter)}"></label>
+            <label>Priority <input id="newTaskPriority" name="priority" type="number" data-preserve value="0"></label>
+            <label>Capabilities <input id="newTaskCaps" name="required_capabilities" data-preserve placeholder="python,deploy"></label>
+            <label>Dependencies <input id="newTaskDeps" name="dependencies" data-preserve placeholder="task_a,task_b"></label>
+            <label class="field-full">Metadata JSON <textarea id="newTaskMetadata" name="metadata" data-preserve placeholder="{}"></textarea></label>
           </div>
         </details>
         <div class="field-full form-actions"><button type="submit">Create</button></div>

--- a/tests/ui/test_ui_shell.py
+++ b/tests/ui/test_ui_shell.py
@@ -97,6 +97,18 @@ def test_ui_assets_styles_css_serves():
     assert "text/css" in resp.headers.get("content-type", "")
 
 
+def test_new_task_form_is_preserved_across_stream_refresh():
+    # A streamed dashboard refresh re-renders via innerHTML; the New Task drawer
+    # + in-progress prompt must survive it (kanban-adopt-01 interim fix). The
+    # markup carries the ids + data-preserve hooks, and the focus-preserving
+    # renderer restores open drawers and preserved field values.
+    app_js = (_UI_ROOT / "app.js").read_text(encoding="utf-8")
+    assert 'id="newTaskDrawer"' in app_js
+    assert 'id="newTaskPrompt"' in app_js and "data-preserve" in app_js
+    assert "details[id][open]" in app_js  # open-drawer snapshot/restore
+    assert "[data-preserve][id]" in app_js  # draft value snapshot/restore
+
+
 def test_ui_assets_vendored_xterm_serves():
     client = _client()
     assert client.get("/ui/assets/vendor/xterm/xterm.js").status_code == 200


### PR DESCRIPTION
## Why

The dashboard stream re-renders the active view (`refreshDashboardFromStream` → `renderPreservingFocusedControl`) roughly every second on a busy fleet. That helper only restored **focus + selection by element id** — and the New Task drawer/fields had no ids — so each tick **collapsed the drawer and wiped a half-typed CEO-mode prompt**. ("Refresh breaks the task view.")

## Fix

- Give the New Task `<details>` drawer + fields stable ids and a `data-preserve` marker.
- Extend `renderPreservingFocusedControl` to, around the re-render:
  - snapshot open `details[id]` and re-open them after render;
  - snapshot `[data-preserve][id]` field values and restore them **only when they differ** (so a value the re-render legitimately set is never clobbered);
  - restore caret for `<textarea>` too (with a try/catch for inputs that reject `setSelectionRange`).

The mechanism is generic: any `details[id]` / `[data-preserve][id]` survives a background refresh, not just the New Task form.

## Tests

Recompiled `app.js` via the documented `tsc` step; +1 UI shell test asserting the preservation hooks are present. 33 UI tests pass.

## Context

Interim fix while the bespoke ledger board is transitioned to the Hermes kanban (`.tickets/kanban-adopt-01.md`, Approach A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)