### PR TITLE
feat(deploy): never-prompt approval posture as a Hermes config default

### DIFF
--- a/src/mac/hermes_config_surface.py
+++ b/src/mac/hermes_config_surface.py
@@ -863,6 +863,33 @@ def _apply_patch_to_hermes_mapping(hermes: Dict[str, Any], patch: Mapping[str, A
             skills["platform_disabled"] = normalized
 
 
+def _ensure_never_prompt_defaults(config: Dict[str, Any]) -> None:
+    """Bake the fleet's never-prompt approval posture into config (sandbox-01).
+
+    Hermes must never block on an approval prompt: the OpenShell sandbox is the
+    enforcement layer, and the legacy gateway prompts went to an open channel
+    where anyone could approve (no real security). Default-if-absent, so an
+    explicit operator ``approvals`` config still wins.
+
+      * ``approvals.mode = off``          -> no dangerous-command approval
+                                             prompts (executor + gateway both
+                                             read this; immune to the
+                                             ``HERMES_YOLO_MODE`` import freeze)
+      * ``approvals.cron_mode = approve`` -> non-interactive runs don't fall to
+                                             the default ``deny``
+
+    Note: enabling never-prompt for the gateway means the (currently
+    un-sandboxed) Slack agent runs silently — real enforcement there requires
+    wrapping the gateway service under OpenShell too (tracked separately).
+    """
+    approvals = config.get("approvals")
+    if not isinstance(approvals, dict):
+        approvals = {}
+    approvals.setdefault("mode", "off")
+    approvals.setdefault("cron_mode", "approve")
+    config["approvals"] = approvals
+
+
 def apply_hermes_surface_payload(
     payload: Mapping[str, Any],
     *,
@@ -885,6 +912,7 @@ def apply_hermes_surface_payload(
     for section in ("plugins", "skills"):
         if isinstance(hermes.get(section), dict) and hermes[section]:
             config[section] = hermes[section]
+    _ensure_never_prompt_defaults(config)
     _atomic_yaml_write(config_path, config, mode=0o600)
     _write_env(env_path, hermes.get("env") if isinstance(hermes.get("env"), dict) else {})
     return {

--- a/tests/test_hermes_config_surface_approvals.py
+++ b/tests/test_hermes_config_surface_approvals.py
@@ -1,0 +1,51 @@
+"""The deploy bakes a never-prompt approval posture into Hermes config
+(sandbox-01): approvals.mode=off + cron_mode=approve, default-if-absent.
+
+OpenShell is the enforcement layer; Hermes must never block on a prompt (the
+old gateway prompts went to an open Slack channel — no real security).
+"""
+
+from __future__ import annotations
+
+import yaml
+
+import mac.hermes_config_surface as hcs
+
+
+def test_defaults_added_to_empty_config():
+    cfg: dict = {}
+    hcs._ensure_never_prompt_defaults(cfg)
+    assert cfg["approvals"]["mode"] == "off"
+    assert cfg["approvals"]["cron_mode"] == "approve"
+
+
+def test_explicit_mode_not_clobbered():
+    cfg = {"approvals": {"mode": "manual"}}
+    hcs._ensure_never_prompt_defaults(cfg)
+    assert cfg["approvals"]["mode"] == "manual"        # operator choice wins
+    assert cfg["approvals"]["cron_mode"] == "approve"  # missing key still filled
+
+
+def test_explicit_cron_mode_not_clobbered():
+    cfg = {"approvals": {"cron_mode": "deny"}}
+    hcs._ensure_never_prompt_defaults(cfg)
+    assert cfg["approvals"]["cron_mode"] == "deny"
+    assert cfg["approvals"]["mode"] == "off"
+
+
+def test_non_dict_approvals_replaced():
+    cfg = {"approvals": "bogus"}
+    hcs._ensure_never_prompt_defaults(cfg)
+    assert cfg["approvals"]["mode"] == "off"
+
+
+def test_apply_payload_writes_never_prompt(tmp_path):
+    home = tmp_path
+    (home / "config.yaml").write_text("{}\n")
+    hcs.apply_hermes_surface_payload({}, target_home=home)
+    written = yaml.safe_load((home / "config.yaml").read_text()) or {}
+    appr = written.get("approvals") or {}
+    # 'off' may round-trip as the YAML 1.1 bool False; both are accepted by the
+    # approval reader (approval.py treats False as the off mode).
+    assert appr.get("mode") in ("off", False)
+    assert appr.get("cron_mode") == "approve"


### PR DESCRIPTION
## What

Bakes a **never-prompt approval posture** into the Hermes config the deploy writes: `approvals.mode = off` + `approvals.cron_mode = approve`, **default-if-absent**, in `apply_hermes_surface_payload` (`mac.hermes_config_surface apply`, the deploy's config step).

## Why

Hermes was still **prompting for approval** — most visibly the gateway posting prompts to an **open Slack channel** (anyone can approve = no real security), and on the executor the `--yolo` flag is subject to an import-order freeze (`approval.py:_YOLO_MODE_FROZEN`). Both the gateway and executor read `~/.hermes/config.yaml`, and `approval_mode == "off"` short-circuits **before** the freeze-dependent checks (`approval.py:1197/1487`), so this is the robust, freeze-immune lever for true never-prompt across both paths. OpenShell is the enforcement layer.

## Change

- `_ensure_never_prompt_defaults(config)` sets `approvals.mode=off` / `cron_mode=approve` only if absent (explicit operator config still wins), called right before the config is written.
- +5 tests (defaults added; explicit mode/cron not clobbered; non-dict replaced; end-to-end apply writes it).

## Caveat (tracked separately)

Enabling never-prompt for the **gateway** means the Slack agent now runs **silently and is not yet sandboxed** — only the executor's task runs are wrapped by OpenShell. The prompts it replaces were open-channel theater (no real security), so nothing real is lost, but genuine enforcement for the gateway requires **wrapping the `mac-hermes-gateway` service under OpenShell** — being taken on as the next step.

## Rollout

Takes effect on the next deploy's config-surface apply (re-roll workers/gateway to pick it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
