### PR TITLE
ADR 0005: elastic executor tier vs static fleet (Proposed)

### DIFF
--- a/deploy/k8s/gpu-worker/README.md
+++ b/deploy/k8s/gpu-worker/README.md
@@ -1,0 +1,128 @@
+# GPU worker nodes
+
+Turn a fleet GPU host (madmax, natasha) into a Kubernetes **GPU worker node** so
+the elastic executor tier ([ADR 0005](../../../docs/adr/0005-elastic-executor-tier-vs-static-fleet.md))
+can run `nvidia.com/gpu`-requesting Jobs on it.
+
+> **Why this is now worth doing for madmax.** The thing that used to "block" the
+> GPU — the long-lived vLLM "LLM brain" Deployment — serves **≈0 hub traffic**
+> (live `llm.route` telemetry, 2026-06-11: 994/1000 routed to cloud `nvidia`, 0
+> to madmax's vLLM, because no caller requests its `Qwen/...` model). See the ADR
+> Evidence section. So the GPU can be **dedicated** to executor Jobs rather than
+> carefully time-sliced around an idle service.
+
+This tree contains the substrate only. It does **not** install drivers (already
+present on the GPU hosts) and does **not** itself schedule GPU work — wiring the
+MAC runner to request GPUs is the documented draft in
+[§ Make GPU Jobs request the GPU](#make-gpu-jobs-request-the-gpu) below.
+
+## Layout
+
+```
+deploy/k8s/gpu-worker/
+├── README.md                     ← you are here
+├── nvidia-device-plugin.yaml     ← DaemonSet: advertises nvidia.com/gpu on labeled nodes
+├── label-gpu-node.sh             ← imperative: label (+ optional taint) a node
+└── kustomization.yaml            ← applies into kube-system
+```
+
+## Prerequisites (per host)
+
+Verified present on madmax (RTX 6000 Ada) and natasha (GB10) in ADR 0005:
+
+- NVIDIA driver loaded (`nvidia-smi` works).
+- **NVIDIA Container Toolkit** (`nvidia-ctk`) + **containerd**, with the `nvidia`
+  runtime wired as containerd's default (or as a `RuntimeClass`). This is the
+  exact mechanism that *cannot* exist on macOS — which is why **bullwinkle is not
+  a candidate** (its Metal GPU is unschedulable; its image-gen stays an
+  off-cluster native service).
+- The node has **joined the cluster** as a worker (kubelet running). `rocky` is
+  the intended control-plane / CPU node; it has no container runtime today, so
+  add containerd there before it can host anything.
+
+natasha caveats (from ADR 0005): it's **arm64** (mixed-arch cluster → build
+workload images for arm64 too) and runs a **kernel-coupled driver** (`6.17-nvidia`
++ driver 580) — keep the per-kernel module package matched (see the
+`reference-fleet-gpu-capability` memory for the exact `apt-get` fix).
+
+## Apply
+
+```bash
+# 1. Label the node (run from a context with the cluster's kubeconfig).
+#    Plain label  -> GPU shareable with other pods.
+#    --taint      -> dedicate the node to GPU work (CPU executor Jobs stay off it).
+deploy/k8s/gpu-worker/label-gpu-node.sh madmax --taint
+
+# 2. Roll out the device plugin. It only lands on nodes carrying the
+#    mac.fleet/capability-gpu=true label set in step 1.
+kubectl apply -k deploy/k8s/gpu-worker
+
+# 3. Verify the node now advertises GPUs as a schedulable resource.
+kubectl describe node madmax | grep -A2 'Capacity:' | grep nvidia.com/gpu
+#   nvidia.com/gpu:  1
+kubectl -n kube-system get pods -l app.kubernetes.io/name=nvidia-device-plugin -o wide
+```
+
+A quick end-to-end check that GPUs are actually schedulable:
+
+```bash
+kubectl run gpu-smoke --rm -it --restart=Never \
+  --image=nvcr.io/nvidia/cuda:12.4.1-base-ubuntu22.04 \
+  --overrides='{"spec":{"nodeSelector":{"mac.fleet/capability-gpu":"true"},
+    "tolerations":[{"key":"mac.fleet/gpu-only","operator":"Exists"}],
+    "containers":[{"name":"gpu-smoke","image":"nvcr.io/nvidia/cuda:12.4.1-base-ubuntu22.04",
+      "command":["nvidia-smi"],"resources":{"limits":{"nvidia.com/gpu":1}}}]}}'
+```
+
+## Conventions
+
+- **Label:** `mac.fleet/capability-gpu=true` — the k8s analogue of the
+  `capability-gpu` node label proven in ADR 0005's kind/colima experiment, in the
+  same `mac.*` namespace as the runner's Job labels (`mac.task.id`, `mac.role`, …).
+- **Optional taint:** `mac.fleet/gpu-only=true:NoSchedule` — keeps non-GPU Jobs
+  off the scarce GPU host. GPU Jobs (and the device plugin) must tolerate it.
+- **Namespace:** the device plugin is node infra → `kube-system`. App workloads
+  (mac-api, mac-runner, task Jobs) stay in `mac`.
+
+## Make GPU Jobs request the GPU (draft — not yet wired)
+
+The device plugin only *advertises* GPUs; the MAC runner must *request* them for
+GPU-tagged tasks. Today `build_job_spec()` in
+[`src/mac/k8s/runner.py`](../../../src/mac/k8s/runner.py) emits a CPU-only pod
+template via `_build_executor_pod_template()`. The minimal change: when a task's
+`required_capabilities` contains `gpu`, inject a nodeSelector, the taint
+toleration, and an `nvidia.com/gpu` limit. Sketch:
+
+```python
+# in _build_executor_pod_template(...), after the base pod spec is built:
+needs_gpu = "gpu" in {str(c) for c in (task.get("required_capabilities") or [])}
+if needs_gpu:
+    pod_spec["nodeSelector"] = {"mac.fleet/capability-gpu": "true"}
+    pod_spec.setdefault("tolerations", []).append(
+        {"key": "mac.fleet/gpu-only", "operator": "Exists", "effect": "NoSchedule"}
+    )
+    container["resources"].setdefault("limits", {})["nvidia.com/gpu"] = "1"
+    # nvidia.com/gpu is integer-only and not over-committable: requests==limits
+    # is enforced by k8s, so do NOT also set it under requests.
+```
+
+This keeps capability matching in the ledger (a task labeled `gpu` lands on a GPU
+node) without a second scheduler — consistent with ADR 0005's "the MAC ledger
+stays the single dispatch brain." Land it behind a test in `tests/` alongside the
+existing `build_job_spec` coverage before enabling.
+
+## What about the vLLM brain?
+
+Because it serves ≈0 traffic, the simplest path is to **stop the vLLM Deployment
+and dedicate madmax's GPU to executor Jobs**. Before decommissioning, confirm
+there's no out-of-band direct consumer (the hub telemetry can't see processes
+that hit `madmax:8000` directly):
+
+```bash
+ssh jkh@madmax.local "curl -s localhost:8000/metrics | grep request_success_total; ss -tnp | grep :8000"
+```
+
+If you still want a local-LLM fallback, keep a **right-sized** vLLM and share the
+GPU via [time-slicing / MPS](https://github.com/NVIDIA/k8s-device-plugin#shared-access-to-gpus)
+(a `ConfigMap` for the device plugin) instead of letting one model server hold the
+whole card — but don't let a 0-traffic service block the node.

--- a/deploy/k8s/gpu-worker/kustomization.yaml
+++ b/deploy/k8s/gpu-worker/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The device plugin is node-level cluster infra, so it lives in kube-system
+# (NOT the `mac` app namespace used by mac-api / mac-runner).
+namespace: kube-system
+resources:
+  - nvidia-device-plugin.yaml

--- a/deploy/k8s/gpu-worker/label-gpu-node.sh
+++ b/deploy/k8s/gpu-worker/label-gpu-node.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Mark a fleet host as a MAC GPU worker node.
+#
+# Node labels can't be expressed as an applyable manifest (Node objects are
+# created by the kubelet at join), so the capability label + the optional
+# "dedicate to GPU work" taint are applied imperatively here.
+#
+# Usage:
+#   ./label-gpu-node.sh madmax           # label only (GPU shared with other pods)
+#   ./label-gpu-node.sh madmax --taint   # label + taint (GPU node runs ONLY gpu jobs)
+#   ./label-gpu-node.sh madmax --unset   # remove label + taint
+#
+# After labeling, `kubectl apply -k deploy/k8s/gpu-worker` rolls the device
+# plugin onto the node, and `kubectl describe node <name>` should then show
+# `nvidia.com/gpu` under Capacity/Allocatable.
+set -euo pipefail
+
+NODE="${1:?usage: label-gpu-node.sh <node-name> [--taint|--unset]}"
+MODE="${2:-label}"
+
+CAP_LABEL="mac.fleet/capability-gpu"
+GPU_ONLY_TAINT="mac.fleet/gpu-only"
+
+case "$MODE" in
+  --unset)
+    echo "==> removing GPU worker label + taint from node/$NODE"
+    kubectl label  node "$NODE" "${CAP_LABEL}-"            --overwrite || true
+    kubectl taint  node "$NODE" "${GPU_ONLY_TAINT}-"                   || true
+    ;;
+  --taint)
+    echo "==> labeling node/$NODE as GPU worker AND tainting it gpu-only"
+    kubectl label  node "$NODE" "${CAP_LABEL}=true" --overwrite
+    # NoSchedule => only pods that tolerate mac.fleet/gpu-only land here, so the
+    # scarce GPU host isn't filled with CPU executor Jobs.
+    kubectl taint  node "$NODE" "${GPU_ONLY_TAINT}=true:NoSchedule" --overwrite
+    ;;
+  label|*)
+    echo "==> labeling node/$NODE as GPU worker (GPU shareable with other pods)"
+    kubectl label  node "$NODE" "${CAP_LABEL}=true" --overwrite
+    ;;
+esac
+
+echo "==> current GPU-relevant state of node/$NODE:"
+kubectl get node "$NODE" -o jsonpath='{.metadata.labels.mac\.fleet/capability-gpu}{"\n"}' \
+  | sed 's/^/   capability-gpu label: /'
+kubectl describe node "$NODE" | grep -E 'Taints:|nvidia\.com/gpu' || true

--- a/deploy/k8s/gpu-worker/nvidia-device-plugin.yaml
+++ b/deploy/k8s/gpu-worker/nvidia-device-plugin.yaml
@@ -1,0 +1,69 @@
+# NVIDIA k8s device plugin — exposes GPUs as the schedulable resource
+# `nvidia.com/gpu` so MAC executor Jobs can request them.
+#
+# Prerequisite (already true on madmax + natasha, per ADR 0005): the host has
+# the NVIDIA driver + NVIDIA Container Toolkit (`nvidia-ctk`) + containerd, and
+# containerd's default (or `nvidia`) runtime injects the driver into containers.
+# This DaemonSet does NOT install drivers — it only advertises the GPUs that the
+# toolkit makes visible. It is the one mechanism that *cannot* exist on a macOS
+# host (see ADR 0005), which is why bullwinkle is excluded.
+#
+# It lands ONLY on nodes explicitly labeled `mac.fleet/capability-gpu=true`
+# (see label-gpu-node.sh / README), so a stray CPU node never tries to run it.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: nvidia-device-plugin
+    app.kubernetes.io/component: gpu-worker
+    app.kubernetes.io/managed-by: mac
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nvidia-device-plugin
+        app.kubernetes.io/component: gpu-worker
+    spec:
+      # The plugin must come up before GPU workloads can schedule.
+      priorityClassName: system-node-critical
+      # Only run on fleet hosts we've opted in as GPU worker nodes.
+      nodeSelector:
+        mac.fleet/capability-gpu: "true"
+      tolerations:
+        # The standard taint the NVIDIA device plugin tolerates.
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        # The optional MAC "dedicate this node to GPU work" taint (see README) —
+        # the plugin itself must still schedule there.
+        - key: mac.fleet/gpu-only
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: nvidia-device-plugin
+          # Pin a digest in production (mirror the image-pinning convention used
+          # by mac-api / mac-runner deployment.yaml).
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.17.1
+          imagePullPolicy: IfNotPresent
+          env:
+            # Fail loudly if the node can't actually see a GPU, rather than
+            # silently advertising zero and masking a driver/toolkit problem.
+            - name: FAIL_ON_INIT_ERROR
+              value: "true"
+          securityContext:
+            # The plugin needs raw access to the driver / device files.
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
+++ b/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
@@ -127,6 +127,47 @@ the design. The only thing that would flip this decision is running a k8s
 cluster being off the table; it isn't (`jordanh-gke` is already a cluster), so
 GitHub-hosted runners' "no cluster to operate" advantage does not apply.
 
+## Evidence: a live multi-node dispatch experiment (2026-06-11)
+
+The flexible-dispatch claim was **tested, not just asserted**. A real 4-node
+Kubernetes cluster was stood up locally (`kind` on `colima`): one control-plane
+node (the "hub") + three worker nodes labeled to mimic the fleet's heterogeneity
+— `madmax` (`capability-gpu`), `bullwinkle` (`capability-image-gen`), `rocky`
+(`capability-ops`). Four Jobs were submitted with no manual placement:
+
+- `nodeSelector: capability-gpu` scheduled onto the `madmax` node;
+  `capability-image-gen` → `bullwinkle`; `capability-ops` → `rocky`. Every
+  capability-targeted Job landed on exactly its matching node.
+- A 6-completion / parallelism-6 Job with **no** selector spread **2 / 2 / 2**
+  across the three worker nodes on the scheduler's own.
+
+**Proven:** a control-plane + worker-node cluster does capability-aware,
+self-balancing Job dispatch across the fleet with zero per-host static config —
+the elastic-executor property this ADR depends on. (Method caveat: `kind` nodes
+are containers on one VM, so the *physical* distribution is simulated; the
+*scheduling logic* exercised is genuine, unmodified upstream Kubernetes.)
+
+**What it does NOT prove — and why that sharpens the decision.** The literal
+"every host simply becomes a node" does not hold:
+
+- **macOS hosts cannot be Linux-container worker nodes.** bullwinkle (darwin /
+  M4 Pro) has no kubelet running Linux pods, and its **Metal/MPS GPU is not a
+  schedulable k8s resource** at all.
+- **NVIDIA GPUs need device plugins.** madmax (RTX 6000 Ada) and natasha (GB10)
+  require drivers + the device plugin to expose GPUs as schedulable resources.
+- **Cross-network CNI.** Fleet hosts sit on different networks joined by
+  Tailscale; one cluster needs node + pod networking across them (e.g. k3s + an
+  overlay/tailnet CNI) — feasible, not "simple."
+- **MAC semantics are still ours to build.** k8s supplies the substrate; the
+  `claim → run → evidence → exit` executor and autoscaling off `GET /tasks/ready`
+  are not provided by k8s.
+
+Crucially, the hosts that *can't* be worker nodes (darwin/image-gen, GPU model
+servers) are exactly the ones this ADR assigns to the **persistent tier**. The
+experiment therefore confirms both the dispatch property *and* the two-tier
+split: Linux hosts → elastic executor nodes; darwin + GPU + long-lived-service
+hosts → persistent agents.
+
 ## Risks / non-goals
 
 - **Do not** dissolve personas/memory/long-lived services into ephemeral workers

--- a/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
+++ b/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
@@ -10,23 +10,33 @@
   every agent were a GitHub self-hosted runner (and any runner an agent), with
   agents registered/created dynamically rather than declared statically?*
 
-## TL;DR verdict
+## Recommendation (the short version)
 
-The proposal bundles two ideas; **separate them**:
+**Do not make agents GitHub runners.** Get the elasticity you want by adding an
+**ephemeral executor tier on k8s Jobs** — which this repo already has (autopilot
+/ `job-per-task`) — autoscaled off the MAC ledger's ready-queue, while keeping
+personas + shared services persistent. The MAC ledger stays the single dispatch
+brain.
+
+GitHub self-hosted runners are the **wrong substrate** for this fleet: they add a
+second control plane and identity/label registry that *duplicate* the ledger and
+its capability matching; they only fit the repo/CI subset of the work (the rest
+gets forced through awkward `repository_dispatch` RPC); and they put agentic code
+next to repo-write + secrets (GitHub's canonical self-hosted-runner footgun).
+GitHub's only sensible role is the **inverse** of the proposal — a GitHub CI
+event *creates a MAC task* (GitHub feeds the ledger; it does not replace it).
+
+Separating the two ideas in the question:
 
 | Idea | Verdict |
 | --- | --- |
-| **Elastic / dynamic registration** instead of static `fleets.yaml` | **Yes** — overdue. The static model is the source of most operational pain we keep hitting. |
-| **Agent ≡ GitHub runner (universally)** | **Half right.** True for the *executor* tier; **wrong** for the *persona/services* tier. |
+| Move off the static `fleets.yaml` to **dynamic/elastic** capacity | **Yes** — overdue; it's behind most of our operational pain. |
+| **Agent ≡ GitHub runner** | **No.** The executor tier *should* be stateless and elastic, but **k8s Jobs** are the right substrate here, not GitHub runners; and persona/services agents must stay **persistent** (soul/memory/Slack identity, the vLLM brain). |
 
-A GitHub runner is **stateless, fungible, short-lived**. A MAC agent, as built, is
-a **stateful persona** (soul, long-term memory, mood, Slack presence, self-driven
-behavior). Forcing every agent into the runner mold throws away the identity
-model the whole Hermes layer (ADR 0001) is built on. The right move is a
-**two-tier split**: keep a small persistent persona/services tier, and make the
-**executor tier elastic** (ephemeral workers that claim a ledger task, run in a
-clean checkout, emit evidence, and die) — with the **MAC task ledger remaining
-the single dispatch brain**.
+A GitHub runner is stateless, fungible, short-lived; a MAC agent (as built) is a
+stateful persona, and that model (ADR 0001) is worth keeping. The fix is a
+**two-tier split** — persistent personas/services + an elastic ephemeral-executor
+tier on k8s — **not** turning every agent into a runner.
 
 ## What is actually true today (ground truth)
 
@@ -83,35 +93,46 @@ elasticity — is what makes the universal equivalence wrong.
    project/capability — and scales the ephemeral worker pool to match. An
    executor's body is essentially `mac task claim → do work → mac task
    evidence/close`.
-4. **Projects → runner groups / labels, not "all projects on every runner."**
-   Capabilities become labels; per-project isolation becomes runner groups so a
-   worker only holds the secrets of the project it serves.
+4. **Per-project isolation, not "all projects on every worker."** Capabilities
+   become labels; each project gets its own isolation boundary (k8s namespace +
+   scoped service account / `MAC_API_TOKENS`) so a worker only holds the secrets
+   of the project it serves.
 
-## Substrate: GitHub runners vs. k8s Jobs
+## Substrate decision: k8s Jobs, not GitHub runners
 
-Both implement the same elastic-executor idea; they are **competing substrates**,
-not different architectures:
+Use **k8s Jobs** for the executor tier. Concretely, because:
 
-- **GitHub ARC / ephemeral runners** — buys GitHub's registration, labels, runner
-  groups, and the natural fit for repo/CI-shaped work (clean checkout + the
-  `pushed=true / pr_url` evidence contract we already enforce). Cost: self-hosted
-  runner **security** (agentic code + repo write + secrets is GitHub's canonical
-  footgun) and a tendency to drag GitHub's event scheduler into the picture.
-- **k8s Jobs (already partly built here)** — we own the scheduler and the
-  isolation; integrates with the existing autopilot/job-per-task work and
-  `jordanh-gke`. Cost: we build the labeling/identity ourselves.
+- **It already exists here** (autopilot, `docs/job-per-task-roles-spec.md`,
+  `jordanh-gke`) — extending it is the lowest-friction path to elasticity;
+  adopting GitHub ARC means standing up a new runner controller, registration-
+  token plumbing, and runner groups.
+- **We control isolation** (namespace / RBAC / network policy) — the right
+  posture for running agentic code, versus self-hosted runners sharing a host
+  with repo-write + secrets.
+- **No second scheduler or registry.** The MAC ledger + capabilities already are
+  the "runner registry + label matcher," and richer (deps, review, evidence). A
+  GitHub runner pool would duplicate that and tempt GitHub's event scheduler into
+  becoming a rival dispatcher.
 
-Recommendation: prefer **k8s Jobs** as the executor substrate where we already
-have it, and treat "register as a GitHub runner" as an *additional* on-ramp for
-genuinely repo/CI-shaped work, not the universal model. Keep the executor
-contract substrate-agnostic so either can drive it.
+**GitHub self-hosted runners are explicitly not adopted** as the agent or
+executor substrate. Their real advantages (registration, labels, runner groups)
+just duplicate the ledger; their event/workflow model fits only repo/CI work;
+and the security cost is real. GitHub's one legitimate role is an **inbound
+bridge**: a GitHub Actions event (push/PR/`workflow_dispatch`) calls the hub to
+*create* a MAC task, so external CI can feed the fleet without becoming it.
+
+We keep the executor contract simple (`claim → run → evidence → exit`) so it
+*could* run on a GitHub-hosted runner in a pinch — but that is a fallback, not
+the design. The only thing that would flip this decision is running a k8s
+cluster being off the table; it isn't (`jordanh-gke` is already a cluster), so
+GitHub-hosted runners' "no cluster to operate" advantage does not apply.
 
 ## Risks / non-goals
 
 - **Do not** dissolve personas/memory/long-lived services into ephemeral workers
   — that breaks ADR 0001's identity model and the brain/router.
 - **Secret blast radius:** a worker serving "all projects" can read all those
-  repos' secrets + TokenHub keys. Scope per project (runner groups / scoped
+  repos' secrets + TokenHub keys. Scope per project (k8s namespace + scoped
   `MAC_API_TOKENS`).
 - **Two-scheduler hazard:** if GitHub events *also* dispatch while the ledger
   dispatches, you get double-dispatch. One brain (the ledger).

--- a/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
+++ b/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
@@ -162,6 +162,35 @@ are containers on one VM, so the *physical* distribution is simulated; the
   `claim → run → evidence → exit` executor and autoscaling off `GET /tasks/ready`
   are not provided by k8s.
 
+### Why a macOS host can't be a worker node — even with Docker + "GPU pass-through"
+
+Established on an M4 Pro Mac (same class as bullwinkle):
+
+1. **macOS doesn't run Linux containers; it runs a Linux VM.** Host kernel is
+   `Darwin 25.5.0 arm64`, but a container on it reports `Linux 6.8.0 aarch64`
+   (Ubuntu): Docker Desktop / colima silently boot a **Linux VM** and run every
+   container inside it (Linux images need Linux-kernel namespaces/cgroups that
+   XNU/Darwin doesn't implement). A "k8s node on the Mac" is therefore the
+   *Linux VM*, not the Mac.
+2. **The Apple GPU is on-SoC + Metal-only — there is nothing to pass through.**
+   `system_profiler`: *Apple M4 Pro, Bus: Built-In, Metal 4* — reached only via
+   the **Metal** API in macOS userspace, not a discrete PCIe card. Linux
+   container GPU access (VFIO/IOMMU + the NVIDIA Container Toolkit) forwards a
+   *PCI device + its Linux kernel driver* into the container; on Apple Silicon
+   there is no PCIe GPU, no Linux driver for it, and Virtualization.framework
+   doesn't expose the GPU to the guest. Inside the container `/dev/dri` and
+   `/dev/nvidia*` don't exist, and `docker run --gpus all` fails outright
+   (`could not select device driver … [[gpu]]`).
+3. **The GPU is reachable only by a native macOS process calling Metal** — which
+   is by definition not a pod; a Linux Job can never touch Metal. (This is why
+   bullwinkle's SDXL/MPS image-gen runs as a native `~/gen` process.)
+4. **Making the Mac a node buys nothing and costs a VM layer:** you'd run Linux
+   pods in a VM on the Mac with no access to the one capability that makes it
+   special — and the genuinely macOS-only work that needs the host (Metal
+   compute; **code-signing / notarization / Xcode builds** — we hit this exact
+   wall when the Electron build required the Mac's "Developer ID" / "Fleet
+   Identity" signing identities) cannot run in a Linux container at all.
+
 Crucially, the hosts that *can't* be worker nodes (darwin/image-gen, GPU model
 servers) are exactly the ones this ADR assigns to the **persistent tier**. The
 experiment therefore confirms both the dispatch property *and* the two-tier

--- a/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
+++ b/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
@@ -1,0 +1,150 @@
+# ADR 0005 — Elastic executor tier vs. the static fleet (and "every agent is a GitHub runner")
+
+- Status: **Proposed**
+- Date: 2026-06-11
+- Decision owner: Jordan Hubbard
+- Context: the fleet is configured statically in `~/.mac/fleets.yaml` — named
+  agents pinned to hosts (rocky→do-host1, natasha→sparky, bullwinkle→puck,
+  madmax→madmax), each deployed by `deploy/deploy-mac-fleet.sh` as a long-lived
+  editable install + systemd/launchd services. The question raised: *what if
+  every agent were a GitHub self-hosted runner (and any runner an agent), with
+  agents registered/created dynamically rather than declared statically?*
+
+## TL;DR verdict
+
+The proposal bundles two ideas; **separate them**:
+
+| Idea | Verdict |
+| --- | --- |
+| **Elastic / dynamic registration** instead of static `fleets.yaml` | **Yes** — overdue. The static model is the source of most operational pain we keep hitting. |
+| **Agent ≡ GitHub runner (universally)** | **Half right.** True for the *executor* tier; **wrong** for the *persona/services* tier. |
+
+A GitHub runner is **stateless, fungible, short-lived**. A MAC agent, as built, is
+a **stateful persona** (soul, long-term memory, mood, Slack presence, self-driven
+behavior). Forcing every agent into the runner mold throws away the identity
+model the whole Hermes layer (ADR 0001) is built on. The right move is a
+**two-tier split**: keep a small persistent persona/services tier, and make the
+**executor tier elastic** (ephemeral workers that claim a ledger task, run in a
+clean checkout, emit evidence, and die) — with the **MAC task ledger remaining
+the single dispatch brain**.
+
+## What is actually true today (ground truth)
+
+- **Static fleet.** `~/.mac/fleets.yaml` enumerates agents→hosts with
+  capabilities + `hub_agent`; `deploy/deploy-mac-fleet.sh` SSHes to each host,
+  installs `~/.mac/src/mac` (`pip install -e`) and runs services (control plane
+  `mac.service` on the hub; worker loop + Hermes gateway per agent).
+- **Agents are durable personas.** Per-agent soul/memory (Qdrant + holographic
+  tiers), mood, journal, Slack home channel, ongoing presence, banter,
+  service-role election. This is the opposite of a disposable job.
+- **Dispatch is a pull/lease model with rich semantics.** The hub ledger
+  (`mac.db`) holds tasks; agents claim/lease by `required_capabilities` +
+  dependency satisfaction; states include `needs_review/reviewing`; outcomes are
+  gated by **evidence/verification contracts** (`verification_contract_failed`,
+  "repo evidence requires pushed=true / pr_url"), multi-attempt with
+  `deployment_learning`s, and hardware gating (GPU). GitHub's job scheduler has
+  almost none of this.
+- **Heterogeneous, partly long-lived hardware.** madmax (RTX 6000 Ada) serves
+  vLLM as the fleet's LLM brain; bullwinkle (M4 Pro) does local image-gen; the
+  in-mac router/media-routing fan work to these. These are **services**, not jobs.
+- **The static model's cost, observed directly.** This is where our recurring
+  pain comes from: manual SSH deploys; bearer-token **drift** (a 403 that needed
+  out-of-band recovery); a default-fleet knob we had to add; ~20 stale
+  **beads-bridge** tasks (a static-bridge artifact) making up half the failure
+  rate; and c26 repo tasks failing on **dirty/stale checkouts** of
+  `/home/jkh/.mac/src/c26`.
+- **The repo already leans dynamic.** `docs/k8s-native-rewrite-plan.md`,
+  `docs/job-per-task-roles-spec.md`, the `mac autopilot` k8s wiring, and the
+  `jordanh-gke` fleet are all "task → ephemeral pod." So we are *already* moving
+  off static; the open question is the substrate, not the direction.
+
+## The fulcrum
+
+GitHub runners are designed to be identical, disposable, and stateless; MAC
+agents are durable identities that evolve. "Any runner can be an agent" works
+only where the work is itself stateless and job-shaped. The mismatch — not the
+elasticity — is what makes the universal equivalence wrong.
+
+## Decision
+
+1. **Two tiers, explicitly.**
+   - **Persistent tier (few):** personas + shared services (LLM router/brain,
+     image-gen, Slack-present teammates). Long-lived (k8s Deployments or a small
+     static set). Owns identity and memory.
+   - **Elastic executor tier (many):** stateless workers that **claim a MAC task
+     → run it in a clean, isolated checkout → emit evidence → exit**. These are
+     the dynamically-registered "runners."
+2. **The MAC ledger stays the single source of truth and dispatch brain.** It
+   keeps the semantics GitHub lacks (deps, review, evidence contracts,
+   capability + hardware gating). The runner substrate is a dumb elastic
+   *where-to-run*, never a second scheduler.
+3. **Autoscale the executor tier off the ready-queue.** The autoscaler polls the
+   hub's `GET /tasks/ready` (shipped in `parity-ready-http-01`) — optionally per
+   project/capability — and scales the ephemeral worker pool to match. An
+   executor's body is essentially `mac task claim → do work → mac task
+   evidence/close`.
+4. **Projects → runner groups / labels, not "all projects on every runner."**
+   Capabilities become labels; per-project isolation becomes runner groups so a
+   worker only holds the secrets of the project it serves.
+
+## Substrate: GitHub runners vs. k8s Jobs
+
+Both implement the same elastic-executor idea; they are **competing substrates**,
+not different architectures:
+
+- **GitHub ARC / ephemeral runners** — buys GitHub's registration, labels, runner
+  groups, and the natural fit for repo/CI-shaped work (clean checkout + the
+  `pushed=true / pr_url` evidence contract we already enforce). Cost: self-hosted
+  runner **security** (agentic code + repo write + secrets is GitHub's canonical
+  footgun) and a tendency to drag GitHub's event scheduler into the picture.
+- **k8s Jobs (already partly built here)** — we own the scheduler and the
+  isolation; integrates with the existing autopilot/job-per-task work and
+  `jordanh-gke`. Cost: we build the labeling/identity ourselves.
+
+Recommendation: prefer **k8s Jobs** as the executor substrate where we already
+have it, and treat "register as a GitHub runner" as an *additional* on-ramp for
+genuinely repo/CI-shaped work, not the universal model. Keep the executor
+contract substrate-agnostic so either can drive it.
+
+## Risks / non-goals
+
+- **Do not** dissolve personas/memory/long-lived services into ephemeral workers
+  — that breaks ADR 0001's identity model and the brain/router.
+- **Secret blast radius:** a worker serving "all projects" can read all those
+  repos' secrets + TokenHub keys. Scope per project (runner groups / scoped
+  `MAC_API_TOKENS`).
+- **Two-scheduler hazard:** if GitHub events *also* dispatch while the ledger
+  dispatches, you get double-dispatch. One brain (the ledger).
+- **Cold-start latency:** per-task spin-up is fine for build/edit work, bad for
+  conversational turns — another reason persona ≠ ephemeral.
+- **GPU / model servers** stay persistent services; they are not jobs.
+
+## Consequences
+
+- **Pros:** elasticity (scale to work, not to a host list); clean ephemeral
+  checkouts eliminate the stale-checkout failure class; far less static config
+  and manual deploy/token drift; the ledger's rich semantics are preserved.
+- **Cons:** a real autoscaler + executor-bootstrap to build and secure; two-tier
+  topology to operate; careful secret scoping; reconciliation so the ledger and
+  the pool don't fight.
+
+## First step (pilot, reversible)
+
+1. Pick **one project** (e.g. `c26`) whose tasks are repo/CI-shaped.
+2. Stand up a small **ephemeral executor pool** (k8s Job-per-task is the shortest
+   path given autopilot already exists) labeled for that project's capability.
+3. Executor lifecycle: register → `mac task claim` a ready task for the project →
+   run in a fresh checkout → `mac task evidence` + `close` → exit. No persona, no
+   memory.
+4. Drive pool size from `GET /tasks/ready?project=c26`.
+5. Compare against the static worker: failure rate (esp. checkout-staleness),
+   latency, cost. If it wins, widen to more projects; keep personas/services on
+   the persistent tier.
+
+## Open questions
+
+- GitHub runner groups vs. k8s namespaces for per-project isolation.
+- How a persistent persona "hands off" a decomposed sub-task to an ephemeral
+  executor (ties to `kanban-adopt-01` / parent-child links) and gets results back.
+- Whether the persistent tier itself should move to k8s Deployments (retire
+  `fleets.yaml` for hosts entirely) or stay a small declared set.

--- a/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
+++ b/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
@@ -191,11 +191,45 @@ Established on an M4 Pro Mac (same class as bullwinkle):
    wall when the Electron build required the Mac's "Developer ID" / "Fleet
    Identity" signing identities) cannot run in a Linux container at all.
 
-Crucially, the hosts that *can't* be worker nodes (darwin/image-gen, GPU model
-servers) are exactly the ones this ADR assigns to the **persistent tier**. The
-experiment therefore confirms both the dispatch property *and* the two-tier
-split: Linux hosts → elastic executor nodes; darwin + GPU + long-lived-service
-hosts → persistent agents.
+### The Linux/NVIDIA hosts (rocky, madmax, natasha) *can* be nodes — container GPU is the supported path
+
+Read-only probes of the actual hosts:
+
+| Host | arch / kernel | GPU (driver) | docker / containerd / nvidia-ctk |
+| --- | --- | --- | --- |
+| **rocky** (do-host1) | x86_64 / 6.8 | none (CPU-only) | no / no / no |
+| **madmax** | x86_64 / 7.0 | RTX 6000 Ada 48 GB (595.71.05) | **yes / yes / yes** |
+| **natasha** | **aarch64** / 6.17-nvidia | GB10 Grace-Blackwell (580.159.03) | **yes / yes / yes** |
+
+Unlike the Mac, these are architecturally fine as k8s nodes, and the
+**container-GPU mechanism that's impossible on macOS is already installed** on
+both GPU hosts: driver + NVIDIA Container Toolkit (`nvidia-ctk`) + containerd.
+The toolkit is exactly what injects `/dev/nvidia*` + the driver into a container
+under `--gpus all`, and the k8s **NVIDIA device plugin** then exposes
+`nvidia.com/gpu` as a schedulable resource. (The toolkit's presence is the
+dispositive fact — it cannot even exist on macOS, where `--gpus all` errors.)
+
+- **rocky** — CPU-only Linux; the natural **control-plane ("hub") node** and/or a
+  CPU worker. Only gap: **no container runtime today** (it runs the mac services
+  as a bare-metal editable install), so containerd must be added.
+- **madmax** — **GPU worker node: ready.** Add the k8s NVIDIA device plugin and
+  pods can request `nvidia.com/gpu`. Caveat: one 48 GB GPU currently held by the
+  long-lived **vLLM brain** (a *Deployment*, not a Job) — so dedicate the GPU to
+  that service or share via GPU **time-slicing / MPS** for Jobs.
+- **natasha** — **GPU worker node: feasible, same mechanism**, with two
+  operational caveats: **arm64** (a mixed-arch cluster — images/workloads must be
+  built arm64) and a **bleeding-edge driver/kernel** (`6.17-nvidia` + driver 580;
+  GB10 drivers are tightly kernel-coupled — the per-kernel-module friction we've
+  seen). Architecturally normal; the work is keeping the driver matched to the
+  kernel.
+
+Crucially, the **only** host that genuinely *can't* be a worker node is the
+**darwin** one (bullwinkle). The GPU hosts *can* be nodes — but their long-lived
+model servers (madmax's vLLM brain) are **Deployments**, not Jobs. So the
+two-tier split maps cleanly onto the hardware: **rocky → control-plane / CPU
+executor nodes; madmax + natasha → GPU nodes hosting a persistent model-server
+Deployment and/or elastic GPU Jobs; bullwinkle → off-cluster persistent
+native-macOS service.**
 
 ## Risks / non-goals
 

--- a/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
+++ b/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
@@ -213,9 +213,13 @@ dispositive fact — it cannot even exist on macOS, where `--gpus all` errors.)
   CPU worker. Only gap: **no container runtime today** (it runs the mac services
   as a bare-metal editable install), so containerd must be added.
 - **madmax** — **GPU worker node: ready.** Add the k8s NVIDIA device plugin and
-  pods can request `nvidia.com/gpu`. Caveat: one 48 GB GPU currently held by the
-  long-lived **vLLM brain** (a *Deployment*, not a Job) — so dedicate the GPU to
-  that service or share via GPU **time-slicing / MPS** for Jobs.
+  pods can request `nvidia.com/gpu`. The often-cited caveat — "one 48 GB GPU is
+  held by the long-lived **vLLM brain** (a *Deployment*, not a Job)" — turns out
+  to be **hollow**: that brain serves ≈0 traffic (see the routing-evidence
+  subsection below), so the GPU can simply be **dedicated to the executor tier**
+  rather than carefully shared via time-slicing / MPS. (If a local-LLM fallback
+  is wanted, keep a *right-sized* vLLM and GPU-share; just don't let a 0-traffic
+  service block the node.)
 - **natasha** — **GPU worker node: feasible, same mechanism**, with two
   operational caveats: **arm64** (a mixed-arch cluster — images/workloads must be
   built arm64) and a **bleeding-edge driver/kernel** (`6.17-nvidia` + driver 580;
@@ -230,6 +234,44 @@ two-tier split maps cleanly onto the hardware: **rocky → control-plane / CPU
 executor nodes; madmax + natasha → GPU nodes hosting a persistent model-server
 Deployment and/or elastic GPU Jobs; bullwinkle → off-cluster persistent
 native-macOS service.**
+
+### The "vLLM brain" serves ≈0 traffic — the GPU it holds is effectively idle (2026-06-11)
+
+A second probe checked whether the persistent service this ADR is most careful to
+protect — madmax's vLLM "LLM brain" — is actually load-bearing. It is not.
+
+Querying the live rocky hub's routing telemetry
+(`mac --fleet rocky observability list --name llm.route`), the last ~1000
+`llm.route` events (spanning 2026-06-08 → 2026-06-11):
+
+| backend provider | events |
+| --- | --- |
+| `nvidia` (cloud inference API, resolving `azure/anthropic/claude-sonnet-4-6`) | 994 |
+| empty / failed route | 6 |
+| **madmax / vLLM / its served model** | **0** |
+
+The cause is structural, not transient. madmax's vLLM *is* wired into the hub
+router — appended to `MAC_ROUTER_PROVIDERS` at priority 0 — but **only for the
+model `Qwen/Qwen3.6-27B-FP8`**. Every fleet agent's `gateway_model` (in
+`~/.mac/fleets.yaml`, including madmax's *own* agent) is
+`azure/anthropic/claude-sonnet-4-6`, which routes to the cloud `nvidia` provider.
+No caller ever requests the model madmax serves, so a 48 GB RTX 6000 Ada sits idle
+on the LLM path. (madmax was additionally tailscale-offline at probe time.)
+
+**Why this sharpens the decision.** The Decision and Risks sections treat "GPU /
+model servers stay persistent services; they are not jobs" as a hard constraint,
+and the madmax node-readiness note above flagged the vLLM Deployment as the reason
+to time-slice rather than dedicate the GPU. The evidence collapses that tension:
+the brain has **no traffic to protect**, so madmax's GPU is the *easiest*, not the
+hardest, to hand to the elastic executor tier — dedicate it outright. The
+persistent-services principle still holds in general (it's right for a brain that
+*is* serving); it just doesn't currently apply to *this* GPU. A concrete
+device-plugin + node-label draft for exactly this conversion lives at
+[`deploy/k8s/gpu-worker/`](../../deploy/k8s/gpu-worker/).
+
+(Method/caveat: the telemetry only captures hub-routed requests; a process hitting
+`madmax:8000` directly would not appear. Confirm with madmax's vLLM
+`/metrics request_success_total` before decommissioning the service.)
 
 ## Risks / non-goals
 


### PR DESCRIPTION
Writes up the "every agent is a GitHub runner / dynamic registration" architecture question as ADR 0005.

**Verdict:** separate the two ideas — *elasticity* (yes; the static `fleets.yaml` is behind most of our recurring pain: manual deploys, token drift, stale beads tasks, dirty checkouts) vs *agent≡runner* (only true for a stateless **executor** tier; wrong for the persistent **persona/services** tier that owns soul/memory/Slack identity and the vLLM brain).

**Proposal:** two tiers — durable personas/services + an elastic ephemeral-executor tier (claim ledger task → clean checkout → evidence → die), with the **MAC ledger as the single dispatch brain** and the executor pool **autoscaled off `GET /tasks/ready`** (which we just shipped). GitHub runners vs k8s Jobs treated as competing substrates (the repo already has k8s job-per-task + autopilot). Includes per-project secret/runner-group scoping, risks (secret blast radius, two-scheduler hazard, cold start, GPU services), and a one-project (c26) pilot.

Status **Proposed** — merge to ratify; I can then file the pilot ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)