### PR TITLE
Serve task ready/search/stats over the hub (parity-ready-http-01)

### DIFF
--- a/.tickets/parity-ready-http-01.md
+++ b/.tickets/parity-ready-http-01.md
@@ -1,6 +1,6 @@
 ---
 id: parity-ready-http-01
-status: open
+status: closed
 deps: []
 links: [parity-tickets-autoemit-01]
 created: 2026-06-09T00:00:00Z
@@ -8,7 +8,18 @@ type: feature
 priority: 2
 audit: mac-task-bd-parity
 discovered_via: parity_audit
+resolution: done
 ---
+
+## Done (2026-06-10)
+
+`GET /tasks/ready`, `/tasks/search`, `/tasks/stats` are served by the hub
+(registered before `/tasks/{task_id}` so the static paths aren't shadowed),
+backed by `ControlPlane.ready_tasks/search_tasks/task_stats`. `RemoteDispatch`
+gained matching methods; the CLI handlers now call them, so `mac task
+ready/search/stats` work in hub mode and keep the direct-SQL path under `--db`.
+The `_RemoteStore` refuse message no longer lists them.
+
 # Serve `mac task ready` / `search` / `stats` over the hub (not SQLite-only)
 
 ## Why this exists

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,8 +67,9 @@ The `mac` CLI is hub-aware. Resolution order (highest priority first):
 all of its functionality lives under `mac` now.
 
 A small set of commands still requires `--db` because they reach into
-SQLite directly: `task ready/search/stats`, `memory list/forget`,
-`observability prune`. Running these in hub mode emits a clear error.
+SQLite directly: `memory list/forget` and `observability prune`. Running
+these in hub mode emits a clear error. (`task ready/search/stats` are now
+served over the hub — parity-ready-http-01.)
 
 ## Session Completion
 

--- a/docs/mac-task-bd-parity-audit.md
+++ b/docs/mac-task-bd-parity-audit.md
@@ -40,9 +40,9 @@ Criteria / Notes / Close Reason — a faithful superset of the bead fields.
 | --- | --- | --- |
 | Project from the repo you file in | `create` defaults `--project` from cwd (git top-level / cwd basename) | **Present** (PR #124) |
 | Scope reads to current project | `list`/`ready`/`search` default to cwd project; `--all` / `--project` widen | **Present** (this PR) |
-| Ready queue (`bd ready --json`) | `mac task ready` (open + deps satisfied + unclaimed) | **Partial — `--db` only, not over the hub** |
-| Keyword search | `mac task search` | **Partial — `--db` only** |
-| Stats / counts | `mac task stats` | **Partial — `--db` only** |
+| Ready queue (`bd ready --json`) | `mac task ready` (open + deps satisfied + unclaimed) | **Present** — served over the hub (parity-ready-http-01) |
+| Keyword search | `mac task search` | **Present** — served over the hub |
+| Stats / counts | `mac task stats` | **Present** — served over the hub |
 | Dependencies / blockers | `--dependencies` on create; `.tickets` `deps:`/`links:`/`parent:` | Present |
 | Status lifecycle | TaskState transitions; `close --cancelled` | Present |
 | Priority | `--priority` (numeric) | Present |
@@ -56,10 +56,10 @@ Criteria / Notes / Close Reason — a faithful superset of the bead fields.
 
 ## Remaining gaps (actionable)
 
-1. **`ready` / `search` / `stats` are SQLite-only.** `bd ready --json` worked
-   against the canonical store from anywhere; the `mac task` equivalents refuse
-   in hub mode, so an operator pointed at the rocky hub can't run them. This is
-   the biggest live parity gap. → serve them over HTTP. (`parity-ready-http-01`)
+1. ~~**`ready` / `search` / `stats` are SQLite-only.**~~ **DONE** —
+   `GET /tasks/ready|search|stats` now serve these from the hub; the CLI uses
+   them in hub mode and keeps the direct-SQL path under `--db`
+   (`parity-ready-http-01`).
 2. **No `.tickets` auto-emit.** `bd` kept the JSONL mirror in sync; `mac task
    create/close` doesn't write/update `.tickets/<id>.md`, so the git-trackable
    mirror drifts from the ledger. → emit on create/close. (`parity-tickets-autoemit-01`)

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -3478,6 +3478,33 @@ def create_app(
     ) -> List[Dict[str, Any]]:
         return [task.to_dict() for task in cp.list_tasks(state, tenant_id)]
 
+    # parity-ready-http-01: serve ready/search/stats so the CLI works in hub
+    # mode (not just --db). Registered before /tasks/{task_id} so these static
+    # paths aren't captured by the path parameter.
+    @app.get("/tasks/ready")
+    def ready_tasks(
+        project: Optional[str] = Query(default=None),
+        tenant_id: Optional[str] = Query(default=None),
+        limit: Optional[int] = Query(default=None),
+    ) -> List[Dict[str, Any]]:
+        return [t.to_dict() for t in cp.ready_tasks(project=project, tenant_id=tenant_id, limit=limit)]
+
+    @app.get("/tasks/search")
+    def search_tasks(
+        q: str = Query(...),
+        project: Optional[str] = Query(default=None),
+        tenant_id: Optional[str] = Query(default=None),
+        limit: int = Query(default=50),
+    ) -> List[Dict[str, Any]]:
+        return [t.to_dict() for t in cp.search_tasks(q, project=project, tenant_id=tenant_id, limit=limit)]
+
+    @app.get("/tasks/stats")
+    def task_stats(
+        project: Optional[str] = Query(default=None),
+        tenant_id: Optional[str] = Query(default=None),
+    ) -> Dict[str, int]:
+        return cp.task_stats(project=project, tenant_id=tenant_id)
+
     @app.get("/tasks/{task_id}")
     def get_task(task_id: str) -> Dict[str, Any]:
         return cp.task_detail(task_id)

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -432,33 +432,10 @@ def cmd_task_show(args: argparse.Namespace) -> None:
 
 def cmd_task_ready(args: argparse.Namespace) -> None:
     """List tasks ready to work — state=open, all dependencies completed,
-    unclaimed. Matches dispatcher dependency semantics."""
+    unclaimed. Works in hub mode (parity-ready-http-01) and local --db mode."""
     cp = _plane(args)
-    from mac.models import TaskState
-
     project = _effective_read_project(args)
-    where = ["state = ?", "owner_agent_id IS NULL", "lease_id IS NULL"]
-    params: list = [TaskState.OPEN.value]
-    if project is not None:
-        where.append("project = ?")
-        params.append(project)
-    rows = cp.store.query_all(
-        "SELECT * FROM tasks WHERE %s ORDER BY priority DESC, created_at"
-        % " AND ".join(where),
-        tuple(params),
-    )
-    out = []
-    for row in rows:
-        task = cp._task_from_row(row)
-        try:
-            dependencies_satisfied = cp._dependencies_satisfied(task)
-        except Exception:  # noqa: BLE001 - missing dep blocks readiness
-            dependencies_satisfied = False
-        if dependencies_satisfied:
-            out.append(task.to_dict())
-        if args.limit and len(out) >= args.limit:
-            break
-    _print(out)
+    _print([t.to_dict() for t in cp.ready_tasks(project=project, limit=args.limit or None)])
 
 
 def cmd_task_claim(args: argparse.Namespace) -> None:
@@ -479,27 +456,13 @@ def cmd_task_close(args: argparse.Namespace) -> None:
 def cmd_task_search(args: argparse.Namespace) -> None:
     cp = _plane(args)
     project = _effective_read_project(args)
-    like = "%" + args.query + "%"
-    where = ["(title LIKE ? OR description LIKE ?)"]
-    params: list = [like, like]
-    if project is not None:
-        where.append("project = ?")
-        params.append(project)
-    params.append(int(args.limit))
-    rows = cp.store.query_all(
-        "SELECT * FROM tasks WHERE %s ORDER BY priority DESC, created_at DESC LIMIT ?"
-        % " AND ".join(where),
-        tuple(params),
-    )
-    _print([cp._task_from_row(row).to_dict() for row in rows])
+    _print([t.to_dict() for t in cp.search_tasks(args.query, project=project, limit=int(args.limit))])
 
 
 def cmd_task_stats(args: argparse.Namespace) -> None:
     cp = _plane(args)
-    rows = cp.store.query_all(
-        "SELECT state, COUNT(*) AS n FROM tasks GROUP BY state ORDER BY state"
-    )
-    _print({row["state"]: int(row["n"]) for row in rows})
+    project = _effective_read_project(args)
+    _print(cp.task_stats(project=project))
 
 
 def cmd_project_list(args: argparse.Namespace) -> None:
@@ -2028,6 +1991,8 @@ def build_parser() -> argparse.ArgumentParser:
     _set(cmd_task_search, search)
 
     stats = task.add_parser("stats", help="count tasks by state")
+    stats.add_argument("--project", help="filter to this project (default: the cwd's project)")
+    stats.add_argument("--all", action="store_true", help="every project (disable cwd scoping)")
     _set(cmd_task_stats, stats)
 
     start = task.add_parser("start")

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -159,8 +159,8 @@ class _RemoteStore:
 
     def _refuse(self, *args: Any, **kwargs: Any) -> Any:
         raise DispatchError(
-            "this command needs direct SQLite access (task ready/search/stats, "
-            "memory list/forget). It is not yet served over HTTP. Pass "
+            "this command needs direct SQLite access (memory list/forget, "
+            "observability prune). It is not yet served over HTTP. Pass "
             "--db <path> to run against a local SQLite database, or wait for "
             "the matching hub endpoint to be added."
         )
@@ -238,6 +238,37 @@ class RemoteDispatch:
         tenant_id: Optional[str] = None,
     ) -> List[_Dictish]:
         return _wrap_list(self._get("/tasks", state=state, tenant_id=tenant_id))
+
+    def ready_tasks(
+        self,
+        *,
+        project: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[_Dictish]:
+        return _wrap_list(
+            self._get("/tasks/ready", project=project, tenant_id=tenant_id, limit=limit)
+        )
+
+    def search_tasks(
+        self,
+        query: str,
+        *,
+        project: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[_Dictish]:
+        return _wrap_list(
+            self._get("/tasks/search", q=query, project=project, tenant_id=tenant_id, limit=limit)
+        )
+
+    def task_stats(
+        self,
+        *,
+        project: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        return self._get("/tasks/stats", project=project, tenant_id=tenant_id)
 
     def task_detail(self, task_id: str) -> _Dictish:
         return _Dictish(self._get("/tasks/%s" % quote(task_id, safe="")))

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -3069,6 +3069,94 @@ class ControlPlane:
             tasks = [task for task in tasks if self._task_tenant_id(task) == tenant_id]
         return tasks
 
+    def ready_tasks(
+        self,
+        *,
+        project: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> List[Task]:
+        """Open tasks with all dependencies completed and no owner/lease.
+
+        The dispatcher's readiness semantics (parity with ``bd ready``), served
+        so the CLI works in hub mode (parity-ready-http-01).
+        """
+        where = ["state = ?", "owner_agent_id IS NULL", "lease_id IS NULL"]
+        params: list = [TaskState.OPEN.value]
+        if project is not None:
+            where.append("project = ?")
+            params.append(project)
+        rows = self.store.query_all(
+            "SELECT * FROM tasks WHERE %s ORDER BY priority DESC, created_at"
+            % " AND ".join(where),
+            tuple(params),
+        )
+        out: List[Task] = []
+        for row in rows:
+            task = self._task_from_row(row)
+            if tenant_id is not None and self._task_tenant_id(task) != tenant_id:
+                continue
+            try:
+                ready = self._dependencies_satisfied(task)
+            except Exception:  # noqa: BLE001 - a missing dependency blocks readiness
+                ready = False
+            if ready:
+                out.append(task)
+            if limit and len(out) >= limit:
+                break
+        return out
+
+    def search_tasks(
+        self,
+        query: str,
+        *,
+        project: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Task]:
+        """Keyword search across title/description (parity with bd search)."""
+        like = "%" + (query or "") + "%"
+        where = ["(title LIKE ? OR description LIKE ?)"]
+        params: list = [like, like]
+        if project is not None:
+            where.append("project = ?")
+            params.append(project)
+        rows = self.store.query_all(
+            "SELECT * FROM tasks WHERE %s ORDER BY priority DESC, created_at DESC LIMIT ?"
+            % " AND ".join(where),
+            tuple(params + [int(limit)]),
+        )
+        tasks = [self._task_from_row(row) for row in rows]
+        if tenant_id is not None:
+            tasks = [t for t in tasks if self._task_tenant_id(t) == tenant_id]
+        return tasks
+
+    def task_stats(
+        self,
+        *,
+        project: Optional[str] = None,
+        tenant_id: Optional[str] = None,
+    ) -> Dict[str, int]:
+        """Task counts by state (parity with bd stats)."""
+        if tenant_id is not None:
+            tasks = self.list_tasks(tenant_id=tenant_id)
+            if project is not None:
+                tasks = [t for t in tasks if t.project == project]
+            counts: Dict[str, int] = {}
+            for t in tasks:
+                counts[t.state] = counts.get(t.state, 0) + 1
+            return dict(sorted(counts.items()))
+        where = ""
+        params: list = []
+        if project is not None:
+            where = " WHERE project = ?"
+            params.append(project)
+        rows = self.store.query_all(
+            "SELECT state, COUNT(*) AS n FROM tasks%s GROUP BY state ORDER BY state" % where,
+            tuple(params),
+        )
+        return {row["state"]: int(row["n"]) for row in rows}
+
     def update_task(
         self,
         task_id: str,

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -917,6 +917,8 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
             kwargs["params"] = {"q": "route coverage", "limit": 1}
         elif path_template == "/v1/memory/dreams/recall":
             kwargs["params"] = {"q": "route coverage dream", "limit": 1, "min_confidence": "low"}
+        elif path_template == "/tasks/search":
+            kwargs["params"] = {"q": "route coverage"}
         return RequestCase(path, kwargs, expected)
 
     if method == "DELETE":

--- a/tests/api/test_task_read_endpoints.py
+++ b/tests/api/test_task_read_endpoints.py
@@ -1,0 +1,80 @@
+"""HTTP endpoints for task ready/search/stats (parity-ready-http-01).
+
+These let `mac task ready/search/stats` work against the hub instead of
+requiring --db (direct SQLite).
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+def _client() -> TestClient:
+    return TestClient(create_app(control_plane=ControlPlane.in_memory()))
+
+
+def _make(client, title, project=None, **extra):
+    body = {"title": title}
+    if project is not None:
+        body["project"] = project
+    body.update(extra)
+    resp = client.post("/tasks", json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_ready_endpoint_lists_open_unclaimed_and_is_not_shadowed_by_task_id():
+    client = _client()
+    a = _make(client, "alpha task", project="alpha")
+    _make(client, "beta task", project="beta")
+
+    ready = client.get("/tasks/ready")
+    assert ready.status_code == 200
+    titles = {t["title"] for t in ready.json()}
+    assert {"alpha task", "beta task"} <= titles
+
+    # /tasks/ready must not be captured by /tasks/{task_id}; the real id still works.
+    assert client.get("/tasks/ready").json().__class__ is list
+    assert client.get(f"/tasks/{a['id']}").json()["task"]["id"] == a["id"]
+
+
+def test_ready_endpoint_filters_by_project_and_limit():
+    client = _client()
+    _make(client, "a1", project="alpha")
+    _make(client, "b1", project="beta")
+    scoped = client.get("/tasks/ready", params={"project": "alpha"}).json()
+    assert {t["project"] for t in scoped} == {"alpha"}
+    assert len(client.get("/tasks/ready", params={"limit": 1}).json()) == 1
+
+
+def test_ready_endpoint_excludes_tasks_with_unmet_dependencies():
+    client = _client()
+    parent = _make(client, "parent", project="p")
+    _make(client, "child", project="p", dependencies=[parent["id"]])
+    ready_titles = {t["title"] for t in client.get("/tasks/ready").json()}
+    assert "parent" in ready_titles
+    assert "child" not in ready_titles  # blocked until parent completes
+
+
+def test_search_endpoint_matches_title_and_filters_project():
+    client = _client()
+    _make(client, "searchable alpha thing", project="alpha")
+    _make(client, "searchable beta thing", project="beta")
+    _make(client, "unrelated", project="alpha")
+    hits = client.get("/tasks/search", params={"q": "searchable"}).json()
+    assert {t["title"] for t in hits} == {"searchable alpha thing", "searchable beta thing"}
+    scoped = client.get("/tasks/search", params={"q": "searchable", "project": "alpha"}).json()
+    assert {t["title"] for t in scoped} == {"searchable alpha thing"}
+
+
+def test_stats_endpoint_counts_by_state_and_filters_project():
+    client = _client()
+    _make(client, "o1", project="alpha")
+    _make(client, "o2", project="alpha")
+    _make(client, "o3", project="beta")
+    allstats = client.get("/tasks/stats").json()
+    assert allstats.get("open") == 3
+    scoped = client.get("/tasks/stats", params={"project": "alpha"}).json()
+    assert scoped == {"open": 2}

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -281,6 +281,31 @@ class _FakeTransport:
         return self.response_for.get(method, {})
 
 
+def test_remote_dispatch_read_endpoints_hit_correct_paths():
+    """ready/search/stats route to the hub endpoints (parity-ready-http-01)."""
+    from mac.http_client import HubClient
+
+    fake = _FakeTransport(
+        response_for={
+            ("GET", "/tasks/ready"): [{"id": "t1"}],
+            ("GET", "/tasks/search"): [{"id": "t2"}],
+            ("GET", "/tasks/stats"): {"open": 5},
+        }
+    )
+    disp = RemoteDispatch(HubClient("http://hub:8789", token="tok", transport=fake))
+
+    assert [x.to_dict() for x in disp.ready_tasks(project="mac", limit=3)] == [{"id": "t1"}]
+    assert [x.to_dict() for x in disp.search_tasks("foo", project="mac")] == [{"id": "t2"}]
+    assert disp.task_stats(project="mac") == {"open": 5}
+
+    gets = [url for (method, url, _body, _tok) in fake.calls if method == "GET"]
+    assert any("/tasks/ready" in u and "project=mac" in u and "limit=3" in u for u in gets)
+    assert any("/tasks/search" in u and "q=foo" in u and "project=mac" in u for u in gets)
+    assert any("/tasks/stats" in u and "project=mac" in u for u in gets)
+    # tenant_id was None and must be omitted from the query string.
+    assert all("tenant_id" not in u for u in gets)
+
+
 def test_remote_dispatch_create_task_via_cli(monkeypatch):
     """End-to-end: `mac --hub-url ... task create` posts to /tasks."""
     import io


### PR DESCRIPTION
Closes the biggest live bd->mac task parity gap (docs/mac-task-bd-parity-audit.md): ready/search/stats reached into ControlPlane.store for direct SQL and were refused in hub mode, so an operator pointed at the hub couldn't run them (bd ready --json worked anywhere).

## Changes
- ControlPlane: ready_tasks / search_tasks / task_stats (project + tenant filters; ready reuses the dispatcher's dependency-satisfied semantics).
- API: GET /tasks/ready, /tasks/search, /tasks/stats — registered before /tasks/{task_id} so the static paths aren't shadowed.
- RemoteDispatch: matching methods; CLI handlers call them, so the commands work in hub mode and keep the direct-SQL path under --db. _RemoteStore refuse message no longer lists them.
- Docs + CLAUDE.md updated; parity-ready-http-01 closed.

## Tests
tests/api/test_task_read_endpoints.py (endpoints + project/limit filters + dependency exclusion + route-ordering guard), a RemoteDispatch path test, route-coverage case for /tasks/search. Full pre-push green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
