### PR TITLE
Fix mac agentbus read in hub mode (RemoteDispatch arg order)

### DIFF
--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -605,9 +605,24 @@ class RemoteDispatch:
     def list_agentbus_streams(self, **kw: Any) -> List[_Dictish]:
         return _wrap_list(self._get("/agentbus/streams", **kw))
 
-    def read_agentbus_chunks(self, stream_id: str, **kw: Any) -> List[_Dictish]:
+    def read_agentbus_chunks(
+        self,
+        agent_id: str,
+        stream_id: str,
+        after_sequence: int = 0,
+        limit: int = 100,
+    ) -> List[_Dictish]:
+        # Match ControlPlane.read_agentbus_chunks(agent_id, stream_id, ...) and the
+        # GET /agentbus/streams/{stream_id}/chunks endpoint (agent_id is a query
+        # param). The old (stream_id, **kw) signature dropped agent_id and broke
+        # `mac agentbus read` in hub mode with a positional-arg TypeError.
         return _wrap_list(
-            self._get("/agentbus/streams/%s/chunks" % quote(stream_id, safe=""), **kw)
+            self._get(
+                "/agentbus/streams/%s/chunks" % quote(stream_id, safe=""),
+                agent_id=agent_id,
+                after_sequence=after_sequence,
+                limit=limit,
+            )
         )
 
     def publish_agentbus_content(self, **kw: Any) -> _Dictish:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -306,6 +306,25 @@ def test_remote_dispatch_read_endpoints_hit_correct_paths():
     assert all("tenant_id" not in u for u in gets)
 
 
+def test_remote_dispatch_read_agentbus_chunks_passes_agent_id():
+    """`mac agentbus read` in hub mode — regression for the (stream_id, **kw)
+    signature that dropped agent_id and raised a positional-arg TypeError."""
+    from mac.http_client import HubClient
+
+    fake = _FakeTransport(
+        response_for={("GET", "/agentbus/streams/bus_x/chunks"): [{"sequence": 0}]}
+    )
+    disp = RemoteDispatch(HubClient("http://hub:8789", token="tok", transport=fake))
+    # Mirror the CLI call shape: agent_id first, then stream_id, kwargs after.
+    chunks = disp.read_agentbus_chunks("agent_rocky", "bus_x", after_sequence=2, limit=5)
+    assert [c.to_dict() for c in chunks] == [{"sequence": 0}]
+    url = next(u for (m, u, _b, _t) in fake.calls if m == "GET")
+    assert "/agentbus/streams/bus_x/chunks" in url
+    assert "agent_id=agent_rocky" in url
+    assert "after_sequence=2" in url
+    assert "limit=5" in url
+
+
 def test_remote_dispatch_create_task_via_cli(monkeypatch):
     """End-to-end: `mac --hub-url ... task create` posts to /tasks."""
     import io


### PR DESCRIPTION
`RemoteDispatch.read_agentbus_chunks(self, stream_id, **kw)` dropped the `agent_id` the CLI passes first, so `mac agentbus read <stream> <agent>` raised `takes 2 positional arguments but 3 were given` against any hub (hit while reading repo-update result streams during the fleet deploy). Now matches `ControlPlane.read_agentbus_chunks(agent_id, stream_id, after_sequence, limit)` and the `GET /agentbus/streams/{stream_id}/chunks` endpoint. +regression test mirroring the CLI call shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)