### PR TITLE
feat(acp): Phase 3 — capability negotiation, manifest, permission→policy bridge, AgentBus mirror

### DIFF
--- a/src/mac/acp/__init__.py
+++ b/src/mac/acp/__init__.py
@@ -20,8 +20,22 @@ package realizes ADR 0006 (Phase 0 + Phase-1 core):
 
 from __future__ import annotations
 
+from .capabilities import (
+    MAC_EXTENSIONS,
+    acp_manifest,
+    mac_agent_capabilities,
+    mac_client_capabilities,
+    mac_meta,
+)
 from .client import ACPClient, PermissionHandler, UpdateHandler
 from .executor import ACPExecutor, ACPRunResult
+from .permission import (
+    PermissionDecision,
+    PermissionMode,
+    evaluate_permission,
+    load_openshell_policy,
+    permission_mode,
+)
 from .peer import DEFERRED, Peer, PendingRequest, RemoteError, stdio_peer
 from .server import (
     ACPAgentServer,
@@ -61,6 +75,16 @@ from .protocol import (
 
 __all__ = [
     "PROTOCOL_VERSION",
+    "MAC_EXTENSIONS",
+    "acp_manifest",
+    "mac_agent_capabilities",
+    "mac_client_capabilities",
+    "mac_meta",
+    "PermissionDecision",
+    "PermissionMode",
+    "evaluate_permission",
+    "load_openshell_policy",
+    "permission_mode",
     "Method",
     "SessionUpdateKind",
     "StopReason",

--- a/src/mac/acp/capabilities.py
+++ b/src/mac/acp/capabilities.py
@@ -1,0 +1,124 @@
+"""mac's ACP capability set, builders, and the well-known manifest (Phase 3).
+
+The :mod:`mac.acp.protocol` module defines the *wire shape* of capabilities
+(:class:`~mac.acp.protocol.ClientCapabilities` /
+:class:`~mac.acp.protocol.AgentCapabilities`). This module pins **mac's actual
+values** for them and adds mac-specific extensions under a ``_meta`` key.
+
+ACP permits vendor extension through a ``_meta`` field on any object (see
+``agentclientprotocol.com/protocol/v1/extensibility``): the keys there are
+ignored by implementations that don't understand them, so mac advertises its
+own feature flags additively without breaking baseline interop. mac groups all
+of its extensions under ``_meta.mac`` so a peer can detect "this is a mac
+endpoint" with a single key check::
+
+    {"mac": {"sandbox": true, "decomposition": true, "evidence": true}}
+
+* ``sandbox`` -- runs agents under the OpenShell kernel sandbox (the real
+  permission gate; see :mod:`mac.acp.permission`).
+* ``decomposition`` -- can auto-split an over-scoped task into child tasks.
+* ``evidence`` -- finalizes every run with a deterministic, typed evidence
+  manifest (the correctness proof, independent of the agent's self-report).
+
+:func:`acp_manifest` produces the ``GET /.well-known/acp`` discovery document.
+This module performs **no I/O** -- it is pure data plus the dict builders.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .protocol import (
+    PROTOCOL_VERSION,
+    AgentCapabilities,
+    ClientCapabilities,
+)
+
+
+__all__ = [
+    "MAC_EXTENSIONS",
+    "mac_meta",
+    "mac_client_capabilities",
+    "mac_agent_capabilities",
+    "acp_manifest",
+]
+
+
+#: mac's advertised feature flags. Additive and ignorable by other ACP
+#: implementations (they live under the vendor ``_meta`` field).
+MAC_EXTENSIONS: Dict[str, bool] = {
+    "sandbox": True,
+    "decomposition": True,
+    "evidence": True,
+}
+
+
+def mac_meta() -> Dict[str, Any]:
+    """The ``_meta`` block mac attaches to its capability/manifest objects.
+
+    A fresh dict each call so callers can mutate the result without leaking
+    state back into :data:`MAC_EXTENSIONS`.
+    """
+
+    return {"mac": dict(MAC_EXTENSIONS)}
+
+
+def mac_client_capabilities() -> ClientCapabilities:
+    """The :class:`ClientCapabilities` mac advertises when it *drives* an agent.
+
+    mac is the host/client: it does not yet expose filesystem or terminal
+    helpers to the driven agent (those would let the agent reach back into the
+    host), so the baseline ACP capability fields stay off. The mac-specific
+    extensions ride in ``_meta`` instead.
+    """
+
+    return ClientCapabilities(
+        fs_read_text_file=False,
+        fs_write_text_file=False,
+        terminal=False,
+        meta=mac_meta(),
+    )
+
+
+def mac_agent_capabilities() -> AgentCapabilities:
+    """The :class:`AgentCapabilities` a mac agent advertises when *driven*.
+
+    mac does not yet rehydrate prior sessions (``loadSession`` off; Phase-2
+    note) but accepts the common prompt content types and surfaces its
+    extensions under ``_meta``.
+    """
+
+    return AgentCapabilities(
+        load_session=False,
+        prompt_capabilities={"image": False, "audio": False, "embeddedContext": True},
+        mcp_capabilities={"http": False},
+        meta=mac_meta(),
+    )
+
+
+def acp_manifest() -> Dict[str, Any]:
+    """The well-known ACP discovery manifest served at ``GET /.well-known/acp``.
+
+    Shape mirrors the ``initialize`` result so a client can pre-flight a mac
+    endpoint without opening a session::
+
+        {
+          "protocolVersion": 1,
+          "agentCapabilities": {...},
+          "authMethods": [...],
+          "agentInfo": {...},
+          "_meta": {"mac": {...}}
+        }
+
+    ``authMethods`` is empty here: mac's HTTP front door authenticates with the
+    existing bearer-token ``TokenPrincipal`` (see ``api.py``), so a standalone
+    ACP ``authenticate`` method is not advertised at the discovery layer.
+    """
+
+    return {
+        "protocolVersion": PROTOCOL_VERSION,
+        "agentCapabilities": mac_agent_capabilities().to_dict(),
+        "authMethods": [],
+        "agentInfo": {"name": "mac", "title": "MAC agent", "version": "0"},
+        "_meta": mac_meta(),
+    }

--- a/src/mac/acp/client.py
+++ b/src/mac/acp/client.py
@@ -59,7 +59,13 @@ class ACPClient:
         client_info: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._peer = peer
-        self._client_capabilities = client_capabilities or ClientCapabilities()
+        # Default to mac's full capability set (incl. _meta extensions) so a
+        # driven agent sees what mac is; an explicit override still wins.
+        if client_capabilities is None:
+            from .capabilities import mac_client_capabilities
+
+            client_capabilities = mac_client_capabilities()
+        self._client_capabilities = client_capabilities
         self._client_info = client_info or {
             "name": "mac",
             "title": "MAC hub",

--- a/src/mac/acp/permission.py
+++ b/src/mac/acp/permission.py
@@ -1,0 +1,208 @@
+"""Permission policy bridge: ACP ``request_permission`` -> OpenShell policy.
+
+This is the Phase-3 replacement for the Phase-1 blanket auto-approve. When mac
+drives an external ACP agent, the agent asks for permission before a tool call
+via ``session/request_permission``. mac must answer *yes/no* with a reason.
+
+The evaluator here is **pure** (no I/O, no env reads beyond the explicit
+``mode`` argument the caller resolves): it maps an ACP ``toolCall.kind`` to an
+intent, then consults a parsed OpenShell policy dict to decide. The OpenShell
+*kernel* sandbox is the real enforcement gate -- when a run is sandboxed the ACP
+prompt is purely advisory, so a sandboxed run short-circuits to *allow*. The
+policy consult only matters for the unsandboxed case, where the ACP decision is
+the only gate mac has.
+
+Decision matrix (``mode == "policy"``):
+
+==========================  =========  ====================================
+ACP toolCall.kind           intent     decision
+==========================  =========  ====================================
+fetch / *network*           NETWORK    allow iff policy.network_policies != {}
+edit/delete/move/create/    FS-WRITE   allow iff policy.filesystem_policy
+  write                                  .read_write != []
+read / search / think       (benign)   allow
+execute / unknown           (gated)    allow iff sandboxed, else deny
+==========================  =========  ====================================
+
+Short-circuits, regardless of kind:
+
+* ``sandboxed`` True            -> allow ("sandbox-enforced")
+* ``mode == "allow"``           -> allow ("mode-allow")
+* ``mode == "deny"``            -> deny ("mode-deny")
+* ``mode == "policy"`` + no policy -> allow ("no-policy-default-allow")
+
+The no-policy default is **allow** to preserve the Phase-1 behavior (mac did not
+deny tool calls before Phase 3). Flip the whole bridge to deny-by-default with
+``MAC_ACP_PERMISSION_MODE=deny`` if you want a hard gate even without a policy.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+__all__ = [
+    "PermissionDecision",
+    "PermissionMode",
+    "permission_mode",
+    "evaluate_permission",
+    "load_openshell_policy",
+    "NETWORK_KINDS",
+    "FS_WRITE_KINDS",
+    "BENIGN_KINDS",
+]
+
+
+@dataclass(frozen=True)
+class PermissionDecision:
+    """The outcome of evaluating one ACP permission request."""
+
+    allow: bool
+    reason: str
+
+
+class PermissionMode:
+    """Values for ``MAC_ACP_PERMISSION_MODE`` (the ``mode`` argument)."""
+
+    POLICY = "policy"  # default: consult the OpenShell policy / sandbox
+    ALLOW = "allow"  # always allow (Phase-1 parity, no gate)
+    DENY = "deny"  # always deny (hard lockdown)
+
+
+#: ACP ``toolCall.kind`` values that mean network egress (a NETWORK intent).
+NETWORK_KINDS = frozenset({"fetch", "network", "request", "http", "download"})
+
+#: ACP ``toolCall.kind`` values that mean a filesystem mutation (FS-WRITE).
+FS_WRITE_KINDS = frozenset({"edit", "delete", "move", "create", "write"})
+
+#: ACP ``toolCall.kind`` values that are read-only / harmless (always allowed).
+BENIGN_KINDS = frozenset({"read", "search", "think"})
+
+
+def permission_mode(raw: Optional[str] = None) -> str:
+    """Resolve the active mode from ``raw`` (or ``MAC_ACP_PERMISSION_MODE``).
+
+    Defaults to :data:`PermissionMode.POLICY`. Unknown values fall back to the
+    default rather than failing, so a typo can't silently disable the gate in
+    an unexpected direction.
+    """
+
+    value = (raw if raw is not None else os.environ.get("MAC_ACP_PERMISSION_MODE", "")).strip().lower()
+    if value in {PermissionMode.POLICY, PermissionMode.ALLOW, PermissionMode.DENY}:
+        return value
+    return PermissionMode.POLICY
+
+
+def _tool_call_kind(tool_call: Dict[str, Any]) -> str:
+    """Best-effort extraction of the ACP ``kind`` from a tool_call dict."""
+
+    return str((tool_call or {}).get("kind") or "").strip().lower()
+
+
+def _network_allowed(policy: Dict[str, Any]) -> bool:
+    """A non-empty ``network_policies`` permits egress; empty/absent == lockdown."""
+
+    network = policy.get("network_policies")
+    return isinstance(network, dict) and len(network) > 0
+
+
+def _fs_write_allowed(policy: Dict[str, Any]) -> bool:
+    """A non-empty ``filesystem_policy.read_write`` permits writes.
+
+    Path-agnostic: ACP rarely hands us a concrete path on the permission
+    request, so this is the best-effort "does the policy allow *any* writable
+    location" check. The kernel sandbox still enforces the exact paths.
+    """
+
+    fs = policy.get("filesystem_policy")
+    if not isinstance(fs, dict):
+        return False
+    read_write = fs.get("read_write")
+    return isinstance(read_write, (list, tuple)) and len(read_write) > 0
+
+
+def evaluate_permission(
+    tool_call: Dict[str, Any],
+    *,
+    policy: Optional[Dict[str, Any]] = None,
+    sandboxed: bool = False,
+    mode: Optional[str] = None,
+) -> PermissionDecision:
+    """Decide whether to allow an ACP tool call. Pure; see the module matrix.
+
+    ``tool_call`` is the ACP ``toolCall`` object (we read its ``kind``).
+    ``policy`` is a parsed OpenShell policy dict (see
+    :func:`load_openshell_policy`); ``None`` means no policy is available.
+    ``sandboxed`` reflects whether the run is confined by the OpenShell kernel
+    sandbox (the real gate). ``mode`` is the resolved permission mode (defaults
+    to ``MAC_ACP_PERMISSION_MODE`` / ``policy``).
+    """
+
+    resolved_mode = permission_mode(mode)
+
+    # The kernel sandbox is the authoritative gate; the ACP prompt is advisory.
+    if sandboxed:
+        return PermissionDecision(allow=True, reason="sandbox-enforced")
+
+    if resolved_mode == PermissionMode.ALLOW:
+        return PermissionDecision(allow=True, reason="mode-allow")
+    if resolved_mode == PermissionMode.DENY:
+        return PermissionDecision(allow=False, reason="mode-deny")
+
+    # mode == policy from here.
+    if not policy:
+        # Preserve Phase-1 behavior: no policy means no per-tool gate. Flip with
+        # MAC_ACP_PERMISSION_MODE=deny for a hard lockdown.
+        return PermissionDecision(allow=True, reason="no-policy-default-allow")
+
+    kind = _tool_call_kind(tool_call)
+
+    if kind in BENIGN_KINDS:
+        return PermissionDecision(allow=True, reason="benign-kind:%s" % (kind or "?"))
+
+    if kind in NETWORK_KINDS:
+        if _network_allowed(policy):
+            return PermissionDecision(allow=True, reason="policy-network-allowed")
+        return PermissionDecision(allow=False, reason="policy-network-lockdown")
+
+    if kind in FS_WRITE_KINDS:
+        if _fs_write_allowed(policy):
+            return PermissionDecision(allow=True, reason="policy-fs-write-allowed")
+        return PermissionDecision(allow=False, reason="policy-fs-write-readonly")
+
+    # execute / unknown -> only safe under the kernel sandbox (handled above).
+    return PermissionDecision(allow=False, reason="policy-unsandboxed-execute:%s" % (kind or "unknown"))
+
+
+def load_openshell_policy(path: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """Load + parse the OpenShell policy YAML, best-effort.
+
+    Resolution: ``path`` -> ``MAC_OPENSHELL_POLICY`` -> ``~/.mac/openshell-
+    policy.yaml`` (mirrors ``task_executor._resolve_openshell_policy`` but never
+    raises and never falls back to the bundled default — a missing/unreadable
+    policy yields ``None`` so the caller treats it as "no policy"). ``yaml`` is
+    already a mac dependency.
+    """
+
+    candidate: Optional[Path]
+    if path:
+        candidate = Path(path)
+    else:
+        explicit = (os.environ.get("MAC_OPENSHELL_POLICY") or "").strip()
+        if explicit:
+            candidate = Path(explicit)
+        else:
+            candidate = Path.home() / ".mac" / "openshell-policy.yaml"
+
+    try:
+        if not candidate.is_file():
+            return None
+        import yaml
+
+        parsed = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001 - best-effort: any failure == no policy
+        return None
+    return parsed if isinstance(parsed, dict) else None

--- a/src/mac/acp/protocol.py
+++ b/src/mac/acp/protocol.py
@@ -337,39 +337,55 @@ class ClientCapabilities:
     ``fs`` advertises filesystem read/write helpers; ``terminal`` advertises
     terminal support. Both default off -- mac drives agents but does not yet
     offer these client-side helpers in Phase 0/1.
+
+    ``meta`` carries the optional ACP ``_meta`` vendor-extension object (Phase
+    3); it is omitted from the wire form when unset, so the baseline shape is
+    unchanged. Keys there are additive and ignorable by other implementations.
     """
 
     fs_read_text_file: bool = False
     fs_write_text_file: bool = False
     terminal: bool = False
+    meta: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
+        out: Dict[str, Any] = {
             "fs": {
                 "readTextFile": self.fs_read_text_file,
                 "writeTextFile": self.fs_write_text_file,
             },
             "terminal": self.terminal,
         }
+        if self.meta:
+            out["_meta"] = self.meta
+        return out
 
     @classmethod
     def from_dict(cls, raw: Optional[Mapping[str, Any]]) -> "ClientCapabilities":
         raw = raw or {}
         fs = raw.get("fs") or {}
+        meta = raw.get("_meta")
         return cls(
             fs_read_text_file=bool(fs.get("readTextFile", False)),
             fs_write_text_file=bool(fs.get("writeTextFile", False)),
             terminal=bool(raw.get("terminal", False)),
+            meta=dict(meta) if isinstance(meta, Mapping) else None,
         )
 
 
 @dataclass
 class AgentCapabilities:
-    """Capabilities an agent advertises in the ``initialize`` result."""
+    """Capabilities an agent advertises in the ``initialize`` result.
+
+    ``meta`` carries the optional ACP ``_meta`` vendor-extension object (Phase
+    3); it is omitted from the wire form when unset, so the baseline shape is
+    unchanged. Keys there are additive and ignorable by other implementations.
+    """
 
     load_session: bool = False
     prompt_capabilities: Dict[str, Any] = field(default_factory=dict)
     mcp_capabilities: Dict[str, Any] = field(default_factory=dict)
+    meta: Optional[Dict[str, Any]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {"loadSession": self.load_session}
@@ -377,15 +393,19 @@ class AgentCapabilities:
             out["promptCapabilities"] = self.prompt_capabilities
         if self.mcp_capabilities:
             out["mcpCapabilities"] = self.mcp_capabilities
+        if self.meta:
+            out["_meta"] = self.meta
         return out
 
     @classmethod
     def from_dict(cls, raw: Optional[Mapping[str, Any]]) -> "AgentCapabilities":
         raw = raw or {}
+        meta = raw.get("_meta")
         return cls(
             load_session=bool(raw.get("loadSession", False)),
             prompt_capabilities=dict(raw.get("promptCapabilities") or {}),
             mcp_capabilities=dict(raw.get("mcpCapabilities") or {}),
+            meta=dict(meta) if isinstance(meta, Mapping) else None,
         )
 
 

--- a/src/mac/acp/server.py
+++ b/src/mac/acp/server.py
@@ -374,7 +374,13 @@ class ACPAgentServer:
     ) -> None:
         self._peer = peer
         self._backend = _as_backend(backend)
-        self._agent_capabilities = agent_capabilities or AgentCapabilities()
+        # Advertise mac's full agent capability set (incl. _meta extensions) by
+        # default; an explicit override still wins.
+        if agent_capabilities is None:
+            from .capabilities import mac_agent_capabilities
+
+            agent_capabilities = mac_agent_capabilities()
+        self._agent_capabilities = agent_capabilities
         self._agent_info = agent_info or {
             "name": "mac",
             "title": "MAC agent",

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1224,6 +1224,10 @@ def _load_auth_tokens_from_env() -> Dict[str, TokenPrincipal]:
 def _required_scope(method: str, path: str) -> Optional[str]:
     if path == "/health":
         return None
+    if path == "/.well-known/acp":
+        # ACP discovery manifest (ADR 0006, Phase 3): a public well-known doc,
+        # like /health. No secrets; just mac's capability advertisement.
+        return None
     if path == "/ui" or path.startswith("/ui/"):
         return None
     if path == "/v1" or path.startswith("/v1/"):
@@ -2962,6 +2966,16 @@ def create_app(
     @app.get("/health")
     def health() -> Dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/.well-known/acp")
+    def acp_manifest_route() -> Dict[str, Any]:
+        # ADR 0006 Phase 3: the well-known ACP discovery manifest. Unauthenticated
+        # (see _required_scope); advertises protocolVersion, mac's agent
+        # capabilities, and the mac-specific _meta extensions. Dependency-light:
+        # no principal, no control-plane access — pure capability advertisement.
+        from mac.acp.capabilities import acp_manifest
+
+        return acp_manifest()
 
     @app.get("/startup/hermes")
     def hermes_startup() -> Dict[str, Any]:

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -54,6 +54,7 @@ import shlex
 import subprocess
 import sys
 import time
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -159,6 +160,32 @@ def _hub_post(path: str, payload: Dict[str, Any], *, timeout: float = 5.0) -> bo
         return True
     except Exception:
         return False
+
+
+def _hub_post_json(path: str, payload: Dict[str, Any], *, timeout: float = 5.0) -> Optional[Any]:
+    """POST JSON and return the parsed response body (or None on any failure).
+
+    Like :func:`_hub_post` but surfaces the response so callers that need a
+    server-assigned id (e.g. an opened AgentBus stream) can read it. Best-effort:
+    returns None when hub env is absent or the call/parse fails."""
+    base_url, token = _hub_env()
+    if not base_url or not token:
+        return None
+    data = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(
+        base_url + path,
+        data=data,
+        headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        raw = urllib.request.urlopen(request, timeout=timeout).read()  # noqa: S310 (operator-configured URL)
+    except Exception:
+        return None
+    try:
+        return json.loads(raw.decode("utf-8", "replace"))
+    except Exception:
+        return None
 
 
 def _hub_get(path: str, *, timeout: float = 5.0) -> Optional[Any]:
@@ -1456,20 +1483,40 @@ def _acp_update_action_event(audit_id: Any, session_id: str, params: Dict[str, A
 
 
 def _acp_permission_handler(audit_id: Any) -> Callable[[Any], Any]:
-    """ACP ``session/request_permission`` handler.
+    """ACP ``session/request_permission`` handler (Phase 3).
 
-    Phase-1 policy: auto-approve (parity with the Hermes ``--yolo`` path, where
-    the real confinement is the OpenShell *sandbox*, not a per-tool prompt) and
-    record each decision as an action-event. Prefers the first ``allow``-kind
-    option the agent offered, else the first option. Evaluating the request
-    against the OpenShell *policy* is the Phase-3 refinement."""
+    Evaluates each request through :func:`mac.acp.permission.evaluate_permission`
+    instead of blanket auto-approving. The OpenShell *kernel sandbox* remains the
+    real gate — when sandboxed the decision short-circuits to allow ("sandbox-
+    enforced") and the ACP prompt is advisory. Unsandboxed, the decision consults
+    the parsed OpenShell *policy* (network lockdown denies egress; an empty
+    read_write set denies writes); with no policy it defaults to allow (Phase-1
+    parity), flippable to deny via ``MAC_ACP_PERMISSION_MODE=deny``.
+
+    On *allow* it selects the first ``allow``-kind option the agent offered (else
+    the first option); on *deny* it selects a ``reject``-kind option if one is
+    offered, else returns a CANCELLED outcome. Every decision + its reason is
+    recorded to ``/action-events`` (``attributes.permission_reason``)."""
+    from mac.acp.permission import evaluate_permission, load_openshell_policy
     from mac.acp.protocol import PermissionOutcome, RequestPermissionResult
+
+    sandboxed = _openshell_enabled()
+    # Load the policy only when it can actually change the decision (unsandboxed
+    # under policy mode). Best-effort: a missing/unreadable policy -> None.
+    policy = None if sandboxed else load_openshell_policy()
 
     def _handler(params: Any) -> Any:
         options = list(getattr(params, "options", None) or [])
-        chosen = next((o for o in options if str(o.kind or "").startswith("allow")), None)
-        chosen = chosen or (options[0] if options else None)
         tool_call = getattr(params, "tool_call", {}) or {}
+        decision = evaluate_permission(tool_call, policy=policy, sandboxed=sandboxed)
+
+        if decision.allow:
+            chosen = next((o for o in options if str(o.kind or "").startswith("allow")), None)
+            chosen = chosen or (options[0] if options else None)
+        else:
+            # Prefer an explicit reject option when the agent offered one.
+            chosen = next((o for o in options if str(o.kind or "").startswith("reject")), None)
+
         _hub_post(
             "/action-events",
             {
@@ -1478,9 +1525,13 @@ def _acp_permission_handler(audit_id: Any) -> Callable[[Any], Any]:
                 "actor": "mac-acp",
                 "action_type": "acp.permission",
                 "action_name": str(tool_call.get("title") or tool_call.get("toolCallId") or "tool_call"),
-                "outcome": "allowed" if chosen else "denied",
+                "outcome": "allowed" if decision.allow else "denied",
                 "severity": "info",
-                "attributes": {"tool_call": tool_call, "auto_approved": bool(chosen)},
+                "attributes": {
+                    "tool_call": tool_call,
+                    "permission_reason": decision.reason,
+                    "allowed": decision.allow,
+                },
             },
         )
         if chosen is not None:
@@ -1488,6 +1539,72 @@ def _acp_permission_handler(audit_id: Any) -> Callable[[Any], Any]:
         return RequestPermissionResult(outcome=PermissionOutcome.CANCELLED)
 
     return _handler
+
+
+#: AgentBus content_type for a mirrored ACP session/update chunk.
+_ACP_AGENTBUS_CONTENT_TYPE = "application/vnd.mac.acp.update+json"
+#: AgentBus topic for the mirrored ACP update stream.
+_ACP_AGENTBUS_TOPIC = "acp.session_update"
+
+
+class _AcpAgentBusMirror:
+    """Best-effort mirror of an ACP ``session/update`` stream onto AgentBus.
+
+    Lifecycle (all via :func:`_hub_post`, so failures never raise):
+
+      * :meth:`open`   -> ``POST /agentbus/streams`` once at run start. mac is
+        both sender and recipient (a self-stream: the worker agent is the only
+        party, and AgentBus requires a concrete recipient), so the worker's own
+        ``local_agent_id`` is used for both ends.
+      * :meth:`append` -> ``POST /agentbus/streams/{id}/chunks`` per update.
+      * :meth:`close`  -> ``POST /agentbus/streams/{id}/close`` at run end.
+
+    If the open fails (no hub env, AgentBus error, unknown agent) the mirror is
+    inert: :attr:`stream_id` stays ``None`` and append/close are no-ops, so the
+    /action-events path is unaffected."""
+
+    def __init__(self, audit_id: Any) -> None:
+        self._agent_id = local_agent_id()
+        self._audit_id = audit_id
+        self.stream_id: Optional[str] = None
+
+    def open(self) -> None:
+        payload: Dict[str, Any] = {
+            "sender_agent_id": self._agent_id,
+            "recipient_agent_id": self._agent_id,
+            "topic": _ACP_AGENTBUS_TOPIC,
+            "content_type": _ACP_AGENTBUS_CONTENT_TYPE,
+            "headers": {"schema": "mac.acp.session_update.v1", "task_id": self._audit_id},
+        }
+        if self._audit_id:
+            payload["task_id"] = str(self._audit_id)
+        resp = _hub_post_json("/agentbus/streams", payload)
+        if isinstance(resp, dict):
+            sid = resp.get("id")
+            if isinstance(sid, str) and sid:
+                self.stream_id = sid
+
+    def append(self, session_id: str, params: Dict[str, Any]) -> None:
+        if not self.stream_id:
+            return
+        _hub_post(
+            "/agentbus/streams/%s/chunks" % self.stream_id,
+            {
+                "sender_agent_id": self._agent_id,
+                "content_type": _ACP_AGENTBUS_CONTENT_TYPE,
+                "payload": {"sessionId": session_id, "update": params.get("update") or {}},
+            },
+        )
+
+    def close(self, status: str = "closed") -> None:
+        if not self.stream_id:
+            return
+        # The close handler takes sender_agent_id + status as query params.
+        _hub_post(
+            "/agentbus/streams/%s/close?sender_agent_id=%s&status=%s"
+            % (self.stream_id, urllib.parse.quote(self._agent_id), urllib.parse.quote(status)),
+            {},
+        )
 
 
 def _invoke_acp_agent(
@@ -1512,6 +1629,12 @@ def _invoke_acp_agent(
         executor = ACPExecutor(argv, cwd=str(workspace))
 
     text_chunks: List[str] = []
+    # AgentBus mirror (ADR 0006 Phase 3): mirror the session/update stream onto an
+    # AgentBus chunk stream alongside the /action-events ledger. Best-effort and
+    # failure-tolerant — if the open fails we simply skip the chunk posts. Only
+    # runs under backend=acp, so the Hermes path takes on no extra latency.
+    mirror = _AcpAgentBusMirror(audit_id)
+    mirror.open()
 
     def _on_update(params: Dict[str, Any]) -> None:
         inner = params.get("update") or {}
@@ -1523,6 +1646,7 @@ def _invoke_acp_agent(
             if isinstance(content, dict) and content.get("type") == ContentBlockType.TEXT:
                 text_chunks.append(str(content.get("text") or ""))
         _hub_post("/action-events", _acp_update_action_event(audit_id, str(params.get("sessionId") or ""), params))
+        mirror.append(str(params.get("sessionId") or ""), params)
 
     argv_label = list(getattr(executor, "_argv", ["acp"]))
     try:
@@ -1533,7 +1657,9 @@ def _invoke_acp_agent(
             timeout=opts.get("timeout"),
         )
     except Exception as exc:  # noqa: BLE001 - a backend failure must finalize, not crash the loop
+        mirror.close(status="errored")
         return subprocess.CompletedProcess(argv_label, 1, "".join(text_chunks), "ACP agent run failed: %s" % exc)
+    mirror.close()
     rc = 0 if run.stop_reason == StopReason.END_TURN else 1
     stderr = "" if rc == 0 else "ACP agent stopped with reason: %s" % run.stop_reason
     return subprocess.CompletedProcess(argv_label, rc, "".join(text_chunks), stderr)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -31,6 +31,26 @@ def test_hub_tick_loop_gated_by_env(monkeypatch):
     assert thread is not None and thread.daemon is True and thread.is_alive()
 
 
+def test_well_known_acp_manifest_is_public_and_advertises_mac_extensions(monkeypatch):
+    # ADR 0006 Phase 3: the discovery manifest is unauthenticated even when the
+    # hub is token-protected, and carries protocolVersion + mac's _meta extensions.
+    monkeypatch.setenv("MAC_API_TOKEN", "secret-token")
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+
+    resp = client.get("/.well-known/acp")  # no Authorization header
+    assert resp.status_code == 200
+    manifest = resp.json()
+    assert manifest["protocolVersion"] == 1
+    assert isinstance(manifest["protocolVersion"], int)
+    assert manifest["_meta"]["mac"] == {
+        "sandbox": True,
+        "decomposition": True,
+        "evidence": True,
+    }
+    assert manifest["agentCapabilities"]["loadSession"] is False
+    assert manifest["agentCapabilities"]["_meta"]["mac"]["evidence"] is True
+
+
 def test_post_tasks_accepts_summary_alias_for_description():
     client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
 

--- a/tests/test_acp_capabilities.py
+++ b/tests/test_acp_capabilities.py
@@ -1,0 +1,71 @@
+"""Phase 3 — ACP capability builders + the well-known manifest (ADR 0006)."""
+
+from __future__ import annotations
+
+from mac.acp.capabilities import (
+    MAC_EXTENSIONS,
+    acp_manifest,
+    mac_agent_capabilities,
+    mac_client_capabilities,
+    mac_meta,
+)
+from mac.acp.protocol import (
+    PROTOCOL_VERSION,
+    AgentCapabilities,
+    ClientCapabilities,
+)
+
+
+def test_mac_meta_carries_the_three_extensions():
+    meta = mac_meta()
+    assert meta == {"mac": {"sandbox": True, "decomposition": True, "evidence": True}}
+    # a fresh dict each call — mutating one must not leak into MAC_EXTENSIONS
+    meta["mac"]["sandbox"] = False
+    assert MAC_EXTENSIONS["sandbox"] is True
+
+
+def test_client_capabilities_baseline_off_with_meta_extensions():
+    caps = mac_client_capabilities()
+    assert isinstance(caps, ClientCapabilities)
+    wire = caps.to_dict()
+    # mac is the host: it offers no fs/terminal helpers to the driven agent
+    assert wire["fs"] == {"readTextFile": False, "writeTextFile": False}
+    assert wire["terminal"] is False
+    # the mac extensions ride under the vendor _meta key
+    assert wire["_meta"] == {"mac": {"sandbox": True, "decomposition": True, "evidence": True}}
+
+
+def test_agent_capabilities_carry_meta_extensions():
+    caps = mac_agent_capabilities()
+    assert isinstance(caps, AgentCapabilities)
+    wire = caps.to_dict()
+    assert wire["loadSession"] is False
+    assert wire["_meta"]["mac"]["evidence"] is True
+
+
+def test_capabilities_meta_roundtrips_through_from_dict():
+    # additive: a peer that re-parses the wire form recovers the extensions
+    parsed = ClientCapabilities.from_dict(mac_client_capabilities().to_dict())
+    assert parsed.meta == {"mac": {"sandbox": True, "decomposition": True, "evidence": True}}
+    parsed_agent = AgentCapabilities.from_dict(mac_agent_capabilities().to_dict())
+    assert parsed_agent.meta == {"mac": {"sandbox": True, "decomposition": True, "evidence": True}}
+
+
+def test_baseline_capabilities_omit_meta_for_interop():
+    # an implementation that doesn't set _meta produces the unchanged baseline
+    assert "_meta" not in ClientCapabilities().to_dict()
+    assert "_meta" not in AgentCapabilities().to_dict()
+
+
+def test_manifest_shape():
+    manifest = acp_manifest()
+    # protocolVersion is an integer MAJOR version (not a string)
+    assert manifest["protocolVersion"] == PROTOCOL_VERSION
+    assert isinstance(manifest["protocolVersion"], int)
+    assert manifest["authMethods"] == []
+    assert manifest["agentInfo"]["name"] == "mac"
+    # agentCapabilities are the real mac agent capabilities
+    assert manifest["agentCapabilities"]["loadSession"] is False
+    # mac-specific extensions advertised at the top-level _meta
+    assert manifest["_meta"] == {"mac": {"sandbox": True, "decomposition": True, "evidence": True}}
+    assert manifest["agentCapabilities"]["_meta"]["mac"]["decomposition"] is True

--- a/tests/test_acp_executor_integration.py
+++ b/tests/test_acp_executor_integration.py
@@ -142,6 +142,149 @@ def test_permission_handler_cancels_when_no_options(monkeypatch):
     assert decision.outcome == PermissionOutcome.CANCELLED
 
 
+# -- Phase 3: permission handler consults the policy evaluator ---------------
+
+
+_LOCKDOWN_POLICY = {"network_policies": {}, "filesystem_policy": {"read_write": []}}
+
+
+def test_permission_handler_denies_network_under_lockdown_policy(monkeypatch):
+    """Unsandboxed + lockdown policy + a network tool_call -> deny (reject option),
+    and the recorded action-event carries the deny reason."""
+    posted = []
+    monkeypatch.setattr(task_executor, "_hub_post", lambda path, payload, **k: posted.append(payload) or True)
+    monkeypatch.setattr(task_executor, "_openshell_enabled", lambda: False)
+    monkeypatch.setattr(task_executor, "_acp_permission_handler", task_executor._acp_permission_handler)
+    # inject the lockdown policy via the loader
+    monkeypatch.setattr("mac.acp.permission.load_openshell_policy", lambda *a, **k: _LOCKDOWN_POLICY)
+    monkeypatch.setenv("MAC_ACP_PERMISSION_MODE", "policy")
+
+    handler = task_executor._acp_permission_handler("task_lock")
+    params = RequestPermissionParams(
+        session_id="s1",
+        tool_call={"kind": "fetch", "title": "fetch url", "toolCallId": "tc1"},
+        options=[
+            PermissionOption(option_id="reject", name="Reject", kind="reject_once"),
+            PermissionOption(option_id="allow", name="Allow", kind="allow_once"),
+        ],
+    )
+    decision = handler(params)
+    # denied -> picks the reject option
+    assert decision.outcome == PermissionOutcome.SELECTED
+    assert decision.option_id == "reject"
+    assert posted and posted[0]["outcome"] == "denied"
+    assert posted[0]["attributes"]["permission_reason"] == "policy-network-lockdown"
+    assert posted[0]["attributes"]["allowed"] is False
+
+
+def test_permission_handler_allows_when_sandboxed(monkeypatch):
+    """Sandboxed run short-circuits to allow ('sandbox-enforced'); the policy is
+    never even loaded."""
+    posted = []
+    monkeypatch.setattr(task_executor, "_hub_post", lambda path, payload, **k: posted.append(payload) or True)
+    monkeypatch.setattr(task_executor, "_openshell_enabled", lambda: True)
+
+    def _boom(*a, **k):  # pragma: no cover - asserts it is never invoked
+        raise AssertionError("policy must not be loaded when sandboxed")
+
+    monkeypatch.setattr("mac.acp.permission.load_openshell_policy", _boom)
+
+    handler = task_executor._acp_permission_handler("task_box")
+    params = RequestPermissionParams(
+        session_id="s1",
+        tool_call={"kind": "execute", "title": "run shell", "toolCallId": "tc2"},
+        options=[
+            PermissionOption(option_id="reject", name="Reject", kind="reject_once"),
+            PermissionOption(option_id="allow", name="Allow", kind="allow_once"),
+        ],
+    )
+    decision = handler(params)
+    assert decision.outcome == PermissionOutcome.SELECTED
+    assert decision.option_id == "allow"
+    assert posted[0]["outcome"] == "allowed"
+    assert posted[0]["attributes"]["permission_reason"] == "sandbox-enforced"
+
+
+# -- Phase 3: AgentBus mirror lifecycle --------------------------------------
+
+
+def test_invoke_acp_agent_mirrors_session_updates_to_agentbus(monkeypatch, tmp_path):
+    """The mirror opens a stream, appends one chunk per session/update, and closes
+    it — alongside (not instead of) the /action-events posts."""
+    posts = []  # (path, payload) for _hub_post
+    json_posts = []  # (path, payload) for _hub_post_json
+
+    def _post(path, payload, **k):
+        posts.append((path, payload))
+        return True
+
+    def _post_json(path, payload, **k):
+        json_posts.append((path, payload))
+        # the open returns the created stream with its server-assigned id
+        return {"id": "bus_acp_1", "status": "open"}
+
+    monkeypatch.setattr(task_executor, "_hub_post", _post)
+    monkeypatch.setattr(task_executor, "_hub_post_json", _post_json)
+    monkeypatch.setattr(task_executor, "local_agent_id", lambda: "agent_test")
+
+    class _FakeExecutor:
+        _argv = ["fake-acp-agent"]
+
+        def run(self, prompt, *, on_update, on_permission, timeout=None):
+            on_update({"sessionId": "s1", "update": {
+                "sessionUpdate": SessionUpdateKind.AGENT_MESSAGE_CHUNK,
+                "content": text_block("hi"),
+            }})
+            on_update({"sessionId": "s1", "update": {"sessionUpdate": SessionUpdateKind.TOOL_CALL}})
+            return types.SimpleNamespace(stop_reason=StopReason.END_TURN)
+
+    result = task_executor._invoke_acp_agent(
+        "go", tmp_path, "task_mirror", {"timeout": None}, executor=_FakeExecutor()
+    )
+    assert result.returncode == 0
+
+    # opened exactly one stream
+    opens = [p for (path, p) in json_posts if path == "/agentbus/streams"]
+    assert len(opens) == 1
+    assert opens[0]["sender_agent_id"] == "agent_test"
+    assert opens[0]["recipient_agent_id"] == "agent_test"  # self-stream
+    assert opens[0]["content_type"] == "application/vnd.mac.acp.update+json"
+
+    # one chunk appended per session/update
+    chunks = [(path, p) for (path, p) in posts if path == "/agentbus/streams/bus_acp_1/chunks"]
+    assert len(chunks) == 2
+    assert chunks[0][1]["payload"]["sessionId"] == "s1"
+
+    # stream closed exactly once
+    closes = [path for (path, p) in posts if path.startswith("/agentbus/streams/bus_acp_1/close")]
+    assert len(closes) == 1
+    assert "sender_agent_id=agent_test" in closes[0]
+    assert "status=closed" in closes[0]
+
+
+def test_invoke_acp_agent_mirror_is_inert_when_open_fails(monkeypatch, tmp_path):
+    """If the stream open fails (no hub / error), append + close are skipped and
+    the run still succeeds — the mirror is best-effort."""
+    posts = []
+    monkeypatch.setattr(task_executor, "_hub_post", lambda path, payload, **k: posts.append((path, payload)) or True)
+    monkeypatch.setattr(task_executor, "_hub_post_json", lambda *a, **k: None)  # open fails
+    monkeypatch.setattr(task_executor, "local_agent_id", lambda: "agent_test")
+
+    class _FakeExecutor:
+        _argv = ["fake"]
+
+        def run(self, prompt, *, on_update, on_permission, timeout=None):
+            on_update({"sessionId": "s1", "update": {"sessionUpdate": SessionUpdateKind.TOOL_CALL}})
+            return types.SimpleNamespace(stop_reason=StopReason.END_TURN)
+
+    result = task_executor._invoke_acp_agent("go", tmp_path, "t", {}, executor=_FakeExecutor())
+    assert result.returncode == 0
+    # no chunk/close posts when the stream never opened
+    assert not [path for (path, p) in posts if "/chunks" in path or "/close" in path]
+    # /action-events still flowed
+    assert [path for (path, p) in posts if path == "/action-events"]
+
+
 def test_acpexecutor_is_the_real_seam_type():
     # guard: the integration imports the real adapter, not a shim
     assert ACPExecutor.__module__ == "mac.acp.executor"

--- a/tests/test_acp_permission.py
+++ b/tests/test_acp_permission.py
@@ -1,0 +1,156 @@
+"""Phase 3 — the pure ACP permission evaluator (ADR 0006)."""
+
+from __future__ import annotations
+
+from mac.acp.permission import (
+    PermissionMode,
+    evaluate_permission,
+    load_openshell_policy,
+    permission_mode,
+)
+
+
+# A policy that allows egress + writes (networked production-style profile).
+_OPEN_POLICY = {
+    "network_policies": {"mac_hub": {"name": "mac-hub", "endpoints": [{"host": "h", "port": 1}]}},
+    "filesystem_policy": {"read_only": ["/usr"], "read_write": ["/tmp", "/work"]},
+}
+
+# A lockdown policy: empty network_policies (deny egress), read-only filesystem.
+_LOCKDOWN_POLICY = {
+    "network_policies": {},
+    "filesystem_policy": {"read_only": ["/usr"], "read_write": []},
+}
+
+
+def _tc(kind):
+    return {"kind": kind, "title": "t", "toolCallId": "tc1"}
+
+
+# -- mode resolution ---------------------------------------------------------
+
+
+def test_permission_mode_defaults_to_policy(monkeypatch):
+    monkeypatch.delenv("MAC_ACP_PERMISSION_MODE", raising=False)
+    assert permission_mode() == PermissionMode.POLICY
+    monkeypatch.setenv("MAC_ACP_PERMISSION_MODE", "DENY")
+    assert permission_mode() == PermissionMode.DENY
+    monkeypatch.setenv("MAC_ACP_PERMISSION_MODE", "nonsense")
+    assert permission_mode() == PermissionMode.POLICY  # unknown -> default
+
+
+# -- explicit allow / deny modes ---------------------------------------------
+
+
+def test_mode_allow_always_allows():
+    d = evaluate_permission(_tc("execute"), policy=_LOCKDOWN_POLICY, mode="allow")
+    assert d.allow is True and d.reason == "mode-allow"
+
+
+def test_mode_deny_always_denies():
+    d = evaluate_permission(_tc("read"), policy=_OPEN_POLICY, mode="deny")
+    assert d.allow is False and d.reason == "mode-deny"
+
+
+# -- sandbox short-circuit ---------------------------------------------------
+
+
+def test_sandboxed_short_circuits_to_allow_even_under_lockdown():
+    # the kernel sandbox is the real gate; the ACP prompt is advisory
+    d = evaluate_permission(_tc("execute"), policy=_LOCKDOWN_POLICY, sandboxed=True, mode="policy")
+    assert d.allow is True and d.reason == "sandbox-enforced"
+    # sandbox even overrides mode=deny
+    d2 = evaluate_permission(_tc("execute"), sandboxed=True, mode="deny")
+    assert d2.allow is True and d2.reason == "sandbox-enforced"
+
+
+# -- no-policy default-allow (Phase-1 parity) --------------------------------
+
+
+def test_policy_mode_without_policy_defaults_to_allow():
+    d = evaluate_permission(_tc("execute"), policy=None, sandboxed=False, mode="policy")
+    assert d.allow is True and d.reason == "no-policy-default-allow"
+
+
+def test_policy_mode_without_policy_can_be_flipped_to_deny():
+    d = evaluate_permission(_tc("execute"), policy=None, sandboxed=False, mode="deny")
+    assert d.allow is False and d.reason == "mode-deny"
+
+
+# -- benign kinds always allowed ---------------------------------------------
+
+
+def test_benign_kinds_allowed_under_lockdown():
+    for kind in ("read", "search", "think"):
+        d = evaluate_permission(_tc(kind), policy=_LOCKDOWN_POLICY, mode="policy")
+        assert d.allow is True, kind
+        assert d.reason.startswith("benign-kind")
+
+
+# -- network intent ----------------------------------------------------------
+
+
+def test_network_lockdown_denies_egress():
+    d = evaluate_permission(_tc("fetch"), policy=_LOCKDOWN_POLICY, mode="policy")
+    assert d.allow is False and d.reason == "policy-network-lockdown"
+
+
+def test_network_allowed_when_policy_has_network_policies():
+    d = evaluate_permission(_tc("fetch"), policy=_OPEN_POLICY, mode="policy")
+    assert d.allow is True and d.reason == "policy-network-allowed"
+
+
+# -- fs-write intent ---------------------------------------------------------
+
+
+def test_fs_write_denied_when_read_write_empty():
+    for kind in ("edit", "delete", "move", "create", "write"):
+        d = evaluate_permission(_tc(kind), policy=_LOCKDOWN_POLICY, mode="policy")
+        assert d.allow is False, kind
+        assert d.reason == "policy-fs-write-readonly"
+
+
+def test_fs_write_allowed_when_read_write_nonempty():
+    d = evaluate_permission(_tc("write"), policy=_OPEN_POLICY, mode="policy")
+    assert d.allow is True and d.reason == "policy-fs-write-allowed"
+
+
+# -- execute / unknown unsandboxed under policy ------------------------------
+
+
+def test_execute_unsandboxed_denied_under_policy():
+    d = evaluate_permission(_tc("execute"), policy=_OPEN_POLICY, sandboxed=False, mode="policy")
+    assert d.allow is False and d.reason.startswith("policy-unsandboxed-execute")
+
+
+def test_unknown_kind_unsandboxed_denied_under_policy():
+    d = evaluate_permission(_tc("teleport"), policy=_OPEN_POLICY, sandboxed=False, mode="policy")
+    assert d.allow is False and d.reason.startswith("policy-unsandboxed-execute")
+
+
+# -- policy loader (best-effort) ---------------------------------------------
+
+
+def test_load_openshell_policy_reads_yaml(tmp_path, monkeypatch):
+    policy_file = tmp_path / "policy.yaml"
+    policy_file.write_text(
+        "version: 1\nnetwork_policies:\n  mac_hub:\n    name: mac-hub\n",
+        encoding="utf-8",
+    )
+    parsed = load_openshell_policy(str(policy_file))
+    assert isinstance(parsed, dict)
+    assert "mac_hub" in parsed["network_policies"]
+
+
+def test_load_openshell_policy_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.delenv("MAC_OPENSHELL_POLICY", raising=False)
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    assert load_openshell_policy() is None
+
+
+def test_load_openshell_policy_uses_env(tmp_path, monkeypatch):
+    policy_file = tmp_path / "env-policy.yaml"
+    policy_file.write_text("network_policies: {}\nfilesystem_policy: {read_write: []}\n", encoding="utf-8")
+    monkeypatch.setenv("MAC_OPENSHELL_POLICY", str(policy_file))
+    parsed = load_openshell_policy()
+    assert parsed == {"network_policies": {}, "filesystem_policy": {"read_write": []}}


### PR DESCRIPTION
Phase 3 of [ADR 0006](docs/adr/0006-acp-support.md). Additive, behind `backend=acp`; the default Hermes path is untouched.

- **Capability negotiation** — `capabilities.py`: `mac_client_capabilities()`/`mac_agent_capabilities()` + `acp_manifest()`, with mac extensions under `_meta.mac` `{sandbox, decomposition, evidence}`. `ACPClient`/`ACPAgentServer` default to them (explicit overrides still win); `protocol.py` gains an optional `meta` field (baseline wire shape unchanged).
- **Manifest endpoint** — `GET /.well-known/acp` (unauthenticated discovery doc) → `acp_manifest()`.
- **Permission → OpenShell-policy bridge** — `permission.py`: `evaluate_permission(tool_call, *, policy, sandboxed, mode)`. `sandboxed` short-circuits to allow (the kernel sandbox is the real gate); under `policy` mode, the ACP tool **kind** maps to an intent and consults the OpenShell policy (network kinds need non-empty `network_policies` else deny; write kinds need `filesystem_policy.read_write` else deny; read/search/think allow; execute/unknown allowed only when sandboxed). No-policy default-allow preserves Phase-1 parity (flippable via `MAC_ACP_PERMISSION_MODE=deny`). The Phase-1 handler now uses it and records the reason in `/action-events`.
- **AgentBus mirror** — `_invoke_acp_agent` mirrors `session/update` to an AgentBus chunk stream (open → append-per-update → close, best-effort) alongside `/action-events`.

107 ACP/api tests + 518 in the broad central-path regression. Phase 3 ticket `task_4bf5b9c4…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)