### PR TITLE
openshell: policy + executor wiring for image-based sandboxed agents

### DIFF
--- a/deploy/openshell/mac-hermes-policy.yaml
+++ b/deploy/openshell/mac-hermes-policy.yaml
@@ -27,27 +27,40 @@ filesystem_policy:
     - /sbin
     - /etc
     - /proc
-    - /dev/urandom
     - /var/log
-    # The vendored Hermes runtime + venv. Match these to your provisioning:
-    # if you bake an image, point at the in-image install path; if you upload,
-    # point at the upload target. The host default for a fleet agent is ~/.mac.
-    - /home/__AGENT_USER__/.mac/venv
-    - /home/__AGENT_USER__/.mac/src
+    # The vendored Hermes runtime + venv. The renderer fills these from the
+    # provisioning mode: host paths (~/.mac/venv, ~/.mac/src) by default, or the
+    # in-image install path (e.g. /opt/mac-venv) when rendered with image_runtime.
+    - __RUNTIME_VENV__
+    - __RUNTIME_SRC__
   read_write:
     - /tmp
-    - /dev/null
-    # The agent's home cache/state (pip, git config, tool caches). Tighten to
-    # specific subpaths if you want a smaller writable surface.
-    - /home/__AGENT_USER__/.cache
-    - /home/__AGENT_USER__/.config
+    # /dev as a directory (not the /dev/null leaf): under hard_requirement on
+    # Landlock ABI >= 3 (kernel 6.x) a device FILE given a directory access
+    # right (ReadDir) is rejected as "incompatible directory-only access-rights".
+    # The directory satisfies ReadDir and covers /dev/null + /dev/urandom.
+    - /dev
+    # The agent's home cache/state (pip, git config, tool caches). Host mode ->
+    # ~/.cache + ~/.config; image mode -> /tmp (the image bakes no per-user home,
+    # and these would otherwise be nonexistent leaves that break hard_requirement,
+    # which rejects a ReadDir right on a path it can't classify as a directory).
+    - __CACHE_DIR__
+    - __CONFIG_DIR__
 
 landlock:
-  # hard_requirement: FAIL the run if the kernel lacks Landlock (5.13+) or a
-  # declared path is unenforceable, rather than silently losing filesystem
-  # confinement. Drop to best_effort only for dev on kernels without Landlock
-  # (it skips unenforceable paths and emits a High-severity finding instead).
-  compatibility: hard_requirement
+  # best_effort — REQUIRED here, not a relaxation: this policy declares
+  # network_policies, and OpenShell's egress proxy adds a directory ReadDir
+  # access-right on its own (non-directory) proxy path. Under hard_requirement,
+  # Landlock ABI >= 3 (kernel 6.x) rejects that as "incompatible directory-only
+  # access-rights" and the sandbox fails to start. best_effort skips ONLY that
+  # one incompatible internal rule and still fully enforces every declared path
+  # (validated: writes to read-only paths and reads of non-granted paths are
+  # denied) plus deny-by-default network egress (the L7 proxy, independent of
+  # Landlock). The one guarantee best_effort drops — aborting on a kernel with
+  # NO Landlock at all — is recovered by the executor's _kernel_has_landlock()
+  # precheck, which fails closed before launching. The deny-all bundled default
+  # (no proxy) keeps hard_requirement.
+  compatibility: best_effort
 
 process:
   # Never root. The supervisor drops privileges to this identity.
@@ -66,7 +79,7 @@ network_policies:
         enforcement: enforce
         access: full
     binaries:
-      - { path: /home/__AGENT_USER__/.mac/venv/bin/python }
+      - { path: __RUNTIME_PY__ }
 
   # --- Model gateway: the agent's LLM calls. Scope to YOUR gateway host. ---
   model_gateway:
@@ -78,7 +91,7 @@ network_policies:
         enforcement: enforce
         access: full
     binaries:
-      - { path: /home/__AGENT_USER__/.mac/venv/bin/python }
+      - { path: __RUNTIME_PY__ }
 
   # --- Git over HTTPS for task results (push branches / read repos). ---
   # If you push over SSH instead, model that as a raw TCP endpoint on port 22

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -705,6 +705,7 @@ def cmd_openshell_render_policy(args: argparse.Namespace) -> None:
         hub_port=args.hub_port,
         model_gateway_host=getattr(args, "model_gateway_host", None),
         shared_services={"qdrant": args.qdrant_port, "firecrawl": args.firecrawl_port},
+        image_runtime=getattr(args, "image_runtime", None),
     )
     if args.into:
         dest = Path(args.into).expanduser()
@@ -2558,6 +2559,11 @@ def build_parser() -> argparse.ArgumentParser:
     osh_render.add_argument("--hub-host", required=True, help="MAC hub host (e.g. 100.125.137.89)")
     osh_render.add_argument("--hub-port", type=int, default=8789)
     osh_render.add_argument("--model-gateway-host", help="LLM gateway host (default: hub host)")
+    osh_render.add_argument(
+        "--image-runtime",
+        help="in-image runtime path (e.g. /opt/mac-venv) when the sandbox runs a "
+        "prebuilt --from image instead of a host-uploaded runtime; caches -> /tmp",
+    )
     osh_render.add_argument("--qdrant-port", type=int, default=6333)
     osh_render.add_argument("--firecrawl-port", type=int, default=3002)
     osh_render.add_argument(

--- a/src/mac/openshell/default-policy.yaml
+++ b/src/mac/openshell/default-policy.yaml
@@ -34,10 +34,14 @@ filesystem_policy:
     - /sbin
     - /etc
     - /proc
-    - /dev/urandom
   read_write:
     - /tmp
-    - /dev/null
+    # /dev as a directory (not individual device leaves): under hard_requirement
+    # on Landlock ABI >= 3 (kernel 6.x), a device FILE given a directory access
+    # right (ReadDir) is rejected as "incompatible directory-only access-rights".
+    # The /dev directory satisfies ReadDir and covers /dev/null + /dev/urandom;
+    # a rootless container's /dev is a minimal safe set (null/zero/urandom/tty).
+    - /dev
 
 landlock:
   # Fail closed: abort if the kernel lacks Landlock (5.13+) or a declared path

--- a/src/mac/openshell_policy.py
+++ b/src/mac/openshell_policy.py
@@ -30,6 +30,7 @@ def render_policy(
     hub_port: int,
     model_gateway_host: Optional[str] = None,
     shared_services: Optional[Dict[str, int]] = None,
+    image_runtime: Optional[str] = None,
 ) -> str:
     """Fill the operator policy template for one fleet.
 
@@ -40,14 +41,38 @@ def render_policy(
     - ``shared_services`` -> {name: port} egress blocks appended to
       network_policies (e.g. {"qdrant": 6333, "firecrawl": 3002}), all on
       ``hub_host`` (the fleet's shared-services manager).
+    - ``image_runtime`` -> when set (e.g. ``/opt/mac-venv``), the runtime/caches
+      resolve to the in-image install paths instead of the host ``~/.mac`` —
+      use this when the sandbox runs a prebuilt image via ``--from`` rather than
+      a host-uploaded runtime. In image mode caches live under ``/tmp`` (the
+      image bakes no per-user home).
 
     Raises ``ValueError`` if any ``__PLACEHOLDER__`` remains unresolved.
     """
     if not agent_user or not hub_host or not hub_port:
         raise ValueError("agent_user, hub_host and hub_port are required")
+    if image_runtime:
+        runtime_venv = image_runtime.rstrip("/")
+        runtime_src = runtime_venv
+        # No per-user home in the image; caches land under /tmp (already in the
+        # writable set, so these resolve to existing, Landlock-classifiable dirs
+        # rather than nonexistent leaves that would break hard_requirement).
+        cache_dir = config_dir = "/tmp"
+    else:
+        base = "/home/%s/.mac" % agent_user
+        runtime_venv = base + "/venv"
+        runtime_src = base + "/src"
+        cache_dir = "/home/%s/.cache" % agent_user
+        config_dir = "/home/%s/.config" % agent_user
+    runtime_py = runtime_venv + "/bin/python"
     text = template_text
     subs = {
         "__AGENT_USER__": agent_user,
+        "__CACHE_DIR__": cache_dir,
+        "__CONFIG_DIR__": config_dir,
+        "__RUNTIME_VENV__": runtime_venv,
+        "__RUNTIME_SRC__": runtime_src,
+        "__RUNTIME_PY__": runtime_py,
         "__MAC_HUB_HOST__": hub_host,
         "__MAC_HUB_PORT__": str(hub_port),
         "__MODEL_GATEWAY_HOST__": str(model_gateway_host or hub_host),
@@ -55,7 +80,7 @@ def render_policy(
     for token, value in subs.items():
         text = text.replace(token, value)
 
-    blocks = _shared_service_blocks(shared_services or {}, hub_host, agent_user)
+    blocks = _shared_service_blocks(shared_services or {}, hub_host, runtime_py)
     if blocks:
         text = text.rstrip() + "\n" + blocks + "\n"
 
@@ -69,11 +94,13 @@ def render_policy(
     return text
 
 
-def _shared_service_blocks(services: Dict[str, int], host: str, agent_user: str) -> str:
+def _shared_service_blocks(services: Dict[str, int], host: str, py: str) -> str:
     """YAML network_policies blocks for the fleet's shared services (Qdrant,
-    Firecrawl, …), appended under the template's existing network_policies."""
+    Firecrawl, …), appended under the template's existing network_policies.
+
+    ``py`` is the runtime python binary allowed to make the egress (host or
+    in-image path), matching the filesystem policy's runtime location."""
     lines: List[str] = []
-    py = "/home/%s/.mac/venv/bin/python" % agent_user
     for name in sorted(services):
         port = int(services[name])
         lines += [

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -1069,11 +1069,22 @@ def write_fallback_evidence_manifest(task_workspace: Path, task: Dict[str, Any],
 
 
 def _hermes_argv(prompt: str) -> List[str]:
-    """The agent invocation. Sets PYTHONPATH for the vendored Hermes runtime."""
-    hermes_py = Path.home() / ".mac" / "venv" / "bin" / "python"
-    hermes_vendored = str(Path.home() / ".mac" / "src" / "mac" / "src" / "mac" / "_hermes")
-    os.environ["PYTHONPATH"] = hermes_vendored + os.pathsep + os.environ.get("PYTHONPATH", "")
-    return [str(hermes_py), "-m", "hermes_cli.main", "chat", "--query", prompt, "--quiet", "--accept-hooks", "--yolo"]
+    """The agent invocation.
+
+    Host mode: the vendored Hermes runtime under ``~/.mac`` — set PYTHONPATH so
+    ``hermes_cli`` resolves. Sandbox image mode: ``MAC_HERMES_PYTHON`` points at
+    the in-image interpreter (e.g. ``/opt/mac-venv/bin/python``) whose
+    site-packages already contain ``hermes_cli``, so no host PYTHONPATH is
+    injected — and the host path would not exist inside the sandbox anyway.
+    """
+    override = (os.environ.get("MAC_HERMES_PYTHON") or "").strip()
+    if override:
+        hermes_py = override
+    else:
+        hermes_py = str(Path.home() / ".mac" / "venv" / "bin" / "python")
+        hermes_vendored = str(Path.home() / ".mac" / "src" / "mac" / "src" / "mac" / "_hermes")
+        os.environ["PYTHONPATH"] = hermes_vendored + os.pathsep + os.environ.get("PYTHONPATH", "")
+    return [hermes_py, "-m", "hermes_cli.main", "chat", "--query", prompt, "--quiet", "--accept-hooks", "--yolo"]
 
 
 # ---------------------------------------------------------------------------
@@ -1151,9 +1162,38 @@ def _openshell_required_for_local_agent() -> bool:
     return base in {"rocky", "bullwinkle", "natasha"}
 
 
+_OPENSHELL_HOST_ALIAS_DEFAULT = "host.openshell.internal"
+_HOST_LOCAL_HOSTS = ("127.0.0.1", "localhost", "0.0.0.0", "[::1]", "::1")
+
+
+def _openshell_host_alias() -> str:
+    """The in-sandbox alias for the host (OpenShell injects this hosts entry).
+    A forwarded ``http://127.0.0.1:8789`` is unreachable from inside the sandbox
+    (that loopback is the sandbox's own); rewrite it to this alias."""
+    return (os.environ.get("MAC_OPENSHELL_HOST_ALIAS") or "").strip() or _OPENSHELL_HOST_ALIAS_DEFAULT
+
+
+def _rewrite_host_local_url(value: str, alias: str) -> str:
+    """Rewrite a URL whose host is the machine's loopback to the sandbox host
+    alias, so forwarded service URLs (MAC_HUB_URL, gateway base) resolve from
+    inside the sandbox. Only touches values that look like URLs (contain '://')
+    and only the authority's loopback host — tokens/other values pass through."""
+    if not value or "://" not in value:
+        return value
+    out = value
+    for h in _HOST_LOCAL_HOSTS:
+        out = out.replace("://%s" % h, "://%s" % alias).replace("@%s" % h, "@%s" % alias)
+    return out
+
+
 def _openshell_env_flags() -> List[str]:
-    """``--env NAME=VALUE`` flags for each *set* passthrough variable."""
+    """``--env NAME=VALUE`` flags for each *set* passthrough variable.
+
+    URL-valued vars have a host loopback rewritten to the sandbox host alias
+    (see :func:`_rewrite_host_local_url`) so a forwarded ``http://127.0.0.1:PORT``
+    hub/gateway URL is reachable from inside the sandbox."""
     names = os.environ.get("MAC_OPENSHELL_ENV_PASSTHROUGH") or _DEFAULT_OPENSHELL_ENV_PASSTHROUGH
+    alias = _openshell_host_alias()
     flags: List[str] = []
     seen = set()
     for raw in names.split(","):
@@ -1164,8 +1204,26 @@ def _openshell_env_flags() -> List[str]:
         val = os.environ.get(name)
         if val is None:
             continue
+        val = _rewrite_host_local_url(val, alias)
         flags += ["--env", "%s=%s" % (name, val)]
     return flags
+
+
+def _kernel_has_landlock() -> bool:
+    """True if the running kernel exposes Landlock (the LSM is listed).
+
+    The operator policy uses ``landlock: best_effort`` because OpenShell's egress
+    proxy is incompatible with ``hard_requirement`` on current kernels (it adds a
+    directory ReadDir right on its own non-directory proxy path, which Landlock
+    ABI >= 3 rejects). best_effort still fully enforces on a Landlock-capable
+    kernel, but would silently run UNCONFINED on a kernel without Landlock — so
+    the executor performs this precheck to recover the fail-closed guarantee.
+    """
+    try:
+        lsm = Path("/sys/kernel/security/lsm").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return "landlock" in (lsm or "").split(",")
 
 
 def _bundled_default_policy() -> Path:
@@ -1220,6 +1278,18 @@ def _maybe_wrap_openshell(argv: List[str]) -> List[str]:
     """
     if not _openshell_enabled():
         return list(argv)
+    # Fail closed if the kernel can't enforce Landlock: the operator policy is
+    # best_effort (forced by OpenShell's proxy/hard_requirement incompatibility),
+    # which would otherwise run UNCONFINED on a Landlock-less kernel. Override
+    # only for a deliberate, audited exception.
+    if not _kernel_has_landlock() and not _truthy(os.environ.get("MAC_OPENSHELL_ALLOW_NO_LANDLOCK")):
+        raise RuntimeError(
+            "OpenShell sandboxing is enabled but the kernel does not expose "
+            "Landlock (/sys/kernel/security/lsm has no 'landlock'); the policy's "
+            "filesystem confinement (best_effort) would not be enforced. Refusing "
+            "to run (fail closed). Use a Landlock-capable kernel (>=5.13, ABI>=3 "
+            "recommended), or set MAC_OPENSHELL_ALLOW_NO_LANDLOCK=1 to override."
+        )
     bin_ = (os.environ.get("MAC_OPENSHELL_BIN") or "openshell").strip() or "openshell"
     wrapped: List[str] = [bin_, "sandbox", "create", "--no-auto-providers"]
     # Always pass one of OUR policies — never omit --policy, which would let

--- a/tests/test_openshell_policy.py
+++ b/tests/test_openshell_policy.py
@@ -91,5 +91,46 @@ def test_real_operator_template_renders(tmp_path):
     assert doc["network_policies"]["mac_hub"]["endpoints"][0]["port"] == 8789
     assert doc["network_policies"]["qdrant"]["endpoints"][0]["port"] == 6333
     assert doc["network_policies"]["firecrawl"]["endpoints"][0]["host"] == "100.125.137.89"
-    assert doc["landlock"]["compatibility"] == "hard_requirement"
+    # operator policy is best_effort (OpenShell egress-proxy incompatibility with
+    # hard_requirement); the executor's Landlock precheck recovers fail-closed.
+    assert doc["landlock"]["compatibility"] == "best_effort"
     assert "/home/jkh/.mac/venv" in out  # agent_user substituted in active config
+
+
+def _real_template():
+    from pathlib import Path
+    repo = Path(__file__).resolve().parents[1]
+    return (repo / "deploy" / "openshell" / "mac-hermes-policy.yaml").read_text(encoding="utf-8")
+
+
+def test_dev_is_directory_not_leaf_under_hard_requirement():
+    # /dev device-FILE leaves (/dev/null, /dev/urandom) given a directory access
+    # right are rejected under hard_requirement on Landlock ABI >= 3; the policy
+    # must list the /dev DIRECTORY instead (in either provisioning mode).
+    for kwargs in ({}, {"image_runtime": "/opt/mac-venv"}):
+        out = op.render_policy(_real_template(), agent_user="jkh", hub_host="h",
+                               hub_port=8789, **kwargs)
+        doc = yaml.safe_load(out)
+        fp = doc["filesystem_policy"]
+        assert "/dev" in fp["read_write"]
+        assert "/dev/null" not in fp["read_write"]
+        assert "/dev/urandom" not in fp["read_only"]
+
+
+def test_image_runtime_uses_in_image_paths_and_tmp_caches():
+    out = op.render_policy(_real_template(), agent_user="jkh", hub_host="100.64.0.1",
+                           hub_port=8789, image_runtime="/opt/mac-venv",
+                           shared_services={"qdrant": 6333})
+    assert "__" not in "\n".join(l for l in out.splitlines() if not l.lstrip().startswith("#"))
+    doc = yaml.safe_load(out)
+    fp = doc["filesystem_policy"]
+    assert "/opt/mac-venv" in fp["read_only"]
+    assert not any("/.mac/venv" in p for p in fp["read_only"])  # not the host runtime
+    # caches resolve to /tmp (already writable) — NOT nonexistent /tmp/.cache
+    # leaves, which would break hard_requirement (ReadDir on an unclassifiable path)
+    assert "/tmp" in fp["read_write"]
+    assert not any(p.endswith("/.cache") or p.endswith("/.config") for p in fp["read_write"])
+    # network binaries reference the in-image python, not the host path
+    py = doc["network_policies"]["mac_hub"]["binaries"][0]["path"]
+    assert py == "/opt/mac-venv/bin/python"
+    assert doc["network_policies"]["qdrant"]["binaries"][0]["path"] == "/opt/mac-venv/bin/python"

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -29,6 +29,9 @@ _OPENSHELL_ENVS = [
     "MAC_OPENSHELL_KEEP",
     "MAC_OPENSHELL_CREATE_ARGS",
     "MAC_OPENSHELL_ENV_PASSTHROUGH",
+    "MAC_OPENSHELL_ALLOW_NO_LANDLOCK",
+    "MAC_OPENSHELL_HOST_ALIAS",
+    "MAC_HERMES_PYTHON",
     "MAC_ALLOW_UNSANDBOXED_YOLO",
     "HERMES_YOLO_MODE",
 ]
@@ -42,6 +45,9 @@ def _clean(monkeypatch, tmp_path):
     for name in _OPENSHELL_ENVS:
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
+    # Construction tests run on non-Landlock hosts (Mac/CI); bypass the kernel
+    # precheck so they exercise the wrap. The precheck has its own tests below.
+    monkeypatch.setenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", "1")
     yield
 
 
@@ -246,6 +252,73 @@ def test_agent_invocation_sandbox_overrides_failclosed_hatch(monkeypatch):
     out = te._agent_invocation("do the thing")
     assert out[0] == "openshell"
     assert "--yolo" in out
+
+
+# ---------------------------------------------------------------------------
+# image-mode runtime path + URL rewriting + Landlock precheck
+# ---------------------------------------------------------------------------
+
+
+def test_hermes_argv_uses_image_python_override(monkeypatch):
+    monkeypatch.setenv("MAC_HERMES_PYTHON", "/opt/mac-venv/bin/python")
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    argv = te._hermes_argv("do it")
+    assert argv[0] == "/opt/mac-venv/bin/python"
+    assert argv[1:4] == ["-m", "hermes_cli.main", "chat"]
+    # image runtime: no host vendored PYTHONPATH injected
+    assert "/.mac/src/" not in os.environ.get("PYTHONPATH", "")
+
+
+def test_hermes_argv_host_default_injects_pythonpath(monkeypatch):
+    monkeypatch.delenv("MAC_HERMES_PYTHON", raising=False)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    argv = te._hermes_argv("do it")
+    assert argv[0].endswith("/.mac/venv/bin/python")
+    assert "/.mac/src/mac/src/mac/_hermes" in os.environ["PYTHONPATH"]
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "0.0.0.0", "::1"])
+def test_rewrite_host_local_url(host):
+    alias = "host.openshell.internal"
+    src = "http://%s:8789/v1/" % ("[::1]" if host == "::1" else host)
+    assert te._rewrite_host_local_url(src, alias) == "http://host.openshell.internal:8789/v1/"
+
+
+def test_rewrite_leaves_nonloopback_and_nonurls():
+    alias = "host.openshell.internal"
+    assert te._rewrite_host_local_url("http://100.64.0.1:8789", alias) == "http://100.64.0.1:8789"
+    assert te._rewrite_host_local_url("secret-token-127.0.0.1", alias) == "secret-token-127.0.0.1"
+
+
+def test_env_flags_rewrite_loopback_urls(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_ENV_PASSTHROUGH", "MAC_HUB_URL,MAC_WORKER_TOKEN")
+    monkeypatch.setenv("MAC_HUB_URL", "http://127.0.0.1:8789")
+    monkeypatch.setenv("MAC_WORKER_TOKEN", "tok-127.0.0.1-abc")  # not a URL -> untouched
+    flags = te._openshell_env_flags()
+    assert "MAC_HUB_URL=http://host.openshell.internal:8789" in flags
+    assert "MAC_WORKER_TOKEN=tok-127.0.0.1-abc" in flags
+
+
+def test_host_alias_override(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_HOST_ALIAS", "10.0.0.1")
+    assert te._rewrite_host_local_url("http://127.0.0.1:8789", te._openshell_host_alias()) == "http://10.0.0.1:8789"
+
+
+def test_landlock_precheck_fail_closed(monkeypatch):
+    # sandbox on, kernel lacks Landlock, override absent -> refuse (fail closed)
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.delenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", raising=False)
+    monkeypatch.setattr(te, "_kernel_has_landlock", lambda: False)
+    with pytest.raises(RuntimeError, match="does not expose .*Landlock"):
+        te._maybe_wrap_openshell(_ARGV)
+
+
+def test_landlock_precheck_passes_when_present(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.delenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", raising=False)
+    monkeypatch.setattr(te, "_kernel_has_landlock", lambda: True)
+    out = te._maybe_wrap_openshell(_ARGV)
+    assert out[:3] == ["openshell", "sandbox", "create"]
 
 
 # --- child HERMES_YOLO_MODE env (fixes the approval.py import-order freeze) ---


### PR DESCRIPTION
## Summary

Turns the (now host-validated) OpenShell sandbox mechanism into a usable guardrail for image-based agents. Validated end-to-end on rocky: gateway mints JWTs, the sandbox authenticates + fetches policy + sets up the egress proxy, a command runs **confined**, and off-policy egress is **denied**. Three concrete fixes fell out, each proven on the host.

### Policy
- **`/dev` as a directory**, not device-file leaves. Under `hard_requirement` on Landlock ABI ≥ 3 (kernel 6.x), a device *file* (`/dev/null`, `/dev/urandom`) given a directory `ReadDir` right is rejected (`incompatible directory-only access-rights`). The `/dev` directory satisfies `ReadDir` and covers them.
- **Renderer image-mode** (`--image-runtime` / `image_runtime=`): filesystem + binary paths resolve to the in-image runtime (e.g. `/opt/mac-venv`) and caches to `/tmp`, instead of the host `~/.mac`. Nonexistent cache leaves (`/tmp/.cache`) also break `hard_requirement`, so image mode omits them.
- **Operator template → `landlock: best_effort`.** Required, not a relaxation: OpenShell's egress proxy adds a `ReadDir` right on its own *non-directory* proxy path, which `hard_requirement` rejects whenever `network_policies` have endpoints (i.e. every real agent). `best_effort` skips only that one internal rule and still enforces every declared path (verified: writes to read-only + reads of non-granted paths denied) + deny-by-default egress. The deny-all **bundled default keeps `hard_requirement`**.

### Executor
- `_hermes_argv` honors **`MAC_HERMES_PYTHON`** (the in-image interpreter whose site-packages already carry `hermes_cli`); no host `PYTHONPATH` injected in image mode.
- Forwarded **URL env vars** (`MAC_HUB_URL`, gateway base) have a loopback host rewritten to the sandbox host alias (`host.openshell.internal`) so they're reachable from inside the sandbox; non-URL values (tokens) untouched.
- **`_kernel_has_landlock()` precheck**: fail closed if the kernel can't enforce Landlock — recovers the guarantee `best_effort` drops (override `MAC_OPENSHELL_ALLOW_NO_LANDLOCK=1`).

## Safety
**Default OFF** (`MAC_OPENSHELL_SANDBOX` unset) — zero behavior change for the running fleet.

## Tests
86 pass — policy renderer image-mode + `/dev`; executor image-python, URL rewrite, Landlock precheck fail-closed.

## Not in this PR (follow-ups, tracked on `task_9babe9…`)
- Hermes config/soul provisioning into the sandbox (the main model gateway URL lives in `~/.hermes/config.yaml`, not the image, and has no env/CLI override) — required before a real task runs sandboxed.
- GPU-host image builds + `--gpu` passthrough for natasha/bullwinkle.
- The `MAC_OPENSHELL_SANDBOX=1` + `MAC_ALLOW_UNSANDBOXED_YOLO=0` fail-closed flip, gated on a proven sandboxed real task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)