### PR TITLE
openshell: worktree upload/download sync for sandboxed task execution

### DIFF
--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -60,6 +60,10 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 from mac import relay_observability
+from mac.openshell_runtime import (
+    openshell_required_for_local_agent as _openshell_required_for_local_agent,
+    truthy as _truthy,
+)
 
 # ---------------------------------------------------------------------------
 # Small utilities (ported verbatim from the deploy heredoc)
@@ -1133,33 +1137,18 @@ def _hermes_argv(prompt: str) -> List[str]:
 _DEFAULT_OPENSHELL_ENV_PASSTHROUGH = (
     "MAC_HUB_URL,MAC_URL,MAC_WORKER_TOKEN,MAC_TOKEN,MAC_API_TOKEN,"
     "MAC_WORKER_AGENT_ID,MAC_WORKER_AGENT_NAME,MAC_AGENT_ID,"
-    "HERMES_GATEWAY_BASE_URL,HERMES_GATEWAY_MODEL,HERMES_SESSION_KEY"
+    "HERMES_GATEWAY_BASE_URL,HERMES_GATEWAY_MODEL,HERMES_SESSION_KEY,"
+    # Model-gateway base_url + api_key live in the agent's ~/.hermes/.env, which
+    # is NOT in the sandbox image; the gateway requires auth. Forward them so the
+    # sandboxed hermes can authenticate (the *_BASE_URL values have their host
+    # loopback rewritten to the sandbox host alias by _openshell_env_flags).
+    "MAC_HERMES_GATEWAY_BASE_URL,MAC_HERMES_GATEWAY_API_KEY,MAC_HERMES_GATEWAY_PROVIDER,"
+    "OPENAI_BASE_URL,OPENAI_API_KEY"
 )
-
-
-def _truthy(value: Optional[str]) -> bool:
-    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _openshell_enabled() -> bool:
     return _truthy(os.environ.get("MAC_OPENSHELL_SANDBOX"))
-
-
-def _openshell_required_for_local_agent() -> bool:
-    explicit = os.environ.get("MAC_OPENSHELL_REQUIRED")
-    if explicit is not None:
-        return _truthy(explicit)
-    name = (
-        os.environ.get("MAC_AGENT_ID")
-        or os.environ.get("MAC_WORKER_AGENT_ID")
-        or os.environ.get("MAC_WORKER_AGENT_NAME")
-        or os.uname().nodename
-    )
-    base = str(name or "").strip().lower()
-    if base.startswith("agent_"):
-        base = base[len("agent_") :]
-    base = base.split(".", 1)[0]
-    return base in {"rocky", "bullwinkle", "natasha"}
 
 
 _OPENSHELL_HOST_ALIAS_DEFAULT = "host.openshell.internal"
@@ -1263,25 +1252,43 @@ def _resolve_openshell_policy() -> str:
     )
 
 
-def _maybe_wrap_openshell(argv: List[str]) -> List[str]:
-    """Wrap *argv* to run inside an OpenShell sandbox, if enabled.
+# OpenShell sandboxes are container copies with NO bind-mount, so the task git
+# worktree must be UPLOADED in and the agent's results DOWNLOADED back out — a
+# plain ``create -- argv`` would run the agent against an empty /sandbox and lose
+# its edits + evidence on teardown. The run is therefore a lifecycle:
+#   create (--upload workspace, run agent in it, KEEP) -> download -> delete.
+# ``include_workdir`` in the policy only grants Landlock access to the path; it
+# does not copy files. /sandbox is OpenShell's writable workspace root (uploads
+# and downloads must live under it).
+_SANDBOX_WORKDIR = "/sandbox"
 
-    Returns *argv* unchanged when sandboxing is disabled. When enabled, a policy
-    is ALWAYS passed via :func:`_resolve_openshell_policy` (explicit ->
-    deployed -> bundled fail-closed default), so OpenShell can never silently
-    apply its image-default profile; if no policy can be resolved this raises.
-    The sandbox is one-shot (torn down when the agent process exits) unless
-    MAC_OPENSHELL_KEEP is set. ``--name`` is omitted by default so OpenShell
-    assigns a unique name per run; set MAC_OPENSHELL_SANDBOX_NAME only to debug
-    a single run. The original *argv* is always preserved verbatim after the
-    ``--`` separator.
-    """
-    if not _openshell_enabled():
-        return list(argv)
-    # Fail closed if the kernel can't enforce Landlock: the operator policy is
-    # best_effort (forced by OpenShell's proxy/hard_requirement incompatibility),
-    # which would otherwise run UNCONFINED on a Landlock-less kernel. Override
-    # only for a deliberate, audited exception.
+
+def _openshell_bin() -> str:
+    return (os.environ.get("MAC_OPENSHELL_BIN") or "openshell").strip() or "openshell"
+
+
+def _sandbox_name() -> str:
+    """A unique name for the kept sandbox so the download + delete steps can
+    target it. Overridable via MAC_OPENSHELL_SANDBOX_NAME (debug a single run)."""
+    explicit = (os.environ.get("MAC_OPENSHELL_SANDBOX_NAME") or "").strip()
+    if explicit:
+        return explicit
+    import uuid
+
+    return "mac-task-" + uuid.uuid4().hex[:12]
+
+
+def _workspace_basename(workspace: Path) -> str:
+    """OpenShell's ``upload <dir> /sandbox`` nests the dir under its basename
+    (-> /sandbox/<basename>); that is where the agent runs and what we download."""
+    return os.path.basename(str(workspace).rstrip("/")) or "workspace"
+
+
+def _ensure_landlock_or_fail() -> None:
+    """Fail closed if the kernel can't enforce Landlock: the operator policy is
+    best_effort (forced by OpenShell's proxy/hard_requirement incompatibility),
+    which would otherwise run UNCONFINED on a Landlock-less kernel. Override only
+    for a deliberate, audited exception."""
     if not _kernel_has_landlock() and not _truthy(os.environ.get("MAC_OPENSHELL_ALLOW_NO_LANDLOCK")):
         raise RuntimeError(
             "OpenShell sandboxing is enabled but the kernel does not expose "
@@ -1290,23 +1297,88 @@ def _maybe_wrap_openshell(argv: List[str]) -> List[str]:
             "to run (fail closed). Use a Landlock-capable kernel (>=5.13, ABI>=3 "
             "recommended), or set MAC_OPENSHELL_ALLOW_NO_LANDLOCK=1 to override."
         )
-    bin_ = (os.environ.get("MAC_OPENSHELL_BIN") or "openshell").strip() or "openshell"
-    wrapped: List[str] = [bin_, "sandbox", "create", "--no-auto-providers"]
-    # Always pass one of OUR policies — never omit --policy, which would let
-    # OpenShell silently apply its own image-default profile. Resolves
-    # explicit -> deployed -> bundled fail-closed default, or raises.
-    wrapped += ["--policy", _resolve_openshell_policy()]
-    name = (os.environ.get("MAC_OPENSHELL_SANDBOX_NAME") or "").strip()
-    if name:
-        wrapped += ["--name", name]
-    if _truthy(os.environ.get("MAC_OPENSHELL_KEEP")):
-        wrapped += ["--keep"]
-    wrapped += _openshell_env_flags()
+
+
+def _build_sandbox_create_argv(
+    name: str, workspace: Path, basename: str, agent_argv: List[str]
+) -> List[str]:
+    """``openshell sandbox create`` argv that uploads the task workspace, runs the
+    agent inside it, and KEEPS the sandbox so results can be downloaded.
+
+    A policy is ALWAYS passed (explicit -> deployed -> bundled fail-closed
+    default) so OpenShell can never silently apply its own image-default profile.
+    The host workspace is uploaded to /sandbox (landing at /sandbox/<basename>);
+    the agent runs there with $MAC_TASK_WORKSPACE/$MAC_TASK_FILE repointed at the
+    in-sandbox paths (the host paths don't exist inside the sandbox), so its
+    evidence manifest is written where ``download`` later fetches it. The agent
+    argv is shell-quoted (shlex.join) into the cd-wrapper — the prompt is task
+    text and must never be able to break out of the command.
+    """
+    sub = "%s/%s" % (_SANDBOX_WORKDIR, basename)
+    argv: List[str] = [_openshell_bin(), "sandbox", "create", "--no-auto-providers"]
+    argv += ["--policy", _resolve_openshell_policy(), "--name", name]
+    argv += _openshell_env_flags()
+    argv += [
+        "--env", "MAC_TASK_WORKSPACE=%s" % sub,
+        "--env", "MAC_TASK_FILE=%s/task.json" % sub,
+    ]
     extra = (os.environ.get("MAC_OPENSHELL_CREATE_ARGS") or "").strip()
     if extra:
-        wrapped += shlex.split(extra)
-    wrapped += ["--", *argv]
-    return wrapped
+        argv += shlex.split(extra)
+    argv += ["--upload", "%s:%s" % (str(workspace), _SANDBOX_WORKDIR)]
+    inner = "cd %s && exec %s" % (shlex.quote(sub), shlex.join(agent_argv))
+    argv += ["--", "bash", "-lc", inner]
+    return argv
+
+
+def _sandbox_step(args: List[str], *, timeout: float) -> "tuple[bool, str]":
+    """Run an openshell lifecycle step (download/delete) out-of-band of the
+    audited agent run. Best-effort: returns (ok, message), never raises."""
+    try:
+        proc = subprocess.run(
+            [_openshell_bin(), "sandbox", *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return proc.returncode == 0, (proc.stderr or proc.stdout or "").strip()
+    except Exception as exc:  # noqa: BLE001 - teardown must never mask the run
+        return False, str(exc)
+
+
+def _sandbox_download(name: str, basename: str, workspace: Path) -> bool:
+    """Sync the agent's edits (+ the evidence manifest) from the kept sandbox
+    back into the host workspace. Best-effort: a failure is logged, not fatal —
+    completeness is still judged by the evidence manifest on the host."""
+    sub = "%s/%s" % (_SANDBOX_WORKDIR, basename)
+    ok, msg = _sandbox_step(["download", name, sub, str(workspace)], timeout=300.0)
+    if not ok:
+        sys.stderr.write("[executor] WARNING: sandbox download failed: %s\n" % msg)
+    return ok
+
+
+def _sandbox_delete(name: str) -> None:
+    ok, msg = _sandbox_step(["delete", name], timeout=120.0)
+    if not ok:
+        sys.stderr.write("[executor] WARNING: sandbox delete failed (possible leak): %s\n" % msg)
+
+
+def _run_sandboxed(
+    runner: Callable[..., Any], agent_argv: List[str], workspace: Path, audit_id: Any, opts: dict
+) -> Any:
+    """Run the agent through the OpenShell sandbox lifecycle: create (upload the
+    workspace + run the agent, keep) -> download results -> delete. The agent
+    runs confined; teardown ALWAYS happens (finally), even on failure."""
+    _force_child_yolo_env()  # truly silent agent; OpenShell is the guardrail
+    _ensure_landlock_or_fail()
+    name = _sandbox_name()
+    basename = _workspace_basename(workspace)
+    create_argv = _build_sandbox_create_argv(name, workspace, basename, agent_argv)
+    try:
+        result = runner(create_argv, workspace, audit_id, opts)
+        _sandbox_download(name, basename, workspace)
+        return result
+    finally:
+        if not _truthy(os.environ.get("MAC_OPENSHELL_KEEP")):
+            _sandbox_delete(name)
 
 
 def _force_child_yolo_env() -> None:
@@ -1326,29 +1398,15 @@ def _force_child_yolo_env() -> None:
     os.environ["HERMES_YOLO_MODE"] = "1"
 
 
-def _agent_invocation(prompt: str) -> List[str]:
-    """Build the agent argv, atomically coupling --yolo to sandbox enforcement.
+def _unsandboxed_agent_argv(prompt: str) -> List[str]:
+    """The agent argv for an UNSANDBOXED run, gated by the yolo escape hatch.
 
-    Invariant: --yolo (which disables Hermes' own approval — see sandbox-01) is
-    only used when the run is confined by OpenShell, so we never launch an
-    *unguarded* YOLO agent.
-
-      * sandbox enabled  -> wrap in OpenShell AND keep --yolo (sandboxed YOLO).
-        ``_maybe_wrap_openshell`` raises if no policy resolves (fail closed), so
-        a misconfigured sandbox can never degrade to unguarded YOLO.
-      * sandbox disabled -> running --yolo is unguarded. Permitted ONLY via the
-        ``MAC_ALLOW_UNSANDBOXED_YOLO`` escape hatch (default "1" to preserve the
-        current live fleet), with a loud warning. Set it to "0" to fail closed
-        once OpenShell is the enforcement layer.
-
-    The escape hatch defaults to allow so deploying this change does not break a
-    fleet that isn't running OpenShell yet; flip it off (or enable the sandbox)
-    to enforce the invariant.
+    --yolo disables Hermes' own approval (sandbox-01); running it unsandboxed is
+    unguarded, permitted ONLY via ``MAC_ALLOW_UNSANDBOXED_YOLO`` (default "1" to
+    preserve the current live fleet; "0" fails closed). Raises when fail-closed.
+    The sandboxed path does not go through here — see :func:`_invoke_agent`.
     """
     argv = _hermes_argv(prompt)  # includes --yolo
-    if _openshell_enabled():
-        _force_child_yolo_env()  # truly silent agent; OpenShell is the guardrail
-        return _maybe_wrap_openshell(argv)
     default_unsandboxed = "0" if _openshell_required_for_local_agent() else "1"
     if _truthy(os.environ.get("MAC_ALLOW_UNSANDBOXED_YOLO", default_unsandboxed)):
         _force_child_yolo_env()
@@ -1365,6 +1423,23 @@ def _agent_invocation(prompt: str) -> List[str]:
         "Set MAC_OPENSHELL_SANDBOX=1 with a policy to enforce silently, or "
         "MAC_ALLOW_UNSANDBOXED_YOLO=1 to explicitly allow unsandboxed YOLO."
     )
+
+
+def _invoke_agent(
+    runner: Callable[..., Any], prompt: str, workspace: Path, audit_id: Any, opts: dict
+) -> Any:
+    """Run the agent for one task, atomically coupling --yolo to enforcement.
+
+    Invariant: --yolo (Hermes' own approval bypass) is only used when the run is
+    confined by OpenShell, so we never launch an *unguarded* YOLO agent.
+      * sandbox enabled  -> full OpenShell lifecycle (upload workspace, run the
+        agent confined, download results, delete). Fails closed if no policy
+        resolves or the kernel can't enforce Landlock.
+      * sandbox disabled -> direct run, gated by MAC_ALLOW_UNSANDBOXED_YOLO.
+    Returns the runner's result (carries .returncode)."""
+    if _openshell_enabled():
+        return _run_sandboxed(runner, _hermes_argv(prompt), workspace, audit_id, opts)
+    return runner(_unsandboxed_agent_argv(prompt), workspace, audit_id, opts)
 
 
 def _agent_timeout() -> Optional[float]:
@@ -1455,8 +1530,9 @@ def _run_executor(
     )
 
     audit_task_id = review_context.get("task_id") if is_review else task_id
-    result = runner(
-        _agent_invocation(prompt),
+    result = _invoke_agent(
+        runner,
+        prompt,
         task_workspace,
         str(audit_task_id) if audit_task_id else None,
         {"execution_kind": "review" if is_review else "task", "timeout": _agent_timeout()},

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -1,13 +1,14 @@
-"""Tests for OpenShell sandbox wrapping in the task executor (sandbox-01).
+"""Tests for OpenShell sandbox enforcement in the task executor (sandbox-01).
 
-The wrap is gated by MAC_OPENSHELL_SANDBOX. These tests pin the default-OFF
-guarantee (zero behavior change), the policy-resolution order, and the exact
-`openshell sandbox create ... -- <argv>` construction so the seam can't drift.
-They never spawn OpenShell.
-
-A policy is ALWAYS passed when enabled (explicit -> deployed -> bundled
-fail-closed default), so enabling can never silently fall back to OpenShell's
-own image-default profile.
+Enforcement is gated by MAC_OPENSHELL_SANDBOX (default OFF). When on, the run is
+a lifecycle — `create` (upload the task workspace, run the agent confined, keep)
+-> `download` (sync edits + evidence back) -> `delete` — because OpenShell
+sandboxes are container copies with no bind-mount. These tests pin the
+default-OFF guarantee, the create-argv construction (policy always passed,
+workspace uploaded, agent run in /sandbox/<basename> with the in-sandbox
+workspace env), the lifecycle orchestration (download + always-teardown), the
+--yolo<->sandbox coupling, the loopback URL rewrite, and the Landlock
+fail-closed precheck. They never spawn OpenShell.
 """
 
 from __future__ import annotations
@@ -45,15 +46,47 @@ def _clean(monkeypatch, tmp_path):
     for name in _OPENSHELL_ENVS:
         monkeypatch.delenv(name, raising=False)
     monkeypatch.setenv("HOME", str(tmp_path))
-    # Construction tests run on non-Landlock hosts (Mac/CI); bypass the kernel
-    # precheck so they exercise the wrap. The precheck has its own tests below.
+    # Tests run on non-Landlock hosts (Mac/CI); bypass the kernel precheck so the
+    # orchestration tests exercise the lifecycle. The precheck has its own tests.
     monkeypatch.setenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", "1")
     yield
 
 
+class _Result:
+    def __init__(self, returncode: int = 0):
+        self.returncode = returncode
+
+
+class FakeRunner:
+    """Records (argv, workspace, audit_id, opts) calls; returns a 0 result."""
+
+    def __init__(self, rc: int = 0, raises: bool = False):
+        self.calls = []
+        self._rc = rc
+        self._raises = raises
+
+    def __call__(self, argv, workspace, audit_id, opts):
+        self.calls.append((list(argv), workspace, audit_id, opts))
+        if self._raises:
+            raise RuntimeError("agent boom")
+        return _Result(self._rc)
+
+
 def _policy_of(out):
-    """Return the value passed after --policy, or None."""
     return out[out.index("--policy") + 1] if "--policy" in out else None
+
+
+def _build(workspace="/work/task-7", argv=None):
+    """Build a create-argv directly (no env gating — that's _invoke_agent's job)."""
+    ws = Path(workspace)
+    return te._build_sandbox_create_argv("sb-test", ws, te._workspace_basename(ws), argv or _ARGV)
+
+
+def _inner(out):
+    """The `bash -lc <inner>` command string after the `--` separator."""
+    i = out.index("--")
+    assert out[i + 1 : i + 3] == ["bash", "-lc"]
+    return out[i + 3]
 
 
 # ---------------------------------------------------------------------------
@@ -78,184 +111,208 @@ def test_enabled_default_off():
 
 
 # ---------------------------------------------------------------------------
-# default OFF -> unchanged argv (the critical safety property)
+# default OFF -> the agent runs directly, unwrapped (critical safety property)
 # ---------------------------------------------------------------------------
 
 
-def test_disabled_returns_equal_argv():
-    assert te._maybe_wrap_openshell(_ARGV) == _ARGV
-
-
-def test_disabled_returns_a_copy():
-    assert te._maybe_wrap_openshell(_ARGV) is not _ARGV
+def test_invoke_unsandboxed_runs_plain_argv():
+    r = FakeRunner()
+    te._invoke_agent(r, "do the thing", Path("/work/t"), "tid", {})
+    assert len(r.calls) == 1
+    argv = r.calls[0][0]
+    assert "openshell" not in argv[0] and argv[0].endswith("python")
+    assert "--yolo" in argv
 
 
 # ---------------------------------------------------------------------------
-# enabled -> a policy is ALWAYS passed (no silent image-default fallback)
+# create-argv: a policy is ALWAYS passed (no silent image-default fallback)
 # ---------------------------------------------------------------------------
 
 
-def test_enabled_falls_back_to_bundled_policy(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
-    out = te._maybe_wrap_openshell(_ARGV)
+def test_build_has_create_prefix_and_bundled_policy():
+    out = _build()
     assert out[:4] == ["openshell", "sandbox", "create", "--no-auto-providers"]
-    # --policy is always present, resolving to the bundled fail-closed default
     assert _policy_of(out) == str(te._bundled_default_policy())
-    # original argv preserved verbatim after the separator
-    sep = out.index("--")
-    assert out[sep + 1 :] == _ARGV
 
 
 def test_bundled_default_policy_exists():
-    """The fail-closed default must ship in the package (it's the fallback)."""
     assert te._bundled_default_policy().is_file()
 
 
-def test_explicit_policy_used(monkeypatch, tmp_path):
+def test_build_explicit_policy_used(monkeypatch, tmp_path):
     p = tmp_path / "my-policy.yaml"
     p.write_text("version: 1\n")
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_POLICY", str(p))
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert _policy_of(out) == str(p)
+    assert _policy_of(_build()) == str(p)
 
 
-def test_missing_explicit_policy_raises(monkeypatch, tmp_path):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+def test_build_missing_explicit_policy_raises(monkeypatch, tmp_path):
     monkeypatch.setenv("MAC_OPENSHELL_POLICY", str(tmp_path / "nope.yaml"))
     with pytest.raises(FileNotFoundError):
-        te._maybe_wrap_openshell(_ARGV)
+        _build()
 
 
-def test_deployed_policy_preferred_over_bundled(monkeypatch, tmp_path):
-    """~/.mac/openshell-policy.yaml wins when no explicit policy is set."""
+def test_build_deployed_policy_preferred_over_bundled(tmp_path):
     mac_dir = tmp_path / ".mac"
     mac_dir.mkdir()
     deployed = mac_dir / "openshell-policy.yaml"
-    deployed.write_text("version: 1\n")
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")  # HOME already == tmp_path
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert _policy_of(out) == str(deployed)
+    deployed.write_text("version: 1\n")  # HOME already == tmp_path
+    assert _policy_of(_build()) == str(deployed)
 
 
 # ---------------------------------------------------------------------------
-# flag construction
+# create-argv construction: name, workspace upload, in-sandbox run + env
 # ---------------------------------------------------------------------------
 
 
-def test_separator_appears_once_and_before_argv(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
-    monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from my-img")
-    out = te._maybe_wrap_openshell(_ARGV)
+def test_build_names_the_sandbox():
+    out = _build()
+    assert "--name" in out and out[out.index("--name") + 1] == "sb-test"
+
+
+def test_build_uploads_workspace_to_sandbox_root():
+    out = _build("/work/task-7")
+    assert "--upload" in out
+    assert "/work/task-7:/sandbox" in out
+
+
+def test_build_runs_agent_in_workspace_subdir_with_yolo():
+    inner = _inner(_build("/work/task-7"))
+    assert inner.startswith("cd /sandbox/task-7 && exec ")
+    assert "hermes_cli.main" in inner and "--yolo" in inner
+
+
+def test_build_repoints_workspace_env_into_sandbox():
+    out = _build("/work/task-7")
+    assert "MAC_TASK_WORKSPACE=/sandbox/task-7" in out
+    assert "MAC_TASK_FILE=/sandbox/task-7/task.json" in out
+
+
+def test_build_separator_appears_once_before_command():
+    out = _build()
     assert out.count("--") == 1
-    assert out.index("--") < out.index(_ARGV[0])
+    assert out.index("--") < out.index("bash")
 
 
-def test_bin_override(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+def test_build_bin_override(monkeypatch):
     monkeypatch.setenv("MAC_OPENSHELL_BIN", "/opt/openshell/bin/openshell")
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert out[0] == "/opt/openshell/bin/openshell"
+    assert _build()[0] == "/opt/openshell/bin/openshell"
 
 
-def test_name_and_keep(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "dbg-run")
-    monkeypatch.setenv("MAC_OPENSHELL_KEEP", "1")
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert "--name" in out and out[out.index("--name") + 1] == "dbg-run"
-    assert "--keep" in out
-
-
-def test_no_name_or_keep_by_default(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert "--name" not in out
-    assert "--keep" not in out
-
-
-def test_create_args_shell_split(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
-    monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from img --upload /a:/b")
-    out = te._maybe_wrap_openshell(_ARGV)
-    for tok in ("--from", "img", "--upload", "/a:/b"):
+def test_build_create_args_spliced(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from img --upload /a:/b --env HOME=/tmp")
+    out = _build()
+    for tok in ("--from", "img", "--upload", "/a:/b", "--env", "HOME=/tmp"):
         assert tok in out
-        assert out.index(tok) < out.index("--")
+        assert out.index(tok) < out.index("bash")
+
+
+def test_build_quotes_prompt_safely():
+    # A shell-hostile prompt must not be able to break out of the cd-wrapper.
+    argv = te._hermes_argv("do; rm -rf / # $(whoami)")
+    inner = _inner(_build(argv=argv))
+    # the dangerous text is single-quoted inside the exec'd command, not bare
+    assert "rm -rf /" not in inner.replace("'do; rm -rf / # $(whoami)'", "")
 
 
 # ---------------------------------------------------------------------------
-# env passthrough
+# env passthrough (forwarded into the sandbox via --env)
 # ---------------------------------------------------------------------------
 
 
 def test_env_passthrough_only_set_vars(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_ENV_PASSTHROUGH", "FOO,BAR,FOO")
     monkeypatch.setenv("FOO", "fooval")
     monkeypatch.delenv("BAR", raising=False)
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert "--env" in out
+    out = _build()
     assert out.count("FOO=fooval") == 1
     assert not any(tok.startswith("BAR=") for tok in out)
 
 
 def test_env_passthrough_default_list_used(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_HUB_URL", "http://hub:8789")
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert "MAC_HUB_URL=http://hub:8789" in out
+    assert "MAC_HUB_URL=http://hub:8789" in _build()
 
 
 # ---------------------------------------------------------------------------
-# _agent_invocation: atomic --yolo <-> sandbox coupling
+# sandbox lifecycle orchestration: create -> download -> always delete
 # ---------------------------------------------------------------------------
 
 
-def test_agent_invocation_sandbox_wraps_and_keeps_yolo(monkeypatch):
+def test_invoke_sandboxed_runs_full_lifecycle(monkeypatch):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
-    out = te._agent_invocation("do the thing")
-    assert out[:4] == ["openshell", "sandbox", "create", "--no-auto-providers"]
-    assert "--policy" in out                  # enforced default policy
-    assert "--yolo" in out                     # YOLO kept, but now sandboxed
-    assert out.index("--") < out.index("--yolo")
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "sb1")
+    steps = []
+    monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (steps.append(args) or (True, "")))
+    r = FakeRunner()
+    te._invoke_agent(r, "do it", Path("/work/task-7"), "tid", {})
+    # 1 audited create call (runs the agent), then download + delete out-of-band
+    assert len(r.calls) == 1
+    create = r.calls[0][0]
+    assert create[:3] == ["openshell", "sandbox", "create"] and "--upload" in create
+    assert steps[0] == ["download", "sb1", "/sandbox/task-7", "/work/task-7"]
+    assert steps[1] == ["delete", "sb1"]
 
 
-def test_agent_invocation_unsandboxed_allowed_by_default(monkeypatch):
-    # hatch unset -> default allow (current fleet), unwrapped, --yolo present
-    monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
-    out = te._agent_invocation("do the thing")
-    assert "openshell" not in out[0]
-    assert out[0].endswith("python")
-    assert "--yolo" in out
+def test_invoke_sandboxed_tears_down_on_agent_failure(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "sb2")
+    steps = []
+    monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (steps.append(args[0]) or (True, "")))
+    with pytest.raises(RuntimeError, match="agent boom"):
+        te._invoke_agent(FakeRunner(raises=True), "do it", Path("/work/task-7"), "tid", {})
+    assert "delete" in steps  # teardown still ran (finally)
 
 
-def test_agent_invocation_unsandboxed_explicit_allow(monkeypatch):
-    monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
+def test_invoke_sandboxed_keep_skips_delete(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_KEEP", "1")
+    steps = []
+    monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (steps.append(args[0]) or (True, "")))
+    te._invoke_agent(FakeRunner(), "do it", Path("/work/task-7"), "tid", {})
+    assert "download" in steps and "delete" not in steps
+
+
+# ---------------------------------------------------------------------------
+# --yolo <-> sandbox coupling (never an unguarded YOLO agent)
+# ---------------------------------------------------------------------------
+
+
+def test_unsandboxed_allowed_by_default(monkeypatch):
+    argv = te._unsandboxed_agent_argv("do the thing")
+    assert "openshell" not in argv[0] and argv[0].endswith("python") and "--yolo" in argv
+
+
+def test_unsandboxed_explicit_allow(monkeypatch):
     monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "1")
-    out = te._agent_invocation("do the thing")
-    assert out[:1] != ["openshell"]
-    assert "--yolo" in out
+    assert "--yolo" in te._unsandboxed_agent_argv("do the thing")
 
 
-def test_agent_invocation_unsandboxed_fail_closed(monkeypatch):
-    # hatch off + no sandbox -> refuse to launch unguarded YOLO
+def test_unsandboxed_fail_closed_raises(monkeypatch):
+    monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "0")
+    with pytest.raises(RuntimeError, match="without an OpenShell sandbox"):
+        te._unsandboxed_agent_argv("do the thing")
+
+
+def test_invoke_unsandboxed_fail_closed_raises(monkeypatch):
     monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
     monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "0")
     with pytest.raises(RuntimeError, match="without an OpenShell sandbox"):
-        te._agent_invocation("do the thing")
+        te._invoke_agent(FakeRunner(), "do it", Path("/work/t"), "tid", {})
 
 
-def test_agent_invocation_sandbox_overrides_failclosed_hatch(monkeypatch):
-    # sandbox on -> safe regardless of the hatch value (no raise)
+def test_invoke_sandbox_overrides_failclosed_hatch(monkeypatch):
+    # sandbox on -> safe regardless of the unsandboxed hatch (no raise)
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "0")
-    out = te._agent_invocation("do the thing")
-    assert out[0] == "openshell"
-    assert "--yolo" in out
+    monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (True, ""))
+    r = FakeRunner()
+    te._invoke_agent(r, "do it", Path("/work/t"), "tid", {})
+    assert r.calls[0][0][0] == "openshell"
 
 
 # ---------------------------------------------------------------------------
-# image-mode runtime path + URL rewriting + Landlock precheck
+# in-image runtime path + loopback URL rewriting
 # ---------------------------------------------------------------------------
 
 
@@ -265,7 +322,6 @@ def test_hermes_argv_uses_image_python_override(monkeypatch):
     argv = te._hermes_argv("do it")
     assert argv[0] == "/opt/mac-venv/bin/python"
     assert argv[1:4] == ["-m", "hermes_cli.main", "chat"]
-    # image runtime: no host vendored PYTHONPATH injected
     assert "/.mac/src/" not in os.environ.get("PYTHONPATH", "")
 
 
@@ -304,41 +360,48 @@ def test_host_alias_override(monkeypatch):
     assert te._rewrite_host_local_url("http://127.0.0.1:8789", te._openshell_host_alias()) == "http://10.0.0.1:8789"
 
 
+# ---------------------------------------------------------------------------
+# Landlock fail-closed precheck
+# ---------------------------------------------------------------------------
+
+
 def test_landlock_precheck_fail_closed(monkeypatch):
-    # sandbox on, kernel lacks Landlock, override absent -> refuse (fail closed)
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.delenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", raising=False)
     monkeypatch.setattr(te, "_kernel_has_landlock", lambda: False)
     with pytest.raises(RuntimeError, match="does not expose .*Landlock"):
-        te._maybe_wrap_openshell(_ARGV)
+        te._invoke_agent(FakeRunner(), "do it", Path("/work/t"), "tid", {})
 
 
 def test_landlock_precheck_passes_when_present(monkeypatch):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.delenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", raising=False)
     monkeypatch.setattr(te, "_kernel_has_landlock", lambda: True)
-    out = te._maybe_wrap_openshell(_ARGV)
-    assert out[:3] == ["openshell", "sandbox", "create"]
+    monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (True, ""))
+    r = FakeRunner()
+    te._invoke_agent(r, "do it", Path("/work/t"), "tid", {})
+    assert r.calls[0][0][:3] == ["openshell", "sandbox", "create"]
 
 
 # --- child HERMES_YOLO_MODE env (fixes the approval.py import-order freeze) ---
 
 
-def test_agent_invocation_sets_child_yolo_env_when_sandboxed(monkeypatch):
+def test_sets_child_yolo_env_when_sandboxed(monkeypatch):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
-    te._agent_invocation("x")
+    monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (True, ""))
+    te._invoke_agent(FakeRunner(), "x", Path("/work/t"), "tid", {})
     assert os.environ.get("HERMES_YOLO_MODE") == "1"
 
 
-def test_agent_invocation_sets_child_yolo_env_when_unsandboxed_allowed(monkeypatch):
+def test_sets_child_yolo_env_when_unsandboxed_allowed(monkeypatch):
     monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
-    te._agent_invocation("x")
+    te._invoke_agent(FakeRunner(), "x", Path("/work/t"), "tid", {})
     assert os.environ.get("HERMES_YOLO_MODE") == "1"
 
 
-def test_agent_invocation_failclosed_does_not_set_yolo_env(monkeypatch):
+def test_failclosed_does_not_set_yolo_env(monkeypatch):
     monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
     monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "0")
     with pytest.raises(RuntimeError):
-        te._agent_invocation("x")
-    assert os.environ.get("HERMES_YOLO_MODE") is None
+        te._invoke_agent(FakeRunner(), "x", Path("/work/t"), "tid", {})
+    assert os.environ.get("HERMES_YOLO_MODE") != "1"


### PR DESCRIPTION
## Summary
Resolves the blocker found validating OpenShell enforcement on rocky: `include_workdir` is only a **Landlock grant, not a file copy**, and OpenShell sandboxes are container copies with **no bind-mount**. The old one-shot `openshell sandbox create -- <argv>` model ran the agent against an **empty `/sandbox`** (worktree never uploaded) and lost the agent's edits + `$MAC_TASK_WORKSPACE/mac-evidence.json` on teardown — so a real coding task could not complete sandboxed.

**Validated end-to-end on rocky:** a real hermes task now creates files + writes its evidence manifest in the sandbox, and they sync back to the host worktree (`hello.txt`=`WORLD`, `mac-evidence.json`=`{status: complete}`).

## What changed
Reworks the sandboxed path into the full OpenShell lifecycle:
> **create** (`--upload <workspace>:/sandbox`, run the agent in `/sandbox/<basename>`, **keep**) → **download** `/sandbox/<basename>` → **delete**

- **`_build_sandbox_create_argv`** — names the sandbox (so download/delete can target it), uploads the workspace, and repoints `$MAC_TASK_WORKSPACE`/`$MAC_TASK_FILE` at the in-sandbox paths so the agent's evidence lands where `download` fetches it. The agent argv (incl. the task **prompt**) is `shlex`-quoted into the cd-wrapper so shell-hostile prompt text can't break out.
- **`_run_sandboxed`** — orchestrates create → download (best-effort sync-back) → delete (**always**, in `finally`; skipped only under `MAC_OPENSHELL_KEEP`). The Landlock fail-closed precheck runs here.
- **`_invoke_agent`** replaces `_agent_invocation` as the single entry: sandboxed lifecycle vs the unsandboxed-yolo gate (`_unsandboxed_agent_argv`). `_run_executor` calls it directly.

## Deploy recipe (env only — no further code)
```
MAC_OPENSHELL_SANDBOX=1
MAC_HERMES_PYTHON=/opt/mac-venv/bin/python
MAC_OPENSHELL_POLICY=<rendered best_effort policy>
MAC_OPENSHELL_CREATE_ARGS="--from <image> --upload <rewritten-config>:/tmp/.hermes/config.yaml --env HOME=/tmp"
```
The executor adds the workspace upload + sandbox name + in-sandbox workspace env automatically.

## Safety
**Default OFF** (`MAC_OPENSHELL_SANDBOX` unset) — zero behavior change for the running fleet.

## Tests
51 sandbox tests (construction, lifecycle orchestration incl. always-teardown + teardown-on-failure, yolo coupling, URL rewrite, Landlock fail-closed) + executor/policy suites pass. Full contract suite green for this change (the 2 `opencode_build` failures seen locally are from unrelated uncommitted WIP in the working tree, not this branch — verified they pass with this commit alone).

Resolves `task_52ef7b6b…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)