### PR TITLE
mac task create: default project from working directory (bd parity)

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -323,6 +323,36 @@ def cmd_task_convert_ticketing(args: argparse.Namespace) -> None:
     )
 
 
+def _default_project_from_cwd() -> Optional[str]:
+    """Infer a task's project from the working directory (bd parity).
+
+    `bd` tagged new issues with the repo they were filed from; `mac task
+    create` historically left ``project`` null unless ``--project`` was passed,
+    so work filed from a checkout never showed up under that project. Use the
+    git top-level directory name (works from any subdirectory of a checkout),
+    falling back to the cwd basename outside git. Returns None when nothing
+    sensible can be derived.
+    """
+    import subprocess
+
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        root = top.stdout.strip()
+        if top.returncode == 0 and root:
+            return os.path.basename(root) or None
+    except Exception:
+        pass
+    try:
+        return os.path.basename(os.getcwd()) or None
+    except OSError:
+        return None
+
+
 def cmd_task_create(args: argparse.Namespace) -> None:
     cp = _plane(args)
     description = _read_text_arg(
@@ -337,11 +367,24 @@ def cmd_task_create(args: argparse.Namespace) -> None:
         label="--metadata",
         default={},
     )
+    # bd parity: when --project is omitted, tag the task with the working
+    # directory's project (git repo name, else cwd basename). Pass an explicit
+    # --project (including --project '' for none) to override.
+    project = args.project
+    if project is None:
+        project = _default_project_from_cwd()
+        if project:
+            print(
+                "mac: tagging task with project %r (inferred from cwd; "
+                "pass --project to override, --project '' for none)" % project,
+                file=sys.stderr,
+            )
+    project = project or None
     _print(
         cp.create_task(
             args.title,
             description=description,
-            project=args.project,
+            project=project,
             priority=args.priority,
             required_capabilities=_csv(args.required_capabilities),
             dependencies=_csv(args.dependencies),
@@ -1901,7 +1944,11 @@ def build_parser() -> argparse.ArgumentParser:
                         help="task description (use --description-file for multi-line / shell-hostile content)")
     create.add_argument("--description-file", dest="description_file",
                         help="read description from file path (or '-' for stdin); avoids shell-quoting hazards")
-    create.add_argument("--project")
+    create.add_argument(
+        "--project",
+        help="project to tag the task with; defaults to the working directory's "
+        "project (git repo name, else cwd basename). Pass --project '' for none.",
+    )
     create.add_argument("--priority", type=int, default=0)
     create.add_argument("--required-capabilities")
     create.add_argument("--dependencies")

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -110,6 +110,50 @@ def test_mac_cli_task_create_and_list(tmp_path):
     assert any(t["id"] == task["id"] for t in tasks)
 
 
+class _FakeProc:
+    def __init__(self, returncode, stdout):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_default_project_from_cwd_uses_git_toplevel(monkeypatch):
+    from mac.cli import _default_project_from_cwd
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _FakeProc(0, "/home/u/Src/myrepo\n"))
+    assert _default_project_from_cwd() == "myrepo"
+
+
+def test_default_project_from_cwd_falls_back_to_cwd_basename(monkeypatch):
+    from mac.cli import _default_project_from_cwd
+
+    monkeypatch.setattr("subprocess.run", lambda *a, **k: _FakeProc(128, ""))
+    monkeypatch.setattr("os.getcwd", lambda: "/tmp/some-project")
+    assert _default_project_from_cwd() == "some-project"
+
+
+def test_task_create_defaults_project_from_cwd(tmp_path, monkeypatch):
+    # bd parity: no --project tags the task with the working directory's project.
+    monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "inferred-proj")
+    rc, task = _run(tmp_path, "task", "create", "Auto project")
+    assert rc == 0
+    assert task["project"] == "inferred-proj"
+
+
+def test_task_create_explicit_project_overrides_cwd(tmp_path, monkeypatch):
+    monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "inferred-proj")
+    rc, task = _run(tmp_path, "task", "create", "Explicit", "--project", "chosen")
+    assert rc == 0
+    assert task["project"] == "chosen"
+
+
+def test_task_create_empty_project_means_none(tmp_path, monkeypatch):
+    # Explicit --project '' opts out of the cwd default (never silently inferred).
+    monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "inferred-proj")
+    rc, task = _run(tmp_path, "task", "create", "No project", "--project", "")
+    assert rc == 0
+    assert task["project"] is None
+
+
 def test_mac_cli_task_show(tmp_path):
     rc, task = _run(tmp_path, "task", "create", "Show me")
     assert rc == 0


### PR DESCRIPTION
## Why

`bd` tagged new issues with the repo they were filed from. `mac task create` left `project` **null** unless `--project` was passed — so tasks filed from `~/Src/mac` (confirmed cwd) landed with `project=null` instead of `mac`. That's the root cause behind *"the mac project doesn't show up in the projects list"*, and a functional-parity gap vs `bd` (the stated goal of `mac task`).

## Fix

`mac task create` now defaults `--project` to the working directory's project:
- **git top-level directory name** (so it works from any subdirectory of a checkout), else the **cwd basename** outside git.
- A one-line **stderr** note shows what was inferred (stdout stays clean JSON).
- `--project <x>` overrides; **`--project ''`** opts out (project is never *silently* inferred when explicitly emptied).

## Verified (local DB)

```
$ mac task create "verify cwd project default"     # from ~/Src/mac
  project = 'mac'   (stderr: mac: tagging task with project 'mac' ...)
$ (cd src/mac && mac task create "from subdir")     # subdir → git toplevel
  project = 'mac'
$ mac task create "no project" --project ''
  project = None
```

## Tests

+5 in `tests/cli/test_mac_cli.py` (git-toplevel inference, cwd fallback, default-applied, explicit override, `--project ''` opt-out). Existing create tests unaffected. 17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)