### PR TITLE
feat(fleet): OpenShell policy renderer + Phase 2b Qdrant memory vetting (steps 1-foundation & 2)

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -782,6 +782,46 @@ def cmd_fleet_soul_push(args: argparse.Namespace) -> None:
     })
 
 
+def cmd_fleet_memory_export(args: argparse.Namespace) -> None:
+    """Phase 2b: export the fleet's Qdrant vector memory to greppable JSONL for
+    vetting (find stale facts that wouldn't surface from the soul text)."""
+    import json as _json
+    from mac import memory_vetting as _mv
+
+    client = _mv.QdrantClient(args.qdrant_url)
+    collections = _csv(args.collections) if args.collections else list(_mv.DEFAULT_COLLECTIONS)
+    records = _mv.export_memory_records(client.scroll, collections, agent_id=args.agent or None)
+    if args.search:
+        records = _mv.search_records(records, args.search)
+    if args.into:
+        dest = Path(args.into).expanduser()
+        dest.write_text("\n".join(_json.dumps(r, default=str) for r in records) + "\n", encoding="utf-8")
+        _print({"qdrant": args.qdrant_url, "collections": collections, "records": len(records),
+                "into": str(dest), "search": args.search})
+    else:
+        for r in records:
+            sys.stdout.write(_json.dumps(r, default=str) + "\n")
+
+
+def cmd_fleet_memory_prune(args: argparse.Namespace) -> None:
+    """Phase 2b: delete vetted Qdrant point ids from a collection (destructive;
+    operator-vetted). Ids come from --id (repeatable) or a JSONL export via
+    --from-jsonl (uses each record's id)."""
+    import json as _json
+    from mac import memory_vetting as _mv
+
+    ids: List[Any] = list(args.id or [])
+    if args.from_jsonl:
+        for line in Path(args.from_jsonl).expanduser().read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                rec = _json.loads(line)
+                if rec.get("id") is not None:
+                    ids.append(rec["id"])
+    client = _mv.QdrantClient(args.qdrant_url)
+    _print(_mv.prune_points(client.delete, args.collection, ids))
+
+
 def _hub_get_mood(agent_id: Optional[str]) -> Optional[Dict[str, Any]]:
     """GET the agent's current mood overlay straight from the hub HTTP API.
 
@@ -2440,6 +2480,28 @@ def build_parser() -> argparse.ArgumentParser:
         "--agent", action="append", help="limit to this agent (repeatable)"
     )
     _set(cmd_fleet_soul_push, fleet_soul_push)
+
+    # Phase 2b: export/vet the fleet's Qdrant vector memory.
+    fleet_mem_export = fleet.add_parser(
+        "memory-export",
+        help="export Qdrant vector memory to greppable JSONL for vetting",
+    )
+    fleet_mem_export.add_argument("--qdrant-url", required=True, help="e.g. http://100.125.137.89:6333")
+    fleet_mem_export.add_argument("--agent", help="filter to this agent_id")
+    fleet_mem_export.add_argument("--collections", help="CSV of collections (default: mac_memory_medium,mac_memory_long)")
+    fleet_mem_export.add_argument("--search", help="case-insensitive substring filter (e.g. a stale name)")
+    fleet_mem_export.add_argument("--into", help="write JSONL here (default: stdout)")
+    _set(cmd_fleet_memory_export, fleet_mem_export)
+
+    fleet_mem_prune = fleet.add_parser(
+        "memory-prune",
+        help="DELETE vetted Qdrant point ids from a collection (destructive)",
+    )
+    fleet_mem_prune.add_argument("--qdrant-url", required=True)
+    fleet_mem_prune.add_argument("--collection", required=True)
+    fleet_mem_prune.add_argument("--id", action="append", help="point id to delete (repeatable)")
+    fleet_mem_prune.add_argument("--from-jsonl", help="delete the ids in this memory-export JSONL")
+    _set(cmd_fleet_memory_prune, fleet_mem_prune)
 
     fleet_refresh = fleet.add_parser(
         "refresh-context",

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -690,6 +690,32 @@ def cmd_fleet_snapshot(args: argparse.Namespace) -> None:
     _print(_plane(args).fleet_snapshot(exclude_agent_id=getattr(args, "agent", None)))
 
 
+def cmd_openshell_render_policy(args: argparse.Namespace) -> None:
+    """Render the OpenShell guardrail policy from the operator template + fleet
+    values; install at ~/.mac/openshell-policy.yaml (or print). The policy half
+    of executor sandbox enforcement (flipping it on additionally needs the
+    Hermes-runtime sandbox image)."""
+    from mac import openshell_policy as _op
+
+    template = Path(args.template).expanduser().read_text(encoding="utf-8")
+    rendered = _op.render_policy(
+        template,
+        agent_user=args.agent_user,
+        hub_host=args.hub_host,
+        hub_port=args.hub_port,
+        model_gateway_host=getattr(args, "model_gateway_host", None),
+        shared_services={"qdrant": args.qdrant_port, "firecrawl": args.firecrawl_port},
+    )
+    if args.into:
+        dest = Path(args.into).expanduser()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(rendered, encoding="utf-8")
+        dest.chmod(0o600)
+        _print({"wrote": str(dest), "bytes": len(rendered)})
+    else:
+        sys.stdout.write(rendered)
+
+
 def _soul_snapshot_setup(args):
     """Resolve (fleet_name, agents, transport) for the soul pull/push commands."""
     import yaml as _yaml
@@ -2289,6 +2315,25 @@ def build_parser() -> argparse.ArgumentParser:
     project_show = project.add_parser("show")
     project_show.add_argument("project")
     _set(cmd_project_show, project_show)
+
+    openshell = sub.add_parser("openshell", help="OpenShell sandbox guardrail commands").add_subparsers(dest="openshell_command", required=True)
+    osh_render = openshell.add_parser(
+        "render-policy",
+        help="render the OpenShell guardrail policy from the operator template for this fleet",
+    )
+    osh_render.add_argument("--agent-user", required=True, help="home owner on the agent host (e.g. jkh)")
+    osh_render.add_argument("--hub-host", required=True, help="MAC hub host (e.g. 100.125.137.89)")
+    osh_render.add_argument("--hub-port", type=int, default=8789)
+    osh_render.add_argument("--model-gateway-host", help="LLM gateway host (default: hub host)")
+    osh_render.add_argument("--qdrant-port", type=int, default=6333)
+    osh_render.add_argument("--firecrawl-port", type=int, default=3002)
+    osh_render.add_argument(
+        "--template",
+        default=str(Path(__file__).resolve().parents[2] / "deploy" / "openshell" / "mac-hermes-policy.yaml"),
+        help="operator policy template path",
+    )
+    osh_render.add_argument("--into", help="write the rendered policy here (default: stdout)")
+    _set(cmd_openshell_render_policy, osh_render)
 
     machine = sub.add_parser("machine", help="machine registry commands").add_subparsers(dest="machine_command", required=True)
     machine_register = machine.add_parser("register")

--- a/src/mac/memory_vetting.py
+++ b/src/mac/memory_vetting.py
@@ -1,0 +1,112 @@
+"""Phase 2b — export the fleet's vector memory for vetting (+ a vetted prune).
+
+The soul snapshot (Phase 1/2) covers the editable identity text and references
+the binary memory blobs. This adds the *semantic* memory layer: export each
+agent's Qdrant memories into a flat, greppable JSONL so an operator can find
+stale facts (a long-dead teammate, a retired directive) that wouldn't surface
+from the soul text alone — and then prune the vetted point ids.
+
+Transport is injectable: pass ``scroll(collection) -> iterable[point]`` and
+``delete(collection, ids)`` callables; the HTTP implementations talk to Qdrant's
+REST API. Pure record-shaping (:func:`export_memory_records`) is unit-tested
+with a fake; the network layer is a thin wrapper.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+DEFAULT_COLLECTIONS: Sequence[str] = ("mac_memory_medium", "mac_memory_long")
+
+# Payload fields worth surfacing for vetting (see the live Qdrant schema).
+_VET_FIELDS = ("memory_id", "agent_id", "summary", "tags", "tier", "subject_type",
+               "subject_id", "created_at")
+
+
+def export_memory_records(
+    scroll: Callable[[str], Iterable[Dict[str, Any]]],
+    collections: Sequence[str] = DEFAULT_COLLECTIONS,
+    *,
+    agent_id: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Flatten Qdrant points across *collections* into vetting records.
+
+    ``scroll(collection)`` yields points shaped ``{id, payload}``. Records keep
+    the point ``id`` + ``collection`` (needed to prune) plus the vetting fields.
+    Filters to ``agent_id`` when given.
+    """
+    out: List[Dict[str, Any]] = []
+    for col in collections:
+        for point in scroll(col):
+            payload = point.get("payload") or {}
+            if agent_id is not None and str(payload.get("agent_id")) != str(agent_id):
+                continue
+            rec: Dict[str, Any] = {"collection": col, "id": point.get("id")}
+            for f in _VET_FIELDS:
+                if f in payload:
+                    rec[f] = payload[f]
+            out.append(rec)
+    return out
+
+
+def search_records(records: Sequence[Dict[str, Any]], needle: str) -> List[Dict[str, Any]]:
+    """Case-insensitive substring match over each record's text (the vetting
+    convenience the operator would otherwise grep for)."""
+    n = needle.lower()
+    return [r for r in records if n in json.dumps(r, default=str).lower()]
+
+
+def prune_points(
+    delete: Callable[[str, List[Any]], Any],
+    collection: str,
+    ids: Sequence[Any],
+) -> Dict[str, Any]:
+    """Delete the vetted point ids from *collection*. No-op for an empty list."""
+    ids = [i for i in ids if i is not None]
+    if not ids:
+        return {"collection": collection, "deleted": 0, "skipped": "no ids"}
+    delete(collection, ids)
+    return {"collection": collection, "deleted": len(ids)}
+
+
+# ---------------------------------------------------------------------------
+# Qdrant REST transport
+# ---------------------------------------------------------------------------
+
+
+class QdrantClient:
+    """Minimal Qdrant REST client: scroll (paginated) + delete-by-id."""
+
+    def __init__(self, base_url: str, *, timeout: float = 15.0, page: int = 256) -> None:
+        self.base = base_url.rstrip("/")
+        self.timeout = timeout
+        self.page = page
+
+    def _post(self, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        req = urllib.request.Request(
+            self.base + path,
+            data=json.dumps(body).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:  # noqa: S310
+            return json.loads(resp.read().decode("utf-8", "replace"))
+
+    def scroll(self, collection: str) -> Iterable[Dict[str, Any]]:
+        offset = None
+        while True:
+            body: Dict[str, Any] = {"limit": self.page, "with_payload": True, "with_vector": False}
+            if offset is not None:
+                body["offset"] = offset
+            result = self._post("/collections/%s/points/scroll" % collection, body).get("result", {})
+            points = result.get("points", []) or []
+            for p in points:
+                yield p
+            offset = result.get("next_page_offset")
+            if not offset or not points:
+                break
+
+    def delete(self, collection: str, ids: List[Any]) -> Dict[str, Any]:
+        return self._post("/collections/%s/points/delete" % collection, {"points": list(ids)})

--- a/src/mac/openshell_policy.py
+++ b/src/mac/openshell_policy.py
@@ -1,0 +1,91 @@
+"""Render the OpenShell guardrail policy from the operator template.
+
+A real policy is fleet-specific — it names the actual hub / Qdrant / Firecrawl
+hosts and the agent's home user — so it can't be committed verbatim; it's
+rendered at deploy time from ``deploy/openshell/mac-hermes-policy.yaml`` and
+installed at ``~/.mac/openshell-policy.yaml`` (where the executor's
+``_resolve_openshell_policy`` finds it). This is the policy half of OpenShell
+enforcement; flipping ``MAC_OPENSHELL_SANDBOX=1`` + fail-closed additionally
+requires the Hermes-runtime sandbox image to be present (tracked separately).
+
+``render_policy`` substitutes the ``__PLACEHOLDER__`` tokens and appends the
+shared-service egress blocks (Qdrant, Firecrawl) the template leaves to the
+operator, then verifies no placeholder survived (fail-closed against a
+half-filled policy).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional
+
+_PLACEHOLDER_RE = re.compile(r"__[A-Z0-9_]+__")
+
+
+def render_policy(
+    template_text: str,
+    *,
+    agent_user: str,
+    hub_host: str,
+    hub_port: int,
+    model_gateway_host: Optional[str] = None,
+    shared_services: Optional[Dict[str, int]] = None,
+) -> str:
+    """Fill the operator policy template for one fleet.
+
+    - ``agent_user`` -> ``__AGENT_USER__`` (the home owner; runtime + caches).
+    - ``hub_host``/``hub_port`` -> the MAC hub (tasks/evidence/LLM router).
+    - ``model_gateway_host`` -> the LLM gateway host; defaults to ``hub_host``
+      (the in-mac router serves ``/v1`` from the hub).
+    - ``shared_services`` -> {name: port} egress blocks appended to
+      network_policies (e.g. {"qdrant": 6333, "firecrawl": 3002}), all on
+      ``hub_host`` (the fleet's shared-services manager).
+
+    Raises ``ValueError`` if any ``__PLACEHOLDER__`` remains unresolved.
+    """
+    if not agent_user or not hub_host or not hub_port:
+        raise ValueError("agent_user, hub_host and hub_port are required")
+    text = template_text
+    subs = {
+        "__AGENT_USER__": agent_user,
+        "__MAC_HUB_HOST__": hub_host,
+        "__MAC_HUB_PORT__": str(hub_port),
+        "__MODEL_GATEWAY_HOST__": str(model_gateway_host or hub_host),
+    }
+    for token, value in subs.items():
+        text = text.replace(token, value)
+
+    blocks = _shared_service_blocks(shared_services or {}, hub_host, agent_user)
+    if blocks:
+        text = text.rstrip() + "\n" + blocks + "\n"
+
+    # Only fail on placeholders in ACTIVE config — the template documents tokens
+    # in prose comments and keeps an optional commented-out block, both of which
+    # legitimately retain __TOKENS__.
+    active = "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith("#"))
+    leftover = sorted(set(_PLACEHOLDER_RE.findall(active)))
+    if leftover:
+        raise ValueError("unresolved policy placeholders: %s" % ", ".join(leftover))
+    return text
+
+
+def _shared_service_blocks(services: Dict[str, int], host: str, agent_user: str) -> str:
+    """YAML network_policies blocks for the fleet's shared services (Qdrant,
+    Firecrawl, …), appended under the template's existing network_policies."""
+    lines: List[str] = []
+    py = "/home/%s/.mac/venv/bin/python" % agent_user
+    for name in sorted(services):
+        port = int(services[name])
+        lines += [
+            "  %s:" % name,
+            "    name: %s" % name,
+            "    endpoints:",
+            "      - host: %s" % host,
+            "        port: %d" % port,
+            "        protocol: rest",
+            "        enforcement: enforce",
+            "        access: full",
+            "    binaries:",
+            "      - { path: %s }" % py,
+        ]
+    return "\n".join(lines)

--- a/tests/test_memory_vetting.py
+++ b/tests/test_memory_vetting.py
@@ -1,0 +1,59 @@
+"""Tests for Phase 2b vector-memory export/vetting (mac/memory_vetting.py)."""
+
+from __future__ import annotations
+
+from mac import memory_vetting as mv
+
+
+def _fake_scroll(store):
+    """store = {collection: [points]} -> a scroll(collection) callable."""
+    return lambda col: list(store.get(col, []))
+
+
+def test_export_flattens_and_keeps_id_collection():
+    store = {
+        "mac_memory_medium": [
+            {"id": 1, "payload": {"agent_id": "natasha", "summary": "knows Boris", "tier": "medium"}},
+            {"id": 2, "payload": {"agent_id": "rocky", "summary": "ships connectors"}},
+        ],
+        "mac_memory_long": [
+            {"id": 9, "payload": {"agent_id": "natasha", "summary": "DGX Spark host"}},
+        ],
+    }
+    recs = mv.export_memory_records(_fake_scroll(store), ["mac_memory_medium", "mac_memory_long"])
+    assert len(recs) == 3
+    r0 = next(r for r in recs if r["id"] == 1)
+    assert r0["collection"] == "mac_memory_medium"
+    assert r0["agent_id"] == "natasha" and r0["summary"] == "knows Boris"
+
+
+def test_export_filters_by_agent():
+    store = {"mac_memory_medium": [
+        {"id": 1, "payload": {"agent_id": "natasha", "summary": "a"}},
+        {"id": 2, "payload": {"agent_id": "rocky", "summary": "b"}},
+    ]}
+    recs = mv.export_memory_records(_fake_scroll(store), ["mac_memory_medium"], agent_id="natasha")
+    assert [r["id"] for r in recs] == [1]
+
+
+def test_search_records_substring_ci():
+    recs = [
+        {"id": 1, "summary": "knows BORIS the spy"},
+        {"id": 2, "summary": "ships connectors"},
+    ]
+    hits = mv.search_records(recs, "boris")
+    assert [r["id"] for r in hits] == [1]
+
+
+def test_prune_points_deletes_vetted_ids():
+    calls = []
+    delete = lambda col, ids: calls.append((col, list(ids)))
+    res = mv.prune_points(delete, "mac_memory_medium", [1, 2, None])
+    assert res["deleted"] == 2          # None filtered out
+    assert calls == [("mac_memory_medium", [1, 2])]
+
+
+def test_prune_noop_on_empty():
+    calls = []
+    res = mv.prune_points(lambda c, i: calls.append(1), "c", [])
+    assert res["deleted"] == 0 and calls == []

--- a/tests/test_openshell_policy.py
+++ b/tests/test_openshell_policy.py
@@ -1,0 +1,95 @@
+"""Tests for the OpenShell policy renderer (fills the operator template per fleet)."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from mac import openshell_policy as op
+
+TEMPLATE = """version: 1
+filesystem_policy:
+  read_only:
+    - /home/__AGENT_USER__/.mac/venv
+network_policies:
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: __MAC_HUB_HOST__
+        port: __MAC_HUB_PORT__
+        protocol: rest
+    binaries:
+      - { path: /home/__AGENT_USER__/.mac/venv/bin/python }
+  model_gateway:
+    name: model-gateway
+    endpoints:
+      - host: __MODEL_GATEWAY_HOST__
+        port: 443
+"""
+
+
+def test_render_substitutes_and_parses():
+    out = op.render_policy(
+        TEMPLATE, agent_user="jkh", hub_host="100.125.137.89", hub_port=8789,
+        shared_services={"qdrant": 6333, "firecrawl": 3002},
+    )
+    assert "__" not in out  # no placeholder survives
+    doc = yaml.safe_load(out)
+    np = doc["network_policies"]
+    assert np["mac_hub"]["endpoints"][0]["host"] == "100.125.137.89"
+    assert np["mac_hub"]["endpoints"][0]["port"] == 8789
+    # model gateway defaults to the hub host
+    assert np["model_gateway"]["endpoints"][0]["host"] == "100.125.137.89"
+    # shared-service blocks appended + valid
+    assert np["qdrant"]["endpoints"][0]["port"] == 6333
+    assert np["firecrawl"]["endpoints"][0]["host"] == "100.125.137.89"
+    assert "/home/jkh/.mac/venv" in out
+
+
+def test_explicit_model_gateway_host():
+    out = op.render_policy(
+        TEMPLATE, agent_user="u", hub_host="hubX", hub_port=8789,
+        model_gateway_host="gw.example",
+    )
+    doc = yaml.safe_load(out)
+    assert doc["network_policies"]["model_gateway"]["endpoints"][0]["host"] == "gw.example"
+
+
+def test_unresolved_placeholder_in_active_config_raises():
+    # an unresolved token in ACTIVE config (not a comment) -> fail closed
+    bad = TEMPLATE + "\n  extra:\n    host: __MYSTERY_TOKEN__\n"
+    with pytest.raises(ValueError, match="unresolved policy placeholders"):
+        op.render_policy(bad, agent_user="u", hub_host="h", hub_port=8789)
+
+
+def test_placeholder_in_comment_is_ignored():
+    # template documentation comments legitimately keep __TOKENS__
+    ok = TEMPLATE + "\n# see __PLACEHOLDER__ docs; optional __PYPI_MIRROR_HOST__\n"
+    out = op.render_policy(ok, agent_user="u", hub_host="h", hub_port=8789)
+    assert "__PLACEHOLDER__" in out  # preserved in the comment, did not raise
+
+
+def test_missing_required_args_raise():
+    with pytest.raises(ValueError):
+        op.render_policy(TEMPLATE, agent_user="", hub_host="h", hub_port=8789)
+
+
+def test_real_operator_template_renders(tmp_path):
+    # The actual shipped template must render to placeholder-free valid YAML.
+    from pathlib import Path
+    repo = Path(__file__).resolve().parents[1]
+    tmpl = (repo / "deploy" / "openshell" / "mac-hermes-policy.yaml").read_text(encoding="utf-8")
+    # render_policy raising on any ACTIVE-config placeholder is the guarantee;
+    # comments may still carry __TOKENS__ (template docs). Verify the parsed
+    # config is correct.
+    out = op.render_policy(
+        tmpl, agent_user="jkh", hub_host="100.125.137.89", hub_port=8789,
+        shared_services={"qdrant": 6333, "firecrawl": 3002},
+    )
+    doc = yaml.safe_load(out)
+    assert doc["network_policies"]["mac_hub"]["endpoints"][0]["host"] == "100.125.137.89"
+    assert doc["network_policies"]["mac_hub"]["endpoints"][0]["port"] == 8789
+    assert doc["network_policies"]["qdrant"]["endpoints"][0]["port"] == 6333
+    assert doc["network_policies"]["firecrawl"]["endpoints"][0]["host"] == "100.125.137.89"
+    assert doc["landlock"]["compatibility"] == "hard_requirement"
+    assert "/home/jkh/.mac/venv" in out  # agent_user substituted in active config


### PR DESCRIPTION
Two additive pieces the user asked for next:

## Task 1 (foundation) — OpenShell guardrail policy renderer
A real policy is fleet-specific, so it's **rendered** from `deploy/openshell/mac-hermes-policy.yaml`. `src/mac/openshell_policy.py::render_policy()` substitutes the `__PLACEHOLDER__` tokens, appends Qdrant/Firecrawl egress blocks on the hub, and **fails closed** if a placeholder survives in active config. CLI: `mac openshell render-policy --agent-user U --hub-host H [--into PATH]`.
- **Remaining (gated):** OpenShell sandboxes are containers (no bind-mount), so flipping `MAC_OPENSHELL_SANDBOX=1` + fail-closed still needs a Hermes-runtime sandbox image + `--upload` worktree + an end-to-end sandboxed-task validation. Not flipped here.

## Task 2 — Phase 2b Qdrant vector-memory vetting
`src/mac/memory_vetting.py`: export each agent's Qdrant memories to greppable JSONL (find stale facts the soul text wouldn't reveal) + a vetted prune. CLI: `mac fleet memory-export` / `mac fleet memory-prune`.
- Validated live against the rocky Qdrant: exported 20 records; `--search boris` returns nothing — confirming the Boris/Sweden staleness was only in the soul text (already fixed via Phase 1), never vectorized.

## Tests
`test_openshell_policy.py` (6) + `test_memory_vetting.py` (5); `test_openshell_sandbox.py` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)