### PR TITLE
fix(deploy): gateway unit TimeoutStopSec=210 (no SIGKILL mid-drain, clears startup warning)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -4936,7 +4936,12 @@ SuccessExitStatus=75
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 \$MAINPID
-TimeoutStopSec=120
+# Must exceed the gateway's restart_drain_timeout so systemd doesn't SIGKILL it
+# mid-drain. Mirrors hermes_cli/gateway.py: max(60, restart_drain_timeout) + 30
+# (=210 for the default drain of 180). A too-low value triggers the gateway's
+# "Stale systemd unit detected" startup warning. Bump if restart_drain_timeout
+# is raised above 180.
+TimeoutStopSec=210
 LimitNOFILE=65536
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
The mac-managed Hermes gateway systemd unit hardcoded `TimeoutStopSec=120`, but the gateway's `restart_drain_timeout` defaults to **180s**. So systemd could SIGKILL the gateway mid-drain, and the gateway emits a `Stale systemd unit detected: ... TimeoutStopSec=120s but drain_timeout=180s (expected >=210s)` warning on every start.

Fix: set `TimeoutStopSec=210`, matching Hermes' own installer formula (`hermes_cli/gateway.py`: `max(60, restart_drain_timeout) + 30` = 210 for the default drain). A comment notes to bump it if `restart_drain_timeout` is raised above 180.

Live rocky-fleet units (do-host1/sparky/madmax) already patched in place + gateways restarted — fresh logs show **0** stale-unit warnings, all gateways active. This PR makes future deploys write the correct value. (gke uses supervisord, not systemd, so it's unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)