### PR TITLE
Auto-emit .tickets mirror on task create/close (parity-tickets-autoemit-01)

### DIFF
--- a/.tickets/parity-tickets-autoemit-01.md
+++ b/.tickets/parity-tickets-autoemit-01.md
@@ -1,6 +1,6 @@
 ---
 id: parity-tickets-autoemit-01
-status: open
+status: closed
 deps: []
 links: [parity-ready-http-01]
 created: 2026-06-09T00:00:00Z
@@ -8,7 +8,18 @@ type: feature
 priority: 2
 audit: mac-task-bd-parity
 discovered_via: parity_audit
+resolution: done
 ---
+
+## Done (2026-06-10)
+
+`src/mac/tickets_mirror.py` renders a wedow-compatible ticket from a mac task
+dict (reusing `beads_migrator._render_ticket` so the format never drifts) and
+writes `.tickets/<id>.md` into the repo's existing `.tickets/` dir (git root,
+else cwd; never creates one). `mac task create` and `mac task close` call it
+(close passes the reason as the Close Reason section); idempotent, and opt-out
+via `--no-ticket` / `MAC_NO_TICKET_MIRROR`.
+
 # Auto-emit the `.tickets/<id>.md` mirror on task create/close
 
 ## Why this exists

--- a/docs/mac-task-bd-parity-audit.md
+++ b/docs/mac-task-bd-parity-audit.md
@@ -50,19 +50,22 @@ Criteria / Notes / Close Reason — a faithful superset of the bead fields.
 | Assignment (assignee/owner) | metadata + `.tickets` `assignee` | Present |
 | External refs | metadata + `.tickets` `external-ref` | Present |
 | Memories | `mac memory remember/list/forget` | Present (`list/forget` are `--db`-only) |
-| `.tickets` markdown mirror **auto-emitted** on create/close | only emitted by `migrate-beads`; not on `mac task create/close` | **Missing — roadmap** (`CLAUDE.md`) |
+| `.tickets` markdown mirror **auto-emitted** on create/close | `mac task create`/`close` write `.tickets/<id>.md` (`tickets_mirror.py`) | **Present** (parity-tickets-autoemit-01) |
 | `bd dolt push/pull` cross-machine sync | — | Removed by design (mac hub is the store) |
 | Two-way `bd update/close` writeback | — | Removed by design (`MAC_BEADS_BRIDGE_ENABLED` gated off) |
 
 ## Remaining gaps (actionable)
 
+Both gaps are now closed:
+
 1. ~~**`ready` / `search` / `stats` are SQLite-only.**~~ **DONE** —
    `GET /tasks/ready|search|stats` now serve these from the hub; the CLI uses
    them in hub mode and keeps the direct-SQL path under `--db`
    (`parity-ready-http-01`).
-2. **No `.tickets` auto-emit.** `bd` kept the JSONL mirror in sync; `mac task
-   create/close` doesn't write/update `.tickets/<id>.md`, so the git-trackable
-   mirror drifts from the ledger. → emit on create/close. (`parity-tickets-autoemit-01`)
+2. ~~**No `.tickets` auto-emit.**~~ **DONE** — `mac task create`/`close` now
+   write/update `.tickets/<id>.md` via `src/mac/tickets_mirror.py` (reusing the
+   migrator's renderer), idempotent and opt-out via `--no-ticket` /
+   `MAC_NO_TICKET_MIRROR` (`parity-tickets-autoemit-01`).
 
 ## Deliberately not parity (recorded so they aren't re-opened as "gaps")
 
@@ -73,7 +76,8 @@ Criteria / Notes / Close Reason — a faithful superset of the bead fields.
 ## Verdict
 
 Core issue-tracking parity is **achieved** (fields, dependencies, lifecycle,
-priority, sections, project-from-cwd for both create and read). The two real
-gaps are operational, not data-model: the read commands don't work over the
-hub, and the `.tickets` mirror isn't auto-emitted. Both are tracked as
-follow-ups; everything else either matches `bd` or was dropped on purpose.
+priority, sections, project-from-cwd for both create and read). The two
+operational gaps that remained — read commands not working over the hub, and the
+`.tickets` mirror not being auto-emitted — are now **both closed**
+(`parity-ready-http-01`, `parity-tickets-autoemit-01`). Everything else either
+matches `bd` or was dropped on purpose.

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -375,6 +375,27 @@ def _effective_read_project(args: argparse.Namespace) -> Optional[str]:
     return inferred
 
 
+def _maybe_emit_ticket(
+    result: Any, args: argparse.Namespace, *, close_reason: Optional[str] = None
+) -> None:
+    """Mirror a created/closed task to ``.tickets/<id>.md`` (parity-tickets-autoemit-01).
+
+    Best-effort and opt-out (``--no-ticket`` / ``MAC_NO_TICKET_MIRROR``); never
+    fails the command if the mirror can't be written.
+    """
+    if getattr(args, "no_ticket", False):
+        return
+    data = result.to_dict() if hasattr(result, "to_dict") else result
+    try:
+        from mac.tickets_mirror import emit
+
+        path = emit(data, close_reason=close_reason)
+    except Exception:  # noqa: BLE001 - the mirror is a convenience, not the operation
+        return
+    if path:
+        print("mac: wrote ticket mirror %s" % path, file=sys.stderr)
+
+
 def cmd_task_create(args: argparse.Namespace) -> None:
     cp = _plane(args)
     description = _read_text_arg(
@@ -402,19 +423,19 @@ def cmd_task_create(args: argparse.Namespace) -> None:
                 file=sys.stderr,
             )
     project = project or None
-    _print(
-        cp.create_task(
-            args.title,
-            description=description,
-            project=project,
-            priority=args.priority,
-            required_capabilities=_csv(args.required_capabilities),
-            dependencies=_csv(args.dependencies),
-            metadata=metadata,
-            max_attempts=args.max_attempts,
-            actor=args.actor,
-        )
+    created = cp.create_task(
+        args.title,
+        description=description,
+        project=project,
+        priority=args.priority,
+        required_capabilities=_csv(args.required_capabilities),
+        dependencies=_csv(args.dependencies),
+        metadata=metadata,
+        max_attempts=args.max_attempts,
+        actor=args.actor,
     )
+    _maybe_emit_ticket(created, args)
+    _print(created)
 
 
 def cmd_task_list(args: argparse.Namespace) -> None:
@@ -450,7 +471,9 @@ def cmd_task_close(args: argparse.Namespace) -> None:
 
     detail = {"reason": args.reason} if args.reason else {}
     target = TaskState.COMPLETED.value if args.success else TaskState.CANCELLED.value
-    _print(cp.transition_task(args.task_id, target, args.actor, detail).to_dict())
+    result = cp.transition_task(args.task_id, target, args.actor, detail)
+    _maybe_emit_ticket(result, args, close_reason=args.reason or None)
+    _print(result)
 
 
 def cmd_task_search(args: argparse.Namespace) -> None:
@@ -1951,6 +1974,8 @@ def build_parser() -> argparse.ArgumentParser:
                         help="read JSON metadata from file path (or '-' for stdin)")
     create.add_argument("--max-attempts", type=int, default=3)
     create.add_argument("--actor", default="human")
+    create.add_argument("--no-ticket", dest="no_ticket", action="store_true",
+                        help="don't write the .tickets/<id>.md mirror for this task")
     _set(cmd_task_create, create)
 
     list_tasks = task.add_parser("list")
@@ -1978,6 +2003,8 @@ def build_parser() -> argparse.ArgumentParser:
     close.add_argument("task_id")
     close.add_argument("--reason", default="")
     close.add_argument("--actor", default="human")
+    close.add_argument("--no-ticket", dest="no_ticket", action="store_true",
+                       help="don't update the .tickets/<id>.md mirror on close")
     close.add_argument("--cancelled", dest="success", action="store_false",
                        help="close as CANCELLED instead of COMPLETED")
     close.set_defaults(success=True)

--- a/src/mac/tickets_mirror.py
+++ b/src/mac/tickets_mirror.py
@@ -1,0 +1,90 @@
+"""Auto-emit the ``.tickets/<id>.md`` mirror on task create/close.
+
+parity-tickets-autoemit-01: `bd` kept its git-distributed mirror in sync with
+every change; `mac task create/close` historically only wrote `.tickets/` during
+`migrate-beads`, so the git-trackable mirror drifted from the ledger. This module
+renders a wedow-compatible ticket from a mac task dict — reusing the migrator's
+renderer so the format never drifts — and writes it into the repo's existing
+`.tickets/` directory.
+
+Emits only when a `.tickets/` dir already exists (git repo root, else cwd); it
+never creates one. Opt out per-call (`--no-ticket`) or globally via
+`MAC_NO_TICKET_MIRROR`.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from mac.beads_migrator import _render_ticket
+
+
+def render_ticket(task: Dict[str, Any], *, close_reason: Optional[str] = None) -> str:
+    """Render the `.tickets/<id>.md` content for a mac task dict."""
+    metadata = task.get("metadata") or {}
+    issue: Dict[str, Any] = {
+        "id": task.get("id"),
+        "status": task.get("state") or "open",
+        # mac task deps are a flat id list; the renderer wants typed dep dicts.
+        "dependencies": [
+            {"type": "blocks", "depends_on_id": dep}
+            for dep in (task.get("dependencies") or [])
+        ],
+        "created_at": task.get("created_at") or "",
+        "issue_type": metadata.get("type") or "task",
+        "priority": task.get("priority"),
+        "title": task.get("title") or task.get("id"),
+        "description": task.get("description") or "",
+    }
+    if close_reason:
+        issue["close_reason"] = close_reason
+    return _render_ticket(issue, str(task.get("id")))
+
+
+def tickets_dir() -> Optional[Path]:
+    """The `.tickets/` directory to mirror into — the git repo root's, else the
+    cwd's. Returns None when no `.tickets/` exists (we never create one)."""
+    candidates = []
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if top.returncode == 0 and top.stdout.strip():
+            candidates.append(Path(top.stdout.strip()) / ".tickets")
+    except Exception:
+        pass
+    try:
+        candidates.append(Path(os.getcwd()) / ".tickets")
+    except OSError:
+        pass
+    for directory in candidates:
+        if directory.is_dir():
+            return directory
+    return None
+
+
+def emit(task: Dict[str, Any], *, close_reason: Optional[str] = None) -> Optional[Path]:
+    """Write/update `.tickets/<id>.md` for a mac task.
+
+    No-op (returns None) when disabled via ``MAC_NO_TICKET_MIRROR``, when there
+    is no `.tickets/` directory, or when the file is already up to date.
+    """
+    if os.environ.get("MAC_NO_TICKET_MIRROR"):
+        return None
+    task_id = task.get("id")
+    if not task_id:
+        return None
+    directory = tickets_dir()
+    if directory is None:
+        return None
+    path = directory / ("%s.md" % task_id)
+    content = render_ticket(task, close_reason=close_reason)
+    if path.exists() and path.read_text(encoding="utf-8") == content:
+        return None
+    path.write_text(content, encoding="utf-8")
+    return path

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -186,6 +186,33 @@ def test_task_search_scopes_to_cwd_project(tmp_path, monkeypatch):
     assert {"alpha", "beta"} <= {t["project"] for t in everything}
 
 
+def test_task_create_emits_ticket_mirror(tmp_path, monkeypatch):
+    import mac.tickets_mirror as tm
+
+    d = tmp_path / ".tickets"
+    d.mkdir()
+    monkeypatch.setattr(tm, "tickets_dir", lambda: d)
+    monkeypatch.delenv("MAC_NO_TICKET_MIRROR", raising=False)
+    rc, task = _run(tmp_path, "task", "create", "Mirror me", "--project", "p")
+    assert rc == 0
+    files = list(d.glob("*.md"))
+    assert len(files) == 1
+    text = files[0].read_text(encoding="utf-8")
+    assert "# Mirror me" in text
+    assert ("id: %s" % task["id"]) in text
+
+
+def test_task_create_no_ticket_skips_mirror(tmp_path, monkeypatch):
+    import mac.tickets_mirror as tm
+
+    d = tmp_path / ".tickets"
+    d.mkdir()
+    monkeypatch.setattr(tm, "tickets_dir", lambda: d)
+    rc, _task = _run(tmp_path, "task", "create", "No mirror", "--project", "p", "--no-ticket")
+    assert rc == 0
+    assert list(d.glob("*.md")) == []
+
+
 def test_mac_cli_task_show(tmp_path):
     rc, task = _run(tmp_path, "task", "create", "Show me")
     assert rc == 0

--- a/tests/test_tickets_mirror.py
+++ b/tests/test_tickets_mirror.py
@@ -1,0 +1,73 @@
+"""Tests for the .tickets/<id>.md auto-emit mirror (parity-tickets-autoemit-01)."""
+from __future__ import annotations
+
+import pytest
+
+from mac import tickets_mirror as tm
+
+TASK = {
+    "id": "task_abc123",
+    "state": "open",
+    "title": "Fix the thing",
+    "description": "Do the fix.\nMore detail.",
+    "dependencies": ["task_dep1"],
+    "priority": 1,
+    "created_at": "2026-06-10T00:00:00Z",
+    "metadata": {"type": "bug"},
+}
+
+
+def test_render_ticket_frontmatter_and_body():
+    out = tm.render_ticket(TASK)
+    assert "id: task_abc123" in out
+    assert "status: open" in out
+    assert "deps: [task_dep1]" in out
+    assert "type: bug" in out
+    assert "priority: 1" in out
+    assert "mac-task-id: task_abc123" in out
+    assert "# Fix the thing" in out
+    assert "Do the fix." in out
+
+
+def test_render_ticket_close_reason():
+    out = tm.render_ticket({**TASK, "state": "completed"}, close_reason="done well")
+    assert "status: completed" in out
+    assert "## Close Reason" in out
+    assert "done well" in out
+
+
+def test_emit_writes_when_tickets_dir_exists(tmp_path, monkeypatch):
+    d = tmp_path / ".tickets"
+    d.mkdir()
+    monkeypatch.setattr(tm, "tickets_dir", lambda: d)
+    monkeypatch.delenv("MAC_NO_TICKET_MIRROR", raising=False)
+    path = tm.emit(TASK)
+    assert path == d / "task_abc123.md"
+    assert "id: task_abc123" in path.read_text(encoding="utf-8")
+    # Idempotent: re-emitting identical content is a no-op.
+    assert tm.emit(TASK) is None
+
+
+def test_emit_noop_without_tickets_dir(monkeypatch):
+    monkeypatch.setattr(tm, "tickets_dir", lambda: None)
+    assert tm.emit(TASK) is None
+
+
+def test_emit_respects_optout_env(tmp_path, monkeypatch):
+    d = tmp_path / ".tickets"
+    d.mkdir()
+    monkeypatch.setattr(tm, "tickets_dir", lambda: d)
+    monkeypatch.setenv("MAC_NO_TICKET_MIRROR", "1")
+    assert tm.emit(TASK) is None
+    assert not (d / "task_abc123.md").exists()
+
+
+def test_emit_updates_on_status_change(tmp_path, monkeypatch):
+    d = tmp_path / ".tickets"
+    d.mkdir()
+    monkeypatch.setattr(tm, "tickets_dir", lambda: d)
+    monkeypatch.delenv("MAC_NO_TICKET_MIRROR", raising=False)
+    tm.emit(TASK)
+    updated = tm.emit({**TASK, "state": "completed"}, close_reason="shipped")
+    assert updated is not None
+    assert "status: completed" in (d / "task_abc123.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes the second gap from docs/mac-task-bd-parity-audit.md. `bd` kept its git-distributed mirror in sync; `mac task create/close` only wrote `.tickets/` during `migrate-beads`, so the git-trackable mirror drifted from the ledger.

## Changes
- New `src/mac/tickets_mirror.py`: renders a wedow-compatible ticket from a mac task dict (reusing `beads_migrator._render_ticket` so the format never drifts) and writes `.tickets/<id>.md` into the repo's existing `.tickets/` dir (git root, else cwd — **never creates one**).
- `mac task create` and `mac task close` call it; close passes the reason as the Close Reason section.
- Idempotent (skips unchanged files); opt-out via `--no-ticket` or `MAC_NO_TICKET_MIRROR`.

## Tests
`tests/test_tickets_mirror.py` (render + emit: writes / no-op-without-dir / opt-out / update-on-status-change) and CLI emit + `--no-ticket` tests. Full pre-push green.

With this + #127, both bd-parity follow-ups from the audit are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
