### PR TITLE
T1: dispatch safety — hold + release + per-project toggle + decompose caps

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -300,6 +300,16 @@ class ProjectCreate(BaseModel):
     status: str = "active"
     actor: str = "human"
     project_id: Optional[str] = None
+    dispatch_paused: Optional[bool] = None
+
+
+class ProjectDispatch(BaseModel):
+    paused: bool
+    actor: str = "human"
+
+
+class TaskRelease(BaseModel):
+    actor: str = "human"
 
 
 class ProjectUpdate(BaseModel):
@@ -3631,6 +3641,12 @@ def create_app(
             data["metadata"] = metadata
         return cp.create_project(actor=actor, **data).to_dict()
 
+    @app.post("/projects/{project}/dispatch")
+    def set_project_dispatch(project: str, body: ProjectDispatch) -> Dict[str, Any]:
+        return cp.set_project_dispatch(
+            project, paused=body.paused, actor=body.actor
+        ).to_dict()
+
     @app.get("/projects/{project}")
     def get_project(project: str) -> Dict[str, Any]:
         return cp.get_project(project)
@@ -3715,6 +3731,10 @@ def create_app(
             limit=20,
         )
         return task.to_dict()
+
+    @app.post("/tasks/{task_id}/release")
+    def release_task(task_id: str, body: TaskRelease = TaskRelease()) -> Dict[str, Any]:
+        return cp.release_task(task_id, actor=body.actor).to_dict()
 
     @app.post("/tasks/{task_id}/submit-for-review")
     def submit_for_review(

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -414,6 +414,10 @@ def cmd_task_create(args: argparse.Namespace) -> None:
         # Stage the task: the loop-mode fleet won't auto-claim it (and it's
         # hidden from `task ready`) until an operator starts it explicitly.
         metadata["no_dispatch"] = True
+    if getattr(args, "no_decompose", False):
+        # Handoff / plan-note guard: the executor will not auto-decompose this
+        # task into child tasks (add_child_tasks refuses with no_decompose).
+        metadata["no_decompose"] = True
     # bd parity: when --project is omitted, tag the task with the working
     # directory's project (git repo name, else cwd basename). Pass an explicit
     # --project (including --project '' for none) to override.
@@ -1999,6 +2003,9 @@ def build_parser() -> argparse.ArgumentParser:
     create.add_argument("--no-dispatch", dest="no_dispatch", action="store_true",
                         help="stage the task: the loop-mode fleet won't auto-claim it "
                              "(and it's hidden from `task ready`) until started explicitly")
+    create.add_argument("--no-decompose", dest="no_decompose", action="store_true",
+                        help="handoff/plan-note guard: the executor will not auto-decompose "
+                             "this task into child tasks")
     _set(cmd_task_create, create)
 
     list_tasks = task.add_parser("list")

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -497,6 +497,9 @@ def cmd_project_list(args: argparse.Namespace) -> None:
 
 
 def cmd_project_create(args: argparse.Namespace) -> None:
+    # New projects default to dispatch-PAUSED so a freshly-onboarded backlog
+    # does not auto-claim before an operator activates the project. Pass
+    # --active to opt straight into autonomous dispatch.
     _print(
         _plane(args).create_project(
             args.name,
@@ -505,8 +508,17 @@ def cmd_project_create(args: argparse.Namespace) -> None:
             status=args.status,
             actor=args.actor,
             project_id=args.project_id,
+            dispatch_paused=args.dispatch_paused,
         )
     )
+
+
+def cmd_project_pause(args: argparse.Namespace) -> None:
+    _print(_plane(args).set_project_dispatch(args.project, paused=True, actor=args.actor))
+
+
+def cmd_project_activate(args: argparse.Namespace) -> None:
+    _print(_plane(args).set_project_dispatch(args.project, paused=False, actor=args.actor))
 
 
 def cmd_project_show(args: argparse.Namespace) -> None:
@@ -515,6 +527,10 @@ def cmd_project_show(args: argparse.Namespace) -> None:
 
 def cmd_task_start(args: argparse.Namespace) -> None:
     _print(_plane(args).start_task(args.task_id, args.agent_id))
+
+
+def cmd_task_release(args: argparse.Namespace) -> None:
+    _print(_plane(args).release_task(args.task_id, actor=args.actor))
 
 
 def cmd_task_submit(args: argparse.Namespace) -> None:
@@ -2034,6 +2050,13 @@ def build_parser() -> argparse.ArgumentParser:
     start.add_argument("agent_id")
     _set(cmd_task_start, start)
 
+    release = task.add_parser(
+        "release", help="clear a --no-dispatch hold so the task can auto-dispatch"
+    )
+    release.add_argument("task_id")
+    release.add_argument("--actor", default="human")
+    _set(cmd_task_release, release)
+
     submit = task.add_parser("submit-review")
     submit.add_argument("task_id")
     submit.add_argument("agent_id")
@@ -2103,7 +2126,33 @@ def build_parser() -> argparse.ArgumentParser:
     project_create.add_argument("--status", default="active")
     project_create.add_argument("--actor", default="human")
     project_create.add_argument("--project-id")
+    project_dispatch = project_create.add_mutually_exclusive_group()
+    project_dispatch.add_argument(
+        "--paused",
+        dest="dispatch_paused",
+        action="store_true",
+        default=True,
+        help="stage the project: its tickets will not auto-dispatch until activated (default)",
+    )
+    project_dispatch.add_argument(
+        "--active",
+        dest="dispatch_paused",
+        action="store_false",
+        help="open the project to autonomous dispatch immediately",
+    )
     _set(cmd_project_create, project_create)
+    project_pause = project.add_parser(
+        "pause", help="hold a project's tickets from autonomous dispatch"
+    )
+    project_pause.add_argument("project")
+    project_pause.add_argument("--actor", default="human")
+    _set(cmd_project_pause, project_pause)
+    project_activate = project.add_parser(
+        "activate", help="open a project to autonomous dispatch"
+    )
+    project_activate.add_argument("project")
+    project_activate.add_argument("--actor", default="human")
+    _set(cmd_project_activate, project_activate)
     project_list = project.add_parser("list")
     _set(cmd_project_list, project_list)
     project_show = project.add_parser("show")

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -410,6 +410,10 @@ def cmd_task_create(args: argparse.Namespace) -> None:
         label="--metadata",
         default={},
     )
+    if getattr(args, "no_dispatch", False):
+        # Stage the task: the loop-mode fleet won't auto-claim it (and it's
+        # hidden from `task ready`) until an operator starts it explicitly.
+        metadata["no_dispatch"] = True
     # bd parity: when --project is omitted, tag the task with the working
     # directory's project (git repo name, else cwd basename). Pass an explicit
     # --project (including --project '' for none) to override.
@@ -1976,6 +1980,9 @@ def build_parser() -> argparse.ArgumentParser:
     create.add_argument("--actor", default="human")
     create.add_argument("--no-ticket", dest="no_ticket", action="store_true",
                         help="don't write the .tickets/<id>.md mirror for this task")
+    create.add_argument("--no-dispatch", dest="no_dispatch", action="store_true",
+                        help="stage the task: the loop-mode fleet won't auto-claim it "
+                             "(and it's hidden from `task ready`) until started explicitly")
     _set(cmd_task_create, create)
 
     list_tasks = task.add_parser("list")

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -324,6 +324,14 @@ class RemoteDispatch:
             )
         )
 
+    def release_task(self, task_id: str, *, actor: Optional[str] = None) -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/tasks/%s/release" % quote(task_id, safe=""),
+                _drop_none({"actor": actor}),
+            )
+        )
+
     def add_evidence(
         self,
         task_id: str,
@@ -361,6 +369,7 @@ class RemoteDispatch:
         status: Optional[str] = None,
         actor: Optional[str] = None,
         project_id: Optional[str] = None,
+        dispatch_paused: Optional[bool] = None,
     ) -> _Dictish:
         body = _drop_none(
             {
@@ -370,9 +379,25 @@ class RemoteDispatch:
                 "status": status,
                 "actor": actor,
                 "project_id": project_id,
+                "dispatch_paused": dispatch_paused,
             }
         )
         return _Dictish(self._post("/projects", body))
+
+    def set_project_dispatch(
+        self,
+        name_or_id: str,
+        *,
+        paused: bool,
+        actor: Optional[str] = None,
+    ) -> _Dictish:
+        body = _drop_none({"paused": bool(paused), "actor": actor})
+        return _Dictish(
+            self._post(
+                "/projects/%s/dispatch" % quote(name_or_id, safe=""),
+                body,
+            )
+        )
 
     def get_project(self, project: str) -> _Dictish:
         return _Dictish(self._get("/projects/%s" % quote(project, safe="")))

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -258,6 +258,33 @@ def _truthy_env(name: str, default: str = "") -> bool:
     return value in {"1", "true", "yes", "on"}
 
 
+def _int_env(name: str, default: int, *, minimum: int = 1) -> int:
+    """Read a positive integer config knob, falling back to *default*.
+
+    Empty / unparseable / below-*minimum* values fall back to the default so a
+    misconfigured env var can never DISABLE a safety cap (only widen/narrow it
+    within sane bounds).
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= minimum else default
+
+
+# Decomposition guardrails (T1 — bound runaway auto-decompose). Enforced
+# server-side in ControlPlane.add_child_tasks so NEITHER decomposition path
+# (the executor prompt that tells the agent to POST /children, nor the
+# declarative maybe_auto_decompose manifest path) can exceed them regardless of
+# agent behavior. Both are overridable via env for operators who need wider
+# trees, but never below the floor of 1.
+DEFAULT_MAX_CHILD_TASKS_PER_PARENT = 10
+DEFAULT_MAX_DECOMPOSE_DEPTH = 2
+
+
 def _beads_cli() -> str:
     configured = os.environ.get("MAC_BEADS_CLI", "").strip()
     if configured:
@@ -3283,6 +3310,30 @@ class ControlPlane:
             return task
         return self.update_task(task_id, metadata=md, actor=actor)
 
+    def _task_decompose_depth(self, task: Task, *, _max_walk: int = 64) -> int:
+        """Count ancestors above *task* via the parent_task_id chain.
+
+        0 = a root task (no parent). Cycle- and runaway-safe: the walk is
+        bounded and de-dups visited ids. Used to enforce the decomposition
+        depth cap so a deep chain of child-of-child tasks can't recurse forever.
+        """
+        depth = 0
+        current = task
+        seen: set = set()
+        for _ in range(_max_walk):
+            meta = ensure_json_object(current.metadata)
+            relationships = ensure_json_object(meta.get("relationships"))
+            parent_id = relationships.get("parent_task_id") or meta.get("parent_task_id")
+            if not parent_id or parent_id in seen:
+                break
+            seen.add(parent_id)
+            try:
+                current = self.get_task(str(parent_id))
+            except NotFoundError:
+                break
+            depth += 1
+        return depth
+
     def add_child_tasks(
         self,
         task_id: str,
@@ -3300,9 +3351,44 @@ class ControlPlane:
             raise ValidationError(
                 "child tasks can only be added to open, blocked, claimed, or running tasks"
             )
+
+        # --- Decomposition guardrails (T1) -----------------------------------
+        # Server-side backstop against the runaway auto-decompose that hit the
+        # live fleet. Refuse to decompose handoff/plan-note tasks, refuse beyond
+        # the depth cap, and bound the cumulative child count per parent.
+        parent_metadata = ensure_json_object(parent.metadata)
+        if parent_metadata.get("no_decompose"):
+            raise ValidationError(
+                "task %s is marked no_decompose (handoff/plan note) — refusing to "
+                "create child tasks; execute or stage it directly" % parent.id
+            )
+        max_depth = _int_env("MAC_MAX_DECOMPOSE_DEPTH", DEFAULT_MAX_DECOMPOSE_DEPTH)
+        depth = self._task_decompose_depth(parent)
+        if depth >= max_depth:
+            raise ValidationError(
+                "decomposition depth limit reached: task %s is at depth %d (max %d) "
+                "— execute it directly instead of decomposing further"
+                % (parent.id, depth, max_depth)
+            )
+
         specs = [ensure_json_object(spec) for spec in children]
         if not specs:
             raise ValidationError("at least one child task is required")
+
+        max_children = _int_env(
+            "MAC_MAX_CHILD_TASKS_PER_PARENT", DEFAULT_MAX_CHILD_TASKS_PER_PARENT
+        )
+        existing_children = _metadata_string_list(
+            ensure_json_object(parent_metadata.get("relationships")).get("child_task_ids")
+        )
+        projected = len(existing_children) + len(specs)
+        if projected > max_children:
+            raise ValidationError(
+                "child task limit exceeded for %s: %d existing + %d requested = %d "
+                "(max %d) — split into a smaller plan or raise "
+                "MAC_MAX_CHILD_TASKS_PER_PARENT"
+                % (parent.id, len(existing_children), len(specs), projected, max_children)
+            )
 
         prepared: List[JsonDict] = []
         for index, spec in enumerate(specs, start=1):

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -3096,6 +3096,8 @@ class ControlPlane:
             task = self._task_from_row(row)
             if tenant_id is not None and self._task_tenant_id(task) != tenant_id:
                 continue
+            if self._task_dispatch_held(task):
+                continue  # staged / do-not-dispatch — not claimable until released
             try:
                 ready = self._dependencies_satisfied(task)
             except Exception:  # noqa: BLE001 - a missing dependency blocks readiness
@@ -12706,7 +12708,22 @@ class ControlPlane:
             ),
         }
 
+    def _task_dispatch_held(self, task: Task) -> bool:
+        """True when a task is explicitly held from autonomous dispatch (staged).
+
+        Set via metadata ``no_dispatch: true`` (e.g. ``mac task create
+        --no-dispatch``) so a backlog — a freshly-onboarded project's tickets,
+        or operator handoff notes — can be filed WITHOUT the loop-mode fleet
+        auto-claiming it. The hold only blocks autonomous claim and hides the
+        task from the ready queue; an operator can still start it explicitly
+        (``mac task claim`` / ``mac task start``). This is the first-class
+        replacement for abusing a sentinel ``required_capabilities`` value.
+        """
+        return bool(ensure_json_object(task.metadata).get("no_dispatch"))
+
     def _task_matches_worker_claim_policy(self, task: Task, policy: JsonDict) -> Tuple[bool, str]:
+        if self._task_dispatch_held(task):
+            return False, "dispatch_held"
         allowed_projects = set(policy.get("allowed_projects") or [])
         if allowed_projects and (task.project or "") not in allowed_projects:
             return False, "project_not_allowed"

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -3098,6 +3098,8 @@ class ControlPlane:
                 continue
             if self._task_dispatch_held(task):
                 continue  # staged / do-not-dispatch — not claimable until released
+            if self._project_dispatch_paused(task.project):
+                continue  # project not yet activated for autonomous dispatch
             try:
                 ready = self._dependencies_satisfied(task)
             except Exception:  # noqa: BLE001 - a missing dependency blocks readiness
@@ -3266,6 +3268,20 @@ class ControlPlane:
             detail,
         )
         return updated
+
+    def release_task(self, task_id: str, *, actor: str = "human") -> Task:
+        """Clear a per-task dispatch hold (``no_dispatch``), un-staging it.
+
+        The inverse of ``mac task create --no-dispatch``: once released the
+        task becomes eligible for autonomous claim and re-appears in the ready
+        queue (subject to dependencies, capability match, and any project-level
+        pause). No-op if the task is not held.
+        """
+        task = self.get_task(task_id)
+        md = ensure_json_object(task.metadata)
+        if not md.pop("no_dispatch", None):
+            return task
+        return self.update_task(task_id, metadata=md, actor=actor)
 
     def add_child_tasks(
         self,
@@ -3533,6 +3549,7 @@ class ControlPlane:
         status: str = "active",
         actor: str = "human",
         project_id: Optional[str] = None,
+        dispatch_paused: Optional[bool] = None,
     ) -> ProjectRecord:
         project_name = str(name or "").strip()
         if not project_name:
@@ -3544,6 +3561,8 @@ class ControlPlane:
         project_metadata = ensure_json_object(metadata)
         if actor:
             project_metadata.setdefault("created_by", actor)
+        if dispatch_paused is not None:
+            project_metadata["dispatch_paused"] = bool(dispatch_paused)
         if existing is not None:
             return self._project_record_from_row(existing)
         now = utcnow()
@@ -3727,6 +3746,26 @@ class ControlPlane:
             metadata={"previous_name": project.name, "actor": actor},
         )
         return self.get_project_record(new_name)
+
+    def set_project_dispatch(
+        self,
+        name_or_id: str,
+        *,
+        paused: bool,
+        actor: str = "human",
+    ) -> ProjectRecord:
+        """Pause or resume autonomous dispatch for an entire project.
+
+        Persists ``metadata.dispatch_paused`` on the project record. When
+        paused, the project's open tickets are hidden from the ready queue and
+        rejected by autonomous claim (reason ``project_dispatch_paused``);
+        operators can still start them explicitly. This is the project-level
+        onboarding gate that complements the per-task ``no_dispatch`` hold.
+        """
+        project = self.get_project_record(name_or_id)
+        md = ensure_json_object(project.metadata)
+        md["dispatch_paused"] = bool(paused)
+        return self.update_project(project.id, metadata=md, actor=actor)
 
     def delete_project(self, name_or_id: str, *, force: bool = False, actor: str = "human") -> None:
         project = self.get_project_record(name_or_id)
@@ -12721,9 +12760,32 @@ class ControlPlane:
         """
         return bool(ensure_json_object(task.metadata).get("no_dispatch"))
 
+    def _project_dispatch_paused(self, project: Optional[str]) -> bool:
+        """True when the task's project is explicitly dispatch-PAUSED.
+
+        Per-project onboarding gate: a newly-created project can be staged
+        (``mac project create`` defaults to paused; ``mac project activate``
+        releases it) so its tickets don't auto-dispatch until the operator
+        turns the project on. IMPLICIT projects (no ``projects`` row — the case
+        for the live fleet's default project) are never paused, so existing
+        autonomous behavior is unchanged. Only projects with a record carrying
+        ``metadata.dispatch_paused`` are held.
+        """
+        if not project:
+            return False
+        try:
+            rec = self.get_project_record(project)
+        except NotFoundError:
+            return False
+        except Exception:  # noqa: BLE001 — never let a lookup error block dispatch
+            return False
+        return bool(ensure_json_object(rec.metadata).get("dispatch_paused"))
+
     def _task_matches_worker_claim_policy(self, task: Task, policy: JsonDict) -> Tuple[bool, str]:
         if self._task_dispatch_held(task):
             return False, "dispatch_held"
+        if self._project_dispatch_paused(task.project):
+            return False, "project_dispatch_paused"
         allowed_projects = set(policy.get("allowed_projects") or [])
         if allowed_projects and (task.project or "") not in allowed_projects:
             return False, "project_not_allowed"

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -304,6 +304,11 @@ def _plan_detection_section(task: Dict[str, Any]) -> str:
     child task, we skip — the agent should just execute, not re-decompose.
     """
     metadata = task.get("metadata") if isinstance(task, dict) else {}
+    # Handoff / plan-note guard: an operator can mark a task no_decompose
+    # (`mac task create --no-decompose`) so the executor won't suggest breaking
+    # it up — and the hub refuses the children call as a backstop.
+    if isinstance(metadata, dict) and metadata.get("no_decompose"):
+        return ""
     relationships = metadata.get("relationships") if isinstance(metadata, dict) else {}
     if isinstance(relationships, dict):
         # Already a child task or already has children — don't recurse
@@ -408,8 +413,10 @@ def maybe_auto_decompose(task_workspace: Path, task: Dict[str, Any]) -> bool:
     if not isinstance(plan_steps, list) or not plan_steps:
         return False
 
-    # Don't decompose child tasks further
+    # Don't decompose child tasks further, or tasks flagged no_decompose.
     metadata = task.get("metadata") if isinstance(task, dict) else {}
+    if isinstance(metadata, dict) and metadata.get("no_decompose"):
+        return False
     relationships = metadata.get("relationships") if isinstance(metadata, dict) else {}
     if isinstance(relationships, dict) and relationships.get("parent_task_id"):
         return False

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -1416,6 +1416,12 @@ edges:
             "actor": "operator",
             "reason": "route coverage rescue",
         },
+        # paused=False keeps the shared coverage project claimable for other cases.
+        ("POST", "/projects/{project}/dispatch"): {
+            "paused": False,
+            "actor": "operator",
+        },
+        ("POST", "/tasks/{task_id}/release"): {"actor": "operator"},
     }
     query_cases: Dict[RouteKey, Dict[str, Any]] = {
         ("POST", "/tasks/{task_id}/claim"): {

--- a/tests/test_decompose_caps.py
+++ b/tests/test_decompose_caps.py
@@ -1,0 +1,111 @@
+"""Tests for the auto-decompose guardrails (T1 — bound runaway decomposition).
+
+The live fleet once auto-decomposed a handoff backlog into runaway child tasks.
+``ControlPlane.add_child_tasks`` now enforces three server-side caps that NO
+decomposition path can bypass:
+
+1. ``no_decompose`` — handoff/plan-note tasks refuse decomposition outright.
+2. depth cap (``MAC_MAX_DECOMPOSE_DEPTH``, default 2) — a deep child-of-child
+   chain can't recurse forever.
+3. cumulative child-count cap (``MAC_MAX_CHILD_TASKS_PER_PARENT``, default 10).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import ValidationError
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+def _kids(n, prefix="child"):
+    return [{"title": "%s %d" % (prefix, i)} for i in range(n)]
+
+
+# -- no_decompose guard -----------------------------------------------------
+
+
+def test_no_decompose_refuses_children(cp):
+    parent = cp.create_task("handoff note", metadata={"no_decompose": True})
+    with pytest.raises(ValidationError, match="no_decompose"):
+        cp.add_child_tasks(parent.id, _kids(2))
+
+
+def test_normal_task_can_decompose(cp):
+    parent = cp.create_task("real plan")
+    result = cp.add_child_tasks(parent.id, _kids(2))
+    assert len(result["children"]) == 2
+
+
+# -- depth cap --------------------------------------------------------------
+
+
+def test_depth_helper_counts_ancestors(cp):
+    root = cp.create_task("root")
+    child_id = cp.add_child_tasks(root.id, _kids(1))["children"][0]["id"]
+    grandchild_id = cp.add_child_tasks(child_id, _kids(1))["children"][0]["id"]
+    assert cp._task_decompose_depth(cp.get_task(root.id)) == 0
+    assert cp._task_decompose_depth(cp.get_task(child_id)) == 1
+    assert cp._task_decompose_depth(cp.get_task(grandchild_id)) == 2
+
+
+def test_depth_cap_blocks_third_level(cp):
+    # default MAC_MAX_DECOMPOSE_DEPTH=2: root(0)->child(1)->grandchild(2) ok,
+    # but a grandchild (depth 2) may NOT decompose further.
+    root = cp.create_task("root")
+    child_id = cp.add_child_tasks(root.id, _kids(1))["children"][0]["id"]
+    grandchild_id = cp.add_child_tasks(child_id, _kids(1))["children"][0]["id"]
+    with pytest.raises(ValidationError, match="depth limit"):
+        cp.add_child_tasks(grandchild_id, _kids(1))
+
+
+def test_depth_cap_env_override(cp, monkeypatch):
+    monkeypatch.setenv("MAC_MAX_DECOMPOSE_DEPTH", "1")
+    root = cp.create_task("root")
+    child_id = cp.add_child_tasks(root.id, _kids(1))["children"][0]["id"]
+    # depth-1 child can no longer decompose when the cap is tightened to 1.
+    with pytest.raises(ValidationError, match="depth limit"):
+        cp.add_child_tasks(child_id, _kids(1))
+
+
+# -- count cap --------------------------------------------------------------
+
+
+def test_count_cap_single_call(cp):
+    parent = cp.create_task("big plan")
+    with pytest.raises(ValidationError, match="child task limit"):
+        cp.add_child_tasks(parent.id, _kids(11))
+
+
+def test_count_cap_at_limit_ok(cp):
+    parent = cp.create_task("ten-step plan")
+    result = cp.add_child_tasks(parent.id, _kids(10))
+    assert len(result["children"]) == 10
+
+
+def test_count_cap_cumulative(cp):
+    parent = cp.create_task("growing plan")
+    cp.add_child_tasks(parent.id, _kids(6, "a"))
+    # 6 existing + 6 new = 12 > 10 → refuse on the second call.
+    with pytest.raises(ValidationError, match="child task limit"):
+        cp.add_child_tasks(parent.id, _kids(6, "b"))
+
+
+def test_count_cap_env_override(cp, monkeypatch):
+    monkeypatch.setenv("MAC_MAX_CHILD_TASKS_PER_PARENT", "3")
+    parent = cp.create_task("small plan")
+    with pytest.raises(ValidationError, match="child task limit"):
+        cp.add_child_tasks(parent.id, _kids(4))
+
+
+def test_bad_env_value_falls_back_to_default(cp, monkeypatch):
+    # A garbage/zero env value must NOT disable the cap.
+    monkeypatch.setenv("MAC_MAX_CHILD_TASKS_PER_PARENT", "not-a-number")
+    parent = cp.create_task("plan")
+    with pytest.raises(ValidationError, match="child task limit"):
+        cp.add_child_tasks(parent.id, _kids(11))

--- a/tests/test_project_dispatch.py
+++ b/tests/test_project_dispatch.py
@@ -1,0 +1,117 @@
+"""Tests for the per-project dispatch toggle and the task release un-stage (T1).
+
+A project can be dispatch-PAUSED (``mac project create`` defaults to paused;
+``mac project pause`` / ``mac project activate`` toggle it): its open tickets are
+hidden from ``ready_tasks`` and rejected by the worker claim policy with reason
+``project_dispatch_paused`` until the project is activated. This is the
+project-level onboarding gate that complements the per-task ``no_dispatch`` hold.
+
+IMPLICIT projects (no ``projects`` row — the live fleet's default) are never
+paused, so existing autonomous behavior is unchanged.
+
+``release_task`` (``mac task release``) clears a per-task ``no_dispatch`` hold.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+# -- per-project pause ------------------------------------------------------
+
+
+def test_implicit_project_never_paused(cp):
+    # A task whose project has no record (the default-fleet case) is not paused.
+    task = cp.create_task("work", project="ghost-project")
+    assert cp._project_dispatch_paused("ghost-project") is False
+    ok, reason = cp._task_matches_worker_claim_policy(task, {})
+    assert (ok, reason) == (True, "matched")
+
+
+def test_no_project_never_paused(cp):
+    assert cp._project_dispatch_paused(None) is False
+    assert cp._project_dispatch_paused("") is False
+
+
+def test_create_project_defaults_active_at_service_layer(cp):
+    # The SERVICE default stays active (non-breaking for API/Hermes-adapter
+    # callers); only the CLI opts new projects into paused.
+    rec = cp.create_project("svc-default")
+    assert cp._project_dispatch_paused(rec.name) is False
+
+
+def test_create_project_paused(cp):
+    rec = cp.create_project("staged-proj", dispatch_paused=True)
+    assert cp._project_dispatch_paused(rec.name) is True
+
+
+def test_paused_project_hides_tasks_from_ready(cp):
+    cp.create_project("paused-proj", dispatch_paused=True)
+    cp.create_project("live-proj", dispatch_paused=False)
+    held = cp.create_task("staged ticket", project="paused-proj")
+    live = cp.create_task("live ticket", project="live-proj")
+    ready_ids = {t.id for t in cp.ready_tasks()}
+    assert live.id in ready_ids
+    assert held.id not in ready_ids
+
+
+def test_paused_project_rejected_by_claim_policy(cp):
+    cp.create_project("paused-proj", dispatch_paused=True)
+    task = cp.create_task("ticket", project="paused-proj")
+    ok, reason = cp._task_matches_worker_claim_policy(task, {})
+    assert (ok, reason) == (False, "project_dispatch_paused")
+
+
+def test_set_project_dispatch_round_trip(cp):
+    cp.create_project("p")
+    task = cp.create_task("ticket", project="p")
+    # active -> claimable
+    assert cp._task_matches_worker_claim_policy(task, {})[0] is True
+    # pause -> rejected
+    cp.set_project_dispatch("p", paused=True)
+    assert cp._task_matches_worker_claim_policy(task, {}) == (False, "project_dispatch_paused")
+    # activate -> claimable again
+    cp.set_project_dispatch("p", paused=False)
+    assert cp._task_matches_worker_claim_policy(task, {})[0] is True
+
+
+def test_set_project_dispatch_preserves_other_metadata(cp):
+    cp.create_project("p", metadata={"keep": "me"})
+    cp.set_project_dispatch("p", paused=True)
+    rec = cp.get_project_record("p")
+    assert rec.metadata.get("keep") == "me"
+    assert rec.metadata.get("dispatch_paused") is True
+
+
+def test_task_hold_precedes_project_pause(cp):
+    # A held task in a paused project reports the task-level hold first.
+    cp.create_project("paused-proj", dispatch_paused=True)
+    task = cp.create_task("ticket", project="paused-proj", metadata={"no_dispatch": True})
+    ok, reason = cp._task_matches_worker_claim_policy(task, {})
+    assert (ok, reason) == (False, "dispatch_held")
+
+
+# -- task release (un-stage) ------------------------------------------------
+
+
+def test_release_clears_no_dispatch(cp):
+    task = cp.create_task("staged", metadata={"no_dispatch": True})
+    assert cp._task_dispatch_held(task) is True
+    released = cp.release_task(task.id)
+    assert cp._task_dispatch_held(released) is False
+    ready_ids = {t.id for t in cp.ready_tasks()}
+    assert released.id in ready_ids
+
+
+def test_release_is_noop_when_not_held(cp):
+    task = cp.create_task("normal")
+    released = cp.release_task(task.id)
+    assert released.id == task.id
+    assert cp._task_dispatch_held(released) is False

--- a/tests/test_task_no_dispatch.py
+++ b/tests/test_task_no_dispatch.py
@@ -1,0 +1,63 @@
+"""Tests for the task do-not-dispatch hold (T1 — safe staging / project onboarding).
+
+A task created with metadata ``no_dispatch: true`` (`mac task create --no-dispatch`)
+is held from autonomous dispatch: hidden from ``ready_tasks`` and rejected by the
+worker claim policy, so a backlog (e.g. a freshly-onboarded project's tickets) can
+be staged WITHOUT the loop-mode fleet auto-claiming it. Default tasks are unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+def _held(cp):
+    return cp.create_task("staged work", metadata={"no_dispatch": True})
+
+
+def _normal(cp):
+    return cp.create_task("normal work")
+
+
+def test_dispatch_held_flag(cp):
+    assert cp._task_dispatch_held(_held(cp)) is True
+    assert cp._task_dispatch_held(_normal(cp)) is False
+
+
+def test_ready_excludes_held_includes_normal(cp):
+    held = _held(cp)
+    normal = _normal(cp)
+    ready_ids = {t.id for t in cp.ready_tasks()}
+    assert normal.id in ready_ids       # default task is claimable
+    assert held.id not in ready_ids     # staged task is hidden from the ready queue
+
+
+def test_claim_policy_rejects_held(cp):
+    ok, reason = cp._task_matches_worker_claim_policy(_held(cp), {})
+    assert ok is False
+    assert reason == "dispatch_held"
+
+
+def test_claim_policy_allows_normal(cp):
+    ok, reason = cp._task_matches_worker_claim_policy(_normal(cp), {})
+    assert ok is True
+    assert reason == "matched"
+
+
+def test_held_check_precedes_project_and_capability_gates(cp):
+    # The hold wins even when project/capability would also reject — staging is
+    # absolute, not dependent on the worker policy.
+    held = cp.create_task(
+        "staged", project="p", required_capabilities=["x"], metadata={"no_dispatch": True}
+    )
+    ok, reason = cp._task_matches_worker_claim_policy(
+        held, {"allowed_projects": ["other"], "capabilities": []}
+    )
+    assert (ok, reason) == (False, "dispatch_held")


### PR DESCRIPTION
## T1: make the autonomous loop safe to run unattended

Closes the auto-claim/runaway-decompose chaos that hit the live fleet when a backlog was filed: tickets were instantly claimed AND auto-decomposed into runaway children before an operator could react. This PR delivers **all three wants** of the T1 ticket (`task_f2a2b3b2…`).

### 1. Per-task dispatch hold
- `mac task create --no-dispatch` stages a task: hidden from `ready_tasks`, rejected by the claim policy (reason `dispatch_held`). Operators can still start it explicitly.
- `mac task release <id>` clears the hold (un-stage); no-op if not held.

### 2. Per-project dispatch toggle (onboarding gate)
- `mac project create` defaults to **PAUSED** (`--active` opts straight in); `mac project pause` / `activate` toggle an existing project.
- `metadata.dispatch_paused` → reason `project_dispatch_paused`, enforced in both `_task_matches_worker_claim_policy` and `ready_tasks`.
- **Implicit projects** (no `projects` row — the live fleet's default) are never paused; the service-layer `create_project` default stays `active`. Non-breaking for the live fleet and API/Hermes-adapter callers.

### 3. Auto-decompose guardrails
Server-side in `add_child_tasks` — unbypassable by either the executor prompt path or the declarative `maybe_auto_decompose` manifest path:
- **`no_decompose`** (`mac task create --no-decompose`): handoff/plan-note tasks refuse decomposition outright.
- **Depth cap** `MAC_MAX_DECOMPOSE_DEPTH` (default 2): `_task_decompose_depth` walks the `parent_task_id` chain (cycle-safe) and refuses beyond the cap.
- **Count cap** `MAC_MAX_CHILD_TASKS_PER_PARENT` (default 10), cumulative across calls.
- A garbage/zero env value falls back to the default — a misconfigured knob can never *disable* a cap.
- The executor is aligned so the agent isn't even prompted to decompose a `no_decompose` task; the hub cap is the backstop.

### Precedence
`dispatch_held` (per-task) → `project_dispatch_paused` (per-project) → `allowed_projects` → capability subset.

### Hub parity
- `RemoteDispatch.set_project_dispatch` + `release_task`; `create_project` forwards `dispatch_paused`.
- API: `POST /projects/{name}/dispatch`, `POST /tasks/{id}/release`, `ProjectCreate.dispatch_paused` (`exclude_unset` keeps the wire non-breaking). Route-coverage cases added for the two new routes.

### Tests
- New: `test_project_dispatch.py` (11), `test_task_no_dispatch.py` (5), `test_decompose_caps.py` (10).
- Regression: `test_control_plane.py` (245), `test_task_executor.py` (40), `tests/api` + `test_dispatch.py` (109) — all green.
- Verified end-to-end via local-DB CLI: pause→0 ready / activate→1 / re-pause→0 / release surfaces the held task; `--no-decompose` sets the flag and `add_child_tasks` refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)