### PR TITLE
Cron deliveries: drop the boilerplate wrapper by default

### DIFF
--- a/src/mac/_hermes/cron/scheduler.py
+++ b/src/mac/_hermes/cron/scheduler.py
@@ -637,13 +637,15 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
 
-    # Optionally wrap the content with a header/footer so the user knows this
-    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
-    wrap_response = True
+    # Optionally wrap the content with a header/footer identifying the cron job.
+    # Off by default: the boilerplate ("Cronjob Response: ... (job_id: ...)" +
+    # "To stop or manage this job ...") makes scheduled posts read as insincere,
+    # so cron output goes out as just the content. Set cron.wrap_response: true
+    # in config.yaml to re-enable the wrapper.
+    wrap_response = False
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        wrap_response = user_cfg.get("cron", {}).get("wrap_response", False)
     except Exception:
         pass
 


### PR DESCRIPTION
Scheduled cron jobs wrapped every Slack/chat post in a `Cronjob Response: <name> (job_id: ...)` header + `To stop or manage this job ...` footer (`cron.wrap_response`, default **True**), which makes the output read as insincere (e.g. the fleet-banter post). Flip the default to **False** in `_hermes/cron/scheduler.py` so cron output is just the content; set `cron.wrap_response: true` in config.yaml to restore the wrapper.

No existing test pins this path; the real verification is the next cron post after deploy carrying no boilerplate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)