### PR TITLE
feat: OpenShell sandbox seam for the Hermes agent (default-off)

### DIFF
--- a/deploy/openshell/mac-hermes-policy.yaml
+++ b/deploy/openshell/mac-hermes-policy.yaml
@@ -1,0 +1,112 @@
+# OpenShell guardrail policy for the MAC / Hermes task executor.
+#
+# This file IS the guardrail specification. Because the agent runs `--yolo`
+# (Hermes' own approval prompts are bypassed), OpenShell is the sole authority
+# over what the agent may touch: filesystem (Landlock), syscalls (seccomp), and
+# network egress (deny-by-default L7 proxy). Anything not allowed here is
+# denied. Start tight; widen deliberately (each added rule is a guardrail hole).
+#
+# This is a TEMPLATE. Substitute the __PLACEHOLDER__ tokens for your fleet and
+# adjust the filesystem paths to match how the Hermes runtime is made available
+# inside the sandbox (a prebuilt image via `--from`, or `--upload`); see
+# docs/openshell-sandbox.md. Apply with:
+#   MAC_OPENSHELL_POLICY=/path/to/this.yaml MAC_OPENSHELL_SANDBOX=1
+# (the executor passes it as `openshell sandbox create --policy ...`).
+
+version: 1
+
+filesystem_policy:
+  # include_workdir auto-adds the task git worktree (the executor's cwd) to the
+  # writable set — that is where the agent does its work and writes evidence.
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /bin
+    - /sbin
+    - /etc
+    - /proc
+    - /dev/urandom
+    - /var/log
+    # The vendored Hermes runtime + venv. Match these to your provisioning:
+    # if you bake an image, point at the in-image install path; if you upload,
+    # point at the upload target. The host default for a fleet agent is ~/.mac.
+    - /home/__AGENT_USER__/.mac/venv
+    - /home/__AGENT_USER__/.mac/src
+  read_write:
+    - /tmp
+    - /dev/null
+    # The agent's home cache/state (pip, git config, tool caches). Tighten to
+    # specific subpaths if you want a smaller writable surface.
+    - /home/__AGENT_USER__/.cache
+    - /home/__AGENT_USER__/.config
+
+landlock:
+  # best_effort: skip paths the kernel can't enforce and continue (emits a
+  # High-severity finding). Set to hard_requirement to FAIL the run if the
+  # kernel lacks Landlock (5.13+) or a path is unavailable — stricter, no
+  # silent loss of filesystem confinement. Recommended for production.
+  compatibility: best_effort
+
+process:
+  # Never root. The supervisor drops privileges to this identity.
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+network_policies:
+  # --- MAC control-plane hub: claim/close tasks, post evidence + telemetry ---
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: __MAC_HUB_HOST__      # e.g. 100.125.137.89
+        port: __MAC_HUB_PORT__      # e.g. 8789
+        # protocol: rest enables L7 inspection; omit for a raw TCP tunnel.
+        protocol: rest
+        enforcement: enforce
+        access: full
+    binaries:
+      - { path: /home/__AGENT_USER__/.mac/venv/bin/python }
+
+  # --- Model gateway: the agent's LLM calls. Scope to YOUR gateway host. ---
+  model_gateway:
+    name: model-gateway
+    endpoints:
+      - host: __MODEL_GATEWAY_HOST__   # e.g. your azure/anthropic gateway
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: full
+    binaries:
+      - { path: /home/__AGENT_USER__/.mac/venv/bin/python }
+
+  # --- Git over HTTPS for task results (push branches / read repos). ---
+  # If you push over SSH instead, model that as a raw TCP endpoint on port 22
+  # to your git host rather than this REST block.
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: full
+      - host: api.github.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: full
+    binaries:
+      - { path: /usr/bin/git }
+      - { path: /usr/lib/git-core/git-remote-https }
+      - { path: /usr/bin/curl }
+
+  # --- OPTIONAL: package installs during a task. Commented out by default —
+  # uncomment only if your tasks legitimately need to fetch dependencies, and
+  # prefer pinning to your internal mirror over the public index. ---
+  # python_packages:
+  #   name: python-packages
+  #   endpoints:
+  #     - { host: __PYPI_MIRROR_HOST__, port: 443, protocol: rest, enforcement: enforce, access: read-only }
+  #   binaries:
+  #     - { path: /home/__AGENT_USER__/.mac/venv/bin/python }

--- a/docs/openshell-sandbox.md
+++ b/docs/openshell-sandbox.md
@@ -1,0 +1,98 @@
+# Running Hermes under the OpenShell sandbox
+
+This describes the optional OpenShell sandbox seam for the task executor: launch
+the Hermes agent as a confined child of an [OpenShell](https://github.com/NVIDIA/OpenShell)
+sandbox so OpenShell is the **sole guardrail authority**, letting the agent run
+full `--yolo` safely.
+
+## Why
+
+The executor already launches Hermes with `--yolo` (Hermes' own approval prompts
+bypassed — see `_hermes_argv` in `src/mac/task_executor.py`). On its own that is
+**unguarded**. Wrapping the process in OpenShell makes YOLO *safe* by enforcing
+every guardrail from a declarative policy:
+
+| Concern | Enforced by | How |
+| --- | --- | --- |
+| Filesystem | OpenShell Landlock | allow-list of read-only / read-write paths |
+| Syscalls / privilege | OpenShell seccomp | syscall filter; never runs as root |
+| Network egress | OpenShell L7 proxy | **deny-by-default**; per-host/per-binary rules |
+
+One guardrail system (the OpenShell policy YAML), not two.
+
+## What this adds
+
+`_maybe_wrap_openshell()` in `src/mac/task_executor.py` — a pure argv transform
+applied at the launch seam. When `MAC_OPENSHELL_SANDBOX` is truthy it wraps the
+Hermes invocation in `openshell sandbox create … -- <argv>`; otherwise it
+returns the argv unchanged (proven by `tests/test_openshell_sandbox.py`), so the
+executor behaves exactly as before when disabled. The default guardrail policy
+template lives at `deploy/openshell/mac-hermes-policy.yaml`.
+
+> Observability is handled separately by the NeMo Relay seam
+> (`src/mac/relay_observability.py`, Phase 1 merged; Phase 2 in PR #133).
+> OpenShell's OCSF event stream (allowed/denied network, process, findings) can
+> be fed into that pipeline as a follow-up.
+
+## Prerequisites
+
+> **macOS:** OpenShell's kernel primitives (Landlock, seccomp, network
+> namespaces) run inside the **Docker Desktop Linux VM**, not on the host. You
+> need Docker Desktop running. On Linux hosts they run natively (kernel ≥ 5.13
+> for Landlock).
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
+# or: uv tool install -U openshell
+openshell status        # gateway must be reachable
+```
+
+## Enable
+
+```bash
+cp deploy/openshell/mac-hermes-policy.yaml /etc/mac/openshell-policy.yaml
+$EDITOR /etc/mac/openshell-policy.yaml      # fill in __PLACEHOLDER__ tokens
+
+export MAC_OPENSHELL_SANDBOX=1
+export MAC_OPENSHELL_POLICY=/etc/mac/openshell-policy.yaml
+# make the runtime + workspace available inside the sandbox, e.g.:
+export MAC_OPENSHELL_CREATE_ARGS="--from my-mac-hermes-image"
+```
+
+### Environment knobs
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `MAC_OPENSHELL_SANDBOX` | _(off)_ | truthy → wrap the agent in OpenShell |
+| `MAC_OPENSHELL_BIN` | `openshell` | path to the `openshell` binary |
+| `MAC_OPENSHELL_POLICY` | _(none)_ | path to the guardrail policy YAML |
+| `MAC_OPENSHELL_SANDBOX_NAME` | _(ephemeral)_ | fixed sandbox name (debug only) |
+| `MAC_OPENSHELL_KEEP` | _(off)_ | truthy → `--keep` (don't tear down; debug) |
+| `MAC_OPENSHELL_CREATE_ARGS` | _(none)_ | extra `sandbox create` args (shell-split), e.g. `--from img`, `--upload /src:/src` |
+| `MAC_OPENSHELL_ENV_PASSTHROUGH` | hub+gateway vars | comma list of env names forwarded via `--env` |
+
+## Verify (requires Docker + OpenShell installed)
+
+1. `openshell status` healthy.
+2. Dry-run the wrap without spawning:
+   ```python
+   import os; os.environ["MAC_OPENSHELL_SANDBOX"]="1"
+   os.environ["MAC_OPENSHELL_POLICY"]="/etc/mac/openshell-policy.yaml"
+   from mac import task_executor as te
+   print(te._maybe_wrap_openshell(te._hermes_argv("hello")))
+   ```
+   Confirm it begins with `openshell sandbox create … --policy … --` and ends
+   with the Hermes argv.
+3. Run one real task with `MAC_OPENSHELL_SANDBOX=1`: the agent completes,
+   evidence is written, the sandbox tears down (one-shot), and an off-policy
+   network attempt is **denied** (`openshell logs <sandbox> --since 5m` shows
+   `action=deny`).
+
+## Follow-up
+
+- Build a sandbox image (or `--upload` payload) containing the Hermes runtime
+  (`~/.mac/venv` + `~/.mac/src`) so `--from` works on fleet hosts.
+- Tune the policy against the real model-gateway/hub hosts; consider
+  `landlock.compatibility: hard_requirement` for production.
+- Feed OpenShell's OCSF event stream into the NeMo Relay / observability
+  pipeline.

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -35,6 +35,14 @@ All hub I/O is best-effort and gated on hub env (URL + token): absent those,
 the executor still runs and writes evidence — it just doesn't emit telemetry,
 recall, or record. The HTTP seam (:func:`_hub_post` / :func:`_hub_get`) and the
 agent runner are injectable so the logic is testable without a live hub.
+
+Optional OpenShell sandboxing (sandbox-01): the agent already runs ``--yolo``
+(Hermes' own approval prompts bypassed). When ``MAC_OPENSHELL_SANDBOX`` is set,
+:func:`_maybe_wrap_openshell` launches that invocation as a confined child of an
+OpenShell sandbox, which then enforces *all* guardrails (filesystem, syscall,
+and deny-by-default network egress) from a declarative policy. Default OFF —
+the wrap is a pure argv transform, so behavior is unchanged unless enabled. See
+``docs/openshell-sandbox.md``.
 """
 
 from __future__ import annotations
@@ -42,6 +50,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import subprocess
 import sys
 import time
@@ -1060,6 +1069,102 @@ def _hermes_argv(prompt: str) -> List[str]:
     return [str(hermes_py), "-m", "hermes_cli.main", "chat", "--query", prompt, "--quiet", "--accept-hooks", "--yolo"]
 
 
+# ---------------------------------------------------------------------------
+# OpenShell sandbox wrapping (sandbox-01)
+#
+# The agent already runs ``--yolo`` (Hermes' own permission/approval prompts are
+# bypassed). On its own that is unguarded. When OpenShell sandboxing is enabled
+# the (still ``--yolo``) Hermes invocation is launched as a *confined child* of
+# an OpenShell sandbox, which then becomes the SOLE guardrail authority:
+#   * Landlock  — filesystem confinement to declared paths
+#   * seccomp   — syscall filtering + privilege drop (never runs as root)
+#   * egress    — deny-by-default network proxy driven by a declarative policy
+# The policy YAML (MAC_OPENSHELL_POLICY) *is* the guardrail specification.
+#
+# Default OFF: with MAC_OPENSHELL_SANDBOX unset/false ``_maybe_wrap_openshell``
+# returns the argv unchanged, so the executor behaves exactly as before. The
+# wrap is a pure argv transform — it does not itself require OpenShell to be
+# installed; that is the deployer's responsibility (see
+# docs/openshell-sandbox.md).
+#
+# Knobs (read at wrap time — nothing is frozen at import):
+#   MAC_OPENSHELL_SANDBOX          truthy -> enable wrapping
+#   MAC_OPENSHELL_BIN             openshell binary (default "openshell")
+#   MAC_OPENSHELL_POLICY          path to the policy YAML (the guardrail spec)
+#   MAC_OPENSHELL_SANDBOX_NAME    fixed sandbox name (debug; default: ephemeral)
+#   MAC_OPENSHELL_KEEP            truthy -> --keep (debug; default one-shot teardown)
+#   MAC_OPENSHELL_CREATE_ARGS     extra `sandbox create` args (shell-split), e.g.
+#                                 "--from my-image" or "--upload /src:/src" used to
+#                                 make the Hermes runtime + workspace available
+#                                 inside the sandbox
+#   MAC_OPENSHELL_ENV_PASSTHROUGH comma list of env names forwarded via --env
+# ---------------------------------------------------------------------------
+
+# Forward the env the agent needs to reach the hub + model gateway from inside
+# the sandbox. (Network reachability is still gated by the OpenShell policy;
+# this only makes the values visible to the process.)
+_DEFAULT_OPENSHELL_ENV_PASSTHROUGH = (
+    "MAC_HUB_URL,MAC_URL,MAC_WORKER_TOKEN,MAC_TOKEN,MAC_API_TOKEN,"
+    "MAC_WORKER_AGENT_ID,MAC_WORKER_AGENT_NAME,MAC_AGENT_ID,"
+    "HERMES_GATEWAY_BASE_URL,HERMES_GATEWAY_MODEL,HERMES_SESSION_KEY"
+)
+
+
+def _truthy(value: Optional[str]) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _openshell_enabled() -> bool:
+    return _truthy(os.environ.get("MAC_OPENSHELL_SANDBOX"))
+
+
+def _openshell_env_flags() -> List[str]:
+    """``--env NAME=VALUE`` flags for each *set* passthrough variable."""
+    names = os.environ.get("MAC_OPENSHELL_ENV_PASSTHROUGH") or _DEFAULT_OPENSHELL_ENV_PASSTHROUGH
+    flags: List[str] = []
+    seen = set()
+    for raw in names.split(","):
+        name = raw.strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        val = os.environ.get(name)
+        if val is None:
+            continue
+        flags += ["--env", "%s=%s" % (name, val)]
+    return flags
+
+
+def _maybe_wrap_openshell(argv: List[str]) -> List[str]:
+    """Wrap *argv* to run inside an OpenShell sandbox, if enabled.
+
+    Pure and best-effort: returns *argv* unchanged when sandboxing is disabled.
+    The sandbox is one-shot (torn down when the agent process exits) unless
+    MAC_OPENSHELL_KEEP is set. ``--name`` is omitted by default so OpenShell
+    assigns a unique name per run; set MAC_OPENSHELL_SANDBOX_NAME only to debug
+    a single run. The original *argv* is always preserved verbatim after the
+    ``--`` separator.
+    """
+    if not _openshell_enabled():
+        return list(argv)
+    bin_ = (os.environ.get("MAC_OPENSHELL_BIN") or "openshell").strip() or "openshell"
+    wrapped: List[str] = [bin_, "sandbox", "create", "--no-auto-providers"]
+    policy = (os.environ.get("MAC_OPENSHELL_POLICY") or "").strip()
+    if policy:
+        wrapped += ["--policy", policy]
+    name = (os.environ.get("MAC_OPENSHELL_SANDBOX_NAME") or "").strip()
+    if name:
+        wrapped += ["--name", name]
+    if _truthy(os.environ.get("MAC_OPENSHELL_KEEP")):
+        wrapped += ["--keep"]
+    wrapped += _openshell_env_flags()
+    extra = (os.environ.get("MAC_OPENSHELL_CREATE_ARGS") or "").strip()
+    if extra:
+        wrapped += shlex.split(extra)
+    wrapped += ["--", *argv]
+    return wrapped
+
+
 def _agent_timeout() -> Optional[float]:
     """Bound a single agent run so a wedged TokenHub turn can't hang the loop
     forever. Default 900s; set MAC_EXECUTOR_AGENT_TIMEOUT=0 to disable."""
@@ -1144,11 +1249,12 @@ def _run_executor(
         task_id=task_id,
         kind="review" if is_review else "task",
         recalled_lessons=len(lessons),
+        sandboxed=_openshell_enabled(),
     )
 
     audit_task_id = review_context.get("task_id") if is_review else task_id
     result = runner(
-        _hermes_argv(prompt),
+        _maybe_wrap_openshell(_hermes_argv(prompt)),
         task_workspace,
         str(audit_task_id) if audit_task_id else None,
         {"execution_kind": "review" if is_review else "task", "timeout": _agent_timeout()},

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -1,0 +1,158 @@
+"""Tests for OpenShell sandbox wrapping in the task executor (sandbox-01).
+
+The wrap is a pure argv transform gated by MAC_OPENSHELL_SANDBOX. These tests
+pin the default-OFF guarantee (zero behavior change) and the exact `openshell
+sandbox create ... -- <argv>` construction so the seam can't drift silently.
+They never spawn OpenShell.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac import task_executor as te
+
+_ARGV = ["/home/x/.mac/venv/bin/python", "-m", "hermes_cli.main", "chat", "--query", "do it", "--yolo"]
+
+_OPENSHELL_ENVS = [
+    "MAC_OPENSHELL_SANDBOX",
+    "MAC_OPENSHELL_BIN",
+    "MAC_OPENSHELL_POLICY",
+    "MAC_OPENSHELL_SANDBOX_NAME",
+    "MAC_OPENSHELL_KEEP",
+    "MAC_OPENSHELL_CREATE_ARGS",
+    "MAC_OPENSHELL_ENV_PASSTHROUGH",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_openshell_env(monkeypatch):
+    """Start every test from a known-empty OpenShell config."""
+    for name in _OPENSHELL_ENVS:
+        monkeypatch.delenv(name, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# truthy / enabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "on", " On "])
+def test_truthy_true(monkeypatch, val):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", val)
+    assert te._openshell_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["", "0", "false", "no", "off", "nope"])
+def test_truthy_false(monkeypatch, val):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", val)
+    assert te._openshell_enabled() is False
+
+
+def test_enabled_default_off():
+    assert te._openshell_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# default OFF -> unchanged argv (the critical safety property)
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_returns_equal_argv():
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert out == _ARGV
+
+
+def test_disabled_returns_a_copy():
+    """Returns a distinct list so callers can't mutate module state."""
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert out is not _ARGV
+
+
+# ---------------------------------------------------------------------------
+# enabled -> wrapped construction
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_minimal_no_policy(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert out[:4] == ["openshell", "sandbox", "create", "--no-auto-providers"]
+    assert "--policy" not in out
+    # original argv preserved verbatim after the separator
+    sep = out.index("--")
+    assert out[sep + 1 :] == _ARGV
+
+
+def test_separator_appears_once_and_before_argv(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from my-img")
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert out.count("--") == 1
+    assert out.index("--") < out.index(_ARGV[0])
+
+
+def test_policy_flag(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_POLICY", "/etc/mac/policy.yaml")
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert "--policy" in out
+    assert out[out.index("--policy") + 1] == "/etc/mac/policy.yaml"
+
+
+def test_bin_override(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_BIN", "/opt/openshell/bin/openshell")
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert out[0] == "/opt/openshell/bin/openshell"
+
+
+def test_name_and_keep(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "dbg-run")
+    monkeypatch.setenv("MAC_OPENSHELL_KEEP", "1")
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert "--name" in out and out[out.index("--name") + 1] == "dbg-run"
+    assert "--keep" in out
+
+
+def test_no_name_or_keep_by_default(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert "--name" not in out
+    assert "--keep" not in out
+
+
+def test_create_args_shell_split(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from img --upload /a:/b")
+    out = te._maybe_wrap_openshell(_ARGV)
+    # tokens are split and land before the separator
+    for tok in ("--from", "img", "--upload", "/a:/b"):
+        assert tok in out
+        assert out.index(tok) < out.index("--")
+
+
+# ---------------------------------------------------------------------------
+# env passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_env_passthrough_only_set_vars(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_ENV_PASSTHROUGH", "FOO,BAR,FOO")
+    monkeypatch.setenv("FOO", "fooval")
+    monkeypatch.delenv("BAR", raising=False)
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert "--env" in out
+    # FOO forwarded exactly once (dedup), BAR (unset) skipped
+    assert out.count("FOO=fooval") == 1
+    assert not any(tok.startswith("BAR=") for tok in out)
+
+
+def test_env_passthrough_default_list_used(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_HUB_URL", "http://hub:8789")
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert "MAC_HUB_URL=http://hub:8789" in out


### PR DESCRIPTION
## What

Optional **OpenShell sandbox** seam for the Hermes task executor: launch the
already-`--yolo` agent as a confined child of an [OpenShell](https://github.com/NVIDIA/OpenShell)
sandbox so OpenShell becomes the **sole guardrail authority** — Landlock
filesystem confinement, seccomp syscall filtering, and deny-by-default network
egress, all from a declarative policy.

## Why

`task_executor._hermes_argv` already passes `--yolo`, bypassing Hermes' own
approval prompts — unguarded on its own. Wrapping the process in OpenShell makes
YOLO safe: the policy YAML becomes the single guardrail spec, instead of two
competing permission systems.

## Changes

- `src/mac/task_executor.py` — `_maybe_wrap_openshell()` wraps the invocation in
  `openshell sandbox create … -- <argv>` when `MAC_OPENSHELL_SANDBOX` is set.
  **Pure argv transform, default OFF → byte-identical behavior when disabled.**
  Adds a `sandboxed` field to the `started` telemetry.
- `deploy/openshell/mac-hermes-policy.yaml` — default guardrail policy template
  (filesystem allow-list, `run_as_user: sandbox`, deny-by-default egress for the
  hub, model gateway, and GitHub).
- `docs/openshell-sandbox.md` — architecture, enable/verify, macOS-needs-Docker note.
- `tests/test_openshell_sandbox.py` — 24 tests (default-off guarantee + flag wiring).

## Testing

`24 passed` for `tests/test_openshell_sandbox.py`. OpenShell itself is not
exercised here (needs Docker + the `openshell` CLI); the argv wrap is fully
unit-tested and live verification steps are in `docs/openshell-sandbox.md`.

## Scope / relation to NeMo Relay

This is the **sandbox** half only. Observability is the separate NeMo Relay seam
(`relay_observability.py` — Phase 1 merged; Phase 2 in #133). OpenShell's OCSF
event stream can feed that pipeline as a follow-up.

## Not done (follow-up)

- Sandbox image / `--upload` payload carrying the Hermes runtime (`~/.mac/venv` +
  `~/.mac/src`) so `--from` works on fleet hosts.
- Policy tuning for the real gateway/hub hosts; `landlock: hard_requirement` for prod.
- Live e2e verification on a Docker-enabled host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
