### PR TITLE
Scope task reads to cwd project + bd-parity audit

### DIFF
--- a/.tickets/parity-ready-http-01.md
+++ b/.tickets/parity-ready-http-01.md
@@ -1,0 +1,37 @@
+---
+id: parity-ready-http-01
+status: open
+deps: []
+links: [parity-tickets-autoemit-01]
+created: 2026-06-09T00:00:00Z
+type: feature
+priority: 2
+audit: mac-task-bd-parity
+discovered_via: parity_audit
+---
+# Serve `mac task ready` / `search` / `stats` over the hub (not SQLite-only)
+
+## Why this exists
+
+`bd ready --json` was the canonical ready queue and worked against the store
+from anywhere. The `mac task` equivalents — `ready`, `search`, `stats` — reach
+into `ControlPlane.store` for direct SQL, so in hub mode they're refused
+(`src/mac/dispatch.py` `_RemoteStore._refuse`: "needs direct SQLite access").
+An operator pointed at the rocky hub (the common case now that flagless `mac`
+resolves the default fleet) can't run them at all. This is the biggest live
+`bd`→`mac task` parity gap (see `docs/mac-task-bd-parity-audit.md`).
+
+## Acceptance criteria
+
+- `GET /tasks/ready` (open + dependencies satisfied + unclaimed, honoring
+  `--project`/`--all` and `--limit`), `GET /tasks/search?q=...`, and a stats
+  endpoint, all served by the hub.
+- `mac task ready/search/stats` use those endpoints in hub mode instead of
+  refusing; `--db` mode keeps the direct-SQL path.
+- The ready endpoint reuses the dispatcher's dependency-satisfied semantics so
+  CLI and dispatcher never diverge.
+
+## Notes
+
+Cross-fleet `stats` may need aggregation; scope can start with ready+search.
+Related: [[parity-tickets-autoemit-01]].

--- a/.tickets/parity-tickets-autoemit-01.md
+++ b/.tickets/parity-tickets-autoemit-01.md
@@ -1,0 +1,35 @@
+---
+id: parity-tickets-autoemit-01
+status: open
+deps: []
+links: [parity-ready-http-01]
+created: 2026-06-09T00:00:00Z
+type: feature
+priority: 2
+audit: mac-task-bd-parity
+discovered_via: parity_audit
+---
+# Auto-emit the `.tickets/<id>.md` mirror on task create/close
+
+## Why this exists
+
+`bd` kept its git-distributed mirror (`.beads/issues.jsonl`) in sync with every
+change. `mac task` only writes `.tickets/<id>.md` during `migrate-beads`, so the
+git-trackable mirror drifts from the ledger as soon as you `mac task create` /
+`close` (CLAUDE.md notes auto-emit is "on the roadmap"). The renderer already
+exists (`src/mac/beads_migrator._render_ticket`).
+
+## Acceptance criteria
+
+- `mac task create` and `mac task close` write/update `.tickets/<id>.md` using
+  the existing ticket renderer (frontmatter: id/status/deps/links/created/type/
+  priority + body sections), when run inside a repo with a `.tickets/` dir.
+- Idempotent: re-emitting an unchanged task is a no-op; status/close-reason
+  updates rewrite the file in place.
+- Opt-out via a flag/env for hub-only flows that don't want local files.
+
+## Notes
+
+Pairs with project-from-cwd (PR #124) so a task filed from a repo both lands in
+that project *and* leaves a reviewable `.tickets` entry in the same checkout.
+Related: [[parity-ready-http-01]].

--- a/docs/mac-task-bd-parity-audit.md
+++ b/docs/mac-task-bd-parity-audit.md
@@ -1,0 +1,79 @@
+# `mac task` ↔ `bd` (beads) functional-parity audit
+
+- Date: 2026-06-09
+- Scope: does `mac task` match the `bd` workflow it replaced? (the stated goal
+  of the `mac task` subcommand). Grounded in this repo's beads migration/bridge
+  code + docs — not external memory of `bd`.
+
+## What `bd` provided (evidence in-repo)
+
+Data model — from `src/mac/beads_migrator.py` (`_create_task_from_bead`,
+`_render_ticket`): `id`, `status` (open/closed/blocked/deferred/in_progress),
+`title`, `description`, `issue_type`, `priority` (numeric), `assignee`, `owner`,
+`dependencies` (typed: `blocks` → deps, `related` → links, `parent-child` →
+parent), `design`, `acceptance_criteria`, `notes`, `close_reason`,
+`external_ref`, timestamps.
+
+`bd` commands referenced in-repo (only these appear — no broader CLI is
+documented here):
+- `bd ready --json` — canonical ready queue (`docs/integration-authority-contract.md:57`, `docs/production-deployment.md:569`).
+- `bd memories --json` — persistent memories export (`beads_migrator.py:228`).
+- `bd update <id> --claim`, `bd close <id>` — claim/close writeback (`integration-authority-contract.md:87-90`).
+- `bd dolt push/pull` — cross-machine sync of the embedded Dolt DB + `.beads/issues.jsonl` mirror (`docs/linear-bridge-spec.md`, `docs/metadata-sync-assessment.md:27`).
+- Project tagging tied to the repo a bead was filed from (`docs/hermes-integration.md:169`).
+
+## `mac task` surface today (`src/mac/cli.py`)
+
+`create, list, show, ready, claim, close, search, stats, start, submit-review,
+evidence, detect-beads, migrate-beads, detect-ticketing, convert-ticketing`.
+`ready`, `search`, `stats` require `--db` (direct SQLite) and are **refused in
+hub mode** (`dispatch.py` `_RemoteStore._refuse`).
+
+`.tickets/<id>.md` mirror frontmatter (`beads_migrator._render_ticket`):
+`id, status, deps, links, created, type, priority` (+ optional `assignee`,
+`external-ref`, `parent`, `mac-task-id`) and body sections Design / Acceptance
+Criteria / Notes / Close Reason — a faithful superset of the bead fields.
+
+## Parity table
+
+| `bd` capability | `mac task` equivalent | Status |
+| --- | --- | --- |
+| Project from the repo you file in | `create` defaults `--project` from cwd (git top-level / cwd basename) | **Present** (PR #124) |
+| Scope reads to current project | `list`/`ready`/`search` default to cwd project; `--all` / `--project` widen | **Present** (this PR) |
+| Ready queue (`bd ready --json`) | `mac task ready` (open + deps satisfied + unclaimed) | **Partial — `--db` only, not over the hub** |
+| Keyword search | `mac task search` | **Partial — `--db` only** |
+| Stats / counts | `mac task stats` | **Partial — `--db` only** |
+| Dependencies / blockers | `--dependencies` on create; `.tickets` `deps:`/`links:`/`parent:` | Present |
+| Status lifecycle | TaskState transitions; `close --cancelled` | Present |
+| Priority | `--priority` (numeric) | Present |
+| Body sections (design/acceptance/notes) | `.tickets` body + metadata | Present |
+| Assignment (assignee/owner) | metadata + `.tickets` `assignee` | Present |
+| External refs | metadata + `.tickets` `external-ref` | Present |
+| Memories | `mac memory remember/list/forget` | Present (`list/forget` are `--db`-only) |
+| `.tickets` markdown mirror **auto-emitted** on create/close | only emitted by `migrate-beads`; not on `mac task create/close` | **Missing — roadmap** (`CLAUDE.md`) |
+| `bd dolt push/pull` cross-machine sync | — | Removed by design (mac hub is the store) |
+| Two-way `bd update/close` writeback | — | Removed by design (`MAC_BEADS_BRIDGE_ENABLED` gated off) |
+
+## Remaining gaps (actionable)
+
+1. **`ready` / `search` / `stats` are SQLite-only.** `bd ready --json` worked
+   against the canonical store from anywhere; the `mac task` equivalents refuse
+   in hub mode, so an operator pointed at the rocky hub can't run them. This is
+   the biggest live parity gap. → serve them over HTTP. (`parity-ready-http-01`)
+2. **No `.tickets` auto-emit.** `bd` kept the JSONL mirror in sync; `mac task
+   create/close` doesn't write/update `.tickets/<id>.md`, so the git-trackable
+   mirror drifts from the ledger. → emit on create/close. (`parity-tickets-autoemit-01`)
+
+## Deliberately not parity (recorded so they aren't re-opened as "gaps")
+
+- Dolt push/pull and two-way `bd` writeback are intentionally gone: the mac hub
+  is the single authoritative store (see `metadata-sync-assessment.md`,
+  `CLAUDE.md`). `bd` must not be run.
+
+## Verdict
+
+Core issue-tracking parity is **achieved** (fields, dependencies, lifecycle,
+priority, sections, project-from-cwd for both create and read). The two real
+gaps are operational, not data-model: the read commands don't work over the
+hub, and the `.tickets` mirror isn't auto-emitted. Both are tracked as
+follow-ups; everything else either matches `bd` or was dropped on purpose.

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -353,6 +353,28 @@ def _default_project_from_cwd() -> Optional[str]:
         return None
 
 
+def _effective_read_project(args: argparse.Namespace) -> Optional[str]:
+    """Project filter for read commands (list/ready/search), bd parity.
+
+    ``--all`` clears the filter (every project); ``--project NAME`` picks one;
+    otherwise default to the working directory's project. Returns None to mean
+    "every project".
+    """
+    if getattr(args, "all", False):
+        return None
+    proj = getattr(args, "project", None)
+    if proj is not None:
+        return proj or None
+    inferred = _default_project_from_cwd()
+    if inferred:
+        print(
+            "mac: scoping to project %r (use --all for every project, "
+            "--project NAME to choose)" % inferred,
+            file=sys.stderr,
+        )
+    return inferred
+
+
 def cmd_task_create(args: argparse.Namespace) -> None:
     cp = _plane(args)
     description = _read_text_arg(
@@ -397,7 +419,11 @@ def cmd_task_create(args: argparse.Namespace) -> None:
 
 def cmd_task_list(args: argparse.Namespace) -> None:
     cp = _plane(args)
-    _print([task.to_dict() for task in cp.list_tasks(args.state)])
+    project = _effective_read_project(args)
+    tasks = [task.to_dict() for task in cp.list_tasks(args.state)]
+    if project is not None:
+        tasks = [t for t in tasks if t.get("project") == project]
+    _print(tasks)
 
 
 def cmd_task_show(args: argparse.Namespace) -> None:
@@ -410,15 +436,16 @@ def cmd_task_ready(args: argparse.Namespace) -> None:
     cp = _plane(args)
     from mac.models import TaskState
 
+    project = _effective_read_project(args)
+    where = ["state = ?", "owner_agent_id IS NULL", "lease_id IS NULL"]
+    params: list = [TaskState.OPEN.value]
+    if project is not None:
+        where.append("project = ?")
+        params.append(project)
     rows = cp.store.query_all(
-        """
-        SELECT * FROM tasks
-        WHERE state = ?
-          AND owner_agent_id IS NULL
-          AND lease_id IS NULL
-        ORDER BY priority DESC, created_at
-        """,
-        (TaskState.OPEN.value,),
+        "SELECT * FROM tasks WHERE %s ORDER BY priority DESC, created_at"
+        % " AND ".join(where),
+        tuple(params),
     )
     out = []
     for row in rows:
@@ -451,15 +478,18 @@ def cmd_task_close(args: argparse.Namespace) -> None:
 
 def cmd_task_search(args: argparse.Namespace) -> None:
     cp = _plane(args)
+    project = _effective_read_project(args)
     like = "%" + args.query + "%"
+    where = ["(title LIKE ? OR description LIKE ?)"]
+    params: list = [like, like]
+    if project is not None:
+        where.append("project = ?")
+        params.append(project)
+    params.append(int(args.limit))
     rows = cp.store.query_all(
-        """
-        SELECT * FROM tasks
-        WHERE title LIKE ? OR description LIKE ?
-        ORDER BY priority DESC, created_at DESC
-        LIMIT ?
-        """,
-        (like, like, int(args.limit)),
+        "SELECT * FROM tasks WHERE %s ORDER BY priority DESC, created_at DESC LIMIT ?"
+        % " AND ".join(where),
+        tuple(params),
     )
     _print([cp._task_from_row(row).to_dict() for row in rows])
 
@@ -1962,6 +1992,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     list_tasks = task.add_parser("list")
     list_tasks.add_argument("--state")
+    list_tasks.add_argument("--project", help="filter to this project (default: the cwd's project)")
+    list_tasks.add_argument("--all", action="store_true", help="every project (disable cwd scoping)")
     _set(cmd_task_list, list_tasks)
 
     show = task.add_parser("show")
@@ -1970,6 +2002,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     ready = task.add_parser("ready", help="list open tasks ready to work (all deps completed, unclaimed)")
     ready.add_argument("--limit", type=int, default=0)
+    ready.add_argument("--project", help="filter to this project (default: the cwd's project)")
+    ready.add_argument("--all", action="store_true", help="every project (disable cwd scoping)")
     _set(cmd_task_ready, ready)
 
     claim = task.add_parser("claim", help="atomically claim a task for an agent")
@@ -1989,6 +2023,8 @@ def build_parser() -> argparse.ArgumentParser:
     search = task.add_parser("search", help="keyword search across task title and description")
     search.add_argument("query")
     search.add_argument("--limit", type=int, default=50)
+    search.add_argument("--project", help="filter to this project (default: the cwd's project)")
+    search.add_argument("--all", action="store_true", help="every project (disable cwd scoping)")
     _set(cmd_task_search, search)
 
     stats = task.add_parser("stats", help="count tasks by state")

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -154,6 +154,38 @@ def test_task_create_empty_project_means_none(tmp_path, monkeypatch):
     assert task["project"] is None
 
 
+def test_task_list_scopes_to_cwd_project(tmp_path, monkeypatch):
+    _run(tmp_path, "task", "create", "A", "--project", "alpha")
+    _run(tmp_path, "task", "create", "B", "--project", "beta")
+    monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "alpha")
+    rc, scoped = _run(tmp_path, "task", "list")
+    assert rc == 0 and {t["project"] for t in scoped} == {"alpha"}
+    rc, everything = _run(tmp_path, "task", "list", "--all")
+    assert {"alpha", "beta"} <= {t["project"] for t in everything}
+    rc, chosen = _run(tmp_path, "task", "list", "--project", "beta")
+    assert {t["project"] for t in chosen} == {"beta"}
+
+
+def test_task_ready_scopes_to_cwd_project(tmp_path, monkeypatch):
+    _run(tmp_path, "task", "create", "RA", "--project", "alpha")
+    _run(tmp_path, "task", "create", "RB", "--project", "beta")
+    monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "alpha")
+    rc, ready = _run(tmp_path, "task", "ready")
+    assert rc == 0 and ready and all(t["project"] == "alpha" for t in ready)
+    rc, everything = _run(tmp_path, "task", "ready", "--all")
+    assert {"alpha", "beta"} <= {t["project"] for t in everything}
+
+
+def test_task_search_scopes_to_cwd_project(tmp_path, monkeypatch):
+    _run(tmp_path, "task", "create", "searchable alpha", "--project", "alpha")
+    _run(tmp_path, "task", "create", "searchable beta", "--project", "beta")
+    monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "alpha")
+    rc, hits = _run(tmp_path, "task", "search", "searchable")
+    assert rc == 0 and hits and all(t["project"] == "alpha" for t in hits)
+    rc, everything = _run(tmp_path, "task", "search", "searchable", "--all")
+    assert {"alpha", "beta"} <= {t["project"] for t in everything}
+
+
 def test_mac_cli_task_show(tmp_path):
     rc, task = _run(tmp_path, "task", "create", "Show me")
     assert rc == 0


### PR DESCRIPTION
**Stacked on #124** (uses `_default_project_from_cwd`); GitHub will retarget this to `main` when #124 merges.

## #1 — cwd-project default on the read side
`mac task list` / `ready` / `search` now default to the working directory's project (the way `bd` scoped to the repo you were in):
- `--all` → every project; `--project NAME` → pick one; otherwise the cwd project (one-line stderr note).
- `list` filters client-side (works over the hub); `ready`/`search` add a `project` WHERE clause.
- +3 CLI tests (scoping + `--all` + `--project` overrides). 20 pass.

## #2 — `docs/mac-task-bd-parity-audit.md`
A `bd` ↔ `mac task` parity table grounded in this repo's beads-migration code. Core issue-tracking parity is achieved (fields, deps, lifecycle, priority, body sections, project-from-cwd for create **and** read). Two real **operational** gaps remain, filed as follow-ups:
- **`parity-ready-http-01`** — `ready`/`search`/`stats` are SQLite-only and refused in hub mode (whereas `bd ready --json` worked anywhere). Biggest live gap.
- **`parity-tickets-autoemit-01`** — `.tickets/<id>.md` mirror isn't auto-emitted on create/close (CLAUDE.md: roadmap).

Deliberately-dropped items (dolt push/pull, two-way `bd` writeback) are recorded so they aren't reopened as "gaps."

🤖 Generated with [Claude Code](https://claude.com/claude-code)