### PR TITLE
ADR 0004 + revert Hermes kanban adoption (one task database)

### DIFF
--- a/.tickets/kanban-adopt-01.md
+++ b/.tickets/kanban-adopt-01.md
@@ -1,6 +1,6 @@
 ---
 id: kanban-adopt-01
-status: open
+status: closed
 deps: []
 links: [ui-modularize-01]
 created: 2026-06-09T00:00:00Z
@@ -8,8 +8,21 @@ type: epic
 priority: 1
 audit: dashboard-ui-review
 discovered_via: architecture_review
+resolution: wont-adopt
 ---
 # Adopt the Hermes kanban plugin instead of the bespoke dashboard board
+
+## Decision (2026-06-09): WON'T ADOPT — reverted
+
+Superseded by ADR 0004. The fleet needs **one task database** (`mac.db`).
+Making Hermes' kanban read from it requires reworking `kanban_db.py` — 7,386
+lines of vendored SQLite with no store seam, ~200 raw-SQL call sites, 7 tables —
+which is not feasible cheaply and would be a heavy fork of upstream
+(contra ADR 0001). Per the decision rule, the Phase-1 adoption (the dashboard
+kanban service link, PR #122) is **reverted** and the bespoke `renderTasks`
+board is kept as the single task surface over `mac.db`. Any future
+kanban-style decomposition UX should be built natively on the ledger, not by
+adopting `kanban.db`. The original plan below is retained for history.
 
 ## Why this exists
 

--- a/docs/adr/0004-task-ledger-vs-hermes-kanban.md
+++ b/docs/adr/0004-task-ledger-vs-hermes-kanban.md
@@ -1,0 +1,101 @@
+# ADR 0004 — MAC task ledger vs. Hermes kanban: coexist with a thin delegation bridge
+
+- Status: **Proposed**
+- Date: 2026-06-09
+- Decision owner: Jordan Hubbard
+- Context: Phase 2 of `kanban-adopt-01`. We decided to **adopt** the Hermes
+  kanban dashboard rather than re-implement a board in the mac dashboard
+  (Phase 1 shipped a link-out, PR #122). That forces the question this ADR
+  answers: how should the Hermes kanban store (`kanban.db`) relate to the MAC
+  hub task ledger (`mac.db`, the `mac task` system)?
+
+## TL;DR verdict
+
+They are **different layers, not duplicates.** Keep both stores; do **not**
+force them into one schema. Add a **thin one-way delegation bridge**: the mac
+ledger stays the canonical fleet work-queue (system of record); a mac task may
+*delegate* to a Hermes kanban board for goal-decomposition / swarm execution,
+and the board's terminal outcome transitions the mac task. The dashboard shows
+the ledger as primary and deep-links to the kanban board for delegated tasks.
+
+## Ground truth (today, not assumptions)
+
+| | **mac.db** task ledger | **kanban.db** Hermes kanban |
+| --- | --- | --- |
+| Purpose | Fleet **work-queue** | **Goal-decomposition + multi-agent swarm** |
+| Model | `models.py` `Task`, `store.py` `tasks` | `_hermes/hermes_cli/kanban_db.py` `tasks` |
+| Distinctive fields | `required_capabilities`, `lease_id`/`leased_until`, `owner_agent_id`, `max_attempts`, `project` | `board`, `workspace_kind`/`workspace_path`/`branch_name` (git worktrees), `task_links` (goal tree), `task_comments`/`task_events`, `task_runs`, `worker_pid`/`last_heartbeat_at`, `claim_lock` CAS |
+| States | `open/blocked/claimed/running/needs_review/reviewing/completed/failed/cancelled` | `triage/todo/scheduled/ready/running/blocked/review/done/archived` |
+| Dispatch | Agent polls; hub leases by capability | Kanban dispatcher subprocess spawns workers (`HERMES_KANBAN_TASK`) |
+| Scope / location | One **shared hub** DB per fleet (`~/.mac/mac.db`) | **Per-board local** SQLite (`~/.hermes/kanban.db`, `boards/<slug>/`) |
+| Answers | "*Who* can do this, and what's the contract?" | "*What's the goal tree*, and are my workers alive?" |
+
+**There is no bridge today.** Nothing in `src/mac/` (outside `_hermes/`) imports
+`kanban_db`/`kanban_tools`; the kanban dispatcher never reads `mac.db`; the mac
+dispatcher never reads `kanban.db`. The only links are an agent's optional
+`hermes_instance_id` and the read-only UI hyperlink added in PR #122. The
+schema divergence is intentional: capability-based fleet dispatch vs. worktree-
+bound worker-lifecycle decomposition solve different problems at different
+scales (fleet vs. single profile/goal).
+
+## Options considered
+
+1. **Unify into one store.** *Rejected.* The schemas, scales, and concerns
+   diverge; migration is large and either bloats the ledger with worktree/worker-
+   liveness columns or strips kanban's swarm semantics. High cost, high risk,
+   little near-term payoff.
+2. **Coexist, no bridge (status quo).** *Insufficient.* The two are invisible to
+   each other: a fleet task that is "really" a kanban swarm has no link, and the
+   dashboard can't show decomposition progress against the ledger item. This is
+   the gap that makes the bespoke board feel like duplication.
+3. **Coexist with a thin one-way delegation bridge.** *Recommended.* See below.
+
+## Decision
+
+Adopt **Option 3.** Roles:
+
+- **mac ledger = system of record** for fleet work and its lifecycle. Every unit
+  of fleet work is a mac task; capability dispatch, leasing, review, and
+  cross-fleet visibility stay here.
+- **Hermes kanban = an execution strategy a task may delegate to** when the work
+  warrants decomposition + a worker swarm (the `decompose`/`specify`/`swarm`
+  pipeline). It owns the *inside* of a delegated task: the goal tree, worktrees,
+  and worker liveness.
+
+**Bridge contract (one-way, ledger-owned):**
+- A mac task records `metadata.kanban = {board_id, dashboard_url}` when delegated.
+- Delegation creates/links a kanban board for that task; the kanban dispatcher
+  runs the swarm as it does today (unchanged).
+- A reconcile step maps the board's **terminal** state back to a mac task
+  transition (`done` → `completed`, `archived/failed` → `failed`), idempotently.
+- The dashboard renders the ledger as primary and, for a delegated task,
+  deep-links to `<hermes-dashboard>/kanban?board=<id>` (extends PR #122). No
+  re-implementation of the board UI.
+
+Direction is strictly one-way: the ledger owns task lifecycle; kanban owns
+intra-task decomposition. We do **not** sync arbitrary status both ways.
+
+## Consequences
+
+- **Pros:** each store keeps doing what it is good at; one pane of glass via the
+  ledger + deep links; incremental and reversible (no migration); the bespoke
+  `renderTasks` board can be retired without losing the fleet work-queue.
+- **Cons:** a small bridge + reconcile to maintain; two stores to back up and
+  observe; write-back can drift if a reconcile is missed (mitigated by making
+  reconcile idempotent and re-runnable).
+- **Non-goals:** migrating kanban into `mac.db`; teaching the ledger about
+  worktrees/worker PIDs; two-way status sync.
+
+## Follow-up work (tickets, not part of this ADR)
+
+1. Bridge: `metadata.kanban.board_id` on mac tasks + an idempotent reconcile
+   (board terminal → task transition). 
+2. Dashboard: deep-link a delegated task to its board (extends `kanban-adopt-01`
+   Phase 1). 
+3. Decide the trigger for delegation (explicit `mac task delegate-kanban`, or a
+   capability/heuristic). 
+4. Once the bridge + link exist, retire the bespoke `renderTasks` lanes
+   (`ui-modularize-01` can drop that view).
+
+Until the bridge lands, Phase 1 (the link-out from PR #122) is the interim
+surface and the two stores remain independent.

--- a/docs/adr/0004-task-ledger-vs-hermes-kanban.md
+++ b/docs/adr/0004-task-ledger-vs-hermes-kanban.md
@@ -1,22 +1,27 @@
-# ADR 0004 — MAC task ledger vs. Hermes kanban: coexist with a thin delegation bridge
+# ADR 0004 — One task database: revert the Hermes kanban adoption, keep our own board
 
-- Status: **Proposed**
+- Status: **Accepted**
 - Date: 2026-06-09
 - Decision owner: Jordan Hubbard
-- Context: Phase 2 of `kanban-adopt-01`. We decided to **adopt** the Hermes
-  kanban dashboard rather than re-implement a board in the mac dashboard
-  (Phase 1 shipped a link-out, PR #122). That forces the question this ADR
-  answers: how should the Hermes kanban store (`kanban.db`) relate to the MAC
-  hub task ledger (`mac.db`, the `mac task` system)?
+- Context: Phase 2 of `kanban-adopt-01`. Phase 1 shipped a dashboard link-out to
+  the Hermes kanban (PR #122). This ADR answers how the Hermes kanban store
+  (`kanban.db`) should relate to the MAC hub task ledger (`mac.db`, the
+  `mac task` system) — and concludes by reversing the Phase-1 adoption.
 
 ## TL;DR verdict
 
-They are **different layers, not duplicates.** Keep both stores; do **not**
-force them into one schema. Add a **thin one-way delegation bridge**: the mac
-ledger stays the canonical fleet work-queue (system of record); a mac task may
-*delegate* to a Hermes kanban board for goal-decomposition / swarm execution,
-and the board's terminal outcome transitions the mac task. The dashboard shows
-the ledger as primary and deep-links to the kanban board for delegated tasks.
+**There must be exactly one task database — the MAC task ledger (`mac.db`).**
+We evaluated making Hermes' kanban read from that ledger (a pluggable task
+store). It is **not feasible cheaply**: `kanban_db.py` is a 7,386-line concrete
+SQLite module with no store seam, ~200 raw-SQL call sites, 7 tables, and
+SQLite-specific CAS/migration machinery — and it is vendored upstream, so a
+semantic rewrite is exactly the heavy fork ADR 0001 tells us not to carry.
+
+Per the decision rule ("if Hermes can't be patched to a pluggable task store
+*easily*, revert and keep our own"): **revert the Hermes kanban adoption** (the
+Phase-1 dashboard link) and keep the bespoke board (`renderTasks`) as the single
+task UI over the single store. An earlier draft of this ADR proposed coexisting
+with a bridge; that is **rejected** in favor of one store.
 
 ## Ground truth (today, not assumptions)
 
@@ -24,78 +29,57 @@ the ledger as primary and deep-links to the kanban board for delegated tasks.
 | --- | --- | --- |
 | Purpose | Fleet **work-queue** | **Goal-decomposition + multi-agent swarm** |
 | Model | `models.py` `Task`, `store.py` `tasks` | `_hermes/hermes_cli/kanban_db.py` `tasks` |
-| Distinctive fields | `required_capabilities`, `lease_id`/`leased_until`, `owner_agent_id`, `max_attempts`, `project` | `board`, `workspace_kind`/`workspace_path`/`branch_name` (git worktrees), `task_links` (goal tree), `task_comments`/`task_events`, `task_runs`, `worker_pid`/`last_heartbeat_at`, `claim_lock` CAS |
+| Distinctive fields | `required_capabilities`, `lease_id`/`leased_until`, `owner_agent_id`, `max_attempts`, `project` | `board`, `workspace_kind`/`workspace_path`/`branch_name` (git worktrees), `task_links`, `task_comments`/`task_events`, `task_runs`, `worker_pid`/`last_heartbeat_at`, `claim_lock` CAS |
 | States | `open/blocked/claimed/running/needs_review/reviewing/completed/failed/cancelled` | `triage/todo/scheduled/ready/running/blocked/review/done/archived` |
-| Dispatch | Agent polls; hub leases by capability | Kanban dispatcher subprocess spawns workers (`HERMES_KANBAN_TASK`) |
-| Scope / location | One **shared hub** DB per fleet (`~/.mac/mac.db`) | **Per-board local** SQLite (`~/.hermes/kanban.db`, `boards/<slug>/`) |
-| Answers | "*Who* can do this, and what's the contract?" | "*What's the goal tree*, and are my workers alive?" |
+| Location | One **shared hub** DB per fleet (`~/.mac/mac.db`) | **Per-board local** SQLite (`~/.hermes/kanban.db`) |
 
-**There is no bridge today.** Nothing in `src/mac/` (outside `_hermes/`) imports
-`kanban_db`/`kanban_tools`; the kanban dispatcher never reads `mac.db`; the mac
-dispatcher never reads `kanban.db`. The only links are an agent's optional
-`hermes_instance_id` and the read-only UI hyperlink added in PR #122. The
-schema divergence is intentional: capability-based fleet dispatch vs. worktree-
-bound worker-lifecycle decomposition solve different problems at different
-scales (fleet vs. single profile/goal).
+No bridge exists today: nothing in `src/mac/` (outside `_hermes/`) imports
+`kanban_db`; neither dispatcher reads the other's DB; the only links were agent
+identity and the PR #122 hyperlink (now reverted).
 
-## Options considered
+## Feasibility of a pluggable kanban store (the decision gate)
 
-1. **Unify into one store.** *Rejected.* The schemas, scales, and concerns
-   diverge; migration is large and either bloats the ledger with worktree/worker-
-   liveness columns or strips kanban's swarm semantics. High cost, high risk,
-   little near-term payoff.
-2. **Coexist, no bridge (status quo).** *Insufficient.* The two are invisible to
-   each other: a fleet task that is "really" a kanban swarm has no link, and the
-   dashboard can't show decomposition progress against the ledger item. This is
-   the gap that makes the bespoke board feel like duplication.
-3. **Coexist with a thin one-way delegation bridge.** *Recommended.* See below.
+Measured against `src/mac/_hermes/hermes_cli/kanban_db.py`:
+
+- **7,386 lines**, **no abstraction seam** — no `Protocol`/`ABC`/`Store`; the
+  classes are data records, not a swappable backend.
+- **Every function takes `conn: sqlite3.Connection`** and runs raw SQL; **~200**
+  `execute`/`BEGIN IMMEDIATE`/`ON CONFLICT`/`RETURNING` sites; plus
+  `_migrate_add_optional_columns`, `_table_has_drifted`, `_rebuild_drifted_tables`,
+  `_check_file_length_invariant` — all SQLite-specific.
+- **Vendored upstream.** Reworking the data layer is a large fork of a
+  fast-moving dependency, contradicting ADR 0001's "pinned, pruned snapshot; no
+  semantic surgery" guidance.
+
+Both routes to "kanban on mac.db" are expensive: (a) introduce a store interface
+and rewrite ~200 call sites in vendored code, or (b) recreate all 7 kanban tables
+inside `mac.db` (which is *hosting* the kanban schema, not *one* tasks table).
+Neither is "easy." → revert.
 
 ## Decision
 
-Adopt **Option 3.** Roles:
-
-- **mac ledger = system of record** for fleet work and its lifecycle. Every unit
-  of fleet work is a mac task; capability dispatch, leasing, review, and
-  cross-fleet visibility stay here.
-- **Hermes kanban = an execution strategy a task may delegate to** when the work
-  warrants decomposition + a worker swarm (the `decompose`/`specify`/`swarm`
-  pipeline). It owns the *inside* of a delegated task: the goal tree, worktrees,
-  and worker liveness.
-
-**Bridge contract (one-way, ledger-owned):**
-- A mac task records `metadata.kanban = {board_id, dashboard_url}` when delegated.
-- Delegation creates/links a kanban board for that task; the kanban dispatcher
-  runs the swarm as it does today (unchanged).
-- A reconcile step maps the board's **terminal** state back to a mac task
-  transition (`done` → `completed`, `archived/failed` → `failed`), idempotently.
-- The dashboard renders the ledger as primary and, for a delegated task,
-  deep-links to `<hermes-dashboard>/kanban?board=<id>` (extends PR #122). No
-  re-implementation of the board UI.
-
-Direction is strictly one-way: the ledger owns task lifecycle; kanban owns
-intra-task decomposition. We do **not** sync arbitrary status both ways.
+1. **`mac.db` is the single task database.** All fleet work is `mac task`.
+2. **Revert the Phase-1 Hermes kanban adoption** — remove the dashboard kanban
+   service link (PR #122). Keep the bespoke `renderTasks` board (with CEO-mode
+   creation, #119, and the refresh fix, #121) as the single task surface.
+3. **Do not fork Hermes kanban.** If the fleet later wants kanban-style
+   decomposition/swarm, build it **natively against `mac.db`** (a board *view* +
+   parent/child task links over the existing ledger), not by adopting a second
+   store.
 
 ## Consequences
 
-- **Pros:** each store keeps doing what it is good at; one pane of glass via the
-  ledger + deep links; incremental and reversible (no migration); the bespoke
-  `renderTasks` board can be retired without losing the fleet work-queue.
-- **Cons:** a small bridge + reconcile to maintain; two stores to back up and
-  observe; write-back can drift if a reconcile is missed (mitigated by making
-  reconcile idempotent and re-runnable).
-- **Non-goals:** migrating kanban into `mac.db`; teaching the ledger about
-  worktrees/worker PIDs; two-way status sync.
+- **Pros:** one store, one source of truth, no second DB to back up/observe, no
+  heavy vendored fork to carry. The board we keep already works (refresh fix +
+  CEO mode shipped).
+- **Cons:** we forgo Hermes' ready-made swarm/decompose UI; any such capability
+  is now ours to build on the ledger.
+- **Reversal:** `kanban-adopt-01` is closed as **won't-adopt**; reopen only if
+  Hermes upstream grows a pluggable task-store seam that removes the fork cost.
 
-## Follow-up work (tickets, not part of this ADR)
+## Follow-up
 
-1. Bridge: `metadata.kanban.board_id` on mac tasks + an idempotent reconcile
-   (board terminal → task transition). 
-2. Dashboard: deep-link a delegated task to its board (extends `kanban-adopt-01`
-   Phase 1). 
-3. Decide the trigger for delegation (explicit `mac task delegate-kanban`, or a
-   capability/heuristic). 
-4. Once the bridge + link exist, retire the bespoke `renderTasks` lanes
-   (`ui-modularize-01` can drop that view).
-
-Until the bridge lands, Phase 1 (the link-out from PR #122) is the interim
-surface and the two stores remain independent.
+- Closes `kanban-adopt-01` (won't-adopt). 
+- Optional, native: parent/child links + a board-style lens over `mac.db` tasks
+  if decomposition UX is wanted later — tracked separately, not by adopting
+  `kanban.db`.

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1943,14 +1943,6 @@ def _dashboard_service_links(
         _lookup_config_value(("FIRECRAWL_API_URL", "FIRECRAWL_GATEWAY_URL"), env_files).get("value")
         or ""
     ).rstrip("/")
-    # kanban-adopt-01: link out to the Hermes dashboard's kanban board rather
-    # than re-implementing one. Shown only when the operator points us at a
-    # running Hermes dashboard.
-    hermes_dashboard_url = str(
-        _lookup_config_value(("MAC_HERMES_DASHBOARD_URL", "HERMES_DASHBOARD_URL"), env_files).get("value")
-        or ""
-    ).rstrip("/")
-    hermes_kanban_url = _join_service_url(hermes_dashboard_url, "/kanban") if hermes_dashboard_url else ""
     tokenhub_admin = _credential_ref(("TOKENHUB_ADMIN_TOKEN",), env_files)
     tokenhub_client = _credential_ref(
         ("TOKENHUB_API_KEY", "TOKENHUB_AGENT_KEY", "OPENAI_API_KEY"),
@@ -2032,30 +2024,6 @@ def _dashboard_service_links(
                 ),
             },
             "credentials": [firecrawl_key],
-        },
-        {
-            "id": "kanban",
-            "name": "Kanban",
-            "kind": "external_ui",
-            "role": "Hermes multi-agent kanban board",
-            "status": "configured" if hermes_dashboard_url else "not_configured",
-            "url": _redact_service_url(hermes_kanban_url),
-            "ui_url": _redact_service_url(hermes_kanban_url),
-            "health_url": (
-                _redact_service_url(_join_service_url(hermes_dashboard_url, "/healthz"))
-                if hermes_dashboard_url else ""
-            ),
-            "auth": {
-                "type": "dashboard_session",
-                "credential_pass_through": False,
-                "pass_through_url": "",
-                "notes": (
-                    "Opens the Hermes dashboard kanban (separate dashboard login)"
-                    if hermes_dashboard_url
-                    else "Set MAC_HERMES_DASHBOARD_URL (or HERMES_DASHBOARD_URL) to link the Hermes kanban board"
-                ),
-            },
-            "credentials": [],
         },
     ]
 

--- a/tests/api/test_dashboard_service_links.py
+++ b/tests/api/test_dashboard_service_links.py
@@ -58,28 +58,6 @@ def test_service_links_present_when_services_configured(monkeypatch):
     assert "firecrawl" in links
 
 
-def test_kanban_link_present_when_hermes_dashboard_configured(monkeypatch):
-    monkeypatch.setenv("MAC_HERMES_DASHBOARD_URL", "http://hermes.internal:8765")
-    client = _client()
-    links = {item["id"]: item for item in client.get("/dashboard/state").json()["service_links"]}
-    assert "kanban" in links
-    k = links["kanban"]
-    assert k["status"] == "configured"
-    assert "hermes.internal:8765/kanban" in k["ui_url"]
-    # Links out to the Hermes dashboard (separate login) — no credential pass-through.
-    assert k["auth"]["credential_pass_through"] is False
-
-
-def test_kanban_link_not_configured_without_hermes_dashboard_url(monkeypatch):
-    monkeypatch.delenv("MAC_HERMES_DASHBOARD_URL", raising=False)
-    monkeypatch.delenv("HERMES_DASHBOARD_URL", raising=False)
-    client = _client()
-    links = {item["id"]: item for item in client.get("/dashboard/state").json()["service_links"]}
-    # Present in the list but unconfigured -> no ui_url, so the sidebar hides it.
-    assert links["kanban"]["status"] == "not_configured"
-    assert not links["kanban"]["ui_url"]
-
-
 def test_service_links_redact_credentials(monkeypatch):
     monkeypatch.setenv("TOKENHUB_URL", "http://tokenhub.internal:8090")
     monkeypatch.setenv("TOKENHUB_ADMIN_TOKEN", "super-secret-admin-key")


### PR DESCRIPTION
## Decision

The fleet needs **one task database** — the MAC task ledger (`mac.db`). Making Hermes' kanban read from it (a pluggable task store) was evaluated and is **not feasible cheaply**: `kanban_db.py` is **7,386 lines** of vendored SQLite with **no store seam**, ~**200** raw-SQL call sites, 7 tables, and SQLite-specific CAS/migration machinery. Reworking it is a heavy fork of fast-moving upstream — exactly what ADR 0001 says not to carry.

Per the decision rule ("if Hermes can't be patched to a pluggable task store easily, revert and keep our own"):

- **Revert** the Phase-1 kanban dashboard service link (#122) — removes the `api.py` entry + its tests.
- **Keep** the bespoke `renderTasks` board as the single task surface over `mac.db` (it already has CEO-mode creation #119 + the refresh fix #121).
- **ADR 0004 → Accepted**: one task DB; no Hermes-kanban fork; any future kanban-style decomposition UX is built natively on the ledger (parent/child links + a board lens), not by adopting `kanban.db`.
- **Closes** `kanban-adopt-01` as won't-adopt.

No runtime effect on the running dashboard: the reverted link only appeared when `MAC_HERMES_DASHBOARD_URL` was set (it wasn't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)