### PR TITLE
feat(deploy): MAC_RELAY_OBSERVABILITY=1 by default (new nodes come up relay-active)

### DIFF
--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -651,6 +651,11 @@ def build_mac_env(
     values.setdefault("MAC_WORKER_EXECUTOR", str(cfg.paths.mac_home / "bin" / "mac-hermes-task-executor"))
     values.setdefault("MAC_AGENT_STARTUP_SELF_TEST", "1")
     values.setdefault("MAC_AGENT_STARTUP_SELF_TEST_TIMEOUT", "120")
+    # NeMo Relay observability on by default for new nodes (nemo-relay ships via
+    # the deploy's `relay` extra + the worker runtime-deps reconcile). setdefault
+    # so an operator's explicit MAC_RELAY_OBSERVABILITY=0 is preserved across
+    # redeploys; set to 0 in mac.env to opt a host out.
+    values.setdefault("MAC_RELAY_OBSERVABILITY", "1")
     values.setdefault("MAC_REVIEW_TICK_HUB_AGENT", cfg.identity.shared_services_manager)
     _apply_router(values, cfg, env)
     _apply_home_channel(values, cfg)

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -176,6 +176,22 @@ def test_build_mac_env_advertises_enabled_webdav_publish_service(tmp_path):
     assert env["MAC_WEBDAV_MAX_UPLOAD_BYTES"] == "1024"
 
 
+def test_build_mac_env_defaults_relay_observability_on(tmp_path):
+    """New nodes come up relay-active by default (nemo-relay ships via the
+    deploy's relay extra + worker reconcile)."""
+    cfg = deploy_env_config(tmp_path)
+    env = build_mac_env({}, cfg, environ={})
+    assert env["MAC_RELAY_OBSERVABILITY"] == "1"
+
+
+def test_build_mac_env_preserves_explicit_relay_opt_out(tmp_path):
+    """An operator's explicit MAC_RELAY_OBSERVABILITY=0 survives redeploys
+    (setdefault, not overwrite)."""
+    cfg = deploy_env_config(tmp_path)
+    env = build_mac_env({"MAC_RELAY_OBSERVABILITY": "0"}, cfg, environ={})
+    assert env["MAC_RELAY_OBSERVABILITY"] == "0"
+
+
 def test_deploy_env_import_is_dependency_light():
     # Regression: deploy-mac-fleet.sh runs `python -m mac.deploy_env write-mac-env`
     # on the bootstrap python BEFORE the deploy venv exists, so importing


### PR DESCRIPTION
Makes NeMo Relay **on by default** for new nodes. `nemo-relay` already ships everywhere (deploy `relay` extra + the worker runtime-deps reconcile), but the enablement flag wasn't a managed default — a fresh node installed the dep yet left relay off until set by hand.

`build_mac_env` now `setdefault`s `MAC_RELAY_OBSERVABILITY=1`:
- **new node** → relay active out of the box
- **operator opt-out** (`MAC_RELAY_OBSERVABILITY=0` in `mac.env`) is **preserved** across redeploys (`setdefault` never overwrites an explicit value)

Safe now that `create_agent_scope` yields exactly once (#146) — relay-active no longer 500s the hub.

Tests: `test_build_mac_env_defaults_relay_observability_on` + `..._preserves_explicit_relay_opt_out`; 60 deploy-env tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)