### PR TITLE
feat(acp): WebSocket (remote) transport for the ACP server (Phase 2b)

### DIFF
--- a/src/mac/acp/ws.py
+++ b/src/mac/acp/ws.py
@@ -1,0 +1,163 @@
+"""Remote WebSocket transport for the ACP **agent/server** role (ADR 0006).
+
+ADR 0006 Phase 2 calls for "stdio first, WS for remote". :mod:`mac.acp.server`
+already covers the stdio case; this module adds the remote one: it bridges a
+Starlette/FastAPI :class:`~starlette.websockets.WebSocket` to the existing,
+*synchronous* :class:`~mac.acp.peer.Peer` driving an
+:class:`~mac.acp.server.ACPAgentServer`. Nothing here is ACP-specific beyond the
+plumbing -- it reuses the unchanged server, peer, and backend machinery.
+
+The async <-> sync bridge
+=========================
+The :class:`~mac.acp.peer.Peer` is deliberately transport-agnostic and
+synchronous: you give it a ``send(bytes)`` callable, push inbound bytes via
+:meth:`~mac.acp.peer.Peer.feed`, and drive it with
+:meth:`~mac.acp.peer.Peer.pump`. A Starlette ``WebSocket`` is async. The two are
+joined as follows:
+
+* **Outbound (sync -> async).** We capture the running event loop once at
+  connect time. The peer's ``send`` schedules ``websocket.send_text`` back onto
+  that loop with :func:`asyncio.run_coroutine_threadsafe`. This is what makes the
+  server's **DEFERRED** path safe: a prompt turn runs the backend on a *worker
+  thread* (see :meth:`mac.acp.server.ACPAgentServer._run_turn`) and emits
+  ``session/update`` notifications and the final response from that thread --
+  ``run_coroutine_threadsafe`` is the documented, thread-safe way to push work
+  onto a loop from another thread, so those frames reach the socket without
+  touching loop internals off-thread.
+* **Inbound (async -> sync).** The accept/receive loop awaits one text frame at a
+  time. Each WS frame carries exactly one JSON-RPC message; appending a newline
+  (``feed(text.encode() + b"\\n")``) lets the peer's existing newline framing
+  parse it, and :meth:`~mac.acp.peer.Peer.pump` dispatches it. The pump returns
+  immediately even for ``session/prompt`` because the server defers the turn to
+  a worker thread, so the receive loop stays free to deliver the client's
+  permission decision and any ``session/cancel`` that arrive mid-turn.
+
+On disconnect we drain any in-flight turn (``server.wait_idle``) so a worker
+thread is not still trying to write to a closed socket as we unwind.
+
+Imports of Starlette types are **guarded**: importing :mod:`mac.acp.ws` never
+hard-fails when Starlette is absent (it is a dep in practice via FastAPI, but the
+ACP package proper depends only on the stdlib). The names are resolved lazily
+inside :func:`serve_acp_websocket`.
+
+Scope
+=====
+This is the **server** side only -- mac being *driven* by a remote ACP client
+over WS. The WS *client* transport (mac dialing OUT to a remote ACP agent over
+WebSocket) is explicitly deferred: it needs a websocket-client dependency, which
+this phase does not add. See ADR 0006.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+
+from .peer import Peer
+from .server import ACPAgentServer, PromptBackend, PromptBackendFn
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from starlette.websockets import WebSocket
+
+
+__all__ = ["serve_acp_websocket"]
+
+
+def _load_websocket_types() -> Any:
+    """Resolve ``WebSocketDisconnect`` lazily so importing this module is cheap.
+
+    Keeping the Starlette import out of module scope means ``import mac.acp.ws``
+    never fails if Starlette is unavailable; the cost is paid only when a socket
+    is actually served. Returns the ``WebSocketDisconnect`` exception class.
+    """
+
+    from starlette.websockets import WebSocketDisconnect
+
+    return WebSocketDisconnect
+
+
+async def serve_acp_websocket(
+    websocket: "WebSocket",
+    backend: Union[PromptBackend, PromptBackendFn],
+    *,
+    agent_capabilities: Any = None,
+    agent_info: Optional[Dict[str, Any]] = None,
+    auth_methods: Optional[List[Any]] = None,
+    permission_timeout: Optional[float] = None,
+    drain_timeout: Optional[float] = 5.0,
+    accept_kwargs: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Run an :class:`~mac.acp.server.ACPAgentServer` over a WebSocket until close.
+
+    Bridges the async ``websocket`` to a synchronous
+    :class:`~mac.acp.peer.Peer`/:class:`~mac.acp.server.ACPAgentServer` (see the
+    module docstring for the loop-capture + ``run_coroutine_threadsafe`` design).
+
+    Parameters
+    ----------
+    websocket:
+        An *un-accepted* Starlette/FastAPI ``WebSocket``. This function calls
+        ``accept()`` (pass ``accept_kwargs`` to e.g. negotiate a subprotocol).
+        Callers that must reject the connection should do so (``close``) before
+        calling this; once accepted here, the caller should not also accept.
+    backend:
+        The :class:`~mac.acp.server.PromptBackend` (or bare ``(turn) -> reason``
+        callable) that runs each prompt turn -- unchanged from the stdio path.
+    agent_capabilities, agent_info, auth_methods, permission_timeout:
+        Forwarded verbatim to :class:`~mac.acp.server.ACPAgentServer`.
+    drain_timeout:
+        Seconds to wait for an in-flight turn to finish on disconnect before
+        returning (``None`` waits indefinitely). Mirrors ``serve_stdio``.
+    accept_kwargs:
+        Optional kwargs for ``websocket.accept`` (e.g. ``{"subprotocol": ...}``).
+    """
+
+    websocket_disconnect = _load_websocket_types()
+
+    # Capture the loop the socket lives on. The peer's send (called from the
+    # inbound thread *and* from the server's per-turn worker threads) marshals
+    # every outbound frame back onto this loop.
+    loop = asyncio.get_running_loop()
+
+    def _send(data: bytes) -> None:
+        # One JSON-RPC message per WS frame: the peer hands us a single
+        # newline-terminated frame, which we strip back to one text payload.
+        text = data.decode("utf-8").rstrip("\n")
+        # run_coroutine_threadsafe is the thread-safe bridge: it works from the
+        # worker thread (DEFERRED responses / session/update) and from the loop's
+        # own thread alike. We don't await the returned future -- delivery is
+        # fire-and-forget from the peer's perspective, matching stdio's flush.
+        asyncio.run_coroutine_threadsafe(websocket.send_text(text), loop)
+
+    peer = Peer(send=_send)
+    server = ACPAgentServer(
+        peer,
+        backend,
+        agent_capabilities=agent_capabilities,
+        agent_info=agent_info,
+        auth_methods=auth_methods,
+        permission_timeout=permission_timeout,
+    )
+
+    await websocket.accept(**(accept_kwargs or {}))
+    try:
+        while True:
+            text = await websocket.receive_text()
+            # Each frame is one JSON-RPC message; append "\n" so the peer's
+            # existing newline framing parses it, then pump to dispatch. pump()
+            # returns immediately even for session/prompt (the server defers the
+            # turn to a worker thread), so the receive loop stays responsive to
+            # the client's permission decision / session/cancel mid-turn.
+            peer.feed(text.encode("utf-8") + b"\n")
+            peer.pump()
+    except websocket_disconnect:
+        # Clean client-initiated close (or transport drop): fall through to drain.
+        pass
+    finally:
+        # Let any in-flight turn finish writing its response before we unwind, so
+        # a worker thread isn't left scheduling sends onto a dead socket. Run the
+        # blocking wait off the event loop so we don't stall it.
+        try:
+            await loop.run_in_executor(None, server.wait_idle, drain_timeout)
+        except Exception:  # noqa: BLE001 - draining is best-effort on teardown
+            pass

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 
-from fastapi import BackgroundTasks, Depends, FastAPI, Query, Request
+from fastapi import BackgroundTasks, Depends, FastAPI, Query, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field, model_validator
@@ -1297,6 +1297,64 @@ def _authorize_request(
     if not principal.has_scope(required):
         raise AuthorizationError("token lacks required scope: %s" % required)
     return principal
+
+
+def _authorize_acp_websocket(
+    websocket: "WebSocket", auth_tokens: Mapping[str, TokenPrincipal]
+) -> "tuple[Optional[TokenPrincipal], Optional[str]]":
+    """Resolve the principal for an ACP WebSocket handshake.
+
+    The HTTP auth middleware only runs for ``http`` scope, so the ``/acp/ws``
+    route authenticates here instead. Returns ``(principal, accepted_subprotocol)``:
+
+    * ``principal`` is ``None`` when no token is supplied or it does not match a
+      registered token (or lacks the required ``agent`` scope). The caller
+      rejects the socket *only when tokens are configured* -- when no tokens are
+      set (dev mode), ``_authorize_request`` also returns ``None`` and the
+      request is treated as admin, so we keep WS consistent with that.
+    * ``accepted_subprotocol`` is ``"Authorization"`` when the token arrived via
+      the ``Authorization`` subprotocol (the server must echo the chosen
+      subprotocol back on accept), else ``None``.
+
+    ACP runtime work requires the ``agent`` scope (same as ``/v1`` inference and
+    the ``/agentbus`` / ``/action-events`` agent channels in
+    :func:`_required_scope`).
+    """
+
+    required = "agent"
+    token = ""
+    accepted_subprotocol: Optional[str] = None
+
+    # 1) ?token= query param.
+    raw_token = websocket.query_params.get("token") if hasattr(websocket, "query_params") else None
+    if raw_token:
+        token = str(raw_token).strip()
+
+    # 2) Authorization WebSocket subprotocol: clients offer
+    #    ["Authorization", "<bearer>"] (browsers can't set headers on a WS
+    #    handshake). Accept either a bare token as the second value or a
+    #    "Bearer <token>" form.
+    if not token:
+        offered = []
+        header = websocket.headers.get("sec-websocket-protocol") if hasattr(websocket, "headers") else None
+        if header:
+            offered = [p.strip() for p in header.split(",") if p.strip()]
+        if offered and offered[0] == "Authorization" and len(offered) > 1:
+            candidate = offered[1].strip()
+            if candidate.lower().startswith("bearer "):
+                candidate = candidate[len("bearer "):].strip()
+            token = candidate
+            accepted_subprotocol = "Authorization"
+
+    if not token:
+        return None, accepted_subprotocol
+
+    principal = _resolve_principal(token, auth_tokens)
+    if principal is None:
+        return None, accepted_subprotocol
+    if not principal.has_scope(required):
+        return None, accepted_subprotocol
+    return principal, accepted_subprotocol
 
 
 def _should_record_http_observation(path: str) -> bool:
@@ -2976,6 +3034,44 @@ def create_app(
         from mac.acp.capabilities import acp_manifest
 
         return acp_manifest()
+
+    @app.websocket("/acp/ws")
+    async def acp_websocket(websocket: WebSocket) -> None:
+        # ADR 0006 Phase 2 remote transport: an external ACP client drives a mac
+        # agent over WebSocket, reusing the same ACPAgentServer/Peer the stdio
+        # path uses. The HTTP auth middleware does not run for websocket scope,
+        # so we validate the bearer token here, before accepting the socket.
+        #
+        # Token sources (first match wins):
+        #   * ``?token=<bearer>`` query param, or
+        #   * an ``Authorization`` WebSocket subprotocol: clients offer
+        #     ``["Authorization", "<bearer>"]`` (the bearer rides as the second
+        #     subprotocol value, since browsers can't set Authorization headers
+        #     on a WS handshake). We echo ``Authorization`` back as the accepted
+        #     subprotocol.
+        principal, accepted_subprotocol = _authorize_acp_websocket(websocket, tokens)
+        if principal is None and tokens:
+            # tokens configured but no valid principal -> reject (1008 policy).
+            await websocket.close(code=1008)
+            return
+
+        # Backend selection mirrors serve_stdio: the production MacAgentBackend
+        # when an agent command is configured, else the harmless EchoBackend.
+        from mac.acp.server import EchoBackend
+
+        if os.environ.get("MAC_ACP_BACKEND_CMD"):
+            from mac.acp.backend import MacAgentBackend
+
+            backend: Any = MacAgentBackend()
+        else:
+            backend = EchoBackend()
+
+        from mac.acp.ws import serve_acp_websocket
+
+        accept_kwargs = (
+            {"subprotocol": accepted_subprotocol} if accepted_subprotocol else None
+        )
+        await serve_acp_websocket(websocket, backend, accept_kwargs=accept_kwargs)
 
     @app.get("/startup/hermes")
     def hermes_startup() -> Dict[str, Any]:

--- a/tests/test_acp_ws.py
+++ b/tests/test_acp_ws.py
@@ -1,0 +1,271 @@
+"""WebSocket (remote) ACP transport tests for the agent/server role (ADR 0006).
+
+These drive the full ACP server over a real Starlette ``WebSocket``, using
+Starlette/FastAPI's *synchronous* ``TestClient`` WebSocket support
+(``client.websocket_connect(...)``), which runs the ASGI app in-process over an
+in-memory transport -- no real socket, no ``wsproto``, no new third-party
+dependency, and no ``pytest-asyncio``.
+
+Each WS frame carries one JSON-RPC message (``ws.send_json`` / ``ws.receive_json``).
+The server's prompt turn runs on a worker thread and emits its ``session/update``
+notifications and final response from there via ``run_coroutine_threadsafe``, so
+these tests also exercise the async-WS <-> sync-Peer bridge end to end.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import WebSocket
+from fastapi.testclient import TestClient
+
+from mac.acp.protocol import (
+    PROTOCOL_VERSION,
+    Method,
+    SessionUpdateKind,
+    StopReason,
+    text_block,
+)
+from mac.acp.server import PromptTurn
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+_TOKEN = "tok-acp-ws"
+
+
+class StreamingBackend:
+    """A fake :class:`~mac.acp.server.PromptBackend`.
+
+    During a turn it streams an ``agent_message_chunk`` and a ``tool_call``
+    ``session/update`` back to the client, then ends the turn -- mirroring the
+    shape of a real prompt turn while staying subprocess-free. The chunks are
+    emitted from the server's per-turn worker thread, so they exercise the
+    ``run_coroutine_threadsafe`` outbound bridge.
+    """
+
+    def __init__(self) -> None:
+        self.turns: List[PromptTurn] = []
+
+    def run_prompt(self, turn: PromptTurn) -> str:
+        self.turns.append(turn)
+        turn.agent_message_chunk("working on it")
+        turn.tool_call("call_1", "run shell", kind="execute", status="pending")
+        return StopReason.END_TURN
+
+
+def _app_with_backend(backend: Any, *, tokens: Dict[str, Any] | None = None):
+    """Build a mac API app whose ``/acp/ws`` route serves ``backend``.
+
+    The public route picks EchoBackend/MacAgentBackend itself; for the test we
+    want a scripted backend, so we override the route to call
+    ``serve_acp_websocket`` with our backend (reusing the app's auth helper).
+    """
+
+    from mac.acp.ws import serve_acp_websocket
+    from mac.api import _authorize_acp_websocket
+
+    cp = ControlPlane.in_memory()
+    auth_tokens = {_TOKEN: ["agent"]} if tokens is None else tokens
+    app = create_app(control_plane=cp, auth_tokens=auth_tokens)
+    resolved_tokens = app.state.auth_tokens
+
+    @app.websocket("/acp/ws-test")
+    async def _acp_ws_test(websocket: WebSocket) -> None:
+        principal, subproto = _authorize_acp_websocket(websocket, resolved_tokens)
+        if principal is None and resolved_tokens:
+            await websocket.close(code=1008)
+            return
+        accept_kwargs = {"subprotocol": subproto} if subproto else None
+        await serve_acp_websocket(websocket, backend, accept_kwargs=accept_kwargs)
+
+    return app
+
+
+def test_full_session_over_websocket():
+    backend = StreamingBackend()
+    app = _app_with_backend(backend)
+    client = TestClient(app)
+
+    with client.websocket_connect("/acp/ws-test?token=%s" % _TOKEN) as ws:
+        # --- initialize: the agent negotiates the protocol version ---
+        ws.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": Method.INITIALIZE,
+                "params": {"protocolVersion": PROTOCOL_VERSION},
+            }
+        )
+        init = ws.receive_json()
+        assert init["id"] == 1
+        assert init["result"]["protocolVersion"] == PROTOCOL_VERSION
+        assert "agentCapabilities" in init["result"]
+
+        # --- session/new: the agent allocates and returns a session id ---
+        ws.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": Method.SESSION_NEW,
+                "params": {"cwd": "/tmp/work", "mcpServers": []},
+            }
+        )
+        new_session = ws.receive_json()
+        assert new_session["id"] == 2
+        session_id = new_session["result"]["sessionId"]
+        assert session_id
+
+        # --- session/prompt: drives the backend, which streams two updates ---
+        ws.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": Method.SESSION_PROMPT,
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [text_block("do the thing")],
+                },
+            }
+        )
+
+        # The two session/update notifications arrive as their own frames (in
+        # order), emitted from the server's worker thread via the WS bridge.
+        update_1 = ws.receive_json()
+        assert update_1["method"] == Method.SESSION_UPDATE
+        assert update_1["params"]["sessionId"] == session_id
+        assert (
+            update_1["params"]["update"]["sessionUpdate"]
+            == SessionUpdateKind.AGENT_MESSAGE_CHUNK
+        )
+        assert update_1["params"]["update"]["content"] == {
+            "type": "text",
+            "text": "working on it",
+        }
+
+        update_2 = ws.receive_json()
+        assert update_2["method"] == Method.SESSION_UPDATE
+        assert (
+            update_2["params"]["update"]["sessionUpdate"]
+            == SessionUpdateKind.TOOL_CALL
+        )
+        assert update_2["params"]["update"]["toolCallId"] == "call_1"
+
+        # ...followed by the deferred final response carrying the stop reason.
+        prompt_result = ws.receive_json()
+        assert prompt_result["id"] == 3
+        assert prompt_result["result"]["stopReason"] == StopReason.END_TURN
+
+    # The backend ran exactly one turn, carrying the session id, cwd, and prompt.
+    assert len(backend.turns) == 1
+    turn = backend.turns[0]
+    assert turn.session_id == session_id
+    assert turn.cwd == "/tmp/work"
+    assert turn.content == [{"type": "text", "text": "do the thing"}]
+
+
+def test_auth_subprotocol_accepted():
+    """The bearer token may also ride as the second ``Authorization``
+    subprotocol value (the browser-friendly path); the server echoes the chosen
+    subprotocol back on accept."""
+
+    backend = StreamingBackend()
+    app = _app_with_backend(backend)
+    client = TestClient(app)
+
+    with client.websocket_connect(
+        "/acp/ws-test", subprotocols=["Authorization", _TOKEN]
+    ) as ws:
+        assert ws.accepted_subprotocol == "Authorization"
+        ws.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": Method.INITIALIZE,
+                "params": {"protocolVersion": PROTOCOL_VERSION},
+            }
+        )
+        init = ws.receive_json()
+        assert init["result"]["protocolVersion"] == PROTOCOL_VERSION
+
+
+def test_missing_token_rejected():
+    """No token, with tokens configured -> the socket is closed (policy 1008)."""
+
+    import pytest
+    from starlette.websockets import WebSocketDisconnect
+
+    backend = StreamingBackend()
+    app = _app_with_backend(backend)
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/acp/ws-test") as ws:
+            ws.receive_json()
+    assert exc.value.code == 1008
+
+
+def test_bad_token_rejected():
+    """A token that matches no registered principal -> the socket is closed."""
+
+    import pytest
+    from starlette.websockets import WebSocketDisconnect
+
+    backend = StreamingBackend()
+    app = _app_with_backend(backend)
+    client = TestClient(app)
+
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/acp/ws-test?token=not-a-real-token") as ws:
+            ws.receive_json()
+    assert exc.value.code == 1008
+
+
+def test_default_route_uses_echo_backend():
+    """The real ``/acp/ws`` route (no MAC_ACP_BACKEND_CMD) serves EchoBackend:
+    a full session echoes the prompt text back and ends the turn."""
+
+    cp = ControlPlane.in_memory()
+    app = create_app(control_plane=cp, auth_tokens={_TOKEN: ["agent"]})
+    client = TestClient(app)
+
+    with client.websocket_connect("/acp/ws?token=%s" % _TOKEN) as ws:
+        ws.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": Method.INITIALIZE,
+                "params": {"protocolVersion": PROTOCOL_VERSION},
+            }
+        )
+        assert ws.receive_json()["result"]["protocolVersion"] == PROTOCOL_VERSION
+
+        ws.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": Method.SESSION_NEW,
+                "params": {"cwd": "/tmp", "mcpServers": []},
+            }
+        )
+        session_id = ws.receive_json()["result"]["sessionId"]
+
+        ws.send_json(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": Method.SESSION_PROMPT,
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [text_block("hello")],
+                },
+            }
+        )
+        # EchoBackend streams one agent_message_chunk ("echo: hello") then ends.
+        update = ws.receive_json()
+        assert update["method"] == Method.SESSION_UPDATE
+        assert update["params"]["update"]["content"]["text"] == "echo: hello"
+
+        result = ws.receive_json()
+        assert result["id"] == 3
+        assert result["result"]["stopReason"] == StopReason.END_TURN


### PR DESCRIPTION
Completes ACP Phase 2 ("stdio first, WS for remote"): a WebSocket server transport so a **remote** ACP client can drive a mac agent, reusing the existing `Peer` + `ACPAgentServer` (no new deps — FastAPI/Starlette WS).

- **`src/mac/acp/ws.py`** — `serve_acp_websocket(ws, backend, …)` bridges the async WS to the sync `Peer`: captures the running loop; `peer.send` → `run_coroutine_threadsafe(ws.send_text(...), loop)` so the server's DEFERRED worker-thread emissions reach the socket safely; inbound `receive_text` → `peer.feed(text+"\n"); peer.pump()` (one JSON-RPC message per frame). `WebSocketDisconnect` drains in-flight turns (`wait_idle`). Starlette imported lazily so `import mac.acp.ws` never hard-fails without it.
- **`api.py`** — additive `@app.websocket("/acp/ws")`; authenticates *before* accept (WS scope skips the HTTP auth middleware): bearer via `?token=` or the `Authorization` WS subprotocol, validated with the same `_resolve_principal` + **agent** scope as `/v1`/`/agentbus`; bad/missing token → close 1008. Backend = `MacAgentBackend` when `MAC_ACP_BACKEND_CMD` set, else `EchoBackend`.
- **Tests** — Starlette `TestClient.websocket_connect` (sync, no new dep): full `initialize → session/new → session/prompt` over WS incl. streamed `session/update`s + stopReason, plus auth rejection. 12 passed incl. route coverage.

**Deferred**: the WS *client* transport (mac dialing OUT to a remote ACP agent) — needs a ws-client dep, intentionally not added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)