### PR TITLE
feat(acp): outbound ACP WebSocket client (mac drives a remote ACP agent)

### DIFF
--- a/src/mac/acp/__init__.py
+++ b/src/mac/acp/__init__.py
@@ -38,6 +38,7 @@ from .permission import (
     permission_mode,
 )
 from .peer import DEFERRED, Peer, PendingRequest, RemoteError, stdio_peer
+from .ws_client import ACPWebSocketClient, connect_acp_websocket
 from .server import (
     ACPAgentServer,
     EchoBackend,
@@ -119,6 +120,8 @@ __all__ = [
     "PermissionHandler",
     "ACPExecutor",
     "ACPRunResult",
+    "connect_acp_websocket",
+    "ACPWebSocketClient",
     "ACPAgentServer",
     "PromptTurn",
     "PromptBackend",

--- a/src/mac/acp/ws.py
+++ b/src/mac/acp/ws.py
@@ -56,11 +56,17 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 from .peer import Peer
 from .server import ACPAgentServer, PromptBackend, PromptBackendFn
 
+# The outbound (client-side) WS transport lives in :mod:`mac.acp.ws_client`; it
+# is re-exported here so ``mac.acp.ws`` is the single import surface for both
+# directions of the WebSocket transport. Its ``websocket`` import is guarded, so
+# this re-export never hard-fails when ``websocket-client`` is absent.
+from .ws_client import ACPWebSocketClient, connect_acp_websocket
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from starlette.websockets import WebSocket
 
 
-__all__ = ["serve_acp_websocket"]
+__all__ = ["serve_acp_websocket", "connect_acp_websocket", "ACPWebSocketClient"]
 
 
 def _load_websocket_types() -> Any:

--- a/src/mac/acp/ws_client.py
+++ b/src/mac/acp/ws_client.py
@@ -1,0 +1,291 @@
+"""Outbound WebSocket transport for the ACP **host/client** role (ADR 0006).
+
+This is the deferred counterpart to :mod:`mac.acp.ws` (the *server* side, where a
+remote ACP client drives a mac agent over WS). Here mac dials **out** to a remote
+ACP agent over WebSocket and drives it with :class:`~mac.acp.client.ACPClient`.
+
+Where the server side bridges an *async* Starlette ``WebSocket`` to the
+synchronous :class:`~mac.acp.peer.Peer`, the client side has no async at all: it
+uses the **synchronous** ``websocket-client`` library (the ``websocket`` module),
+which fits the peer's existing threaded model exactly the way
+:func:`~mac.acp.peer.stdio_peer` wires a subprocess:
+
+* **Outbound (peer -> socket).** The peer is constructed with a ``send(bytes)``
+  callable that decodes the single newline-terminated frame back to one text
+  payload and calls ``connection.send(text)``. ``websocket-client`` sockets are
+  safe to send on from any thread for our fire-and-forget framing, so the client
+  can issue requests from its own thread while the reader thread feeds responses.
+* **Inbound (socket -> peer).** A background reader thread loops
+  ``connection.recv()`` and feeds each text frame into the peer
+  (``feed(text.encode() + b"\\n")`` then ``pump()``), exactly mirroring
+  :meth:`mac.acp.peer._StdioPeer._read_loop`. Each WS frame carries exactly one
+  JSON-RPC message, so the appended newline lets the peer's existing framing
+  parse it. ``pump()`` returns immediately, so a streamed run (many
+  ``session/update`` notifications followed by the final response) is delivered
+  frame-by-frame while the caller's blocking ``request().result()`` waits.
+
+Authentication mirrors the server in :mod:`mac.api` / :mod:`mac.acp.ws`, which
+accepts a bearer token either as an ``Authorization: Bearer <token>`` header or
+as the ``Authorization`` WebSocket subprotocol (``["Authorization", "<token>"]``,
+the browser-friendly path). :func:`connect_acp_websocket` sends both by default
+when a ``token`` is given, so it works against either acceptance path.
+
+The ``websocket`` import is **guarded**: importing this module never hard-fails if
+``websocket-client`` is absent. The dependency is required only when actually
+dialing a real socket; injecting a ``connection=`` (the test seam) needs nothing.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Dict, List, Optional
+
+from .client import ACPClient
+from .peer import Peer
+from .protocol import ClientCapabilities
+
+
+__all__ = ["connect_acp_websocket", "ACPWebSocketClient", "WSConnection"]
+
+
+def _load_websocket() -> Any:
+    """Resolve the ``websocket`` module lazily so importing this module is cheap.
+
+    Keeping the import out of module scope means ``import mac.acp.ws_client``
+    never fails when ``websocket-client`` is unavailable; the cost (and a clear
+    error if it is missing) is paid only when :func:`connect_acp_websocket` is
+    actually asked to dial a real socket. Returns the ``websocket`` module.
+    """
+
+    try:
+        import websocket  # type: ignore
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch in tests
+        raise RuntimeError(
+            "connect_acp_websocket requires the 'websocket-client' package "
+            "(the 'websocket' module) to dial a real socket; install it or pass "
+            "connection= to inject a transport."
+        ) from exc
+    return websocket
+
+
+class WSConnection:
+    """Minimal duck-typed protocol for the injectable transport.
+
+    Anything with ``send(str)``, ``recv() -> str``, and ``close()`` works -- a
+    real ``websocket-client`` ``WebSocket`` satisfies it, and tests inject a fake
+    backed by in-memory queues. This is documentation-only (the code never
+    isinstance-checks it); it exists so the seam's contract is explicit.
+    """
+
+    def send(self, data: str) -> None:  # pragma: no cover - protocol shape
+        ...
+
+    def recv(self) -> str:  # pragma: no cover - protocol shape
+        ...
+
+    def close(self) -> None:  # pragma: no cover - protocol shape
+        ...
+
+
+class _WebSocketPeer(Peer):
+    """A :class:`Peer` bound to a synchronous WebSocket connection.
+
+    A background reader thread streams inbound text frames into :meth:`feed` and
+    drives :meth:`pump`, so callers interact purely through the :class:`Peer` API
+    (``request`` / ``notify`` + registered handlers) -- the WS analogue of
+    :class:`~mac.acp.peer._StdioPeer`.
+    """
+
+    def __init__(self, connection: Any) -> None:
+        self._conn = connection
+        super().__init__(send=self._send_to_socket)
+        self._stop = threading.Event()
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+
+    def _send_to_socket(self, data: bytes) -> None:
+        # The peer hands us a single newline-terminated frame; one JSON-RPC
+        # message per WS text frame, so strip the trailing newline.
+        if self._stop.is_set():
+            return
+        text = data.decode("utf-8").rstrip("\n")
+        self._conn.send(text)
+
+    def _read_loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                message = self._conn.recv()
+            except Exception:  # noqa: BLE001 - socket closed / dropped -> stop reading
+                break
+            if message is None or message == "":
+                # Empty frame on a closed/closing socket -> treat as EOF.
+                break
+            if isinstance(message, bytes):
+                data = message
+            else:
+                data = message.encode("utf-8")
+            # Each frame is one JSON-RPC message; append "\n" so the peer's
+            # existing newline framing parses it, then pump to dispatch.
+            self.feed(data + b"\n")
+            self.pump()
+
+    def close(self) -> None:
+        """Stop the reader thread and close the underlying connection."""
+
+        self._stop.set()
+        try:
+            self._conn.close()
+        except Exception:  # noqa: BLE001 - best-effort teardown
+            pass
+
+
+def connect_acp_websocket(
+    url: Optional[str] = None,
+    *,
+    token: Optional[str] = None,
+    header: Optional[Any] = None,
+    subprotocols: Optional[List[str]] = None,
+    connection: Optional[Any] = None,
+    **ws_opts: Any,
+) -> Peer:
+    """Open an outbound ACP WebSocket and return a :class:`Peer` wired to it.
+
+    The returned peer exposes a ``close()`` method (like
+    :func:`~mac.acp.peer.stdio_peer`) that stops the reader thread and closes the
+    socket; the caller owns its teardown.
+
+    Parameters
+    ----------
+    url:
+        The ``ws://`` / ``wss://`` URL of the remote ACP agent. Required unless
+        ``connection`` is injected.
+    token:
+        Optional bearer token. When set, it is sent **both** as an
+        ``Authorization: Bearer <token>`` header and as the ``Authorization``
+        WebSocket subprotocol (``["Authorization", "<token>"]``), matching the two
+        acceptance paths of mac's server (:func:`mac.api._authorize_acp_websocket`
+        / :mod:`mac.acp.ws`). This works against either, including browser-style
+        servers that can only read the subprotocol.
+    header:
+        Optional extra headers (list of ``"Name: value"`` strings or a dict),
+        merged with the ``Authorization`` header derived from ``token``.
+    subprotocols:
+        Optional explicit subprotocol list. When ``token`` is set and this is
+        omitted, ``["Authorization", "<token>"]`` is offered automatically.
+    connection:
+        Injectable transport seam. When provided, it is used verbatim instead of
+        dialing a real socket; it must implement ``send(str)``, ``recv() -> str``,
+        and ``close()`` (see :class:`WSConnection`). Tests inject a fake; ``url``,
+        ``token``, ``header`` and ``subprotocols`` are then ignored, and the
+        ``websocket-client`` package is not required.
+    **ws_opts:
+        Extra keyword options forwarded to ``websocket.create_connection``
+        (e.g. ``timeout=``, ``sslopt=``).
+
+    Returns
+    -------
+    Peer
+        A live peer; its ``close`` attribute tears down the reader + socket.
+    """
+
+    if connection is None:
+        if not url:
+            raise ValueError("connect_acp_websocket requires a url (or connection=)")
+        websocket = _load_websocket()
+
+        headers = _normalize_headers(header)
+        offered_subprotocols = list(subprotocols) if subprotocols is not None else None
+        if token:
+            # Header path: Authorization: Bearer <token>.
+            headers.append("Authorization: Bearer %s" % token)
+            # Subprotocol path: ["Authorization", "<token>"] (browser-friendly).
+            if offered_subprotocols is None:
+                offered_subprotocols = ["Authorization", token]
+
+        create_kwargs: Dict[str, Any] = dict(ws_opts)
+        if headers:
+            create_kwargs["header"] = headers
+        if offered_subprotocols is not None:
+            create_kwargs["subprotocols"] = offered_subprotocols
+
+        connection = websocket.create_connection(url, **create_kwargs)
+
+    return _WebSocketPeer(connection)
+
+
+def _normalize_headers(header: Optional[Any]) -> List[str]:
+    """Coerce ``header`` (None / dict / list of "Name: value") to a list."""
+
+    if header is None:
+        return []
+    if isinstance(header, dict):
+        return ["%s: %s" % (k, v) for k, v in header.items()]
+    return list(header)
+
+
+class ACPWebSocketClient:
+    """Convenience wrapper: an :class:`ACPClient` driving a remote agent over WS.
+
+    Wires ``ACPClient(connect_acp_websocket(...))`` so a caller can run
+    ``initialize`` / ``session_new`` / ``session_prompt`` against a remote ACP
+    agent over WebSocket, then :meth:`close` to tear the transport down. Use it as
+    a context manager to guarantee cleanup::
+
+        with ACPWebSocketClient("wss://host/acp/ws", token=tok) as client:
+            client.initialize()
+            session_id = client.session_new(cwd="/work")
+            result = client.session_prompt(session_id, "do the thing")
+
+    The wrapped :class:`ACPClient` is exposed as :attr:`client` (and proxied via
+    ``__getattr__``) for any method not surfaced directly here.
+    """
+
+    def __init__(
+        self,
+        url: Optional[str] = None,
+        *,
+        token: Optional[str] = None,
+        header: Optional[Any] = None,
+        subprotocols: Optional[List[str]] = None,
+        connection: Optional[Any] = None,
+        client_capabilities: Optional[ClientCapabilities] = None,
+        client_info: Optional[Dict[str, Any]] = None,
+        **ws_opts: Any,
+    ) -> None:
+        self._peer = connect_acp_websocket(
+            url,
+            token=token,
+            header=header,
+            subprotocols=subprotocols,
+            connection=connection,
+            **ws_opts,
+        )
+        self.client = ACPClient(
+            self._peer,
+            client_capabilities=client_capabilities,
+            client_info=client_info,
+        )
+
+    @property
+    def peer(self) -> Peer:
+        """The underlying :class:`Peer` (its ``close`` tears down the transport)."""
+
+        return self._peer
+
+    def close(self) -> None:
+        """Close the WebSocket transport and stop its reader thread."""
+
+        closer = getattr(self._peer, "close", None)
+        if callable(closer):
+            closer()
+
+    def __getattr__(self, name: str) -> Any:
+        # Proxy ACPClient methods (initialize / session_new / session_prompt /
+        # on_update / ...) so callers can drive the remote agent directly.
+        return getattr(self.client, name)
+
+    def __enter__(self) -> "ACPWebSocketClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/tests/test_acp_ws_client.py
+++ b/tests/test_acp_ws_client.py
@@ -1,0 +1,237 @@
+"""Outbound WebSocket ACP client transport tests (ADR 0006).
+
+These exercise :func:`mac.acp.ws_client.connect_acp_websocket` -- mac dialing
+*out* to a remote ACP agent over WebSocket -- without any real socket. A fake
+``connection`` (the injectable seam) is backed by a queue and wired to a **real**
+server-side :class:`~mac.acp.peer.Peer` driving an
+:class:`~mac.acp.server.ACPAgentServer`, so the client's
+``connection.send(text)`` feeds the server and the server's outbound frames flow
+back through ``connection.recv()``. This mirrors the in-memory paired-transport
+harness in ``test_acp_server.py`` / ``test_acp_ws.py`` -- no asyncio, no
+subprocess, no third-party socket, no ``pytest-asyncio``.
+
+The client's blocking calls (``initialize`` / ``session_new`` / ``session_prompt``)
+run on a worker thread, like the other ACP tests, since the client peer's reader
+thread must stay free to deliver responses while the call blocks.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from mac.acp.client import ACPClient
+from mac.acp.peer import Peer
+from mac.acp.protocol import (
+    InitializeResult,
+    PromptResult,
+    SessionUpdateKind,
+    StopReason,
+)
+from mac.acp.server import ACPAgentServer, PromptTurn
+from mac.acp.ws_client import connect_acp_websocket
+
+
+class StreamingBackend:
+    """A scripted :class:`~mac.acp.server.PromptBackend`.
+
+    During a turn it streams an ``agent_message_chunk`` and a ``tool_call``
+    ``session/update`` back to the client (from the server's per-turn worker
+    thread), then ends the turn -- the shape of a real prompt turn, subprocess
+    free. Captures the turns it ran for assertions.
+    """
+
+    def __init__(self) -> None:
+        self.turns: List[PromptTurn] = []
+
+    def run_prompt(self, turn: PromptTurn) -> str:
+        self.turns.append(turn)
+        turn.agent_message_chunk("working on it")
+        turn.tool_call("call_1", "run shell", kind="execute", status="pending")
+        return StopReason.END_TURN
+
+
+class FakeWSConnection:
+    """A fake WebSocket ``connection`` wired to a real server-side peer.
+
+    Implements the ``send(str)`` / ``recv() -> str`` / ``close()`` seam
+    :func:`connect_acp_websocket` expects:
+
+    * ``send(text)`` (the client peer's outbound) feeds the **server** peer one
+      JSON-RPC frame and pumps it. The server's prompt handler defers the turn to
+      its own worker thread, so ``pump`` returns immediately and never deadlocks
+      against this caller.
+    * The server peer's outbound ``send`` (responses + ``session/update``
+      notifications, some emitted from the worker thread) enqueues text frames
+      here; ``recv()`` blocks on that queue and hands them to the client peer's
+      reader thread.
+    * ``close()`` unblocks any pending ``recv`` with a sentinel so the client's
+      reader thread exits cleanly.
+    """
+
+    _CLOSED = object()
+
+    def __init__(self, backend: Any, **server_kwargs: Any) -> None:
+        self._inbound: "queue.Queue[Any]" = queue.Queue()
+        self.server_peer = Peer(send=self._server_outbound)
+        self.server = ACPAgentServer(self.server_peer, backend, **server_kwargs)
+        self._closed = False
+
+    # -- server peer outbound -> client recv queue ---------------------------
+
+    def _server_outbound(self, data: bytes) -> None:
+        # One JSON-RPC message per WS frame: the peer hands us a single
+        # newline-terminated frame; strip it to the text payload a WS carries.
+        self._inbound.put(data.decode("utf-8").rstrip("\n"))
+
+    # -- the WSConnection seam -----------------------------------------------
+
+    def send(self, text: str) -> None:
+        # Client -> server: feed one frame and pump. The server defers prompt
+        # turns to a worker thread, so this returns promptly.
+        self.server_peer.feed(text.encode("utf-8") + b"\n")
+        self.server_peer.pump()
+
+    def recv(self) -> str:
+        item = self._inbound.get()
+        if item is self._CLOSED:
+            # EOF: returning "" makes the client's reader loop treat it as a
+            # closed socket and stop.
+            return ""
+        return item
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._inbound.put(self._CLOSED)
+
+
+def _run_in_thread(fn, *args, **kwargs):
+    """Run ``fn`` on a worker thread; return a ``(thread, box)`` pair.
+
+    The client's blocking calls must not run on the thread that also pumps the
+    client peer -- here the client peer pumps on its own reader thread, so the
+    blocking call runs on this worker while the reader delivers the response.
+    """
+
+    box: Dict[str, Any] = {}
+
+    def _target() -> None:
+        try:
+            box["value"] = fn(*args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 - surface to the test
+            box["error"] = exc
+
+    thread = threading.Thread(target=_target)
+    thread.start()
+    return thread, box
+
+
+def _await(thread, box, *, timeout: float = 5.0) -> Any:
+    thread.join(timeout)
+    assert not thread.is_alive(), "client call did not complete in time"
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
+
+
+def test_full_session_over_ws_client():
+    """initialize -> session/new -> session/prompt against a remote agent over a
+    fake WS connection: negotiated version, streamed updates, and stop reason."""
+
+    backend = StreamingBackend()
+    fake = FakeWSConnection(
+        backend, agent_info={"name": "remote-agent", "version": "7"}
+    )
+
+    peer = connect_acp_websocket(connection=fake)
+    client = ACPClient(peer)
+
+    received_updates: List[Dict[str, Any]] = []
+    client.on_update(lambda update: received_updates.append(update))
+
+    try:
+        # --- initialize: the remote agent negotiates the protocol version ---
+        t, box = _run_in_thread(client.initialize, timeout=5)
+        init = _await(t, box)
+        assert isinstance(init, InitializeResult)
+        assert init.protocol_version == 1
+        assert init.agent_info == {"name": "remote-agent", "version": "7"}
+
+        # --- session/new allocates and returns an id ---
+        t, box = _run_in_thread(client.session_new, "/tmp/work", timeout=5)
+        session_id = _await(t, box)
+        assert session_id
+        assert session_id in fake.server.session_ids()
+
+        # --- session/prompt drives the backend, which streams two updates ---
+        t, box = _run_in_thread(
+            client.session_prompt, session_id, "do the thing", timeout=5
+        )
+        result = _await(t, box)
+        assert isinstance(result, PromptResult)
+        assert result.stop_reason == StopReason.END_TURN
+    finally:
+        peer.close()
+
+    # The backend ran exactly one turn carrying the session id, cwd, and prompt.
+    assert len(backend.turns) == 1
+    turn = backend.turns[0]
+    assert turn.session_id == session_id
+    assert turn.cwd == "/tmp/work"
+    assert turn.content == [{"type": "text", "text": "do the thing"}]
+
+    # The client's update handler saw both streamed notifications, in order,
+    # delivered over the WS bridge (server worker thread -> recv queue -> client
+    # reader thread).
+    kinds = [u["update"]["sessionUpdate"] for u in received_updates]
+    assert kinds == [
+        SessionUpdateKind.AGENT_MESSAGE_CHUNK,
+        SessionUpdateKind.TOOL_CALL,
+    ]
+    assert received_updates[0]["sessionId"] == session_id
+    assert received_updates[0]["update"]["content"] == {
+        "type": "text",
+        "text": "working on it",
+    }
+    assert received_updates[1]["update"]["toolCallId"] == "call_1"
+
+
+def test_peer_close_is_exposed():
+    """The returned peer exposes a ``close`` (like ``stdio_peer``) that tears the
+    transport down."""
+
+    fake = FakeWSConnection(StreamingBackend())
+    peer = connect_acp_websocket(connection=fake)
+    assert callable(getattr(peer, "close", None))
+    peer.close()
+
+
+def test_connect_requires_websocket_module_when_no_connection(monkeypatch):
+    """Without an injected ``connection`` and with ``websocket`` unavailable,
+    ``connect_acp_websocket`` raises a clear error (not an opaque ImportError)."""
+
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _fake_import(name: str, *args: Any, **kwargs: Any):
+        if name == "websocket":
+            raise ImportError("No module named 'websocket'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+
+    with pytest.raises(RuntimeError) as exc:
+        connect_acp_websocket("ws://example.invalid/acp/ws", token="tok")
+    assert "websocket-client" in str(exc.value)
+
+
+def test_connect_requires_url_or_connection():
+    """No url and no injected connection is a programming error, surfaced early."""
+
+    with pytest.raises(ValueError):
+        connect_acp_websocket()


### PR DESCRIPTION
Counterpart to the WS server transport (#170): `connect_acp_websocket(url, token, connection=)` builds a `Peer` over a synchronous `websocket-client` connection (already a dep — no new deps), mirroring `stdio_peer`; `ACPWebSocketClient` wires `ACPClient` over it, and `ACPExecutor(peer_factory=...)` works unchanged. Auth matches the server (bearer header + Authorization subprotocol). Injectable `connection=` seam; lazy/guarded `websocket` import. 4 new tests (full session over a fake WS connection backed by a real `ACPAgentServer`; guarded-import + missing-url errors); 14 combined. Deferred: wiring it into a remote-agent config knob.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)