### PR TITLE
feat(relay): bring the OCSF→observation translator into mac (unify with mac-dev)

### DIFF
--- a/src/mac/relay_observability.py
+++ b/src/mac/relay_observability.py
@@ -1,16 +1,48 @@
-"""NeMo Relay observability seam for MAC/Hermes.
+"""Optional NeMo Relay observability adapter (relay-01).
 
-Import-guarded seam so behaviour is fully unchanged when nemo-relay is absent.
-Activate by setting MAC_RELAY_OBSERVABILITY=1 in the environment; any other
-value (or absent) leaves the module in no-op mode.
+NeMo Relay (https://docs.nvidia.com/nemo/relay) is a framework-neutral agent
+*execution runtime*: hierarchical scopes, managed tool/LLM calls with lifecycle
+events (ATOF), middleware, and multi-backend export (ATOF / ATIF / OpenTelemetry
+/ OpenInference). This module is the **seam**, not the full integration:
+
+* It lets the control plane open Relay scopes and emit marks/events *when* the
+  ``nemo_relay`` Python binding is installed, and degrades to a safe no-op when
+  it is absent. Relay is pre-1.0 and is intentionally NOT a hard dependency of
+  ``mac`` — nothing here imports ``nemo_relay`` at module import (the seam below
+  guards the import so absence simply becomes ``is_available() -> False``).
+
+* It exposes managed scope helpers — ``create_agent_scope`` (a root Agent scope
+  per executor run / per request), ``relay_tool_context`` (a Tool child scope
+  per tool dispatch), and ``relay_llm_context`` (an Llm child scope per provider
+  call) — so the executor, tool dispatcher, and LLM call sites can be wrapped
+  with zero conditional logic at the call site.
+
+* It translates OpenShell's OCSF event records (the sandbox's allowed/denied
+  network, HTTP, process, and finding stream) into the same observation shape
+  the rest of ``mac`` already records, so sandbox *enforcement* decisions become
+  first-class observations alongside the executor's own telemetry. This is the
+  bridge between the two halves of the OpenShell + NeMo Relay design: OpenShell
+  produces the security events, Relay/observability consumes them.
+
+Activate by setting ``MAC_RELAY_OBSERVABILITY=1`` in the environment (and with
+the ``nemo_relay`` package installed); any other value (or absent) leaves the
+scope/export half in no-op mode. The pure OCSF translation half is always
+available — it has no nemo-relay dependency. The full scope/managed-call/
+exporter rollout is tracked as follow-up work; see
+``docs/openshell-nemo-relay-integration.md``.
 
 Public surface
 --------------
+is_available()                            -> bool   (relay importable AND opted-in)
+enabled()                                 -> bool   (alias of is_available)
+relay_available()                         -> bool   (relay importable, ignoring opt-in)
 create_agent_scope(session_id)            -> context manager (sync)   [Phase 1]
 relay_tool_context(tool_name, input_dict) -> context manager (sync)   [Phase 2]
 relay_llm_context(model, provider, ...)   -> context manager (sync)   [Phase 2]
+scope(name, scope_type, **fields)         -> context manager (legacy handle-yielding)
+record_event(name, *, data)               -> bool
 flush()                                   -> None
-is_available()                            -> bool
+ocsf_to_observation / iter_ocsf_observations / parse_ocsf_lines  (pure translation)
 
 All scopes are opened with ``nemo_relay.scope.scope(name, ScopeType.X,
 data=...)`` and async export is drained with
@@ -24,12 +56,51 @@ conditional logic.
 from __future__ import annotations
 
 import contextlib
+import logging
 import os
 import sys
-from typing import Any, Dict, Generator, Optional
+from contextlib import contextmanager
+from typing import Any, Dict, Generator, Iterable, Iterator, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# mac observation layer for sandbox-sourced events. Must satisfy the hub's layer
+# regex ``^[A-Za-z0-9][A-Za-z0-9._\-/:]{0,127}$``.
+SANDBOX_LAYER = "sandbox"
+
+# OCSF class_uid -> (short name suffix). See OCSF v1.x category 4 (Network),
+# 1 (System), 2 (Findings), 5 (Discovery), 6 (Application).
+_OCSF_CLASS_NAMES = {
+    4001: "network",
+    4002: "http",
+    4007: "ssh",
+    1007: "process",
+    2004: "finding",
+    5019: "config",
+    6002: "lifecycle",
+}
+
+# OCSF severity_id -> mac observation level.
+_OCSF_SEVERITY_LEVELS = {
+    0: "info",   # Unknown
+    1: "info",   # Informational
+    2: "info",   # Low
+    3: "warning",  # Medium
+    4: "error",  # High
+    5: "critical",  # Critical
+    6: "critical",  # Fatal
+}
+
+_LEVEL_RANK = {"debug": 0, "info": 1, "warning": 2, "error": 3, "critical": 4}
+
 
 # ---------------------------------------------------------------------------
-# Optional import guard — never raises; absence becomes is_available() -> False
+# Optional import guard — never raises; absence becomes is_available() -> False.
+#
+# Eagerly resolving the binding (and the 0.3.0 ``flush_subscribers`` native
+# entry point) at import time gives the scope/tool/LLM seam a single source of
+# truth (``_NEMO_RELAY_AVAILABLE`` / ``_nemo_relay``) that tests monkey-patch to
+# simulate a relay-present environment without a wheel installed.
 # ---------------------------------------------------------------------------
 try:
     import nemo_relay as _nemo_relay
@@ -41,13 +112,29 @@ except ImportError:
     _NEMO_RELAY_AVAILABLE = False
 
 
-def is_available() -> bool:
-    """Return True when nemo-relay is importable AND MAC_RELAY_OBSERVABILITY=1."""
-    return _NEMO_RELAY_AVAILABLE and _relay_enabled()
+def _truthy(value: Optional[str]) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _relay_enabled() -> bool:
-    return os.environ.get("MAC_RELAY_OBSERVABILITY", "").strip() == "1"
+    return _truthy(os.environ.get("MAC_RELAY_OBSERVABILITY"))
+
+
+def relay_available() -> bool:
+    """True if the ``nemo_relay`` Python binding is importable (ignores opt-in)."""
+    return _NEMO_RELAY_AVAILABLE
+
+
+def is_available() -> bool:
+    """True when nemo-relay is importable AND ``MAC_RELAY_OBSERVABILITY`` is truthy."""
+    return _NEMO_RELAY_AVAILABLE and _relay_enabled()
+
+
+# Backwards-compatible alias: the OCSF/legacy half historically called this
+# ``enabled()``. Kept so existing callers/tests keep working.
+def enabled() -> bool:
+    """True only when the operator opted in AND the binding is importable."""
+    return is_available()
 
 
 def flush() -> None:
@@ -58,6 +145,45 @@ def flush() -> None:
         _flush_subscribers()  # type: ignore[misc]
     except Exception:  # noqa: BLE001 — observability must never break a task run
         pass
+
+
+def record_event(name: str, *, data: Optional[Dict[str, Any]] = None) -> bool:
+    """Emit a Relay mark event. No-op (returns False) when Relay is unavailable.
+
+    Best-effort: any failure in the pre-1.0 binding is swallowed and logged at
+    debug so callers never have to guard the call.
+    """
+    if not is_available():
+        return False
+    try:  # pragma: no cover - exercised only with nemo_relay installed
+        _nemo_relay.scope.event(name, data=dict(data or {}))  # type: ignore[union-attr]
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("relay record_event(%s) failed: %s", name, exc)
+        return False
+
+
+@contextmanager
+def scope(name: str, scope_type: str = "Agent", **fields: Any) -> Iterator[Any]:
+    """Open a Relay scope around a block of work, yielding the scope handle.
+
+    Yields the Relay scope handle when active, else ``None``. Always safe to use
+    as ``with relay_observability.scope(...) as handle:`` regardless of whether
+    Relay is installed. This is the legacy handle-yielding helper; the managed
+    ``create_agent_scope`` / ``relay_tool_context`` / ``relay_llm_context``
+    helpers below are preferred for new call sites.
+    """
+    if not is_available():
+        yield None
+        return
+    try:  # pragma: no cover - exercised only with nemo_relay installed
+        nr = _nemo_relay  # type: ignore[union-attr]
+        st = getattr(nr.ScopeType, scope_type, nr.ScopeType.Agent)
+        with nr.scope.scope(name, st, input=dict(fields)) as handle:
+            yield handle
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("relay scope(%s) failed: %s", name, exc)
+        yield None
 
 
 @contextlib.contextmanager
@@ -209,10 +335,105 @@ def relay_llm_context(
         yield
 
 
+# ---------------------------------------------------------------------------
+# OpenShell OCSF -> mac observation translation (pure; always available)
+# ---------------------------------------------------------------------------
+
+
+def _bump_level(level: str, floor: str) -> str:
+    """Return whichever of *level*/*floor* is more severe."""
+    if _LEVEL_RANK.get(floor, 1) > _LEVEL_RANK.get(level, 1):
+        return floor
+    return level
+
+
+def ocsf_to_observation(record: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Translate one OpenShell OCSF JSONL record into a mac observation dict.
+
+    Returns a dict shaped for ``ObservabilityService.record_log`` /
+    ``record_observation`` (``kind``, ``layer``, ``level``, ``name``, ``source``,
+    ``detail``), or ``None`` if *record* is not a usable mapping. Pure and
+    dependency-free: callable whether or not Relay/OpenShell are installed.
+    """
+    if not isinstance(record, dict):
+        return None
+
+    class_uid = record.get("class_uid")
+    suffix = _OCSF_CLASS_NAMES.get(class_uid, "event")
+    name = "sandbox.%s" % suffix
+
+    # Severity: prefer the numeric severity_id; fall back to info.
+    severity_id = record.get("severity_id")
+    level = _OCSF_SEVERITY_LEVELS.get(severity_id, "info")
+
+    # A denied/blocked enforcement decision is at least a warning regardless of
+    # the record's own severity, so policy denials are never logged below WARN.
+    action = str(record.get("action") or "").strip().lower()
+    disposition = str(record.get("disposition") or "").strip().lower()
+    if action in {"denied", "deny", "blocked"} or disposition in {"blocked", "denied"}:
+        level = _bump_level(level, "warning")
+
+    return {
+        "kind": "log",
+        "layer": SANDBOX_LAYER,
+        "level": level,
+        "name": name,
+        "source": "openshell",
+        "detail": record,
+    }
+
+
+def iter_ocsf_observations(
+    records: Iterable[Any],
+) -> Iterator[Dict[str, Any]]:
+    """Map an iterable of OCSF records (e.g. parsed JSONL lines) to observations.
+
+    Non-dict / unusable records are skipped so a malformed log line can't abort
+    ingestion of the rest of the stream.
+    """
+    for rec in records:
+        obs = ocsf_to_observation(rec) if isinstance(rec, dict) else None
+        if obs is not None:
+            yield obs
+
+
+def parse_ocsf_lines(lines: Iterable[str]) -> List[Dict[str, Any]]:
+    """Parse OpenShell ``*-ocsf.*.log`` JSONL lines into observation dicts.
+
+    Blank lines and non-JSON / non-object lines are skipped (OpenShell also
+    writes a human-readable shorthand log; only the JSONL stream is structured).
+    """
+    import json
+
+    out: List[Dict[str, Any]] = []
+    for line in lines:
+        line = (line or "").strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        obs = ocsf_to_observation(rec) if isinstance(rec, dict) else None
+        if obs is not None:
+            out.append(obs)
+    return out
+
+
 __all__ = [
+    # scope-export seam
     "is_available",
+    "relay_available",
+    "enabled",
     "create_agent_scope",
     "relay_tool_context",
     "relay_llm_context",
+    "scope",
+    "record_event",
     "flush",
+    # OCSF translation
+    "SANDBOX_LAYER",
+    "ocsf_to_observation",
+    "iter_ocsf_observations",
+    "parse_ocsf_lines",
 ]

--- a/tests/test_relay_observability.py
+++ b/tests/test_relay_observability.py
@@ -11,6 +11,7 @@ the module's internal flags — no nemo-relay wheel is needed in the test env.
 from __future__ import annotations
 
 import importlib
+import json
 import os
 import sys
 from contextlib import contextmanager
@@ -19,6 +20,12 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 
 import mac.relay_observability as ro
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("MAC_RELAY_OBSERVABILITY", raising=False)
+    yield
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +53,34 @@ def _reload_module_with_env(**env_overrides):
                 os.environ[k] = orig
         # Restore the original module reference
         sys.modules["mac.relay_observability"] = ro
+
+
+# ---------------------------------------------------------------------------
+# enable gating + no-op safety
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_by_default():
+    assert ro.enabled() is False
+
+
+def test_enabled_requires_binding(monkeypatch):
+    """Even opted-in, enabled() is False unless nemo_relay is importable."""
+    monkeypatch.setenv("MAC_RELAY_OBSERVABILITY", "1")
+    assert ro.enabled() is (ro.relay_available())
+
+
+def test_record_event_noop_when_disabled():
+    assert ro.record_event("x", data={"a": 1}) is False
+
+
+def test_scope_yields_none_when_disabled():
+    with ro.scope("agent-run", "Agent", task="t1") as handle:
+        assert handle is None
+
+
+def test_flush_noop_does_not_raise():
+    ro.flush()  # must not raise when disabled
 
 
 # ---------------------------------------------------------------------------
@@ -475,3 +510,78 @@ def test_sanitize_attrs_keeps_scalars_drops_objects():
         "obj": object(),
     })
     assert out == {"s": "x", "i": 1, "f": 1.5, "b": True, "n": None, "list_ok": [1, "a", None]}
+
+
+# ---------------------------------------------------------------------------
+# OCSF -> observation translation (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_network_denied_bumped_to_warning():
+    rec = {
+        "class_uid": 4001,
+        "severity_id": 1,  # Informational
+        "action": "Denied",
+        "disposition": "Blocked",
+        "dst_endpoint": {"domain": "httpbin.org", "port": 443},
+    }
+    obs = ro.ocsf_to_observation(rec)
+    assert obs is not None
+    assert obs["kind"] == "log"
+    assert obs["layer"] == "sandbox"
+    assert obs["source"] == "openshell"
+    assert obs["name"] == "sandbox.network"
+    assert obs["level"] == "warning"  # bumped up from info because Denied
+    assert obs["detail"] is rec
+
+
+def test_process_info_stays_info():
+    obs = ro.ocsf_to_observation({"class_uid": 1007, "severity_id": 1, "action": "Allowed"})
+    assert obs["name"] == "sandbox.process"
+    assert obs["level"] == "info"
+
+
+@pytest.mark.parametrize(
+    "severity_id,expected",
+    [(0, "info"), (1, "info"), (2, "info"), (3, "warning"), (4, "error"), (5, "critical"), (6, "critical")],
+)
+def test_severity_mapping(severity_id, expected):
+    obs = ro.ocsf_to_observation({"class_uid": 2004, "severity_id": severity_id})
+    assert obs["level"] == expected
+    assert obs["name"] == "sandbox.finding"
+
+
+def test_unknown_class_uses_generic_name():
+    obs = ro.ocsf_to_observation({"class_uid": 9999, "severity_id": 1})
+    assert obs["name"] == "sandbox.event"
+
+
+def test_non_dict_returns_none():
+    assert ro.ocsf_to_observation("not-a-dict") is None
+    assert ro.ocsf_to_observation(None) is None
+
+
+def test_iter_skips_non_dicts():
+    records = [{"class_uid": 1007, "severity_id": 1}, "garbage", 42, {"class_uid": 4002, "severity_id": 1}]
+    out = list(ro.iter_ocsf_observations(records))
+    assert [o["name"] for o in out] == ["sandbox.process", "sandbox.http"]
+
+
+# ---------------------------------------------------------------------------
+# JSONL parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_ocsf_lines_filters_noise():
+    lines = [
+        "",  # blank
+        "not json at all",  # human shorthand line
+        json.dumps([1, 2, 3]),  # JSON but not an object
+        json.dumps({"class_uid": 4001, "severity_id": 4, "action": "Allowed"}),
+        json.dumps({"class_uid": 4001, "severity_id": 1, "action": "Denied"}),
+    ]
+    out = ro.parse_ocsf_lines(lines)
+    assert len(out) == 2
+    assert out[0]["level"] == "error"  # severity 4 (High)
+    assert out[1]["level"] == "warning"  # denied bump from info
+    assert all(o["layer"] == "sandbox" for o in out)


### PR DESCRIPTION
The reverse half of the unify: mac's `relay_observability.py` now carries BOTH its NeMo-Relay scope seam AND mac-dev's OCSF→observation translator, so the two forks' relay modules match.

- Added (from mac-dev): `SANDBOX_LAYER`, OCSF class/severity maps, `ocsf_to_observation` (denied→warning bump, non-dict→None), `iter_ocsf_observations`, `parse_ocsf_lines` (JSONL), and `enabled()`/`relay_available()`/legacy `scope()`/`record_event()` compat helpers.
- Kept all of mac's scope seam verbatim (`is_available`/`create_agent_scope`/`relay_tool_context`/`relay_llm_context` + the hub-500 teardown + 128-char truncation fixes). Single availability guard backs both halves.
- Tests merged (mac's scope/teardown/truncation + mac-dev's OCSF mapping/parse). Identity-neutral — no de-personalization needed.

`has scope: True | has ocsf: True`. 60 tests pass (relay + ACP-executor consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)