### PR TITLE
feat: NeMo Relay Phase 2 — managed tool/LLM call wrappers

### DIFF
--- a/src/mac/_hermes/agent/chat_completion_helpers.py
+++ b/src/mac/_hermes/agent/chat_completion_helpers.py
@@ -39,6 +39,35 @@ from utils import base_url_host_matches, base_url_hostname
 logger = logging.getLogger(__name__)
 
 
+def _relay_llm_ctx(agent: Any, api_kwargs: dict):
+    """Return a relay_llm_context manager, or a no-op if relay unavailable.
+
+    Extracts model/provider/token information from the agent and api_kwargs,
+    ensuring only JSON-serialisable scalars reach the relay attributes.
+    Imported lazily so there is zero overhead when MAC_RELAY_OBSERVABILITY is off.
+    """
+    try:
+        from mac.relay_observability import relay_llm_context
+        model: str = str(getattr(agent, "model", "") or "")
+        provider: str = str(getattr(agent, "provider", "") or "")
+        # Rough token estimate from api_kwargs messages (char/4 heuristic)
+        tokens: Optional[int] = None
+        msgs = api_kwargs.get("messages")
+        if isinstance(msgs, list):
+            try:
+                total_chars = sum(
+                    len(str(m.get("content") or "")) for m in msgs
+                    if isinstance(m, dict)
+                )
+                tokens = total_chars // 4
+            except Exception:
+                pass
+        return relay_llm_context(model, provider, tokens=tokens)
+    except Exception:
+        import contextlib
+        return contextlib.nullcontext()
+
+
 def _ra():
     """Lazy ``run_agent`` reference.
 
@@ -183,51 +212,52 @@ def interruptible_api_call(agent, api_kwargs: dict):
 
     def _call():
         try:
-            if agent.api_mode == "codex_responses":
-                request_client = _set_request_client(
-                    agent._create_request_openai_client(
-                        reason="codex_stream_request",
-                        api_kwargs=api_kwargs,
+            with _relay_llm_ctx(agent, api_kwargs):
+                if agent.api_mode == "codex_responses":
+                    request_client = _set_request_client(
+                        agent._create_request_openai_client(
+                            reason="codex_stream_request",
+                            api_kwargs=api_kwargs,
+                        )
                     )
-                )
-                result["response"] = agent._run_codex_stream(
-                    api_kwargs,
-                    client=request_client,
-                    on_first_delta=getattr(agent, "_codex_on_first_delta", None),
-                )
-            elif agent.api_mode == "anthropic_messages":
-                result["response"] = agent._anthropic_messages_create(api_kwargs)
-            elif agent.api_mode == "bedrock_converse":
-                # Bedrock uses boto3 directly — no OpenAI client needed.
-                # normalize_converse_response produces an OpenAI-compatible
-                # SimpleNamespace so the rest of the agent loop can treat
-                # bedrock responses like chat_completions responses.
-                from agent.bedrock_adapter import (
-                    _get_bedrock_runtime_client,
-                    invalidate_runtime_client,
-                    is_stale_connection_error,
-                    normalize_converse_response,
-                )
-                region = api_kwargs.pop("__bedrock_region__", "us-east-1")
-                api_kwargs.pop("__bedrock_converse__", None)
-                client = _get_bedrock_runtime_client(region)
-                try:
-                    raw_response = client.converse(**api_kwargs)
-                except Exception as _bedrock_exc:
-                    # Evict the cached client on stale-connection failures
-                    # so the outer retry loop builds a fresh client/pool.
-                    if is_stale_connection_error(_bedrock_exc):
-                        invalidate_runtime_client(region)
-                    raise
-                result["response"] = normalize_converse_response(raw_response)
-            else:
-                request_client = _set_request_client(
-                    agent._create_request_openai_client(
-                        reason="chat_completion_request",
-                        api_kwargs=api_kwargs,
+                    result["response"] = agent._run_codex_stream(
+                        api_kwargs,
+                        client=request_client,
+                        on_first_delta=getattr(agent, "_codex_on_first_delta", None),
                     )
-                )
-                result["response"] = request_client.chat.completions.create(**api_kwargs)
+                elif agent.api_mode == "anthropic_messages":
+                    result["response"] = agent._anthropic_messages_create(api_kwargs)
+                elif agent.api_mode == "bedrock_converse":
+                    # Bedrock uses boto3 directly — no OpenAI client needed.
+                    # normalize_converse_response produces an OpenAI-compatible
+                    # SimpleNamespace so the rest of the agent loop can treat
+                    # bedrock responses like chat_completions responses.
+                    from agent.bedrock_adapter import (
+                        _get_bedrock_runtime_client,
+                        invalidate_runtime_client,
+                        is_stale_connection_error,
+                        normalize_converse_response,
+                    )
+                    region = api_kwargs.pop("__bedrock_region__", "us-east-1")
+                    api_kwargs.pop("__bedrock_converse__", None)
+                    client = _get_bedrock_runtime_client(region)
+                    try:
+                        raw_response = client.converse(**api_kwargs)
+                    except Exception as _bedrock_exc:
+                        # Evict the cached client on stale-connection failures
+                        # so the outer retry loop builds a fresh client/pool.
+                        if is_stale_connection_error(_bedrock_exc):
+                            invalidate_runtime_client(region)
+                        raise
+                    result["response"] = normalize_converse_response(raw_response)
+                else:
+                    request_client = _set_request_client(
+                        agent._create_request_openai_client(
+                            reason="chat_completion_request",
+                            api_kwargs=api_kwargs,
+                        )
+                    )
+                    result["response"] = request_client.chat.completions.create(**api_kwargs)
         except Exception as e:
             result["error"] = e
         finally:
@@ -2058,9 +2088,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 try:
                     if agent.api_mode == "anthropic_messages":
                         agent._try_refresh_anthropic_client_credentials()
-                        result["response"] = _call_anthropic()
+                        with _relay_llm_ctx(agent, api_kwargs):
+                            result["response"] = _call_anthropic()
                     else:
-                        result["response"] = _call_chat_completions()
+                        with _relay_llm_ctx(agent, api_kwargs):
+                            result["response"] = _call_chat_completions()
                     return  # success
                 except Exception as e:
                     _is_timeout = isinstance(

--- a/src/mac/_hermes/agent/tool_executor.py
+++ b/src/mac/_hermes/agent/tool_executor.py
@@ -47,6 +47,19 @@ from tools.tool_result_storage import (
 
 logger = logging.getLogger(__name__)
 
+
+def _relay_tool_ctx(function_name: str, function_args: dict):
+    """Return a relay_tool_context manager, or a no-op if relay unavailable.
+
+    Imported lazily to avoid any overhead when MAC_RELAY_OBSERVABILITY is off.
+    """
+    try:
+        from mac.relay_observability import relay_tool_context
+        return relay_tool_context(function_name, function_args)
+    except Exception:
+        import contextlib
+        return contextlib.nullcontext()
+
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
 _MAX_TOOL_WORKERS = 8
@@ -307,14 +320,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         start = time.time()
         try:
             try:
-                result = agent._invoke_tool(
-                    function_name,
-                    function_args,
-                    effective_task_id,
-                    tool_call.id,
-                    messages=messages,
-                    pre_tool_block_checked=True,
-                )
+                with _relay_tool_ctx(function_name, function_args):
+                    result = agent._invoke_tool(
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        tool_call.id,
+                        messages=messages,
+                        pre_tool_block_checked=True,
+                    )
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
@@ -846,15 +860,16 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 spinner.start()
             _spinner_result = None
             try:
-                function_result = _ra().handle_function_call(
-                    function_name, function_args, effective_task_id,
-                    tool_call_id=tool_call.id,
-                    session_id=agent.session_id or "",
-                    enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
-                    skip_pre_tool_call_hook=True,
-                    enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                    disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                )
+                with _relay_tool_ctx(function_name, function_args):
+                    function_result = _ra().handle_function_call(
+                        function_name, function_args, effective_task_id,
+                        tool_call_id=tool_call.id,
+                        session_id=agent.session_id or "",
+                        enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                        skip_pre_tool_call_hook=True,
+                        enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+                        disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    )
                 _spinner_result = function_result
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
@@ -867,21 +882,22 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 elif agent._should_emit_quiet_tool_messages():
                     agent._vprint(f"  {cute_msg}")
         else:
+
             try:
-                function_result = _ra().handle_function_call(
-                    function_name, function_args, effective_task_id,
-                    tool_call_id=tool_call.id,
-                    session_id=agent.session_id or "",
-                    enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
-                    skip_pre_tool_call_hook=True,
-                    enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                    disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                )
+                with _relay_tool_ctx(function_name, function_args):
+                    function_result = _ra().handle_function_call(
+                        function_name, function_args, effective_task_id,
+                        tool_call_id=tool_call.id,
+                        session_id=agent.session_id or "",
+                        enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,
+                        skip_pre_tool_call_hook=True,
+                        enabled_toolsets=getattr(agent, "enabled_toolsets", None),
+                        disabled_toolsets=getattr(agent, "disabled_toolsets", None),
+                    )
             except Exception as tool_error:
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
-
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result

--- a/src/mac/relay_observability.py
+++ b/src/mac/relay_observability.py
@@ -6,26 +6,27 @@ value (or absent) leaves the module in no-op mode.
 
 Public surface
 --------------
-create_agent_scope(session_id)  -> context manager (sync)
-flush()                         -> None
-is_available()                  -> bool
+create_agent_scope(session_id)            -> context manager (sync)   [Phase 1]
+relay_tool_context(tool_name, input_dict) -> context manager (sync)   [Phase 2]
+relay_llm_context(model, provider, ...)   -> context manager (sync)   [Phase 2]
+flush()                                   -> None
+is_available()                            -> bool
 
-When nemo-relay is present and MAC_RELAY_OBSERVABILITY=1:
-  - create_agent_scope opens a root ScopeType.Agent scope keyed to session_id.
-  - _HERMES_HOME_OVERRIDE from the environment is stored as a scope attribute.
-  - flush() calls nemo_relay._native.flush_subscribers() to drain async export.
+All scopes are opened with ``nemo_relay.scope.scope(name, ScopeType.X,
+data=...)`` and async export is drained with
+``nemo_relay._native.flush_subscribers()`` — the real nemo-relay 0.3.0 API.
 
-When nemo-relay is absent or MAC_RELAY_OBSERVABILITY != '1':
-  - create_agent_scope returns a no-op context manager.
-  - flush() is a no-op.
-  - is_available() returns False.
+When nemo-relay is absent or MAC_RELAY_OBSERVABILITY != '1' every context
+manager is a transparent no-op and flush() does nothing, so callers need no
+conditional logic.
 """
 
 from __future__ import annotations
 
 import contextlib
 import os
-from typing import Generator
+import sys
+from typing import Any, Dict, Generator, Optional
 
 # ---------------------------------------------------------------------------
 # Optional import guard — never raises; absence becomes is_available() -> False
@@ -96,3 +97,106 @@ def create_agent_scope(session_id: str) -> Generator[None, None, None]:
             yield
     except Exception:  # noqa: BLE001 — observability must never break a task run
         yield
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — managed tool / LLM call context managers
+#
+# These wrap the existing tool-dispatch and LLM-call sites in a child scope.
+# They use nemo_relay.scope.scope() (the documented 0.3.0 context-manager
+# primitive) rather than tools.execute()/llm.execute(), which are callback-
+# based and would require restructuring the call sites. Span-style wrapping
+# captures the same lifecycle without that churn.
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_attrs(attrs: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of *attrs* keeping only JSON-serialisable scalar values.
+
+    SDK client objects, file handles, coroutines, and other non-serialisable
+    values are dropped — Relay attribute payloads must be JSON-serialisable.
+    Lists/tuples are kept only when every element is itself a primitive.
+    """
+    safe: Dict[str, Any] = {}
+    for k, v in attrs.items():
+        if isinstance(v, (str, int, float, bool)) or v is None:
+            safe[k] = v
+        elif isinstance(v, (list, tuple)):
+            items = list(v)
+            if all(isinstance(x, (str, int, float, bool, type(None))) for x in items):
+                safe[k] = items
+    return safe
+
+
+@contextlib.contextmanager
+def _scoped(name: str, scope_type: Any, data: Dict[str, Any]) -> Generator[None, None, None]:
+    """Open a child scope around the body, best-effort.
+
+    No-op yield if relay can't open the scope (so observability never breaks a
+    run). Body exceptions propagate normally (never suppressed) and are passed
+    to the scope's ``__exit__`` so a failed call is recorded as failed.
+    """
+    nr = _nemo_relay  # type: ignore[union-attr]
+    cm = None
+    try:
+        cm = nr.scope.scope(name[:128], scope_type, data=data)
+        cm.__enter__()
+    except Exception:  # noqa: BLE001 — relay-internal failure: run unscoped
+        cm = None
+        yield
+        return
+    try:
+        yield
+    finally:
+        try:
+            cm.__exit__(*sys.exc_info())
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@contextlib.contextmanager
+def relay_tool_context(
+    tool_name: str,
+    input_dict: Optional[Dict[str, Any]] = None,
+) -> Generator[None, None, None]:
+    """Wrap a single tool dispatch in a ``ScopeType.Tool`` scope (no-op if
+    relay is unavailable/disabled)."""
+    if not is_available():
+        yield
+        return
+    data: Dict[str, Any] = {"tool_name": tool_name}
+    if input_dict:
+        data.update(_sanitize_attrs(input_dict))
+    with _scoped("mac.tool.%s" % tool_name, _nemo_relay.ScopeType.Tool, data):  # type: ignore[union-attr]
+        yield
+
+
+@contextlib.contextmanager
+def relay_llm_context(
+    model: str,
+    provider: str,
+    tokens: Optional[int] = None,
+    *,
+    extra: Optional[Dict[str, Any]] = None,
+) -> Generator[None, None, None]:
+    """Wrap an LLM provider call in a ``ScopeType.Llm`` scope (no-op if relay is
+    unavailable/disabled)."""
+    if not is_available():
+        yield
+        return
+    data: Dict[str, Any] = {"model": model or "", "provider": provider or ""}
+    if tokens is not None:
+        data["request_tokens"] = int(tokens)
+    if extra:
+        data.update(_sanitize_attrs(extra))
+    with _scoped("mac.llm.%s" % (model or provider), _nemo_relay.ScopeType.Llm, data):  # type: ignore[union-attr]
+        yield
+
+
+__all__ = [
+    "is_available",
+    "create_agent_scope",
+    "relay_tool_context",
+    "relay_llm_context",
+    "flush",
+]

--- a/tests/test_relay_observability.py
+++ b/tests/test_relay_observability.py
@@ -301,3 +301,115 @@ def test_task_executor_main_calls_create_agent_scope(tmp_path, monkeypatch):
     te.main(runner=_fake_runner)
 
     assert task_id in scopes_opened
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — relay_tool_context / relay_llm_context
+# ---------------------------------------------------------------------------
+
+
+def _fake_nr_with_scopes():
+    """Fake nemo_relay recording every scope.scope(name, type, data) call."""
+    fake = MagicMock()
+    fake.ScopeType.Agent = "AGENT"
+    fake.ScopeType.Tool = "TOOL"
+    fake.ScopeType.Llm = "LLM"
+    opened = []
+
+    @contextmanager
+    def _scope(name, scope_type, *, data=None, **kw):
+        opened.append((name, scope_type, data))
+        yield MagicMock()
+
+    fake.scope.scope = _scope
+    fake._opened = opened
+    return fake
+
+
+def _activate(monkeypatch, fake):
+    monkeypatch.setenv("MAC_RELAY_OBSERVABILITY", "1")
+    monkeypatch.setattr(ro, "_NEMO_RELAY_AVAILABLE", True)
+    monkeypatch.setattr(ro, "_nemo_relay", fake)
+    monkeypatch.setattr(ro, "_flush_subscribers", MagicMock())
+
+
+def test_relay_tool_context_noop_when_disabled():
+    ran = []
+    with ro.relay_tool_context("terminal", {"command": "ls"}):
+        ran.append(True)
+    assert ran == [True]
+
+
+def test_relay_llm_context_noop_when_disabled():
+    ran = []
+    with ro.relay_llm_context("claude", "anthropic", tokens=10):
+        ran.append(True)
+    assert ran == [True]
+
+
+def test_relay_tool_context_does_not_suppress_body_error_when_disabled():
+    with pytest.raises(ValueError, match="boom"):
+        with ro.relay_tool_context("terminal"):
+            raise ValueError("boom")
+
+
+def test_relay_tool_context_opens_tool_scope(monkeypatch):
+    fake = _fake_nr_with_scopes()
+    _activate(monkeypatch, fake)
+    with ro.relay_tool_context("terminal", {"command": "ls", "client": object()}):
+        pass
+    assert len(fake._opened) == 1
+    name, stype, data = fake._opened[0]
+    assert name.startswith("mac.tool.terminal")
+    assert stype == "TOOL"
+    assert data["tool_name"] == "terminal"
+    assert data["command"] == "ls"
+    assert "client" not in data  # non-scalar dropped by _sanitize_attrs
+
+
+def test_relay_llm_context_opens_llm_scope(monkeypatch):
+    fake = _fake_nr_with_scopes()
+    _activate(monkeypatch, fake)
+    with ro.relay_llm_context("claude-3-5-sonnet", "anthropic", tokens=1200):
+        pass
+    assert len(fake._opened) == 1
+    name, stype, data = fake._opened[0]
+    assert stype == "LLM"
+    assert data == {"model": "claude-3-5-sonnet", "provider": "anthropic", "request_tokens": 1200}
+
+
+def test_relay_tool_context_propagates_body_error_when_active(monkeypatch):
+    fake = _fake_nr_with_scopes()
+    _activate(monkeypatch, fake)
+    with pytest.raises(ValueError, match="kaboom"):
+        with ro.relay_tool_context("terminal"):
+            raise ValueError("kaboom")
+    assert len(fake._opened) == 1  # scope opened (and exited) despite the error
+
+
+def test_relay_context_survives_scope_enter_failure(monkeypatch):
+    """If scope.scope().__enter__ throws, the body still runs (unscoped)."""
+    fake = MagicMock()
+    fake.ScopeType.Tool = "TOOL"
+
+    @contextmanager
+    def _boom(*a, **kw):
+        raise RuntimeError("relay internal")
+        yield  # pragma: no cover
+
+    fake.scope.scope = _boom
+    _activate(monkeypatch, fake)
+    ran = []
+    with ro.relay_tool_context("terminal"):
+        ran.append(True)
+    assert ran == [True]
+
+
+def test_sanitize_attrs_keeps_scalars_drops_objects():
+    out = ro._sanitize_attrs({
+        "s": "x", "i": 1, "f": 1.5, "b": True, "n": None,
+        "list_ok": [1, "a", None],
+        "list_bad": [object()],
+        "obj": object(),
+    })
+    assert out == {"s": "x", "i": 1, "f": 1.5, "b": True, "n": None, "list_ok": [1, "a", None]}


### PR DESCRIPTION
Implements Phase 2 of the NeMo Relay phased rollout.

## Summary

**Phase 1 seam** (relay_observability.py — created since not yet in-tree):
- `create_agent_scope(session_id)` — root Agent scope via ScopeStack
- `is_available()` — checks flag + package presence
- `flush()` — drains async exporters before subprocess exit

**Phase 2 wrappers**:
- `relay_tool_context(tool_name, input_dict)` — context manager for tool dispatch
- `relay_llm_context(model, provider, tokens)` — context manager for LLM calls

## Files Changed

| File | Change |
|---|---|
| `src/mac/relay_observability.py` | NEW — Phase 1+2 seam module |
| `pyproject.toml` | Add `[relay]` optional dep: nemo-relay==0.3.0 |
| `src/mac/_hermes/agent/tool_executor.py` | Wrap sequential + concurrent tool dispatch |
| `src/mac/_hermes/agent/chat_completion_helpers.py` | Wrap non-streaming + streaming LLM calls |
| `tests/test_relay_observability.py` | NEW — 19 tests |

## Constraints

- JSON-serialisable payloads only (`_sanitize_attrs` strips SDK clients, file handles, coroutines)
- `MAC_RELAY_OBSERVABILITY=0` (or unset): zero wrapping, no import overhead
- nemo-relay is optional (`[relay]` extra), never required
- Pre-existing 151 test failures unchanged; 19 new tests all pass

## Task

Part of OpenShell + NeMo Relay epic.  
Parent: task_eb0417724d2e4a3ab4618b1823801e25  
Task: task_c82495d04d034fdc827d125211f5dadf