### PR TITLE
fix(tests): stop dispatch tests leaking .tickets mirrors into the repo

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -11,13 +11,6 @@ def _mac_secret_key(monkeypatch):
     monkeypatch.setenv("MAC_SECRET_KEY", "cli-test-key-with-at-least-32-characters")
 
 
-@pytest.fixture(autouse=True)
-def _no_ticket_mirror(monkeypatch):
-    """Stop `mac task create/close` tests from auto-emitting real
-    `.tickets/<id>.md` files into the repo. The CLI runs with cwd = the repo, so
-    `tickets_mirror.tickets_dir()` resolves to the repo's `.tickets/` and every
-    throwaway test task would otherwise litter it (parity-tickets-autoemit-01).
-    The dedicated emit tests opt back in by deleting this var and pointing
-    `tickets_dir` at a tmp directory.
-    """
-    monkeypatch.setenv("MAC_NO_TICKET_MIRROR", "1")
+# Note: the `_no_ticket_mirror` autouse guard now lives in the top-level
+# tests/conftest.py so it covers every test dir (tests/test_dispatch.py et al.),
+# not just tests/cli/. Don't re-add it here.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,21 @@ def pytest_collection_modifyitems(items: list) -> None:
             item.add_marker(pytest.mark.ui)
 
 
+@pytest.fixture(autouse=True)
+def _no_ticket_mirror(monkeypatch):
+    """Stop any test that drives `mac task create/close` from auto-emitting real
+    `.tickets/<id>.md` files into the working repo.
+
+    `tickets_mirror.emit()` targets the git repo root's `.tickets/` dir, so a
+    CLI-driven test (e.g. tests/test_dispatch.py's hub create/close cases) would
+    otherwise litter version control with throwaway mirrors like `task_xyz.md`
+    / `task_remote_1.md`. Suite-wide so it covers every test dir, not just
+    tests/cli/. Dedicated emit tests opt back in by deleting this var and
+    pointing `tickets_dir` at a tmp directory.
+    """
+    monkeypatch.setenv("MAC_NO_TICKET_MIRROR", "1")
+
+
 # ----------------------------------------------------------------------
 # Live-Postgres fixtures (K8s Phase 3.6).
 #


### PR DESCRIPTION
Mirror of NVIDIA-dev/mac #9 (identical conftest baselines across forks). This is the fork where the leak actually manifested — fixture mirrors (`task_xyz.md`, `task_remote_1.md`) showed up untracked in `.tickets/`.

**Cause:** `tests/test_dispatch.py` drives the real CLI `task create`/`close`; `_maybe_emit_ticket` → `tickets_mirror.emit()` writes `.tickets/<id>.md` into the repo root's `.tickets/`. The `_no_ticket_mirror` autouse guard (`MAC_NO_TICKET_MIRROR=1`) only lived in `tests/cli/conftest.py`, so it covered `tests/cli/` but not top-level tests.

**Fix:** promote the guard to the top-level `tests/conftest.py` (covers every test dir); drop the redundant `tests/cli/` copy. Dedicated emit tests (`test_tickets_mirror.py`, `cli/test_mac_cli.py`) still pass — they opt back in via `monkeypatch.delenv` + a tmp `tickets_dir`.

Verified on NVIDIA-dev #9: 59 + 8 tests pass and no fixture mirror is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)