### PR TITLE
feat(a2a): inbound A2A agent-to-agent federation (Phase 4)

### DIFF
--- a/src/mac/a2a/__init__.py
+++ b/src/mac/a2a/__init__.py
@@ -1,0 +1,32 @@
+"""Inbound A2A (Agent2Agent) federation for mac (ACP roadmap Phase 4).
+
+A2A (https://a2a-protocol.org, Linux Foundation; absorbed IBM's "Agent
+Communication Protocol") is the open JSON-RPC 2.0 standard for **agent <->
+agent** delegation. This package lets an *external* A2A agent discover mac via
+its AgentCard and delegate work to it; the work lands on mac's existing task
+ledger (no parallel store).
+
+This is the agent<->agent axis -- distinct from :mod:`mac.acp`, which is the
+host<->agent runtime seam. Layers:
+
+* :mod:`mac.a2a.card` -- the AgentCard discovery document (pure data).
+* :mod:`mac.a2a.protocol` -- JSON-RPC 2.0 envelope + A2A wire types
+  (Message / Part / Task / TaskState); pure.
+* :mod:`mac.a2a.service` -- :class:`~mac.a2a.service.A2AService`, mapping the
+  A2A RPCs (``message/send`` / ``tasks/get`` / ``tasks/cancel``) onto the mac
+  control plane.
+
+The HTTP wiring (``GET /.well-known/agent-card.json`` + ``POST /a2a``) lives in
+:mod:`mac.api`.
+
+Deferred (out of scope this phase): ``message/stream`` SSE streaming, push
+notifications, and the *outbound* A2A client (mac delegating to other agents).
+"""
+
+from __future__ import annotations
+
+from .card import agent_card
+from .protocol import Message, Task, TaskState
+from .service import A2AService
+
+__all__ = ["agent_card", "A2AService", "Message", "Task", "TaskState"]

--- a/src/mac/a2a/card.py
+++ b/src/mac/a2a/card.py
@@ -1,0 +1,135 @@
+"""mac's A2A AgentCard builder (inbound A2A federation, ACP roadmap Phase 4).
+
+The AgentCard is the A2A "business card": a small JSON document served at the
+well-known discovery path that lets an *external* A2A client discover this
+agent's identity, service endpoint, capabilities, and skills. See the A2A
+specification (https://a2a-protocol.org, Linux Foundation; absorbed IBM's
+Agent Communication Protocol) -- this module pins mac's card shape.
+
+Spec notes pinned by this implementation (verified against
+``a2a-protocol.org`` / the agent-discovery topic on 2026-06-17):
+
+* The canonical well-known path is ``/.well-known/agent-card.json`` (A2A
+  v0.3+). Earlier drafts used ``/.well-known/agent.json``; api.py serves both
+  (the latter as a legacy alias) so older clients still resolve.
+* Property names are ``camelCase`` (``defaultInputModes`` etc.).
+* In the JSON-RPC binding, a text :class:`~mac.a2a.protocol.Part` is
+  ``{"kind": "text", "text": ...}`` and ``TaskState`` values are the
+  lowercase-hyphenated strings (``submitted`` / ``working`` /
+  ``input-required`` / ...). This module only emits identity/capability data;
+  the wire types live in :mod:`mac.a2a.protocol`.
+
+This module performs **no I/O** -- it is pure data. ``base_url`` is the only
+input, supplied by the HTTP layer from the inbound request so the advertised
+``url`` matches however the caller reached mac.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+__all__ = [
+    "A2A_PROTOCOL_VERSION",
+    "MAC_VERSION",
+    "A2A_ENDPOINT_PATH",
+    "WELL_KNOWN_CARD_PATH",
+    "WELL_KNOWN_CARD_PATH_LEGACY",
+    "DEFAULT_INPUT_MODES",
+    "DEFAULT_OUTPUT_MODES",
+    "mac_skills",
+    "agent_card",
+]
+
+
+#: The A2A protocol version mac's card declares. A2A versions its spec with a
+#: ``MAJOR.MINOR.PATCH`` string (unlike ACP's single integer), so this is a str.
+A2A_PROTOCOL_VERSION: str = "0.3.0"
+
+#: mac's own software version (mirrors ``pyproject.toml`` / the FastAPI app
+#: version in :func:`mac.api.create_app`). Surfaced as the card's ``version``.
+MAC_VERSION: str = "0.1.0"
+
+#: The path, relative to the card's ``base_url``, where mac serves the A2A
+#: JSON-RPC endpoint (see ``POST /a2a`` in api.py).
+A2A_ENDPOINT_PATH: str = "/a2a"
+
+#: Canonical A2A discovery path (v0.3+).
+WELL_KNOWN_CARD_PATH: str = "/.well-known/agent-card.json"
+
+#: Legacy discovery path (pre-v0.3 drafts). Served as an alias for old clients.
+WELL_KNOWN_CARD_PATH_LEGACY: str = "/.well-known/agent.json"
+
+#: Content the agent accepts / produces by default. mac's task ledger is
+#: text-driven in this phase (title + description), so plain text only.
+DEFAULT_INPUT_MODES: List[str] = ["text/plain"]
+DEFAULT_OUTPUT_MODES: List[str] = ["text/plain"]
+
+
+def mac_skills() -> List[Dict[str, Any]]:
+    """The :class:`AgentSkill` list mac advertises.
+
+    A mac agent is a general software-task executor backed by the fleet task
+    ledger: an A2A peer delegates a unit of work (a message describing a task)
+    and mac runs it through the same create -> dispatch -> review -> complete
+    lifecycle as any locally-filed task. We advertise a single broad skill for
+    that surface in this phase; per-capability skills can be derived from the
+    fleet's role/capability catalog in a later phase.
+
+    AgentSkill fields per the A2A spec: ``id``, ``name``, ``description``,
+    ``tags``, ``examples``, plus optional ``inputModes`` / ``outputModes``
+    (omitted here so the card's defaults apply).
+    """
+
+    return [
+        {
+            "id": "software-task",
+            "name": "General agent task",
+            "description": (
+                "Delegate a software / general agent task to the mac fleet. "
+                "The message text becomes a task in mac's ledger, which is "
+                "dispatched to a capable agent, executed, reviewed, and "
+                "driven to a terminal state."
+            ),
+            "tags": ["software", "agent", "task", "mac", "fleet"],
+            "examples": [
+                "Fix the failing test in module X and open a PR.",
+                "Investigate why the nightly job is timing out.",
+                "Summarize the open issues in the repo.",
+            ],
+        }
+    ]
+
+
+def agent_card(base_url: str) -> Dict[str, Any]:
+    """Build mac's A2A AgentCard as a plain dict.
+
+    ``base_url`` is the externally-visible origin the caller used to reach mac
+    (scheme + host[:port], no trailing slash required). The advertised A2A
+    service ``url`` is ``base_url`` + :data:`A2A_ENDPOINT_PATH` so a client that
+    fetched the card can immediately address the JSON-RPC endpoint.
+
+    Capabilities are conservative for Phase 4 (inbound, polling-based):
+    ``streaming`` (``message/stream`` SSE) and ``pushNotifications`` are both
+    advertised as ``false`` -- they are explicitly deferred. A client therefore
+    drives long-running work by polling ``tasks/get``.
+    """
+
+    base = base_url.rstrip("/")
+    return {
+        "protocolVersion": A2A_PROTOCOL_VERSION,
+        "name": "mac",
+        "description": (
+            "MAC multi-agent control plane. Accepts delegated tasks over A2A "
+            "and runs them on its fleet via the shared task ledger."
+        ),
+        "url": base + A2A_ENDPOINT_PATH,
+        "version": MAC_VERSION,
+        "capabilities": {
+            "streaming": False,
+            "pushNotifications": False,
+        },
+        "defaultInputModes": list(DEFAULT_INPUT_MODES),
+        "defaultOutputModes": list(DEFAULT_OUTPUT_MODES),
+        "skills": mac_skills(),
+    }

--- a/src/mac/a2a/protocol.py
+++ b/src/mac/a2a/protocol.py
@@ -1,0 +1,322 @@
+"""Pure data types and (de)serialization for inbound A2A (Agent2Agent).
+
+A2A (https://a2a-protocol.org, Linux Foundation; absorbed IBM's "Agent
+Communication Protocol") is the open JSON-RPC 2.0 standard for **agent <->
+agent** delegation. This module is the wire layer for mac's inbound A2A
+server: it defines the JSON-RPC 2.0 envelope, the A2A method-name constants,
+the ``TaskState`` constants, and the structured ``Message`` / ``Part`` /
+``Task`` payload types. It performs **no I/O** -- everything here is pure data
+plus ``to_dict`` / ``from_dict`` (de)serialization, so it can be exercised
+without a transport.
+
+This is the agent<->agent axis and is distinct from :mod:`mac.acp.protocol`,
+which is the host<->agent runtime seam. Both speak JSON-RPC 2.0, so the
+envelope mirrors ACP's, but the method names and payload shapes are A2A's.
+
+Spec notes pinned by this implementation (verified against
+``a2a-protocol.org`` on 2026-06-17):
+
+* JSON-RPC method names are slash-namespaced: ``message/send``,
+  ``message/stream`` (deferred), ``tasks/get``, ``tasks/cancel``.
+* A ``Part`` in the JSON binding is discriminated by a ``kind`` field; a text
+  part is ``{"kind": "text", "text": ...}``. (The gRPC/protobuf binding uses a
+  ``OneOf`` instead -- not used here.)
+* ``TaskState`` JSON values are lowercase, hyphenated: ``submitted`` /
+  ``working`` / ``input-required`` / ``completed`` / ``canceled`` (one ``l``,
+  US spelling) / ``failed`` / ``rejected`` / ``auth-required``.
+* ``Task.status`` is a ``TaskStatus`` object: ``{"state", "timestamp",
+  "message"?}``.
+* ``Message`` carries ``role`` ("user" / "agent"), ``parts``, and
+  ``messageId``; ``contextId`` / ``taskId`` are optional.
+
+Property names are ``camelCase`` to match the wire.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Union
+
+
+__all__ = [
+    "JSONRPC_VERSION",
+    "Method",
+    "PartKind",
+    "Role",
+    "TaskState",
+    "ERROR_PARSE",
+    "ERROR_INVALID_REQUEST",
+    "ERROR_METHOD_NOT_FOUND",
+    "ERROR_INVALID_PARAMS",
+    "ERROR_INTERNAL",
+    "ERROR_TASK_NOT_FOUND",
+    "JSONRPCError",
+    "json_dumps",
+    "new_message_id",
+    "text_part",
+    "text_from_parts",
+    "Message",
+    "TaskStatus",
+    "Task",
+    "rpc_result",
+    "rpc_error",
+]
+
+
+#: JSON-RPC envelope version. Constant for the protocol.
+JSONRPC_VERSION: str = "2.0"
+
+
+class Method:
+    """Canonical A2A JSON-RPC method names (slash-namespaced per the spec)."""
+
+    MESSAGE_SEND = "message/send"
+    MESSAGE_STREAM = "message/stream"  # deferred (SSE) -- declared, not served
+    TASKS_GET = "tasks/get"
+    TASKS_CANCEL = "tasks/cancel"
+
+
+class PartKind:
+    """Discriminator values for the ``kind`` field of a message ``Part``."""
+
+    TEXT = "text"
+    FILE = "file"
+    DATA = "data"
+
+
+class Role:
+    """A2A message roles. The remote peer is the ``user``; mac is the ``agent``."""
+
+    USER = "user"
+    AGENT = "agent"
+
+
+class TaskState:
+    """A2A ``TaskState`` JSON values (lowercase, hyphenated per the spec)."""
+
+    SUBMITTED = "submitted"
+    WORKING = "working"
+    INPUT_REQUIRED = "input-required"
+    COMPLETED = "completed"
+    CANCELED = "canceled"  # US spelling, single 'l', per the A2A spec
+    FAILED = "failed"
+    REJECTED = "rejected"
+    AUTH_REQUIRED = "auth-required"
+
+
+# Standard JSON-RPC 2.0 error codes plus an A2A-specific task-not-found code.
+ERROR_PARSE = -32700
+ERROR_INVALID_REQUEST = -32600
+ERROR_METHOD_NOT_FOUND = -32601
+ERROR_INVALID_PARAMS = -32602
+ERROR_INTERNAL = -32603
+#: A2A reserves -32001 for "task not found" (TaskNotFoundError).
+ERROR_TASK_NOT_FOUND = -32001
+
+
+def json_dumps(value: Any) -> str:
+    """Deterministic, compact JSON encoding.
+
+    Mirrors :func:`mac.models.json_dumps` and :func:`mac.acp.protocol.json_dumps`
+    (sorted keys, no whitespace) so A2A frames are byte-stable for tests and
+    logging.
+    """
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def new_message_id() -> str:
+    """A fresh ``messageId`` for an agent-authored A2A message."""
+
+    return "msg-" + uuid.uuid4().hex
+
+
+def text_part(text: str) -> Dict[str, Any]:
+    """Build a text ``Part`` -- ``{"kind": "text", "text": ...}``."""
+
+    return {"kind": PartKind.TEXT, "text": text}
+
+
+def text_from_parts(parts: Any) -> str:
+    """Concatenate the text of all text-kind parts in ``parts``.
+
+    Tolerant of the two part encodings seen in the wild: the JSON-RPC binding's
+    ``{"kind": "text", "text": ...}`` and the looser ``{"type": "text", ...}``
+    some clients still emit. Non-text parts are skipped. Returns ``""`` when no
+    text is present (the caller decides whether that is an error).
+    """
+
+    if not isinstance(parts, (list, tuple)):
+        return ""
+    chunks: List[str] = []
+    for part in parts:
+        if not isinstance(part, Mapping):
+            continue
+        kind = part.get("kind") or part.get("type")
+        if kind not in (None, PartKind.TEXT):
+            continue
+        text = part.get("text")
+        if isinstance(text, str) and text:
+            chunks.append(text)
+    return "\n".join(chunks)
+
+
+@dataclass
+class JSONRPCError:
+    """The ``error`` object of a JSON-RPC 2.0 failure response."""
+
+    code: int
+    message: str
+    data: Any = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.data is not None:
+            out["data"] = self.data
+        return out
+
+
+@dataclass
+class Message:
+    """An A2A ``Message`` -- a turn from a peer (``user``) or mac (``agent``).
+
+    ``parts`` are raw dicts (each a text/file/data part); :func:`text_part`
+    builds the common text case and :func:`text_from_parts` extracts it.
+    """
+
+    role: str
+    parts: List[Dict[str, Any]] = field(default_factory=list)
+    message_id: str = field(default_factory=new_message_id)
+    context_id: Optional[str] = None
+    task_id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+    def text(self) -> str:
+        return text_from_parts(self.parts)
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "role": self.role,
+            "parts": list(self.parts),
+            "messageId": self.message_id,
+            "kind": "message",
+        }
+        if self.context_id is not None:
+            out["contextId"] = self.context_id
+        if self.task_id is not None:
+            out["taskId"] = self.task_id
+        if self.metadata is not None:
+            out["metadata"] = self.metadata
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Mapping[str, Any]]) -> "Message":
+        raw = raw or {}
+        parts = raw.get("parts")
+        meta = raw.get("metadata")
+        return cls(
+            role=str(raw.get("role", Role.USER)),
+            parts=[dict(p) for p in parts if isinstance(p, Mapping)]
+            if isinstance(parts, (list, tuple))
+            else [],
+            message_id=str(raw.get("messageId") or new_message_id()),
+            context_id=raw.get("contextId"),
+            task_id=raw.get("taskId"),
+            metadata=dict(meta) if isinstance(meta, Mapping) else None,
+        )
+
+
+@dataclass
+class TaskStatus:
+    """An A2A ``TaskStatus`` -- the current lifecycle ``state`` + ``timestamp``.
+
+    ``message`` is an optional agent ``Message`` providing context for the
+    state (e.g. why it is ``input-required``); omitted from the wire when unset.
+    """
+
+    state: str
+    timestamp: Optional[str] = None
+    message: Optional[Message] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {"state": self.state}
+        if self.timestamp is not None:
+            out["timestamp"] = self.timestamp
+        if self.message is not None:
+            out["message"] = self.message.to_dict()
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "TaskStatus":
+        msg = raw.get("message")
+        return cls(
+            state=str(raw["state"]),
+            timestamp=raw.get("timestamp"),
+            message=Message.from_dict(msg) if isinstance(msg, Mapping) else None,
+        )
+
+
+@dataclass
+class Task:
+    """An A2A ``Task`` -- the unit of delegated work tracked across turns.
+
+    ``id`` is the task's stable identifier (mac binds it to the ledger task id);
+    ``contextId`` groups related tasks for one logical interaction. ``history``
+    is the ordered list of messages exchanged about the task.
+    """
+
+    id: str
+    context_id: str
+    status: TaskStatus
+    history: List[Message] = field(default_factory=list)
+    metadata: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "id": self.id,
+            "contextId": self.context_id,
+            "status": self.status.to_dict(),
+            "history": [m.to_dict() for m in self.history],
+            "kind": "task",
+        }
+        if self.metadata is not None:
+            out["metadata"] = self.metadata
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> "Task":
+        history = raw.get("history")
+        meta = raw.get("metadata")
+        return cls(
+            id=str(raw["id"]),
+            context_id=str(raw.get("contextId", "")),
+            status=TaskStatus.from_dict(raw.get("status") or {"state": TaskState.SUBMITTED}),
+            history=[Message.from_dict(m) for m in history if isinstance(m, Mapping)]
+            if isinstance(history, (list, tuple))
+            else [],
+            metadata=dict(meta) if isinstance(meta, Mapping) else None,
+        )
+
+
+# JSON-RPC id may be a string, number, or null per the spec.
+RpcId = Union[str, int, None]
+
+
+def rpc_result(rpc_id: RpcId, result: Any) -> Dict[str, Any]:
+    """Build a JSON-RPC 2.0 success response envelope."""
+
+    return {"jsonrpc": JSONRPC_VERSION, "id": rpc_id, "result": result}
+
+
+def rpc_error(
+    rpc_id: RpcId, code: int, message: str, data: Any = None
+) -> Dict[str, Any]:
+    """Build a JSON-RPC 2.0 error response envelope."""
+
+    return {
+        "jsonrpc": JSONRPC_VERSION,
+        "id": rpc_id,
+        "error": JSONRPCError(code=code, message=message, data=data).to_dict(),
+    }

--- a/src/mac/a2a/service.py
+++ b/src/mac/a2a/service.py
@@ -1,0 +1,293 @@
+"""Inbound A2A service: maps A2A JSON-RPC methods onto mac's task ledger.
+
+This is the agent<->agent server (ACP roadmap Phase 4). An *external* A2A
+client discovers mac via its AgentCard (:mod:`mac.a2a.card`) and delegates work
+by calling A2A JSON-RPC methods at ``POST /a2a``. Each method maps onto mac's
+existing task ledger via :class:`~mac.services.ControlPlane` -- there is **no
+parallel task store**:
+
+* ``message/send`` -- the message text becomes a new mac task (title +
+  description); we return an A2A :class:`~mac.a2a.protocol.Task` in the
+  ``submitted`` state whose ``id`` is the mac task id.
+* ``tasks/get`` -- look up the mac task and project its state onto the A2A
+  ``TaskState`` enum.
+* ``tasks/cancel`` -- transition the mac task to ``cancelled`` and return the
+  updated A2A Task.
+
+:meth:`A2AService.handle_rpc` is the dispatcher: it returns a JSON-RPC 2.0
+result/error envelope (a plain dict). It performs no transport I/O; the HTTP
+layer in ``api.py`` reads the request body and writes the returned dict.
+
+Deferred (out of scope this phase): ``message/stream`` (SSE streaming),
+``tasks/resubscribe``, push notifications, and the *outbound* A2A client (mac
+delegating to other agents).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional
+
+from mac.models import MACError, NotFoundError, TransitionError, utcnow
+from mac.models import TaskState as MacTaskState
+from mac.services import ControlPlane
+
+from .protocol import (
+    ERROR_INTERNAL,
+    ERROR_INVALID_PARAMS,
+    ERROR_METHOD_NOT_FOUND,
+    ERROR_TASK_NOT_FOUND,
+    Message,
+    Method,
+    Role,
+    Task,
+    TaskState,
+    TaskStatus,
+    new_message_id,
+    rpc_error,
+    rpc_result,
+    text_part,
+)
+
+
+__all__ = ["A2AService", "MAC_STATE_TO_A2A", "map_task_state"]
+
+
+#: Projection of mac's ledger ``TaskState`` onto the A2A ``TaskState`` enum.
+#:
+#: mac's lifecycle is richer than A2A's, so several mac states collapse onto one
+#: A2A state:
+#:   open / (no deps yet)      -> submitted   (accepted, not yet being worked)
+#:   blocked                   -> submitted   (accepted, waiting on deps)
+#:   claimed / running         -> working     (an agent is actively on it)
+#:   needs_review / reviewing  -> working     (still in flight from the peer's view)
+#:   completed                 -> completed
+#:   failed                    -> failed
+#:   cancelled                 -> canceled    (A2A uses the single-'l' spelling)
+#:
+#: A mac state of ``blocked`` that represents "waiting for the caller" would map
+#: to ``input-required``; mac's ``blocked`` today means dependency-blocked, so
+#: it maps to ``submitted``. ``input-required`` is reserved for a future
+#: needs-input signal carried in task metadata (see :func:`map_task_state`).
+MAC_STATE_TO_A2A: Dict[str, str] = {
+    MacTaskState.OPEN.value: TaskState.SUBMITTED,
+    MacTaskState.BLOCKED.value: TaskState.SUBMITTED,
+    MacTaskState.CLAIMED.value: TaskState.WORKING,
+    MacTaskState.RUNNING.value: TaskState.WORKING,
+    MacTaskState.NEEDS_REVIEW.value: TaskState.WORKING,
+    MacTaskState.REVIEWING.value: TaskState.WORKING,
+    MacTaskState.COMPLETED.value: TaskState.COMPLETED,
+    MacTaskState.FAILED.value: TaskState.FAILED,
+    MacTaskState.CANCELLED.value: TaskState.CANCELED,
+}
+
+
+def map_task_state(task: Any) -> str:
+    """Project a mac :class:`~mac.models.Task` onto an A2A ``TaskState`` value.
+
+    Honors an explicit ``metadata.a2a.needs_input`` flag: a task an agent has
+    parked pending caller input surfaces as ``input-required`` regardless of its
+    ledger state, so an A2A peer knows to send another ``message/send``. Unknown
+    ledger states fall back to ``submitted`` (accepted but not classified).
+    """
+
+    metadata = getattr(task, "metadata", None) or {}
+    a2a_meta = metadata.get("a2a") if isinstance(metadata, Mapping) else None
+    if isinstance(a2a_meta, Mapping) and a2a_meta.get("needs_input"):
+        state = getattr(task, "state", "")
+        if state not in {
+            MacTaskState.COMPLETED.value,
+            MacTaskState.FAILED.value,
+            MacTaskState.CANCELLED.value,
+        }:
+            return TaskState.INPUT_REQUIRED
+    return MAC_STATE_TO_A2A.get(getattr(task, "state", ""), TaskState.SUBMITTED)
+
+
+class A2AService:
+    """Maps A2A JSON-RPC methods onto a :class:`~mac.services.ControlPlane`.
+
+    Stateless beyond the injected control plane; safe to construct per request.
+    """
+
+    #: A2A "context" for tasks created over this transport. A2A allows a server
+    #: to assign a ``contextId`` grouping related tasks; mac uses one stable
+    #: federation context unless the caller supplies its own ``contextId``.
+    DEFAULT_CONTEXT_ID = "a2a"
+
+    #: Actor recorded in the mac ledger for A2A-originated tasks.
+    ACTOR = "a2a"
+
+    #: Cap on how much history we surface back to a peer per ``tasks/get``.
+    HISTORY_LIMIT = 50
+
+    def __init__(self, control_plane: ControlPlane) -> None:
+        self.cp = control_plane
+
+    # -- dispatcher ---------------------------------------------------------
+
+    def handle_rpc(
+        self, method: str, params: Optional[Mapping[str, Any]], rpc_id: Any = None
+    ) -> Dict[str, Any]:
+        """Dispatch one A2A JSON-RPC call, returning a result/error envelope.
+
+        Translates mac control-plane exceptions into JSON-RPC errors:
+        :class:`~mac.models.NotFoundError` -> task-not-found (-32001); other
+        :class:`~mac.models.MACError` (validation / transition) -> invalid
+        params (-32602); anything else -> internal error (-32603).
+        """
+
+        params = dict(params or {})
+        try:
+            if method == Method.MESSAGE_SEND:
+                return rpc_result(rpc_id, self.message_send(params))
+            if method == Method.TASKS_GET:
+                return rpc_result(rpc_id, self.tasks_get(params))
+            if method == Method.TASKS_CANCEL:
+                return rpc_result(rpc_id, self.tasks_cancel(params))
+            if method == Method.MESSAGE_STREAM:
+                # Declared in the card as unsupported (capabilities.streaming =
+                # false); a peer that ignores that and calls it gets a clear
+                # method-not-found rather than a silent hang.
+                return rpc_error(
+                    rpc_id,
+                    ERROR_METHOD_NOT_FOUND,
+                    "streaming is not supported by this agent (message/stream deferred)",
+                )
+            return rpc_error(
+                rpc_id, ERROR_METHOD_NOT_FOUND, "method not found: %s" % method
+            )
+        except NotFoundError as exc:
+            return rpc_error(rpc_id, ERROR_TASK_NOT_FOUND, str(exc))
+        except MACError as exc:
+            return rpc_error(rpc_id, ERROR_INVALID_PARAMS, str(exc))
+        except Exception as exc:  # noqa: BLE001 - never leak a stack to the peer
+            return rpc_error(rpc_id, ERROR_INTERNAL, "internal error: %s" % exc)
+
+    # -- methods ------------------------------------------------------------
+
+    def message_send(self, params: Mapping[str, Any]) -> Dict[str, Any]:
+        """``message/send``: create a mac task from the message, return a Task.
+
+        The message's text parts form the task: the first non-empty line is the
+        title, the full text is the description. We record the inbound message
+        in ``metadata.a2a`` so ``tasks/get`` can replay it as history. The
+        returned A2A Task has ``id`` == the mac task id and state ``submitted``.
+        """
+
+        message = Message.from_dict(params.get("message"))
+        text = message.text().strip()
+        if not text:
+            raise _InvalidParams("message/send requires at least one non-empty text part")
+
+        context_id = (
+            message.context_id
+            or str(params.get("contextId") or "").strip()
+            or self.DEFAULT_CONTEXT_ID
+        )
+        title = text.splitlines()[0].strip()[:200] or "A2A delegated task"
+
+        task = self.cp.create_task(
+            title=title,
+            description=text,
+            actor=self.ACTOR,
+            metadata={
+                "a2a": {
+                    "context_id": context_id,
+                    "incoming_message_id": message.message_id,
+                    "history": [message.to_dict()],
+                }
+            },
+        )
+        return self._task_to_a2a(task, context_id=context_id).to_dict()
+
+    def tasks_get(self, params: Mapping[str, Any]) -> Dict[str, Any]:
+        """``tasks/get``: look up the mac task and return its A2A Task view."""
+
+        task_id = self._require_task_id(params)
+        task = self.cp.get_task(task_id)
+        return self._task_to_a2a(task).to_dict()
+
+    def tasks_cancel(self, params: Mapping[str, Any]) -> Dict[str, Any]:
+        """``tasks/cancel``: cancel the mac task, return the updated Task.
+
+        Mac refuses to cancel an already-terminal task (the ledger has no
+        completed/failed -> cancelled edge). Per A2A, that surfaces as an
+        invalid-params error rather than silently lying about the state.
+        """
+
+        task_id = self._require_task_id(params)
+        # Surfaces NotFoundError for an unknown id before we attempt the
+        # transition (handle_rpc maps it to task-not-found).
+        self.cp.get_task(task_id)
+        try:
+            task = self.cp.transition_task(
+                task_id,
+                MacTaskState.CANCELLED.value,
+                actor=self.ACTOR,
+                detail={"source": "a2a.tasks/cancel"},
+            )
+        except TransitionError as exc:
+            # e.g. completed/failed tasks are not cancelable.
+            raise _InvalidParams(str(exc)) from exc
+        return self._task_to_a2a(task).to_dict()
+
+    # -- helpers ------------------------------------------------------------
+
+    def _task_to_a2a(self, task: Any, context_id: Optional[str] = None) -> Task:
+        """Build an A2A :class:`Task` from a mac ledger task."""
+
+        metadata = getattr(task, "metadata", None) or {}
+        a2a_meta = metadata.get("a2a") if isinstance(metadata, Mapping) else None
+        if context_id is None:
+            context_id = (
+                a2a_meta.get("context_id")
+                if isinstance(a2a_meta, Mapping)
+                else None
+            ) or self.DEFAULT_CONTEXT_ID
+
+        history = self._history_from_metadata(a2a_meta)
+        status = TaskStatus(
+            state=map_task_state(task),
+            timestamp=getattr(task, "updated_at", None) or utcnow(),
+        )
+        return Task(
+            id=getattr(task, "id"),
+            context_id=context_id,
+            status=status,
+            history=history,
+        )
+
+    def _history_from_metadata(self, a2a_meta: Any) -> List[Message]:
+        if not isinstance(a2a_meta, Mapping):
+            return []
+        raw = a2a_meta.get("history")
+        if not isinstance(raw, (list, tuple)):
+            return []
+        return [Message.from_dict(m) for m in raw[: self.HISTORY_LIMIT] if isinstance(m, Mapping)]
+
+    @staticmethod
+    def _require_task_id(params: Mapping[str, Any]) -> str:
+        task_id = params.get("id") or params.get("taskId")
+        task_id = str(task_id or "").strip()
+        if not task_id:
+            raise _InvalidParams("params.id (the task id) is required")
+        return task_id
+
+    @staticmethod
+    def agent_message(text: str, *, context_id: Optional[str] = None) -> Message:
+        """Build an agent-authored A2A message (used for status messages)."""
+
+        return Message(
+            role=Role.AGENT,
+            parts=[text_part(text)],
+            message_id=new_message_id(),
+            context_id=context_id,
+        )
+
+
+class _InvalidParams(MACError):
+    """Internal: a bad-params condition that maps to JSON-RPC -32602.
+
+    A subclass of :class:`~mac.models.MACError` so ``handle_rpc`` catches it on
+    the generic-MACError path (-> invalid params) without a dedicated branch.
+    """

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1228,6 +1228,17 @@ def _required_scope(method: str, path: str) -> Optional[str]:
         # ACP discovery manifest (ADR 0006, Phase 3): a public well-known doc,
         # like /health. No secrets; just mac's capability advertisement.
         return None
+    if path in ("/.well-known/agent-card.json", "/.well-known/agent.json"):
+        # A2A AgentCard discovery (Phase 4, agent<->agent axis): an
+        # unauthenticated well-known doc, like /.well-known/acp. Identity +
+        # capabilities + skills only; no secrets. The canonical path is
+        # agent-card.json (A2A v0.3+); agent.json is the legacy alias.
+        return None
+    if path == "/a2a":
+        # A2A JSON-RPC endpoint (Phase 4): inbound delegation is an agent
+        # action, so it requires the agent scope (admin inherits it), the same
+        # bar as /v1 inference and the /acp/ws runtime seam.
+        return "agent"
     if path == "/ui" or path.startswith("/ui/"):
         return None
     if path == "/v1" or path.startswith("/v1/"):
@@ -3034,6 +3045,61 @@ def create_app(
         from mac.acp.capabilities import acp_manifest
 
         return acp_manifest()
+
+    def _a2a_base_url(request: Request) -> str:
+        # The externally-visible origin the caller used to reach mac, so the
+        # AgentCard advertises a ``url`` a client can actually address. Honor a
+        # reverse-proxy's forwarded host/proto when present (the hub may sit
+        # behind one); fall back to the request's own base URL.
+        forwarded_host = request.headers.get("x-forwarded-host")
+        forwarded_proto = request.headers.get("x-forwarded-proto")
+        if forwarded_host:
+            scheme = (forwarded_proto or request.url.scheme or "https").split(",")[0].strip()
+            host = forwarded_host.split(",")[0].strip()
+            return "%s://%s" % (scheme, host)
+        return str(request.base_url).rstrip("/")
+
+    @app.get("/.well-known/agent-card.json")
+    @app.get("/.well-known/agent.json")
+    def a2a_agent_card_route(request: Request) -> Dict[str, Any]:
+        # A2A AgentCard discovery (Phase 4): the unauthenticated "business card"
+        # an external A2A agent fetches to learn mac's identity, A2A endpoint,
+        # capabilities, and skills. Pure data; the canonical path is
+        # agent-card.json (A2A v0.3+), agent.json is a legacy alias. No
+        # control-plane access.
+        from mac.a2a.card import agent_card
+
+        return agent_card(_a2a_base_url(request))
+
+    @app.post("/a2a")
+    async def a2a_rpc_route(request: Request) -> JSONResponse:
+        # A2A JSON-RPC 2.0 endpoint (Phase 4): an external agent delegates work
+        # here (message/send -> mac task; tasks/get; tasks/cancel). Requires the
+        # agent scope (see _required_scope). Builds the A2AService from the
+        # app's control plane, mirroring how other routes use ``cp``.
+        from mac.a2a.protocol import (
+            ERROR_INVALID_REQUEST,
+            ERROR_PARSE,
+            rpc_error,
+        )
+        from mac.a2a.service import A2AService
+
+        try:
+            payload = await request.json()
+        except Exception:  # noqa: BLE001 - malformed body is a JSON-RPC parse error
+            return JSONResponse(content=rpc_error(None, ERROR_PARSE, "invalid JSON body"))
+        if not isinstance(payload, dict) or payload.get("jsonrpc") != "2.0" or "method" not in payload:
+            rpc_id = payload.get("id") if isinstance(payload, dict) else None
+            return JSONResponse(
+                content=rpc_error(
+                    rpc_id, ERROR_INVALID_REQUEST, "not a valid JSON-RPC 2.0 request"
+                )
+            )
+        service = A2AService(cp)
+        result = service.handle_rpc(
+            str(payload.get("method")), payload.get("params"), payload.get("id")
+        )
+        return JSONResponse(content=result)
 
     @app.websocket("/acp/ws")
     async def acp_websocket(websocket: WebSocket) -> None:

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -1044,6 +1044,18 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
             "repository_url": "https://github.com/example/route-coverage.git",
             "required_capabilities": ["python"],
         },
+        ("POST", "/a2a"): {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "message/send",
+            "params": {
+                "message": {
+                    "role": "user",
+                    "messageId": "msg-route-coverage",
+                    "parts": [{"kind": "text", "text": "route coverage a2a task"}],
+                }
+            },
+        },
         ("POST", "/tasks/{task_id}/children"): {
             "children": [{"title": "child route task", "required_capabilities": ["python"]}]
         },

--- a/tests/test_a2a.py
+++ b/tests/test_a2a.py
@@ -1,0 +1,288 @@
+"""Tests for inbound A2A (Agent2Agent) federation (ACP roadmap Phase 4).
+
+Exercises the A2A package against an in-memory control plane via the FastAPI
+TestClient (no pytest-asyncio), mirroring tests/api/test_api.py. Covers the
+AgentCard discovery document, the JSON-RPC surface (message/send -> a real
+ledger task, tasks/get state reflection, tasks/cancel), and JSON-RPC error
+handling for unknown methods.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from mac.a2a import agent_card
+from mac.a2a.protocol import Method, TaskState
+from mac.a2a.service import A2AService, map_task_state
+from mac.api import create_app
+from mac.models import TaskState as MacTaskState
+from mac.services import ControlPlane
+
+
+# -- AgentCard (pure data) --------------------------------------------------
+
+
+def test_agent_card_shape():
+    card = agent_card("https://hub.example.test")
+
+    assert card["name"] == "mac"
+    assert card["description"]
+    assert card["url"] == "https://hub.example.test/a2a"
+    assert card["version"] == "0.1.0"
+    # Phase 4 is inbound + polling only: streaming and push are off.
+    assert card["capabilities"] == {"streaming": False, "pushNotifications": False}
+    assert card["defaultInputModes"] == ["text/plain"]
+    assert card["defaultOutputModes"] == ["text/plain"]
+    assert isinstance(card["skills"], list) and card["skills"], "at least one skill"
+    skill = card["skills"][0]
+    assert skill["id"] == "software-task"
+    assert skill["name"] and skill["description"]
+
+
+def test_agent_card_strips_trailing_slash():
+    assert agent_card("https://hub.example.test/")["url"] == "https://hub.example.test/a2a"
+
+
+# -- well-known discovery endpoint ------------------------------------------
+
+
+def test_well_known_agent_card_is_public(monkeypatch):
+    # Unauthenticated even when the hub is token-protected (like /.well-known/acp).
+    monkeypatch.setenv("MAC_API_TOKEN", "secret-token")
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+
+    resp = client.get("/.well-known/agent-card.json")  # no Authorization header
+    assert resp.status_code == 200, resp.text
+    card = resp.json()
+    assert card["name"] == "mac"
+    assert card["url"].endswith("/a2a")
+    assert card["capabilities"]["streaming"] is False
+    assert card["skills"][0]["id"] == "software-task"
+
+
+def test_well_known_legacy_agent_json_alias_is_public(monkeypatch):
+    monkeypatch.setenv("MAC_API_TOKEN", "secret-token")
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+
+    resp = client.get("/.well-known/agent.json")  # legacy path, no auth
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "mac"
+
+
+def test_a2a_card_url_reflects_request_host():
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+    resp = client.get("/.well-known/agent-card.json")
+    assert resp.status_code == 200
+    # TestClient default base is http://testserver.
+    assert resp.json()["url"] == "http://testserver/a2a"
+
+
+# -- message/send binds to the ledger ---------------------------------------
+
+
+def test_message_send_creates_real_ledger_task():
+    cp = ControlPlane.in_memory()
+    client = TestClient(create_app(control_plane=cp))
+
+    resp = client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": "req-1",
+            "method": Method.MESSAGE_SEND,
+            "params": {
+                "message": {
+                    "role": "user",
+                    "messageId": "msg-abc",
+                    "parts": [
+                        {"kind": "text", "text": "Fix the flaky test\nin module X"}
+                    ],
+                }
+            },
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == "req-1"
+    task = body["result"]
+
+    # Submitted state, and id is a *real* task in the ledger.
+    assert task["status"]["state"] == TaskState.SUBMITTED
+    assert task["contextId"] == "a2a"
+    assert task["kind"] == "task"
+    ledger_task = cp.get_task(task["id"])
+    assert ledger_task.state == MacTaskState.OPEN.value
+    # First line becomes the title; full text the description.
+    assert ledger_task.title == "Fix the flaky test"
+    assert ledger_task.description == "Fix the flaky test\nin module X"
+    # The inbound message is replayed as history.
+    assert task["history"][0]["messageId"] == "msg-abc"
+
+
+def test_message_send_empty_text_is_invalid_params():
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+    resp = client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": Method.MESSAGE_SEND,
+            "params": {"message": {"role": "user", "parts": []}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32602
+
+
+# -- tasks/get reflects ledger state ----------------------------------------
+
+
+def test_tasks_get_reflects_state():
+    cp = ControlPlane.in_memory()
+    client = TestClient(create_app(control_plane=cp))
+
+    send = client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": Method.MESSAGE_SEND,
+            "params": {
+                "message": {
+                    "role": "user",
+                    "parts": [{"kind": "text", "text": "work item"}],
+                }
+            },
+        },
+    ).json()
+    task_id = send["result"]["id"]
+
+    def get_state() -> str:
+        resp = client.post(
+            "/a2a",
+            json={"jsonrpc": "2.0", "id": 9, "method": Method.TASKS_GET, "params": {"id": task_id}},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["result"]["status"]["state"]
+
+    assert get_state() == TaskState.SUBMITTED
+
+    # Drive the ledger task into a "working" state and confirm the projection.
+    cp.transition_task(task_id, MacTaskState.CLAIMED.value, actor="tester")
+    assert get_state() == TaskState.WORKING
+
+
+def test_tasks_get_unknown_task_is_task_not_found():
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+    resp = client.post(
+        "/a2a",
+        json={"jsonrpc": "2.0", "id": 1, "method": Method.TASKS_GET, "params": {"id": "task_missing"}},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["error"]["code"] == -32001
+
+
+# -- tasks/cancel -----------------------------------------------------------
+
+
+def test_tasks_cancel_cancels_the_ledger_task():
+    cp = ControlPlane.in_memory()
+    client = TestClient(create_app(control_plane=cp))
+
+    send = client.post(
+        "/a2a",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": Method.MESSAGE_SEND,
+            "params": {
+                "message": {"role": "user", "parts": [{"kind": "text", "text": "cancel me"}]}
+            },
+        },
+    ).json()
+    task_id = send["result"]["id"]
+
+    resp = client.post(
+        "/a2a",
+        json={"jsonrpc": "2.0", "id": 2, "method": Method.TASKS_CANCEL, "params": {"id": task_id}},
+    )
+    assert resp.status_code == 200, resp.text
+    task = resp.json()["result"]
+    assert task["status"]["state"] == TaskState.CANCELED
+    assert cp.get_task(task_id).state == MacTaskState.CANCELLED.value
+
+
+# -- JSON-RPC dispatch errors -----------------------------------------------
+
+
+def test_unknown_method_is_method_not_found():
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+    resp = client.post(
+        "/a2a",
+        json={"jsonrpc": "2.0", "id": 7, "method": "tasks/teleport", "params": {}},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == 7
+    assert body["error"]["code"] == -32601
+
+
+def test_message_stream_is_method_not_found_until_implemented():
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+    resp = client.post(
+        "/a2a",
+        json={"jsonrpc": "2.0", "id": 1, "method": Method.MESSAGE_STREAM, "params": {}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["error"]["code"] == -32601
+
+
+def test_non_jsonrpc_body_is_invalid_request():
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+    resp = client.post("/a2a", json={"hello": "world"})
+    assert resp.status_code == 200
+    assert resp.json()["error"]["code"] == -32600
+
+
+# -- state mapping table (unit) ---------------------------------------------
+
+
+def test_state_mapping_covers_all_mac_states():
+    cp = ControlPlane.in_memory()
+
+    class _T:
+        def __init__(self, state, metadata=None):
+            self.state = state
+            self.metadata = metadata or {}
+
+    expected = {
+        MacTaskState.OPEN.value: TaskState.SUBMITTED,
+        MacTaskState.BLOCKED.value: TaskState.SUBMITTED,
+        MacTaskState.CLAIMED.value: TaskState.WORKING,
+        MacTaskState.RUNNING.value: TaskState.WORKING,
+        MacTaskState.NEEDS_REVIEW.value: TaskState.WORKING,
+        MacTaskState.REVIEWING.value: TaskState.WORKING,
+        MacTaskState.COMPLETED.value: TaskState.COMPLETED,
+        MacTaskState.FAILED.value: TaskState.FAILED,
+        MacTaskState.CANCELLED.value: TaskState.CANCELED,
+    }
+    for mac_state, a2a_state in expected.items():
+        assert map_task_state(_T(mac_state)) == a2a_state
+
+    # needs_input metadata overrides a non-terminal state to input-required.
+    assert (
+        map_task_state(_T(MacTaskState.RUNNING.value, {"a2a": {"needs_input": True}}))
+        == TaskState.INPUT_REQUIRED
+    )
+    # ... but not a terminal state.
+    assert (
+        map_task_state(_T(MacTaskState.COMPLETED.value, {"a2a": {"needs_input": True}}))
+        == TaskState.COMPLETED
+    )
+    # A2AService is constructible from the control plane.
+    assert A2AService(cp).cp is cp


### PR DESCRIPTION
Phase 4 of the ACP roadmap — the **agent↔agent** axis (distinct from ACP's host↔agent runtime seam): external agents can discover and delegate work to a mac agent via A2A (Agent2Agent, Linux Foundation; absorbed IBM's "Agent Communication Protocol"). Bound to the **real mac task ledger** — no parallel store.

- **AgentCard** — `GET /.well-known/agent-card.json` (canonical A2A v0.3 path; `/.well-known/agent.json` kept as a legacy alias), unauthenticated discovery: name/description/url/version/capabilities/skills.
- **`POST /a2a`** (JSON-RPC 2.0, agent scope): `message/send` extracts the message text → `ControlPlane.create_task` (the returned A2A `Task.id` **is** the mac task id); `tasks/get` maps mac state → A2A `TaskState` (open→submitted, claimed/running→working, completed→completed, cancelled→canceled, …); `tasks/cancel` → `transition_task(cancelled)`. Control-plane errors map to JSON-RPC error codes.
- New self-contained `src/mac/a2a/` package (`card`/`protocol`/`service`); api.py additive only.
- **Spec-verified** (a2a-protocol.org): canonical well-known path, `canceled` (single-l) wire spelling, JSON-RPC method names + `TaskState` values. 15 A2A tests + 57 api (no regression).

**Deferred**: `message/stream` SSE, push notifications, per-capability skills, and the **outbound** A2A client (mac delegating to *other* agents) — all noted in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)