### PR TITLE
Kanban service link to Hermes dashboard (adopt, don't re-implement)

### DIFF
--- a/.tickets/kanban-adopt-01.md
+++ b/.tickets/kanban-adopt-01.md
@@ -1,0 +1,80 @@
+---
+id: kanban-adopt-01
+status: open
+deps: []
+links: [ui-modularize-01]
+created: 2026-06-09T00:00:00Z
+type: epic
+priority: 1
+audit: dashboard-ui-review
+discovered_via: architecture_review
+---
+# Adopt the Hermes kanban plugin instead of the bespoke dashboard board
+
+## Why this exists
+
+The mac dashboard re-implements a task board (`renderTasks` in
+`src/mac/ui/app.ts`, lanes over `TASK_STATES`) while the vendored Hermes runtime
+already ships a complete kanban system. Decision (2026-06-09): adopt Hermes'
+kanban rather than keep growing the bespoke board.
+
+## What Hermes already provides
+
+- **Board + store:** `hermes_cli/kanban_db.py` — SQLite `kanban.db`, multi-board,
+  CAS status updates. Statuses: `triage/todo/scheduled/ready/running/blocked/
+  review/done/archived`.
+- **Coordination:** `hermes_cli/kanban_{decompose,specify,swarm,diagnostics}.py`,
+  `tools/kanban_tools.py`, a dispatcher (`plugins/kanban/systemd/
+  hermes-kanban-dispatcher.service`), and devops skills (kanban-worker/-orchestrator).
+- **Dashboard plugin:** `_hermes/plugins/kanban/dashboard/` — `manifest.json`
+  (tab `/kanban`, entry `dist/index.js`, css `dist/style.css`, api `plugin_api.py`)
+  + `plugin_api.py` (93 KB FastAPI router, drag-drop board, comment threads,
+  `/events` WebSocket, session-token auth). Mounted at `/api/plugins/kanban/`.
+
+## The two gaps that make this non-trivial
+
+1. **Frontend not vendored.** Only `plugin_api.py` + `manifest.json` are in this
+   repo; the built React bundle (`dist/index.js`, `dist/style.css`) lives upstream
+   (`NousResearch/hermes-agent`) and is lazily installed by `hermes dashboard`.
+2. **Different server + different store.** The plugin targets the *Hermes*
+   dashboard server (`hermes_cli/web_server.py`) with its own auth
+   (`window.__HERMES_SESSION_TOKEN__`); the mac dashboard is served by the mac hub
+   (`src/mac/api.py`, no plugin system). And the board reads **`kanban.db`**, a
+   different store than the **mac task ledger** (`mac.db`, `mac task`) the current
+   dashboard view shows. So "adopt the plugin" also forces a data decision:
+   does the kanban view *supplement* the ledger view, or do the two task stores
+   *unify*? (Ties to the Hermes-unification ADR.)
+
+## Integration options
+
+- **A — Link/embed the Hermes dashboard kanban.** Add a "Kanban" nav entry that
+  opens the Hermes dashboard's `/kanban` (link or iframe). Zero UI
+  re-implementation; needs the Hermes dashboard process running + its built
+  frontend; auth/origin are separate.
+- **B — Mount the plugin into the mac hub.** Include `plugin_api.py`'s APIRouter
+  on the mac hub app, vendor/build the kanban `dist/` into the mac UI, adapt the
+  plugin's session-token auth to the hub's bearer auth. One dashboard, one server,
+  one auth — most work.
+- **C — Reconcile stores first (ADR).** Decide the single source of truth
+  (mac ledger vs kanban.db vs bridge) before any UI, since the board is only as
+  useful as the data behind it.
+
+## Recommended phasing
+
+1. **Phase 1 (fast):** Option A — surface the existing Hermes kanban from the mac
+   dashboard with a nav link, proving the real plugin end-to-end with no
+   re-implementation. Keep the bespoke ledger board (with CEO-mode creation, #119)
+   during the transition.
+2. **Phase 2 (durable):** resolve the store question (C), then if warranted do B
+   and retire `renderTasks`' bespoke lanes.
+
+## Interim
+
+If the bespoke board lives through the transition, fix its refresh regression:
+the streamed-update `render()` replaces the DOM and wipes an open New Task drawer
++ half-typed prompt (worse now that CEO mode invites long prompts). Preserve the
+drawer's open state + field values across re-renders.
+
+## Notes
+
+Surfaced during the dashboard UI review. Related: [[ui-modularize-01]].

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1943,6 +1943,14 @@ def _dashboard_service_links(
         _lookup_config_value(("FIRECRAWL_API_URL", "FIRECRAWL_GATEWAY_URL"), env_files).get("value")
         or ""
     ).rstrip("/")
+    # kanban-adopt-01: link out to the Hermes dashboard's kanban board rather
+    # than re-implementing one. Shown only when the operator points us at a
+    # running Hermes dashboard.
+    hermes_dashboard_url = str(
+        _lookup_config_value(("MAC_HERMES_DASHBOARD_URL", "HERMES_DASHBOARD_URL"), env_files).get("value")
+        or ""
+    ).rstrip("/")
+    hermes_kanban_url = _join_service_url(hermes_dashboard_url, "/kanban") if hermes_dashboard_url else ""
     tokenhub_admin = _credential_ref(("TOKENHUB_ADMIN_TOKEN",), env_files)
     tokenhub_client = _credential_ref(
         ("TOKENHUB_API_KEY", "TOKENHUB_AGENT_KEY", "OPENAI_API_KEY"),
@@ -2024,6 +2032,30 @@ def _dashboard_service_links(
                 ),
             },
             "credentials": [firecrawl_key],
+        },
+        {
+            "id": "kanban",
+            "name": "Kanban",
+            "kind": "external_ui",
+            "role": "Hermes multi-agent kanban board",
+            "status": "configured" if hermes_dashboard_url else "not_configured",
+            "url": _redact_service_url(hermes_kanban_url),
+            "ui_url": _redact_service_url(hermes_kanban_url),
+            "health_url": (
+                _redact_service_url(_join_service_url(hermes_dashboard_url, "/healthz"))
+                if hermes_dashboard_url else ""
+            ),
+            "auth": {
+                "type": "dashboard_session",
+                "credential_pass_through": False,
+                "pass_through_url": "",
+                "notes": (
+                    "Opens the Hermes dashboard kanban (separate dashboard login)"
+                    if hermes_dashboard_url
+                    else "Set MAC_HERMES_DASHBOARD_URL (or HERMES_DASHBOARD_URL) to link the Hermes kanban board"
+                ),
+            },
+            "credentials": [],
         },
     ]
 

--- a/tests/api/test_dashboard_service_links.py
+++ b/tests/api/test_dashboard_service_links.py
@@ -58,6 +58,28 @@ def test_service_links_present_when_services_configured(monkeypatch):
     assert "firecrawl" in links
 
 
+def test_kanban_link_present_when_hermes_dashboard_configured(monkeypatch):
+    monkeypatch.setenv("MAC_HERMES_DASHBOARD_URL", "http://hermes.internal:8765")
+    client = _client()
+    links = {item["id"]: item for item in client.get("/dashboard/state").json()["service_links"]}
+    assert "kanban" in links
+    k = links["kanban"]
+    assert k["status"] == "configured"
+    assert "hermes.internal:8765/kanban" in k["ui_url"]
+    # Links out to the Hermes dashboard (separate login) — no credential pass-through.
+    assert k["auth"]["credential_pass_through"] is False
+
+
+def test_kanban_link_not_configured_without_hermes_dashboard_url(monkeypatch):
+    monkeypatch.delenv("MAC_HERMES_DASHBOARD_URL", raising=False)
+    monkeypatch.delenv("HERMES_DASHBOARD_URL", raising=False)
+    client = _client()
+    links = {item["id"]: item for item in client.get("/dashboard/state").json()["service_links"]}
+    # Present in the list but unconfigured -> no ui_url, so the sidebar hides it.
+    assert links["kanban"]["status"] == "not_configured"
+    assert not links["kanban"]["ui_url"]
+
+
 def test_service_links_redact_credentials(monkeypatch):
     monkeypatch.setenv("TOKENHUB_URL", "http://tokenhub.internal:8090")
     monkeypatch.setenv("TOKENHUB_ADMIN_TOKEN", "super-secret-admin-key")


### PR DESCRIPTION
## Why

Hermes already ships a complete kanban (board, dispatcher, swarm, and a dashboard plugin). Decision: **adopt it, don't re-implement** a board in the mac dashboard. This is Phase 1 — the lowest-risk step that uses the real Hermes kanban with zero UI re-implementation.

## What

Add a **"Kanban"** entry to `_dashboard_service_links` (`api.py`) that links to `<hermes-dashboard>/kanban`:
- Appears only when `MAC_HERMES_DASHBOARD_URL` (or `HERMES_DASHBOARD_URL`) is configured — the sidebar already hides links with no `url`, and the existing click-to-open handler opens it. **Server-side only**; no client changes.
- `external_ui`, no credential pass-through (the Hermes dashboard has its own session login).

## Not in this PR (tracked in `.tickets/kanban-adopt-01.md`)

- **The data-store question**: the Hermes board reads `kanban.db`; the mac dashboard's bespoke board reads the mac task ledger (`mac.db`). Whether they unify or coexist is Phase 2.
- **Phase 2**: optionally mount the plugin's router into the mac hub + vendor its frontend (the built `dist/` isn't in this repo), then retire the bespoke `renderTasks` lanes.

The bespoke ledger board (with CEO-mode creation, #119) stays during the transition; its refresh regression is fixed in #121.

## Tests

2 new cases in `tests/api/test_dashboard_service_links.py` (kanban link present + `/kanban` URL when configured; `not_configured` + hidden when unset). 15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)