### PR TITLE
fix(dispatch,cli): enforce no_dispatch/project-pause in push dispatcher; serialize list output

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -78,7 +78,20 @@ def _read_json_arg(
 def _print(value: Any) -> None:
     if hasattr(value, "to_dict"):
         value = value.to_dict()
-    print(json.dumps(value, indent=2, sort_keys=True))
+
+    def _to_serializable(obj: Any) -> Any:
+        # Hub-mode handlers return _Dictish wrappers; a top-level one is
+        # unwrapped above, but list/nested results (e.g. `project list` ->
+        # list[_Dictish]) reach json.dumps un-unwrapped. Unwrap anything that
+        # exposes the .to_dict() contract here so every command serializes.
+        to_dict = getattr(obj, "to_dict", None)
+        if callable(to_dict):
+            return to_dict()
+        raise TypeError(
+            "Object of type %s is not JSON serializable" % type(obj).__name__
+        )
+
+    print(json.dumps(value, indent=2, sort_keys=True, default=_to_serializable))
 
 
 def _plane(args: argparse.Namespace) -> Any:

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -7620,6 +7620,14 @@ class ControlPlane:
         agents = self._available_agents()
         unmatched: List[Task] = []
         for task in tasks:
+            # Autonomous-dispatch gates: a per-task no_dispatch hold or a
+            # project-level pause must keep the push dispatcher from auto-
+            # claiming, exactly as they keep tasks out of ready_tasks() and the
+            # worker-pull claim policy. claim_task() deliberately does NOT
+            # enforce these (operators may still claim/start a staged task
+            # explicitly), so the gate has to live on every autonomous path.
+            if self._task_dispatch_held(task) or self._project_dispatch_paused(task.project):
+                continue
             matched = False
             for agent in agents:
                 if not self._agent_available_for(agent, task):

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -41,6 +41,23 @@ def test_mac_cli_init_creates_db(tmp_path):
     assert result["status"] == "initialized"
 
 
+def test_print_serializes_list_of_dictish():
+    # Regression: hub-mode list commands (e.g. `mac project list`) return
+    # list[_Dictish]; _print only unwrapped a single top-level to_dict object,
+    # so a list crashed with "Object of type _Dictish is not JSON serializable".
+    from mac.cli import _print
+    from mac.dispatch import _Dictish
+
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        _print([_Dictish({"project": "ova"}), _Dictish({"project": "widget"})])
+    finally:
+        sys.stdout = old
+    assert json.loads(out.getvalue()) == [{"project": "ova"}, {"project": "widget"}]
+
+
 # ---------------------------------------------------------------------------
 # tenant
 # ---------------------------------------------------------------------------

--- a/tests/test_project_dispatch.py
+++ b/tests/test_project_dispatch.py
@@ -69,6 +69,22 @@ def test_paused_project_rejected_by_claim_policy(cp):
     assert (ok, reason) == (False, "project_dispatch_paused")
 
 
+def test_dispatch_once_does_not_claim_paused_project(cp):
+    # Regression: the server-push dispatcher (dispatch_once) bypassed the
+    # project-pause gate and auto-claimed a paused project's tickets. It must
+    # claim the live project's ticket and leave the paused one staged.
+    machine = cp.register_machine("worker-host", resources={"cpu": 4, "memory_gb": 8})
+    cp.register_agent(machine.id, "worker", capabilities=[])
+    cp.create_project("paused-proj", dispatch_paused=True)
+    cp.create_project("live-proj", dispatch_paused=False)
+    staged = cp.create_task("staged ticket", project="paused-proj")  # considered first
+    live = cp.create_task("live ticket", project="live-proj")
+    assignment = cp.dispatch_once()
+    assert assignment is not None
+    assert assignment["task"]["id"] == live.id
+    assert cp.get_task(staged.id).state == "open"
+
+
 def test_set_project_dispatch_round_trip(cp):
     cp.create_project("p")
     task = cp.create_task("ticket", project="p")

--- a/tests/test_task_no_dispatch.py
+++ b/tests/test_task_no_dispatch.py
@@ -26,6 +26,11 @@ def _normal(cp):
     return cp.create_task("normal work")
 
 
+def _worker(cp, capabilities=None):
+    machine = cp.register_machine("worker-host", resources={"cpu": 4, "memory_gb": 8})
+    return cp.register_agent(machine.id, "worker", capabilities=capabilities or [])
+
+
 def test_dispatch_held_flag(cp):
     assert cp._task_dispatch_held(_held(cp)) is True
     assert cp._task_dispatch_held(_normal(cp)) is False
@@ -61,3 +66,24 @@ def test_held_check_precedes_project_and_capability_gates(cp):
         held, {"allowed_projects": ["other"], "capabilities": []}
     )
     assert (ok, reason) == (False, "dispatch_held")
+
+
+def test_dispatch_once_does_not_claim_held_task(cp):
+    # Regression: the server-push dispatcher (dispatch_once) used to claim
+    # straight from the open queue without the no_dispatch gate, so a staged
+    # ticket got auto-claimed anyway. With only a held task open, it must
+    # claim nothing and leave the task staged.
+    _worker(cp)
+    held = _held(cp)
+    assert cp.dispatch_once() is None
+    assert cp.get_task(held.id).state == "open"
+
+
+def test_dispatch_once_claims_normal_skips_held(cp):
+    _worker(cp)
+    held = _held(cp)  # created first, so considered before `normal`
+    normal = _normal(cp)
+    assignment = cp.dispatch_once()
+    assert assignment is not None
+    assert assignment["task"]["id"] == normal.id
+    assert cp.get_task(held.id).state == "open"


### PR DESCRIPTION
Ports the two defects fixed upstream (NVIDIA-dev/mac #5) to this fork.

## 1. `dispatch_once` bypassed the autonomous-dispatch gates
The server-**push** dispatcher (`_dispatch_once_impl`) iterated the open queue and called `claim_task` directly, gated only by `_agent_available_for`. `claim_task` enforces the tenant gate but not the per-task `no_dispatch` hold or project-level pause, and `_dispatch_ordered_tasks` doesn't pre-filter them — so a `--no-dispatch` staged ticket (and a paused project's tickets) got **auto-claimed anyway**. Only `ready_tasks()` and the worker-**pull** claim policy honored the gates.

**Fix:** gate the push loop on `_task_dispatch_held` / `_project_dispatch_paused`. Kept **out** of `claim_task` so explicit operator claim/start of a staged task still works.

## 2. `mac project list` crashed in hub mode
`TypeError: Object of type _Dictish is not JSON serializable` — `_print` unwrapped a single top-level `to_dict` object but passed `list[_Dictish]` straight to `json.dumps`. **Fix:** a `json.dumps(default=...)` hook that unwraps any `.to_dict()` object. **Verified live:** the installed `mac project list` now returns clean JSON for all hub projects.

## Testing
42 affected tests pass through the hermetic `scripts/run-contract-tests.sh` (dispatch + CLI). New regression tests: `dispatch_once` leaves held/paused tasks staged and claims the live one; `_print` serializes a list of `_Dictish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)