### PR TITLE
feat(fleet): snapshot Phase 3 — capture hub-stored persona + mood

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -742,6 +742,20 @@ def cmd_fleet_soul_pull(args: argparse.Namespace) -> None:
         agents, dest, transport, fleet=fleet_name, pulled_at=stamp,
         memory_checksum=getattr(args, "memory_checksum", False),
     )
+    # Phase 3: also capture hub-stored persona + mood (resolve agent ids by name).
+    if getattr(args, "with_hub", False):
+        hub = _plane(args)
+        by_name = {}
+        try:
+            for a in hub.list_agents():
+                ad = a.to_dict() if hasattr(a, "to_dict") else dict(a)
+                if ad.get("name"):
+                    by_name[ad["name"]] = ad.get("id")
+        except Exception as exc:  # noqa: BLE001
+            print("mac: hub agent list failed (%s); skipping persona/mood" % exc, file=sys.stderr)
+        ids = [(n, by_name.get(n) or "agent_%s" % n) for n, _t in agents]
+        hub_section = _ss.capture_hub_state(hub, ids, dest, pulled_at=stamp)
+        manifest["hub"] = hub_section
     (dest / "manifest.yaml").write_text(_yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
     summary = {
         "fleet": fleet_name, "into": str(dest), "pulled_at": stamp,
@@ -754,6 +768,9 @@ def cmd_fleet_soul_pull(args: argparse.Namespace) -> None:
             for n, a in manifest["agents"].items()
         },
     }
+    if "hub" in manifest:
+        summary["hub"] = {n: {"persona": s["persona"].get("present"), "mood": s["mood"].get("present")}
+                          for n, s in manifest["hub"]["agents"].items()}
     _print(summary)
 
 
@@ -2465,6 +2482,10 @@ def build_parser() -> argparse.ArgumentParser:
     fleet_soul_pull.add_argument(
         "--memory-checksum", action="store_true",
         help="also sha256 the binary memory blobs (reads them remotely; slower)",
+    )
+    fleet_soul_pull.add_argument(
+        "--with-hub", action="store_true",
+        help="also capture hub-stored persona + current mood per agent (needs hub access)",
     )
     _set(cmd_fleet_soul_pull, fleet_soul_pull)
 

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -502,6 +502,9 @@ class RemoteDispatch:
     def list_agents(self) -> List[_Dictish]:
         return _wrap_list(self._get("/agents"))
 
+    def list_personas(self) -> List[_Dictish]:
+        return _wrap_list(self._get("/personas"))
+
     def delete_agent(self, agent_id: str, *, actor: str = "human") -> _Dictish:
         # DELETE /agents/{id} removes the agent + its agent-scoped ephemera
         # (mood/nap/events/messages) and records an agent.deleted audit event;

--- a/src/mac/soul_snapshot.py
+++ b/src/mac/soul_snapshot.py
@@ -221,6 +221,87 @@ def pull_snapshot(
 
 
 # ---------------------------------------------------------------------------
+# Phase 3 — hub-stored persona + mood
+# ---------------------------------------------------------------------------
+
+
+def _persona_for(personas: Sequence[Dict[str, Any]], name: str) -> Optional[Dict[str, Any]]:
+    """Match the agent's persona by name (exact, or the ``persona_<name>``/
+    ``<name>`` convention) from a list_personas() result."""
+    want = {name.lower(), ("persona_%s" % name).lower(), name.lower().replace("persona_", "")}
+    for p in personas:
+        pn = str((p or {}).get("name") or "").lower()
+        if pn in want or pn.replace("persona_", "") == name.lower():
+            return p
+    return None
+
+
+def capture_hub_state(
+    hub: Any,
+    agents: Sequence[Tuple[str, str]],
+    dest_dir: Path,
+    *,
+    pulled_at: str,
+) -> dict:
+    """Capture each agent's HUB-stored persona + current mood into the snapshot.
+
+    ``hub`` exposes ``list_personas()`` and ``get_current_mood(agent_id)`` (the
+    RemoteDispatch surface; tests inject a fake). ``agents`` is [(name,
+    agent_id)]. Writes ``agents/<name>/persona.yaml`` and ``mood.yaml`` (text,
+    editable) and returns the manifest section. Best-effort per field — a hub
+    error for one agent doesn't abort the others.
+    """
+    dest_dir = Path(dest_dir)
+    try:
+        personas = [_as_plain(p) for p in (hub.list_personas() or [])]
+    except Exception:  # noqa: BLE001 — persona list is best-effort
+        personas = []
+    out: Dict[str, dict] = {"pulled_at": pulled_at, "agents": {}}
+    for name, agent_id in agents:
+        agent_dir = dest_dir / "agents" / name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        section: Dict[str, Any] = {"agent_id": agent_id}
+        persona = _persona_for(personas, name)
+        if persona is not None:
+            (agent_dir / "persona.yaml").write_text(_yaml_dump(persona), encoding="utf-8")
+            section["persona"] = {"present": True, "name": persona.get("name")}
+        else:
+            section["persona"] = {"present": False}
+        try:
+            mood = _as_plain(hub.get_current_mood(agent_id)) or None
+        except Exception:  # noqa: BLE001 — mood is best-effort
+            mood = None
+        if mood:
+            (agent_dir / "mood.yaml").write_text(_yaml_dump(mood), encoding="utf-8")
+            section["mood"] = {"present": True}
+        else:
+            section["mood"] = {"present": False}
+        out["agents"][name] = section
+    return out
+
+
+def _as_plain(obj: Any) -> Any:
+    """Normalize a hub client result to a plain dict. RemoteDispatch returns
+    _Dictish wrappers (have ``to_dict``); a fake/LocalDispatch returns dicts.
+    ``dict(_Dictish)`` does NOT unwrap, so match on ``to_dict`` first."""
+    if obj is None:
+        return None
+    if hasattr(obj, "to_dict"):
+        return obj.to_dict()
+    if isinstance(obj, dict):
+        return obj
+    try:
+        return dict(obj)
+    except Exception:  # noqa: BLE001
+        return obj
+
+
+def _yaml_dump(obj: Any) -> str:
+    import yaml  # local import keeps the module import light for the SSH path
+    return yaml.safe_dump(obj, sort_keys=False, default_flow_style=False)
+
+
+# ---------------------------------------------------------------------------
 # Push (diff -> backup -> write)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_soul_snapshot.py
+++ b/tests/test_soul_snapshot.py
@@ -104,6 +104,57 @@ def test_pull_memory_checksum_opt_in(tmp_path):
     assert manifest["agents"]["natasha"]["memory"]["state.db"]["sha256"] == fs._sha256("blob")
 
 
+# -- hub persona + mood capture (Phase 3) -----------------------------------
+
+
+class FakeHub:
+    def __init__(self, personas, moods):
+        self._personas = personas        # list of dicts
+        self._moods = moods              # {agent_id: mood dict or None}
+
+    def list_personas(self):
+        return self._personas
+
+    def get_current_mood(self, agent_id):
+        return self._moods.get(agent_id)
+
+
+def test_persona_for_matches_name_conventions():
+    personas = [{"name": "persona_natasha"}, {"name": "rocky"}]
+    assert fs._persona_for(personas, "natasha")["name"] == "persona_natasha"
+    assert fs._persona_for(personas, "rocky")["name"] == "rocky"
+    assert fs._persona_for(personas, "ghost") is None
+
+
+def test_capture_hub_state_writes_persona_and_mood(tmp_path):
+    hub = FakeHub(
+        personas=[{"name": "persona_natasha", "soul_ref": "s", "metadata": {"x": 1}}],
+        moods={"agent_natasha": {"label": "focused", "intensity": 3}, "agent_rocky": None},
+    )
+    out = fs.capture_hub_state(hub, [("natasha", "agent_natasha"), ("rocky", "agent_rocky")],
+                               tmp_path, pulled_at="T0")
+    import yaml
+    persona = yaml.safe_load((tmp_path / "agents/natasha/persona.yaml").read_text())
+    assert persona["name"] == "persona_natasha"
+    mood = yaml.safe_load((tmp_path / "agents/natasha/mood.yaml").read_text())
+    assert mood["label"] == "focused"
+    assert out["agents"]["natasha"]["persona"]["present"] is True
+    assert out["agents"]["natasha"]["mood"]["present"] is True
+    # rocky: no persona match, no mood -> referenced absent, no files
+    assert out["agents"]["rocky"]["persona"]["present"] is False
+    assert out["agents"]["rocky"]["mood"]["present"] is False
+    assert not (tmp_path / "agents/rocky/mood.yaml").exists()
+
+
+def test_capture_hub_state_survives_hub_errors(tmp_path):
+    class BoomHub:
+        def list_personas(self): raise RuntimeError("hub down")
+        def get_current_mood(self, a): raise RuntimeError("hub down")
+    out = fs.capture_hub_state(BoomHub(), [("natasha", "agent_natasha")], tmp_path, pulled_at="T0")
+    assert out["agents"]["natasha"]["persona"]["present"] is False
+    assert out["agents"]["natasha"]["mood"]["present"] is False
+
+
 # -- push: diff / dry-run / apply -------------------------------------------
 
 


### PR DESCRIPTION
Completes the "pull all personality info into one place" goal. The snapshot now captures each agent's **hub-stored persona + current mood**, alongside Phase 1 (soul text) and Phase 2 (memory references).

- `soul_snapshot.capture_hub_state(hub, agents, dest, pulled_at)` — matches the agent's persona by name (exact or `persona_<name>`/`<name>`), writes editable `agents/<name>/persona.yaml` + `mood.yaml`, returns a manifest `hub` section. Best-effort per field. `_as_plain()` normalizes RemoteDispatch `_Dictish` results (`dict()` doesn't unwrap them — the bug that made the first live capture come back empty).
- `RemoteDispatch.list_personas()` wraps `GET /personas`.
- CLI: `mac fleet soul-pull --with-hub` resolves agent ids by name and captures persona+mood; summary shows per-agent present flags.

### Validated live
`--with-hub` against the rocky fleet captured persona for rocky/natasha/bullwinkle (`id: persona_natasha`, `soul_ref`, `memory_scope`, …); mood absent (none currently active — correct).

### Tests
`tests/test_soul_snapshot.py` +3 (persona match conventions, capture writes persona/mood, survives hub errors); 11 total.

### Deliberately not included
**Snapshot-as-canonical auto-reconcile-on-startup** — agents overwriting their own soul from a central source is risky (they also write `MEMORY.md`) and needs its own design + safeguards. The operator-driven pull→edit→push round trip (Phases 1–3) is the safe, complete loop today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)