### PR TITLE
feat(agent): first-class mac agent delete + migrate commands

### DIFF
--- a/src/mac/agent_migrate.py
+++ b/src/mac/agent_migrate.py
@@ -1,0 +1,151 @@
+"""First-class agent migration: move an agent (soul + memory) between hosts.
+
+Codifies the manual playbook for relocating a fleet agent — e.g. moving
+``bullwinkle`` from a macOS host to a Linux host:
+
+  1. back up the soul from the source host (selective: memory/state IN; host
+     cruft, host-specific runtime config, and deploy-managed skills OUT),
+  2. retarget the agent in the fleet topology (``fleets.yaml``),
+  3. deploy to the destination host (the agent NAME is pinned, so the hub-stored
+     persona/memories/mood follow ``agent_<name>`` automatically),
+  4. restore the soul over the deploy's fresh home (keeping the deploy's
+     host-correct ``config.yaml``/``.env``/skills),
+  5. optionally decommission the source + retire its agent record,
+  6. verify the soul transferred (``SOUL.md`` sha256 matches).
+
+The pure helpers (``SOUL_BACKUP_EXCLUDES``, ``retarget_fleet_agent``,
+``migration_plan``) are unit-tested. ``execute_migration`` shells out to
+ssh/scp + the fleet deploy and is gated behind an explicit ``execute=True``.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+# ~/.hermes entries that must NOT migrate with the soul:
+#   * host-local cruft (old checkouts, logs, bins, caches)
+#   * host-specific runtime config the deploy re-writes for the new host
+#   * deploy-managed skills (the deploy installs fleet + per-host GPU skills)
+SOUL_BACKUP_EXCLUDES: List[str] = [
+    ".hermes/hermes-agent.old-feature-branch",
+    ".hermes/logs",
+    ".hermes/bin",
+    ".hermes/cache",
+    ".hermes/audio_cache",
+    ".hermes/skills",
+    ".hermes/config.yaml",
+    ".hermes/config.yaml.*",
+    ".hermes/.env",
+    ".hermes/.env.*",
+]
+
+# Services to stop before swapping the live state.db, and restart after.
+_FLEET_SERVICES = ["mac-agent", "mac-hermes-gateway", "mac", "mac-gen-server"]
+
+
+def soul_backup_tar_excludes() -> List[str]:
+    """``--exclude=`` args for the selective soul backup tar."""
+    return ["--exclude=%s" % e for e in SOUL_BACKUP_EXCLUDES]
+
+
+def retarget_fleet_agent(
+    registry: Mapping[str, Any],
+    fleet: str,
+    name: str,
+    *,
+    target: str,
+    os: Optional[str] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Point an agent at a new host in a parsed ``fleets.yaml`` mapping (mutates
+    it in place). Returns the previous ``(target, os)``. Raises KeyError if the
+    fleet or agent is absent."""
+    try:
+        agents = registry["fleets"][fleet]["agents"]
+    except (KeyError, TypeError) as exc:
+        raise KeyError("fleet %r not found in registry" % fleet) from exc
+    for agent in agents:
+        if isinstance(agent, dict) and agent.get("name") == name:
+            previous = (agent.get("target"), agent.get("os"))
+            agent["target"] = target
+            if os is not None:
+                agent["os"] = os
+            return previous
+    raise KeyError("agent %r not found in fleet %r" % (name, fleet))
+
+
+def migration_plan(
+    name: str,
+    *,
+    src_target: str,
+    dst_target: str,
+    fleet: str,
+    deploy_cmd: str = "deploy/deploy-mac-fleet.sh",
+    keep_source: bool = False,
+    retire_source_agent: Optional[str] = None,
+) -> List[Tuple[str, str]]:
+    """Ordered ``(step, command)`` runbook for the migration. Pure — builds the
+    exact shell the operator (or ``execute_migration``) runs, soul-clobber-safe."""
+    tgz = "/tmp/%s-soul.tgz" % name
+    excludes = " ".join(soul_backup_tar_excludes())
+    svcs = " ".join(_FLEET_SERVICES)
+    steps: List[Tuple[str, str]] = [
+        ("backup-soul",
+         "ssh %s 'cd \"$HOME\" && tar czf %s %s .hermes'" % (src_target, tgz, excludes)),
+        ("transfer",
+         "scp -3 %s:%s %s:%s" % (src_target, tgz, dst_target, tgz)),
+        ("retarget-fleet",
+         "(fleets.yaml) set agent %r target=%s" % (name, dst_target)),
+        ("deploy",
+         "%s --hub %s %s" % (deploy_cmd, fleet, name)),
+        ("restore-soul",
+         "ssh %s 'sudo systemctl stop %s; cd \"$HOME\" && tar xzf %s; "
+         "sudo systemctl start %s'" % (dst_target, svcs, tgz, svcs)),
+        ("verify",
+         "compare sha256 ~/.hermes/SOUL.md on %s vs %s; mac agent list" % (src_target, dst_target)),
+    ]
+    if not keep_source:
+        steps.append((
+            "decommission-source",
+            "ssh %s 'launchctl unload ~/Library/LaunchAgents/com.mac*.plist 2>/dev/null "
+            "|| sudo systemctl stop %s'" % (src_target, svcs)))
+    if retire_source_agent:
+        steps.append(("retire-source-agent", "mac agent delete %s" % retire_source_agent))
+    return steps
+
+
+def render_plan(name: str, steps: List[Tuple[str, str]]) -> str:
+    lines = ["migration plan for agent %r (DRY-RUN — pass --execute to run):" % name]
+    for i, (step, cmd) in enumerate(steps, 1):
+        lines.append("  %d. [%s]\n       %s" % (i, step, cmd))
+    return "\n".join(lines)
+
+
+def execute_migration(
+    name: str,
+    steps: List[Tuple[str, str]],
+    *,
+    runner: Callable[[str], int] = None,
+) -> Dict[str, Any]:
+    """Run the migration runbook step by step, stopping on the first failure.
+
+    ``runner(command) -> returncode`` is injectable for testing; the default
+    runs each command through the shell. Returns a result dict with per-step
+    status. The ``retarget-fleet`` step is a marker handled by the CLI (it edits
+    fleets.yaml in-process), not a shell command.
+    """
+    if runner is None:
+        def runner(cmd: str) -> int:
+            return subprocess.run(cmd, shell=True).returncode  # noqa: S602 — operator-invoked
+
+    results: List[Dict[str, Any]] = []
+    for step, cmd in steps:
+        if step == "retarget-fleet":
+            results.append({"step": step, "status": "handled-in-process"})
+            continue
+        rc = runner(cmd)
+        results.append({"step": step, "command": cmd, "returncode": rc})
+        if rc != 0:
+            return {"agent": name, "ok": False, "failed_step": step, "results": results}
+    return {"agent": name, "ok": True, "results": results}

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -560,6 +560,64 @@ def cmd_agent_list(args: argparse.Namespace) -> None:
     _print([agent.to_dict() for agent in _plane(args).list_agents()])
 
 
+def cmd_agent_delete(args: argparse.Namespace) -> None:
+    """Hard-delete an agent record (mood/nap/events/messages); task history is
+    task-keyed and preserved. Refused while the agent holds an active lease."""
+    _plane(args).delete_agent(args.agent_id, actor=args.actor or "human")
+    _print({"deleted": args.agent_id})
+
+
+def cmd_agent_migrate(args: argparse.Namespace) -> None:
+    """Move an agent (soul + memory) to a new host. Dry-run by default; pass
+    --execute to run the backup -> retarget -> deploy -> restore -> verify
+    playbook. The agent NAME is preserved, so its hub-stored persona / memories
+    / mood follow ``agent_<name>`` automatically."""
+    import shutil
+    import time
+
+    import yaml
+
+    from mac import agent_migrate as am
+    from mac.hermes_config_surface import registry_path
+
+    reg_path = registry_path()
+    registry = yaml.safe_load(reg_path.read_text(encoding="utf-8")) or {}
+    fleets = registry.get("fleets") or {}
+    fleet = args.fleet or next(
+        (f for f, d in fleets.items()
+         if any((a or {}).get("name") == args.name for a in (d.get("agents") or []))),
+        None,
+    )
+    if not fleet or fleet not in fleets:
+        raise SystemExit("agent %r not found in any fleet in %s" % (args.name, reg_path))
+    agents = fleets[fleet].get("agents") or []
+    cur = next((a for a in agents if (a or {}).get("name") == args.name), None)
+    if cur is None:
+        raise SystemExit("agent %r not in fleet %r" % (args.name, fleet))
+    src = args.from_target or cur.get("target")
+    if not src:
+        raise SystemExit("no source target for %r; pass --from" % args.name)
+
+    steps = am.migration_plan(
+        args.name,
+        src_target=src,
+        dst_target=args.to_target,
+        fleet=fleet,
+        keep_source=args.keep_source,
+        retire_source_agent=args.retire_source_agent,
+    )
+    if not args.execute:
+        print(am.render_plan(args.name, steps))
+        return
+    # --execute: retarget fleets.yaml (backup first), then run the playbook.
+    backup = "%s.bak.%d" % (reg_path, int(time.time()))
+    shutil.copy2(reg_path, backup)
+    am.retarget_fleet_agent(registry, fleet, args.name, target=args.to_target, os=args.to_os)
+    reg_path.write_text(yaml.safe_dump(registry, sort_keys=False), encoding="utf-8")
+    print("retargeted %s -> %s in %s (backup: %s)" % (args.name, args.to_target, reg_path, backup))
+    _print(am.execute_migration(args.name, steps))
+
+
 def cmd_agent_hardware(args: argparse.Namespace) -> None:
     """Fleet hardware inventory from self-reported resources["hardware"], with the
     hub-derived gen capability (can this agent host media generation, and is it
@@ -2140,6 +2198,28 @@ def build_parser() -> argparse.ArgumentParser:
         help="runtime_environments.digest declaring which build this agent is running",
     )
     _set(cmd_agent_heartbeat, heartbeat)
+
+    agent_delete = agent.add_parser(
+        "delete",
+        help="hard-delete an agent record (removes mood/nap/events/messages; task history is kept)",
+    )
+    agent_delete.add_argument("agent_id")
+    agent_delete.add_argument("--actor", default="human")
+    _set(cmd_agent_delete, agent_delete)
+
+    agent_migrate = agent.add_parser(
+        "migrate",
+        help="move an agent (soul + memory) to a new host; dry-run unless --execute",
+    )
+    agent_migrate.add_argument("name")
+    agent_migrate.add_argument("--to", dest="to_target", required=True, help="destination user@host")
+    agent_migrate.add_argument("--from", dest="from_target", help="source user@host (default: current fleets.yaml target)")
+    agent_migrate.add_argument("--to-os", default="linux")
+    agent_migrate.add_argument("--fleet", help="fleet name (default: auto-resolve from fleets.yaml)")
+    agent_migrate.add_argument("--execute", action="store_true", help="run it (default: print the plan)")
+    agent_migrate.add_argument("--keep-source", action="store_true", help="don't decommission the source host")
+    agent_migrate.add_argument("--retire-source-agent", help="agent_id to `mac agent delete` after migration")
+    _set(cmd_agent_migrate, agent_migrate)
 
     fleet = sub.add_parser("fleet", help="fleet-wide queries").add_subparsers(
         dest="fleet_command", required=True

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -477,6 +477,13 @@ class RemoteDispatch:
     def list_agents(self) -> List[_Dictish]:
         return _wrap_list(self._get("/agents"))
 
+    def delete_agent(self, agent_id: str, *, actor: str = "human") -> _Dictish:
+        # DELETE /agents/{id} removes the agent + its agent-scoped ephemera
+        # (mood/nap/events/messages) and records an agent.deleted audit event;
+        # task history is task-keyed and preserved. Refused if it holds a lease.
+        path = "/agents/%s?actor=%s" % (quote(agent_id, safe=""), quote(actor, safe=""))
+        return _Dictish(self._delete(path))
+
     def heartbeat_agent(self, agent_id: str, **kw: Any) -> _Dictish:
         return _Dictish(
             self._post("/agents/%s/heartbeat" % quote(agent_id, safe=""), _drop_none(kw))

--- a/tests/test_agent_migrate.py
+++ b/tests/test_agent_migrate.py
@@ -1,0 +1,132 @@
+"""Tests for the first-class agent migration helpers (mac agent migrate).
+
+Covers the pure, testable core: the soul-backup exclude set, the fleets.yaml
+retarget, the migration runbook, and the step runner (with an injected runner
+so no real ssh/deploy happens).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac import agent_migrate as am
+
+
+# --- soul backup excludes ---------------------------------------------------
+
+
+def test_excludes_drop_host_config_skills_and_cruft():
+    ex = set(am.SOUL_BACKUP_EXCLUDES)
+    # host-specific config + secrets + deploy-managed skills must NOT migrate
+    assert ".hermes/config.yaml" in ex
+    assert ".hermes/.env" in ex
+    assert ".hermes/skills" in ex
+    # cruft
+    assert ".hermes/hermes-agent.old-feature-branch" in ex
+    assert ".hermes/logs" in ex
+
+
+def test_tar_exclude_args_format():
+    args = am.soul_backup_tar_excludes()
+    assert all(a.startswith("--exclude=") for a in args)
+    assert "--exclude=.hermes/.env" in args
+
+
+# --- retarget_fleet_agent ---------------------------------------------------
+
+
+def _registry():
+    return {
+        "fleets": {
+            "rocky": {
+                "agents": [
+                    {"name": "rocky", "target": "jkh@do-host1", "os": "linux"},
+                    {"name": "bullwinkle", "target": "jkh@puck.local", "os": "darwin"},
+                ]
+            }
+        }
+    }
+
+
+def test_retarget_updates_target_and_os_and_returns_old():
+    reg = _registry()
+    old = am.retarget_fleet_agent(reg, "rocky", "bullwinkle", target="jkh@madmax.local", os="linux")
+    assert old == ("jkh@puck.local", "darwin")
+    bw = [a for a in reg["fleets"]["rocky"]["agents"] if a["name"] == "bullwinkle"][0]
+    assert bw["target"] == "jkh@madmax.local"
+    assert bw["os"] == "linux"
+
+
+def test_retarget_missing_agent_raises():
+    with pytest.raises(KeyError):
+        am.retarget_fleet_agent(_registry(), "rocky", "ghost", target="jkh@x")
+
+
+def test_retarget_missing_fleet_raises():
+    with pytest.raises(KeyError):
+        am.retarget_fleet_agent(_registry(), "nope", "bullwinkle", target="jkh@x")
+
+
+# --- migration_plan ---------------------------------------------------------
+
+
+def test_plan_is_ordered_and_soul_safe():
+    steps = am.migration_plan(
+        "bullwinkle", src_target="jkh@puck.local", dst_target="jkh@madmax.local", fleet="rocky"
+    )
+    order = [s for s, _ in steps]
+    # backup must precede transfer/deploy; restore must come AFTER deploy
+    assert order.index("backup-soul") < order.index("transfer") < order.index("deploy")
+    assert order.index("deploy") < order.index("restore-soul") < order.index("verify")
+    # default decommissions the source
+    assert "decommission-source" in order
+    assert "retire-source-agent" not in order
+
+
+def test_plan_keep_source_skips_decommission():
+    steps = am.migration_plan(
+        "x", src_target="a@b", dst_target="a@c", fleet="rocky", keep_source=True
+    )
+    assert "decommission-source" not in [s for s, _ in steps]
+
+
+def test_plan_retire_source_agent_appends_delete():
+    steps = am.migration_plan(
+        "x", src_target="a@b", dst_target="a@c", fleet="rocky", retire_source_agent="agent_madmax"
+    )
+    cmds = dict(steps)
+    assert "retire-source-agent" in cmds
+    assert "mac agent delete agent_madmax" in cmds["retire-source-agent"]
+
+
+def test_plan_backup_excludes_host_config():
+    steps = dict(am.migration_plan("x", src_target="a@b", dst_target="a@c", fleet="rocky"))
+    assert "--exclude=.hermes/config.yaml" in steps["backup-soul"]
+    assert "--exclude=.hermes/.env" in steps["backup-soul"]
+
+
+# --- execute_migration (injected runner; no real ssh/deploy) ----------------
+
+
+def test_execute_runs_steps_in_order_and_skips_retarget_marker():
+    steps = am.migration_plan("x", src_target="a@b", dst_target="a@c", fleet="rocky")
+    ran = []
+    res = am.execute_migration("x", steps, runner=lambda cmd: ran.append(cmd) or 0)
+    assert res["ok"] is True
+    # retarget-fleet is handled in-process, not shelled out
+    assert all("fleets.yaml" not in c for c in ran)
+    assert any(c.startswith("ssh ") and "tar czf" in c for c in ran)  # backup ran
+
+
+def test_execute_stops_on_first_failure():
+    steps = am.migration_plan("x", src_target="a@b", dst_target="a@c", fleet="rocky")
+
+    calls = {"n": 0}
+
+    def runner(cmd: str) -> int:
+        calls["n"] += 1
+        return 1 if "scp" in cmd else 0  # fail at the transfer step
+
+    res = am.execute_migration("x", steps, runner=runner)
+    assert res["ok"] is False
+    assert res["failed_step"] == "transfer"


### PR DESCRIPTION
## What

Promotes two agent lifecycle operations to **first-class CLI commands** — they recurred during the bullwinkle puck→madmax migration, and (as the operator noted) this won't be the last time.

### `mac agent delete <agent_id>`
Wires the existing `delete_agent` service + `DELETE /agents/{id}` API to the CLI and `RemoteDispatch` (it had neither). Removes the agent + its agent-scoped ephemera (mood / nap / events / messages) and records an `agent.deleted` audit event; **task history is task-keyed and preserved**, and it's refused while the agent holds an active lease. (Used live to retire `agent_madmax`.)

### `mac agent migrate <name> --to user@host [--execute]`
Codifies the soul-migration playbook into one command (`mac/agent_migrate.py`):
1. selective **soul backup** (memory/state IN; host cruft, host-specific `config.yaml`/`.env`, and deploy-managed skills OUT),
2. fleet **retarget** (`fleets.yaml`),
3. **deploy** to the destination (agent NAME pinned → hub-stored persona/memories/mood follow `agent_<name>`),
4. **soul restore** over the deploy's fresh home (keeping the host-correct config),
5. optional source **decommission** + `--retire-source-agent`,
6. **verify** (`SOUL.md` sha256).

**Dry-run by default** (prints the runbook); `--execute` runs it. Pure helpers (`SOUL_BACKUP_EXCLUDES`, `retarget_fleet_agent`, `migration_plan`, `execute_migration` with an injectable runner) are unit-tested.

## Tests
+11 tests for the migrate helpers (exclude set, retarget, ordered/soul-safe plan, runner stops-on-failure). `delete` validated end-to-end against the live hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
