### PR TITLE
fix(docs): guard catches underscore-prefixed identity (agent_rocky) + fix missed occurrence

### DIFF
--- a/docs/openshell-sandbox.md
+++ b/docs/openshell-sandbox.md
@@ -77,7 +77,7 @@ $EDITOR /etc/mac/openshell-policy.yaml      # fill in __PLACEHOLDER__ tokens
 export MAC_OPENSHELL_POLICY=/etc/mac/openshell-policy.yaml
 export MAC_OPENSHELL_REQUIRED=1
 export MAC_ALLOW_UNSANDBOXED_YOLO=0
-mac-openshell-supervisor --agent-id agent_rocky --policy "$MAC_OPENSHELL_POLICY" -- mac-hermes-gateway
+mac-openshell-supervisor --agent-id agent_hub --policy "$MAC_OPENSHELL_POLICY" -- mac-hermes-gateway
 ```
 
 ### Environment knobs

--- a/tests/test_docs_no_operator_identity.py
+++ b/tests/test_docs_no_operator_identity.py
@@ -49,10 +49,13 @@ _TOKENS = [
     "devuser",
     "agentuser",
 ]
-# Word-boundary, case-insensitive. `do-host` is matched specially below because
-# the hyphen is not a word character (so a trailing \b would behave oddly).
+# Boundaries are alphanumeric-only (NOT \b), so an underscore counts as a
+# separator: this catches `agent_rocky` / `hermes_hosta` forms that a `\b`
+# regex misses because `_` is a word character. `do-host` is matched with the
+# same left boundary (the hyphen already terminates it on the right).
 IDENTITY = re.compile(
-    r"\b(?:" + "|".join(re.escape(t) for t in _TOKENS) + r")\b" r"|\bdo-host",
+    r"(?<![A-Za-z0-9])(?:" + "|".join(re.escape(t) for t in _TOKENS) + r")(?![A-Za-z0-9])"
+    r"|(?<![A-Za-z0-9])do-host",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
Closes a gap in the doc-identity guard (#177):  boundaries miss `agent_rocky`/`hermes_hosta` (underscore is a word char). Tightened to alphanumeric-only boundaries — now catches `_`-adjacent identity while staying clean on `localhostb`/`rockyroad`. Also fixes the one occurrence the sweep missed: `docs/openshell-sandbox.md` `agent_rocky`→`agent_hub`. 7 tests pass.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)