### PR TITLE
chore(docs): genericize per-fleet operator identity out of docs/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The identity framework reflects that split:
 - `tenant`: an organization or isolated user deployment.
 - `user`: a human identity inside a tenant.
 - `persona`: a named Hermes personality with a `soul_ref` and `memory_scope`.
-- `hermes_instance`: a running or durable Hermes identity such as Rocky.
+- `hermes_instance`: a running or durable Hermes identity such as `worker-1`.
 - `platform_binding`: a Slack workspace/channel, Telegram chat, or similar binding.
 - interaction task: a durable task created from a Hermes conversation with origin metadata, not copied private memory.
 
@@ -158,7 +158,7 @@ Key route groups:
 
 For Beads-backed repository work, the production path is:
 
-1. Rocky's hub polls registered Beads repositories and treats `bd ready --json`
+1. The hub polls registered Beads repositories and treats `bd ready --json`
    as canonical when it is available.
 2. Each ready Bead becomes one durable mac task with repository contract,
    execution contract, origin metadata, and Beads provenance.

--- a/deploy/hermes/SNAPSHOT.md
+++ b/deploy/hermes/SNAPSHOT.md
@@ -42,7 +42,7 @@ files.** Reachable subtrees, with file counts:
 
 ### Runtime trace result (validates the static manifest)
 
-A real oneshot (`hermes -z` under `python -v`) on rocky confirmed:
+A real oneshot (`hermes -z` under `python -v`) on the hub confirmed:
 - **`plugins/` loads 273 files at runtime** (vs 20 statically — dynamic
   loading). It is essential; omitting it would break the vendor.
 - `hermes_cli` (87), `agent` (78), `gateway` (27), `tools` (15), `providers`

--- a/deploy/k8s/gpu-worker/README.md
+++ b/deploy/k8s/gpu-worker/README.md
@@ -1,13 +1,13 @@
 # GPU worker nodes
 
-Turn a fleet GPU host (hostb, hostc) into a Kubernetes **GPU worker node** so
+Turn a fleet GPU host (gpu-node, gpu-node-arm) into a Kubernetes **GPU worker node** so
 the elastic executor tier ([ADR 0005](../../../docs/adr/0005-elastic-executor-tier-vs-static-fleet.md))
 can run `nvidia.com/gpu`-requesting Jobs on it.
 
-> **Why this is now worth doing for hostb.** The thing that used to "block" the
+> **Why this is now worth doing for gpu-node.** The thing that used to "block" the
 > GPU — the long-lived vLLM "LLM brain" Deployment — serves **≈0 hub traffic**
 > (live `llm.route` telemetry, 2026-06-11: 994/1000 routed to cloud `nvidia`, 0
-> to hostb's vLLM, because no caller requests its `Qwen/...` model). See the ADR
+> to gpu-node's vLLM, because no caller requests its `Qwen/...` model). See the ADR
 > Evidence section. So the GPU can be **dedicated** to executor Jobs rather than
 > carefully time-sliced around an idle service.
 
@@ -28,19 +28,19 @@ deploy/k8s/gpu-worker/
 
 ## Prerequisites (per host)
 
-Verified present on hostb (RTX 6000 Ada) and hostc (GB10) in ADR 0005:
+Verified present on gpu-node (RTX 6000 Ada) and gpu-node-arm (GB10) in ADR 0005:
 
 - NVIDIA driver loaded (`nvidia-smi` works).
 - **NVIDIA Container Toolkit** (`nvidia-ctk`) + **containerd**, with the `nvidia`
   runtime wired as containerd's default (or as a `RuntimeClass`). This is the
-  exact mechanism that *cannot* exist on macOS — which is why **hostd is not
+  exact mechanism that *cannot* exist on macOS — which is why **mac-node is not
   a candidate** (its Metal GPU is unschedulable; its image-gen stays an
   off-cluster native service).
-- The node has **joined the cluster** as a worker (kubelet running). `hosta` is
+- The node has **joined the cluster** as a worker (kubelet running). `hub-node` is
   the intended control-plane / CPU node; it has no container runtime today, so
   add containerd there before it can host anything.
 
-hostc caveats (from ADR 0005): it's **arm64** (mixed-arch cluster → build
+gpu-node-arm caveats (from ADR 0005): it's **arm64** (mixed-arch cluster → build
 workload images for arm64 too) and runs a **kernel-coupled driver** (`6.17-nvidia`
 + driver 580) — keep the per-kernel module package matched (see the
 `reference-fleet-gpu-capability` memory for the exact `apt-get` fix).
@@ -51,14 +51,14 @@ workload images for arm64 too) and runs a **kernel-coupled driver** (`6.17-nvidi
 # 1. Label the node (run from a context with the cluster's kubeconfig).
 #    Plain label  -> GPU shareable with other pods.
 #    --taint      -> dedicate the node to GPU work (CPU executor Jobs stay off it).
-deploy/k8s/gpu-worker/label-gpu-node.sh hostb --taint
+deploy/k8s/gpu-worker/label-gpu-node.sh gpu-node --taint
 
 # 2. Roll out the device plugin. It only lands on nodes carrying the
 #    mac.fleet/capability-gpu=true label set in step 1.
 kubectl apply -k deploy/k8s/gpu-worker
 
 # 3. Verify the node now advertises GPUs as a schedulable resource.
-kubectl describe node hostb | grep -A2 'Capacity:' | grep nvidia.com/gpu
+kubectl describe node gpu-node | grep -A2 'Capacity:' | grep nvidia.com/gpu
 #   nvidia.com/gpu:  1
 kubectl -n kube-system get pods -l app.kubernetes.io/name=nvidia-device-plugin -o wide
 ```
@@ -114,12 +114,12 @@ existing `build_job_spec` coverage before enabling.
 ## What about the vLLM brain?
 
 Because it serves ≈0 traffic, the simplest path is to **stop the vLLM Deployment
-and dedicate hostb's GPU to executor Jobs**. Before decommissioning, confirm
+and dedicate gpu-node's GPU to executor Jobs**. Before decommissioning, confirm
 there's no out-of-band direct consumer (the hub telemetry can't see processes
-that hit `hostb:8000` directly):
+that hit `gpu-node:8000` directly):
 
 ```bash
-ssh dev@hostb.local "curl -s localhost:8000/metrics | grep request_success_total; ss -tnp | grep :8000"
+ssh <user>@<gpu-node-host> "curl -s localhost:8000/metrics | grep request_success_total; ss -tnp | grep :8000"
 ```
 
 If you still want a local-LLM fallback, keep a **right-sized** vLLM and share the

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -80,7 +80,7 @@ should be selected from the target dropdown.
 
 The packaged UI also exposes `Fleet hub` and `Bearer token` controls in the
 top bar. Token values from `~/.mac/.env` stay in Electron main; the renderer
-only receives token-source labels such as `Hub token (ROCKY)` or `Manual
+only receives token-source labels such as `Hub token (HUB)` or `Manual
 bearer token`.
 
 ## Profile Shape
@@ -89,7 +89,7 @@ Profiles are plain JSON:
 
 ```json
 {
-  "displayName": "Rocky / horde",
+  "displayName": "hub / horde",
   "tokenEnv": "MAC_DESKTOP_API_TOKEN",
   "ssh": {
     "target": "horde@example.test",

--- a/docs/adr/0003-tokenhub-core-into-mac.md
+++ b/docs/adr/0003-tokenhub-core-into-mac.md
@@ -114,9 +114,9 @@ Two clarifications from building this out:
 
 ### Validated (2026-05-31)
 
-A **wrap-TokenHub canary** on `natasha` is live: its gateway is cut over to its
+A **wrap-TokenHub canary** on `worker-1` is live: its gateway is cut over to its
 local in-mac router (recovering breaker + fail-fast + streaming passthrough),
-which forwards through TokenHub using natasha's own key. Streaming chat verified
+which forwards through TokenHub using worker-1's own key. Streaming chat verified
 end-to-end (real SSE deltas, `"*"`→`azure/anthropic/claude-sonnet-4-6`); rest of the
 fleet untouched. This proved the router code carries live agent traffic before
 any upstream credential is moved into the vault.

--- a/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
+++ b/docs/adr/0005-elastic-executor-tier-vs-static-fleet.md
@@ -2,10 +2,10 @@
 
 - Status: **Proposed**
 - Date: 2026-06-11
-- Decision owner: Dev User
+- Decision owner: `<user>`
 - Context: the fleet is configured statically in `~/.mac/fleets.yaml` — named
-  agents pinned to hosts (hosta→node1, hostc→hoste, hostd→hostf,
-  hostb→hostb), each deployed by `deploy/deploy-mac-fleet.sh` as a long-lived
+  agents pinned to hosts (hub-node, gpu-node, gpu-node-arm, mac-node each on
+  their own host), each deployed by `deploy/deploy-mac-fleet.sh` as a long-lived
   editable install + systemd/launchd services. The question raised: *what if
   every agent were a GitHub self-hosted runner (and any runner an agent), with
   agents registered/created dynamically rather than declared statically?*
@@ -54,18 +54,18 @@ tier on k8s — **not** turning every agent into a runner.
   "repo evidence requires pushed=true / pr_url"), multi-attempt with
   `deployment_learning`s, and hardware gating (GPU). GitHub's job scheduler has
   almost none of this.
-- **Heterogeneous, partly long-lived hardware.** hostb (RTX 6000 Ada) serves
-  vLLM as the fleet's LLM brain; hostd (M4 Pro) does local image-gen; the
+- **Heterogeneous, partly long-lived hardware.** gpu-node (RTX 6000 Ada) serves
+  vLLM as the fleet's LLM brain; mac-node (M4 Pro) does local image-gen; the
   in-mac router/media-routing fan work to these. These are **services**, not jobs.
 - **The static model's cost, observed directly.** This is where our recurring
   pain comes from: manual SSH deploys; bearer-token **drift** (a 403 that needed
   out-of-band recovery); a default-fleet knob we had to add; ~20 stale
   **beads-bridge** tasks (a static-bridge artifact) making up half the failure
   rate; and c26 repo tasks failing on **dirty/stale checkouts** of
-  `/home/dev/.mac/src/c26`.
+  `/home/<user>/.mac/src/c26`.
 - **The repo already leans dynamic.** `docs/k8s-native-rewrite-plan.md`,
   `docs/job-per-task-roles-spec.md`, the `mac autopilot` k8s wiring, and the
-  `devuser-gke` fleet are all "task → ephemeral pod." So we are *already* moving
+  `<user>-gke` fleet are all "task → ephemeral pod." So we are *already* moving
   off static; the open question is the substrate, not the direction.
 
 ## The fulcrum
@@ -103,7 +103,7 @@ elasticity — is what makes the universal equivalence wrong.
 Use **k8s Jobs** for the executor tier. Concretely, because:
 
 - **It already exists here** (autopilot, `docs/job-per-task-roles-spec.md`,
-  `devuser-gke`) — extending it is the lowest-friction path to elasticity;
+  `<user>-gke`) — extending it is the lowest-friction path to elasticity;
   adopting GitHub ARC means standing up a new runner controller, registration-
   token plumbing, and runner groups.
 - **We control isolation** (namespace / RBAC / network policy) — the right
@@ -124,7 +124,7 @@ bridge**: a GitHub Actions event (push/PR/`workflow_dispatch`) calls the hub to
 We keep the executor contract simple (`claim → run → evidence → exit`) so it
 *could* run on a GitHub-hosted runner in a pinch — but that is a fallback, not
 the design. The only thing that would flip this decision is running a k8s
-cluster being off the table; it isn't (`devuser-gke` is already a cluster), so
+cluster being off the table; it isn't (`<user>-gke` is already a cluster), so
 GitHub-hosted runners' "no cluster to operate" advantage does not apply.
 
 ## Evidence: a live multi-node dispatch experiment (2026-06-11)
@@ -132,11 +132,11 @@ GitHub-hosted runners' "no cluster to operate" advantage does not apply.
 The flexible-dispatch claim was **tested, not just asserted**. A real 4-node
 Kubernetes cluster was stood up locally (`kind` on `colima`): one control-plane
 node (the "hub") + three worker nodes labeled to mimic the fleet's heterogeneity
-— `hostb` (`capability-gpu`), `hostd` (`capability-image-gen`), `hosta`
+— `gpu-node` (`capability-gpu`), `mac-node` (`capability-image-gen`), `hub-node`
 (`capability-ops`). Four Jobs were submitted with no manual placement:
 
-- `nodeSelector: capability-gpu` scheduled onto the `hostb` node;
-  `capability-image-gen` → `hostd`; `capability-ops` → `hosta`. Every
+- `nodeSelector: capability-gpu` scheduled onto the `gpu-node` node;
+  `capability-image-gen` → `mac-node`; `capability-ops` → `hub-node`. Every
   capability-targeted Job landed on exactly its matching node.
 - A 6-completion / parallelism-6 Job with **no** selector spread **2 / 2 / 2**
   across the three worker nodes on the scheduler's own.
@@ -150,10 +150,10 @@ are containers on one VM, so the *physical* distribution is simulated; the
 **What it does NOT prove — and why that sharpens the decision.** The literal
 "every host simply becomes a node" does not hold:
 
-- **macOS hosts cannot be Linux-container worker nodes.** hostd (darwin /
+- **macOS hosts cannot be Linux-container worker nodes.** mac-node (darwin /
   M4 Pro) has no kubelet running Linux pods, and its **Metal/MPS GPU is not a
   schedulable k8s resource** at all.
-- **NVIDIA GPUs need device plugins.** hostb (RTX 6000 Ada) and hostc (GB10)
+- **NVIDIA GPUs need device plugins.** gpu-node (RTX 6000 Ada) and gpu-node-arm (GB10)
   require drivers + the device plugin to expose GPUs as schedulable resources.
 - **Cross-network CNI.** Fleet hosts sit on different networks joined by
   Tailscale; one cluster needs node + pod networking across them (e.g. k3s + an
@@ -164,7 +164,7 @@ are containers on one VM, so the *physical* distribution is simulated; the
 
 ### Why a macOS host can't be a worker node — even with Docker + "GPU pass-through"
 
-Established on an M4 Pro Mac (same class as hostd):
+Established on an M4 Pro Mac (same class as mac-node):
 
 1. **macOS doesn't run Linux containers; it runs a Linux VM.** Host kernel is
    `Darwin 25.5.0 arm64`, but a container on it reports `Linux 6.8.0 aarch64`
@@ -183,7 +183,7 @@ Established on an M4 Pro Mac (same class as hostd):
    (`could not select device driver … [[gpu]]`).
 3. **The GPU is reachable only by a native macOS process calling Metal** — which
    is by definition not a pod; a Linux Job can never touch Metal. (This is why
-   hostd's SDXL/MPS image-gen runs as a native `~/gen` process.)
+   mac-node's SDXL/MPS image-gen runs as a native `~/gen` process.)
 4. **Making the Mac a node buys nothing and costs a VM layer:** you'd run Linux
    pods in a VM on the Mac with no access to the one capability that makes it
    special — and the genuinely macOS-only work that needs the host (Metal
@@ -191,15 +191,15 @@ Established on an M4 Pro Mac (same class as hostd):
    wall when the Electron build required the Mac's "Developer ID" / "Fleet
    Identity" signing identities) cannot run in a Linux container at all.
 
-### The Linux/NVIDIA hosts (hosta, hostb, hostc) *can* be nodes — container GPU is the supported path
+### The Linux/NVIDIA hosts (hub-node, gpu-node, gpu-node-arm) *can* be nodes — container GPU is the supported path
 
 Read-only probes of the actual hosts:
 
 | Host | arch / kernel | GPU (driver) | docker / containerd / nvidia-ctk |
 | --- | --- | --- | --- |
-| **hosta** (node1) | x86_64 / 6.8 | none (CPU-only) | no / no / no |
-| **hostb** | x86_64 / 7.0 | RTX 6000 Ada 48 GB (595.71.05) | **yes / yes / yes** |
-| **hostc** | **aarch64** / 6.17-nvidia | GB10 Grace-Blackwell (580.159.03) | **yes / yes / yes** |
+| **hub-node** | x86_64 / 6.8 | none (CPU-only) | no / no / no |
+| **gpu-node** | x86_64 / 7.0 | RTX 6000 Ada 48 GB (595.71.05) | **yes / yes / yes** |
+| **gpu-node-arm** | **aarch64** / 6.17-nvidia | GB10 Grace-Blackwell (580.159.03) | **yes / yes / yes** |
 
 Unlike the Mac, these are architecturally fine as k8s nodes, and the
 **container-GPU mechanism that's impossible on macOS is already installed** on
@@ -209,10 +209,10 @@ under `--gpus all`, and the k8s **NVIDIA device plugin** then exposes
 `nvidia.com/gpu` as a schedulable resource. (The toolkit's presence is the
 dispositive fact — it cannot even exist on macOS, where `--gpus all` errors.)
 
-- **hosta** — CPU-only Linux; the natural **control-plane ("hub") node** and/or a
+- **hub-node** — CPU-only Linux; the natural **control-plane ("hub") node** and/or a
   CPU worker. Only gap: **no container runtime today** (it runs the mac services
   as a bare-metal editable install), so containerd must be added.
-- **hostb** — **GPU worker node: ready.** Add the k8s NVIDIA device plugin and
+- **gpu-node** — **GPU worker node: ready.** Add the k8s NVIDIA device plugin and
   pods can request `nvidia.com/gpu`. The often-cited caveat — "one 48 GB GPU is
   held by the long-lived **vLLM brain** (a *Deployment*, not a Job)" — turns out
   to be **hollow**: that brain serves ≈0 traffic (see the routing-evidence
@@ -220,7 +220,7 @@ dispositive fact — it cannot even exist on macOS, where `--gpus all` errors.)
   rather than carefully shared via time-slicing / MPS. (If a local-LLM fallback
   is wanted, keep a *right-sized* vLLM and GPU-share; just don't let a 0-traffic
   service block the node.)
-- **hostc** — **GPU worker node: feasible, same mechanism**, with two
+- **gpu-node-arm** — **GPU worker node: feasible, same mechanism**, with two
   operational caveats: **arm64** (a mixed-arch cluster — images/workloads must be
   built arm64) and a **bleeding-edge driver/kernel** (`6.17-nvidia` + driver 580;
   GB10 drivers are tightly kernel-coupled — the per-kernel-module friction we've
@@ -228,41 +228,41 @@ dispositive fact — it cannot even exist on macOS, where `--gpus all` errors.)
   kernel.
 
 Crucially, the **only** host that genuinely *can't* be a worker node is the
-**darwin** one (hostd). The GPU hosts *can* be nodes — but their long-lived
-model servers (hostb's vLLM brain) are **Deployments**, not Jobs. So the
-two-tier split maps cleanly onto the hardware: **hosta → control-plane / CPU
-executor nodes; hostb + hostc → GPU nodes hosting a persistent model-server
-Deployment and/or elastic GPU Jobs; hostd → off-cluster persistent
+**darwin** one (mac-node). The GPU hosts *can* be nodes — but their long-lived
+model servers (gpu-node's vLLM brain) are **Deployments**, not Jobs. So the
+two-tier split maps cleanly onto the hardware: **hub-node → control-plane / CPU
+executor nodes; gpu-node + gpu-node-arm → GPU nodes hosting a persistent model-server
+Deployment and/or elastic GPU Jobs; mac-node → off-cluster persistent
 native-macOS service.**
 
 ### The "vLLM brain" serves ≈0 traffic — the GPU it holds is effectively idle (2026-06-11)
 
 A second probe checked whether the persistent service this ADR is most careful to
-protect — hostb's vLLM "LLM brain" — is actually load-bearing. It is not.
+protect — gpu-node's vLLM "LLM brain" — is actually load-bearing. It is not.
 
-Querying the live hosta hub's routing telemetry
-(`mac --fleet hosta observability list --name llm.route`), the last ~1000
+Querying the live hub's routing telemetry
+(`mac --fleet <hub> observability list --name llm.route`), the last ~1000
 `llm.route` events (spanning 2026-06-08 → 2026-06-11):
 
 | backend provider | events |
 | --- | --- |
 | `nvidia` (cloud inference API, resolving `azure/anthropic/claude-sonnet-4-6`) | 994 |
 | empty / failed route | 6 |
-| **hostb / vLLM / its served model** | **0** |
+| **gpu-node / vLLM / its served model** | **0** |
 
-The cause is structural, not transient. hostb's vLLM *is* wired into the hub
+The cause is structural, not transient. gpu-node's vLLM *is* wired into the hub
 router — appended to `MAC_ROUTER_PROVIDERS` at priority 0 — but **only for the
 model `Qwen/Qwen3.6-27B-FP8`**. Every fleet agent's `gateway_model` (in
-`~/.mac/fleets.yaml`, including hostb's *own* agent) is
+`~/.mac/fleets.yaml`, including gpu-node's *own* agent) is
 `azure/anthropic/claude-sonnet-4-6`, which routes to the cloud `nvidia` provider.
-No caller ever requests the model hostb serves, so a 48 GB RTX 6000 Ada sits idle
-on the LLM path. (hostb was additionally tailscale-offline at probe time.)
+No caller ever requests the model gpu-node serves, so a 48 GB RTX 6000 Ada sits idle
+on the LLM path. (gpu-node was additionally tailscale-offline at probe time.)
 
 **Why this sharpens the decision.** The Decision and Risks sections treat "GPU /
 model servers stay persistent services; they are not jobs" as a hard constraint,
-and the hostb node-readiness note above flagged the vLLM Deployment as the reason
+and the gpu-node node-readiness note above flagged the vLLM Deployment as the reason
 to time-slice rather than dedicate the GPU. The evidence collapses that tension:
-the brain has **no traffic to protect**, so hostb's GPU is the *easiest*, not the
+the brain has **no traffic to protect**, so gpu-node's GPU is the *easiest*, not the
 hardest, to hand to the elastic executor tier — dedicate it outright. The
 persistent-services principle still holds in general (it's right for a brain that
 *is* serving); it just doesn't currently apply to *this* GPU. A concrete
@@ -270,7 +270,7 @@ device-plugin + node-label draft for exactly this conversion lives at
 [`deploy/k8s/gpu-worker/`](../../deploy/k8s/gpu-worker/).
 
 (Method/caveat: the telemetry only captures hub-routed requests; a process hitting
-`hostb:8000` directly would not appear. Confirm with hostb's vLLM
+`gpu-node:8000` directly would not appear. Confirm with gpu-node's vLLM
 `/metrics request_success_total` before decommissioning the service.)
 
 ## Risks / non-goals

--- a/docs/dashboard-connection.md
+++ b/docs/dashboard-connection.md
@@ -41,13 +41,13 @@ contextBridge.exposeInMainWorld("macDashboard", {
     return {
       mode: "electron-managed",
       apiBaseUrl: "http://127.0.0.1:18789",
-      displayName: "Rocky / horde",
-      targetId: "fleet:rocky"
+      displayName: "hub / bastion",
+      targetId: "fleet:hub"
     };
   },
   async targets() {
     return [
-      { id: "fleet:rocky", label: "mac / rocky", mode: "fleet-direct" },
+      { id: "fleet:hub", label: "mac / hub", mode: "fleet-direct" },
       { id: "testing-url", label: "Testing URL", mode: "testing-url" }
     ];
   },

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ Think of MAC as a project office for AI workers:
 - Tenant: an isolated organization or personal deployment.
 - User: a human identity inside a tenant.
 - Persona: a Hermes personality and memory scope.
-- Hermes instance: a running named Hermes identity, such as Rocky.
+- Hermes instance: a running named Hermes identity, such as `worker-1`.
 - Platform binding: a Slack channel, Telegram chat, Discord channel, or similar
   place where Hermes talks to humans.
 - Fleet: a set of MAC machines and agents managed together.

--- a/docs/hermes-boundary.md
+++ b/docs/hermes-boundary.md
@@ -5,7 +5,7 @@ The system needs both roles.
 
 Without Hermes, OpenClaw, or an equivalent runtime, the control plane can track
 tasks and machines but has no conversational continuity, adaptive personality,
-or lived memory. Rocky, Bullwinkle, Natasha, and similar agents are not just
+or lived memory. `hub`, `worker-1`, `worker-2`, and similar agents are not just
 worker names; they are Hermes identities with souls, user context, prior
 conversation memory, and situational behavior.
 
@@ -42,7 +42,7 @@ instances:
 - `user`: a human inside a tenant.
 - `persona`: the durable identity contract for a Hermes agent, including
   `soul_ref` and `memory_scope`.
-- `hermes_instance`: a running or recoverable Hermes identity, such as Rocky.
+- `hermes_instance`: a running or recoverable Hermes identity, such as `worker-1`.
 - `platform_binding`: the Slack workspace/channel, Telegram chat, Discord
   guild/channel, or other message surface attached to a Hermes instance.
 

--- a/docs/memory-tier-schema.md
+++ b/docs/memory-tier-schema.md
@@ -5,9 +5,9 @@ vector writer (mem-07), nap consolidator (mem-08), recall API (mem-09),
 and health check (mem-10) build against. Amend by PR; the schema lives
 in code in `src/mac/models.py`.
 
-**Audit context:** the 2026-05-28 review of rocky's `mac.db` (3.1GB,
+**Audit context:** the 2026-05-28 review of the hub's `mac.db` (3.1GB,
 2.09M observability events) found that the Qdrant container was running
-on `100.125.137.89:6333` with **zero collections** and `vector_refs` had
+on `<mesh-ip>:6333` with **zero collections** and `vector_refs` had
 **zero rows**. The medium-term and long-term memory tiers documented in
 the design existed only as table stubs; no writer, no reader, no schema
 contract. This document closes that gap.

--- a/docs/memory-tier-verification.md
+++ b/docs/memory-tier-verification.md
@@ -3,10 +3,10 @@
 Verification record for the audit-driven memory-tier work shipped in
 mem-06 through mem-10 + mem-04 + mem-02 + mem-11 + mem-12 + mem-13.
 This document captures the operational evidence that the system works
-end to end on the rocky fleet, not just in unit tests.
+end to end on a live fleet, not just in unit tests.
 
 **Date:** 2026-05-30
-**Hub:** rocky (do-host1, Tailscale 100.125.137.89)
+**Hub:** hub (`<host>`, Tailscale `<mesh-ip>`)
 **Commits exercised:**
 `106abce` (mem-06 schema) →
 `898085e` (mem-07 writer) →
@@ -23,13 +23,13 @@ deselected.
 | Component | How | Result |
 |---|---|---|
 | **Qdrant provisioning** | `WORKSPACE=… bash deploy/install-qdrant-service.sh` with `MAC_MEMORY_EMBEDDING_DIM=2048` | Both `mac_memory_medium` and `mac_memory_long` collections created at the right dim with HNSW indexes. |
-| **Embedding via TokenHub** | `MAC_MEMORY_EMBED_BACKEND=tokenhub MAC_MEMORY_EMBED_MODEL=nvcf/nvidia/llama-3.2-nv-embedqa-1b-v2 mac memory backfill --limit 20` | 20/20 of rocky's real `memory_records` embedded into Qdrant with no failures. Vectors are 2048-dim from the real NVIDIA embedding model, not the hash stub. |
+| **Embedding via TokenHub** | `MAC_MEMORY_EMBED_BACKEND=tokenhub MAC_MEMORY_EMBED_MODEL=nvcf/nvidia/llama-3.2-nv-embedqa-1b-v2 mac memory backfill --limit 20` | 20/20 of the hub's real `memory_records` embedded into Qdrant with no failures. Vectors are 2048-dim from the real NVIDIA embedding model, not the hash stub. |
 | **Semantic recall (the actual test)** | `mac memory recall "github repository for the ACC project"` (paraphrased — no exact words match the stored content) | Top hit is the `repo-beads-acc` ACC project record at cosine score **0.4115**, with the next four hits all ACC-related task records at 0.36–0.37. The model successfully matched "github repository for ACC" → stored JSON about `jordanhubbard/ACC` without word-level overlap. |
 | **Round-trip recall** (write → embed → search → retrieve) | `tests/test_vector_writer_service.py::test_embed_memory_round_trip_recall_finds_the_record` | Three memories written, embedded, queried by one memory's content → that memory ranks #1 with score > 0.99 in fake Qdrant; in unit form for CI. |
 | **Consolidator + recall** | `tests/test_nap_consolidator.py::test_consolidate_and_recall_end_to_end` | Two agents author distinct memory_records, consolidator produces one nap_summary per agent, both summaries embed into Qdrant, recall against one summary's content returns that summary as top hit. |
 | **Structured dream artifacts** | `tests/test_nap_consolidator.py::test_consolidate_writes_structured_dream_artifact_with_evidence` and `::test_dream_artifacts_embed_with_payload_filters_and_recall_rules` | Nap consolidation writes typed `mac.dream.v1` records with evidence/scope/confidence/retrieval metadata; vector payload filters can recall only matching dream artifacts by project, agent, scope, kind, and confidence. |
-| **Real consolidator on rocky** | `mac nap consolidate agent_rocky` | agent_rocky's 31 real memory_records on rocky were consolidated into per-task summaries, each summary embedded into the medium tier; recall against one summary's content returned it at score 1.0. |
-| **Health check** | `mac memory health` against rocky | Schema `mac.memory_health.v1`. `memory_records_count: 362`, `vector_refs_count: 20`, `qdrant.collections.mac_memory_medium.points_count: 20` — all three numbers consistent. `observability_events_count: 545,297` (down from the audit's 2,088,341 thanks to mem-02 prune + mem-04 suppression). Alerts surface the `no_nap_history` warning correctly because no `nap_runs` row exists yet (consolidator was driven via CLI, not the nap lifecycle). |
+| **Real consolidator on the hub** | `mac nap consolidate agent_hub` | agent_hub's 31 real memory_records on the hub were consolidated into per-task summaries, each summary embedded into the medium tier; recall against one summary's content returned it at score 1.0. |
+| **Health check** | `mac memory health` against the hub | Schema `mac.memory_health.v1`. `memory_records_count: 362`, `vector_refs_count: 20`, `qdrant.collections.mac_memory_medium.points_count: 20` — all three numbers consistent. `observability_events_count: 545,297` (down from the audit's 2,088,341 thanks to mem-02 prune + mem-04 suppression). Alerts surface the `no_nap_history` warning correctly because no `nap_runs` row exists yet (consolidator was driven via CLI, not the nap lifecycle). |
 | **Defense-in-depth invariants** | unit tests for mem-11/12/13 | `operator_result` for repo-coupled tasks rejected at write (mem-11). Reviews capped at 3 retracts per task → fail (mem-12). `git ls-remote` verifies `pushed=true` claims (mem-13). |
 | **CLI parity** | `mac memory backfill / recall / health / embed` and `mac nap consolidate` | All work in both local (`--db`) and hub modes; remote dispatch wraps the HTTP routes. |
 
@@ -39,7 +39,7 @@ deselected.
   Qdrant → recall round-trips correctly on real data.
 * The embed backend is pluggable: hash for tests/offline, TokenHub
   for production semantic recall — and TokenHub is the path the
-  rocky fleet already uses (`OPENAI_API_KEY` + `OPENAI_BASE_URL`
+  fleet already uses (`OPENAI_API_KEY` + `OPENAI_BASE_URL`
   shipped pre-set in `~/.mac/mac.env`).
 * Semantic recall is real: a paraphrased query that shares **no exact
   words** with the stored content still returns the right memory as
@@ -61,7 +61,7 @@ runs `mac nap cycle <agent_id>` for each:
 |---|---|
 | `deploy/systemd/mac-nap-tick.{service,timer}` | Oneshot service + 15-min OnUnitActiveSec timer. Service body: `mac nap due | python -c (...extract agent_ids...) | xargs mac nap cycle`. |
 | `deploy/install-nap-tick-service.sh` | Installer mirroring `install-observability-prune.sh` (detects User= from mac.service, substitutes into template). Provisions `/etc/mac/nap-tick.env` with commented-out TokenHub embedding knobs. |
-| Verified on rocky | Cleared `agent_rocky`'s `last_completed_at`; ran `systemctl start mac-nap-tick.service`; service picked up agent_rocky, drove the full cycle (begin → consolidate → embed → complete), produced `nap_run=nap_c00be4c…` with `status=completed`, agent back to IDLE. No operator command in the chain. |
+| Verified on the hub | Cleared `agent_hub`'s `last_completed_at`; ran `systemctl start mac-nap-tick.service`; service picked up agent_hub, drove the full cycle (begin → consolidate → embed → complete), produced `nap_run=nap_c00be4c…` with `status=completed`, agent back to IDLE. No operator command in the chain. |
 
 What this means: between `mac memory backfill` (which embeds historic
 memory_records once) and the nap-tick timer (which catches newly

--- a/docs/metadata-sync-assessment.md
+++ b/docs/metadata-sync-assessment.md
@@ -98,7 +98,7 @@ issue rather than blocking the migration on it.
   autonomous-merge blocker; not a sync problem)
 - `mac-ykkc` (P0): reviewer review-claim retry storm (also blocks
   autonomous merge; bridge-off doesn't fix it)
-- `mac-zpku` (P0): bullwinkle macOS push auth (resolved on inspection;
+- `mac-zpku` (P0): worker-1 macOS push auth (resolved on inspection;
   deploy key is installed and `ssh -T git@github.com` works; v2
   failure was Hermes choosing not to push, not auth)
 - Schema cleanup (not yet filed): drop `acc_metadata.beads_*` and

--- a/docs/openshell-sandbox.md
+++ b/docs/openshell-sandbox.md
@@ -84,7 +84,7 @@ mac-openshell-supervisor --agent-id agent_rocky --policy "$MAC_OPENSHELL_POLICY"
 
 | Variable | Default | Meaning |
 | --- | --- | --- |
-| `MAC_OPENSHELL_REQUIRED` | rocky/bullwinkle/natasha required | fail closed when OpenShell/policy is unavailable |
+| `MAC_OPENSHELL_REQUIRED` | hub/worker-1/worker-2 required | fail closed when OpenShell/policy is unavailable |
 | `MAC_OPENSHELL_BIN` | `openshell` | path to the `openshell` binary |
 | `MAC_OPENSHELL_POLICY` | _(resolved)_ | explicit policy path; MAC-managed materialized policy should be set here |
 | `MAC_OPENSHELL_EVENTS_FILE` | _(none)_ | JSONL/OCSF event stream for `mac-openshell-collector` |
@@ -107,7 +107,7 @@ mac-openshell-supervisor --agent-id agent_rocky --policy "$MAC_OPENSHELL_POLICY"
    ```
    Confirm it begins with `openshell sandbox create … --policy … --` and ends
    with the Hermes argv.
-3. Start `mac-openshell-supervisor` on rocky, bullwinkle, and natasha. Confirm
+3. Start `mac-openshell-supervisor` on hub, worker-1, and worker-2. Confirm
    the gateway, task executor, finalizers, and Hermes sessions inherit the same
    sandbox id.
 4. Trigger an off-policy filesystem or network attempt. Confirm the denial

--- a/docs/soul-preservation-runbook.md
+++ b/docs/soul-preservation-runbook.md
@@ -106,8 +106,8 @@ produces no duplicate persona / instance / binding rows and that the
 
 - **`hermes_instances.last_seen_at` is registration freshness, not worker
   liveness.** It advances when the Hermes identity re-registers. Use the
-  `agents.last_seen_at`, lease, and heartbeat records to decide whether Rocky,
-  Natasha, Bullwinkle, or another worker process is alive and claim-capable.
+  `agents.last_seen_at`, lease, and heartbeat records to decide whether `hub`,
+  `worker-1`, `worker-2`, or another worker process is alive and claim-capable.
 - **`memory_scope` URI unreachable.** `mac` does not validate that the URI
   resolves — that's Hermes's responsibility. A broken URI manifests as a
   Hermes startup failure, not a `mac` error.

--- a/skills/setup-mac-fleet/SKILL.md
+++ b/skills/setup-mac-fleet/SKILL.md
@@ -123,7 +123,7 @@ available".
   Tailscale/Headscale mesh so the agent reaches the hub at its mesh IP.
 - **Deploy:** `make deploy HUB=<node>`; first hub on a fresh box:
   `bash setup.sh --new-hub <node> --target user@host`.
-- *Example:* the `mac` fleet hub `rocky` (`jkh@do-host1`) — Linux, systemd,
+- *Example:* the `mac` fleet hub `hub` (`<user>@<host>`) — Linux, systemd,
   Tailscale hub URL `http://<tailscale-ip>:8789`.
 
 ### Virtual-machine agents
@@ -134,7 +134,7 @@ available".
 - **OS / supervisor:** `linux`+`systemd` or `darwin`+`launchd` (or `auto`).
 - **Transport:** direct SSH or Tailscale/Headscale mesh.
 - **Deploy:** same commands as bare metal.
-- *Example:* `mac` fleet workers `natasha` / `bullwinkle` — Linux VMs/hosts under
+- *Example:* `mac` fleet workers `worker-1` / `worker-2` — Linux VMs/hosts under
   systemd, joined to the fleet mesh and reached by SSH.
 
 ### Containerized agents

--- a/tests/test_docs_no_operator_identity.py
+++ b/tests/test_docs_no_operator_identity.py
@@ -1,0 +1,106 @@
+"""Guard: checked-in docs/skills must read as generic for ANY fleet owner.
+
+The mac repo documents a *generic* fleet, never the maintainer's specific one.
+Operational identity — real agent names, the operator user, concrete hosts —
+belongs OUTSIDE git (in ~/.mac/specs / ~/.mac/fleets.yaml), not in the docs that
+travel with the repo. This test fails loudly the moment any such token sneaks
+back into a checked-in doc, skill, or deploy markdown file.
+
+It forbids BOTH de-personalized example schemes so neither fork's identity can
+leak: the maintainer's real fleet names (rocky/natasha/bullwinkle/madmax/puck/
+sparky/jkh/do-host...) AND the older mac-dev placeholders (hosta..hostf,
+worker2, devuser, agentuser). It does NOT forbid `jordanhubbard` / `NVIDIA-dev`
+— those are this fork's legitimate repo-org slug, not operator identity.
+
+Genericize new docs with READABLE role names instead: hub / worker-1 /
+worker-2 / gpu-worker, and placeholders like <user> / <host> / <mesh-ip>.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# This test file itself legitimately *names* the forbidden tokens (in the regex
+# and docstring), so it must be excluded from the scan.
+SELF = Path(__file__).resolve()
+
+# Operational-identity tokens that must never appear in a checked-in doc.
+# Matched word-boundary + case-insensitive. Includes the maintainer's real
+# fleet identity AND the de-personalized mac-dev example names, so neither
+# fork's example identity can come back.
+_TOKENS = [
+    "rocky",
+    "natasha",
+    "bullwinkle",
+    "madmax",
+    "puck",
+    "sparky",
+    "worker2",
+    "jkh",
+    "hosta",
+    "hostb",
+    "hostc",
+    "hostd",
+    "hoste",
+    "hostf",
+    "devuser",
+    "agentuser",
+]
+# Word-boundary, case-insensitive. `do-host` is matched specially below because
+# the hyphen is not a word character (so a trailing \b would behave oddly).
+IDENTITY = re.compile(
+    r"\b(?:" + "|".join(re.escape(t) for t in _TOKENS) + r")\b" r"|\bdo-host",
+    re.IGNORECASE,
+)
+
+
+def _scanned_files() -> list[Path]:
+    """git-tracked docs/skills/deploy-md/root-md, minus the excluded trees."""
+    out = subprocess.run(
+        ["git", "ls-files"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    files: list[Path] = []
+    for rel in out.stdout.splitlines():
+        # Exclusions first.
+        if rel.startswith("src/mac/_hermes/") or rel.startswith(".tickets/"):
+            continue
+        path = (ROOT / rel).resolve()
+        if path == SELF:
+            continue
+        # In-scope globs.
+        in_docs = rel.startswith("docs/")
+        in_skills = rel.startswith("skills/")
+        in_deploy_skills = rel.startswith("deploy/skills/")
+        in_deploy_md = rel.startswith("deploy/") and rel.endswith(".md")
+        in_root_md = "/" not in rel and rel.endswith(".md")
+        if in_docs or in_skills or in_deploy_skills or in_deploy_md or in_root_md:
+            files.append(path)
+    return files
+
+
+def test_docs_carry_no_operator_identity():
+    scanned = _scanned_files()
+    assert scanned, "expected to scan at least one checked-in doc/skill file"
+    offenders: list[str] = []
+    for path in scanned:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            match = IDENTITY.search(line)
+            if match:
+                offenders.append(
+                    "%s:%d: %r (matched %r)"
+                    % (path.relative_to(ROOT), lineno, line.strip(), match.group(0))
+                )
+    assert not offenders, (
+        "operator/per-fleet identity leaked into checked-in docs — the repo must "
+        "read as generic for any fleet owner. Replace with readable role names "
+        "(hub / worker-1 / worker-2 / gpu-worker) or placeholders "
+        "(<user> / <host> / <mesh-ip>):\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
Extends the bleed-through cleanup (#176) from fleet *files* to docs/skills *prose*: the system must read as generic for any fleet owner, not document the maintainer's specific fleet. Genericized ~60 operational-identity references across 15 docs/skills to readable placeholders/role names (`hub`, `worker-1/2`, `gpu-worker`, `<user>`, `<host>`, `<mesh-ip>`); rephrased "Rocky's hub polls…" → "the hub polls…".

**Kept** (legitimate, not bleed-through): the `jordanhubbard/…` repo-org URLs, public NVIDIA API endpoints, RFC/loopback IPs.

**Guard test** `tests/test_docs_no_operator_identity.py`: scans tracked docs/skills/markdown (excl. vendored `_hermes/`, `.tickets/`, itself) and fails on any operational-identity token (`rocky natasha bullwinkle madmax jkh do-host hosta hostb hostc hostd devuser agentuser …`, word-boundary, case-insensitive — incl. the de-personalized names so neither fork's identity can sneak in). Verified non-vacuous (fails on a planted violation). 7 tests pass.

Pairs with the same sweep in mac-dev so the forks converge on identical generic docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)