### PR TITLE
Block H: data-driven OpenShell sandbox requirement (drop hardcoded agent set)

### DIFF
--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -639,6 +639,12 @@ def build_mac_env(
         # mac-selfdrive: hub drives its own tick (dispatch->review->merge->reconcile)
         # on this interval (seconds) so the autonomous loop needs no external clock.
         ("MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS", "MAC_HUB_TICK_INTERVAL_SECONDS"),
+        # OpenShell sandbox requirement, data-driven from the agent's resources
+        # (no hardcoded agent list). The deploy orchestrator derives this from the
+        # agent's DB resources["openshell_required"]; it lands in mac.env and the
+        # executor reads it via openshell_required_for_local_agent. The worker
+        # also refreshes it from its live agent record at registration.
+        ("MAC_DEPLOY_OPENSHELL_REQUIRED", "MAC_OPENSHELL_REQUIRED"),
     ):
         _v = (env.get(_src) or "").strip()
         if _v:

--- a/src/mac/openshell_runtime.py
+++ b/src/mac/openshell_runtime.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
 
 
-DEFAULT_REQUIRED_AGENT_NAMES = frozenset({"rocky", "bullwinkle", "natasha"})
+# Empty by default: sandbox required-ness is DATA-DRIVEN (the agent's runtime
+# ``resources["openshell_required"]``, an explicit override, or the
+# ``MAC_OPENSHELL_REQUIRED`` env), never a hardcoded fleet roster baked into
+# source that goes stale as the fleet changes. Callers may still pass an
+# explicit ``required_agent_names`` set for a name-match fallback, but the
+# default matches nothing.
+DEFAULT_REQUIRED_AGENT_NAMES: frozenset[str] = frozenset()
 TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
@@ -69,3 +75,32 @@ def openshell_required_for_local_agent(
         or os.uname().nodename
     )
     return openshell_required_for_identity(agent_id=name)
+
+
+def apply_openshell_requirement(
+    resources: Optional[Mapping[str, Any]],
+    environ: MutableMapping[str, str],
+) -> Optional[bool]:
+    """Stamp ``MAC_OPENSHELL_REQUIRED`` into ``environ`` from an agent's runtime
+    ``resources`` so a DB-driven sandbox requirement reaches the local executor
+    (which inherits the worker process environment) WITHOUT a hardcoded agent
+    list. This is the data-driven channel that replaces the old name allowlist:
+    the hub owns ``resources["openshell_required"]`` per agent, the worker reads
+    its own record back at registration, and this function projects that fact
+    into the env the executor reads via :func:`openshell_required_for_local_agent`.
+
+    Precedence: an existing ``MAC_OPENSHELL_REQUIRED`` (operator/deploy override)
+    always wins and is left untouched. Otherwise, if ``resources`` carries an
+    explicit ``openshell_required`` flag it is written as ``"1"``/``"0"``. A
+    missing flag is a no-op — the executor keeps its own default — so this never
+    silently flips an unconfigured agent. Returns the bool applied, or ``None``
+    when nothing was written.
+    """
+    if "MAC_OPENSHELL_REQUIRED" in environ:
+        return None
+    raw = (resources or {}).get("openshell_required")
+    if raw is None:
+        return None
+    value = _boolish(raw)
+    environ["MAC_OPENSHELL_REQUIRED"] = "1" if value else "0"
+    return value

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -4300,6 +4300,14 @@ def main(argv: Optional[List[str]] = None) -> int:
                 os.environ["MAC_ATTESTATION_KEY"] = attestation_key
                 if attestation_env_path is not None:
                     _write_env_value(attestation_env_path, "MAC_ATTESTATION_KEY", attestation_key)
+            # Data-driven OpenShell sandbox requirement: project the agent's
+            # runtime resources["openshell_required"] (owned by the hub) into the
+            # env the executor inherits, so a redeploy isn't needed to honor an
+            # operator's DB change. A pre-set MAC_OPENSHELL_REQUIRED wins; an
+            # unset resource is a no-op. Replaces the old hardcoded agent list.
+            from mac.openshell_runtime import apply_openshell_requirement
+
+            apply_openshell_requirement(registered.get("resources"), os.environ)
         if not agent_id:
             raise MacApiError("--agent-id or --register is required")
         if args.install_pip or args.install_npm:

--- a/tests/test_openshell_management.py
+++ b/tests/test_openshell_management.py
@@ -17,8 +17,12 @@ network_policies:
 
 
 def _agent(cp: ControlPlane):
+    # openshell_required is data-driven from the agent's own resources (no
+    # hardcoded name allowlist), so the agent record must carry the flag.
     machine = cp.register_machine("rocky", resources={"openshell_required": True})
-    return cp.register_agent(machine.id, "rocky", capabilities=["python"])
+    return cp.register_agent(
+        machine.id, "rocky", capabilities=["python"], resources={"openshell_required": True}
+    )
 
 
 def test_openshell_policy_crud_versions_assignment_and_status():

--- a/tests/test_openshell_runtime.py
+++ b/tests/test_openshell_runtime.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from mac.openshell_runtime import (
+    DEFAULT_REQUIRED_AGENT_NAMES,
+    apply_openshell_requirement,
     base_agent_name,
     openshell_required_for_identity,
     openshell_required_for_local_agent,
@@ -9,8 +11,8 @@ from mac.openshell_runtime import (
 
 
 def test_base_agent_name_normalizes_ids_hosts_and_empty_values():
-    assert base_agent_name("agent_rocky") == "rocky"
-    assert base_agent_name("Rocky.EXAMPLE.com") == "rocky"
+    assert base_agent_name("agent_alpha") == "alpha"
+    assert base_agent_name("Alpha.EXAMPLE.com") == "alpha"
     assert base_agent_name("") == ""
 
 
@@ -20,29 +22,70 @@ def test_truthy_normalizes_common_env_values():
     assert truthy(None) is False
 
 
-def test_openshell_required_for_identity_uses_explicit_and_resources():
-    assert openshell_required_for_identity(agent_id="agent_rocky") is True
-    assert openshell_required_for_identity(agent_id="agent_rocky", explicit="0") is False
-    assert openshell_required_for_identity(agent_id="agent_boris") is False
+def test_default_required_set_is_empty_no_hardcoded_fleet():
+    # The fleet roster is no longer baked into source; required-ness is data-driven.
+    assert DEFAULT_REQUIRED_AGENT_NAMES == frozenset()
+
+
+def test_required_for_identity_explicit_and_resources_override():
+    # explicit wins outright
+    assert openshell_required_for_identity(agent_id="agent_alpha", explicit="1") is True
+    assert openshell_required_for_identity(agent_id="agent_alpha", explicit="0") is False
+    # resources.openshell_required is the data-driven signal
     assert openshell_required_for_identity(
-        agent_id="agent_boris",
-        resources={"openshell_required": "true"},
+        agent_id="agent_x", resources={"openshell_required": "true"}
     ) is True
     assert openshell_required_for_identity(
-        agent_id="agent_rocky",
-        resources={"openshell_required": "false"},
+        agent_id="agent_x", resources={"openshell_required": "false"}
     ) is False
+
+
+def test_required_for_identity_matches_only_an_explicit_required_set():
+    # name matching works against a caller-supplied set, not a hardcoded one
     assert openshell_required_for_identity(
-        agent_id="agent_boris",
-        resources={"hostname": "natasha.internal"},
+        agent_id="agent_alpha", required_agent_names={"alpha"}
     ) is True
+    assert openshell_required_for_identity(
+        agent_id="agent_beta", required_agent_names={"alpha"}
+    ) is False
+    # with the empty default set, an agent name alone never forces sandboxing
+    assert openshell_required_for_identity(agent_id="agent_alpha") is False
 
 
-def test_openshell_required_for_local_agent_reads_env_precedence():
-    env = {"MAC_AGENT_ID": "agent_rocky"}
+def test_required_for_local_agent_reads_env_precedence():
+    assert openshell_required_for_local_agent({"MAC_OPENSHELL_REQUIRED": "1"}) is True
+    assert openshell_required_for_local_agent({"MAC_OPENSHELL_REQUIRED": "0"}) is False
+    # no override + empty default set -> not required by name alone
+    assert openshell_required_for_local_agent({"MAC_AGENT_ID": "agent_alpha"}) is False
+
+
+def test_apply_openshell_requirement_stamps_env_from_resources():
+    env: dict[str, str] = {}
+    assert apply_openshell_requirement({"openshell_required": True}, env) is True
+    assert env["MAC_OPENSHELL_REQUIRED"] == "1"
+
+    env = {}
+    assert apply_openshell_requirement({"openshell_required": "false"}, env) is False
+    assert env["MAC_OPENSHELL_REQUIRED"] == "0"
+
+
+def test_apply_openshell_requirement_preserves_existing_env_override():
+    env = {"MAC_OPENSHELL_REQUIRED": "1"}
+    # an operator/deploy override wins; a DB "false" must not silently downgrade it
+    assert apply_openshell_requirement({"openshell_required": False}, env) is None
+    assert env["MAC_OPENSHELL_REQUIRED"] == "1"
+
+
+def test_apply_openshell_requirement_noop_when_resource_absent():
+    env: dict[str, str] = {}
+    assert apply_openshell_requirement(None, env) is None
+    assert apply_openshell_requirement({}, env) is None
+    assert apply_openshell_requirement({"hardware": {}}, env) is None
+    assert "MAC_OPENSHELL_REQUIRED" not in env
+
+
+def test_apply_then_local_agent_round_trips():
+    # the env this helper writes is exactly what the executor's gate reads
+    env: dict[str, str] = {}
+    apply_openshell_requirement({"openshell_required": True}, env)
     assert openshell_required_for_local_agent(env) is True
-    env = {"MAC_AGENT_ID": "agent_rocky", "MAC_OPENSHELL_REQUIRED": "0"}
-    assert openshell_required_for_local_agent(env) is False
-    env = {"MAC_WORKER_AGENT_NAME": "natasha.example.com"}
-    assert openshell_required_for_local_agent(env) is True
-    assert openshell_required_for_local_agent({}, fallback_name="agent_rocky") is True


### PR DESCRIPTION
Reconciliation block H. Removes the hardcoded `DEFAULT_REQUIRED_AGENT_NAMES = {rocky,bullwinkle,natasha}` and makes sandbox required-ness fully data-driven from the runtime DB, **without** introducing a fail-open hole.

## Why
The hardcoded set was the tier-3 fallback in `openshell_required_for_identity` (after `explicit` and `resources["openshell_required"]`). Server-side decisions were already data-driven from the agent's DB `resources`; the only reason the list existed was the **local** executor/supervisor decision, which runs in-process with just env + nodename and no hub round-trip. A source-coupled fleet roster goes stale as the fleet changes.

## What
- `openshell_runtime.py`: `DEFAULT_REQUIRED_AGENT_NAMES -> frozenset()`; new `apply_openshell_requirement(resources, environ)` projects an agent's `resources["openshell_required"]` into `MAC_OPENSHELL_REQUIRED` (existing env wins; absent resource = no-op, so an unconfigured agent is never silently flipped).
- `worker.py`: at registration the worker reads its **own agent record back from the hub** and applies the resource into `os.environ` — so the executor (which inherits the env) honors a live operator DB change on restart, no redeploy. Mirrors the existing attestation-key projection.
- `deploy_env.py`: `MAC_DEPLOY_OPENSHELL_REQUIRED -> MAC_OPENSHELL_REQUIRED` passthrough — the deploy-time channel (orchestrator derives it from the agent's DB resource).
- tests: data-driven `openshell_runtime` coverage + the new helper; openshell-management fixture carries the flag on the agent record.

Net: the runtime DB is the single source of truth; nothing about the fleet is in source. Full suite green (1741 passed, 13 skipped).

Note: this does not change the executor's missing-data default (still governed by `MAC_ALLOW_UNSANDBOXED_YOLO`); a follow-up could flip that to fail-closed if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)