### PR TITLE
feat(fleet): Phase 1 soul snapshot — pull/edit/push agent identity (single source of truth)

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -690,6 +690,63 @@ def cmd_fleet_snapshot(args: argparse.Namespace) -> None:
     _print(_plane(args).fleet_snapshot(exclude_agent_id=getattr(args, "agent", None)))
 
 
+def _soul_snapshot_setup(args):
+    """Resolve (fleet_name, agents, transport) for the soul pull/push commands."""
+    import yaml as _yaml
+    from mac import soul_snapshot as _ss
+
+    cfg = _yaml.safe_load(Path(args.fleets_config).expanduser().read_text(encoding="utf-8")) or {}
+    fleet_name = args.fleet or next(iter((cfg.get("fleets") or {})), None)
+    if not fleet_name:
+        raise SystemExit("no fleet found; pass --fleet")
+    agents = _ss.load_fleet_agents(cfg, fleet_name)
+    return fleet_name, agents, _ss.SSHTransport()
+
+
+def cmd_fleet_soul_pull(args: argparse.Namespace) -> None:
+    """Phase 1 fleet snapshot: pull each agent's editable soul text into a local tree."""
+    from datetime import datetime, timezone
+    import yaml as _yaml
+    from mac import soul_snapshot as _ss
+
+    fleet_name, agents, transport = _soul_snapshot_setup(args)
+    dest = Path(args.into).expanduser()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    manifest = _ss.pull_snapshot(agents, dest, transport, fleet=fleet_name, pulled_at=stamp)
+    (dest / "manifest.yaml").write_text(_yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    summary = {
+        "fleet": fleet_name, "into": str(dest), "pulled_at": stamp,
+        "agents": {n: {f: m.get("present") for f, m in a["files"].items()}
+                   for n, a in manifest["agents"].items()},
+    }
+    _print(summary)
+
+
+def cmd_fleet_soul_push(args: argparse.Namespace) -> None:
+    """Phase 1 fleet snapshot: diff edited soul tree vs live, back up + write changes."""
+    from datetime import datetime, timezone
+    import yaml as _yaml
+    from mac import soul_snapshot as _ss
+
+    src = Path(getattr(args, "from_dir")).expanduser()
+    manifest = _yaml.safe_load((src / "manifest.yaml").read_text(encoding="utf-8"))
+    transport = _ss.SSHTransport()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    res = _ss.plan_and_push(
+        src, manifest, transport, stamp=stamp,
+        dry_run=args.dry_run, only_agents=(args.agent or None),
+    )
+    _print({
+        "dry_run": res.dry_run,
+        "changes": [
+            {"agent": c.agent, "file": c.relpath, "status": c.status,
+             "applied": c.applied, "backup": c.backup_path}
+            for c in res.changes
+        ],
+        "to_apply": [f"{c.agent}/{c.relpath}" for c in res.to_apply],
+    })
+
+
 def _hub_get_mood(agent_id: Optional[str]) -> Optional[Dict[str, Any]]:
     """GET the agent's current mood overlay straight from the hub HTTP API.
 
@@ -2300,6 +2357,31 @@ def build_parser() -> argparse.ArgumentParser:
     )
     fleet_snap.add_argument("--agent", help="exclude this agent id (the caller) from the snapshot")
     _set(cmd_fleet_snapshot, fleet_snap)
+
+    # Phase 1 fleet snapshot: pull/edit/push the editable agent soul text layer.
+    fleet_soul_pull = fleet.add_parser(
+        "soul-pull",
+        help="pull each agent's editable soul text (SOUL/USER/MEMORY.md) into a local tree",
+    )
+    fleet_soul_pull.add_argument("--fleet", help="fleet name (default: first in fleets.yaml)")
+    fleet_soul_pull.add_argument("--into", required=True, help="destination directory for the snapshot")
+    fleet_soul_pull.add_argument(
+        "--fleets-config", default=str(Path.home() / ".mac" / "fleets.yaml")
+    )
+    _set(cmd_fleet_soul_pull, fleet_soul_pull)
+
+    fleet_soul_push = fleet.add_parser(
+        "soul-push",
+        help="diff an edited soul snapshot vs live and write changes (backup-before-replace)",
+    )
+    fleet_soul_push.add_argument("--from", dest="from_dir", required=True, help="snapshot directory")
+    fleet_soul_push.add_argument(
+        "--dry-run", action="store_true", help="show the plan; write nothing (default off)"
+    )
+    fleet_soul_push.add_argument(
+        "--agent", action="append", help="limit to this agent (repeatable)"
+    )
+    _set(cmd_fleet_soul_push, fleet_soul_push)
 
     fleet_refresh = fleet.add_parser(
         "refresh-context",

--- a/src/mac/soul_snapshot.py
+++ b/src/mac/soul_snapshot.py
@@ -1,0 +1,253 @@
+"""Phase 1 fleet snapshot — pull / edit / push the editable agent *soul* text.
+
+The fleet's curated identity drifts host-locally with no single source of truth
+(e.g. an agent still "knows" a long-dead teammate). Phase 1 captures the
+editable TEXT layer — each agent's ``~/.hermes`` soul markdown — into a
+git-friendly tree so an operator can edit it and push it back **safely**:
+
+  * pull  -> read SOUL_FILES from every agent into <dir>/agents/<name>/soul/
+             plus a manifest.yaml (target, per-file sha256, byte size).
+  * edit  -> the operator edits the markdown locally.
+  * push  -> diff snapshot vs the agent's CURRENT files, back up the remote
+             copy, then write only the files that actually changed. ``dry_run``
+             prints the plan and writes nothing.
+
+Out of scope for Phase 1 (referenced as follow-ups): binary memory blobs
+(state.db / Qdrant vectors), secrets, and hub-stored persona/mood.
+
+Transport is pluggable. The default :class:`SSHTransport` reaches each agent at
+its ``~/.mac/fleets.yaml`` target; tests inject an in-memory fake.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Protocol, Sequence, Tuple
+
+# The editable text layer. Relative to each agent's Hermes home (~/.hermes).
+SOUL_FILES: Tuple[str, ...] = ("SOUL.md", "USER.md", "MEMORY.md")
+
+SNAPSHOT_SCHEMA = "mac.soul_snapshot.v1"
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+
+class Transport(Protocol):
+    """Read/write/backup a file under an agent's Hermes home, keyed by target."""
+
+    def read_text(self, target: str, relpath: str) -> Optional[str]:
+        """Return file contents, or None if the file does not exist."""
+
+    def write_text(self, target: str, relpath: str, content: str) -> None:
+        """Overwrite the file (caller has already taken a backup)."""
+
+    def backup(self, target: str, relpath: str, *, stamp: str) -> Optional[str]:
+        """Copy the current file aside; return the backup path, or None if absent."""
+
+
+class SSHTransport:
+    """Transport over ssh, relative to ``$HOME/.hermes`` on each target host.
+
+    ``stamp`` is supplied by the caller (not generated here) so a snapshot's
+    backups share one timestamp and the module stays deterministic/testable.
+    """
+
+    def __init__(self, *, hermes_subdir: str = ".hermes", connect_timeout: int = 10,
+                 ssh_extra: Optional[Sequence[str]] = None) -> None:
+        self._sub = hermes_subdir
+        self._ssh = [
+            "ssh", "-o", "BatchMode=yes", "-o", f"ConnectTimeout={connect_timeout}",
+            *(ssh_extra or []),
+        ]
+
+    def _remote(self, relpath: str) -> str:
+        # Single-quoted for the remote shell; relpath is a fixed allowlisted name.
+        return '"$HOME/%s/%s"' % (self._sub, relpath)
+
+    def read_text(self, target: str, relpath: str) -> Optional[str]:
+        # The remote command is passed as ONE argument; ssh hands it to the
+        # remote login shell verbatim. (Passing "sh","-c",script as separate
+        # argv items makes ssh flatten them and lose the quoting.)
+        path = self._remote(relpath)
+        cmd = "if [ -f %s ]; then cat %s; else exit 7; fi" % (path, path)
+        proc = subprocess.run([*self._ssh, target, cmd], capture_output=True, text=True)
+        if proc.returncode == 7:
+            return None
+        if proc.returncode != 0:
+            raise RuntimeError("read %s on %s failed: %s" % (relpath, target, proc.stderr.strip()))
+        return proc.stdout
+
+    def backup(self, target: str, relpath: str, *, stamp: str) -> Optional[str]:
+        path = self._remote(relpath)
+        bak = '"$HOME/%s/%s.bak.%s"' % (self._sub, relpath, stamp)
+        cmd = "if [ -f %s ]; then cp -f %s %s && echo COPIED; fi" % (path, path, bak)
+        proc = subprocess.run([*self._ssh, target, cmd], capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise RuntimeError("backup %s on %s failed: %s" % (relpath, target, proc.stderr.strip()))
+        return ("%s.bak.%s" % (relpath, stamp)) if "COPIED" in proc.stdout else None
+
+    def write_text(self, target: str, relpath: str, content: str) -> None:
+        path = self._remote(relpath)
+        cmd = 'mkdir -p "$(dirname %s)" && cat > %s' % (path, path)
+        proc = subprocess.run(
+            [*self._ssh, target, cmd], input=content, capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError("write %s on %s failed: %s" % (relpath, target, proc.stderr.strip()))
+
+
+# ---------------------------------------------------------------------------
+# Fleet roster
+# ---------------------------------------------------------------------------
+
+
+def load_fleet_agents(fleets_config: dict, fleet_name: str) -> List[Tuple[str, str]]:
+    """Return [(agent_name, ssh_target), ...] for *fleet_name* from a fleets.yaml dict."""
+    fleets = (fleets_config or {}).get("fleets") or {}
+    fleet = fleets.get(fleet_name)
+    if not fleet:
+        raise KeyError("fleet %r not found (have: %s)" % (fleet_name, sorted(fleets)))
+    out: List[Tuple[str, str]] = []
+    for agent in fleet.get("agents") or []:
+        name = str(agent.get("name") or "").strip()
+        target = str(agent.get("target") or "").strip()
+        if name and target:
+            out.append((name, target))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Pull
+# ---------------------------------------------------------------------------
+
+
+def pull_snapshot(
+    agents: Sequence[Tuple[str, str]],
+    dest_dir: Path,
+    transport: Transport,
+    *,
+    fleet: str,
+    pulled_at: str,
+    soul_files: Sequence[str] = SOUL_FILES,
+) -> dict:
+    """Pull SOUL_FILES from each agent into ``dest_dir`` and return the manifest.
+
+    Writes ``<dest>/agents/<name>/soul/<file>`` for present files and a
+    ``<dest>/manifest.yaml``. ``pulled_at`` is supplied by the caller.
+    """
+    dest_dir = Path(dest_dir)
+    manifest: dict = {
+        "schema": SNAPSHOT_SCHEMA,
+        "layer": "soul",
+        "fleet": fleet,
+        "pulled_at": pulled_at,
+        "soul_files": list(soul_files),
+        "agents": {},
+    }
+    for name, target in agents:
+        soul_dir = dest_dir / "agents" / name / "soul"
+        soul_dir.mkdir(parents=True, exist_ok=True)
+        files_meta: Dict[str, dict] = {}
+        for rel in soul_files:
+            content = transport.read_text(target, rel)
+            if content is None:
+                files_meta[rel] = {"present": False}
+                continue
+            (soul_dir / rel).write_text(content, encoding="utf-8")
+            files_meta[rel] = {
+                "present": True,
+                "sha256": _sha256(content),
+                "bytes": len(content.encode("utf-8")),
+            }
+        manifest["agents"][name] = {"target": target, "files": files_meta}
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Push (diff -> backup -> write)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FileChange:
+    agent: str
+    target: str
+    relpath: str
+    status: str  # "changed" | "new" | "unchanged" | "missing_in_snapshot"
+    local_sha: Optional[str] = None
+    remote_sha: Optional[str] = None
+    backup_path: Optional[str] = None
+    applied: bool = False
+
+
+@dataclass
+class PushResult:
+    changes: List[FileChange] = field(default_factory=list)
+    dry_run: bool = True
+
+    @property
+    def to_apply(self) -> List[FileChange]:
+        return [c for c in self.changes if c.status in ("changed", "new")]
+
+
+def plan_and_push(
+    snapshot_dir: Path,
+    manifest: dict,
+    transport: Transport,
+    *,
+    stamp: str,
+    dry_run: bool = True,
+    only_agents: Optional[Sequence[str]] = None,
+) -> PushResult:
+    """Diff each snapshot soul file against the agent's CURRENT file and, unless
+    ``dry_run``, back up + write the ones that changed.
+
+    Safety: never deletes; only writes files present in the snapshot whose
+    content differs from the live file. A file present live but absent from the
+    snapshot is reported (``missing_in_snapshot``) and left untouched.
+    """
+    snapshot_dir = Path(snapshot_dir)
+    result = PushResult(dry_run=dry_run)
+    agents_meta = (manifest or {}).get("agents") or {}
+    want = set(only_agents) if only_agents else None
+    for name, meta in agents_meta.items():
+        if want is not None and name not in want:
+            continue
+        target = str(meta.get("target") or "")
+        for rel, fmeta in (meta.get("files") or {}).items():
+            if not fmeta.get("present"):
+                continue  # not captured at pull time -> nothing to push
+            local_path = snapshot_dir / "agents" / name / "soul" / rel
+            if not local_path.exists():
+                continue
+            local = local_path.read_text(encoding="utf-8")
+            local_sha = _sha256(local)
+            remote = transport.read_text(target, rel)
+            remote_sha = _sha256(remote) if remote is not None else None
+            if remote is None:
+                status = "new"
+            elif remote_sha == local_sha:
+                status = "unchanged"
+            else:
+                status = "changed"
+            change = FileChange(
+                agent=name, target=target, relpath=rel, status=status,
+                local_sha=local_sha, remote_sha=remote_sha,
+            )
+            if status in ("changed", "new") and not dry_run:
+                change.backup_path = transport.backup(target, rel, stamp=stamp)
+                transport.write_text(target, rel, local)
+                change.applied = True
+            result.changes.append(change)
+    return result

--- a/tests/test_soul_snapshot.py
+++ b/tests/test_soul_snapshot.py
@@ -1,0 +1,128 @@
+"""Tests for Phase 1 soul snapshot (pull/edit/push of the agent soul text layer)."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from mac import soul_snapshot as fs
+
+
+class FakeTransport:
+    """In-memory transport: {target: {relpath: content}}."""
+
+    def __init__(self, store):
+        self.store = store
+        self.backups = []
+        self.writes = []
+
+    def read_text(self, target, relpath):
+        return self.store.get(target, {}).get(relpath)
+
+    def backup(self, target, relpath, *, stamp):
+        if relpath in self.store.get(target, {}):
+            bp = "%s.bak.%s" % (relpath, stamp)
+            self.backups.append((target, relpath, bp))
+            return bp
+        return None
+
+    def write_text(self, target, relpath, content):
+        self.store.setdefault(target, {})[relpath] = content
+        self.writes.append((target, relpath))
+
+
+def _agents():
+    return [("natasha", "u@sparky"), ("rocky", "u@do1")]
+
+
+# -- roster -----------------------------------------------------------------
+
+
+def test_load_fleet_agents():
+    cfg = {"fleets": {"rocky": {"agents": [
+        {"name": "rocky", "target": "u@do1", "os": "linux"},
+        {"name": "natasha", "target": "u@sparky"},
+        {"name": "", "target": "skip"},
+    ]}}}
+    assert fs.load_fleet_agents(cfg, "rocky") == [("rocky", "u@do1"), ("natasha", "u@sparky")]
+    with pytest.raises(KeyError):
+        fs.load_fleet_agents(cfg, "ghost")
+
+
+# -- pull -------------------------------------------------------------------
+
+
+def test_pull_writes_tree_manifest_and_sha(tmp_path):
+    t = FakeTransport({
+        "u@sparky": {"USER.md": "I am Natasha", "MEMORY.md": "notes"},  # no SOUL.md
+        "u@do1": {"SOUL.md": "rocky soul"},
+    })
+    manifest = fs.pull_snapshot(_agents(), tmp_path, t, fleet="rocky", pulled_at="T0")
+    assert (tmp_path / "agents/natasha/soul/USER.md").read_text() == "I am Natasha"
+    assert (tmp_path / "agents/rocky/soul/SOUL.md").read_text() == "rocky soul"
+    nm = manifest["agents"]["natasha"]
+    assert nm["target"] == "u@sparky"
+    assert nm["files"]["USER.md"]["present"] is True
+    assert nm["files"]["USER.md"]["sha256"] == fs._sha256("I am Natasha")
+    assert nm["files"]["SOUL.md"] == {"present": False}
+    assert manifest["schema"] == fs.SNAPSHOT_SCHEMA and manifest["fleet"] == "rocky"
+
+
+# -- push: diff / dry-run / apply -------------------------------------------
+
+
+def _pulled(tmp_path, store):
+    t = FakeTransport(store)
+    manifest = fs.pull_snapshot(_agents(), tmp_path, t, fleet="rocky", pulled_at="T0")
+    (tmp_path / "manifest.yaml").write_text(yaml.safe_dump(manifest))
+    return manifest
+
+
+def test_push_dry_run_detects_change_and_writes_nothing(tmp_path):
+    store = {"u@sparky": {"USER.md": "old"}, "u@do1": {"SOUL.md": "rsoul"}}
+    manifest = _pulled(tmp_path, store)
+    (tmp_path / "agents/natasha/soul/USER.md").write_text("NEW natasha")
+    t = FakeTransport(store)
+    res = fs.plan_and_push(tmp_path, manifest, t, stamp="S1", dry_run=True)
+    by = {(c.agent, c.relpath): c for c in res.changes}
+    assert by[("natasha", "USER.md")].status == "changed"
+    assert by[("rocky", "SOUL.md")].status == "unchanged"
+    assert t.writes == [] and t.backups == []
+    assert store["u@sparky"]["USER.md"] == "old"
+
+
+def test_push_apply_backs_up_and_writes_only_changed(tmp_path):
+    store = {"u@sparky": {"USER.md": "old"}, "u@do1": {"SOUL.md": "rsoul"}}
+    manifest = _pulled(tmp_path, store)
+    (tmp_path / "agents/natasha/soul/USER.md").write_text("NEW natasha")
+    t = FakeTransport(store)
+    res = fs.plan_and_push(tmp_path, manifest, t, stamp="S1", dry_run=False)
+    assert store["u@sparky"]["USER.md"] == "NEW natasha"
+    assert ("u@sparky", "USER.md", "USER.md.bak.S1") in t.backups
+    assert t.writes == [("u@sparky", "USER.md")]
+    applied = [c for c in res.changes if c.applied]
+    assert len(applied) == 1 and applied[0].agent == "natasha"
+
+
+def test_push_new_file_when_absent_remote(tmp_path):
+    store = {"u@sparky": {"USER.md": "x"}, "u@do1": {}}
+    src = {"u@sparky": {"USER.md": "x"}, "u@do1": {"SOUL.md": "fresh"}}
+    manifest = _pulled(tmp_path, src)
+    t = FakeTransport(store)
+    res = fs.plan_and_push(tmp_path, manifest, t, stamp="S1", dry_run=False)
+    by = {(c.agent, c.relpath): c for c in res.changes}
+    assert by[("rocky", "SOUL.md")].status == "new"
+    assert store["u@do1"]["SOUL.md"] == "fresh"
+    assert by[("rocky", "SOUL.md")].backup_path is None
+
+
+def test_push_only_agents_scopes(tmp_path):
+    store = {"u@sparky": {"USER.md": "old"}, "u@do1": {"SOUL.md": "rsoul"}}
+    manifest = _pulled(tmp_path, store)
+    (tmp_path / "agents/natasha/soul/USER.md").write_text("NEW")
+    (tmp_path / "agents/rocky/soul/SOUL.md").write_text("NEWROCKY")
+    t = FakeTransport(store)
+    res = fs.plan_and_push(tmp_path, manifest, t, stamp="S1", dry_run=False, only_agents=["natasha"])
+    assert store["u@sparky"]["USER.md"] == "NEW"
+    assert store["u@do1"]["SOUL.md"] == "rsoul"
+    assert all(c.agent == "natasha" for c in res.changes)


### PR DESCRIPTION
First slice of the fleet-snapshot architecture: capture the **editable identity text layer** so an operator can pull it to one place, edit it, and push it back safely — the fix for host-local identity drift (natasha still "knew" a long-dead **Boris**, a retired **Sweden GPU fleet**, and **Bullwinkle on the wrong host**).

### `src/mac/soul_snapshot.py`
- `pull_snapshot()` — read `SOUL.md`/`USER.md`/`MEMORY.md` from every fleet agent into `<dir>/agents/<name>/soul/` + a `manifest.yaml` (target, per-file sha256, bytes).
- `plan_and_push()` — diff snapshot vs each agent's **current** file; **back up (`cp .bak.<stamp>`) then write only changed files**; `dry_run` prints the plan and writes nothing; never deletes; `only_agents` scopes.
- Pluggable `Transport`; `SSHTransport` reaches each `fleets.yaml` target (remote command passed as a single arg so the login shell parses it).
- **Out of scope (Phase 2/3):** binary memory blobs (state.db/Qdrant), secrets, hub-stored persona/mood.

### CLI
`mac fleet soul-pull --fleet N --into DIR` · `mac fleet soul-push --from DIR [--dry-run] [--agent N ...]`

### Tests
`tests/test_soul_snapshot.py` (6) with an in-memory transport: pull tree/manifest/sha, dry-run writes nothing, apply backs up + writes only deltas, new-file, only-agents scoping. The unrelated pre-existing `test_fleet_snapshot.py` (ControlPlane awareness) is untouched.

### Validated live (the "good test")
Pulled the rocky fleet → corrected natasha's soul (Boris / Sweden fleet / Bullwinkle-host / retired AgentFS) → dry-ran (only `natasha/USER.md`+`MEMORY.md` flagged) → applied with `.bak` backups → restarted her gateway. Her live soul now reads `Bullwinkle (madmax, Linux). All three are Linux hosts.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)