### PR TITLE
feat(openshell): enforce our policy as default; Landlock hard_requirement

### DIFF
--- a/deploy/openshell/mac-hermes-policy.yaml
+++ b/deploy/openshell/mac-hermes-policy.yaml
@@ -43,11 +43,11 @@ filesystem_policy:
     - /home/__AGENT_USER__/.config
 
 landlock:
-  # best_effort: skip paths the kernel can't enforce and continue (emits a
-  # High-severity finding). Set to hard_requirement to FAIL the run if the
-  # kernel lacks Landlock (5.13+) or a path is unavailable — stricter, no
-  # silent loss of filesystem confinement. Recommended for production.
-  compatibility: best_effort
+  # hard_requirement: FAIL the run if the kernel lacks Landlock (5.13+) or a
+  # declared path is unenforceable, rather than silently losing filesystem
+  # confinement. Drop to best_effort only for dev on kernels without Landlock
+  # (it skips unenforceable paths and emits a High-severity finding instead).
+  compatibility: hard_requirement
 
 process:
   # Never root. The supervisor drops privileges to this identity.

--- a/docs/openshell-sandbox.md
+++ b/docs/openshell-sandbox.md
@@ -24,10 +24,28 @@ One guardrail system (the OpenShell policy YAML), not two.
 
 `_maybe_wrap_openshell()` in `src/mac/task_executor.py` — a pure argv transform
 applied at the launch seam. When `MAC_OPENSHELL_SANDBOX` is truthy it wraps the
-Hermes invocation in `openshell sandbox create … -- <argv>`; otherwise it
-returns the argv unchanged (proven by `tests/test_openshell_sandbox.py`), so the
-executor behaves exactly as before when disabled. The default guardrail policy
-template lives at `deploy/openshell/mac-hermes-policy.yaml`.
+Hermes invocation in `openshell sandbox create … --policy <P> -- <argv>`;
+otherwise it returns the argv unchanged (proven by
+`tests/test_openshell_sandbox.py`), so the executor behaves exactly as before
+when disabled.
+
+**A policy is always passed — enabling can never silently fall back to
+OpenShell's image-default profile.** `_resolve_openshell_policy()` resolves `<P>`
+in this order, and raises if none is found (fail closed):
+
+1. `MAC_OPENSHELL_POLICY` (explicit) — must exist, else error.
+2. `~/.mac/openshell-policy.yaml` — the operator-filled fleet policy.
+3. the bundled fail-closed default `src/mac/openshell/default-policy.yaml`.
+
+The **bundled default is a lockdown**: filesystem-confined, never root,
+`landlock: hard_requirement`, and **all network egress denied** (empty
+`network_policies`). Under it the agent can't reach the hub/gateway, so an
+unconfigured deployment fails closed rather than running under an unknown
+profile. For real use, copy the **operator template**
+`deploy/openshell/mac-hermes-policy.yaml` (which allows the hub, model gateway,
+and GitHub, and also defaults to `landlock: hard_requirement`), fill in the
+`__PLACEHOLDER__` hosts, and install it at `~/.mac/openshell-policy.yaml` or
+point `MAC_OPENSHELL_POLICY` at it.
 
 > Observability is handled separately by the NeMo Relay seam
 > (`src/mac/relay_observability.py`, Phase 1 merged; Phase 2 in PR #133).
@@ -65,7 +83,7 @@ export MAC_OPENSHELL_CREATE_ARGS="--from my-mac-hermes-image"
 | --- | --- | --- |
 | `MAC_OPENSHELL_SANDBOX` | _(off)_ | truthy → wrap the agent in OpenShell |
 | `MAC_OPENSHELL_BIN` | `openshell` | path to the `openshell` binary |
-| `MAC_OPENSHELL_POLICY` | _(none)_ | path to the guardrail policy YAML |
+| `MAC_OPENSHELL_POLICY` | _(resolved)_ | explicit policy path; if unset, resolves `~/.mac/openshell-policy.yaml` → bundled fail-closed default (a policy is always passed) |
 | `MAC_OPENSHELL_SANDBOX_NAME` | _(ephemeral)_ | fixed sandbox name (debug only) |
 | `MAC_OPENSHELL_KEEP` | _(off)_ | truthy → `--keep` (don't tear down; debug) |
 | `MAC_OPENSHELL_CREATE_ARGS` | _(none)_ | extra `sandbox create` args (shell-split), e.g. `--from img`, `--upload /src:/src` |
@@ -92,7 +110,8 @@ export MAC_OPENSHELL_CREATE_ARGS="--from my-mac-hermes-image"
 
 - Build a sandbox image (or `--upload` payload) containing the Hermes runtime
   (`~/.mac/venv` + `~/.mac/src`) so `--from` works on fleet hosts.
-- Tune the policy against the real model-gateway/hub hosts; consider
-  `landlock.compatibility: hard_requirement` for production.
+- Tune the operator policy against the real model-gateway/hub hosts (both the
+  bundled default and the operator template already use
+  `landlock: hard_requirement`).
 - Feed OpenShell's OCSF event stream into the NeMo Relay / observability
   pipeline.

--- a/src/mac/openshell/default-policy.yaml
+++ b/src/mac/openshell/default-policy.yaml
@@ -1,0 +1,52 @@
+# OpenShell FAIL-CLOSED default policy for MAC / Hermes (bundled fallback).
+#
+# The task executor passes THIS policy to `openshell sandbox create` whenever
+# MAC_OPENSHELL_SANDBOX is enabled but no policy is configured (no
+# MAC_OPENSHELL_POLICY and no ~/.mac/openshell-policy.yaml). Its sole purpose is
+# to guarantee that enabling sandboxing can NEVER silently fall back to
+# OpenShell's own image-default profile — a known, reviewed policy is always
+# applied.
+#
+# It is deliberately a LOCKDOWN and is NOT meant to be the production profile:
+#   * filesystem confined to the OS + workdir + /tmp
+#   * never root (run_as_user: sandbox)
+#   * Landlock REQUIRED (hard_requirement) — fail if the kernel can't enforce it
+#   * ALL network egress DENIED (empty network_policies => deny-by-default)
+#
+# Under this default the agent cannot reach the MAC hub, the model gateway, or
+# the Hermes runtime under ~/.mac, so an unconfigured deployment FAILS CLOSED
+# (tasks error) rather than running under an unknown or over-permissive profile.
+#
+# To run real networked agents, provide a proper policy: copy
+# deploy/openshell/mac-hermes-policy.yaml, fill in your hub/gateway hosts and the
+# agent's home paths, then either install it at ~/.mac/openshell-policy.yaml or
+# point MAC_OPENSHELL_POLICY at it.
+
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /bin
+    - /sbin
+    - /etc
+    - /proc
+    - /dev/urandom
+  read_write:
+    - /tmp
+    - /dev/null
+
+landlock:
+  # Fail closed: abort if the kernel lacks Landlock (5.13+) or a declared path
+  # is unenforceable, rather than running without filesystem confinement.
+  compatibility: hard_requirement
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# Empty => deny-by-default with nothing allowed == ALL network egress denied.
+network_policies: {}

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -1090,7 +1090,12 @@ def _hermes_argv(prompt: str) -> List[str]:
 # Knobs (read at wrap time — nothing is frozen at import):
 #   MAC_OPENSHELL_SANDBOX          truthy -> enable wrapping
 #   MAC_OPENSHELL_BIN             openshell binary (default "openshell")
-#   MAC_OPENSHELL_POLICY          path to the policy YAML (the guardrail spec)
+#   MAC_OPENSHELL_POLICY          explicit policy YAML path (the guardrail spec).
+#                                 When unset, the wrap resolves a policy in this
+#                                 order and ALWAYS passes one (never the OpenShell
+#                                 image default): explicit -> ~/.mac/openshell-
+#                                 policy.yaml -> bundled fail-closed default
+#                                 (src/mac/openshell/default-policy.yaml).
 #   MAC_OPENSHELL_SANDBOX_NAME    fixed sandbox name (debug; default: ephemeral)
 #   MAC_OPENSHELL_KEEP            truthy -> --keep (debug; default one-shot teardown)
 #   MAC_OPENSHELL_CREATE_ARGS     extra `sandbox create` args (shell-split), e.g.
@@ -1135,10 +1140,50 @@ def _openshell_env_flags() -> List[str]:
     return flags
 
 
+def _bundled_default_policy() -> Path:
+    """Path to the fail-closed OpenShell policy bundled in this package."""
+    return Path(__file__).resolve().parent / "openshell" / "default-policy.yaml"
+
+
+def _resolve_openshell_policy() -> str:
+    """Resolve the policy passed to ``openshell sandbox create``.
+
+    Resolution order (first hit wins):
+      1. ``MAC_OPENSHELL_POLICY`` (explicit) — must exist, else raise.
+      2. ``~/.mac/openshell-policy.yaml`` — the operator-filled fleet policy.
+      3. the package's bundled fail-closed default (``openshell/default-policy.yaml``).
+
+    A policy is *always* returned (or we raise) — the wrap never omits
+    ``--policy``, so enabling sandboxing can never silently fall back to
+    OpenShell's own image-default profile. The bundled default denies all
+    network egress, so an unconfigured deployment fails closed (tasks can't
+    reach the hub/gateway) rather than running under an unknown profile.
+    """
+    explicit = (os.environ.get("MAC_OPENSHELL_POLICY") or "").strip()
+    if explicit:
+        if not Path(explicit).is_file():
+            raise FileNotFoundError("MAC_OPENSHELL_POLICY=%r but no such file" % explicit)
+        return explicit
+    deployed = Path.home() / ".mac" / "openshell-policy.yaml"
+    if deployed.is_file():
+        return str(deployed)
+    bundled = _bundled_default_policy()
+    if bundled.is_file():
+        return str(bundled)
+    raise FileNotFoundError(
+        "OpenShell sandboxing is enabled but no policy could be resolved "
+        "(set MAC_OPENSHELL_POLICY, install %s, or ship %s). Refusing to run "
+        "without an explicit policy." % (deployed, bundled)
+    )
+
+
 def _maybe_wrap_openshell(argv: List[str]) -> List[str]:
     """Wrap *argv* to run inside an OpenShell sandbox, if enabled.
 
-    Pure and best-effort: returns *argv* unchanged when sandboxing is disabled.
+    Returns *argv* unchanged when sandboxing is disabled. When enabled, a policy
+    is ALWAYS passed via :func:`_resolve_openshell_policy` (explicit ->
+    deployed -> bundled fail-closed default), so OpenShell can never silently
+    apply its image-default profile; if no policy can be resolved this raises.
     The sandbox is one-shot (torn down when the agent process exits) unless
     MAC_OPENSHELL_KEEP is set. ``--name`` is omitted by default so OpenShell
     assigns a unique name per run; set MAC_OPENSHELL_SANDBOX_NAME only to debug
@@ -1149,9 +1194,10 @@ def _maybe_wrap_openshell(argv: List[str]) -> List[str]:
         return list(argv)
     bin_ = (os.environ.get("MAC_OPENSHELL_BIN") or "openshell").strip() or "openshell"
     wrapped: List[str] = [bin_, "sandbox", "create", "--no-auto-providers"]
-    policy = (os.environ.get("MAC_OPENSHELL_POLICY") or "").strip()
-    if policy:
-        wrapped += ["--policy", policy]
+    # Always pass one of OUR policies — never omit --policy, which would let
+    # OpenShell silently apply its own image-default profile. Resolves
+    # explicit -> deployed -> bundled fail-closed default, or raises.
+    wrapped += ["--policy", _resolve_openshell_policy()]
     name = (os.environ.get("MAC_OPENSHELL_SANDBOX_NAME") or "").strip()
     if name:
         wrapped += ["--name", name]

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -1,12 +1,18 @@
 """Tests for OpenShell sandbox wrapping in the task executor (sandbox-01).
 
-The wrap is a pure argv transform gated by MAC_OPENSHELL_SANDBOX. These tests
-pin the default-OFF guarantee (zero behavior change) and the exact `openshell
-sandbox create ... -- <argv>` construction so the seam can't drift silently.
+The wrap is gated by MAC_OPENSHELL_SANDBOX. These tests pin the default-OFF
+guarantee (zero behavior change), the policy-resolution order, and the exact
+`openshell sandbox create ... -- <argv>` construction so the seam can't drift.
 They never spawn OpenShell.
+
+A policy is ALWAYS passed when enabled (explicit -> deployed -> bundled
+fail-closed default), so enabling can never silently fall back to OpenShell's
+own image-default profile.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
 
 import pytest
 
@@ -26,11 +32,19 @@ _OPENSHELL_ENVS = [
 
 
 @pytest.fixture(autouse=True)
-def _clean_openshell_env(monkeypatch):
-    """Start every test from a known-empty OpenShell config."""
+def _clean(monkeypatch, tmp_path):
+    """Empty OpenShell config + isolated HOME so ~/.mac/openshell-policy.yaml
+    (an operator-deployed policy) can't leak in from the dev machine and make
+    resolution non-deterministic."""
     for name in _OPENSHELL_ENVS:
         monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
     yield
+
+
+def _policy_of(out):
+    """Return the value passed after --policy, or None."""
+    return out[out.index("--policy") + 1] if "--policy" in out else None
 
 
 # ---------------------------------------------------------------------------
@@ -60,29 +74,64 @@ def test_enabled_default_off():
 
 
 def test_disabled_returns_equal_argv():
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert out == _ARGV
+    assert te._maybe_wrap_openshell(_ARGV) == _ARGV
 
 
 def test_disabled_returns_a_copy():
-    """Returns a distinct list so callers can't mutate module state."""
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert out is not _ARGV
+    assert te._maybe_wrap_openshell(_ARGV) is not _ARGV
 
 
 # ---------------------------------------------------------------------------
-# enabled -> wrapped construction
+# enabled -> a policy is ALWAYS passed (no silent image-default fallback)
 # ---------------------------------------------------------------------------
 
 
-def test_enabled_minimal_no_policy(monkeypatch):
+def test_enabled_falls_back_to_bundled_policy(monkeypatch):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     out = te._maybe_wrap_openshell(_ARGV)
     assert out[:4] == ["openshell", "sandbox", "create", "--no-auto-providers"]
-    assert "--policy" not in out
+    # --policy is always present, resolving to the bundled fail-closed default
+    assert _policy_of(out) == str(te._bundled_default_policy())
     # original argv preserved verbatim after the separator
     sep = out.index("--")
     assert out[sep + 1 :] == _ARGV
+
+
+def test_bundled_default_policy_exists():
+    """The fail-closed default must ship in the package (it's the fallback)."""
+    assert te._bundled_default_policy().is_file()
+
+
+def test_explicit_policy_used(monkeypatch, tmp_path):
+    p = tmp_path / "my-policy.yaml"
+    p.write_text("version: 1\n")
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_POLICY", str(p))
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert _policy_of(out) == str(p)
+
+
+def test_missing_explicit_policy_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_POLICY", str(tmp_path / "nope.yaml"))
+    with pytest.raises(FileNotFoundError):
+        te._maybe_wrap_openshell(_ARGV)
+
+
+def test_deployed_policy_preferred_over_bundled(monkeypatch, tmp_path):
+    """~/.mac/openshell-policy.yaml wins when no explicit policy is set."""
+    mac_dir = tmp_path / ".mac"
+    mac_dir.mkdir()
+    deployed = mac_dir / "openshell-policy.yaml"
+    deployed.write_text("version: 1\n")
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")  # HOME already == tmp_path
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert _policy_of(out) == str(deployed)
+
+
+# ---------------------------------------------------------------------------
+# flag construction
+# ---------------------------------------------------------------------------
 
 
 def test_separator_appears_once_and_before_argv(monkeypatch):
@@ -91,14 +140,6 @@ def test_separator_appears_once_and_before_argv(monkeypatch):
     out = te._maybe_wrap_openshell(_ARGV)
     assert out.count("--") == 1
     assert out.index("--") < out.index(_ARGV[0])
-
-
-def test_policy_flag(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
-    monkeypatch.setenv("MAC_OPENSHELL_POLICY", "/etc/mac/policy.yaml")
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert "--policy" in out
-    assert out[out.index("--policy") + 1] == "/etc/mac/policy.yaml"
 
 
 def test_bin_override(monkeypatch):
@@ -128,7 +169,6 @@ def test_create_args_shell_split(monkeypatch):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from img --upload /a:/b")
     out = te._maybe_wrap_openshell(_ARGV)
-    # tokens are split and land before the separator
     for tok in ("--from", "img", "--upload", "/a:/b"):
         assert tok in out
         assert out.index(tok) < out.index("--")
@@ -146,7 +186,6 @@ def test_env_passthrough_only_set_vars(monkeypatch):
     monkeypatch.delenv("BAR", raising=False)
     out = te._maybe_wrap_openshell(_ARGV)
     assert "--env" in out
-    # FOO forwarded exactly once (dedup), BAR (unset) skipped
     assert out.count("FOO=fooval") == 1
     assert not any(tok.startswith("BAR=") for tok in out)
 


### PR DESCRIPTION
## What

Follow-up to #134. Closes the "silent image-default fallback" gap: when OpenShell sandboxing is enabled, the executor now **always passes one of our policies**, so it can never silently run under OpenShell's own image-default profile.

## Changes

- **`_resolve_openshell_policy()`** (`src/mac/task_executor.py`) — resolves the policy in order and **always** passes `--policy` (or raises — fail closed):
  1. `MAC_OPENSHELL_POLICY` (explicit; must exist),
  2. `~/.mac/openshell-policy.yaml` (operator-filled fleet policy),
  3. **bundled fail-closed default** `src/mac/openshell/default-policy.yaml`.
- **Bundled default is a lockdown**: filesystem-confined, never root, `landlock: hard_requirement`, **all network egress denied** (empty `network_policies`). An unconfigured deployment therefore fails closed (agent can't reach the hub/gateway) rather than running under an unknown/over-permissive profile.
- **`deploy/openshell/mac-hermes-policy.yaml`** (operator template): `landlock` `best_effort` → **`hard_requirement`**.
- Tests rewritten (**27 passing**) for the always-pass-policy behavior, the resolution order, the fail-closed `raise`, and the bundled default shipping in the package.
- Docs + in-code knob comments updated.

## Safety

- **Default-OFF unchanged**: with `MAC_OPENSHELL_SANDBOX` unset, `_maybe_wrap_openshell` returns the argv untouched — zero behavior change.
- The bundled `.yaml` ships in the wheel (`packages = ["src/mac"]` sweeps all of `src/mac`).
- Activation still requires OpenShell installed on the hosts; this PR only changes the policy that *would* apply once enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
