### PR TITLE
fix(relay): create_agent_scope yields exactly once (fixes hub 500 'generator didn't stop')

### DIFF
--- a/src/mac/relay_observability.py
+++ b/src/mac/relay_observability.py
@@ -92,11 +92,27 @@ def create_agent_scope(session_id: str) -> Generator[None, None, None]:
     if hermes_home_override:
         scope_data["hermes_home_override"] = hermes_home_override
 
+    # Open the scope by hand (mirrors _scoped) so this generator yields EXACTLY
+    # ONCE on every path. The previous `try: with ...: yield / except: yield`
+    # double-yielded when the scope's __exit__ raised — contextmanager then hit
+    # "RuntimeError: generator didn't stop", 500-ing every authenticated request
+    # once relay was active on the hub. Opening failure -> run unscoped; teardown
+    # failure -> swallowed; body exceptions propagate (and reach __exit__).
+    cm = None
     try:
-        with nr.scope.scope(scope_name, nr.ScopeType.Agent, data=scope_data):
-            yield
-    except Exception:  # noqa: BLE001 — observability must never break a task run
+        cm = nr.scope.scope(scope_name, nr.ScopeType.Agent, data=scope_data)
+        cm.__enter__()
+    except Exception:  # noqa: BLE001 — relay-internal failure: run unscoped
+        cm = None
         yield
+        return
+    try:
+        yield
+    finally:
+        try:
+            cm.__exit__(*sys.exc_info())
+        except Exception:  # noqa: BLE001 — observability must never break a task run
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_relay_observability.py
+++ b/tests/test_relay_observability.py
@@ -152,6 +152,68 @@ def test_create_agent_scope_opens_relay_scope_when_available(monkeypatch):
     assert data.get("session_id") == "my-session"
 
 
+def test_create_agent_scope_survives_scope_teardown_error(monkeypatch):
+    """Regression (hub 500 incident): a relay scope whose __exit__ RAISES must
+    not yield twice / raise 'generator didn't stop'. The old
+    `try: with ...: yield / except: yield` double-yielded on teardown error and
+    500-ed every authenticated request once relay was active on the hub."""
+    fake_nr = MagicMock()
+    fake_nr.ScopeType = MagicMock()
+    fake_nr.ScopeType.Agent = "AGENT"
+
+    class _BadScope:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            raise RuntimeError("relay teardown boom")
+
+    fake_nr.scope.scope = lambda *a, **k: _BadScope()
+    monkeypatch.setenv("MAC_RELAY_OBSERVABILITY", "1")
+    monkeypatch.setattr(ro, "_NEMO_RELAY_AVAILABLE", True)
+    monkeypatch.setattr(ro, "_nemo_relay", fake_nr)
+    monkeypatch.setattr(ro, "_flush_subscribers", MagicMock())
+
+    ran = []
+    with ro.create_agent_scope("sess"):  # must NOT raise
+        ran.append(True)
+    assert ran == [True]  # body ran exactly once; teardown error swallowed
+
+
+def test_create_agent_scope_open_failure_runs_unscoped(monkeypatch):
+    """If opening the relay scope raises, the body still runs (once, unscoped)."""
+    fake_nr = MagicMock()
+    fake_nr.ScopeType = MagicMock()
+    fake_nr.ScopeType.Agent = "AGENT"
+
+    def _boom(*a, **k):
+        raise RuntimeError("cannot open scope")
+
+    fake_nr.scope.scope = _boom
+    monkeypatch.setenv("MAC_RELAY_OBSERVABILITY", "1")
+    monkeypatch.setattr(ro, "_NEMO_RELAY_AVAILABLE", True)
+    monkeypatch.setattr(ro, "_nemo_relay", fake_nr)
+    monkeypatch.setattr(ro, "_flush_subscribers", MagicMock())
+
+    ran = []
+    with ro.create_agent_scope("sess"):
+        ran.append(True)
+    assert ran == [True]
+
+
+def test_create_agent_scope_body_exception_propagates_when_available(monkeypatch):
+    """A body exception still propagates (never suppressed) with a live scope."""
+    fake_nr = _make_fake_nemo_relay()
+    monkeypatch.setenv("MAC_RELAY_OBSERVABILITY", "1")
+    monkeypatch.setattr(ro, "_NEMO_RELAY_AVAILABLE", True)
+    monkeypatch.setattr(ro, "_nemo_relay", fake_nr)
+    monkeypatch.setattr(ro, "_flush_subscribers", MagicMock())
+
+    with pytest.raises(ValueError):
+        with ro.create_agent_scope("sess"):
+            raise ValueError("body boom")
+
+
 def test_create_agent_scope_name_truncated_at_128_chars(monkeypatch):
     fake_nr = _make_fake_nemo_relay()
     monkeypatch.setenv("MAC_RELAY_OBSERVABILITY", "1")


### PR DESCRIPTION
## Incident
Enabling NeMo Relay on the live fleet and restarting `mac.service` caused the hub to **500 every authenticated request** (`/personas`, `/v1/chat/completions`, heartbeat) with `RuntimeError: generator didn't stop`, crash-looping the agents (their startup self-test POSTs `/personas`, got 500s, exited; `NRestarts` climbed). Relay was disabled fleet-wide to stabilize.

## Root cause
`relay_observability.create_agent_scope` (Phase 1), used by `api.py:authenticate`:
```python
try:
    with nr.scope.scope(...):
        yield
except Exception:
    yield        # ← second yield when the scope's __exit__ raises
```
A `@contextmanager` must yield **exactly once**. When the relay scope's `__exit__` raised, the `except` ran a second `yield`, so on context exit the generator didn't stop → `RuntimeError`. Latent until now because relay had never been active *in the hub process* (prior enables restarted only `mac-agent`/gateway, not `mac.service`).

## Fix
Open the scope by hand — mirroring the already-correct Phase-2 `_scoped` — so the generator yields exactly once on every path:
- open failure → run unscoped (single yield)
- teardown failure → swallowed
- body exceptions still propagate (and are passed to the scope's `__exit__`)

Phase-2 `relay_tool_context` / `relay_llm_context` were already correct (verified).

## Tests
3 regressions in `test_relay_observability.py`: teardown-error survives (the exact failure), open-failure runs unscoped, body exception propagates. 28 relay tests green.

## Rollout
After merge: redeploy the 3 rocky agents, then re-enable relay (hub first, validate no 500s) — relay stays disabled until the fixed code is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)