### PR TITLE
openshell: mac-hermes Containerfile + node bootstrap script (standard for new nodes)

### DIFF
--- a/deploy/openshell/bootstrap-openshell.sh
+++ b/deploy/openshell/bootstrap-openshell.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# bootstrap-openshell.sh — stand up OpenShell sandbox enforcement on a mac node.
+#
+# Run ON the target node (it touches the local user's ~/.mac, ~/.local, docker/
+# podman, and — with sudo — the CDI spec + a firewall). Idempotent: safe to
+# re-run. Encodes the recipe proven across the fleet (rocky x86 podman,
+# bullwinkle x86 GPU podman, natasha aarch64 GPU docker).
+#
+# It does NOT flip enforcement by default. After it succeeds, validate a real
+# task, then enable:  --enable (MAC_OPENSHELL_SANDBOX=1) and, once validated,
+# --fail-closed (MAC_ALLOW_UNSANDBOXED_YOLO=0).
+#
+# Knobs (env):
+#   OPENSHELL_VERSION   default 0.0.62        — CLI + gateway version (must match)
+#   MAC_HOME            default $HOME/.mac
+#   MAC_SRC             default $MAC_HOME/src/mac    — mac source tree (image build context)
+#   OSH_DRIVER          auto|podman|docker   — auto: podman>=5 else docker
+#   OSH_GPU             auto|yes|no          — auto: detect nvidia-smi
+#   OSH_HUB_URL         default from mac.env MAC_HUB_URL — the hub the sandbox egresses to
+#   OSH_FIREWALL_NIC    default: the default-route NIC
+# Flags: --enable  --fail-closed  --skip-image
+set -euo pipefail
+
+OPENSHELL_VERSION="${OPENSHELL_VERSION:-0.0.62}"
+MAC_HOME="${MAC_HOME:-$HOME/.mac}"
+MAC_SRC="${MAC_SRC:-$MAC_HOME/src/mac}"
+OSH_DRIVER="${OSH_DRIVER:-auto}"
+OSH_GPU="${OSH_GPU:-auto}"
+ENVF="$MAC_HOME/mac.env"
+OSH_DIR="$MAC_HOME/openshell"
+BIN="$HOME/.local/bin"
+ARCH="$(uname -m)"   # x86_64 | aarch64
+DO_ENABLE=0; DO_FAILCLOSED=0; SKIP_IMAGE=0
+for a in "$@"; do case "$a" in
+  --enable) DO_ENABLE=1;; --fail-closed) DO_FAILCLOSED=1; DO_ENABLE=1;; --skip-image) SKIP_IMAGE=1;;
+  *) echo "unknown arg: $a" >&2; exit 2;; esac; done
+log(){ printf '[bootstrap-openshell] %s\n' "$*"; }
+export PATH="$BIN:$PATH" XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+mkdir -p "$OSH_DIR" "$BIN"
+
+# --- driver + GPU detection -------------------------------------------------
+[ "$OSH_GPU" = auto ] && { command -v nvidia-smi >/dev/null && nvidia-smi -L >/dev/null 2>&1 && OSH_GPU=yes || OSH_GPU=no; }
+if [ "$OSH_DRIVER" = auto ]; then
+  pmaj="$(podman --version 2>/dev/null | grep -oE '[0-9]+' | head -1 || echo 0)"
+  # podman < 5 can't parse current nvidia-ctk CDI specs (0.7.0) -> docker
+  if [ "${pmaj:-0}" -ge 5 ]; then OSH_DRIVER=podman; else OSH_DRIVER=docker; fi
+fi
+log "arch=$ARCH gpu=$OSH_GPU driver=$OSH_DRIVER version=$OPENSHELL_VERSION"
+BUILDER="$OSH_DRIVER"   # build the image with the same engine the gateway uses
+
+# --- 1. openshell CLI (uv tool, else pip venv) ------------------------------
+if ! command -v openshell >/dev/null; then
+  if command -v uv >/dev/null; then
+    uv tool install "openshell==$OPENSHELL_VERSION"
+  else
+    python3 -m venv "$HOME/.openshell-cli-venv"
+    "$HOME/.openshell-cli-venv/bin/pip" install -q "openshell==$OPENSHELL_VERSION"
+    ln -sf "$HOME/.openshell-cli-venv/bin/openshell" "$BIN/openshell"
+  fi
+fi
+log "openshell CLI: $(openshell --version 2>&1 | head -1)"
+
+# --- 2. openshell-gateway daemon (prebuilt per-arch release asset) ----------
+if ! [ -x "$BIN/openshell-gateway" ]; then
+  case "$ARCH" in
+    x86_64)  ga="openshell-gateway-x86_64-unknown-linux-gnu.tar.gz";;
+    aarch64) ga="openshell-gateway-aarch64-unknown-linux-gnu.tar.gz";;
+    *) echo "unsupported arch $ARCH" >&2; exit 1;;
+  esac
+  url="https://github.com/NVIDIA/OpenShell/releases/download/v$OPENSHELL_VERSION/$ga"
+  log "fetching gateway: $url"
+  tmp="$(mktemp -d)"; curl -fsSL -o "$tmp/gw.tgz" "$url"; tar -xzf "$tmp/gw.tgz" -C "$tmp"
+  install -m755 "$(find "$tmp" -name openshell-gateway -type f | head -1)" "$BIN/openshell-gateway"
+  rm -rf "$tmp"
+fi
+log "gateway bin: $(openshell-gateway --version 2>&1 | head -1)"
+
+# --- 3. GPU: refresh the CDI spec to the current driver ---------------------
+if [ "$OSH_GPU" = yes ]; then
+  log "regenerating CDI spec for driver $(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1)"
+  sudo mkdir -p /etc/cdi && sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml >/dev/null 2>&1 || true
+fi
+
+# --- 4. mac-hermes image (native build; multi-arch Containerfile) -----------
+if [ "$SKIP_IMAGE" = 0 ]; then
+  cf="$(cd "$(dirname "$0")" && pwd)/mac-hermes.Containerfile"
+  log "building localhost/mac-hermes:net with $BUILDER from $MAC_SRC"
+  ( cd "$MAC_SRC" && "$BUILDER" build -t localhost/mac-hermes:net -f "$cf" . )
+fi
+
+# --- 5. JWT signing keys ----------------------------------------------------
+[ -f "$OSH_DIR/pki/jwt/signing.pem" ] || openshell-gateway generate-certs --output-dir "$OSH_DIR/pki" >/dev/null 2>&1
+log "jwt keys: $(ls "$OSH_DIR/pki/jwt" 2>/dev/null | tr '\n' ' ')"
+
+# --- 6. gateway.toml (driver-specific) --------------------------------------
+common_top() { cat <<EOF
+[openshell]
+version = 1
+[openshell.gateway]
+bind_address = "0.0.0.0:17670"
+log_level = "info"
+compute_drivers = ["$OSH_DRIVER"]
+disable_tls = true
+[openshell.gateway.auth]
+allow_unauthenticated_users = true
+[openshell.gateway.gateway_jwt]
+signing_key_path = "$OSH_DIR/pki/jwt/signing.pem"
+public_key_path = "$OSH_DIR/pki/jwt/public.pem"
+kid_path = "$OSH_DIR/pki/jwt/kid"
+EOF
+}
+if [ "$OSH_DRIVER" = podman ]; then
+  command -v loginctl >/dev/null && sudo loginctl enable-linger "$USER" >/dev/null 2>&1 || true
+  systemctl --user enable --now podman.socket >/dev/null 2>&1 || true
+  { common_top; cat <<EOF
+[openshell.drivers.podman]
+socket_path = "/run/user/$(id -u)/podman/podman.sock"
+grpc_endpoint = "http://host.openshell.internal:17670"
+supervisor_image = "ghcr.io/nvidia/openshell/supervisor:latest"
+default_image = "localhost/mac-hermes:net"
+EOF
+  } > "$OSH_DIR/gateway.toml"
+else
+  { common_top; cat <<EOF
+[openshell.drivers.docker]
+default_image = "localhost/mac-hermes:net"
+supervisor_image = "ghcr.io/nvidia/openshell/supervisor:latest"
+network_name = "openshell-docker"
+grpc_endpoint = "http://host.openshell.internal:17670"
+image_pull_policy = "IfNotPresent"
+EOF
+  } > "$OSH_DIR/gateway.toml"
+fi
+
+# --- 7. gateway systemd --user service + register ---------------------------
+mkdir -p "$HOME/.config/systemd/user"
+cat > "$HOME/.config/systemd/user/openshell-gateway.service" <<EOF
+[Unit]
+Description=OpenShell gateway ($OSH_DRIVER driver)
+After=podman.socket
+Wants=podman.socket
+[Service]
+ExecStart=%h/.local/bin/openshell-gateway --config %h/.mac/openshell/gateway.toml
+Restart=on-failure
+[Install]
+WantedBy=default.target
+EOF
+systemctl --user daemon-reload
+systemctl --user enable --now openshell-gateway >/dev/null 2>&1
+sleep 3
+openshell gateway add http://127.0.0.1:17670 >/dev/null 2>&1 || true
+openshell gateway select openshell >/dev/null 2>&1 || true
+log "gateway: $(systemctl --user is-active openshell-gateway) | listening: $(ss -tlnp 2>/dev/null | grep -c :17670)"
+
+# --- 8. firewall :17670 (block public/LAN NIC; persistent) ------------------
+NIC="${OSH_FIREWALL_NIC:-$(ip route show default 2>/dev/null | grep -oP 'dev \K\S+' | head -1)}"
+if [ -n "$NIC" ]; then
+  sudo tee /usr/local/sbin/mac-openshell-firewall.sh >/dev/null <<EOF
+#!/usr/bin/env bash
+for ipt in iptables ip6tables; do command -v \$ipt >/dev/null || continue
+  \$ipt -C INPUT -i $NIC -p tcp --dport 17670 -j DROP 2>/dev/null || \$ipt -I INPUT 1 -i $NIC -p tcp --dport 17670 -j DROP
+done
+EOF
+  sudo chmod +x /usr/local/sbin/mac-openshell-firewall.sh
+  sudo tee /etc/systemd/system/mac-openshell-firewall.service >/dev/null <<'EOF'
+[Unit]
+Description=Block external access to the OpenShell gateway (:17670)
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/mac-openshell-firewall.sh
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target
+EOF
+  sudo systemctl daemon-reload && sudo systemctl enable --now mac-openshell-firewall.service >/dev/null 2>&1
+  log "firewall: $NIC :17670 ($(sudo iptables -S INPUT 2>/dev/null | grep -c 17670) rules)"
+fi
+
+# --- 9. policy (egress to this node's hub) ----------------------------------
+HUB_URL="${OSH_HUB_URL:-$(grep -oE '^MAC_HUB_URL=[^ ]+' "$ENVF" 2>/dev/null | head -1 | cut -d= -f2-)}"
+HUB_HOST="$(printf '%s' "$HUB_URL" | sed -E 's#^https?://##; s#[:/].*##')"
+case "$HUB_HOST" in 127.0.0.1|localhost|0.0.0.0|"") POLICY_HUB=host.openshell.internal;; *) POLICY_HUB="$HUB_HOST";; esac
+HUB_PORT="$(printf '%s' "$HUB_URL" | grep -oE ':[0-9]+' | tr -d : | head -1)"; HUB_PORT="${HUB_PORT:-8789}"
+log "policy egress hub: $POLICY_HUB:$HUB_PORT"
+"$MAC_HOME/venv/bin/mac" openshell render-policy \
+  --template "$(cd "$(dirname "$0")" && pwd)/mac-hermes-policy.yaml" \
+  --agent-user "$USER" --hub-host "$POLICY_HUB" --hub-port "$HUB_PORT" \
+  --image-runtime /opt/mac-venv --into "$MAC_HOME/openshell-policy.yaml" >/dev/null
+chmod 600 "$MAC_HOME/openshell-policy.yaml"
+
+# --- 10. rewritten hermes config for the sandbox ----------------------------
+# Loopback base_url -> host.openshell.internal (a remote hub IP passes through).
+sed 's#127\.0\.0\.1#host.openshell.internal#g' "$HOME/.hermes/config.yaml" > "$OSH_DIR/sandbox-hermes-config.yaml"
+chmod 600 "$OSH_DIR/sandbox-hermes-config.yaml"
+
+# --- 11. env recipe in mac.env (quoted — mac.env is shell-sourced) ----------
+gpuarg=""; [ "$OSH_GPU" = yes ] && gpuarg=" --gpu"
+cp -a "$ENVF" "$ENVF.bak-openshell-$(date +%Y%m%dT%H%M%S 2>/dev/null || echo bootstrap)"
+sed -i '/^# OpenShell sandbox enforcement/d;/^MAC_OPENSHELL_SANDBOX=/d;/^MAC_HERMES_PYTHON=/d;/^MAC_OPENSHELL_POLICY=/d;/^MAC_OPENSHELL_BIN=/d;/^MAC_OPENSHELL_CREATE_ARGS=/d;/^MAC_ALLOW_UNSANDBOXED_YOLO=/d' "$ENVF"
+{
+  echo ""
+  echo "# OpenShell sandbox enforcement (bootstrap-openshell.sh; $OSH_DRIVER driver, gpu=$OSH_GPU)"
+  echo "MAC_OPENSHELL_SANDBOX=$DO_ENABLE"
+  echo "MAC_HERMES_PYTHON=/opt/mac-venv/bin/python"
+  echo "MAC_OPENSHELL_POLICY=$MAC_HOME/openshell-policy.yaml"
+  echo "MAC_OPENSHELL_BIN=$BIN/openshell"
+  echo "MAC_OPENSHELL_CREATE_ARGS=\"--from localhost/mac-hermes:net$gpuarg --upload $OSH_DIR/sandbox-hermes-config.yaml:/tmp/.hermes/config.yaml --env HOME=/tmp\""
+  [ "$DO_FAILCLOSED" = 1 ] && echo "MAC_ALLOW_UNSANDBOXED_YOLO=0"
+} >> "$ENVF"
+# sanity: mac.env must still source cleanly (quoting)
+( set -a; . "$ENVF" >/dev/null 2>&1; ) || { echo "ERROR: mac.env failed to source after edit" >&2; exit 1; }
+
+log "DONE. sandbox-enabled=$DO_ENABLE fail-closed=$DO_FAILCLOSED"
+[ "$DO_ENABLE" = 1 ] && log "restart the agent to apply: sudo systemctl restart mac-agent.service (then validate a real task)" \
+                     || log "set up but NOT enforcing yet; re-run with --enable (then --fail-closed once a real task validates)"

--- a/deploy/openshell/mac-hermes.Containerfile
+++ b/deploy/openshell/mac-hermes.Containerfile
@@ -1,0 +1,52 @@
+# mac-hermes sandbox image — the runtime image OpenShell runs the Hermes agent
+# inside (`openshell sandbox create --from localhost/mac-hermes:net`).
+#
+# Multi-arch: python:3.12-slim resolves to the host architecture, so the SAME
+# Containerfile builds natively on x86_64 (rocky, bullwinkle) and aarch64
+# (natasha / GB10). Build from the mac source tree as context:
+#
+#   docker build  -t localhost/mac-hermes:net -f deploy/openshell/mac-hermes.Containerfile <mac-src>
+#   podman build  -t localhost/mac-hermes:net -f deploy/openshell/mac-hermes.Containerfile <mac-src>
+#
+# (Use the driver the gateway is configured with — docker for hosts whose podman
+# is too old for the system CDI spec version, podman otherwise.)
+#
+# Hard-won requirements baked in (each line below is load-bearing — see the
+# comments): a `sandbox` user/group, `iproute2` (the egress proxy's `ip`), the
+# hermes_cli path hook, and a sandbox-writable /sandbox for the docker driver.
+
+FROM docker.io/library/python:3.12-slim-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# iproute2: OpenShell's network-isolation proxy requires `ip` ("trusted ip
+#   helper not found" otherwise). git/curl: task work + git push egress.
+# sandbox user/group: OpenShell refuses any image lacking a `sandbox` user.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends iproute2 iptables git curl ca-certificates \
+    && groupadd -r sandbox && useradd -r -g sandbox -m -d /home/sandbox sandbox \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/mac-venv && /opt/mac-venv/bin/pip install --no-cache-dir --upgrade pip
+
+# Install the mac runtime into the in-image venv. The vendored Hermes lives at
+# mac/_hermes/hermes_cli, which `import hermes_cli` only finds if mac/_hermes is
+# on sys.path — so drop a .pth that adds it (the executor runs
+# `python -m hermes_cli.main chat`).
+COPY . /tmp/mac-src
+RUN /opt/mac-venv/bin/pip install --no-cache-dir /tmp/mac-src \
+    && HP="$(/opt/mac-venv/bin/python -c 'import mac,os;print(os.path.join(os.path.dirname(mac.__file__),"_hermes"))')" \
+    && SP="$(/opt/mac-venv/bin/python -c 'import site;print(site.getsitepackages()[0])')" \
+    && printf '%s\n' "$HP" > "$SP/zz_hermes_vendor.pth" \
+    && /opt/mac-venv/bin/python -c "import hermes_cli, mac; print('IMPORT_OK')" \
+    && rm -rf /tmp/mac-src
+
+# The executor uploads the task workspace to /sandbox and the upload (ssh+tar)
+# runs as the `sandbox` user. The docker driver creates /sandbox root-owned, so
+# make it sandbox-writable or the upload fails ("tar: Cannot mkdir: Permission
+# denied"). Harmless for the podman driver.
+RUN mkdir -p /sandbox && chown sandbox:sandbox /sandbox
+
+ENV VIRTUAL_ENV=/opt/mac-venv PATH="/opt/mac-venv/bin:/usr/local/bin:/usr/bin:/bin"
+WORKDIR /sandbox
+CMD ["python3"]

--- a/tests/test_opencode_build_executor.py
+++ b/tests/test_opencode_build_executor.py
@@ -256,12 +256,13 @@ def _make_fake_bin(
     # Fake cargo: `test` fails rc=127 until .mac-provisioned exists. The
     # provisioning agent fallback is what creates that marker, so a green
     # run proves the fallback ran AND the gate re-judged the real command.
+    _cargo_ok = json.dumps("test result: ok. 3 passed\\n")  # extracted: no backslash inside an f-string expression (py3.11 compat, requires-python >=3.11)
     _write_exec(
         bindir / "cargo",
         "#!/usr/bin/env bash\n"
         'if [ "$1" = "test" ]; then\n'
         '  if [ -f .mac-provisioned ]; then\n'
-        f'    printf "%s" {json.dumps("test result: ok. 3 passed\\n")}\n'
+        f'    printf "%s" {_cargo_ok}\n'
         '    exit 0\n'
         '  fi\n'
         '  echo "error: linker cc not found" >&2\n'


### PR DESCRIPTION
## Summary
Makes OpenShell sandbox-enforcement reproducible for any new node (`task_cb6aee7…`), encoding the recipe **proven across the fleet** this session: **rocky** (x86/podman), **bullwinkle** (x86 GPU/podman), **natasha** (aarch64 GPU/docker) — all now enforcing + fail-closed. There was **no committed build recipe** before (the working image was built ad-hoc).

### `deploy/openshell/mac-hermes.Containerfile`
The runtime sandbox image, **multi-arch** (`python:3.12-slim` builds natively on x86_64 + aarch64). Bakes in the four hard-won requirements: a **`sandbox` user/group**, **`iproute2`** (the egress proxy's `ip`), a **`hermes_cli` `.pth`** (vendored `mac/_hermes` on `sys.path`), and a **sandbox-writable `/sandbox`** (docker driver creates it root-owned → upload fails otherwise).

### `deploy/openshell/bootstrap-openshell.sh`
Idempotent per-node bootstrap: detects arch/GPU, **picks the driver** (podman ≥5 + current CDI, else docker — podman 4.9.3 can't parse nvidia-ctk's 0.7.0 CDI spec), installs the CLI + **prebuilt per-arch `openshell-gateway` release asset** (no source build), regenerates the GPU CDI spec, builds the image, writes the **driver-specific `gateway.toml`** + JWT + systemd service + firewall (`:17670`), registers the gateway, renders the policy (egress to the node's hub — local `host.openshell.internal` or remote tailscale IP), preps the rewritten hermes config, and writes the `mac.env` recipe (**quoted** `CREATE_ARGS`, **absolute** `MAC_OPENSHELL_BIN`, `--gpu` on GPU hosts). Enforcement is opt-in: `--enable`, then `--fail-closed` after a real task validates.

## Also (incidental, unblocks the pre-push gate)
`c4e5860` had introduced a backslash inside an f-string **expression** in `test_opencode_build_executor.py` — a SyntaxError on Python 3.11, which the project supports (`requires-python >=3.11`) and the pre-push hook + dev env run. Fixed by extracting the expression to a variable (no behavior change). The pre-push gate (140 api/cli/ui tests) now passes.

## Safety
The two openshell files are new + inert (nothing runs them automatically). `bash -n` clean; `render-policy` dependency verified; pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)