### PR TITLE
feat(a2a): outbound A2A client (mac delegates to external agents)

### DIFF
--- a/src/mac/a2a/__init__.py
+++ b/src/mac/a2a/__init__.py
@@ -14,19 +14,31 @@ host<->agent runtime seam. Layers:
   (Message / Part / Task / TaskState); pure.
 * :mod:`mac.a2a.service` -- :class:`~mac.a2a.service.A2AService`, mapping the
   A2A RPCs (``message/send`` / ``tasks/get`` / ``tasks/cancel``) onto the mac
-  control plane.
+  control plane (inbound).
+* :mod:`mac.a2a.client` -- :class:`~mac.a2a.client.A2AClient`, the reciprocal
+  *outbound* client: discover a remote A2A agent and delegate work to it.
 
 The HTTP wiring (``GET /.well-known/agent-card.json`` + ``POST /a2a``) lives in
 :mod:`mac.api`.
 
-Deferred (out of scope this phase): ``message/stream`` SSE streaming, push
-notifications, and the *outbound* A2A client (mac delegating to other agents).
+Deferred (out of scope this phase): ``message/stream`` SSE streaming and push
+notifications. Both the inbound service and the outbound client poll
+``tasks/get`` for long-running work.
 """
 
 from __future__ import annotations
 
 from .card import agent_card
+from .client import A2AClient, A2AClientError
 from .protocol import Message, Task, TaskState
 from .service import A2AService
 
-__all__ = ["agent_card", "A2AService", "Message", "Task", "TaskState"]
+__all__ = [
+    "agent_card",
+    "A2AService",
+    "A2AClient",
+    "A2AClientError",
+    "Message",
+    "Task",
+    "TaskState",
+]

--- a/src/mac/a2a/client.py
+++ b/src/mac/a2a/client.py
@@ -1,0 +1,280 @@
+"""Outbound A2A client: delegate work to *external* A2A agents.
+
+This is the client side of the same JSON-RPC 2.0 protocol mac serves inbound
+(:mod:`mac.a2a.service`). Where the service maps incoming A2A RPCs onto mac's
+task ledger, this module lets a mac agent **discover** a remote A2A agent via
+its AgentCard and **delegate** work to it: send a message, then poll / cancel
+the resulting :class:`~mac.a2a.protocol.Task`.
+
+A2A (https://a2a-protocol.org, Linux Foundation; absorbed IBM's "Agent
+Communication Protocol") is the open agent<->agent standard. The wire types
+(JSON-RPC envelope, ``Message`` / ``Part`` / ``Task`` / ``TaskState``, the
+method-name constants) live in :mod:`mac.a2a.protocol` and are **reused** here
+verbatim -- this module adds only the transport and request-building.
+
+Transport is an injectable seam (:class:`A2AClient`'s ``transport`` arg) so the
+client can be exercised in-process against the real inbound server with no
+socket. The default :class:`_UrllibTransport` is a thin stdlib ``urllib``
+implementation: it POSTs JSON-RPC frames to ``{base_url}/a2a`` and GETs the
+AgentCard, adding ``Authorization: Bearer {token}`` when a token is set.
+
+Spec notes pinned by this implementation (matching the inbound side):
+
+* JSON-RPC method names are slash-namespaced (``message/send`` / ``tasks/get``
+  / ``tasks/cancel``); the wire is JSON-RPC 2.0.
+* ``message/send`` params carry a single ``message`` object (role ``user``,
+  one text ``Part``) plus a fresh ``messageId``; the result is a ``Task``.
+* The canonical discovery path is ``/.well-known/agent-card.json`` (A2A v0.3+),
+  with ``/.well-known/agent.json`` as the pre-v0.3 legacy fallback.
+
+Deferred (out of scope, mirroring the inbound side): ``message/stream`` SSE
+consumption, ``tasks/resubscribe``, and push notifications. A caller drives
+long-running delegated work by polling :meth:`A2AClient.get_task`.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Mapping, Optional, Protocol
+
+from .card import WELL_KNOWN_CARD_PATH, WELL_KNOWN_CARD_PATH_LEGACY
+from .protocol import (
+    JSONRPC_VERSION,
+    Message,
+    Method,
+    Role,
+    Task,
+    json_dumps,
+    new_message_id,
+    text_part,
+)
+
+
+__all__ = ["A2AClient", "A2AClientError", "Transport"]
+
+
+class A2AClientError(Exception):
+    """A JSON-RPC error returned by a remote A2A agent.
+
+    Carries the JSON-RPC ``code`` and ``message`` (and optional ``data``) so a
+    caller can branch on, e.g., task-not-found (-32001) vs invalid-params
+    (-32602) without re-parsing the envelope.
+    """
+
+    def __init__(self, code: int, message: str, data: Any = None) -> None:
+        super().__init__("A2A error %s: %s" % (code, message))
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+class Transport(Protocol):
+    """The transport seam :class:`A2AClient` drives.
+
+    An implementation does plain request/response over whatever wire it likes;
+    the client supplies fully-formed JSON-RPC bodies and parses the returned
+    dicts. The default is :class:`_UrllibTransport`; tests inject an in-process
+    fake that routes straight to the inbound server.
+    """
+
+    def post(self, path: str, json_body: Mapping[str, Any]) -> Dict[str, Any]:
+        """POST ``json_body`` to ``path`` (relative to the base URL); return the
+        decoded JSON response object."""
+
+    def get(self, path: str) -> Dict[str, Any]:
+        """GET ``path`` (relative to the base URL); return the decoded JSON."""
+
+
+class _NotFound(Exception):
+    """Raised by a transport's ``get`` for an HTTP 404, so the client can apply
+    the legacy-discovery-path fallback. Transports that cannot distinguish 404
+    simply never raise this."""
+
+
+class _UrllibTransport:
+    """Default stdlib ``urllib`` transport (no third-party deps).
+
+    POSTs JSON-RPC frames to ``{base_url}{path}`` and GETs JSON documents,
+    decoding the response body as JSON. Adds ``Authorization: Bearer {token}``
+    when a token is configured. A 404 on ``get`` is surfaced as :class:`_NotFound`
+    so :meth:`A2AClient.fetch_agent_card` can fall back to the legacy path.
+    """
+
+    def __init__(self, base_url: str, *, token: Optional[str] = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+
+    def _headers(self, *, content_type: bool) -> Dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if content_type:
+            headers["Content-Type"] = "application/json"
+        if self.token:
+            headers["Authorization"] = "Bearer %s" % self.token
+        return headers
+
+    def post(self, path: str, json_body: Mapping[str, Any]) -> Dict[str, Any]:
+        data = json_dumps(json_body).encode("utf-8")
+        req = urllib.request.Request(
+            self.base_url + path,
+            data=data,
+            headers=self._headers(content_type=True),
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310 - explicit URL
+            return _decode_json(resp.read())
+
+    def get(self, path: str) -> Dict[str, Any]:
+        req = urllib.request.Request(
+            self.base_url + path,
+            headers=self._headers(content_type=False),
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:  # noqa: S310 - explicit URL
+                return _decode_json(resp.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                raise _NotFound(path) from exc
+            raise
+
+
+def _decode_json(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8")
+    value = json.loads(raw) if isinstance(raw, str) else raw
+    if not isinstance(value, dict):
+        raise A2AClientError(-32603, "expected a JSON object response, got %r" % type(value).__name__)
+    return value
+
+
+class A2AClient:
+    """Outbound A2A client for delegating work to a remote A2A agent.
+
+    ``base_url`` is the remote agent's origin (scheme + host[:port]); the
+    JSON-RPC endpoint is ``{base_url}/a2a`` (per its AgentCard). ``token``, when
+    set, is sent as a bearer credential by the default transport. ``transport``
+    overrides the default :class:`_UrllibTransport` -- inject a fake to route
+    in-process for tests.
+
+    The client is stateless beyond its transport; methods reuse
+    :mod:`mac.a2a.protocol` types for (de)serialization.
+    """
+
+    #: The remote A2A JSON-RPC endpoint, relative to ``base_url``. Mirrors the
+    #: inbound ``A2A_ENDPOINT_PATH``; a peer's card may advertise the same.
+    RPC_PATH = "/a2a"
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        token: Optional[str] = None,
+        transport: Optional[Transport] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.transport: Transport = transport or _UrllibTransport(
+            self.base_url, token=token
+        )
+        # Monotonic per-client JSON-RPC request id (string form for stability).
+        self._next_id = 0
+
+    # -- discovery ----------------------------------------------------------
+
+    def fetch_agent_card(self) -> Dict[str, Any]:
+        """GET the remote agent's AgentCard discovery document.
+
+        Tries the canonical ``/.well-known/agent-card.json`` (A2A v0.3+); on a
+        404 it falls back to the pre-v0.3 ``/.well-known/agent.json`` alias so
+        older agents still resolve. Returns the card as a plain dict.
+        """
+
+        try:
+            return self.transport.get(WELL_KNOWN_CARD_PATH)
+        except _NotFound:
+            return self.transport.get(WELL_KNOWN_CARD_PATH_LEGACY)
+
+    # -- delegation ---------------------------------------------------------
+
+    def send_message(
+        self,
+        text: str,
+        *,
+        context_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+    ) -> Task:
+        """``message/send``: delegate ``text`` as a new unit of work.
+
+        Builds a ``user``-role :class:`~mac.a2a.protocol.Message` with a single
+        text ``Part`` (generating a ``messageId`` when not supplied), POSTs the
+        ``message/send`` request, and parses the result into a
+        :class:`~mac.a2a.protocol.Task`.
+        """
+
+        message = Message(
+            role=Role.USER,
+            parts=[text_part(text)],
+            message_id=message_id or new_message_id(),
+            context_id=context_id,
+        )
+        params: Dict[str, Any] = {"message": message.to_dict()}
+        if context_id is not None:
+            params["contextId"] = context_id
+        return self._rpc_task(Method.MESSAGE_SEND, params)
+
+    def get_task(self, task_id: str) -> Task:
+        """``tasks/get``: fetch the current state of a delegated task."""
+
+        return self._rpc_task(Method.TASKS_GET, {"id": task_id})
+
+    def cancel_task(self, task_id: str) -> Task:
+        """``tasks/cancel``: request cancellation of a delegated task."""
+
+        return self._rpc_task(Method.TASKS_CANCEL, {"id": task_id})
+
+    # -- internals ----------------------------------------------------------
+
+    def _rpc_task(self, method: str, params: Mapping[str, Any]) -> Task:
+        """Make a JSON-RPC call whose ``result`` is an A2A Task; parse it."""
+
+        result = self._call(method, params)
+        if not isinstance(result, Mapping):
+            raise A2AClientError(
+                -32603, "expected a Task object in result, got %r" % type(result).__name__
+            )
+        return Task.from_dict(result)
+
+    def _call(self, method: str, params: Mapping[str, Any]) -> Any:
+        """POST one JSON-RPC request and return its ``result`` (or raise).
+
+        Raises :class:`A2AClientError` carrying the JSON-RPC ``code`` /
+        ``message`` when the response is an error envelope.
+        """
+
+        request = {
+            "jsonrpc": JSONRPC_VERSION,
+            "id": self._make_id(),
+            "method": method,
+            "params": dict(params),
+        }
+        response = self.transport.post(self.RPC_PATH, request)
+        if not isinstance(response, Mapping):
+            raise A2AClientError(
+                -32603, "expected a JSON-RPC response object, got %r" % type(response).__name__
+            )
+        error = response.get("error")
+        if error is not None:
+            if isinstance(error, Mapping):
+                raise A2AClientError(
+                    int(error.get("code", -32603)),
+                    str(error.get("message", "unknown error")),
+                    error.get("data"),
+                )
+            raise A2AClientError(-32603, "malformed JSON-RPC error: %r" % (error,))
+        return response.get("result")
+
+    def _make_id(self) -> str:
+        self._next_id += 1
+        return "a2a-out-%d" % self._next_id

--- a/tests/test_a2a_client.py
+++ b/tests/test_a2a_client.py
@@ -1,0 +1,222 @@
+"""Tests for the outbound A2A (Agent2Agent) client.
+
+Drives :class:`mac.a2a.client.A2AClient` against the *real* inbound server
+in-process via an injected transport -- no socket. The fake transport's
+``post("/a2a", body)`` forwards straight to :meth:`A2AService.handle_rpc`
+(which already returns a JSON-RPC result/error envelope), and its ``get(path)``
+returns the AgentCard, so the full client round-trip exercises the same code an
+external peer would hit over HTTP. A single stdlib-mock test confirms the
+default :class:`~mac.a2a.client._UrllibTransport` builds a bearer-authenticated
+JSON-RPC POST.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Mapping
+
+import pytest
+
+from mac.a2a import A2AClient, A2AClientError
+from mac.a2a.card import agent_card
+from mac.a2a.client import _NotFound, _UrllibTransport
+from mac.a2a.protocol import TaskState
+from mac.a2a.service import A2AService
+from mac.models import TaskState as MacTaskState
+from mac.services import ControlPlane
+
+
+# -- in-process transport wired to the real inbound service -----------------
+
+
+class _InProcessTransport:
+    """Routes client calls to a real :class:`A2AService` with no I/O.
+
+    ``post`` unwraps the JSON-RPC request and calls ``handle_rpc`` (returning
+    the envelope verbatim). ``get`` serves the AgentCard at the canonical path
+    and, by default, 404s the legacy path so the fallback is testable; flip
+    ``card_path`` to simulate an agent that only serves the legacy alias.
+    """
+
+    def __init__(self, service: A2AService, *, base_url: str, card_path: str | None = None) -> None:
+        self.service = service
+        self.base_url = base_url
+        # When set, only this well-known path returns the card; others 404.
+        self.card_path = card_path
+        self.posted: list[Dict[str, Any]] = []
+
+    def post(self, path: str, json_body: Mapping[str, Any]) -> Dict[str, Any]:
+        assert path == "/a2a", path
+        self.posted.append(dict(json_body))
+        return self.service.handle_rpc(
+            json_body["method"], json_body.get("params"), json_body.get("id")
+        )
+
+    def get(self, path: str) -> Dict[str, Any]:
+        if self.card_path is not None and path != self.card_path:
+            raise _NotFound(path)
+        return agent_card(self.base_url)
+
+
+def _client(card_path: str | None = None):
+    cp = ControlPlane.in_memory()
+    service = A2AService(cp)
+    transport = _InProcessTransport(service, base_url="https://remote.test", card_path=card_path)
+    client = A2AClient("https://remote.test", transport=transport)
+    return client, cp, transport
+
+
+# -- delegation round-trip ---------------------------------------------------
+
+
+def test_send_message_creates_real_ledger_task():
+    client, cp, transport = _client()
+
+    task = client.send_message("do X\nwith details")
+
+    # The returned Task's id is a *real* task in the remote control plane.
+    assert task.status.state == TaskState.SUBMITTED
+    assert task.context_id == "a2a"
+    ledger_task = cp.get_task(task.id)
+    assert ledger_task.state == MacTaskState.OPEN.value
+    assert ledger_task.title == "do X"
+    assert ledger_task.description == "do X\nwith details"
+
+    # The client built a real message/send JSON-RPC request with a text part.
+    sent = transport.posted[-1]
+    assert sent["jsonrpc"] == "2.0"
+    assert sent["method"] == "message/send"
+    part = sent["params"]["message"]["parts"][0]
+    assert part == {"kind": "text", "text": "do X\nwith details"}
+    # A messageId was generated for us.
+    assert sent["params"]["message"]["messageId"]
+
+
+def test_send_message_honours_explicit_ids():
+    client, _cp, transport = _client()
+
+    client.send_message("hi", context_id="ctx-7", message_id="msg-fixed")
+
+    sent = transport.posted[-1]["params"]
+    assert sent["contextId"] == "ctx-7"
+    assert sent["message"]["messageId"] == "msg-fixed"
+    assert sent["message"]["contextId"] == "ctx-7"
+
+
+def test_get_task_reflects_state():
+    client, cp, _transport = _client()
+    task = client.send_message("work item")
+
+    assert client.get_task(task.id).status.state == TaskState.SUBMITTED
+
+    # Drive the remote ledger into a "working" state and confirm the projection.
+    cp.transition_task(task.id, MacTaskState.CLAIMED.value, actor="tester")
+    assert client.get_task(task.id).status.state == TaskState.WORKING
+
+
+def test_cancel_task_cancels_remote_ledger_task():
+    client, cp, _transport = _client()
+    task = client.send_message("cancel me")
+
+    cancelled = client.cancel_task(task.id)
+
+    assert cancelled.status.state == TaskState.CANCELED
+    assert cp.get_task(task.id).state == MacTaskState.CANCELLED.value
+
+
+# -- JSON-RPC errors surface as A2AClientError -------------------------------
+
+
+def test_get_unknown_task_raises_task_not_found():
+    client, _cp, _transport = _client()
+
+    with pytest.raises(A2AClientError) as excinfo:
+        client.get_task("task_missing")
+    assert excinfo.value.code == -32001
+    assert "task_missing" in excinfo.value.message
+
+
+def test_send_empty_message_raises_invalid_params():
+    # An empty/whitespace message has no text part -> service returns -32602.
+    client, _cp, _transport = _client()
+
+    with pytest.raises(A2AClientError) as excinfo:
+        client.send_message("   ")
+    assert excinfo.value.code == -32602
+
+
+# -- agent card discovery + legacy fallback ----------------------------------
+
+
+def test_fetch_agent_card_canonical_path():
+    # Default fake transport serves the card on every well-known path.
+    client, _cp, _transport = _client()
+
+    card = client.fetch_agent_card()
+    assert card["name"] == "mac"
+    assert card["url"] == "https://remote.test/a2a"
+
+
+def test_fetch_agent_card_falls_back_to_legacy_on_404():
+    # Agent only serves the pre-v0.3 /.well-known/agent.json alias.
+    client, _cp, _transport = _client(card_path="/.well-known/agent.json")
+
+    card = client.fetch_agent_card()
+    assert card["name"] == "mac"
+
+
+# -- default urllib transport request building (stdlib-mock) -----------------
+
+
+def test_urllib_transport_posts_jsonrpc_with_bearer(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    class _FakeResp:
+        def __init__(self, payload: bytes) -> None:
+            self._payload = payload
+
+        def read(self) -> bytes:
+            return self._payload
+
+        def __enter__(self) -> "_FakeResp":
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+    def _fake_urlopen(req, *args, **kwargs):  # noqa: ANN001 - urllib.Request
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["data"] = req.data
+        # urllib normalizes header keys to Capitalized form.
+        captured["headers"] = dict(req.header_items())
+        return _FakeResp(b'{"jsonrpc":"2.0","id":"a2a-out-1","result":{"ok":true}}')
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    transport = _UrllibTransport("https://remote.test/", token="sekret")
+    body = {"jsonrpc": "2.0", "id": "a2a-out-1", "method": "tasks/get", "params": {"id": "t1"}}
+    out = transport.post("/a2a", body)
+
+    assert out == {"jsonrpc": "2.0", "id": "a2a-out-1", "result": {"ok": True}}
+    assert captured["url"] == "https://remote.test/a2a"
+    assert captured["method"] == "POST"
+    # Bearer header is present (urllib title-cases header keys).
+    headers = {k.lower(): v for k, v in captured["headers"].items()}
+    assert headers["authorization"] == "Bearer sekret"
+    assert headers["content-type"] == "application/json"
+    # The POST body is the JSON-RPC request we handed in.
+    assert json.loads(captured["data"].decode("utf-8")) == body
+
+
+def test_urllib_transport_get_raises_notfound_on_404(monkeypatch):
+    import urllib.error
+
+    def _fake_urlopen(req, *args, **kwargs):  # noqa: ANN001
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", hdrs=None, fp=None)
+
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen)
+
+    transport = _UrllibTransport("https://remote.test")
+    with pytest.raises(_NotFound):
+        transport.get("/.well-known/agent-card.json")


### PR DESCRIPTION
Reciprocal of the inbound A2A federation (#171): `A2AClient(base_url, token, transport=)` lets a mac agent discover (`fetch_agent_card`, canonical + legacy path) and delegate to external A2A agents — `send_message`/`get_task`/`cancel_task` over JSON-RPC, reusing `a2a/protocol.py` types. stdlib urllib transport with an injectable seam (tests drive a real in-process `A2AService` round-trip). 10 new tests (24 combined). JSON-RPC errors → `A2AClientError`. Deferred: `message/stream` SSE consumption + surfacing the client to mac agents via a route/config.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)