### PR TITLE
fix(deploy): enforce never-prompt approval posture (stale approvals.mode=manual kept gateway prompting)

### DIFF
--- a/src/mac/hermes_config_surface.py
+++ b/src/mac/hermes_config_surface.py
@@ -881,12 +881,21 @@ def _ensure_never_prompt_defaults(config: Dict[str, Any]) -> None:
     Note: enabling never-prompt for the gateway means the (currently
     un-sandboxed) Slack agent runs silently — real enforcement there requires
     wrapping the gateway service under OpenShell too (tracked separately).
+
+    ENFORCED, not default-if-absent: agents carry a stale ``approvals.mode:
+    manual`` / ``cron_mode: deny`` from an earlier lifecycle, and a setdefault
+    left those in place so the gateway kept showing "Command Approval Required".
+    The never-prompt posture is a fleet invariant, so we overwrite. An operator
+    can opt a single host back into interactive approvals with
+    ``MAC_HERMES_ALLOW_APPROVAL_PROMPTS=1`` (then their existing config wins).
     """
+    if os.environ.get("MAC_HERMES_ALLOW_APPROVAL_PROMPTS", "").strip().lower() in {"1", "true", "yes", "on"}:
+        return
     approvals = config.get("approvals")
     if not isinstance(approvals, dict):
         approvals = {}
-    approvals.setdefault("mode", "off")
-    approvals.setdefault("cron_mode", "approve")
+    approvals["mode"] = "off"          # no dangerous-command approval prompts
+    approvals["cron_mode"] = "approve"  # non-interactive runs must not fall to deny
     config["approvals"] = approvals
 
 

--- a/tests/test_hermes_config_surface_approvals.py
+++ b/tests/test_hermes_config_surface_approvals.py
@@ -1,8 +1,11 @@
 """The deploy bakes a never-prompt approval posture into Hermes config
-(sandbox-01): approvals.mode=off + cron_mode=approve, default-if-absent.
+(sandbox-01): approvals.mode=off + cron_mode=approve, ENFORCED.
 
 OpenShell is the enforcement layer; Hermes must never block on a prompt (the
-old gateway prompts went to an open Slack channel — no real security).
+old gateway prompts went to an open Slack channel — no real security). The
+posture is enforced (not default-if-absent) because agents carried a stale
+approvals.mode=manual / cron_mode=deny that kept the gateway prompting; an
+operator opts out per-host with MAC_HERMES_ALLOW_APPROVAL_PROMPTS=1.
 """
 
 from __future__ import annotations
@@ -19,18 +22,28 @@ def test_defaults_added_to_empty_config():
     assert cfg["approvals"]["cron_mode"] == "approve"
 
 
-def test_explicit_mode_not_clobbered():
+def test_stale_manual_mode_is_enforced_off():
+    # The regression: a baked-in 'manual' must be overwritten to 'off', else the
+    # gateway keeps showing "Command Approval Required".
     cfg = {"approvals": {"mode": "manual"}}
     hcs._ensure_never_prompt_defaults(cfg)
-    assert cfg["approvals"]["mode"] == "manual"        # operator choice wins
-    assert cfg["approvals"]["cron_mode"] == "approve"  # missing key still filled
-
-
-def test_explicit_cron_mode_not_clobbered():
-    cfg = {"approvals": {"cron_mode": "deny"}}
-    hcs._ensure_never_prompt_defaults(cfg)
-    assert cfg["approvals"]["cron_mode"] == "deny"
     assert cfg["approvals"]["mode"] == "off"
+    assert cfg["approvals"]["cron_mode"] == "approve"
+
+
+def test_stale_cron_mode_deny_is_enforced_approve():
+    cfg = {"approvals": {"cron_mode": "deny", "mode": "manual"}}
+    hcs._ensure_never_prompt_defaults(cfg)
+    assert cfg["approvals"]["cron_mode"] == "approve"
+    assert cfg["approvals"]["mode"] == "off"
+
+
+def test_env_opt_out_preserves_operator_config(monkeypatch):
+    monkeypatch.setenv("MAC_HERMES_ALLOW_APPROVAL_PROMPTS", "1")
+    cfg = {"approvals": {"mode": "manual", "cron_mode": "deny"}}
+    hcs._ensure_never_prompt_defaults(cfg)
+    assert cfg["approvals"]["mode"] == "manual"   # opt-out: operator config wins
+    assert cfg["approvals"]["cron_mode"] == "deny"
 
 
 def test_non_dict_approvals_replaced():


### PR DESCRIPTION
## Symptom
rocky kept showing **"Command Approval Required"** (Allow Once / Deny) in Slack for `execute_code`/terminal — despite the fleet's never-prompt posture (sandbox-01 / #140).

## Root cause
`_ensure_never_prompt_defaults` used `setdefault`, intending "operator config wins." But rocky/natasha carried a stale `approvals.mode: manual` + `cron_mode: deny` from an earlier lifecycle, so the never-prompt default **never applied** — the gateway kept prompting.

## Fix
The never-prompt posture is a fleet invariant (OpenShell is the guardrail; the old prompts went to an open Slack channel = no real security), so **enforce** it: overwrite `approvals.mode=off` + `cron_mode=approve`. Per-host opt-out via `MAC_HERMES_ALLOW_APPROVAL_PROMPTS=1` (then the operator's config wins).

## Tests
`test_hermes_config_surface_approvals.py` updated for enforce semantics: stale `manual`→`off`, stale `deny`→`approve`, env opt-out preserves operator config. 6 pass.

## Live
Already flipped on rocky/natasha (`manual`→`off`) + gateways restarted; bullwinkle was already `off`. This keeps it off across redeploys. Caveat: OpenShell enforcement is still staged, so this is currently "no prompt + no sandbox" on the Slack-facing agents — matching the accepted "total YOLO" posture until the sandbox lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)