### PR TITLE
Stop CLI tests from auto-emitting real .tickets files

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -9,3 +9,15 @@ import pytest
 def _mac_secret_key(monkeypatch):
     """mac CLI uses ControlPlane(SQLiteStore(...)) which needs MAC_SECRET_KEY."""
     monkeypatch.setenv("MAC_SECRET_KEY", "cli-test-key-with-at-least-32-characters")
+
+
+@pytest.fixture(autouse=True)
+def _no_ticket_mirror(monkeypatch):
+    """Stop `mac task create/close` tests from auto-emitting real
+    `.tickets/<id>.md` files into the repo. The CLI runs with cwd = the repo, so
+    `tickets_mirror.tickets_dir()` resolves to the repo's `.tickets/` and every
+    throwaway test task would otherwise litter it (parity-tickets-autoemit-01).
+    The dedicated emit tests opt back in by deleting this var and pointing
+    `tickets_dir` at a tmp directory.
+    """
+    monkeypatch.setenv("MAC_NO_TICKET_MIRROR", "1")


### PR DESCRIPTION
Follow-up to parity-tickets-autoemit-01. CLI create/close tests run with cwd = the repo, so `tickets_dir()` resolved to the repo's `.tickets/` and every throwaway test task emitted a real `.tickets/<id>.md` (62 junk files had accumulated — now removed). Adds an autouse fixture setting `MAC_NO_TICKET_MIRROR=1` for CLI tests; the dedicated emit tests already opt back in (delenv + `tickets_dir`→tmp). Verified the full CLI suite now emits **zero** `.tickets/task_*.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)