### PR TITLE
feat(fleet): soul-snapshot Phase 2 — reference the binary memory layer (no content transfer)

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -712,12 +712,21 @@ def cmd_fleet_soul_pull(args: argparse.Namespace) -> None:
     fleet_name, agents, transport = _soul_snapshot_setup(args)
     dest = Path(args.into).expanduser()
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    manifest = _ss.pull_snapshot(agents, dest, transport, fleet=fleet_name, pulled_at=stamp)
+    manifest = _ss.pull_snapshot(
+        agents, dest, transport, fleet=fleet_name, pulled_at=stamp,
+        memory_checksum=getattr(args, "memory_checksum", False),
+    )
     (dest / "manifest.yaml").write_text(_yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
     summary = {
         "fleet": fleet_name, "into": str(dest), "pulled_at": stamp,
-        "agents": {n: {f: m.get("present") for f, m in a["files"].items()}
-                   for n, a in manifest["agents"].items()},
+        "agents": {
+            n: {
+                "soul": {f: m.get("present") for f, m in a["files"].items()},
+                "memory_refs": {f: m.get("bytes") for f, m in a.get("memory", {}).items()
+                                if m.get("present")},
+            }
+            for n, a in manifest["agents"].items()
+        },
     }
     _print(summary)
 
@@ -2367,6 +2376,10 @@ def build_parser() -> argparse.ArgumentParser:
     fleet_soul_pull.add_argument("--into", required=True, help="destination directory for the snapshot")
     fleet_soul_pull.add_argument(
         "--fleets-config", default=str(Path.home() / ".mac" / "fleets.yaml")
+    )
+    fleet_soul_pull.add_argument(
+        "--memory-checksum", action="store_true",
+        help="also sha256 the binary memory blobs (reads them remotely; slower)",
     )
     _set(cmd_fleet_soul_pull, fleet_soul_pull)
 

--- a/src/mac/soul_snapshot.py
+++ b/src/mac/soul_snapshot.py
@@ -26,10 +26,15 @@ import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Protocol, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple
 
 # The editable text layer. Relative to each agent's Hermes home (~/.hermes).
 SOUL_FILES: Tuple[str, ...] = ("SOUL.md", "USER.md", "MEMORY.md")
+
+# Phase 2: the binary memory layer — NOT editable, captured as references
+# (agent, date, size, optional sha256) in the manifest, never inlined. Content
+# is only transferred on explicit opt-in (these can be gigabytes).
+MEMORY_FILES: Tuple[str, ...] = ("state.db", "memory_store.db")
 
 SNAPSHOT_SCHEMA = "mac.soul_snapshot.v1"
 
@@ -54,6 +59,11 @@ class Transport(Protocol):
 
     def backup(self, target: str, relpath: str, *, stamp: str) -> Optional[str]:
         """Copy the current file aside; return the backup path, or None if absent."""
+
+    def stat(self, target: str, relpath: str, *, checksum: bool = False) -> Optional[Dict[str, Any]]:
+        """Return {bytes, mtime[, sha256]} for a file WITHOUT transferring it, or
+        None if absent. ``checksum`` adds sha256 (reads the file; can be slow on
+        large blobs)."""
 
 
 class SSHTransport:
@@ -106,6 +116,27 @@ class SSHTransport:
         if proc.returncode != 0:
             raise RuntimeError("write %s on %s failed: %s" % (relpath, target, proc.stderr.strip()))
 
+    def stat(self, target: str, relpath: str, *, checksum: bool = False) -> Optional[Dict[str, Any]]:
+        path = self._remote(relpath)
+        # Emit size+mtime on one line (instant), sha256 on the next (opt-in; it
+        # reads the whole file). Direct commands — no nested echo "$(...)" whose
+        # quoting gets mangled over ssh.
+        sha = (" sha256sum %s | cut -d' ' -f1;" % path) if checksum else ""
+        cmd = 'if [ -f %s ]; then stat -c "%%s %%Y" %s;%s else exit 7; fi' % (path, path, sha)
+        proc = subprocess.run([*self._ssh, target, cmd], capture_output=True, text=True)
+        if proc.returncode == 7:
+            return None
+        if proc.returncode != 0:
+            raise RuntimeError("stat %s on %s failed: %s" % (relpath, target, proc.stderr.strip()))
+        parts = proc.stdout.split()  # "<size> <mtime>[ <sha>]" across 1-2 lines
+        meta: Dict[str, Any] = {"present": True}
+        if len(parts) >= 2 and parts[0].isdigit():
+            meta["bytes"] = int(parts[0])
+            meta["mtime"] = int(parts[1])
+        if checksum and len(parts) >= 3:
+            meta["sha256"] = parts[2]
+        return meta
+
 
 # ---------------------------------------------------------------------------
 # Fleet roster
@@ -140,19 +171,27 @@ def pull_snapshot(
     fleet: str,
     pulled_at: str,
     soul_files: Sequence[str] = SOUL_FILES,
+    memory_files: Sequence[str] = MEMORY_FILES,
+    memory_checksum: bool = False,
 ) -> dict:
     """Pull SOUL_FILES from each agent into ``dest_dir`` and return the manifest.
 
     Writes ``<dest>/agents/<name>/soul/<file>`` for present files and a
     ``<dest>/manifest.yaml``. ``pulled_at`` is supplied by the caller.
+
+    Also records the binary memory layer (MEMORY_FILES) as **references** under
+    each agent's ``memory`` key — {present, bytes, mtime[, sha256]} — WITHOUT
+    transferring the (potentially gigabyte) content. ``memory_checksum`` adds a
+    sha256 (reads the remote blob; slower).
     """
     dest_dir = Path(dest_dir)
     manifest: dict = {
         "schema": SNAPSHOT_SCHEMA,
-        "layer": "soul",
+        "layer": "soul+memory-refs",
         "fleet": fleet,
         "pulled_at": pulled_at,
         "soul_files": list(soul_files),
+        "memory_files": list(memory_files),
         "agents": {},
     }
     for name, target in agents:
@@ -170,7 +209,14 @@ def pull_snapshot(
                 "sha256": _sha256(content),
                 "bytes": len(content.encode("utf-8")),
             }
-        manifest["agents"][name] = {"target": target, "files": files_meta}
+        # Binary memory: reference-only (metadata), never inlined.
+        memory_meta: Dict[str, dict] = {}
+        for rel in memory_files:
+            meta = transport.stat(target, rel, checksum=memory_checksum)
+            memory_meta[rel] = meta if meta is not None else {"present": False}
+        manifest["agents"][name] = {
+            "target": target, "files": files_meta, "memory": memory_meta,
+        }
     return manifest
 
 

--- a/tests/test_soul_snapshot.py
+++ b/tests/test_soul_snapshot.py
@@ -30,6 +30,15 @@ class FakeTransport:
         self.store.setdefault(target, {})[relpath] = content
         self.writes.append((target, relpath))
 
+    def stat(self, target, relpath, *, checksum=False):
+        content = self.store.get(target, {}).get(relpath)
+        if content is None:
+            return None
+        meta = {"present": True, "bytes": len(content.encode("utf-8")), "mtime": 1234567890}
+        if checksum:
+            meta["sha256"] = fs._sha256(content)
+        return meta
+
 
 def _agents():
     return [("natasha", "u@sparky"), ("rocky", "u@do1")]
@@ -66,6 +75,33 @@ def test_pull_writes_tree_manifest_and_sha(tmp_path):
     assert nm["files"]["USER.md"]["sha256"] == fs._sha256("I am Natasha")
     assert nm["files"]["SOUL.md"] == {"present": False}
     assert manifest["schema"] == fs.SNAPSHOT_SCHEMA and manifest["fleet"] == "rocky"
+
+
+# -- memory references (Phase 2) --------------------------------------------
+
+
+def test_pull_captures_memory_refs_not_content(tmp_path):
+    t = FakeTransport({
+        "u@sparky": {"USER.md": "n", "state.db": "x" * 5000, "memory_store.db": "y" * 99},
+        "u@do1": {"SOUL.md": "r"},
+    })
+    manifest = fs.pull_snapshot(_agents(), tmp_path, t, fleet="rocky", pulled_at="T0")
+    mem = manifest["agents"]["natasha"]["memory"]
+    assert mem["state.db"]["present"] is True
+    assert mem["state.db"]["bytes"] == 5000
+    assert "mtime" in mem["state.db"]
+    assert "sha256" not in mem["state.db"]
+    assert mem["memory_store.db"]["bytes"] == 99
+    assert manifest["agents"]["rocky"]["memory"]["state.db"] == {"present": False}
+    assert not (tmp_path / "agents/natasha/soul/state.db").exists()
+    assert not (tmp_path / "agents/natasha/memory").exists()
+
+
+def test_pull_memory_checksum_opt_in(tmp_path):
+    t = FakeTransport({"u@sparky": {"state.db": "blob"}, "u@do1": {}})
+    manifest = fs.pull_snapshot(_agents(), tmp_path, t, fleet="rocky", pulled_at="T0",
+                                memory_checksum=True)
+    assert manifest["agents"]["natasha"]["memory"]["state.db"]["sha256"] == fs._sha256("blob")
 
 
 # -- push: diff / dry-run / apply -------------------------------------------


### PR DESCRIPTION
Phase 2 of the fleet-snapshot architecture: capture each agent's **binary memory** (`state.db`, `memory_store.db`) as **references** in the manifest — `{present, bytes, mtime, optional sha256}` under the agent's `memory` key — **without transferring** the (gigabyte) content. This is the "binary blobs aren't editable but are referenced with date + agent metadata" layer.

- `Transport.stat(target, relpath, checksum=False)` — size+mtime instantly (no transfer); sha256 only on opt-in (reads the blob). `SSHTransport` uses `stat -c "%s %Y"` (+ optional `sha256sum`), passed as a single ssh arg to avoid quote-mangling.
- `pull_snapshot` records a `memory` ref section per agent; content is **never inlined**. **`push` is unchanged** (soul-text only) — so a snapshot can never clobber the live multi-GB memory by accident.
- CLI: `mac fleet soul-pull --memory-checksum`; the summary now shows `soul` + `memory_refs`.

### Validated live
`mac fleet soul-pull --fleet rocky` now records: bullwinkle `state.db` 1.55 GB, natasha 1.85 GB, rocky 2.42 GB — referenced, not pulled.

### Tests
`tests/test_soul_snapshot.py` (8): memory refs captured (metadata not content), checksum opt-in, plus the Phase 1 pull/push suite.

Remaining snapshot follow-ups (Phase 2b/3): Qdrant vector export + vetting (the deeper "Boris exorcism"), hub-stored persona/mood, and snapshot-as-canonical reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)