### PR TITLE
feat(acp): Agent Client Protocol Phase 0 + executor adapter (ADR 0006)

### DIFF
--- a/src/mac/acp/__init__.py
+++ b/src/mac/acp/__init__.py
@@ -1,0 +1,84 @@
+"""Agent Client Protocol (ACP) support for mac.
+
+ACP (https://agentclientprotocol.com) is the open JSON-RPC 2.0 standard for
+host/client <-> agent communication -- the role LSP plays for editors. This
+package realizes ADR 0006 (Phase 0 + Phase-1 core):
+
+* :mod:`mac.acp.protocol` -- pure wire types, method constants, PROTOCOL_VERSION.
+* :mod:`mac.acp.peer` -- a transport-agnostic, synchronously-drivable JSON-RPC
+  2.0 peer plus a thin stdio binding.
+* :mod:`mac.acp.client` -- :class:`ACPClient`, the host side that drives an
+  external ACP agent.
+* :mod:`mac.acp.executor` -- :class:`ACPExecutor`, the standalone adapter the
+  task executor will sit behind under ``MAC_EXECUTOR_BACKEND=acp`` (integration
+  is a deliberate Phase-1 follow-up; not wired here).
+"""
+
+from __future__ import annotations
+
+from .client import ACPClient, PermissionHandler, UpdateHandler
+from .executor import ACPExecutor, ACPRunResult
+from .peer import Peer, PendingRequest, RemoteError, stdio_peer
+from .protocol import (
+    PROTOCOL_VERSION,
+    AgentCapabilities,
+    AuthMethod,
+    ClientCapabilities,
+    ContentBlockType,
+    InitializeParams,
+    InitializeResult,
+    JSONRPCError,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResponse,
+    Method,
+    NewSessionParams,
+    NewSessionResult,
+    PermissionOption,
+    PermissionOutcome,
+    PromptParams,
+    PromptResult,
+    RequestPermissionParams,
+    RequestPermissionResult,
+    SessionUpdateKind,
+    StopReason,
+    decode_message,
+    text_block,
+)
+
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "Method",
+    "SessionUpdateKind",
+    "StopReason",
+    "ContentBlockType",
+    "PermissionOutcome",
+    "JSONRPCError",
+    "JSONRPCRequest",
+    "JSONRPCResponse",
+    "JSONRPCNotification",
+    "decode_message",
+    "text_block",
+    "ClientCapabilities",
+    "AgentCapabilities",
+    "AuthMethod",
+    "InitializeParams",
+    "InitializeResult",
+    "NewSessionParams",
+    "NewSessionResult",
+    "PromptParams",
+    "PromptResult",
+    "PermissionOption",
+    "RequestPermissionParams",
+    "RequestPermissionResult",
+    "Peer",
+    "PendingRequest",
+    "RemoteError",
+    "stdio_peer",
+    "ACPClient",
+    "UpdateHandler",
+    "PermissionHandler",
+    "ACPExecutor",
+    "ACPRunResult",
+]

--- a/src/mac/acp/client.py
+++ b/src/mac/acp/client.py
@@ -1,0 +1,174 @@
+"""``ACPClient`` -- the host/client side of the Agent Client Protocol.
+
+This is the role mac plays when it *drives* an external ACP-compliant agent. It
+wraps a :class:`~mac.acp.peer.Peer` and exposes the baseline client-initiated
+methods (``initialize``, ``authenticate``, ``session/new``, ``session/prompt``)
+as ordinary blocking calls, while letting the caller register handlers for the
+two agent-initiated channels:
+
+* ``session/update`` notifications (streaming turn progress) via
+  :meth:`on_update`.
+* ``session/request_permission`` requests via :meth:`on_request_permission`,
+  so mac can later route permission decisions through its own policy/sandbox.
+
+The client is transport-agnostic: it takes a ready :class:`Peer`. Pair it with
+:func:`~mac.acp.peer.stdio_peer` for a real subprocess agent, or with an
+in-memory paired peer in tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+from .peer import Peer
+from .protocol import (
+    AuthenticateParams,
+    ClientCapabilities,
+    InitializeParams,
+    InitializeResult,
+    Method,
+    NewSessionParams,
+    NewSessionResult,
+    PromptParams,
+    PromptResult,
+    RequestPermissionParams,
+    RequestPermissionResult,
+    text_block,
+)
+
+
+__all__ = ["ACPClient", "UpdateHandler", "PermissionHandler"]
+
+
+#: Receives the raw ``params`` dict of a ``session/update`` notification.
+UpdateHandler = Callable[[Dict[str, Any]], None]
+
+#: Receives a parsed :class:`RequestPermissionParams` and returns the client's
+#: :class:`RequestPermissionResult` decision.
+PermissionHandler = Callable[[RequestPermissionParams], RequestPermissionResult]
+
+
+class ACPClient:
+    """Client-side driver for an ACP agent over a :class:`Peer`."""
+
+    def __init__(
+        self,
+        peer: Peer,
+        *,
+        client_capabilities: Optional[ClientCapabilities] = None,
+        client_info: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._peer = peer
+        self._client_capabilities = client_capabilities or ClientCapabilities()
+        self._client_info = client_info or {
+            "name": "mac",
+            "title": "MAC hub",
+            "version": "0",
+        }
+        self._update_handler: Optional[UpdateHandler] = None
+        self._permission_handler: Optional[PermissionHandler] = None
+        self.agent_capabilities: Optional[InitializeResult] = None
+
+        # Wire the agent-initiated channels into the peer.
+        peer.on_notification(Method.SESSION_UPDATE, self._dispatch_update)
+        peer.on_request(
+            Method.SESSION_REQUEST_PERMISSION, self._dispatch_request_permission
+        )
+
+    # -- handler registration ------------------------------------------------
+
+    def on_update(self, handler: UpdateHandler) -> None:
+        """Register the sink for ``session/update`` notifications."""
+
+        self._update_handler = handler
+
+    def on_request_permission(self, handler: PermissionHandler) -> None:
+        """Register the responder for ``session/request_permission`` requests."""
+
+        self._permission_handler = handler
+
+    # -- agent-initiated dispatch -------------------------------------------
+
+    def _dispatch_update(self, params: Optional[Dict[str, Any]]) -> None:
+        if self._update_handler is not None:
+            self._update_handler(params or {})
+
+    def _dispatch_request_permission(
+        self, params: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        parsed = RequestPermissionParams.from_dict(params or {})
+        if self._permission_handler is None:
+            # No policy registered -> decline by cancelling, the safe default.
+            return RequestPermissionResult(outcome="cancelled").to_dict()
+        decision = self._permission_handler(parsed)
+        return decision.to_dict()
+
+    # -- baseline client methods --------------------------------------------
+
+    def initialize(
+        self, *, timeout: Optional[float] = None
+    ) -> InitializeResult:
+        """Negotiate the protocol version and capabilities with the agent."""
+
+        params = InitializeParams(
+            client_capabilities=self._client_capabilities,
+            client_info=self._client_info,
+        )
+        raw = self._peer.request(Method.INITIALIZE, params.to_dict()).result(timeout)
+        result = InitializeResult.from_dict(raw or {})
+        self.agent_capabilities = result
+        return result
+
+    def authenticate(
+        self, method_id: str, *, timeout: Optional[float] = None
+    ) -> None:
+        """Authenticate using one of the agent-advertised auth methods."""
+
+        params = AuthenticateParams(method_id=method_id)
+        self._peer.request(Method.AUTHENTICATE, params.to_dict()).result(timeout)
+
+    def session_new(
+        self,
+        cwd: str,
+        *,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
+        timeout: Optional[float] = None,
+    ) -> str:
+        """Create a new session and return its ``sessionId``."""
+
+        params = NewSessionParams(cwd=cwd, mcp_servers=mcp_servers or [])
+        raw = self._peer.request(Method.SESSION_NEW, params.to_dict()).result(timeout)
+        return NewSessionResult.from_dict(raw or {}).session_id
+
+    def session_prompt(
+        self,
+        session_id: str,
+        prompt: Any,
+        *,
+        timeout: Optional[float] = None,
+    ) -> PromptResult:
+        """Drive a prompt turn; blocks until the agent returns a stop reason.
+
+        ``prompt`` may be a plain string (wrapped into a single ``text`` content
+        block) or an explicit list of content-block dicts.
+        """
+
+        blocks = self._normalize_prompt(prompt)
+        params = PromptParams(session_id=session_id, prompt=blocks)
+        raw = self._peer.request(Method.SESSION_PROMPT, params.to_dict()).result(
+            timeout
+        )
+        return PromptResult.from_dict(raw or {})
+
+    def cancel(self, session_id: str) -> None:
+        """Send a ``session/cancel`` notification for the given session."""
+
+        self._peer.notify(Method.SESSION_CANCEL, {"sessionId": session_id})
+
+    @staticmethod
+    def _normalize_prompt(prompt: Any) -> List[Dict[str, Any]]:
+        if isinstance(prompt, str):
+            return [text_block(prompt)]
+        if isinstance(prompt, dict):
+            return [prompt]
+        return list(prompt)

--- a/src/mac/acp/executor.py
+++ b/src/mac/acp/executor.py
@@ -1,0 +1,138 @@
+"""``ACPExecutor`` -- standalone adapter that runs one ACP agent prompt turn.
+
+This is the seam that ``task_executor`` will sit behind once
+``MAC_EXECUTOR_BACKEND=acp`` is wired up (the Phase-1 integration follow-up).
+For Phase 0/1-core it is a self-contained, independently testable adapter: give
+it an agent command (argv) and a prompt, and it
+
+1. spawns the agent over stdio,
+2. runs ``initialize`` -> ``session/new`` -> ``session/prompt``,
+3. forwards every ``session/update`` notification to an ``on_update`` callback
+   (the future ``/action-events`` sink), and
+4. returns an :class:`ACPRunResult` carrying the final stop reason.
+
+It deliberately does **not** import or touch ``task_executor``, ``api``,
+``services``, or any other existing module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from .client import ACPClient
+from .peer import Peer, stdio_peer
+from .protocol import (
+    ClientCapabilities,
+    InitializeResult,
+    RequestPermissionParams,
+    RequestPermissionResult,
+)
+
+
+__all__ = ["ACPExecutor", "ACPRunResult", "OnUpdate", "OnPermission"]
+
+
+#: The action-events sink: receives each raw ``session/update`` params dict.
+OnUpdate = Callable[[Dict[str, Any]], None]
+
+#: Optional permission policy; defaults to "cancel" (deny) when unset.
+OnPermission = Callable[[RequestPermissionParams], RequestPermissionResult]
+
+
+@dataclass
+class ACPRunResult:
+    """Outcome of a single :meth:`ACPExecutor.run` invocation."""
+
+    session_id: str
+    stop_reason: str
+    initialize: InitializeResult
+    updates: List[Dict[str, Any]] = field(default_factory=list)
+
+
+class ACPExecutor:
+    """Run a prompt against an ACP agent, streaming updates to a callback.
+
+    Parameters
+    ----------
+    argv:
+        The agent command to spawn (e.g. ``["claude-code", "acp"]``). Ignored
+        when ``peer_factory`` is supplied (tests inject an in-memory peer).
+    cwd:
+        Working directory advertised to the agent in ``session/new``.
+    peer_factory:
+        Optional hook returning a ready :class:`Peer` given a ``send`` callable.
+        Used to inject a paired in-memory transport in tests; when ``None`` the
+        executor spawns ``argv`` over stdio via :func:`stdio_peer`.
+    """
+
+    def __init__(
+        self,
+        argv: List[str],
+        *,
+        cwd: str = ".",
+        client_capabilities: Optional[ClientCapabilities] = None,
+        client_info: Optional[Dict[str, Any]] = None,
+        peer_factory: Optional[Callable[[], Peer]] = None,
+    ) -> None:
+        self._argv = list(argv)
+        self._cwd = cwd
+        self._client_capabilities = client_capabilities
+        self._client_info = client_info
+        self._peer_factory = peer_factory
+
+    def run(
+        self,
+        prompt: Any,
+        *,
+        on_update: Optional[OnUpdate] = None,
+        on_permission: Optional[OnPermission] = None,
+        timeout: Optional[float] = None,
+    ) -> ACPRunResult:
+        """Execute one prompt turn end-to-end and return the result.
+
+        Every ``session/update`` is appended to :attr:`ACPRunResult.updates` and
+        also forwarded to ``on_update`` if provided. Blocks until the agent
+        returns a stop reason (or ``timeout`` elapses).
+        """
+
+        peer, closer = self._build_peer()
+        try:
+            client = ACPClient(
+                peer,
+                client_capabilities=self._client_capabilities,
+                client_info=self._client_info,
+            )
+            collected: List[Dict[str, Any]] = []
+
+            def _sink(update: Dict[str, Any]) -> None:
+                collected.append(update)
+                if on_update is not None:
+                    on_update(update)
+
+            client.on_update(_sink)
+            if on_permission is not None:
+                client.on_request_permission(on_permission)
+
+            init = client.initialize(timeout=timeout)
+            session_id = client.session_new(self._cwd, timeout=timeout)
+            prompt_result = client.session_prompt(
+                session_id, prompt, timeout=timeout
+            )
+            return ACPRunResult(
+                session_id=session_id,
+                stop_reason=prompt_result.stop_reason,
+                initialize=init,
+                updates=collected,
+            )
+        finally:
+            if closer is not None:
+                closer()
+
+    def _build_peer(self):
+        """Return ``(peer, closer)`` where ``closer`` (if any) tears it down."""
+
+        if self._peer_factory is not None:
+            return self._peer_factory(), None
+        stdio = stdio_peer(self._argv)
+        return stdio, stdio.close

--- a/src/mac/acp/peer.py
+++ b/src/mac/acp/peer.py
@@ -1,0 +1,286 @@
+"""A transport-agnostic JSON-RPC 2.0 peer for the Agent Client Protocol.
+
+The :class:`Peer` is the heart of the ACP wiring: it owns request/response
+correlation by ``id``, dispatches inbound notifications and inbound requests to
+registered handlers, and frames messages as newline-delimited JSON (one JSON
+object per line -- ACP's stdio framing).
+
+It is **transport-agnostic and synchronously drivable**: construct it with a
+``send`` callable (anything that accepts ``bytes``), push inbound bytes in via
+:meth:`feed`, and call :meth:`pump` to process complete frames. There is no
+asyncio and no third-party dependency, so it can be exercised directly in unit
+tests by pairing two peers over in-memory buffers.
+
+A thin stdio binding (:func:`stdio_peer`) is provided for the real local-
+subprocess case, but it is strictly a convenience wrapper around the pure core.
+"""
+
+from __future__ import annotations
+
+import itertools
+import subprocess
+import threading
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from .protocol import (
+    ERROR_INTERNAL,
+    ERROR_METHOD_NOT_FOUND,
+    JSONRPCError,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResponse,
+    decode_message,
+    json_dumps,
+)
+
+
+__all__ = ["Peer", "PendingRequest", "RemoteError", "stdio_peer"]
+
+
+SendFn = Callable[[bytes], None]
+
+#: A request handler maps inbound ``params`` to a result (returned to the peer)
+#: or raises to produce a JSON-RPC error. Handlers are synchronous.
+RequestHandler = Callable[[Optional[Dict[str, Any]]], Any]
+
+#: A notification handler consumes inbound ``params``; its return value (if any)
+#: is ignored, since notifications have no response.
+NotificationHandler = Callable[[Optional[Dict[str, Any]]], None]
+
+
+class RemoteError(Exception):
+    """Raised when a peer returns a JSON-RPC error response to our request."""
+
+    def __init__(self, error: JSONRPCError) -> None:
+        super().__init__("%s (code %s)" % (error.message, error.code))
+        self.error = error
+
+
+class PendingRequest:
+    """A future-like handle for an outbound request awaiting its response.
+
+    Deliberately synchronous: :meth:`result` blocks on a
+    :class:`threading.Event` so the peer works both in single-threaded test
+    drivers (where the response is fed before ``result`` is called, or another
+    thread pumps) and in the threaded stdio binding.
+    """
+
+    def __init__(self, request_id: Union[str, int]) -> None:
+        self.request_id = request_id
+        self._event = threading.Event()
+        self._response: Optional[JSONRPCResponse] = None
+
+    def _fulfill(self, response: JSONRPCResponse) -> None:
+        self._response = response
+        self._event.set()
+
+    def done(self) -> bool:
+        return self._event.is_set()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        """Block until the response arrives; return its ``result`` payload.
+
+        Raises :class:`RemoteError` if the peer returned an error, or
+        :class:`TimeoutError` if ``timeout`` elapses first.
+        """
+
+        if not self._event.wait(timeout):
+            raise TimeoutError(
+                "no response for request id=%r within %s s" % (self.request_id, timeout)
+            )
+        assert self._response is not None  # set alongside the event
+        if self._response.is_error:
+            assert self._response.error is not None
+            raise RemoteError(self._response.error)
+        return self._response.result
+
+
+class Peer:
+    """A synchronous JSON-RPC 2.0 endpoint over newline-delimited frames."""
+
+    def __init__(self, send: SendFn) -> None:
+        self._send = send
+        self._id_counter = itertools.count(1)
+        self._pending: Dict[Union[str, int], PendingRequest] = {}
+        self._request_handlers: Dict[str, RequestHandler] = {}
+        self._notification_handlers: Dict[str, NotificationHandler] = {}
+        self._inbox = bytearray()
+        self._lock = threading.Lock()
+
+    # -- handler registration ------------------------------------------------
+
+    def on_request(self, method: str, handler: RequestHandler) -> None:
+        """Register a handler for inbound requests with the given ``method``."""
+
+        self._request_handlers[method] = handler
+
+    def on_notification(self, method: str, handler: NotificationHandler) -> None:
+        """Register a handler for inbound notifications with ``method``."""
+
+        self._notification_handlers[method] = handler
+
+    # -- outbound ------------------------------------------------------------
+
+    def request(
+        self, method: str, params: Optional[Dict[str, Any]] = None
+    ) -> PendingRequest:
+        """Send a request and return a :class:`PendingRequest` to await it."""
+
+        with self._lock:
+            request_id = next(self._id_counter)
+            pending = PendingRequest(request_id)
+            self._pending[request_id] = pending
+        self._write(JSONRPCRequest(id=request_id, method=method, params=params))
+        return pending
+
+    def notify(self, method: str, params: Optional[Dict[str, Any]] = None) -> None:
+        """Send a notification (fire-and-forget, no response correlation)."""
+
+        self._write(JSONRPCNotification(method=method, params=params))
+
+    def _write(self, message: Any) -> None:
+        line = json_dumps(message.to_dict()) + "\n"
+        self._send(line.encode("utf-8"))
+
+    # -- inbound -------------------------------------------------------------
+
+    def feed(self, data: bytes) -> None:
+        """Append raw inbound bytes; complete lines are processed by :meth:`pump`."""
+
+        self._inbox.extend(data)
+
+    def pump(self) -> int:
+        """Process every complete newline-delimited frame currently buffered.
+
+        Returns the number of frames processed. Partial trailing data is
+        retained for the next call. Safe to call repeatedly.
+        """
+
+        processed = 0
+        while True:
+            idx = self._inbox.find(b"\n")
+            if idx < 0:
+                break
+            raw = bytes(self._inbox[:idx])
+            del self._inbox[: idx + 1]
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            self._dispatch(stripped)
+            processed += 1
+        return processed
+
+    def feed_and_pump(self, data: bytes) -> int:
+        """Convenience: :meth:`feed` then :meth:`pump`."""
+
+        self.feed(data)
+        return self.pump()
+
+    def _dispatch(self, raw: bytes) -> None:
+        message = decode_message(raw)
+        if isinstance(message, JSONRPCResponse):
+            self._handle_response(message)
+        elif isinstance(message, JSONRPCRequest):
+            self._handle_request(message)
+        elif isinstance(message, JSONRPCNotification):
+            self._handle_notification(message)
+
+    def _handle_response(self, response: JSONRPCResponse) -> None:
+        with self._lock:
+            pending = self._pending.pop(response.id, None)
+        if pending is not None:
+            pending._fulfill(response)
+
+    def _handle_request(self, request: JSONRPCRequest) -> None:
+        handler = self._request_handlers.get(request.method)
+        if handler is None:
+            self._write(
+                JSONRPCResponse(
+                    id=request.id,
+                    error=JSONRPCError(
+                        code=ERROR_METHOD_NOT_FOUND,
+                        message="method not found: %s" % request.method,
+                    ),
+                )
+            )
+            return
+        try:
+            result = handler(request.params)
+        except RemoteError as exc:  # handler chose to surface a wire error
+            self._write(JSONRPCResponse(id=request.id, error=exc.error))
+            return
+        except Exception as exc:  # noqa: BLE001 -- map any handler failure to a JSON-RPC error
+            self._write(
+                JSONRPCResponse(
+                    id=request.id,
+                    error=JSONRPCError(code=ERROR_INTERNAL, message=str(exc)),
+                )
+            )
+            return
+        self._write(JSONRPCResponse(id=request.id, result=result))
+
+    def _handle_notification(self, notification: JSONRPCNotification) -> None:
+        handler = self._notification_handlers.get(notification.method)
+        if handler is not None:
+            handler(notification.params)
+
+
+# ---------------------------------------------------------------------------
+# stdio binding (thin convenience wrapper around the pure core)
+# ---------------------------------------------------------------------------
+
+
+class _StdioPeer(Peer):
+    """A :class:`Peer` bound to a subprocess's stdin/stdout.
+
+    A background reader thread streams the child's stdout into :meth:`feed` and
+    drives :meth:`pump`, so callers interact purely through the
+    :class:`Peer` API (``request``/``notify`` + registered handlers).
+    """
+
+    def __init__(self, argv: List[str], **popen_kwargs: Any) -> None:
+        self._proc = subprocess.Popen(  # noqa: S603 -- argv supplied by caller/config
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            **popen_kwargs,
+        )
+        assert self._proc.stdin is not None and self._proc.stdout is not None
+        super().__init__(send=self._send_to_stdin)
+        self._stop = threading.Event()
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _send_to_stdin(self, data: bytes) -> None:
+        assert self._proc.stdin is not None
+        self._proc.stdin.write(data)
+        self._proc.stdin.flush()
+
+    def _read_loop(self) -> None:
+        stdout = self._proc.stdout
+        assert stdout is not None
+        while not self._stop.is_set():
+            line = stdout.readline()
+            if not line:  # EOF -- child closed stdout / exited
+                break
+            self.feed(line if isinstance(line, bytes) else line.encode("utf-8"))
+            self.pump()
+
+    def close(self) -> None:
+        """Stop the reader and terminate the subprocess."""
+
+        self._stop.set()
+        if self._proc.poll() is None:
+            self._proc.terminate()
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+
+
+def stdio_peer(argv: List[str], **popen_kwargs: Any) -> _StdioPeer:
+    """Spawn ``argv`` as a subprocess and return a :class:`Peer` wired to its
+    stdio (newline-delimited JSON-RPC). Caller is responsible for calling
+    ``close()`` (or using it as a context-manager-style resource)."""
+
+    return _StdioPeer(argv, **popen_kwargs)

--- a/src/mac/acp/protocol.py
+++ b/src/mac/acp/protocol.py
@@ -1,0 +1,628 @@
+"""Pure data types and (de)serialization for the Agent Client Protocol (ACP).
+
+ACP (https://agentclientprotocol.com) is the open JSON-RPC 2.0 standard for
+**host/client <-> agent** communication. This module is the wire layer: it
+defines the JSON-RPC 2.0 message envelope, the ACP method-name constants, and
+the small set of structured payload types (capabilities, content blocks, stop
+reasons). It performs **no I/O** -- everything here is pure data plus
+``to_dict`` / ``from_dict`` (de)serialization, so it can be exercised without a
+transport.
+
+Spec notes pinned by this implementation (verified against
+``agentclientprotocol.com/protocol/v1/*`` on 2026-06-16):
+
+* The protocol version is a single **integer** identifying a MAJOR version
+  (currently ``1``) -- *not* a string.
+* Property names are ``camelCase``; discriminator string values are
+  ``snake_case``.
+* ``session/cancel`` is a **notification** (client -> agent), not a request.
+* ``session/update`` is a client **notification** (agent -> client).
+* ``session/request_permission`` is a client **request** (agent -> client).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+
+__all__ = [
+    "PROTOCOL_VERSION",
+    "JSONRPC_VERSION",
+    "Method",
+    "SessionUpdateKind",
+    "StopReason",
+    "ContentBlockType",
+    "PermissionOutcome",
+    "JSONRPCError",
+    "JSONRPCRequest",
+    "JSONRPCResponse",
+    "JSONRPCNotification",
+    "JSONRPCMessage",
+    "decode_message",
+    "json_dumps",
+    "text_block",
+    "ClientCapabilities",
+    "AgentCapabilities",
+    "AuthMethod",
+    "InitializeParams",
+    "InitializeResult",
+    "AuthenticateParams",
+    "NewSessionParams",
+    "NewSessionResult",
+    "PromptParams",
+    "PromptResult",
+    "RequestPermissionParams",
+    "PermissionOption",
+    "RequestPermissionResult",
+]
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: The ACP MAJOR protocol version this package speaks. A single integer per the
+#: spec (``agentclientprotocol.com/protocol/v1/initialization``).
+PROTOCOL_VERSION: int = 1
+
+#: JSON-RPC envelope version. Constant for the protocol.
+JSONRPC_VERSION: str = "2.0"
+
+
+class Method:
+    """Canonical ACP JSON-RPC method names.
+
+    Grouped by direction/role per the spec. These are plain string constants so
+    they round-trip transparently onto the wire's ``method`` field.
+    """
+
+    # --- Agent methods (client -> agent requests) ---
+    INITIALIZE = "initialize"
+    AUTHENTICATE = "authenticate"
+    SESSION_NEW = "session/new"
+    SESSION_PROMPT = "session/prompt"
+    SESSION_LOAD = "session/load"  # optional capability (loadSession)
+    SESSION_SET_MODE = "session/set_mode"  # optional
+    LOGOUT = "logout"  # optional
+
+    # --- Agent notifications (client -> agent, no response) ---
+    SESSION_CANCEL = "session/cancel"
+
+    # --- Client methods (agent -> client requests) ---
+    SESSION_REQUEST_PERMISSION = "session/request_permission"
+    FS_READ_TEXT_FILE = "fs/read_text_file"  # optional client capability
+    FS_WRITE_TEXT_FILE = "fs/write_text_file"  # optional client capability
+    TERMINAL_CREATE = "terminal/create"  # optional client capability
+    TERMINAL_OUTPUT = "terminal/output"
+    TERMINAL_RELEASE = "terminal/release"
+    TERMINAL_WAIT_FOR_EXIT = "terminal/wait_for_exit"
+    TERMINAL_KILL = "terminal/kill"
+
+    # --- Client notifications (agent -> client, no response) ---
+    SESSION_UPDATE = "session/update"
+
+
+class SessionUpdateKind:
+    """Discriminator values for the ``sessionUpdate`` field of a
+    ``session/update`` notification payload (snake_case per spec)."""
+
+    AGENT_MESSAGE_CHUNK = "agent_message_chunk"
+    AGENT_THOUGHT_CHUNK = "agent_thought_chunk"
+    USER_MESSAGE_CHUNK = "user_message_chunk"
+    TOOL_CALL = "tool_call"
+    TOOL_CALL_UPDATE = "tool_call_update"
+    PLAN = "plan"
+    AVAILABLE_COMMANDS_UPDATE = "available_commands_update"
+    USAGE_UPDATE = "usage_update"
+
+
+class StopReason:
+    """Allowed values for the ``stopReason`` of a ``session/prompt`` result."""
+
+    END_TURN = "end_turn"
+    MAX_TOKENS = "max_tokens"
+    MAX_TURN_REQUESTS = "max_turn_requests"
+    REFUSAL = "refusal"
+    CANCELLED = "cancelled"
+
+
+class ContentBlockType:
+    """Discriminator values for the ``type`` field of a content block."""
+
+    TEXT = "text"
+    IMAGE = "image"
+    AUDIO = "audio"
+    RESOURCE = "resource"
+    RESOURCE_LINK = "resource_link"
+
+
+class PermissionOutcome:
+    """Values for the ``outcome.outcome`` field of a permission response."""
+
+    SELECTED = "selected"
+    CANCELLED = "cancelled"
+
+
+# Standard JSON-RPC 2.0 error codes (subset relevant to ACP peers).
+ERROR_PARSE = -32700
+ERROR_INVALID_REQUEST = -32600
+ERROR_METHOD_NOT_FOUND = -32601
+ERROR_INVALID_PARAMS = -32602
+ERROR_INTERNAL = -32603
+
+
+def json_dumps(value: Any) -> str:
+    """Deterministic, compact JSON encoding.
+
+    Mirrors :func:`mac.models.json_dumps` (sorted keys, no whitespace) so ACP
+    frames are byte-stable for tests and logging. ACP framing is one JSON object
+    per line, so the result must contain no embedded newlines -- ``json.dumps``
+    guarantees this for the value types used here.
+    """
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC 2.0 envelope
+# ---------------------------------------------------------------------------
+
+# A JSON-RPC id may be a string, number, or null per the spec. ACP peers use
+# integers, but we accept any of these on decode.
+RpcId = Union[str, int, None]
+
+
+@dataclass
+class JSONRPCError:
+    """The ``error`` object of a JSON-RPC 2.0 failure response."""
+
+    code: int
+    message: str
+    data: Any = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.data is not None:
+            out["data"] = self.data
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "JSONRPCError":
+        return cls(
+            code=int(raw["code"]),
+            message=str(raw.get("message", "")),
+            data=raw.get("data"),
+        )
+
+
+@dataclass
+class JSONRPCRequest:
+    """A JSON-RPC 2.0 request (expects a correlated response by ``id``)."""
+
+    id: RpcId
+    method: str
+    params: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "jsonrpc": JSONRPC_VERSION,
+            "id": self.id,
+            "method": self.method,
+        }
+        if self.params is not None:
+            out["params"] = self.params
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "JSONRPCRequest":
+        return cls(
+            id=raw.get("id"),
+            method=str(raw["method"]),
+            params=raw.get("params"),
+        )
+
+
+@dataclass
+class JSONRPCNotification:
+    """A JSON-RPC 2.0 notification: a method call with no ``id`` and no
+    response."""
+
+    method: str
+    params: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"jsonrpc": JSONRPC_VERSION, "method": self.method}
+        if self.params is not None:
+            out["params"] = self.params
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "JSONRPCNotification":
+        return cls(method=str(raw["method"]), params=raw.get("params"))
+
+
+@dataclass
+class JSONRPCResponse:
+    """A JSON-RPC 2.0 response: carries exactly one of ``result`` or ``error``.
+
+    ``result`` of ``None`` is ambiguous (a successful empty result also encodes
+    as ``null``), so success is tracked explicitly via :attr:`error`.
+    """
+
+    id: RpcId
+    result: Any = None
+    error: Optional[JSONRPCError] = None
+
+    @property
+    def is_error(self) -> bool:
+        return self.error is not None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"jsonrpc": JSONRPC_VERSION, "id": self.id}
+        if self.error is not None:
+            out["error"] = self.error.to_dict()
+        else:
+            # A successful response MUST include ``result`` (may be null).
+            out["result"] = self.result
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "JSONRPCResponse":
+        err = raw.get("error")
+        return cls(
+            id=raw.get("id"),
+            result=raw.get("result"),
+            error=JSONRPCError.from_dict(err) if isinstance(err, Mapping) else None,
+        )
+
+
+JSONRPCMessage = Union[JSONRPCRequest, JSONRPCResponse, JSONRPCNotification]
+
+
+def decode_message(raw: Union[str, bytes, Mapping[str, Any]]) -> JSONRPCMessage:
+    """Decode a single JSON-RPC frame into the appropriate envelope type.
+
+    Accepts a JSON string, bytes, or an already-parsed mapping. The message kind
+    is determined structurally per JSON-RPC 2.0:
+
+    * has ``method`` and ``id`` -> :class:`JSONRPCRequest`
+    * has ``method`` and no ``id`` -> :class:`JSONRPCNotification`
+    * has ``result`` or ``error`` -> :class:`JSONRPCResponse`
+
+    Raises :class:`ValueError` for frames that match none of these shapes.
+    """
+
+    if isinstance(raw, (str, bytes)):
+        obj = json.loads(raw)
+    else:
+        obj = raw
+    if not isinstance(obj, Mapping):
+        raise ValueError("JSON-RPC frame must be a JSON object")
+
+    if "method" in obj:
+        if "id" in obj and obj.get("id") is not None:
+            return JSONRPCRequest.from_dict(obj)
+        # An id of explicit null is still a request per JSON-RPC, but ACP peers
+        # treat a missing id as a notification. Disambiguate on key presence.
+        if "id" in obj:
+            return JSONRPCRequest.from_dict(obj)
+        return JSONRPCNotification.from_dict(obj)
+    if "result" in obj or "error" in obj:
+        return JSONRPCResponse.from_dict(obj)
+    raise ValueError("frame is not a valid JSON-RPC request, response, or notification")
+
+
+# ---------------------------------------------------------------------------
+# Content blocks
+# ---------------------------------------------------------------------------
+
+
+def text_block(text: str) -> Dict[str, Any]:
+    """Build a ``text`` content block, the most common prompt/response unit."""
+
+    return {"type": ContentBlockType.TEXT, "text": text}
+
+
+# ---------------------------------------------------------------------------
+# ACP payload types (the ``params`` / ``result`` bodies of ACP methods)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClientCapabilities:
+    """Capabilities the client (mac) advertises in ``initialize``.
+
+    ``fs`` advertises filesystem read/write helpers; ``terminal`` advertises
+    terminal support. Both default off -- mac drives agents but does not yet
+    offer these client-side helpers in Phase 0/1.
+    """
+
+    fs_read_text_file: bool = False
+    fs_write_text_file: bool = False
+    terminal: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "fs": {
+                "readTextFile": self.fs_read_text_file,
+                "writeTextFile": self.fs_write_text_file,
+            },
+            "terminal": self.terminal,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Mapping[str, Any]]) -> "ClientCapabilities":
+        raw = raw or {}
+        fs = raw.get("fs") or {}
+        return cls(
+            fs_read_text_file=bool(fs.get("readTextFile", False)),
+            fs_write_text_file=bool(fs.get("writeTextFile", False)),
+            terminal=bool(raw.get("terminal", False)),
+        )
+
+
+@dataclass
+class AgentCapabilities:
+    """Capabilities an agent advertises in the ``initialize`` result."""
+
+    load_session: bool = False
+    prompt_capabilities: Dict[str, Any] = field(default_factory=dict)
+    mcp_capabilities: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"loadSession": self.load_session}
+        if self.prompt_capabilities:
+            out["promptCapabilities"] = self.prompt_capabilities
+        if self.mcp_capabilities:
+            out["mcpCapabilities"] = self.mcp_capabilities
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Mapping[str, Any]]) -> "AgentCapabilities":
+        raw = raw or {}
+        return cls(
+            load_session=bool(raw.get("loadSession", False)),
+            prompt_capabilities=dict(raw.get("promptCapabilities") or {}),
+            mcp_capabilities=dict(raw.get("mcpCapabilities") or {}),
+        )
+
+
+@dataclass
+class AuthMethod:
+    """An authentication method advertised in the ``initialize`` result."""
+
+    id: str
+    name: str
+    description: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"id": self.id, "name": self.name}
+        if self.description is not None:
+            out["description"] = self.description
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "AuthMethod":
+        return cls(
+            id=str(raw["id"]),
+            name=str(raw.get("name", "")),
+            description=raw.get("description"),
+        )
+
+
+@dataclass
+class InitializeParams:
+    """Params for the ``initialize`` request."""
+
+    protocol_version: int = PROTOCOL_VERSION
+    client_capabilities: ClientCapabilities = field(default_factory=ClientCapabilities)
+    client_info: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "protocolVersion": self.protocol_version,
+            "clientCapabilities": self.client_capabilities.to_dict(),
+        }
+        if self.client_info is not None:
+            out["clientInfo"] = self.client_info
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "InitializeParams":
+        return cls(
+            protocol_version=int(raw.get("protocolVersion", PROTOCOL_VERSION)),
+            client_capabilities=ClientCapabilities.from_dict(
+                raw.get("clientCapabilities")
+            ),
+            client_info=raw.get("clientInfo"),
+        )
+
+
+@dataclass
+class InitializeResult:
+    """Result of the ``initialize`` request (returned by the agent)."""
+
+    protocol_version: int = PROTOCOL_VERSION
+    agent_capabilities: AgentCapabilities = field(default_factory=AgentCapabilities)
+    auth_methods: List[AuthMethod] = field(default_factory=list)
+    agent_info: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "protocolVersion": self.protocol_version,
+            "agentCapabilities": self.agent_capabilities.to_dict(),
+            "authMethods": [m.to_dict() for m in self.auth_methods],
+        }
+        if self.agent_info is not None:
+            out["agentInfo"] = self.agent_info
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "InitializeResult":
+        return cls(
+            protocol_version=int(raw.get("protocolVersion", PROTOCOL_VERSION)),
+            agent_capabilities=AgentCapabilities.from_dict(
+                raw.get("agentCapabilities")
+            ),
+            auth_methods=[
+                AuthMethod.from_dict(m) for m in (raw.get("authMethods") or [])
+            ],
+            agent_info=raw.get("agentInfo"),
+        )
+
+
+@dataclass
+class AuthenticateParams:
+    """Params for the ``authenticate`` request."""
+
+    method_id: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"methodId": self.method_id}
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "AuthenticateParams":
+        return cls(method_id=str(raw["methodId"]))
+
+
+@dataclass
+class NewSessionParams:
+    """Params for the ``session/new`` request."""
+
+    cwd: str
+    mcp_servers: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"cwd": self.cwd, "mcpServers": list(self.mcp_servers)}
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "NewSessionParams":
+        return cls(
+            cwd=str(raw.get("cwd", "")),
+            mcp_servers=list(raw.get("mcpServers") or []),
+        )
+
+
+@dataclass
+class NewSessionResult:
+    """Result of ``session/new``."""
+
+    session_id: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"sessionId": self.session_id}
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "NewSessionResult":
+        return cls(session_id=str(raw["sessionId"]))
+
+
+@dataclass
+class PromptParams:
+    """Params for the ``session/prompt`` request."""
+
+    session_id: str
+    prompt: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"sessionId": self.session_id, "prompt": list(self.prompt)}
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "PromptParams":
+        return cls(
+            session_id=str(raw["sessionId"]),
+            prompt=list(raw.get("prompt") or []),
+        )
+
+
+@dataclass
+class PromptResult:
+    """Result of ``session/prompt`` -- carries the turn's terminating reason."""
+
+    stop_reason: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"stopReason": self.stop_reason}
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "PromptResult":
+        return cls(stop_reason=str(raw["stopReason"]))
+
+
+@dataclass
+class PermissionOption:
+    """An option offered in a ``session/request_permission`` request."""
+
+    option_id: str
+    name: str
+    kind: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"optionId": self.option_id, "name": self.name}
+        if self.kind is not None:
+            out["kind"] = self.kind
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "PermissionOption":
+        return cls(
+            option_id=str(raw["optionId"]),
+            name=str(raw.get("name", "")),
+            kind=raw.get("kind"),
+        )
+
+
+@dataclass
+class RequestPermissionParams:
+    """Params for the ``session/request_permission`` request (agent -> client)."""
+
+    session_id: str
+    tool_call: Dict[str, Any]
+    options: List[PermissionOption] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "sessionId": self.session_id,
+            "toolCall": self.tool_call,
+            "options": [o.to_dict() for o in self.options],
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "RequestPermissionParams":
+        return cls(
+            session_id=str(raw["sessionId"]),
+            tool_call=dict(raw.get("toolCall") or {}),
+            options=[
+                PermissionOption.from_dict(o) for o in (raw.get("options") or [])
+            ],
+        )
+
+
+@dataclass
+class RequestPermissionResult:
+    """Result of ``session/request_permission`` -- the client's decision.
+
+    The wire shape nests the decision under ``outcome``::
+
+        {"outcome": {"outcome": "selected", "optionId": "allow"}}
+        {"outcome": {"outcome": "cancelled"}}
+    """
+
+    outcome: str
+    option_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        inner: Dict[str, Any] = {"outcome": self.outcome}
+        if self.option_id is not None:
+            inner["optionId"] = self.option_id
+        return {"outcome": inner}
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "RequestPermissionResult":
+        inner = raw.get("outcome") or {}
+        return cls(
+            outcome=str(inner.get("outcome", PermissionOutcome.CANCELLED)),
+            option_id=inner.get("optionId"),
+        )

--- a/tests/test_acp_client.py
+++ b/tests/test_acp_client.py
@@ -1,0 +1,195 @@
+"""End-to-end ACPClient test driven by a fake in-process ACP agent.
+
+The two endpoints (mac's :class:`ACPClient` and a scripted fake agent) are wired
+over an in-memory **paired transport**: each peer's ``send`` enqueues bytes into
+a shared buffer, and a small ``drive`` loop pumps both peers until their inboxes
+drain. This exercises the full peer/client stack synchronously with no asyncio,
+no subprocess, and no third-party deps.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from mac.acp.client import ACPClient
+from mac.acp.peer import Peer
+from mac.acp.protocol import (
+    AgentCapabilities,
+    InitializeResult,
+    Method,
+    NewSessionResult,
+    PromptResult,
+    RequestPermissionParams,
+    RequestPermissionResult,
+    SessionUpdateKind,
+    StopReason,
+    text_block,
+)
+
+
+class _Pipe:
+    """A pair of peers connected to each other's inbox, pumpable in a loop."""
+
+    def __init__(self) -> None:
+        self.client_peer = Peer(send=self._to_agent)
+        self.agent_peer = Peer(send=self._to_client)
+
+    def _to_agent(self, data: bytes) -> None:
+        self.agent_peer.feed(data)
+
+    def _to_client(self, data: bytes) -> None:
+        self.client_peer.feed(data)
+
+    def drive(self, rounds: int = 10) -> None:
+        """Pump both peers until neither processes a frame (steady state)."""
+
+        for _ in range(rounds):
+            processed = self.agent_peer.pump() + self.client_peer.pump()
+            if processed == 0:
+                break
+
+
+class FakeAgent:
+    """A minimal scripted ACP agent: answers the baseline methods and emits a
+    couple of ``session/update`` notifications during the prompt turn, then asks
+    the client for permission before finishing."""
+
+    def __init__(self, peer: Peer) -> None:
+        self._peer = peer
+        self.permission_result: Optional[RequestPermissionResult] = None
+        peer.on_request(Method.INITIALIZE, self._initialize)
+        peer.on_request(Method.SESSION_NEW, self._session_new)
+        peer.on_request(Method.SESSION_PROMPT, self._session_prompt)
+
+    def _initialize(self, params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        return InitializeResult(
+            agent_capabilities=AgentCapabilities(load_session=True),
+            agent_info={"name": "fake-agent", "version": "1"},
+        ).to_dict()
+
+    def _session_new(self, params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        return NewSessionResult(session_id="sess_fake_1").to_dict()
+
+    def _session_prompt(self, params: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        session_id = (params or {})["sessionId"]
+        # Stream two update notifications back to the client mid-turn.
+        self._peer.notify(
+            Method.SESSION_UPDATE,
+            {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": SessionUpdateKind.AGENT_MESSAGE_CHUNK,
+                    "content": text_block("working on it"),
+                },
+            },
+        )
+        self._peer.notify(
+            Method.SESSION_UPDATE,
+            {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": SessionUpdateKind.TOOL_CALL,
+                    "toolCallId": "call_1",
+                    "title": "run shell",
+                },
+            },
+        )
+        # Ask the client for permission; the response is correlated by the peer.
+        pending = self._peer.request(
+            Method.SESSION_REQUEST_PERMISSION,
+            RequestPermissionParams(
+                session_id=session_id,
+                tool_call={"toolCallId": "call_1", "title": "run shell"},
+                options=[],
+            ).to_dict(),
+        )
+        # We don't block here (single-threaded test); record the decision once
+        # the client answers. The pending future resolves during ``drive``.
+        self._pending_permission = pending
+        return PromptResult(stop_reason=StopReason.END_TURN).to_dict()
+
+
+def test_full_session_with_updates_and_permission():
+    pipe = _Pipe()
+    agent = FakeAgent(pipe.agent_peer)
+    client = ACPClient(pipe.client_peer)
+
+    received_updates: List[Dict[str, Any]] = []
+    client.on_update(lambda update: received_updates.append(update))
+
+    permission_calls: List[RequestPermissionParams] = []
+
+    def _permit(req: RequestPermissionParams) -> RequestPermissionResult:
+        permission_calls.append(req)
+        return RequestPermissionResult(
+            outcome="selected", option_id="allow"
+        )
+
+    client.on_request_permission(_permit)
+
+    # --- initialize ---
+    init = _call(pipe, lambda: client.initialize())
+    assert isinstance(init, InitializeResult)
+    assert init.protocol_version == 1
+    assert init.agent_capabilities.load_session is True
+
+    # --- session/new ---
+    session_id = _call(pipe, lambda: client.session_new(cwd="/tmp/work"))
+    assert session_id == "sess_fake_1"
+
+    # --- session/prompt (drives updates + a permission round-trip) ---
+    result = _call(pipe, lambda: client.session_prompt(session_id, "do the thing"))
+    assert isinstance(result, PromptResult)
+    assert result.stop_reason == StopReason.END_TURN
+
+    # The update handler saw both streamed notifications.
+    kinds = [u["update"]["sessionUpdate"] for u in received_updates]
+    assert kinds == [
+        SessionUpdateKind.AGENT_MESSAGE_CHUNK,
+        SessionUpdateKind.TOOL_CALL,
+    ]
+
+    # The permission request round-tripped to the client handler...
+    assert len(permission_calls) == 1
+    assert permission_calls[0].session_id == session_id
+    assert permission_calls[0].tool_call["toolCallId"] == "call_1"
+
+    # ...and the agent received the client's "selected/allow" decision.
+    decision = RequestPermissionResult.from_dict(
+        agent._pending_permission.result(timeout=0)
+    )
+    assert decision.outcome == "selected"
+    assert decision.option_id == "allow"
+
+
+def _call(pipe: _Pipe, fn):
+    """Run a blocking client call against the synchronous paired transport.
+
+    The client's ``request`` returns a PendingRequest whose ``result`` blocks; we
+    instead issue the request, drive both peers to steady state so the response
+    is delivered, then read the (now-resolved) result with a zero timeout. We do
+    this by monkey-poking: the client methods call ``.result()`` internally, so
+    we drive the pipe on a background-free trick -- issue then pump.
+
+    Implementation: the client methods block on ``PendingRequest.result``. To
+    keep everything single-threaded we run the call on a tiny worker thread and
+    pump the pipe from the main thread until it returns.
+    """
+
+    import threading
+
+    box: Dict[str, Any] = {}
+
+    def _worker():
+        box["value"] = fn()
+
+    t = threading.Thread(target=_worker)
+    t.start()
+    # Pump until the worker finishes (responses get delivered as we pump).
+    for _ in range(1000):
+        pipe.drive()
+        if not t.is_alive():
+            break
+    t.join(timeout=5)
+    assert "value" in box, "client call did not complete"
+    return box["value"]

--- a/tests/test_acp_protocol.py
+++ b/tests/test_acp_protocol.py
@@ -1,0 +1,121 @@
+"""Round-trip (de)serialization tests for the ACP wire layer."""
+
+from __future__ import annotations
+
+from mac.acp.protocol import (
+    PROTOCOL_VERSION,
+    InitializeParams,
+    InitializeResult,
+    JSONRPCError,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResponse,
+    Method,
+    SessionUpdateKind,
+    StopReason,
+    decode_message,
+)
+
+
+def test_protocol_version_is_pinned_integer():
+    # The ACP protocolVersion is a single MAJOR integer (currently 1), not a
+    # string -- a correction vs the original research notes.
+    assert PROTOCOL_VERSION == 1
+    assert isinstance(PROTOCOL_VERSION, int)
+
+
+def test_initialize_request_round_trips():
+    req = JSONRPCRequest(
+        id=1,
+        method=Method.INITIALIZE,
+        params=InitializeParams().to_dict(),
+    )
+    wire = req.to_dict()
+    assert wire["jsonrpc"] == "2.0"
+    assert wire["method"] == "initialize"
+    assert wire["params"]["protocolVersion"] == PROTOCOL_VERSION
+
+    decoded = decode_message(wire)
+    assert isinstance(decoded, JSONRPCRequest)
+    assert decoded.id == 1
+    assert decoded.method == "initialize"
+
+    params = InitializeParams.from_dict(decoded.params)
+    assert params.protocol_version == PROTOCOL_VERSION
+    assert "fs" in params.client_capabilities.to_dict()
+
+
+def test_initialize_result_round_trips():
+    result = InitializeResult()
+    response = JSONRPCResponse(id=1, result=result.to_dict())
+    wire = response.to_dict()
+    assert "result" in wire and "error" not in wire
+    assert wire["result"]["protocolVersion"] == PROTOCOL_VERSION
+    assert wire["result"]["authMethods"] == []
+
+    decoded = decode_message(wire)
+    assert isinstance(decoded, JSONRPCResponse)
+    assert not decoded.is_error
+    parsed = InitializeResult.from_dict(decoded.result)
+    assert parsed.protocol_version == PROTOCOL_VERSION
+    assert parsed.agent_capabilities.load_session is False
+
+
+def test_error_response_round_trips():
+    response = JSONRPCResponse(
+        id=7,
+        error=JSONRPCError(code=-32601, message="method not found", data={"m": "x"}),
+    )
+    wire = response.to_dict()
+    assert "error" in wire and "result" not in wire
+    assert wire["error"]["code"] == -32601
+
+    decoded = decode_message(wire)
+    assert isinstance(decoded, JSONRPCResponse)
+    assert decoded.is_error
+    assert decoded.error is not None
+    assert decoded.error.code == -32601
+    assert decoded.error.message == "method not found"
+    assert decoded.error.data == {"m": "x"}
+
+
+def test_session_update_notification_round_trips():
+    notif = JSONRPCNotification(
+        method=Method.SESSION_UPDATE,
+        params={
+            "sessionId": "sess_abc",
+            "update": {
+                "sessionUpdate": SessionUpdateKind.AGENT_MESSAGE_CHUNK,
+                "content": {"type": "text", "text": "hello"},
+            },
+        },
+    )
+    wire = notif.to_dict()
+    assert wire["method"] == "session/update"
+    assert "id" not in wire  # notifications carry no id
+
+    decoded = decode_message(wire)
+    assert isinstance(decoded, JSONRPCNotification)
+    assert decoded.method == "session/update"
+    assert decoded.params["update"]["sessionUpdate"] == "agent_message_chunk"
+
+
+def test_decode_distinguishes_request_notification_response():
+    assert isinstance(
+        decode_message({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
+        JSONRPCRequest,
+    )
+    assert isinstance(
+        decode_message({"jsonrpc": "2.0", "method": "session/update"}),
+        JSONRPCNotification,
+    )
+    assert isinstance(
+        decode_message({"jsonrpc": "2.0", "id": 1, "result": {}}),
+        JSONRPCResponse,
+    )
+
+
+def test_stop_reason_constants_present():
+    assert StopReason.END_TURN == "end_turn"
+    assert StopReason.CANCELLED == "cancelled"
+    assert StopReason.MAX_TURN_REQUESTS == "max_turn_requests"


### PR DESCRIPTION
First implementation step of [ADR 0006](docs/adr/0006-acp-support.md): a self-contained, **stdlib-only** `src/mac/acp/` package that establishes the Agent Client Protocol (host↔agent, JSON-RPC 2.0) foundation. No existing module is touched; Hermes remains the default executor.

## What's here
- **`protocol.py`** — JSON-RPC 2.0 envelope + ACP wire types (Initialize/NewSession/Prompt/RequestPermission, capabilities, `SessionUpdateKind`, `StopReason`, content blocks), `PROTOCOL_VERSION = 1`, method constants. Spec-accurate (protocolVersion is an int; `session/cancel` is a notification; permission decision nests under `outcome`).
- **`peer.py`** — transport-agnostic JSON-RPC peer (newline-delimited framing, id-correlated responses, notification + inbound-request dispatch), drivable synchronously in tests; thin stdio subprocess binding for real use.
- **`client.py`** — `ACPClient` (initialize/authenticate/session_new/session_prompt + update & permission handlers).
- **`executor.py`** — `ACPExecutor`: runs a session and forwards every `session/update` to an `on_update` callback (the future `/action-events` sink). This is the seam `task_executor` will use behind `MAC_EXECUTOR_BACKEND=acp`.
- **tests** — protocol round-trips + a full session driven against an in-process **fake ACP agent** (incl. a `request_permission` round-trip). **8 passed**, no new deps, no `pytest-asyncio`.

## Deferred to Phase 1 integration (tracked)
Wiring `ACPExecutor` into `task_executor` behind `MAC_EXECUTOR_BACKEND=acp`, mapping `session/update` → AgentBus/`/action-events`, and bridging `session/request_permission` → the OpenShell policy. `task_executor.py` is intentionally untouched here.

Closes ACP Phase 0 (`task_cf17a088…`); Phase 1 = `task_01bf8c23…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)