### PR TITLE
feat(worker): version-aware probe+install for agent runtime deps (lifecycle self-update)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -3971,13 +3971,16 @@ install_github_review_key
 install_or_validate_shared_services
 write_hermes_memory_topology
 
-log "installing mac Python package (with vendored Hermes runtime + gateway extra)"
+log "installing mac Python package (with vendored Hermes runtime + gateway + relay extras)"
 "$PY" -m venv "$VENV"
 "$VENV/bin/python" -m pip install --upgrade pip wheel >/dev/null
 # ADR 0001 hu-04: install the hermes-gateway extra so the vendored Hermes
 # runtime (src/mac/_hermes) runs in-process from this one venv — no separate
 # hermes-agent venv needed. The gateway service execs mac-hermes-gateway.
-"$VENV/bin/python" -m pip install -e "${SRC_DIR}[hermes-gateway]" >/dev/null
+# The relay extra ships nemo-relay so the gateway has the observability seam at
+# deploy time (the worker also reconciles REQUIRED_RUNTIME_PIP at lifecycle
+# start, so a stale node self-upgrades on demand — see mac/worker.py).
+"$VENV/bin/python" -m pip install -e "${SRC_DIR}[hermes-gateway,relay]" >/dev/null
 mkdir -p "$HOME/.local/bin"
 ln -sf "$VENV/bin/mac" "$HOME/.local/bin/mac"
 install_or_validate_web_search_service

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -370,6 +370,19 @@ def register_worker(
     return agent
 
 
+# Declarative manifest of pip dependencies every agent must have to function,
+# as (name + version) specifiers. Reconciled at agent-lifecycle startup via
+# MacWorker.reconcile_runtime_deps() with a version-aware probe+install, so a
+# fresh or stale node converges to the right versions on demand WITHOUT waiting
+# for a redeploy. Add fleet-wide runtime deps here; keep them pinned.
+REQUIRED_RUNTIME_PIP: List[str] = [
+    # NeMo Relay observability seam (src/mac/relay_observability.py). Present on
+    # every agent so MAC_RELAY_OBSERVABILITY=1 actually activates rather than
+    # silently no-opping on a missing import.
+    "nemo-relay==0.3.0",
+]
+
+
 class MacWorker:
     """Small worker harness for mac-owned tasks.
 
@@ -449,6 +462,11 @@ class MacWorker:
         prior_handlers = self._install_signal_handlers()
         results: List[WorkerRunResult] = []
         iterations = 0
+        # Lifecycle self-update: in daemon mode (no max_iterations), probe+install
+        # the declared runtime deps before serving so the agent converges to the
+        # required versions on (re)start. Skipped for bounded test runs.
+        if max_iterations is None:
+            self._reconcile_runtime_deps_best_effort()
         try:
             while not self._stop and (max_iterations is None or iterations < max_iterations):
                 iterations += 1
@@ -2746,15 +2764,54 @@ class MacWorker:
             return ("@" + parts[1]).lower() if len(parts) >= 2 else spec.lower()
         return spec.split("@", 1)[0].lower()
 
-    def _pip_installed(self, py: str) -> set:
+    def _pip_installed(self, py: str) -> Dict[str, str]:
+        """Map of installed pip package name -> version (normalized names).
+
+        ``pip list --format=json`` already carries the version; we keep it so the
+        probe can compare name+version tuples instead of presence-only.
+        """
         try:
             out = subprocess.run(
                 [py, "-m", "pip", "list", "--format=json"],
                 capture_output=True, text=True, timeout=120, check=False,
             ).stdout
-            return {str(p.get("name", "")).lower().replace("_", "-") for p in json.loads(out or "[]")}
+            return {
+                str(p.get("name", "")).lower().replace("_", "-"): str(p.get("version", ""))
+                for p in json.loads(out or "[]")
+            }
         except Exception:
-            return set()
+            return {}
+
+    @classmethod
+    def _pip_spec_satisfied(cls, spec: str, installed: Dict[str, str]) -> bool:
+        """True when *spec* (name + optional version constraint) is already met.
+
+        ``installed`` is name->version (see :meth:`_pip_installed`). The probe is
+        version-aware: a present-but-out-of-range package is NOT satisfied, so it
+        gets reinstalled/upgraded to match. Uses ``packaging`` for correct PEP 440
+        comparison when available, with a conservative fallback (exact ``==``
+        match, else presence) so a missing ``packaging`` can never wrongly skip an
+        install of something absent.
+        """
+        name = cls._pip_base_name(spec)
+        have = installed.get(name)
+        if have is None:
+            return False  # absent -> must install
+        try:
+            from packaging.requirements import Requirement
+
+            req = Requirement(spec)
+            if not req.specifier:
+                return True  # no version pin -> presence is enough
+            return req.specifier.contains(have, prereleases=True)
+        except Exception:
+            # Fallback without packaging: honor an exact "==" pin, else accept
+            # presence (can't reason about ranges safely).
+            marker = "=="
+            if marker in spec:
+                want = spec.split(marker, 1)[1].strip().split(",")[0].strip()
+                return have == want
+            return True
 
     def _npm_installed(self, prefix: str) -> set:
         try:
@@ -2836,7 +2893,11 @@ class MacWorker:
             return {"ok": True, "skipped": "no specs"}
         py = self._agent_venv_python()
         installed = self._pip_installed(py)
-        pending = [s for s in specs if self._pip_base_name(s) not in installed]
+        # Version-aware probe: install/upgrade only the (name, version) tuples
+        # that are missing OR present at an unsatisfying version. pip moves a
+        # present-but-wrong version to satisfy the constraint (no --upgrade, so
+        # we don't churn transitive deps).
+        pending = [s for s in specs if not self._pip_spec_satisfied(s, installed)]
         if not pending:
             self._update_footprint("pip", specs, index_url=index_url)
             return {"ok": True, "skipped": "already satisfied", "specs": specs}
@@ -2871,6 +2932,42 @@ class MacWorker:
         finally:
             lock.close()
         return result
+
+    def reconcile_runtime_deps(self, specs: Optional[List[str]] = None) -> JsonDict:
+        """Probe + install the agent's declared runtime deps (idempotent).
+
+        Version-aware via :meth:`ensure_pip`: installs/upgrades only the
+        (name, version) tuples that are missing or unsatisfied, and is a fast
+        no-op when everything already matches. Invoked at lifecycle startup so a
+        fresh or stale agent self-converges to the required dependency versions
+        on demand — no redeploy needed. ``specs`` defaults to
+        :data:`REQUIRED_RUNTIME_PIP`.
+        """
+        specs = list(REQUIRED_RUNTIME_PIP) if specs is None else list(specs)
+        if not specs:
+            return {"ok": True, "skipped": "no runtime deps"}
+        return self.ensure_pip(specs, reason="runtime-deps reconcile")
+
+    def _reconcile_runtime_deps_best_effort(self) -> None:
+        """Run :meth:`reconcile_runtime_deps` without ever breaking the loop.
+
+        Gated by ``MAC_AGENT_RECONCILE_RUNTIME_DEPS`` (default on); set to a
+        falsey value to skip (e.g. air-gapped hosts that provision deps out of
+        band).
+        """
+        if os.environ.get("MAC_AGENT_RECONCILE_RUNTIME_DEPS", "1").strip().lower() in {"0", "false", "no", "off"}:
+            return
+        try:
+            result = self.reconcile_runtime_deps()
+            self._observe_log(
+                "worker.runtime_deps.reconciled",
+                level="debug",
+                detail={k: result.get(k) for k in ("ok", "skipped", "specs") if k in result},
+            )
+        except Exception as exc:  # noqa: BLE001 - dep reconcile must never crash the loop
+            self._observe_log(
+                "worker.runtime_deps.error", level="warning", detail={"error": str(exc)}
+            )
 
     def _maybe_sync_service_claims(self) -> None:
         # media-01: claim/renew the media service-roles this host is willing to

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2134,7 +2134,7 @@ def test_mac_worker_self_install_pip_audits_and_reports_footprint(tmp_path: Path
         attestation_key=cp._agent_attestation_key(agent.id),
     )
     monkeypatch.setenv("MAC_HOME", str(tmp_path / "machome"))
-    monkeypatch.setattr(worker, "_pip_installed", lambda py: set())
+    monkeypatch.setattr(worker, "_pip_installed", lambda py: {})
 
     calls: Dict[str, Any] = {}
 
@@ -2158,8 +2158,9 @@ def test_mac_worker_self_install_pip_audits_and_reports_footprint(tmp_path: Path
     footprint = cp.get_agent(agent.id).installed_packages
     assert any(e["name"] == "diffusers" for e in footprint["pip"])
 
-    # idempotency: report it as already installed -> no subprocess invocation
-    monkeypatch.setattr(worker, "_pip_installed", lambda py: {"diffusers"})
+    # idempotency: report it as already installed at the pinned version -> no
+    # subprocess invocation (version-aware probe sees it satisfied).
+    monkeypatch.setattr(worker, "_pip_installed", lambda py: {"diffusers": "0.31"})
     calls.clear()
     again = worker.ensure_pip(["diffusers==0.31"], reason="again")
     assert again.get("skipped") == "already satisfied"

--- a/tests/test_worker_runtime_deps.py
+++ b/tests/test_worker_runtime_deps.py
@@ -1,0 +1,103 @@
+"""Tests for the agent's version-aware probe+install dependency reconciliation.
+
+`ensure_pip` must install/upgrade only the (name, version) tuples that are
+missing or out-of-range — not blindly skip a present-but-stale package (the old
+name-only behavior) and not reinstall an already-satisfied one. The declarative
+`REQUIRED_RUNTIME_PIP` manifest is reconciled at agent-lifecycle startup so a
+fresh or stale node self-converges to the right versions on demand.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.worker import REQUIRED_RUNTIME_PIP, MacWorker
+
+
+class _DummyLock:
+    def close(self) -> None:  # matches the file-handle returned by _install_lock
+        pass
+
+
+def _worker() -> MacWorker:
+    """A bare MacWorker with the heavy/side-effecting bits stubbed."""
+    w = object.__new__(MacWorker)
+    w._agent_venv_python = lambda: "python3"
+    w._install_lock = lambda: _DummyLock()
+    w._update_footprint = lambda *a, **k: None
+    return w
+
+
+# -- version-aware probe ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec,installed,expected",
+    [
+        ("nemo-relay==0.3.0", {"nemo-relay": "0.3.0"}, True),   # exact match
+        ("nemo-relay==0.3.0", {"nemo-relay": "0.2.0"}, False),  # present but stale -> upgrade
+        ("nemo-relay==0.3.0", {}, False),                       # absent -> install
+        ("nemo-relay>=0.3.0", {"nemo-relay": "0.3.1"}, True),   # range satisfied
+        ("nemo-relay>=0.3.0", {"nemo-relay": "0.2.9"}, False),  # range not met
+        ("requests", {"requests": "2.0"}, True),                # no pin -> presence is enough
+        ("requests", {}, False),                                # no pin, absent
+        ("Nemo_Relay==0.3.0", {"nemo-relay": "0.3.0"}, True),   # name normalization
+    ],
+)
+def test_pip_spec_satisfied(spec, installed, expected):
+    assert MacWorker._pip_spec_satisfied(spec, installed) is expected
+
+
+# -- ensure_pip installs only the deltas ------------------------------------
+
+
+def test_ensure_pip_skips_when_all_satisfied():
+    w = _worker()
+    w._pip_installed = lambda py: {"nemo-relay": "0.3.0"}
+    called = []
+    w._run_install = lambda argv, **k: called.append(argv) or {"ok": True}
+    res = w.ensure_pip(["nemo-relay==0.3.0"])
+    assert res.get("skipped") == "already satisfied"
+    assert called == []  # nothing installed when already satisfied
+
+
+def test_ensure_pip_installs_only_unsatisfied():
+    w = _worker()
+    # nemo-relay present but stale -> reinstall; requests satisfied -> skip
+    w._pip_installed = lambda py: {"nemo-relay": "0.2.0", "requests": "2.31.0"}
+    captured = {}
+    w._run_install = lambda argv, **k: captured.update(argv=argv) or {"ok": True}
+    res = w.ensure_pip(["nemo-relay==0.3.0", "requests"])
+    assert res.get("ok")
+    assert "nemo-relay==0.3.0" in captured["argv"]
+    assert "requests" not in captured["argv"]
+
+
+def test_ensure_pip_installs_when_absent():
+    w = _worker()
+    w._pip_installed = lambda py: {}
+    captured = {}
+    w._run_install = lambda argv, **k: captured.update(argv=argv) or {"ok": True}
+    res = w.ensure_pip(["nemo-relay==0.3.0"])
+    assert res.get("ok")
+    assert "nemo-relay==0.3.0" in captured["argv"]
+
+
+# -- lifecycle reconcile uses the manifest ----------------------------------
+
+
+def test_reconcile_runtime_deps_uses_manifest():
+    w = _worker()
+    seen = {}
+    w.ensure_pip = lambda specs, **k: seen.update(specs=specs, reason=k.get("reason")) or {
+        "ok": True,
+        "skipped": "already satisfied",
+    }
+    res = w.reconcile_runtime_deps()
+    assert res.get("ok")
+    assert seen["specs"] == list(REQUIRED_RUNTIME_PIP)
+    assert "nemo-relay==0.3.0" in seen["specs"]
+
+
+def test_required_runtime_manifest_contains_relay():
+    assert any(s.startswith("nemo-relay==") for s in REQUIRED_RUNTIME_PIP)


### PR DESCRIPTION
## Problem
Agent dependency handling was **presence-only**: `ensure_pip` checked just the package *name* (`_pip_base_name(s) not in installed`), so a present-but-stale package — e.g. `nemo-relay 0.2.0` when `nemo-relay==0.3.0` is required — was reported "already satisfied" and **never upgraded**. There was also no lifecycle mechanism for an agent to converge its required deps on demand.

## Change — probe + install on the (name, version) tuple
- `_pip_installed` now returns `name -> version` (the version was already in `pip list --format=json`, just discarded).
- `_pip_spec_satisfied(spec, installed)`: version-aware probe — **absent or out-of-range ⇒ not satisfied**. Uses `packaging` for correct PEP 440 comparison, with a conservative fallback (exact `==` match, else presence) so a missing `packaging` can never wrongly *skip* installing something absent.
- `ensure_pip` installs/upgrades **only the unsatisfied deltas** (pip moves a present-but-wrong version to satisfy the constraint; no `--upgrade` churn of transitive deps).

## Lifecycle self-update
- Declarative `REQUIRED_RUNTIME_PIP` manifest + `reconcile_runtime_deps()`, invoked at `run_forever` **startup** (daemon mode only — bounded test runs skip it), gated by `MAC_AGENT_RECONCILE_RUNTIME_DEPS` (default on), best-effort so it never breaks the loop. A fresh or stale node self-converges to the required versions **on demand, without a redeploy**.
- Seeded with `nemo-relay==0.3.0` so the relay observability seam is present/current on every agent.
- The deploy now installs the `relay` extra too, so a new node's **gateway** has `nemo-relay` at deploy time (the worker reconcile keeps it current thereafter).

## Tests
- `tests/test_worker_runtime_deps.py` (13): probe matrix (exact / stale-upgrade / absent / `>=` range / no-pin / name-normalization), `ensure_pip` installs only deltas, reconcile uses the manifest.
- Existing self-install test updated for the `name->version` dict contract.
- All worker suites green (74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)