### PR TITLE
fix(deploy): promote slack_accounts.json tokens into config env (durable Slack for migrated agents)

### DIFF
--- a/src/mac/hermes_config_surface.py
+++ b/src/mac/hermes_config_surface.py
@@ -899,6 +899,43 @@ def _ensure_never_prompt_defaults(config: Dict[str, Any]) -> None:
     config["approvals"] = approvals
 
 
+def _promote_slack_accounts_tokens(config: Dict[str, Any], home: Path) -> None:
+    """Promote Slack tokens from ~/.hermes/slack_accounts.json into config['env'].
+
+    An agent provisioned via a multi-workspace ``slack_accounts.json`` (e.g. one
+    migrated from another host) carries its bot/app tokens there, NOT in the
+    config.yaml ``env:`` block — and the gateway enables the Slack platform off
+    the env tokens, so without this it comes up "No messaging platforms enabled"
+    (the bullwinkle case). Promote the first account's xoxb/xapp pair so a
+    redeploy keeps Slack working. setdefault: an explicit env token wins, and
+    slack_accounts.json still drives the actual multi-workspace connections.
+    """
+    env = config.get("env") if isinstance(config.get("env"), dict) else {}
+    if env.get("SLACK_BOT_TOKEN") and env.get("SLACK_APP_TOKEN"):
+        return  # already enabled via explicit env tokens
+    accts = home / "slack_accounts.json"
+    if not accts.exists():
+        return
+    try:
+        data = json.loads(accts.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 — malformed accounts file: leave config as-is
+        return
+    accounts = data if isinstance(data, list) else (data.get("accounts") or data.get("agents") or [])
+    for acct in accounts:
+        if not isinstance(acct, dict):
+            continue
+        bot = str(acct.get("bot_token") or "")
+        app = str(acct.get("app_token") or "")
+        if bot.startswith("xoxb") and app.startswith("xapp"):
+            env.setdefault("SLACK_BOT_TOKEN", bot)
+            env.setdefault("SLACK_APP_TOKEN", app)
+            user = str(acct.get("user_token") or "")
+            if user:
+                env.setdefault("SLACK_USER_TOKEN", user)
+            config["env"] = env
+            return
+
+
 def apply_hermes_surface_payload(
     payload: Mapping[str, Any],
     *,
@@ -922,6 +959,7 @@ def apply_hermes_surface_payload(
         if isinstance(hermes.get(section), dict) and hermes[section]:
             config[section] = hermes[section]
     _ensure_never_prompt_defaults(config)
+    _promote_slack_accounts_tokens(config, home)
     _atomic_yaml_write(config_path, config, mode=0o600)
     _write_env(env_path, hermes.get("env") if isinstance(hermes.get("env"), dict) else {})
     return {

--- a/tests/test_hermes_config_surface_slack_tokens.py
+++ b/tests/test_hermes_config_surface_slack_tokens.py
@@ -1,0 +1,61 @@
+"""The config surface promotes slack_accounts.json tokens into config.yaml's env
+block so a redeploy keeps the Slack platform enabled (the bullwinkle case).
+
+An agent provisioned via a multi-workspace slack_accounts.json carries its
+bot/app tokens there, not in config.yaml's env: block — and the gateway enables
+Slack off the env tokens. Without promotion a restarted gateway reports "No
+messaging platforms enabled".
+"""
+
+from __future__ import annotations
+
+import json
+
+import yaml
+
+import mac.hermes_config_surface as hcs
+
+
+def _write_accounts(home, accounts):
+    (home / "slack_accounts.json").write_text(json.dumps(accounts), encoding="utf-8")
+
+
+def test_promotes_first_valid_account_tokens(tmp_path):
+    _write_accounts(tmp_path, [
+        {"name": "offtera", "bot_token": "xoxb-AAA", "app_token": "xapp-BBB", "user_token": "xoxp-CCC"},
+        {"name": "omgjkh", "bot_token": "xoxb-DDD", "app_token": "xapp-EEE"},
+    ])
+    cfg: dict = {}
+    hcs._promote_slack_accounts_tokens(cfg, tmp_path)
+    assert cfg["env"]["SLACK_BOT_TOKEN"] == "xoxb-AAA"
+    assert cfg["env"]["SLACK_APP_TOKEN"] == "xapp-BBB"
+    assert cfg["env"]["SLACK_USER_TOKEN"] == "xoxp-CCC"
+
+
+def test_explicit_env_tokens_win(tmp_path):
+    _write_accounts(tmp_path, [{"name": "x", "bot_token": "xoxb-AAA", "app_token": "xapp-BBB"}])
+    cfg = {"env": {"SLACK_BOT_TOKEN": "xoxb-EXPLICIT", "SLACK_APP_TOKEN": "xapp-EXPLICIT"}}
+    hcs._promote_slack_accounts_tokens(cfg, tmp_path)
+    assert cfg["env"]["SLACK_BOT_TOKEN"] == "xoxb-EXPLICIT"  # not clobbered
+
+
+def test_no_accounts_file_is_noop(tmp_path):
+    cfg: dict = {}
+    hcs._promote_slack_accounts_tokens(cfg, tmp_path)
+    assert "env" not in cfg or not cfg["env"].get("SLACK_BOT_TOKEN")
+
+
+def test_skips_accounts_without_valid_token_shape(tmp_path):
+    _write_accounts(tmp_path, [{"name": "bad", "bot_token": "not-a-token", "app_token": ""}])
+    cfg: dict = {}
+    hcs._promote_slack_accounts_tokens(cfg, tmp_path)
+    assert not cfg.get("env", {}).get("SLACK_BOT_TOKEN")
+
+
+def test_apply_payload_promotes_tokens_end_to_end(tmp_path):
+    (tmp_path / "config.yaml").write_text("{}\n")
+    _write_accounts(tmp_path, [{"name": "offtera", "bot_token": "xoxb-LIVE", "app_token": "xapp-LIVE"}])
+    hcs.apply_hermes_surface_payload({}, target_home=tmp_path)
+    written = yaml.safe_load((tmp_path / "config.yaml").read_text()) or {}
+    assert (written.get("env") or {}).get("SLACK_BOT_TOKEN") == "xoxb-LIVE"
+    assert (written.get("env") or {}).get("SLACK_APP_TOKEN") == "xapp-LIVE"


### PR DESCRIPTION
## Symptom
After a redeploy, bullwinkle's gateway came up `No messaging platforms enabled` (didn't respond in Slack). Its Slack bot/app tokens live in a multi-workspace `~/.hermes/slack_accounts.json` (carried from its puck→madmax migration), **not** in `config.yaml`'s `env:` block — and the gateway enables the Slack platform off the env tokens. The config-surface regen on each deploy therefore left it Slack-less. (Fixed live by hand; this makes it durable.)

## Fix
`apply_hermes_surface_payload` now calls `_promote_slack_accounts_tokens()`: when `config.yaml`'s `env` lacks `SLACK_BOT_TOKEN`/`SLACK_APP_TOKEN` but `slack_accounts.json` has a valid `xoxb`/`xapp` account, promote the first such pair into `config['env']`.
- `setdefault` — an explicit env token wins; `slack_accounts.json` still drives the actual multi-workspace connections.
- Idempotent; no-op when tokens are already set or there's no accounts file.

## Tests
`tests/test_hermes_config_surface_slack_tokens.py` (5), incl. end-to-end through `apply_hermes_surface_payload`. The never-prompt approval tests remain green (11 total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)