### PR TITLE
feat(gateway): sandbox the Hermes gateway service under OpenShell (default-off)

### DIFF
--- a/src/mac/hermes_gateway.py
+++ b/src/mac/hermes_gateway.py
@@ -14,8 +14,93 @@ Console script: ``mac-hermes-gateway`` -> ``mac.hermes_gateway:main``.
 from __future__ import annotations
 
 import json
+import os
+import shlex
 import sys
-from typing import Callable, Optional
+from pathlib import Path
+from typing import Callable, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# OpenShell gateway sandboxing (sandbox-01)
+#
+# The gateway is a long-running service that runs tools in response to chat
+# messages. With never-prompt approval on (approvals.mode=off) it acts silently,
+# so OpenShell must be its enforcement layer. When MAC_OPENSHELL_GATEWAY is
+# enabled, the entrypoint RE-EXECS itself as a confined child of an *ephemeral*
+# OpenShell sandbox (no --keep/--name, so the sandbox lifetime == the gateway
+# process lifetime and supervisor restarts never collide). A guard env breaks
+# the re-exec loop once we're inside the sandbox.
+#
+# Default OFF: with MAC_OPENSHELL_GATEWAY unset the entrypoint runs exactly as
+# before. A policy is ALWAYS passed (never OpenShell's image default); if none
+# resolves we raise rather than run the gateway unconfined.
+#
+# Knobs:
+#   MAC_OPENSHELL_GATEWAY              truthy -> sandbox the gateway service
+#   MAC_OPENSHELL_BIN                 openshell binary (default "openshell")
+#   MAC_OPENSHELL_GATEWAY_POLICY      explicit policy path (else resolved)
+#   MAC_OPENSHELL_GATEWAY_CREATE_ARGS extra `sandbox create` args (shell-split)
+# ---------------------------------------------------------------------------
+
+_GATEWAY_ACTIVE_ENV = "_MAC_OPENSHELL_GATEWAY_ACTIVE"
+
+
+def _gateway_sandbox_enabled() -> bool:
+    return (os.environ.get("MAC_OPENSHELL_GATEWAY") or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _resolve_gateway_policy() -> str:
+    """Resolve the gateway's OpenShell policy (always returns one, or raises).
+
+    explicit MAC_OPENSHELL_GATEWAY_POLICY -> ~/.mac/openshell-gateway-policy.yaml
+    -> bundled fail-closed default. Never returns empty, so the gateway can't
+    silently run under OpenShell's image-default profile.
+    """
+    explicit = (os.environ.get("MAC_OPENSHELL_GATEWAY_POLICY") or "").strip()
+    if explicit:
+        if not Path(explicit).is_file():
+            raise FileNotFoundError("MAC_OPENSHELL_GATEWAY_POLICY=%r but no such file" % explicit)
+        return explicit
+    deployed = Path.home() / ".mac" / "openshell-gateway-policy.yaml"
+    if deployed.is_file():
+        return str(deployed)
+    bundled = Path(__file__).resolve().parent / "openshell" / "gateway-default-policy.yaml"
+    if bundled.is_file():
+        return str(bundled)
+    raise FileNotFoundError(
+        "MAC_OPENSHELL_GATEWAY is enabled but no gateway policy could be resolved "
+        "(set MAC_OPENSHELL_GATEWAY_POLICY, install %s, or ship %s)." % (deployed, bundled)
+    )
+
+
+def _build_gateway_sandbox_argv() -> List[str]:
+    """``openshell sandbox create ... -- <python> -m mac.hermes_gateway`` (ephemeral)."""
+    bin_ = (os.environ.get("MAC_OPENSHELL_BIN") or "openshell").strip() or "openshell"
+    argv: List[str] = [bin_, "sandbox", "create", "--no-auto-providers"]
+    argv += ["--policy", _resolve_gateway_policy()]
+    extra = (os.environ.get("MAC_OPENSHELL_GATEWAY_CREATE_ARGS") or "").strip()
+    if extra:
+        argv += shlex.split(extra)
+    argv += ["--", sys.executable, "-m", "mac.hermes_gateway"]
+    return argv
+
+
+def _maybe_reexec_under_openshell() -> None:
+    """Re-exec the gateway under an OpenShell sandbox when enabled (no-op else).
+
+    Replaces the current process (``os.execvp``) so the sandbox becomes the
+    service's main process; the supervisor (systemd/launchd) manages restarts.
+    The guard env stops the re-exec recursing once we're inside the sandbox.
+    """
+    if not _gateway_sandbox_enabled():
+        return
+    if os.environ.get(_GATEWAY_ACTIVE_ENV) == "1":
+        return  # already inside the sandbox — run the gateway for real
+    os.environ[_GATEWAY_ACTIVE_ENV] = "1"
+    argv = _build_gateway_sandbox_argv()
+    sys.stderr.write("[mac.hermes_gateway] re-exec under OpenShell: %s\n" % " ".join(argv))
+    os.execvp(argv[0], argv)  # noqa: S606 — operator-enabled, fixed argv shape
 
 
 def log_provider_decision(stream=sys.stderr) -> Optional[dict]:
@@ -45,6 +130,12 @@ def main(argv: Optional[list] = None, _cli_main: Optional[Callable[[], int]] = N
     ``_cli_main`` is injectable for testing so the launch path can be verified
     without booting the real gateway (which needs platform config).
     """
+    if _cli_main is None:
+        # Real launch path: confine the whole gateway under OpenShell when
+        # enabled (replaces this process). Skipped when _cli_main is injected
+        # (tests verify the launch path without re-exec'ing).
+        _maybe_reexec_under_openshell()
+
     from mac.hermes_vendor import ensure_on_path
 
     ensure_on_path()

--- a/src/mac/openshell/gateway-default-policy.yaml
+++ b/src/mac/openshell/gateway-default-policy.yaml
@@ -1,0 +1,63 @@
+# OpenShell FAIL-CLOSED default policy for the MAC Hermes GATEWAY service.
+#
+# Used when MAC_OPENSHELL_GATEWAY is enabled but no gateway policy is configured
+# (no MAC_OPENSHELL_GATEWAY_POLICY and no ~/.mac/openshell-gateway-policy.yaml).
+# Like the executor default it guarantees the gateway never silently runs under
+# OpenShell's own image-default profile.
+#
+# It is a LOCKDOWN: filesystem-confined, never root, Landlock REQUIRED, and ALL
+# network egress DENIED. Under it the gateway cannot reach Slack/Discord/Teams,
+# the model gateway, or the hub — so an unconfigured deployment FAILS CLOSED
+# (the gateway can't connect) rather than running unconfined.
+#
+# The gateway legitimately needs broad chat-platform egress, so you MUST provide
+# a real policy to run it sandboxed: copy this file, uncomment + fill the
+# network_policies for your platforms + hub + model gateway + agent home paths,
+# and install it at ~/.mac/openshell-gateway-policy.yaml (or point
+# MAC_OPENSHELL_GATEWAY_POLICY at it).
+
+version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+    - /lib
+    - /lib64
+    - /bin
+    - /sbin
+    - /etc
+    - /proc
+    - /dev/urandom
+  read_write:
+    - /tmp
+    - /dev/null
+
+landlock:
+  compatibility: hard_requirement
+
+process:
+  run_as_user: sandbox
+  run_as_group: sandbox
+
+# Empty => deny-by-default with nothing allowed == ALL egress denied (lockdown).
+# A real gateway policy replaces this with, e.g.:
+#
+# network_policies:
+#   slack:
+#     name: slack
+#     endpoints:
+#       - { host: slack.com,        port: 443, protocol: rest, enforcement: enforce, access: full }
+#       - { host: api.slack.com,    port: 443, protocol: rest, enforcement: enforce, access: full }
+#       - { host: wss-primary.slack.com, port: 443, protocol: websocket, enforcement: enforce, access: full }
+#     binaries:
+#       - { path: /home/__AGENT_USER__/.mac/venv/bin/python }
+#   model_gateway:
+#     name: model-gateway
+#     endpoints:
+#       - { host: __MODEL_GATEWAY_HOST__, port: 443, protocol: rest, enforcement: enforce, access: full }
+#   mac_hub:
+#     name: mac-hub
+#     endpoints:
+#       - { host: __MAC_HUB_HOST__, port: __MAC_HUB_PORT__, protocol: rest, enforcement: enforce, access: full }
+network_policies: {}

--- a/tests/test_hermes_gateway_sandbox.py
+++ b/tests/test_hermes_gateway_sandbox.py
@@ -1,0 +1,141 @@
+"""Tests for OpenShell gateway sandboxing (sandbox-01).
+
+The gateway entrypoint self-re-execs under an ephemeral OpenShell sandbox when
+MAC_OPENSHELL_GATEWAY is enabled. Default OFF; a policy is always passed; the
+re-exec is guarded so it doesn't recurse once inside the sandbox. No process is
+ever actually replaced here — os.execvp is patched.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from mac import hermes_gateway as hg
+
+_ENVS = [
+    "MAC_OPENSHELL_GATEWAY",
+    "MAC_OPENSHELL_BIN",
+    "MAC_OPENSHELL_GATEWAY_POLICY",
+    "MAC_OPENSHELL_GATEWAY_CREATE_ARGS",
+    "_MAC_OPENSHELL_GATEWAY_ACTIVE",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch, tmp_path):
+    for n in _ENVS:
+        monkeypatch.delenv(n, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))  # isolate ~/.mac/openshell-gateway-policy.yaml
+    yield
+
+
+# --- enable gate ---
+
+
+def test_disabled_by_default():
+    assert hg._gateway_sandbox_enabled() is False
+
+
+@pytest.mark.parametrize("v", ["1", "true", "On", "yes"])
+def test_enabled_truthy(monkeypatch, v):
+    monkeypatch.setenv("MAC_OPENSHELL_GATEWAY", v)
+    assert hg._gateway_sandbox_enabled() is True
+
+
+# --- policy resolution ---
+
+
+def test_resolve_bundled_fallback():
+    out = hg._resolve_gateway_policy()
+    assert out.endswith("gateway-default-policy.yaml")
+    assert Path(out).is_file()
+
+
+def test_resolve_explicit(monkeypatch, tmp_path):
+    p = tmp_path / "gw.yaml"
+    p.write_text("version: 1\n")
+    monkeypatch.setenv("MAC_OPENSHELL_GATEWAY_POLICY", str(p))
+    assert hg._resolve_gateway_policy() == str(p)
+
+
+def test_resolve_missing_explicit_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("MAC_OPENSHELL_GATEWAY_POLICY", str(tmp_path / "nope.yaml"))
+    with pytest.raises(FileNotFoundError):
+        hg._resolve_gateway_policy()
+
+
+def test_resolve_deployed_preferred(tmp_path):
+    macd = tmp_path / ".mac"
+    macd.mkdir()
+    dep = macd / "openshell-gateway-policy.yaml"
+    dep.write_text("version: 1\n")  # HOME already == tmp_path
+    assert hg._resolve_gateway_policy() == str(dep)
+
+
+# --- argv construction ---
+
+
+def test_build_argv_shape():
+    argv = hg._build_gateway_sandbox_argv()
+    assert argv[:4] == ["openshell", "sandbox", "create", "--no-auto-providers"]
+    assert "--policy" in argv
+    assert argv.count("--") == 1
+    assert argv[-3:] == [sys.executable, "-m", "mac.hermes_gateway"]
+    assert "--keep" not in argv and "--name" not in argv  # ephemeral
+
+
+def test_build_argv_create_args_and_bin(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_BIN", "/opt/os/openshell")
+    monkeypatch.setenv("MAC_OPENSHELL_GATEWAY_CREATE_ARGS", "--from gw-img --cpu 2")
+    argv = hg._build_gateway_sandbox_argv()
+    assert argv[0] == "/opt/os/openshell"
+    for tok in ("--from", "gw-img", "--cpu", "2"):
+        assert tok in argv and argv.index(tok) < argv.index("--")
+
+
+# --- re-exec guard ---
+
+
+def test_reexec_noop_when_disabled(monkeypatch):
+    called = []
+    monkeypatch.setattr(os, "execvp", lambda *a: called.append(a))
+    hg._maybe_reexec_under_openshell()
+    assert called == []
+
+
+def test_reexec_execs_when_enabled(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_GATEWAY", "1")
+    captured = {}
+    monkeypatch.setattr(os, "execvp", lambda f, a: captured.update(file=f, args=a))
+    hg._maybe_reexec_under_openshell()
+    assert captured["file"] == "openshell"
+    assert captured["args"][:3] == ["openshell", "sandbox", "create"]
+    assert captured["args"][-2:] == ["-m", "mac.hermes_gateway"]
+    assert os.environ.get("_MAC_OPENSHELL_GATEWAY_ACTIVE") == "1"
+
+
+def test_reexec_noop_when_already_active(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_GATEWAY", "1")
+    monkeypatch.setenv("_MAC_OPENSHELL_GATEWAY_ACTIVE", "1")
+    called = []
+    monkeypatch.setattr(os, "execvp", lambda *a: called.append(a))
+    hg._maybe_reexec_under_openshell()
+    assert called == []  # already inside the sandbox
+
+
+def test_main_with_injected_cli_does_not_reexec(monkeypatch):
+    # Even with the flag on, the test-injection path must not re-exec.
+    monkeypatch.setenv("MAC_OPENSHELL_GATEWAY", "1")
+
+    def _boom(*a):
+        raise AssertionError("must not re-exec when _cli_main is injected")
+
+    monkeypatch.setattr(os, "execvp", _boom)
+    monkeypatch.setattr("mac.hermes_vendor.ensure_on_path", lambda: None)
+    monkeypatch.setattr(hg, "log_provider_decision", lambda *a, **k: None)
+    monkeypatch.setattr(sys, "argv", list(sys.argv))  # isolate argv mutation
+    assert hg.main(_cli_main=lambda: 0) == 0


### PR DESCRIPTION
## What

Wraps the long-running **Hermes gateway service** under OpenShell, so its now-silent (never-prompt) behavior is actually enforced — the counterpart to the executor seam. Default OFF.

## How

The gateway entrypoint (`mac.hermes_gateway:main`) **re-execs itself under an ephemeral OpenShell sandbox** when `MAC_OPENSHELL_GATEWAY=1`:

- `_maybe_reexec_under_openshell()` runs first in `main()` (skipped when `_cli_main` is injected, i.e. tests). With the flag off it's a no-op — the entrypoint is unchanged.
- **Ephemeral** sandbox (no `--keep`/`--name`): the sandbox's lifetime == the gateway process, so supervisor (systemd/launchd) restarts just get a fresh sandbox — no name collision, no leak. A guard env (`_MAC_OPENSHELL_GATEWAY_ACTIVE`) breaks the re-exec loop once inside.
- **Always passes a policy** (`MAC_OPENSHELL_GATEWAY_POLICY` → `~/.mac/openshell-gateway-policy.yaml` → bundled fail-closed default), never OpenShell's image default; raises if none resolves.
- Bundled `gateway-default-policy.yaml` is a lockdown (no egress) with commented Slack/Discord/Teams + hub + model-gateway examples — operators must supply a real gateway policy to run it (fail-closed otherwise).

No bash/deploy changes — the existing wrapper still execs `python -m mac.hermes_gateway`; the entrypoint self-wraps. **+15 tests.**

## Why this shape

The deploy's `bin/hermes-gateway` wrapper (used by both systemd and launchd) is the single launch chokepoint, but a self-wrapping Python entrypoint is testable and bash-free. Ephemeral-per-process is the clean lifecycle for a supervised service.

## Deferred (needs Docker + a real policy)

- Live verification on a Docker-enabled host (**bullwinkle** has Docker).
- A tuned gateway policy with the fleet's actual chat-platform + hub + gateway hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
