### PR TITLE
feat(task): reopen + force-complete recovery actions (recovery-gap fix)

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -438,6 +438,11 @@ class TransitionRequest(BaseModel):
     detail: Dict[str, Any] = Field(default_factory=dict)
 
 
+class TaskRecoveryRequest(BaseModel):
+    actor: str
+    reason: Optional[str] = None
+
+
 class EvidenceCreate(BaseModel):
     kind: str
     uri: str
@@ -4035,6 +4040,19 @@ def create_app(
     ) -> Dict[str, Any]:
         task, lease = cp.claim_task(task_id, agent_id, lease_seconds, sync_beads=False)
         return {"task": task.to_dict(), "lease": lease.to_dict()}
+
+    @app.post("/tasks/{task_id}/reopen")
+    def reopen_task(task_id: str, body: TaskRecoveryRequest) -> Dict[str, Any]:
+        # Recovery: return a stuck/terminal task (failed/cancelled/blocked) to
+        # OPEN so it can be retried or reconciled. Counterpart to force-complete.
+        return cp.reopen_task(task_id, body.actor, body.reason).to_dict()
+
+    @app.post("/tasks/{task_id}/force-complete")
+    def force_complete_task(task_id: str, body: TaskRecoveryRequest) -> Dict[str, Any]:
+        # Operator override: mark a task COMPLETED regardless of state/review,
+        # for reconciling work done out-of-band (e.g. merged via PR) or a task
+        # stranded in a terminal state. Bypasses the review gate (audited).
+        return cp.force_complete_task(task_id, body.actor, body.reason).to_dict()
 
     @app.post("/leases/{lease_id}/renew")
     def renew_lease(lease_id: str, body: LeaseRenewRequest) -> Dict[str, Any]:

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -492,6 +492,18 @@ def cmd_task_close(args: argparse.Namespace) -> None:
     _print(result)
 
 
+def cmd_task_reopen(args: argparse.Namespace) -> None:
+    # Recovery: return a stuck/terminal task to OPEN (failed/cancelled reset
+    # attempt_count so the requeue isn't immediately re-exhausted).
+    _print(_plane(args).reopen_task(args.task_id, args.actor, args.reason or None))
+
+
+def cmd_task_force_complete(args: argparse.Namespace) -> None:
+    # Operator override: mark a task COMPLETED regardless of state/review, for
+    # reconciling work done out-of-band or recovering a stranded terminal task.
+    _print(_plane(args).force_complete_task(args.task_id, args.actor, args.reason or None))
+
+
 def cmd_task_search(args: argparse.Namespace) -> None:
     cp = _plane(args)
     project = _effective_read_project(args)
@@ -2441,6 +2453,24 @@ def build_parser() -> argparse.ArgumentParser:
                        help="close as CANCELLED instead of COMPLETED")
     close.set_defaults(success=True)
     _set(cmd_task_close, close)
+
+    reopen = task.add_parser(
+        "reopen",
+        help="recovery: return a stuck/terminal task (failed/cancelled/blocked) to OPEN for retry or reconciliation",
+    )
+    reopen.add_argument("task_id")
+    reopen.add_argument("--reason", default="")
+    reopen.add_argument("--actor", default="human")
+    _set(cmd_task_reopen, reopen)
+
+    force_complete = task.add_parser(
+        "force-complete",
+        help="operator override: mark a task COMPLETED regardless of state/review (bypasses the review gate; audited)",
+    )
+    force_complete.add_argument("task_id")
+    force_complete.add_argument("--reason", default="")
+    force_complete.add_argument("--actor", default="human")
+    _set(cmd_task_force_complete, force_complete)
 
     search = task.add_parser("search", help="keyword search across task title and description")
     search.add_argument("query")

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -308,6 +308,24 @@ class RemoteDispatch:
         )
         return _Dictish(self._post("/tasks/%s/transition" % quote(task_id, safe=""), body))
 
+    def reopen_task(
+        self,
+        task_id: str,
+        actor: str,
+        reason: Optional[str] = None,
+    ) -> _Dictish:
+        body = _drop_none({"actor": actor, "reason": reason})
+        return _Dictish(self._post("/tasks/%s/reopen" % quote(task_id, safe=""), body))
+
+    def force_complete_task(
+        self,
+        task_id: str,
+        actor: str,
+        reason: Optional[str] = None,
+    ) -> _Dictish:
+        body = _drop_none({"actor": actor, "reason": reason})
+        return _Dictish(self._post("/tasks/%s/force-complete" % quote(task_id, safe=""), body))
+
     def start_task(self, task_id: str, agent_id: str) -> _Dictish:
         return _Dictish(
             self._post(

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -5103,6 +5103,76 @@ class ControlPlane:
         transitioned = self.get_task(task_id)
         return transitioned
 
+    def reopen_task(
+        self,
+        task_id: str,
+        actor: str,
+        reason: Optional[str] = None,
+    ) -> Task:
+        """Recovery action: return a stuck/terminal task to OPEN so it can be
+        retried or reconciled.
+
+        Valid from ``failed``/``cancelled`` (resets ``attempt_count`` and clears
+        ``completed_at`` so the requeue isn't immediately re-exhausted) and from
+        ``blocked``; the state machine rejects reopening an already-``completed``
+        task. Records who reopened it and why. Counterpart to
+        :meth:`force_complete_task`.
+        """
+        detail: Dict[str, Any] = {"via": "operator_reopen"}
+        if reason:
+            detail["reason"] = reason
+        return self.transition_task(task_id, TaskState.OPEN.value, actor, detail)
+
+    def force_complete_task(
+        self,
+        task_id: str,
+        actor: str,
+        reason: Optional[str] = None,
+    ) -> Task:
+        """Operator override: mark a task COMPLETED regardless of its current
+        state or review status.
+
+        For reconciling work done out-of-band (e.g. a task whose change merged
+        via a PR) or recovering a task stranded in a terminal state where the
+        normal review→publish path can no longer run. This deliberately bypasses
+        the review/evidence completion gate, so it records who forced it, the
+        prior state, and why. Recovery counterpart to :meth:`reopen_task`.
+        """
+        task = self.get_task(task_id)
+        if task.state == TaskState.COMPLETED.value:
+            return task
+        now = utcnow()
+        detail: Dict[str, Any] = {"via": "operator_force_complete", "from_state": task.state}
+        if reason:
+            detail["reason"] = reason
+        with self.store.transaction() as conn:
+            if task.lease_id:
+                conn.execute(
+                    "UPDATE leases SET status = ?, updated_at = ? WHERE id = ? AND status = ?",
+                    (LeaseStatus.RELEASED.value, now, task.lease_id, LeaseStatus.ACTIVE.value),
+                )
+            if task.owner_agent_id:
+                self._set_agent_idle(task.owner_agent_id, conn=conn)
+            conn.execute(
+                """
+                UPDATE tasks
+                SET state = ?, owner_agent_id = NULL, lease_id = NULL, leased_until = NULL,
+                    completed_at = COALESCE(completed_at, ?), updated_at = ?
+                WHERE id = ?
+                """,
+                (TaskState.COMPLETED.value, now, now, task_id),
+            )
+            self._record_history(
+                task_id,
+                "task.force_completed",
+                actor,
+                task.state,
+                TaskState.COMPLETED.value,
+                detail,
+                conn=conn,
+            )
+        return self.get_task(task_id)
+
     def claim_task(
         self,
         task_id: str,

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -466,6 +466,8 @@ network_policies:
     ctx["delete_task_id"] = task("route delete task", caps=["delete-only"])["id"]
     ctx["parent_task_id"] = task("route parent task")["id"]
     ctx["transition_task_id"] = task("route transition task")["id"]
+    ctx["reopen_task_id"] = task("route reopen task")["id"]
+    ctx["force_complete_task_id"] = task("route force-complete task")["id"]
     ctx["claim_task_id"] = task("route claim task")["id"]
     ctx["claim_next_task_id"] = task("route claim-next task")["id"]
     ctx["evidence_task_id"] = task("route evidence task")["id"]
@@ -882,6 +884,8 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("POST", "/tasks/{task_id}/children"): {"task_id": "parent_task_id"},
         ("DELETE", "/tasks/{task_id}"): {"task_id": "delete_task_id"},
         ("POST", "/tasks/{task_id}/transition"): {"task_id": "transition_task_id"},
+        ("POST", "/tasks/{task_id}/reopen"): {"task_id": "reopen_task_id"},
+        ("POST", "/tasks/{task_id}/force-complete"): {"task_id": "force_complete_task_id"},
         ("POST", "/tasks/{task_id}/claim"): {"task_id": "claim_task_id"},
         ("POST", "/tasks/{task_id}/start"): {"task_id": "start_task_id"},
         ("POST", "/tasks/{task_id}/submit-for-review"): {"task_id": "submit_task_id"},
@@ -1106,6 +1110,14 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
             "target_state": "blocked",
             "actor": "operator",
             "detail": {"reason": "route coverage transition"},
+        },
+        ("POST", "/tasks/{task_id}/reopen"): {
+            "actor": "operator",
+            "reason": "route coverage reopen",
+        },
+        ("POST", "/tasks/{task_id}/force-complete"): {
+            "actor": "operator",
+            "reason": "route coverage force-complete",
         },
         ("POST", "/leases/{lease_id}/renew"): {"agent_id": ctx["lease_agent_id"], "lease_seconds": 120},
         ("POST", "/leases/{lease_id}/delegate"): {

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -7056,3 +7056,47 @@ def test_project_repository_registry_migrates_from_legacy_beads_table(tmp_path):
         "SELECT name FROM sqlite_master WHERE type='table' AND name='beads_repositories'"
     ).fetchone()
     assert legacy is None
+
+
+def test_reopen_task_requeues_terminal_task_and_resets_attempts(cp):
+    """Recovery: a failed task (e.g. flap-killed) can be reopened back to OPEN,
+    clearing the owner/lease and resetting attempt_count so the requeue is not
+    immediately re-exhausted."""
+    worker = register_agent(cp, "recover-worker", ["python"])
+    task = cp.create_task("recover me", required_capabilities=["python"])
+    cp.claim_task(task.id, worker.id, sync_beads=False)
+    cp.transition_task(task.id, TaskState.FAILED.value, "dispatcher", {"reason": "heartbeat_offline"})
+    assert cp.get_task(task.id).state == TaskState.FAILED.value
+
+    reopened = cp.reopen_task(task.id, "operator", reason="hub flap; retry")
+    assert reopened.state == TaskState.OPEN.value
+    assert reopened.owner_agent_id is None
+    assert reopened.lease_id is None
+    assert reopened.attempt_count == 0
+    hist = cp.task_history(task.id)
+    assert hist[-1].to_state == TaskState.OPEN.value
+    assert hist[-1].detail.get("via") == "operator_reopen"
+
+
+def test_reopen_task_recovers_blocked_task(cp):
+    task = cp.create_task("blocked recover", required_capabilities=["python"])
+    cp.transition_task(task.id, TaskState.BLOCKED.value, "dispatcher", {})
+    reopened = cp.reopen_task(task.id, "operator")
+    assert reopened.state == TaskState.OPEN.value
+
+
+def test_force_complete_overrides_review_gate_for_stranded_task(cp):
+    """Operator override: a task stranded in a terminal state (or whose work
+    merged out-of-band) can be force-completed without the review/evidence gate,
+    and the override is audited (who, prior state, why)."""
+    task = cp.create_task("done out of band", required_capabilities=["python"])
+    cp.transition_task(task.id, TaskState.FAILED.value, "dispatcher", {"reason": "flap"})
+
+    completed = cp.force_complete_task(task.id, "operator", reason="merged via PR #181")
+    assert completed.state == TaskState.COMPLETED.value
+    assert completed.completed_at is not None
+    assert completed.owner_agent_id is None
+    hist = cp.task_history(task.id)
+    assert hist[-1].event_type == "task.force_completed"
+    assert hist[-1].detail.get("reason") == "merged via PR #181"
+    assert hist[-1].detail.get("from_state") == TaskState.FAILED.value


### PR DESCRIPTION
## Why
A task stranded in a **terminal** state (`failed`/`cancelled`) or `blocked` had **no operator path** back to `OPEN` or `COMPLETED`. So flap-killed tasks couldn't be retried and out-of-band-done work (e.g. a change merged via PR) couldn't be reconciled in the ledger — the hub rejects `failed → completed` with HTTP 400. This is the recovery-gap surfaced during the live-fleet diagnosis (and why the corrected-G2 ticket is stuck `failed`).

## What
- **`ControlPlane.reopen_task`** — `failed`/`cancelled`/`blocked` → `OPEN`. Reuses `transition_task`'s dead-letter requeue, so it resets `attempt_count` and clears `completed_at`/owner/lease (a flap-killed task isn't immediately re-exhausted). The state machine already permits these transitions; this exposes them as an operator action.
- **`ControlPlane.force_complete_task`** — operator override → `COMPLETED` from any state, **bypassing the review/evidence gate**, for reconciling work done out-of-band or recovering a stranded terminal task. Audited via a `task.force_completed` history event (actor, prior state, reason).
- **API**: `POST /tasks/{id}/reopen`, `POST /tasks/{id}/force-complete` (write scope, like `transition`).
- **Hub proxies** (`RemoteDispatch`) + **CLI**: `mac task reopen <id> [--reason]`, `mac task force-complete <id> [--reason]`.

## Tests
3 behavior tests (reopen-from-failed resets attempts; reopen-from-blocked; force-complete overrides the gate and audits) + route-coverage cases for the 2 new routes. Full suite: **1862 passed, 0 failed**.

> Reconciling the live `corrected-G2` ticket with `mac task force-complete` requires the hub (rocky) to be redeployed with this code; the running hub doesn't have the endpoint yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)