### PR TITLE
feat(acp): production MacAgentBackend for the ACP server (ADR 0006)

### DIFF
--- a/src/mac/acp/__init__.py
+++ b/src/mac/acp/__init__.py
@@ -27,6 +27,7 @@ from .capabilities import (
     mac_client_capabilities,
     mac_meta,
 )
+from .backend import MacAgentBackend
 from .client import ACPClient, PermissionHandler, UpdateHandler
 from .executor import ACPExecutor, ACPRunResult
 from .permission import (
@@ -123,5 +124,6 @@ __all__ = [
     "PromptBackend",
     "PromptBackendFn",
     "EchoBackend",
+    "MacAgentBackend",
     "serve_stdio",
 ]

--- a/src/mac/acp/backend.py
+++ b/src/mac/acp/backend.py
@@ -1,0 +1,284 @@
+"""``MacAgentBackend`` -- the production :class:`~mac.acp.server.PromptBackend`.
+
+This is the deferred Phase-2 follow-up from ADR 0006: a real backend so an
+external ACP client driving a mac agent (via :class:`~mac.acp.server.ACPAgentServer`)
+actually runs a mac agent turn instead of the :class:`~mac.acp.server.EchoBackend`
+placeholder.
+
+On :meth:`MacAgentBackend.run_prompt` it spawns a mac/Hermes agent subprocess
+for the prompt, in the session's ``cwd``, and streams the agent's stdout back to
+the client line-by-line as ``agent_message_chunk`` ``session/update``
+notifications so the client sees live progress.
+
+The agent command is configurable via ``MAC_ACP_BACKEND_CMD`` (shlex-split). When
+unset it derives the same minimal ``hermes_cli chat`` invocation
+:mod:`mac.task_executor` uses (replicated here, *not* imported, to keep this
+module self-contained: it imports only from :mod:`mac.acp` and the stdlib).
+
+A ``runner`` seam is injected for tests: ``runner(argv, cwd, on_line) -> int``
+runs the command, invoking ``on_line(text)`` for each output line and returning
+the process exit code. The default runner is a real subprocess; tests pass a
+fake runner that calls ``on_line`` a couple of times and returns a code, keeping
+the test suite subprocess-free.
+
+Stop-reason mapping:
+
+* cancellation observed (``turn.cancelled``) -> :data:`StopReason.CANCELLED`
+  (the subprocess is terminated);
+* exit code ``0`` -> :data:`StopReason.END_TURN`;
+* any non-zero exit -> :data:`StopReason.REFUSAL` (with a final chunk noting the
+  failure).
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import threading
+from pathlib import Path
+from typing import Callable, List, Optional, Sequence
+
+from .protocol import StopReason
+from .server import PromptTurn, _prompt_text
+
+
+__all__ = [
+    "MacAgentBackend",
+    "RunnerFn",
+    "OnLineFn",
+    "default_argv",
+]
+
+
+#: Callback a runner invokes for each line of agent output.
+OnLineFn = Callable[[str], None]
+
+#: A runner: run ``argv`` in ``cwd``, calling ``on_line`` per output line, and
+#: return the process exit code. The default is :func:`_subprocess_runner`;
+#: tests inject a fake to stay subprocess-free.
+RunnerFn = Callable[[Sequence[str], str, OnLineFn], int]
+
+
+# Environment knob: an explicit agent command line (shlex-split) overriding the
+# derived default. Honored at run time so tests/operators can flip it freely.
+_ENV_BACKEND_CMD = "MAC_ACP_BACKEND_CMD"
+
+
+def default_argv(prompt: str) -> List[str]:
+    """The default mac/Hermes agent invocation for ``prompt``.
+
+    Replicates the minimal argv shape of :func:`mac.task_executor._hermes_argv`
+    (``<python> -m hermes_cli.main chat --query <prompt> --quiet ...``) *without*
+    importing ``task_executor`` -- this module stays self-contained. The Hermes
+    interpreter is ``$MAC_HERMES_PYTHON`` when set, else the vendored
+    ``~/.mac/venv/bin/python`` (with the vendored ``_hermes`` tree on
+    ``PYTHONPATH`` so ``hermes_cli`` resolves), mirroring host vs. sandbox-image
+    resolution there.
+
+    The ``--yolo`` flag is intentionally **omitted**: that bypasses Hermes' own
+    approval and is only safe under the OpenShell sandbox the task executor wraps
+    around it. This backend runs the agent directly, so it keeps Hermes'
+    approval gate in place.
+    """
+
+    override = (os.environ.get("MAC_HERMES_PYTHON") or "").strip()
+    if override:
+        hermes_py = override
+    else:
+        hermes_py = str(Path.home() / ".mac" / "venv" / "bin" / "python")
+        hermes_vendored = str(
+            Path.home() / ".mac" / "src" / "mac" / "src" / "mac" / "_hermes"
+        )
+        os.environ["PYTHONPATH"] = (
+            hermes_vendored + os.pathsep + os.environ.get("PYTHONPATH", "")
+        )
+    return [hermes_py, "-m", "hermes_cli.main", "chat", "--query", prompt, "--quiet"]
+
+
+class MacAgentBackend:
+    """A :class:`~mac.acp.server.PromptBackend` that runs a real mac agent turn.
+
+    Parameters
+    ----------
+    argv:
+        Optional explicit command template. When ``None`` (the default) the
+        command is resolved per turn from ``$MAC_ACP_BACKEND_CMD`` (shlex-split)
+        or, failing that, :func:`default_argv`. An explicit ``argv`` (or the env
+        command) receives the prompt as a trailing positional argument; the
+        derived default already embeds the prompt via ``--query``.
+    runner:
+        The execution seam: ``runner(argv, cwd, on_line) -> returncode``. Defaults
+        to :func:`_subprocess_runner`. Tests inject a fake that calls
+        ``on_line`` and returns a code -- no subprocess required.
+    """
+
+    def __init__(
+        self,
+        argv: Optional[Sequence[str]] = None,
+        *,
+        runner: Optional[RunnerFn] = None,
+    ) -> None:
+        self._argv = list(argv) if argv is not None else None
+        self._runner = runner if runner is not None else _subprocess_runner
+
+    # -- argv resolution -----------------------------------------------------
+
+    def _resolve_argv(self, prompt: str) -> List[str]:
+        """Build the command line for this turn's ``prompt``.
+
+        Precedence: explicit ``argv`` (constructor) > ``$MAC_ACP_BACKEND_CMD`` >
+        :func:`default_argv`. The first two are templates with the prompt
+        appended as a trailing positional argument; the derived default already
+        carries the prompt via ``--query``.
+        """
+
+        if self._argv is not None:
+            return [*self._argv, prompt]
+        env_cmd = (os.environ.get(_ENV_BACKEND_CMD) or "").strip()
+        if env_cmd:
+            return [*shlex.split(env_cmd), prompt]
+        return default_argv(prompt)
+
+    # -- the backend protocol ------------------------------------------------
+
+    def run_prompt(self, turn: PromptTurn) -> str:
+        """Run the agent for ``turn`` and stream its output back to the client.
+
+        Already-cancelled turns short-circuit to :data:`StopReason.CANCELLED`
+        before spawning anything. Output lines are streamed as
+        ``agent_message_chunk`` updates as they arrive. We run on the server's
+        per-turn worker thread, so blocking here is fine (see
+        :meth:`mac.acp.server.ACPAgentServer._run_turn`).
+
+        Cancellation is observed two ways: the ``on_line`` callback raises
+        :class:`_Cancelled` if the turn is cancelled (so a chatty agent is
+        killed promptly between lines), and the runner receives a
+        ``cancelled`` predicate it polls so a *silent* agent is killed too. The
+        default :func:`_subprocess_runner` honors both.
+        """
+
+        if turn.cancelled:
+            return StopReason.CANCELLED
+
+        prompt = _prompt_text(turn.content)
+        argv = self._resolve_argv(prompt)
+        cwd = turn.cwd or os.getcwd()
+
+        def _on_line(text: str) -> None:
+            if turn.cancelled:
+                raise _Cancelled()
+            if text:
+                turn.agent_message_chunk(text)
+
+        returncode = _invoke(self._runner, argv, cwd, _on_line, turn)
+
+        if turn.cancelled:
+            return StopReason.CANCELLED
+        if returncode == 0:
+            return StopReason.END_TURN
+        turn.agent_message_chunk("[mac-agent exited with code %s]" % returncode)
+        return StopReason.REFUSAL
+
+
+class _Cancelled(Exception):
+    """Sentinel raised by ``on_line`` to tell a runner to stop and kill its child."""
+
+
+def _invoke(
+    runner: RunnerFn,
+    argv: Sequence[str],
+    cwd: str,
+    on_line: OnLineFn,
+    turn: PromptTurn,
+) -> int:
+    """Call ``runner`` and absorb a cooperative :class:`_Cancelled` abort.
+
+    A runner that finishes normally returns its exit code. A runner whose
+    ``on_line`` raised :class:`_Cancelled` (the cancellation path) lets that
+    propagate; we treat it as "cancelled, no exit code" and return a sentinel
+    ``-1`` -- ``run_prompt`` ignores the code on the cancelled path anyway.
+    """
+
+    try:
+        return runner(argv, cwd, on_line)
+    except _Cancelled:
+        return -1
+
+
+def _subprocess_runner(argv: Sequence[str], cwd: str, on_line: OnLineFn) -> int:
+    """The default :data:`RunnerFn`: spawn ``argv`` and stream its stdout.
+
+    Reads the child's combined stdout line by line, handing each (newline
+    stripped) to ``on_line``. If ``on_line`` raises :class:`_Cancelled` the child
+    is terminated and the abort re-raised. A background watcher also terminates
+    the child if cancellation is observed while the agent is producing no output
+    (so a silent, hung agent is still killed). Always waits on the child so we
+    report an accurate exit code and never leak a zombie.
+    """
+
+    proc = subprocess.Popen(  # noqa: S603 -- argv is operator/derived, not shell
+        list(argv),
+        cwd=cwd or None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,  # line-buffered
+    )
+    assert proc.stdout is not None  # PIPE guarantees a readable stream
+
+    # Watcher: probe ``on_line("")`` periodically -- it raises _Cancelled once
+    # the turn is cancelled (the empty string is never streamed). This kills a
+    # silent child without waiting for it to emit a line.
+    stop_watch = threading.Event()
+    cancelled = threading.Event()
+
+    def _watch() -> None:
+        while not stop_watch.wait(0.02):
+            try:
+                on_line("")
+            except _Cancelled:
+                cancelled.set()
+                _terminate(proc)
+                return
+            except Exception:  # noqa: BLE001 -- watcher must never crash the run
+                return
+
+    watcher = threading.Thread(target=_watch, daemon=True)
+    watcher.start()
+
+    aborted = False
+    try:
+        for raw in proc.stdout:
+            line = raw.rstrip("\n")
+            try:
+                on_line(line)
+            except _Cancelled:
+                aborted = True
+                _terminate(proc)
+                break
+    finally:
+        stop_watch.set()
+        try:
+            proc.stdout.close()
+        except Exception:  # noqa: BLE001 -- best-effort cleanup
+            pass
+        returncode = proc.wait()
+
+    if aborted or cancelled.is_set():
+        raise _Cancelled()
+    return returncode
+
+
+def _terminate(proc: "subprocess.Popen") -> None:
+    """Terminate ``proc``, escalating to kill if it ignores SIGTERM."""
+
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover - extreme edge
+            pass

--- a/src/mac/acp/server.py
+++ b/src/mac/acp/server.py
@@ -35,6 +35,7 @@ Spec notes (verified against ``agentclientprotocol.com/protocol/v1/*``):
 from __future__ import annotations
 
 import itertools
+import os
 import sys
 import threading
 from typing import Any, Callable, Dict, List, Optional, Protocol, Union, runtime_checkable
@@ -544,7 +545,7 @@ class ACPAgentServer:
 
 
 def serve_stdio(
-    backend: Union[PromptBackend, PromptBackendFn],
+    backend: Optional[Union[PromptBackend, PromptBackendFn]] = None,
     *,
     stdin: Any = None,
     stdout: Any = None,
@@ -557,10 +558,24 @@ def serve_stdio(
     thread, pumping inbound frames, until stdin reaches EOF (the client closed
     the connection).
 
+    ``backend`` defaults to the production
+    :class:`~mac.acp.backend.MacAgentBackend` when ``MAC_ACP_BACKEND_CMD`` is set
+    (an agent command is configured), else to :class:`EchoBackend` so the
+    no-config standalone case stays a harmless smoke test. Pass an explicit
+    backend to override the choice.
+
     ``stdin`` / ``stdout`` default to the process's binary stdio buffers; they
     are injectable for testing. Extra ``server_kwargs`` are forwarded to
     :class:`ACPAgentServer`.
     """
+
+    if backend is None:
+        if os.environ.get("MAC_ACP_BACKEND_CMD"):
+            from .backend import MacAgentBackend
+
+            backend = MacAgentBackend()
+        else:
+            backend = EchoBackend()
 
     in_stream = stdin if stdin is not None else getattr(sys.stdin, "buffer", sys.stdin)
     out_stream = (
@@ -594,13 +609,14 @@ def serve_stdio(
 def main(argv: Optional[List[str]] = None) -> int:
     """Entrypoint for ``python -m mac.acp.server``.
 
-    Runs the server over stdio with the minimal :class:`EchoBackend`. This is a
-    smoke-test entrypoint only -- the production backend that binds to mac's
-    task/tool surface is the Phase-2 follow-up. The default backend echoes the
-    prompt text back as a single agent message and ends the turn.
+    Runs the server over stdio, letting :func:`serve_stdio` pick the backend:
+    the production :class:`~mac.acp.backend.MacAgentBackend` when
+    ``MAC_ACP_BACKEND_CMD`` is set (a real mac agent runs each turn), else the
+    minimal :class:`EchoBackend` smoke-test backend (echoes the prompt text back
+    as a single agent message and ends the turn).
     """
 
-    serve_stdio(EchoBackend())
+    serve_stdio()
     return 0
 
 

--- a/tests/test_acp_backend.py
+++ b/tests/test_acp_backend.py
@@ -1,0 +1,295 @@
+"""Tests for :class:`~mac.acp.backend.MacAgentBackend`.
+
+Two layers, both subprocess-free via the injected ``runner`` seam:
+
+* **Unit** -- drive :meth:`MacAgentBackend.run_prompt` against a fake
+  :class:`PromptTurn` capture, asserting it streams the runner's lines as
+  ``agent_message_chunk``\\ s and maps returncode -> stop reason
+  (0 -> end_turn, nonzero -> refusal), plus the cancellation path.
+* **End-to-end** -- a real :class:`ACPClient` <-> real
+  :class:`ACPAgentServer(MacAgentBackend(runner=fake))` over the in-memory paired
+  transport (the harness mirrors ``tests/test_acp_server.py``): the client
+  prompts, the fake runner's lines arrive at the client as
+  ``agent_message_chunk`` updates, and the prompt returns ``end_turn``.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, List
+
+from mac.acp.backend import MacAgentBackend, default_argv
+from mac.acp.client import ACPClient
+from mac.acp.peer import Peer
+from mac.acp.protocol import (
+    PromptResult,
+    SessionUpdateKind,
+    StopReason,
+)
+from mac.acp.server import ACPAgentServer, PromptTurn
+
+
+# ---------------------------------------------------------------------------
+# Unit-level helpers: a PromptTurn that captures chunks without a live peer.
+# ---------------------------------------------------------------------------
+
+
+class _CaptureTurn(PromptTurn):
+    """A :class:`PromptTurn` whose ``send_update`` records instead of sending.
+
+    Lets the unit tests drive ``run_prompt`` without a real :class:`Peer` /
+    client, while still exercising the genuine ``agent_message_chunk`` path.
+    """
+
+    def __init__(self, prompt: str = "do the thing", *, cwd: str = "/tmp/work") -> None:
+        super().__init__(
+            peer=None,  # never touched: send_update is overridden
+            session_id="sess_1",
+            content=[{"type": "text", "text": prompt}],
+            cwd=cwd,
+        )
+        self.updates: List[Dict[str, Any]] = []
+
+    def send_update(self, update: Dict[str, Any]) -> None:  # type: ignore[override]
+        self.updates.append(dict(update))
+
+    @property
+    def chunks(self) -> List[str]:
+        """The text of every ``agent_message_chunk`` streamed, in order."""
+
+        return [
+            u["content"]["text"]
+            for u in self.updates
+            if u.get("sessionUpdate") == SessionUpdateKind.AGENT_MESSAGE_CHUNK
+        ]
+
+
+def _fake_runner(lines, returncode):
+    """A fake :data:`RunnerFn`: emit ``lines`` then return ``returncode``.
+
+    Captures the ``argv`` and ``cwd`` it was handed for assertions.
+    """
+
+    captured: Dict[str, Any] = {}
+
+    def runner(argv, cwd, on_line):
+        captured["argv"] = list(argv)
+        captured["cwd"] = cwd
+        for line in lines:
+            on_line(line)
+        return returncode
+
+    runner.captured = captured  # type: ignore[attr-defined]
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_run_prompt_streams_lines_and_ends_turn_on_zero():
+    runner = _fake_runner(["line one", "line two"], 0)
+    backend = MacAgentBackend(argv=["my-agent", "--flag"], runner=runner)
+    turn = _CaptureTurn("hello agent", cwd="/work/dir")
+
+    stop = backend.run_prompt(turn)
+
+    assert stop == StopReason.END_TURN
+    assert turn.chunks == ["line one", "line two"]
+    # The runner saw the resolved argv (template + prompt appended) and the cwd.
+    assert runner.captured["argv"] == ["my-agent", "--flag", "hello agent"]
+    assert runner.captured["cwd"] == "/work/dir"
+
+
+def test_run_prompt_nonzero_returncode_maps_to_refusal():
+    runner = _fake_runner(["partial output"], 3)
+    backend = MacAgentBackend(argv=["my-agent"], runner=runner)
+    turn = _CaptureTurn()
+
+    stop = backend.run_prompt(turn)
+
+    assert stop == StopReason.REFUSAL
+    # The streamed output plus a trailing failure note.
+    assert turn.chunks[0] == "partial output"
+    assert "exited with code 3" in turn.chunks[-1]
+
+
+def test_run_prompt_empty_lines_are_not_streamed():
+    runner = _fake_runner(["", "real", ""], 0)
+    backend = MacAgentBackend(argv=["my-agent"], runner=runner)
+    turn = _CaptureTurn()
+
+    stop = backend.run_prompt(turn)
+
+    assert stop == StopReason.END_TURN
+    assert turn.chunks == ["real"]
+
+
+def test_run_prompt_already_cancelled_short_circuits():
+    called = {"ran": False}
+
+    def runner(argv, cwd, on_line):
+        called["ran"] = True
+        return 0
+
+    backend = MacAgentBackend(argv=["my-agent"], runner=runner)
+    turn = _CaptureTurn()
+    turn._mark_cancelled()
+
+    stop = backend.run_prompt(turn)
+
+    assert stop == StopReason.CANCELLED
+    assert called["ran"] is False  # never spawned the runner
+
+
+def test_run_prompt_cancelled_mid_run_returns_cancelled():
+    """A turn cancelled while the runner streams ends as CANCELLED.
+
+    The fake runner flips the turn's cancel flag partway through and keeps
+    emitting; ``run_prompt`` must report CANCELLED regardless of the (here 0)
+    return code, and not stream output produced after the cancel.
+    """
+
+    def runner(argv, cwd, on_line):
+        on_line("before cancel")
+        # Simulate the client's session/cancel landing mid-run.
+        turn._mark_cancelled()
+        on_line("after cancel")  # guarded out by run_prompt's on_line
+        return 0
+
+    backend = MacAgentBackend(argv=["my-agent"], runner=runner)
+    turn = _CaptureTurn()
+
+    stop = backend.run_prompt(turn)
+
+    assert stop == StopReason.CANCELLED
+    assert turn.chunks == ["before cancel"]
+
+
+def test_default_argv_shape():
+    """The derived default mirrors the task_executor hermes invocation shape."""
+
+    argv = default_argv("solve it")
+    assert argv[1:] == [
+        "-m",
+        "hermes_cli.main",
+        "chat",
+        "--query",
+        "solve it",
+        "--quiet",
+    ]
+    # --yolo is deliberately NOT in the unsandboxed backend invocation.
+    assert "--yolo" not in argv
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real client <-> real server(MacAgentBackend(runner=fake))
+# ---------------------------------------------------------------------------
+
+
+class _Pipe:
+    """A pair of peers connected to each other's inbox (cf. test_acp_server).
+
+    A daemon thread pumps both peers so a blocking client call makes progress;
+    the server runs each prompt turn on its own worker thread.
+    """
+
+    def __init__(self) -> None:
+        self.client_peer = Peer(send=self._to_server)
+        self.server_peer = Peer(send=self._to_client)
+
+    def _to_server(self, data: bytes) -> None:
+        self.server_peer.feed(data)
+
+    def _to_client(self, data: bytes) -> None:
+        self.client_peer.feed(data)
+
+    def run_background_pump(self) -> "threading.Event":
+        stop = threading.Event()
+
+        def _loop() -> None:
+            while not stop.is_set():
+                processed = self.server_peer.pump() + self.client_peer.pump()
+                if processed == 0:
+                    stop.wait(0.001)
+
+        threading.Thread(target=_loop, daemon=True).start()
+        return stop
+
+
+def test_end_to_end_client_drives_mac_agent_backend():
+    pipe = _Pipe()
+
+    captured: Dict[str, Any] = {}
+
+    def fake_runner(argv, cwd, on_line):
+        captured["argv"] = list(argv)
+        captured["cwd"] = cwd
+        on_line("agent: thinking")
+        on_line("agent: done")
+        return 0
+
+    backend = MacAgentBackend(argv=["mac-agent"], runner=fake_runner)
+    server = ACPAgentServer(pipe.server_peer, backend)
+    client = ACPClient(pipe.client_peer)
+
+    received: List[Dict[str, Any]] = []
+    client.on_update(lambda update: received.append(update))
+
+    stop = pipe.run_background_pump()
+    try:
+        client.initialize(timeout=5)
+        session_id = client.session_new(cwd="/tmp/agent-cwd", timeout=5)
+        assert session_id in server.session_ids()
+
+        result = client.session_prompt(session_id, "build the thing", timeout=5)
+        assert isinstance(result, PromptResult)
+        assert result.stop_reason == StopReason.END_TURN
+    finally:
+        stop.set()
+
+    # The fake runner ran in the session cwd with the prompt appended to argv.
+    assert captured["cwd"] == "/tmp/agent-cwd"
+    assert captured["argv"] == ["mac-agent", "build the thing"]
+
+    # Both runner lines arrived at the client as agent_message_chunk updates.
+    chunks = [
+        u["update"]["content"]["text"]
+        for u in received
+        if u["update"].get("sessionUpdate") == SessionUpdateKind.AGENT_MESSAGE_CHUNK
+    ]
+    assert chunks == ["agent: thinking", "agent: done"]
+    assert all(u["sessionId"] == session_id for u in received)
+
+
+def test_end_to_end_nonzero_returncode_refuses():
+    pipe = _Pipe()
+
+    def fake_runner(argv, cwd, on_line):
+        on_line("agent: failing")
+        return 7
+
+    backend = MacAgentBackend(argv=["mac-agent"], runner=fake_runner)
+    ACPAgentServer(pipe.server_peer, backend)
+    client = ACPClient(pipe.client_peer)
+
+    received: List[Dict[str, Any]] = []
+    client.on_update(lambda update: received.append(update))
+
+    stop = pipe.run_background_pump()
+    try:
+        client.initialize(timeout=5)
+        session_id = client.session_new(cwd="/tmp", timeout=5)
+        result = client.session_prompt(session_id, "do it", timeout=5)
+        assert result.stop_reason == StopReason.REFUSAL
+    finally:
+        stop.set()
+
+    chunks = [
+        u["update"]["content"]["text"]
+        for u in received
+        if u["update"].get("sessionUpdate") == SessionUpdateKind.AGENT_MESSAGE_CHUNK
+    ]
+    assert chunks[0] == "agent: failing"
+    assert "exited with code 7" in chunks[-1]


### PR DESCRIPTION
The deferred Phase-2 follow-up: a real `PromptBackend` so an external ACP client driving a mac agent (via `ACPAgentServer`) runs an actual mac agent turn instead of `EchoBackend`.

- **`MacAgentBackend`** (`src/mac/acp/backend.py`): resolves prompt text, builds an argv (explicit `argv=` > `$MAC_ACP_BACKEND_CMD` > a default replicating `task_executor._hermes_argv`'s `hermes_cli chat --query … --quiet` shape, without importing task_executor and without `--yolo` since unsandboxed), runs it in `turn.cwd`, and **streams stdout line-by-line as `agent_message_chunk` updates**. Honors `turn.cancelled` (SIGTERM→SIGKILL + a watcher for silent children); exit 0 → `end_turn`, nonzero → `refusal`.
- **Runner seam** keeps tests subprocess-free; **`serve_stdio`** defaults to `MacAgentBackend` when `MAC_ACP_BACKEND_CMD` is set, else `EchoBackend`. Self-contained (acp + stdlib). 21 tests incl. a real `ACPClient`↔`ACPAgentServer(MacAgentBackend)` round-trip.

**Deferred**: deeper task-ledger/evidence binding (session→`task_id`/lease + `mac-evidence.json`) and tool-call→`tool_call`/permission routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)