### PR TITLE
Harden canonical publication and sandbox execution

### DIFF
--- a/deploy/codex-runner/mac-task-executor-opencode-build
+++ b/deploy/codex-runner/mac-task-executor-opencode-build
@@ -89,8 +89,11 @@ REPO_URL=""
 REPO_BRANCH="main"
 PROJECT=""
 if [ -n "${MAC_URL}" ] && [ -n "${MAC_TASK_ID}" ] && [ -n "${MAC_WORKER_TOKEN}" ]; then
-    task_json="$(curl -fsS -H "Authorization: Bearer ${MAC_WORKER_TOKEN}" \
-        "${MAC_URL}/tasks/${MAC_TASK_ID}" 2>/dev/null || true)"
+    task_json="$(curl -fsS --config - \
+        "${MAC_URL}/tasks/${MAC_TASK_ID}" 2>/dev/null <<CURL || true
+header = "Authorization: Bearer ${MAC_WORKER_TOKEN}"
+CURL
+)"
     if [ -n "${task_json}" ]; then
         eval "$(printf '%s' "${task_json}" | python3 -c '
 import json, shlex, sys
@@ -144,8 +147,11 @@ print("SKIP_PR_OPEN=%s" % ("true" if meta.get("skip_pr_open") else ""))
     fi
     # If task didn't carry the repo URL, fall back to project metadata. GET /projects/{name} returns a wrapper {project, summary, record, tasks,...}; the project record (with its metadata) is nested under `record`.
     if [ -z "${REPO_URL}" ] && [ -n "${PROJECT}" ]; then
-        project_json="$(curl -fsS -H "Authorization: Bearer ${MAC_WORKER_TOKEN}" \
-            "${MAC_URL}/projects/${PROJECT}" 2>/dev/null || true)"
+        project_json="$(curl -fsS --config - \
+            "${MAC_URL}/projects/${PROJECT}" 2>/dev/null <<CURL || true
+header = "Authorization: Bearer ${MAC_WORKER_TOKEN}"
+CURL
+)"
         if [ -n "${project_json}" ]; then
             eval "$(printf '%s' "${project_json}" | python3 -c '
 import json, shlex, sys

--- a/deploy/codex-runner/mac-task-executor-opencode-review
+++ b/deploy/codex-runner/mac-task-executor-opencode-review
@@ -85,8 +85,11 @@ fi
 
 PROMPT="Review task ${MAC_TASK_ID} (target evidence ${REVIEW_TARGET})"
 if [ -n "${MAC_URL}" ] && [ -n "${MAC_TASK_ID}" ] && [ -n "${MAC_WORKER_TOKEN}" ]; then
-    task_json="$(curl -fsS -H "Authorization: Bearer ${MAC_WORKER_TOKEN}" \
-        "${MAC_URL}/tasks/${MAC_TASK_ID}" 2>/dev/null || true)"
+    task_json="$(curl -fsS --config - \
+        "${MAC_URL}/tasks/${MAC_TASK_ID}" 2>/dev/null <<CURL || true
+header = "Authorization: Bearer ${MAC_WORKER_TOKEN}"
+CURL
+)"
     if [ -n "${task_json}" ]; then
         PROMPT="$(printf '%s' "${task_json}" | python3 -c 'import json,sys
 d=json.load(sys.stdin)

--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -2,6 +2,15 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Direct fleet deploys use the same authoritative operator configuration as
+# setup.py. Load it before any deployment defaults are derived so callers do
+# not have to remember a separate `source ~/.mac/.env` step.
+DEPLOY_ENV_FILE="${MAC_DEPLOY_ENV_FILE:-$HOME/.mac/.env}"
+if [ -f "$DEPLOY_ENV_FILE" ]; then
+  set -a
+  . "$DEPLOY_ENV_FILE"
+  set +a
+fi
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 TMPDIR_LOCAL="${TMPDIR:-/tmp}/mac-fleet-deploy-${TS}.$$"
 ARCHIVE="${TMPDIR_LOCAL}/mac.tar.gz"
@@ -1008,6 +1017,50 @@ exec "$bs" $MAC_DEPLOY_OPENSHELL_ARGS
 REMOTE
   then
     echo "==> ${agent}: WARNING: OpenShell bootstrap exited non-zero (non-fatal; re-run $mac_home/src/mac/deploy/openshell/bootstrap-openshell.sh by hand)" >&2
+  fi
+}
+
+validate_router_topology_spec() {
+  # Local, read-only preflight. Run before tunnels, archive copies, or remote
+  # service/source mutation so an incomplete inproc topology cannot replace a
+  # working deployment with a process-healthy but model-dead configuration.
+  local spec="$1" hub_token="${2:-}" agent hub_url shared_services_manager
+  local router_backend router_backend_lc router_providers local_token
+  IFS='|' read -r agent _ _ _ _ _ _ hub_url _ _ _ _ _ _ _ shared_services_manager _ <<<"$spec"
+  router_backend="$(fleet_scoped_env MAC_ROUTER_BACKEND "$agent")"
+  router_backend_lc="$(printf '%s' "$router_backend" | tr 'A-Z' 'a-z')"
+  [ "$router_backend_lc" = "inproc" ] || return 0
+  if [ "$agent" = "$shared_services_manager" ]; then
+    router_providers="$(fleet_scoped_env MAC_ROUTER_PROVIDERS "$agent")"
+    if [ -z "$router_providers" ]; then
+      echo "ERROR: ${agent}: inproc router hub requires MAC_ROUTER_PROVIDERS (exported remotely as MAC_DEPLOY_ROUTER_PROVIDERS)" >&2
+      return 1
+    fi
+    local provider_spec
+    while IFS= read -r provider_spec; do
+      [ -n "$provider_spec" ] || continue
+      case ",$provider_spec," in
+        *,key=secret:*) ;;
+        *)
+          echo "ERROR: ${agent}: every inproc router provider must use key=secret:<name>" >&2
+          return 1
+          ;;
+      esac
+    done < <(printf '%s' "$router_providers" | tr ';' '\n')
+    return 0
+  fi
+  if [ -z "$hub_url" ]; then
+    echo "ERROR: ${agent}: inproc router spoke requires a hub URL" >&2
+    return 1
+  fi
+  if [ -z "$hub_token" ]; then
+    echo "ERROR: ${agent}: inproc router spoke requires a hub-facing token" >&2
+    return 1
+  fi
+  local_token="$(fleet_scoped_env MAC_API_TOKEN "$agent")"
+  if [ -n "$local_token" ] && [ "$hub_token" = "$local_token" ]; then
+    echo "ERROR: ${agent}: inproc router spoke hub token must differ from its local MAC_API_TOKEN" >&2
+    return 1
   fi
 }
 
@@ -4561,10 +4614,12 @@ mark_worker_offline() {
   local agent_id
   agent_id="${MAC_WORKER_AGENT_ID:-$(stable_agent_id)}"
   curl -fsS --max-time 10 -X POST \
-    -H "Authorization: Bearer $MAC_WORKER_TOKEN" \
     -H "Content-Type: application/json" \
+    --config - \
     --data '{"status":"offline","health_status":"degraded"}' \
-    "$MAC_HUB_URL/agents/$agent_id/heartbeat" >/dev/null || true
+    "$MAC_HUB_URL/agents/$agent_id/heartbeat" >/dev/null <<CURL || true
+header = "Authorization: Bearer $MAC_WORKER_TOKEN"
+CURL
 }
 trap mark_worker_offline TERM INT
 
@@ -4575,7 +4630,6 @@ fi
 common=(
   "$HOME/.mac/venv/bin/mac-agent"
   --url "$MAC_HUB_URL"
-  --token "$MAC_WORKER_TOKEN"
   --register
   --agent-id "${MAC_AGENT_ID:-$(stable_agent_id)}"
   --agent-name "$agent_name"
@@ -5484,8 +5538,10 @@ verify_hub_registration() {
   log "verifying mac-agent registration with hub ${check_url}"
   local attempt
   for attempt in $(seq 1 10); do
-    if curl -fsS --max-time 10 -H "Authorization: Bearer $token" \
-      "${check_url}/agents" > "$LOG_DIR/hub-agents.json"; then
+    if curl -fsS --max-time 10 --config - \
+      "${check_url}/agents" > "$LOG_DIR/hub-agents.json" <<CURL; then
+header = "Authorization: Bearer $token"
+CURL
       if "$PY" - "$LOG_DIR/hub-agents.json" "${MAC_WORKER_AGENT_NAME:-$AGENT}" <<'PY'; then
 import json
 import sys
@@ -5542,9 +5598,11 @@ fi
 
 log "verifying mac health and Hermes startup report"
 curl -fsS "http://127.0.0.1:$MAC_PORT/health" > "$LOG_DIR/health.json"
-curl -fsS -H "Authorization: Bearer $MAC_API_TOKEN" \
+curl -fsS --config - \
   "http://127.0.0.1:$MAC_PORT/startup/hermes" \
-  > "$LOG_DIR/startup-hermes.json"
+  > "$LOG_DIR/startup-hermes.json" <<CURL
+header = "Authorization: Bearer $MAC_API_TOKEN"
+CURL
 "$PY" - "$LOG_DIR/startup-hermes.json" <<'PY'
 import json
 import sys
@@ -5818,6 +5876,7 @@ main() {
       hub_token="$(read_hub_token)"
       upsert_local_env "$hub_token_key" "$hub_token"
     fi
+    validate_router_topology_spec "$spec" "$hub_token"
     allow_degraded_services=0
     if [ "$agent" != "$hub_agent" ] && [ "$direct_mesh_hub" != "1" ]; then
       # Detect brand-new nodes: if the remote mac API is unreachable before deploy,

--- a/src/mac/agent_command.py
+++ b/src/mac/agent_command.py
@@ -1,0 +1,80 @@
+"""Run a fleet agent without placing its task prompt in the OS process argv."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+PROMPT_SENTINEL = "__MAC_PROMPT_FROM_PRIVATE_FILE__"
+
+
+def _read_private_inputs(command_file: Path, prompt_file: Path) -> tuple[list[str], str]:
+    try:
+        loaded = json.loads(command_file.read_text(encoding="utf-8"))
+        argv = loaded.get("argv") if isinstance(loaded, dict) else None
+        if not isinstance(argv, list) or not argv or not all(isinstance(arg, str) for arg in argv):
+            raise ValueError("agent command file must contain a non-empty string argv")
+        prompt = prompt_file.read_text(encoding="utf-8")
+        if argv.count(PROMPT_SENTINEL) != 1:
+            raise ValueError("agent command must contain exactly one prompt sentinel")
+        return list(argv), prompt
+    finally:
+        # Inputs are single-use. Unlink before the long-running agent starts so
+        # credentials/task text do not linger in a copied sandbox workspace.
+        command_file.unlink(missing_ok=True)
+        prompt_file.unlink(missing_ok=True)
+
+
+def _is_hermes_module(argv: Sequence[str]) -> bool:
+    return len(argv) >= 4 and argv[1:3] == ["-m", "hermes_cli.main"]
+
+
+def _run_hermes_in_process(argv: list[str], prompt: str) -> int:
+    # The wrapper already runs under the selected Hermes interpreter. Running
+    # the module in-process keeps the real prompt out of /proc/<pid>/cmdline.
+    sys.argv = ["hermes_cli.main", *argv[3:]]
+    sys.argv[sys.argv.index(PROMPT_SENTINEL)] = prompt
+    try:
+        runpy.run_module("hermes_cli.main", run_name="__main__", alter_sys=False)
+    except SystemExit as exc:
+        return int(exc.code or 0) if isinstance(exc.code, (int, type(None))) else 1
+    return 0
+
+
+def _run_external_with_stdin(argv: list[str], prompt: str) -> int:
+    sentinel_index = argv.index(PROMPT_SENTINEL)
+    executable = Path(argv[0]).name.lower()
+    if executable in {"codex", "codex.exe"} or (
+        len(argv) > 1 and argv[1] == "exec"
+    ):
+        argv[sentinel_index] = "-"
+    else:
+        # Claude, Cursor, and explicit command overrides consume the prompt on
+        # stdin. This is the only supported override contract because appending
+        # prompt text to argv exposes it for the lifetime of the child process.
+        del argv[sentinel_index]
+    completed = subprocess.run(argv, input=prompt, text=True, check=False)
+    return int(completed.returncode)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--command-file", required=True)
+    parser.add_argument("--prompt-file", required=True)
+    args = parser.parse_args(argv)
+    command, prompt = _read_private_inputs(
+        Path(args.command_file), Path(args.prompt_file)
+    )
+    if _is_hermes_module(command):
+        return _run_hermes_in_process(command, prompt)
+    return _run_external_with_stdin(command, prompt)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -490,18 +490,16 @@ def _apply_inproc_router_hub(
         values["MAC_ROUTER_DEFAULT_MODEL"] = router["default_model"]
     if router["wildcard_models"]:
         values["MAC_ROUTER_WILDCARD_MODELS"] = router["wildcard_models"]
-    if router["providers"]:
-        values["MAC_ROUTER_PROVIDERS"] = router["providers"]
-        local_router_v1 = "http://127.0.0.1:%s/v1" % cfg.control.port
-        values["OPENAI_BASE_URL"] = local_router_v1
-        values["CUSTOM_BASE_URL"] = local_router_v1
-        values["MAC_HERMES_GATEWAY_BASE_URL"] = local_router_v1
-        values["ACC_HERMES_GATEWAY_BASE_URL"] = local_router_v1
-        local_token = values.get("MAC_API_TOKEN") or ""
-        if local_token:
-            values["OPENAI_API_KEY"] = local_token
-            values["MAC_HERMES_GATEWAY_API_KEY"] = local_token
-            values["ACC_HERMES_GATEWAY_API_KEY"] = local_token
+    values["MAC_ROUTER_PROVIDERS"] = router["providers"]
+    local_router_v1 = "http://127.0.0.1:%s/v1" % cfg.control.port
+    values["OPENAI_BASE_URL"] = local_router_v1
+    values["CUSTOM_BASE_URL"] = local_router_v1
+    values["MAC_HERMES_GATEWAY_BASE_URL"] = local_router_v1
+    values["ACC_HERMES_GATEWAY_BASE_URL"] = local_router_v1
+    local_token = values["MAC_API_TOKEN"]
+    values["OPENAI_API_KEY"] = local_token
+    values["MAC_HERMES_GATEWAY_API_KEY"] = local_token
+    values["ACC_HERMES_GATEWAY_API_KEY"] = local_token
     # Modality reverse-proxies (image/audio/video): set the upstream + vault key
     # ref when a key for that modality is available. The image key is DISTINCT
     # from the chat key — prefer NVIDIA_IMAGE_API_KEY (set at cluster init), fall
@@ -524,16 +522,10 @@ def _apply_inproc_router_hub(
 
 def _apply_inproc_router_spoke(values: MutableMapping[str, str], cfg: DeployEnvConfig) -> None:
     """Spoke: route the gateway (chat + image) through the hub's /v1 with the
-    hub-facing token and hold no upstream keys. Leaves the gateway unconfigured
-    when there is no usable hub token — never points at the hub with the
-    degenerate local token."""
+    validated hub-facing token and hold no upstream keys."""
     hub_base = (values.get("MAC_HUB_URL") or cfg.control.hub_url or "").rstrip("/")
     local_token = values.get("MAC_API_TOKEN") or ""
-    hub_token = cfg.control.hub_token or values.get("MAC_WORKER_TOKEN") or ""
-    if hub_token and hub_token == local_token:
-        hub_token = ""
-    if not hub_base or not hub_token:
-        return
+    hub_token = (cfg.control.hub_token or values.get("MAC_WORKER_TOKEN") or "").strip()
     hub_v1 = "%s/v1" % hub_base
     values["OPENAI_BASE_URL"] = hub_v1
     values["CUSTOM_BASE_URL"] = hub_v1
@@ -551,6 +543,38 @@ def _apply_inproc_router(
 ) -> None:
     """Clear stale routing/provider state, then configure the hub to run the
     router or a spoke to route through it (credentials centralize on the hub)."""
+    router = _deploy_router_config(env)
+    if cfg.identity.is_hub:
+        if not router["providers"]:
+            raise ValueError(
+                "inproc router hub requires MAC_DEPLOY_ROUTER_PROVIDERS"
+            )
+        invalid_specs = [
+            spec
+            for spec in router["providers"].split(";")
+            if spec.strip() and "key=secret:" not in spec
+        ]
+        if invalid_specs:
+            raise ValueError(
+                "inproc router providers must use key=secret:<name>: %s"
+                % ";".join(invalid_specs)
+            )
+        if not (values.get("MAC_API_TOKEN") or "").strip():
+            raise ValueError("inproc router hub requires a local MAC_API_TOKEN")
+    else:
+        hub_base = (values.get("MAC_HUB_URL") or cfg.control.hub_url or "").strip()
+        local_token = (values.get("MAC_API_TOKEN") or "").strip()
+        hub_token = (
+            cfg.control.hub_token or values.get("MAC_WORKER_TOKEN") or ""
+        ).strip()
+        if not hub_base:
+            raise ValueError("inproc router spoke requires MAC_HUB_URL")
+        if not hub_token:
+            raise ValueError("inproc router spoke requires a hub-facing token")
+        if hub_token == local_token:
+            raise ValueError(
+                "inproc router spoke requires a hub-facing token distinct from MAC_API_TOKEN"
+            )
     _clear(values, INPROC_MANAGED_KEYS)
     if cfg.identity.is_hub:
         _apply_inproc_router_hub(values, cfg, env)

--- a/src/mac/executor-policy.txt
+++ b/src/mac/executor-policy.txt
@@ -1,0 +1,27 @@
+mac.executor_policy.v1
+
+Fleet workers are autonomous: do not ask the operator for confirmation. Use
+task.json as the source of truth, preserve secrets, and never print bearer
+tokens. Work only in the prepared task worktree. Registered source checkouts
+are read-only except for an explicit source-remediation task.
+
+For repository work, run the declared bootstrap when required, run the exact
+contract test, and commit all intended files. Source/build/dependency/runtime
+changes require a passing CodeGraph sync/affected audit. Do not push directly;
+the deterministic host finalizer validates canonical freshness, tests,
+CodeGraph, worktree cleanliness, and publication.
+
+Write $MAC_TASK_WORKSPACE/mac-evidence.json using mac.worker_evidence.v1 with
+status=complete and an accurate evidence_type. Repository evidence includes
+head/base/ref, dirty=false, files_changed, tests/checks, and CodeGraph where
+required. Deployment evidence includes targets/services and passing checks.
+Non-repository directives may use operator_result. Never claim unverified work.
+
+Install software only in the task workspace/project environment—not with sudo,
+host package managers, global npm/pip/pipx, or the shared worker/Hermes venv.
+Record task-local dependency changes under verification.environment_delta with
+the package manager, commands, dependencies, lockfile path/digest, base runtime
+digest when known, and reason.
+
+Checked-in docs/examples must be fleet-generic: use role names and placeholders,
+not real usernames, hosts, personal paths, tokens, or local fleet identities.

--- a/src/mac/gitops.py
+++ b/src/mac/gitops.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
 import os
 import re
+import subprocess
+import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, field as dataclass_field
+from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import quote as _quote, urlparse, urlsplit, urlunsplit
 
@@ -16,6 +21,93 @@ class PullRequestResult:
     number: int
     url: str
     state: str
+
+
+_GIT_REMOTE_URL_RE = re.compile(
+    r"^(?:https?://|ssh://|git://|file://|git@|/)[A-Za-z0-9._\-:/@%+~?=&]*$"
+)
+_GIT_REF_RE = re.compile(r"^[A-Za-z0-9._/\-]+$")
+_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def validate_git_remote_url(value: str) -> str:
+    """Validate a remote URL before it is passed to git as an argument."""
+    if not value or value.startswith("-"):
+        raise ValueError("git remote URL is empty or looks like a flag: %r" % value)
+    if len(value) > 2048:
+        raise ValueError("git remote URL exceeds 2048 byte limit")
+    if not _GIT_REMOTE_URL_RE.match(value):
+        raise ValueError("git remote URL does not match a recognised scheme: %r" % value)
+    if value.startswith(("https://", "http://")) and urlsplit(value).username:
+        raise ValueError(
+            "git remote URL must not embed credentials; use environment-backed authentication"
+        )
+    return value
+
+
+def validate_git_ref(value: str) -> str:
+    """Validate a branch/ref component before it is passed to git."""
+    if not value or value.startswith("-"):
+        raise ValueError("git ref is empty or looks like a flag: %r" % value)
+    if len(value) > 512:
+        raise ValueError("git ref exceeds 512 byte limit")
+    if not _GIT_REF_RE.match(value):
+        raise ValueError("git ref contains disallowed characters: %r" % value)
+    if (
+        value.startswith("/")
+        or value.endswith(("/", "."))
+        or ".." in value
+        or "//" in value
+        or "@{" in value
+        or any(part.endswith(".lock") for part in value.split("/"))
+    ):
+        raise ValueError("git ref has an invalid shape: %r" % value)
+    return value
+
+
+@dataclass(frozen=True)
+class CanonicalPublicationTarget:
+    """The exact canonical source and task destination used by a guarded push."""
+
+    worktree: Path
+    canonical_remote_url: str = dataclass_field(repr=False)
+    remote: str = dataclass_field(repr=False)
+    remote_display: str
+    canonical_branch: str
+    destination_branch: str
+    prepared_base_sha: str
+    task_head_sha: str
+    isolated_ref: str
+    git_common_dir: Path
+    lock_path: Path
+
+
+@dataclass(frozen=True)
+class CanonicalFreshnessResult:
+    ok: bool
+    target: Optional[CanonicalPublicationTarget]
+    head_sha: str = ""
+    canonical_tip_sha: str = ""
+    files_changed: Tuple[str, ...] = ()
+    error: str = ""
+    push_returncode: Optional[int] = None
+    push_stdout: str = ""
+    push_stderr: str = ""
+    remote_verified: bool = False
+
+    def evidence(self) -> dict[str, object]:
+        target = self.target
+        return {
+            "ok": self.ok,
+            "remote": target.remote_display if target else "",
+            "canonical_branch": target.canonical_branch if target else "",
+            "prepared_base_sha": target.prepared_base_sha if target else "",
+            "canonical_tip_sha": self.canonical_tip_sha,
+            "task_head_sha": self.head_sha or (target.task_head_sha if target else ""),
+            "isolated_ref": target.isolated_ref if target else "",
+            "ancestry_valid": self.ok,
+            "error": self.error,
+        }
 
 
 def detect_host(repo_url: str) -> str:
@@ -107,6 +199,361 @@ def redact_git_remote_auth_in_text(value: str) -> str:
     if "://" not in text or "@" not in text:
         return text
     return _AUTHED_HTTP_REMOTE_RE.sub(r"\1\2:<redacted>@\4", text)
+
+
+def _run_git(worktree: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    argv = ["git", *args]
+    try:
+        return subprocess.run(
+            argv,
+            cwd=str(worktree),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        return subprocess.CompletedProcess(argv, 127, "", str(exc))
+
+
+def _git_failure(proc: subprocess.CompletedProcess[str], fallback: str) -> str:
+    detail = (proc.stderr or proc.stdout or "").strip() or fallback
+    return redact_git_remote_auth_in_text(detail)
+
+
+def resolve_canonical_publication_target(
+    *,
+    worktree: Path,
+    canonical_remote: str,
+    canonical_branch: str,
+    destination_branch: str,
+    prepared_base_sha: str,
+    isolation_key: str,
+) -> CanonicalPublicationTarget:
+    """Resolve and validate the immutable target reused by check and push."""
+    root = Path(worktree).expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError("publication worktree is missing: %s" % root)
+    inside = _run_git(root, ["rev-parse", "--is-inside-work-tree"])
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        raise ValueError("publication worktree is not a git worktree: %s" % root)
+    try:
+        canonical_branch = validate_git_ref(str(canonical_branch or "").strip())
+        destination_branch = validate_git_ref(str(destination_branch or "").strip())
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    for branch in (canonical_branch, destination_branch):
+        checked = _run_git(root, ["check-ref-format", "--branch", branch])
+        if checked.returncode != 0:
+            raise ValueError("git branch failed check-ref-format: %r" % branch)
+
+    remote_value = str(canonical_remote or "").strip()
+    try:
+        validate_git_remote_url(remote_value)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+
+    prepared = str(prepared_base_sha or "").strip()
+    if not prepared:
+        raise ValueError("prepared repository base SHA is missing")
+    if not _GIT_SHA_RE.fullmatch(prepared):
+        raise ValueError("prepared repository base SHA is invalid: %r" % prepared)
+    prepared_commit = _run_git(
+        root, ["rev-parse", "--verify", "%s^{commit}" % prepared]
+    )
+    if prepared_commit.returncode != 0 or prepared_commit.stdout.strip() != prepared:
+        raise ValueError("prepared repository base is not a commit: %s" % prepared)
+
+    head = _run_git(root, ["rev-parse", "--verify", "HEAD^{commit}"])
+    task_head = head.stdout.strip()
+    if head.returncode != 0 or not _GIT_SHA_RE.fullmatch(task_head):
+        raise ValueError(
+            "could not resolve task HEAD: %s" % _git_failure(head, "invalid SHA")
+        )
+    prepared_ancestor = _run_git(
+        root, ["merge-base", "--is-ancestor", prepared, task_head]
+    )
+    if prepared_ancestor.returncode != 0:
+        raise ValueError(
+            "prepared base %s is not an ancestor of task HEAD %s"
+            % (prepared[:12], task_head[:12])
+        )
+
+    key = str(isolation_key or "").strip()
+    if not key:
+        raise ValueError("publication isolation key is missing")
+    isolated_ref = _isolated_publication_ref(key)
+    ref_check = _run_git(root, ["check-ref-format", isolated_ref])
+    if ref_check.returncode != 0:
+        raise ValueError("isolated publication ref failed check-ref-format: %r" % isolated_ref)
+
+    common, common_error = _git_common_directory(root)
+    if common is None:
+        raise ValueError(common_error)
+
+    authed = inject_git_remote_auth(remote_value)
+    return CanonicalPublicationTarget(
+        worktree=root,
+        canonical_remote_url=remote_value,
+        remote=authed,
+        remote_display=redact_git_remote_auth(authed),
+        canonical_branch=canonical_branch,
+        destination_branch=destination_branch,
+        prepared_base_sha=prepared,
+        task_head_sha=task_head,
+        isolated_ref=isolated_ref,
+        git_common_dir=common,
+        lock_path=common / "mac_prepare_worktree.lock",
+    )
+
+
+def _git_common_directory(worktree: Path) -> tuple[Optional[Path], str]:
+    result = _run_git(worktree, ["rev-parse", "--git-common-dir"])
+    raw = result.stdout.strip()
+    if result.returncode != 0 or not raw:
+        return None, "could not resolve git common directory: %s" % _git_failure(
+            result, "empty result"
+        )
+    common = Path(raw)
+    if not common.is_absolute():
+        common = (worktree / common).resolve()
+    if not common.is_dir():
+        return None, "git common directory is not a directory: %s" % common
+    return common, ""
+
+
+def _isolated_publication_ref(common_key: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9._-]+", "-", str(common_key or "task")).strip("-.")
+    safe = (safe or "task")[:64]
+    nonce = hashlib.sha256(
+        ("%s:%s:%s" % (common_key, os.getpid(), time.time_ns())).encode("utf-8")
+    ).hexdigest()[:16]
+    return "refs/mac/publication/%s-%s" % (safe, nonce)
+
+
+def _canonical_freshness_locked(
+    target: CanonicalPublicationTarget,
+    *,
+    push: bool,
+) -> CanonicalFreshnessResult:
+    worktree = target.worktree
+    head = _run_git(worktree, ["rev-parse", "--verify", "HEAD^{commit}"])
+    head_sha = head.stdout.strip()
+    if head.returncode != 0 or not _GIT_SHA_RE.fullmatch(head_sha):
+        return CanonicalFreshnessResult(
+            False, target, error="could not resolve task HEAD: %s" % _git_failure(head, "invalid SHA")
+        )
+    if head_sha != target.task_head_sha:
+        return CanonicalFreshnessResult(
+            False,
+            target,
+            head_sha=head_sha,
+            error="task HEAD changed after publication target resolution: %s -> %s"
+            % (target.task_head_sha[:12], head_sha[:12]),
+        )
+
+    expected = _run_git(
+        worktree, ["rev-parse", "--verify", "%s^{commit}" % target.prepared_base_sha]
+    )
+    if expected.returncode != 0:
+        return CanonicalFreshnessResult(
+            False,
+            target,
+            head_sha=head_sha,
+            error="prepared repository base is not a commit: %s"
+            % target.prepared_base_sha,
+        )
+
+    fetch_ref = target.isolated_ref
+    fetch = _run_git(
+        worktree,
+        [
+            "fetch",
+            "--no-tags",
+            target.remote,
+            "+refs/heads/%s:%s" % (target.canonical_branch, fetch_ref),
+        ],
+    )
+    result: Optional[CanonicalFreshnessResult] = None
+    if fetch.returncode != 0:
+        result = CanonicalFreshnessResult(
+            False,
+            target,
+            head_sha=head_sha,
+            error="fetch of canonical branch %r from %s failed: %s"
+            % (
+                target.canonical_branch,
+                target.remote_display,
+                _git_failure(fetch, "non-zero exit"),
+            ),
+        )
+    else:
+        resolve = _run_git(worktree, ["rev-parse", "--verify", "%s^{commit}" % fetch_ref])
+        canonical_tip = resolve.stdout.strip()
+        if resolve.returncode != 0 or not _GIT_SHA_RE.fullmatch(canonical_tip):
+            result = CanonicalFreshnessResult(
+                False,
+                target,
+                head_sha=head_sha,
+                error="fetched canonical ref did not resolve to a commit: %s"
+                % _git_failure(resolve, "invalid SHA"),
+            )
+        else:
+            ancestor = _run_git(
+                worktree, ["merge-base", "--is-ancestor", canonical_tip, head_sha]
+            )
+            if ancestor.returncode != 0:
+                result = CanonicalFreshnessResult(
+                    False,
+                    target,
+                    head_sha=head_sha,
+                    canonical_tip_sha=canonical_tip,
+                    error=(
+                        "canonical tip %s is not an ancestor of task HEAD %s; "
+                        "rebase or merge %s before publication"
+                    )
+                    % (canonical_tip[:12], head_sha[:12], target.canonical_branch),
+                )
+            else:
+                diff = _run_git(
+                    worktree, ["diff", "--name-only", "%s..%s" % (canonical_tip, head_sha)]
+                )
+                if diff.returncode != 0:
+                    result = CanonicalFreshnessResult(
+                        False,
+                        target,
+                        head_sha=head_sha,
+                        canonical_tip_sha=canonical_tip,
+                        error="could not compute canonical diff: %s"
+                        % _git_failure(diff, "non-zero exit"),
+                    )
+                else:
+                    result = CanonicalFreshnessResult(
+                        True,
+                        target,
+                        head_sha=head_sha,
+                        canonical_tip_sha=canonical_tip,
+                        files_changed=tuple(
+                            line for line in diff.stdout.splitlines() if line.strip()
+                        ),
+                    )
+
+    cleanup = _run_git(worktree, ["update-ref", "-d", fetch_ref])
+    if cleanup.returncode != 0:
+        return CanonicalFreshnessResult(
+            False,
+            target,
+            head_sha=head_sha,
+            canonical_tip_sha=(result.canonical_tip_sha if result else ""),
+            files_changed=(result.files_changed if result else ()),
+            error="could not clean isolated canonical fetch ref %s: %s"
+            % (fetch_ref, _git_failure(cleanup, "non-zero exit")),
+        )
+    assert result is not None
+    if not result.ok or not push:
+        return result
+
+    destination_ref = "refs/heads/%s" % target.destination_branch
+    pushed = _run_git(
+        worktree, ["push", target.remote, "HEAD:%s" % destination_ref]
+    )
+    if pushed.returncode != 0:
+        return CanonicalFreshnessResult(
+            False,
+            target,
+            head_sha=result.head_sha,
+            canonical_tip_sha=result.canonical_tip_sha,
+            files_changed=result.files_changed,
+            error="git push to %s failed: %s"
+            % (target.remote_display, _git_failure(pushed, "non-zero exit")),
+            push_returncode=int(pushed.returncode),
+            push_stdout=redact_git_remote_auth_in_text(pushed.stdout or ""),
+            push_stderr=redact_git_remote_auth_in_text(pushed.stderr or ""),
+        )
+    remote = _run_git(worktree, ["ls-remote", target.remote, destination_ref])
+    remote_sha = (remote.stdout.split() or [""])[0] if remote.returncode == 0 else ""
+    if remote_sha != result.head_sha:
+        return CanonicalFreshnessResult(
+            False,
+            target,
+            head_sha=result.head_sha,
+            canonical_tip_sha=result.canonical_tip_sha,
+            files_changed=result.files_changed,
+            error="push completed but remote branch verification failed for %s"
+            % destination_ref,
+            push_returncode=0,
+            push_stdout=redact_git_remote_auth_in_text(pushed.stdout or ""),
+            push_stderr=redact_git_remote_auth_in_text(pushed.stderr or ""),
+        )
+    return CanonicalFreshnessResult(
+        True,
+        target,
+        head_sha=result.head_sha,
+        canonical_tip_sha=result.canonical_tip_sha,
+        files_changed=result.files_changed,
+        push_returncode=0,
+        push_stdout=redact_git_remote_auth_in_text(pushed.stdout or ""),
+        push_stderr=redact_git_remote_auth_in_text(pushed.stderr or ""),
+        remote_verified=True,
+    )
+
+
+def check_canonical_freshness(
+    target: CanonicalPublicationTarget,
+) -> CanonicalFreshnessResult:
+    """Fetch and verify canonical ancestry without publishing anything."""
+    return _canonical_publication_operation(target, push=False)
+
+
+def guarded_push(
+    target: CanonicalPublicationTarget,
+) -> CanonicalFreshnessResult:
+    """Re-fetch canonical state and push only when task HEAD contains it.
+
+    Validation, canonical fetch, ancestry checking, temporary-ref cleanup,
+    publication, and remote verification all happen under the repository's
+    shared git-common-dir lock. The authenticated URL checked here is the exact
+    URL passed to both ``git push`` and ``git ls-remote``.
+    """
+    return _canonical_publication_operation(target, push=True)
+
+
+def _canonical_publication_operation(
+    target: CanonicalPublicationTarget,
+    *,
+    push: bool,
+) -> CanonicalFreshnessResult:
+    try:
+        lock = target.lock_path.open("a+", encoding="utf-8")
+    except OSError as exc:
+        return CanonicalFreshnessResult(
+            False, target, head_sha=target.task_head_sha, error="could not open publication lock: %s" % exc
+        )
+    result: Optional[CanonicalFreshnessResult] = None
+    try:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+        except OSError as exc:
+            return CanonicalFreshnessResult(
+                False,
+                target,
+                head_sha=target.task_head_sha,
+                error="could not acquire publication lock: %s" % exc,
+            )
+        result = _canonical_freshness_locked(target, push=push)
+        try:
+            fcntl.flock(lock, fcntl.LOCK_UN)
+        except OSError as exc:
+            return CanonicalFreshnessResult(
+                False,
+                target,
+                head_sha=result.head_sha,
+                canonical_tip_sha=result.canonical_tip_sha,
+                files_changed=result.files_changed,
+                error="could not release publication lock: %s" % exc,
+            )
+        return result
+    finally:
+        lock.close()
 
 
 def _parse_owner_repo(repo_url: str) -> Tuple[str, str]:

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -55,14 +55,17 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.parse
 import urllib.request
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from mac import relay_observability
+from mac.agent_command import PROMPT_SENTINEL
 from mac.codegraph_audit import (
     codegraph_audit_check,
     codegraph_audit_manifest_problems,
@@ -70,9 +73,10 @@ from mac.codegraph_audit import (
     run_codegraph_audit,
 )
 from mac.gitops import (
-    inject_git_remote_auth as _inject_git_remote_auth,
-    redact_git_remote_auth as _redact_git_remote_auth,
-    redact_git_remote_auth_in_text as _redact_git_remote_auth_in_text,
+    CanonicalFreshnessResult,
+    check_canonical_freshness,
+    guarded_push,
+    resolve_canonical_publication_target,
 )
 from mac.openshell_runtime import (
     openshell_required_for_local_agent as _openshell_required_for_local_agent,
@@ -598,6 +602,11 @@ def emit_telemetry(event: str, *, task_id: Optional[str] = None, level: str = "i
 # ---------------------------------------------------------------------------
 
 DEPLOYMENT_LEARNING_PREFIX = "deployment_learning"
+_LESSON_PROMPT_BUDGET = 1600
+_LESSON_STOPWORDS = {
+    "add", "build", "change", "create", "deploy", "deployment", "fix", "implement",
+    "improve", "make", "next", "task", "test", "the", "this", "update", "with",
+}
 
 
 def _task_project(task: Dict[str, Any]) -> str:
@@ -620,6 +629,26 @@ def _format_learning_content(raw: str) -> str:
     if outcome == "failure" and err:
         line += " — failed: %s" % err
     return line[:300]
+
+
+def _lesson_terms(value: str) -> set[str]:
+    return {
+        token
+        for token in _re.findall(r"[a-z0-9][a-z0-9_-]{2,}", value.lower())
+        if token not in _LESSON_STOPWORDS
+    }
+
+
+def _append_lesson_with_budget(lessons: List[str], value: str) -> bool:
+    lesson = value.strip()
+    if not lesson:
+        return True
+    used = sum(len(item) for item in lessons)
+    remaining = _LESSON_PROMPT_BUDGET - used
+    if remaining <= 0:
+        return False
+    lessons.append(lesson if len(lesson) <= remaining else lesson[: max(0, remaining - 3)] + "...")
+    return sum(len(item) for item in lessons) < _LESSON_PROMPT_BUDGET
 
 
 def recall_deployment_lessons(task: Dict[str, Any], *, limit: int = 5) -> List[str]:
@@ -650,21 +679,38 @@ def recall_deployment_lessons(task: Dict[str, Any], *, limit: int = 5) -> List[s
             if not isinstance(item, dict):
                 continue
             text = str(item.get("content") or item.get("text") or item.get("summary") or "").strip()
-            if text:
-                lessons.append(text if len(text) <= 500 else text[:497] + "...")
+            if text and not _append_lesson_with_budget(
+                lessons, text if len(text) <= 500 else text[:497] + "..."
+            ):
+                break
     if lessons:
         return lessons[:limit]
 
     records = _hub_get("/memory?%s" % urlencode({"subject_type": "project", "subject_id": project}))
     if isinstance(records, list):
+        query_terms = _lesson_terms(
+            " ".join(
+                [
+                    title,
+                    str(task.get("description") or "")[:1000],
+                    str(task.get("project") or ""),
+                ]
+            )
+        )
         learnings = [
             r
             for r in records
             if isinstance(r, dict) and str(r.get("record_type") or "").startswith(DEPLOYMENT_LEARNING_PREFIX)
         ]
         learnings.sort(key=lambda r: str(r.get("created_at") or ""), reverse=True)
-        for record in learnings[:limit]:
-            lessons.append(_format_learning_content(str(record.get("content") or "")))
+        for record in learnings:
+            content = str(record.get("content") or "")
+            if not query_terms.intersection(_lesson_terms(content)):
+                continue
+            if not _append_lesson_with_budget(lessons, _format_learning_content(content)):
+                break
+            if len(lessons) >= limit:
+                break
     return lessons[:limit]
 
 
@@ -816,19 +862,28 @@ def repository_contract_section(task: Dict[str, Any]) -> str:
             "No repository runtime contract is attached and no checkout was provided. "
             "Do not guess bootstrap or test commands; report this as a task contract failure."
         )
-    summary = {
-        "schema": contract.get("schema"),
-        "project": contract.get("project"),
-        "contract_path": contract.get("contract_path"),
-        "platforms": contract.get("platforms"),
-        "toolchain": contract.get("toolchain"),
-        "bootstrap": contract.get("bootstrap"),
-        "test": contract.get("test"),
-        "evidence": contract.get("evidence"),
-    }
+    toolchain = contract.get("toolchain") if isinstance(contract.get("toolchain"), dict) else {}
+    bootstrap = contract.get("bootstrap") if isinstance(contract.get("bootstrap"), dict) else {}
+    test = contract.get("test") if isinstance(contract.get("test"), dict) else {}
+    required_commands = [
+        str(item).strip()
+        for item in (toolchain.get("required_commands") or [])
+        if str(item).strip()
+    ]
+    summary = "; ".join(
+        item
+        for item in (
+            "project=%s" % contract.get("project") if contract.get("project") else "",
+            "required_commands=%s" % ",".join(required_commands) if required_commands else "",
+            "bootstrap=%s" % bootstrap.get("command") if bootstrap.get("command") else "",
+            "test=%s" % test.get("command") if test.get("command") else "",
+        )
+        if item
+    )
     return "\n".join(
         [
-            json.dumps(summary, indent=2, sort_keys=True),
+            "Repository contract summary: %s" % (summary or "see task.json"),
+            "The complete repository and execution contracts remain in task.json; read them there when more detail is needed.",
             "For normal repository tasks, MAC prepares a task-owned git worktree before the executor starts.",
             "Use $MAC_TASK_REPO_WORKTREE, or metadata.runtime.repository_worktree in task.json, as the only writable checkout.",
             "Treat origin.repository_path / $MAC_TASK_REPO_SOURCE as read-only registered source state; do not edit it for feature or bug work.",
@@ -944,13 +999,45 @@ def _repository_contract_canonical_branch(task: Dict[str, Any]) -> str:
     runtime_raw = metadata.get("runtime")
     runtime: Dict[str, Any] = runtime_raw if isinstance(runtime_raw, dict) else {}
     branch = str(runtime.get("repository_canonical_branch") or "").strip()
-    return branch
+    if branch:
+        return branch
+    return os.environ.get("MAC_TASK_REPO_DEFAULT_BRANCH", "").strip()
 
 
-def _repository_push_remote(task: Dict[str, Any], fallback_remote: str = "") -> tuple[str, str]:
-    remote = _repository_contract_canonical_remote(task) or str(fallback_remote or "").strip() or "origin"
-    authed = _inject_git_remote_auth(remote)
-    return authed, _redact_git_remote_auth(authed)
+def _repository_publication_remote(task: Dict[str, Any]) -> str:
+    canonical = _repository_contract_canonical_remote(task)
+    if canonical:
+        return canonical
+    metadata = task.get("metadata") if isinstance(task, dict) else {}
+    origin = metadata.get("origin") if isinstance(metadata, dict) else {}
+    if isinstance(origin, dict):
+        remote = str(origin.get("repository_url") or "").strip()
+        if remote:
+            return remote
+    runtime = metadata.get("runtime") if isinstance(metadata, dict) else {}
+    if isinstance(runtime, dict):
+        remote = str(runtime.get("repository_canonical_remote_url") or "").strip()
+        if remote:
+            return remote
+    return os.environ.get("MAC_TASK_CANONICAL_REMOTE", "").strip()
+
+
+def _repository_prepared_base(task: Dict[str, Any]) -> str:
+    value = os.environ.get("MAC_TASK_REPO_BASE_SHA", "").strip()
+    if value:
+        return value
+    metadata = task.get("metadata") if isinstance(task, dict) else {}
+    runtime = metadata.get("runtime") if isinstance(metadata, dict) else {}
+    return str(runtime.get("repository_base_sha") or "").strip() if isinstance(runtime, dict) else ""
+
+
+def _repository_lease_id(task: Dict[str, Any]) -> str:
+    value = os.environ.get("MAC_TASK_REPO_LEASE_ID", "").strip()
+    if value:
+        return value
+    metadata = task.get("metadata") if isinstance(task, dict) else {}
+    runtime = metadata.get("runtime") if isinstance(metadata, dict) else {}
+    return str(runtime.get("repository_lease_id") or "").strip() if isinstance(runtime, dict) else ""
 
 
 def _repository_contract_bootstrap(task: Dict[str, Any]) -> Dict[str, Any]:
@@ -1068,21 +1155,9 @@ MAC_TASK_SUMMARY_END = "=== END MAC TASK SUMMARY ==="
 def build_task_prompt(task: Dict[str, Any], task_file: Path, lessons: Optional[List[str]] = None) -> str:
     parts = [
         "You are running as a MAC fleet worker. Complete the assigned task from first principles.",
-        "You are AUTONOMOUS: never ask the operator for confirmation or permission, and never end your turn with a question. If the task is underspecified, make the most reasonable assumption, proceed, and record the assumption in your evidence. Ending with 'should I proceed?' instead of doing the work is a failed run.",
-        "Use the task JSON as the source of truth. Preserve secrets and do not print bearer tokens.",
-        "When you finish, report the exact outcome, files changed, tests run, and any blockers.",
-        "Also write a verifiable evidence manifest to $MAC_TASK_WORKSPACE/mac-evidence.json.",
-        "Use schema mac.worker_evidence.v1 with status=complete and evidence_type set to one of repo_change, documentation, investigation, deployment, test, artifact, no_change, or operator_result.",
-        "For tasks with a repository runtime contract, default to evidence_type=repo_change. Use operator_result only for tasks that are not tied to a repository contract.",
-        "For no-repository planning or operator directive work, use evidence_type=operator_result with summary and result fields describing the completed work.",
-        "For repo/code work include repo.head_sha, repo.remote_ref or repo.pr_url, repo.pushed=true, repo.dirty=false, repo.files_changed, and passing tests/checks. Passing tests/checks should use returncode=0, status=pass, result=passed, or boolean/count fields that make success unambiguous. For deployments include targets/services plus passing checks. If you cannot produce this manifest, say why; MAC will not auto-publish unverifiable work.",
-        "For repo/code work that changes source, build, dependency, or runtime config files, include a passing codegraph audit object in mac-evidence.json. Docs-only/media-only changes may omit it or record codegraph.status=skipped with reason=non_code_change.",
-        "Before you declare the task done, RUN the repository contract test command yourself in the worktree and make it pass cleanly. The worker re-runs the exact same suite at finalize and REFUSES TO PUSH if anything fails, which blocks the task. Fix every failure you introduce, including lint/guard/docs tests, not just the feature tests.",
-        "COMMIT your work: after the changes pass, run `git add -A && git commit` in the worktree so your new/edited files are committed (a single commit is fine). The worker treats an uncommitted worktree as incomplete and blocks it; do not leave new files untracked.",
-        "Do the task yourself in THIS task — do NOT split it into child/sub tasks unless it is genuinely too large for one run; a normal 'add a test suite' or 'implement X' task should be completed as a single unit, not decomposed into many tasks that overload the fleet.",
-        "Any docs, comments, or examples you add or edit must read generically for ANY fleet owner: use readable role names (hub, worker-1, worker-2, gpu-worker) and placeholders like <user> / <host> / <mesh-ip>. Never hard-code real agent names, hostnames, usernames, or personal paths from this fleet into checked-in docs/skills/deploy markdown -- repos commonly lint for exactly that, and a single leaked name fails the contract test and blocks the push.",
-        "If the task needs new software, install it only in the task workspace or project worktree, such as a task-local .venv, uv project env, or project-local npm/pnpm install. Do not use sudo, host package managers, global npm/pip/pipx installs, or the shared Hermes/worker virtualenv.",
-        "When you add task-local dependencies, include verification.environment_delta in mac-evidence.json with package_manager, commands, added_dependencies, lockfile_path, lockfile_digest, base_runtime_digest when known, and reason. MAC records that as a proposed runtime delta; it does not mutate the fleet runtime until an operator validates and promotes it.",
+        "You are AUTONOMOUS: never ask the operator for confirmation or permission. Make a reasonable assumption, proceed, and record it when necessary.",
+        "First read the versioned execution policy at $MAC_TASK_WORKSPACE/.mac-executor-policy.txt, then read task.json as the source of truth.",
+        "Repository tasks default to evidence_type=repo_change; use operator_result only when no repository contract exists. Deterministic host code enforces tests, CodeGraph, cleanliness, and publication.",
         "Repository runtime contract:\n%s" % repository_contract_section(task),
     ]
     parts.append(
@@ -1129,36 +1204,6 @@ def build_review_prompt(task: Dict[str, Any], task_workspace: Path, review_conte
 # Deterministic finalizers + fail-closed fallback (ported, behavior preserved)
 # ---------------------------------------------------------------------------
 
-# Compiled once for the finalizer git-validation helpers below.
-_TE_GIT_SHA_RE = _re.compile(r"^[0-9a-fA-F]{40}$")
-_TE_GIT_REMOTE_URL_RE = _re.compile(
-    r"^(?:https?://|ssh://|git://|file://|git@|/)[A-Za-z0-9._\-:/@%+~?=&]*$"
-)
-_TE_GIT_REF_RE = _re.compile(r"^[A-Za-z0-9._/\-]+$")
-
-
-def _te_validate_git_remote_url(value: str) -> str:
-    """Reject git remote URLs that could smuggle argv flags or be empty."""
-    if not value or value.startswith("-"):
-        raise ValueError("git remote URL is empty or looks like a flag: %r" % value)
-    if len(value) > 2048:
-        raise ValueError("git remote URL exceeds 2048 byte limit")
-    if not _TE_GIT_REMOTE_URL_RE.match(value):
-        raise ValueError("git remote URL does not match a recognised scheme: %r" % value)
-    return value
-
-
-def _te_validate_git_ref(value: str) -> str:
-    """Reject git refs that could be confused with argv flags."""
-    if not value or value.startswith("-"):
-        raise ValueError("git ref is empty or looks like a flag: %r" % value)
-    if len(value) > 512:
-        raise ValueError("git ref exceeds 512 byte limit")
-    if not _TE_GIT_REF_RE.match(value):
-        raise ValueError("git ref contains disallowed characters: %r" % value)
-    return value
-
-
 def _git(args, cwd):
     return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True, check=False)
 
@@ -1187,7 +1232,6 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
         )
     head_sha = _git(["rev-parse", "HEAD"], worktree_path).stdout.strip()
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], worktree_path).stdout.strip() or "HEAD"
-    push_target = "refs/heads/%s" % branch if branch != "HEAD" else "refs/heads/auto/%s" % (task.get("id") or "task")
     # Purge synced build artifacts before the host build. The agent built in the
     # task SANDBOX (e.g. Linux); those object files / binaries sync back into this
     # worktree, but this finalizer runs on the EXECUTOR HOST, which may be a
@@ -1226,145 +1270,34 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
         }
     bootstrap_ok = bootstrap is None or bootstrap.get("returncode") == 0
     tests_ok = tests is None or tests.get("returncode") == 0
-    # --- Canonical freshness check (fail-closed) ---
-    # Resolve the canonical remote and branch from the task contract.
-    # An explicit value that fails validation is a hard error; we do not
-    # fall back to cached state or local origin/main.
-    canonical_remote_raw = _repository_contract_canonical_remote(task)
-    if not canonical_remote_raw:
-        canonical_remote_raw = os.environ.get("MAC_TASK_REPO_REMOTE", "").strip()
-    if not canonical_remote_raw:
-        canonical_remote_raw = os.environ.get("MAC_TASK_CANONICAL_REMOTE", "").strip()
+    canonical_remote_raw = _repository_publication_remote(task)
     canonical_branch = _repository_contract_canonical_branch(task)
-    if not canonical_branch:
-        canonical_branch = os.environ.get("MAC_TASK_REPO_DEFAULT_BRANCH", "").strip()
-    if not canonical_branch:
-        canonical_branch = "main"
+    prepared_base_sha = _repository_prepared_base(task)
+    lease_id = _repository_lease_id(task)
+    destination_branch = branch if branch != "HEAD" else ""
+    publication_target = None
     try:
-        _te_validate_git_ref(canonical_branch)
-    except ValueError as exc:
-        base_sha = ""
-        files_changed: List[str] = []
-        codegraph = run_codegraph_audit(worktree_path, files_changed)
-        codegraph_ok = not codegraph_audit_manifest_problems(
-            {"repo": {"files_changed": files_changed}, "codegraph": codegraph}
+        if not lease_id:
+            raise ValueError("repository context is missing repository_lease_id")
+        publication_target = resolve_canonical_publication_target(
+            worktree=worktree_path,
+            canonical_remote=canonical_remote_raw,
+            canonical_branch=canonical_branch,
+            destination_branch=destination_branch,
+            prepared_base_sha=prepared_base_sha,
+            isolation_key="%s-%s" % (str(task.get("id") or "task"), lease_id),
         )
-        push_evidence = {
-            "remote": "",
-            "returncode": 1,
-            "status": "skipped",
-            "reason": "canonical branch failed validation: %s" % exc,
-        }
-        manifest: Dict[str, Any] = {
-            "schema": "mac.worker_evidence.v1",
-            "status": "complete",
-            "evidence_type": "repo_change",
-            "summary": "Deterministic finalizer: blocked — canonical branch validation failed",
-            "freshness_error": str(exc),
-            "repo": {
-                "head_sha": head_sha,
-                "base_sha": base_sha,
-                "pushed": False,
-                "remote_ref": "refs/heads/" + branch if branch != "HEAD" else push_target,
-                "push_remote": "",
-                "dirty": bool(_git(["status", "--porcelain"], worktree_path).stdout.strip()),
-                "files_changed": files_changed,
-            },
-            "codegraph": codegraph,
-            "tests": [tests] if tests is not None else None,
-            "push": push_evidence,
-            "checks": (
-                ([codegraph_audit_check(codegraph)] if str(codegraph.get("status") or "") != "skipped" else [])
-                + [{"name": "git_finalizer", "returncode": 1, "status": "fail"}]
-            ),
-        }
-        if bootstrap is not None:
-            manifest["bootstrap"] = bootstrap
-        (task_workspace / "mac-evidence.json").write_text(
-            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        freshness = check_canonical_freshness(publication_target)
+    except (OSError, ValueError) as exc:
+        freshness = CanonicalFreshnessResult(
+            False,
+            publication_target,
+            head_sha=head_sha,
+            error=str(exc),
         )
-        return
-    # Fetch the canonical branch into a per-task isolated ref so the check
-    # never touches refs/remotes/origin/* or any cached tracking state.
-    # Failure is fail-closed: any fetch, resolve, or ancestry failure blocks push.
-    _canonical_fetch_ref = "refs/mac/finalizer/%s" % safe_path_component(
-        str(task.get("id") or "task")
-    )
-    canonical_fetch_remote = canonical_remote_raw
-    canonical_fetch_remote_authed = _inject_git_remote_auth(canonical_fetch_remote)
-    canonical_fetch_remote_display = _redact_git_remote_auth(canonical_fetch_remote_authed)
-    # The canonical_remote_url is allowed to use SSH (git@) — don't validate
-    # scheme when the remote was taken from the contract (trusted), but DO
-    # validate it is not empty or a flag.
-    freshness_error: Optional[str] = None
-    base_sha = ""
-    canonical_tip_sha = ""
-    if canonical_remote_raw:
-        try:
-            _te_validate_git_remote_url(canonical_remote_raw)
-        except ValueError as exc:
-            freshness_error = "canonical remote URL failed validation: %s" % exc
-    if freshness_error is None:
-        fetch = _git(
-            ["fetch", "--no-tags", canonical_fetch_remote_authed,
-             "+refs/heads/%s:%s" % (canonical_branch, _canonical_fetch_ref)],
-            worktree_path,
-        )
-        if fetch.returncode != 0:
-            freshness_error = (
-                "fetch of canonical branch %r from %s failed: %s"
-                % (
-                    canonical_branch,
-                    canonical_fetch_remote_display,
-                    _redact_git_remote_auth_in_text(
-                        (fetch.stderr or fetch.stdout or "").strip()
-                    ) or "non-zero exit",
-                )
-            )
-    if freshness_error is None:
-        resolve = _git(["rev-parse", _canonical_fetch_ref], worktree_path)
-        if resolve.returncode != 0 or not resolve.stdout.strip():
-            freshness_error = (
-                "could not resolve fetched canonical ref %r: %s"
-                % (
-                    _canonical_fetch_ref,
-                    (resolve.stderr or resolve.stdout or "").strip() or "empty SHA",
-                )
-            )
-        else:
-            canonical_tip_sha = resolve.stdout.strip()
-            if not _TE_GIT_SHA_RE.match(canonical_tip_sha):
-                freshness_error = (
-                    "fetched canonical ref %r resolved to an invalid SHA: %r"
-                    % (_canonical_fetch_ref, canonical_tip_sha)
-                )
-    if freshness_error is None:
-        # Ancestry check: canonical tip must be an ancestor of task HEAD.
-        # Accepts a correctly rebased/merged branch; rejects a stale branch
-        # that omits newly published canonical commits.
-        ancestor_check = _git(
-            ["merge-base", "--is-ancestor", canonical_tip_sha, "HEAD"],
-            worktree_path,
-        )
-        if ancestor_check.returncode != 0:
-            freshness_error = (
-                "canonical tip %s is not an ancestor of task HEAD %s; "
-                "rebase or merge the canonical branch before pushing"
-                % (canonical_tip_sha[:12], head_sha[:12])
-            )
-        else:
-            base_sha = canonical_tip_sha
-    # Clean up the temporary fetch ref (best-effort; failure is non-fatal).
-    _git(["update-ref", "-d", _canonical_fetch_ref], worktree_path)
-    # Compute files_changed from the resolved canonical tip when available;
-    # fall back to comparing with HEAD only when the freshness check failed
-    # (so the manifest still records a useful diff for diagnostics).
-    if base_sha:
-        diff_result = _git(["diff", "--name-only", "%s..HEAD" % base_sha], worktree_path)
-        files_changed = [f for f in (diff_result.stdout or "").splitlines() if f.strip()]
-    else:
-        diff_result = _git(["diff", "--name-only", "HEAD~1..HEAD"], worktree_path) if head_sha else None
-        files_changed = [f for f in ((diff_result.stdout or "") if diff_result else "").splitlines() if f.strip()]
+    freshness_error: Optional[str] = None if freshness.ok else freshness.error
+    base_sha = freshness.canonical_tip_sha or prepared_base_sha
+    files_changed = list(freshness.files_changed)
     # Record the diff base (canonical tip) so the reviewer can compute a
     # non-empty base..head diff. Without base_sha the review snapshot's
     # files_changed is always [] (which the repo_change validator rejects).
@@ -1377,18 +1310,29 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
     clean = not bool(final_status)
     freshness_ok = freshness_error is None
     pushed = False
-    push_remote, push_remote_display = _repository_push_remote(
-        task,
-        os.environ.get("MAC_TASK_REPO_REMOTE", "").strip(),
+    publication: Optional[CanonicalFreshnessResult] = None
+    push_remote_display = (
+        freshness.target.remote_display if freshness.target is not None else ""
     )
     if bootstrap_ok and tests_ok and codegraph_ok and clean and freshness_ok:
-        push = _git(["push", push_remote, "HEAD:%s" % push_target], worktree_path)
-        pushed = push.returncode == 0
+        assert publication_target is not None
+        publication = guarded_push(publication_target)
+        push_remote_display = (
+            publication.target.remote_display
+            if publication.target is not None
+            else push_remote_display
+        )
+        pushed = publication.ok and publication.remote_verified
+        if publication.canonical_tip_sha:
+            base_sha = publication.canonical_tip_sha
+        if not publication.ok:
+            freshness_error = publication.error
+            freshness_ok = False
         push_evidence = {
             "remote": push_remote_display,
-            "returncode": int(push.returncode),
-            "status": "pass" if push.returncode == 0 else "fail",
-            "stderr": _redact_git_remote_auth_in_text(push.stderr or "")[:4000],
+            "returncode": int(publication.push_returncode or (0 if pushed else 1)),
+            "status": "pass" if pushed else "fail",
+            "stderr": (publication.push_stderr or publication.error)[:4000],
         }
     elif not clean:
         push_evidence = {
@@ -1430,10 +1374,11 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
             "head_sha": head_sha,
             "base_sha": base_sha,
             "pushed": pushed,
-            "remote_ref": "refs/heads/" + branch if branch != "HEAD" else push_target,
+            "remote_ref": "refs/heads/" + branch if branch != "HEAD" else "",
             "push_remote": push_remote_display,
             "dirty": bool(final_status),
             "files_changed": files_changed,
+            "freshness": (publication or freshness).evidence(),
         },
         "codegraph": codegraph,
         # mac-wjy3: verification.tests is the CANONICAL list of test-result
@@ -1621,6 +1566,77 @@ def _hermes_argv(prompt: str) -> List[str]:
     return [_hermes_python(), "-m", "hermes_cli.main", "chat", "--query", prompt, "--quiet", "--accept-hooks", "--yolo"]
 
 
+@dataclass(frozen=True)
+class _AgentCommandBundle:
+    workspace: Path
+    prompt_file: Path
+    command_file: Path
+    policy_file: Path
+    interpreter: str
+
+    def argv(self, *, sandbox_workspace: Optional[str] = None) -> List[str]:
+        if sandbox_workspace:
+            command_file = "%s/%s" % (sandbox_workspace.rstrip("/"), self.command_file.name)
+            prompt_file = "%s/%s" % (sandbox_workspace.rstrip("/"), self.prompt_file.name)
+            interpreter = (
+                os.environ.get("MAC_HERMES_PYTHON") or "/opt/mac-venv/bin/python"
+            )
+        else:
+            command_file = str(self.command_file)
+            prompt_file = str(self.prompt_file)
+            interpreter = self.interpreter
+        return [
+            interpreter,
+            "-m",
+            "mac.agent_command",
+            "--command-file",
+            command_file,
+            "--prompt-file",
+            prompt_file,
+        ]
+
+    def cleanup(self) -> None:
+        self.command_file.unlink(missing_ok=True)
+        self.prompt_file.unlink(missing_ok=True)
+        self.policy_file.unlink(missing_ok=True)
+
+
+def _write_agent_command_bundle(
+    workspace: Path, prompt: str, agent_argv: List[str]
+) -> _AgentCommandBundle:
+    import uuid
+
+    if agent_argv.count(PROMPT_SENTINEL) != 1:
+        raise ValueError("agent argv must contain exactly one private-prompt sentinel")
+    workspace.mkdir(parents=True, exist_ok=True)
+    nonce = uuid.uuid4().hex
+    prompt_file = workspace / (".mac-agent-prompt-%s" % nonce)
+    command_file = workspace / (".mac-agent-command-%s.json" % nonce)
+    policy_file = workspace / ".mac-executor-policy.txt"
+    prompt_file.write_text(prompt, encoding="utf-8")
+    command_file.write_text(
+        json.dumps({"schema": "mac.agent_command.v1", "argv": agent_argv}),
+        encoding="utf-8",
+    )
+    prompt_file.chmod(0o600)
+    command_file.chmod(0o600)
+    policy_file.write_text(
+        (Path(__file__).resolve().parent / "executor-policy.txt").read_text(
+            encoding="utf-8"
+        ),
+        encoding="utf-8",
+    )
+    policy_file.chmod(0o600)
+    interpreter = agent_argv[0] if agent_argv[1:3] == ["-m", "hermes_cli.main"] else sys.executable
+    return _AgentCommandBundle(
+        workspace=workspace,
+        prompt_file=prompt_file,
+        command_file=command_file,
+        policy_file=policy_file,
+        interpreter=interpreter,
+    )
+
+
 def _mcp_serve_argv() -> List[str]:
     """The vendored messaging MCP server command (registered with a coding-agent
     CLI for messaging-tool parity, where the CLI supports per-invocation MCP)."""
@@ -1660,7 +1676,8 @@ def _mcp_serve_argv() -> List[str]:
 #                                 "--from my-image" or "--upload /src:/src" used to
 #                                 make the Hermes runtime + workspace available
 #                                 inside the sandbox
-#   MAC_OPENSHELL_ENV_PASSTHROUGH comma list of env names forwarded via --env
+#   MAC_OPENSHELL_ENV_PASSTHROUGH comma list of env names copied through a
+#                                 private mode-0600 workspace file
 #   MAC_ALLOW_UNSANDBOXED_YOLO    truthy (default "1") -> allow --yolo with no
 #                                 sandbox (current fleet, logs a warning). Set
 #                                 "0" to fail closed: refuse unguarded YOLO so
@@ -1677,7 +1694,7 @@ _DEFAULT_OPENSHELL_ENV_PASSTHROUGH = (
     # Model-gateway base_url + api_key live in the agent's ~/.hermes/.env, which
     # is NOT in the sandbox image; the gateway requires auth. Forward them so the
     # sandboxed hermes can authenticate (the *_BASE_URL values have their host
-    # loopback rewritten to the sandbox host alias by _openshell_env_flags).
+    # loopback rewritten to the sandbox host alias in the private env file).
     "MAC_HERMES_GATEWAY_BASE_URL,MAC_HERMES_GATEWAY_API_KEY,MAC_HERMES_GATEWAY_PROVIDER,"
     "OPENAI_BASE_URL,OPENAI_API_KEY,"
     # Coding-agent CLI credentials (see mac.coding_agent). A sandboxed coding
@@ -1717,15 +1734,11 @@ def _rewrite_host_local_url(value: str, alias: str) -> str:
     return out
 
 
-def _openshell_env_flags() -> List[str]:
-    """``--env NAME=VALUE`` flags for each *set* passthrough variable.
-
-    URL-valued vars have a host loopback rewritten to the sandbox host alias
-    (see :func:`_rewrite_host_local_url`) so a forwarded ``http://127.0.0.1:PORT``
-    hub/gateway URL is reachable from inside the sandbox."""
+def _openshell_environment() -> Dict[str, str]:
+    """Environment copied through a private workspace file, never process argv."""
     names = os.environ.get("MAC_OPENSHELL_ENV_PASSTHROUGH") or _DEFAULT_OPENSHELL_ENV_PASSTHROUGH
     alias = _openshell_host_alias()
-    flags: List[str] = []
+    values: Dict[str, str] = {}
     seen = set()
     for raw in names.split(","):
         name = raw.strip()
@@ -1735,9 +1748,8 @@ def _openshell_env_flags() -> List[str]:
         val = os.environ.get(name)
         if val is None:
             continue
-        val = _rewrite_host_local_url(val, alias)
-        flags += ["--env", "%s=%s" % (name, val)]
-    return flags
+        values[name] = _rewrite_host_local_url(val, alias)
+    return values
 
 
 def _kernel_has_landlock() -> bool:
@@ -1838,20 +1850,27 @@ def _sandbox_path_for_workspace_child(workspace: Path, sandbox_workspace: str, v
     return "%s/%s" % (sandbox_workspace.rstrip("/"), str(rel).replace(os.sep, "/"))
 
 
-def _sandbox_repository_env_flags(workspace: Path, sandbox_workspace: str) -> List[str]:
-    flags: List[str] = []
+def _sandbox_repository_environment(workspace: Path, sandbox_workspace: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
     mapped_worktree = _sandbox_path_for_workspace_child(
         workspace,
         sandbox_workspace,
         os.environ.get("MAC_TASK_REPO_WORKTREE", ""),
     )
     if mapped_worktree:
-        flags += ["--env", "MAC_TASK_REPO_WORKTREE=%s" % mapped_worktree]
-    for name in ("MAC_TASK_REPO_BRANCH", "MAC_TASK_REPO_BASE_SHA", "MAC_TASK_REPO_REMOTE"):
+        values["MAC_TASK_REPO_WORKTREE"] = mapped_worktree
+    for name in (
+        "MAC_TASK_REPO_BRANCH",
+        "MAC_TASK_REPO_LEASE_ID",
+        "MAC_TASK_REPO_BASE_SHA",
+        "MAC_TASK_REPO_REMOTE",
+        "MAC_TASK_CANONICAL_REMOTE",
+        "MAC_TASK_REPO_DEFAULT_BRANCH",
+    ):
         value = os.environ.get(name)
         if value:
-            flags += ["--env", "%s=%s" % (name, value)]
-    return flags
+            values[name] = value
+    return values
 
 
 def _ensure_landlock_or_fail() -> None:
@@ -2408,6 +2427,36 @@ PY''',
     )
 
 
+def _write_private_shell_env(path: Path, values: Mapping[str, str]) -> Path:
+    env_lines = [
+        "export %s=%s" % (name, shlex.quote(value))
+        for name, value in sorted(values.items())
+        if _re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)
+    ]
+    path.write_text("\n".join(env_lines) + "\n", encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def _write_sandbox_runtime_files(
+    workspace: Path, sandbox_workspace: str
+) -> tuple[Path, Path]:
+    env_values: Dict[str, str] = {
+        **_openshell_environment(),
+        **_sandbox_repository_environment(workspace, sandbox_workspace),
+        "MAC_TASK_WORKSPACE": sandbox_workspace,
+        "MAC_TASK_FILE": "%s/task.json" % sandbox_workspace.rstrip("/"),
+    }
+    env_file = _write_private_shell_env(
+        workspace / ".mac-openshell-env.sh", env_values
+    )
+
+    toolchain_file = workspace / ".mac-sandbox-toolchain.sh"
+    toolchain_file.write_text(_sandbox_toolchain_setup_shell(), encoding="utf-8")
+    toolchain_file.chmod(0o700)
+    return env_file, toolchain_file
+
+
 def _build_sandbox_create_argv(
     name: str, workspace: Path, basename: str, agent_argv: List[str]
 ) -> List[str]:
@@ -2420,27 +2469,35 @@ def _build_sandbox_create_argv(
     the agent runs there with $MAC_TASK_WORKSPACE/$MAC_TASK_FILE repointed at the
     in-sandbox paths (the host paths don't exist inside the sandbox), so its
     evidence manifest is written where ``download`` later fetches it. The agent
-    argv is shell-quoted (shlex.join) into the cd-wrapper — the prompt is task
-    text and must never be able to break out of the command.
+    ``agent_argv`` is the private-file wrapper, not the underlying prompt-bearing
+    command. Secrets and the toolchain body are sourced from uploaded mode-0600
+    files, keeping the host's process list small and credential-free.
     """
+    if "mac.agent_command" not in agent_argv:
+        raise ValueError("sandbox agent argv must use the private-file command wrapper")
     sub = "%s/%s" % (_SANDBOX_WORKDIR, basename)
     argv: List[str] = [_openshell_bin(), "sandbox", "create", "--no-auto-providers"]
     argv += ["--policy", _resolve_openshell_policy(), "--name", name]
-    argv += _openshell_env_flags()
-    argv += [
-        "--env", "MAC_TASK_WORKSPACE=%s" % sub,
-        "--env", "MAC_TASK_FILE=%s/task.json" % sub,
-    ]
-    argv += _sandbox_repository_env_flags(workspace, sub)
     extra = (os.environ.get("MAC_OPENSHELL_CREATE_ARGS") or "").strip()
     if extra:
-        argv += shlex.split(extra)
+        extra_argv = shlex.split(extra)
+        if "--env" in extra_argv or "--" in extra_argv:
+            raise ValueError(
+                "MAC_OPENSHELL_CREATE_ARGS may not contain --env or --; "
+                "use MAC_OPENSHELL_ENV_PASSTHROUGH for private environment transfer"
+            )
+        argv += extra_argv
     argv += ["--upload", "%s:%s" % (str(workspace), _SANDBOX_WORKDIR)]
     inner = "\n".join(
         [
             "cd %s" % shlex.quote(sub),
+            "set -a",
+            ". ./.mac-openshell-env.sh",
+            "set +a",
+            "rm -f ./.mac-openshell-env.sh",
             'if [ -n "${MAC_TASK_REPO_WORKTREE:-}" ] && [ -d "$MAC_TASK_REPO_WORKTREE" ] && [ ! -e /sandbox/mac-clone ]; then ln -s "$MAC_TASK_REPO_WORKTREE" /sandbox/mac-clone || true; fi',
-            _sandbox_toolchain_setup_shell(),
+            ". ./.mac-sandbox-toolchain.sh",
+            "rm -f ./.mac-sandbox-toolchain.sh",
             "mac_sandbox_toolchain_setup || true",
             "exec %s" % shlex.join(agent_argv),
         ]
@@ -2622,11 +2679,13 @@ def _merge_sandbox_download_tree(download_root: Path, workspace: Path) -> None:
                 shutil.copy2(src, dst)
 
 
-def _sandbox_run_repository_verification(name: str, basename: str, workspace: Path, task: Any) -> None:
+def _sandbox_run_repository_verification(
+    name: str, basename: str, workspace: Path, task: Any
+) -> Optional[bool]:
     if not isinstance(task, dict) or not task_is_repo_coupled(task):
-        return
+        return None
     if not _repository_contract_test_command(task):
-        return
+        return None
     sub = "%s/%s" % (_SANDBOX_WORKDIR, basename)
     script_path = workspace / ".mac-sandbox-repository-verify.sh"
     script_path.write_text(_sandbox_repository_verification_shell() + "\n", encoding="utf-8")
@@ -2638,7 +2697,7 @@ def _sandbox_run_repository_verification(name: str, basename: str, workspace: Pa
     )
     if not ok:
         sys.stderr.write("[executor] WARNING: sandbox repository verification upload failed: %s\n" % msg)
-        return
+        return False
     try:
         timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "600"))
     except ValueError:
@@ -2661,6 +2720,7 @@ def _sandbox_run_repository_verification(name: str, basename: str, workspace: Pa
     )
     if not ok:
         sys.stderr.write("[executor] WARNING: sandbox repository verification failed: %s\n" % msg)
+    return ok
 
 
 def _sandbox_download(name: str, basename: str, workspace: Path) -> bool:
@@ -2686,10 +2746,195 @@ def _sandbox_download(name: str, basename: str, workspace: Path) -> bool:
     return ok
 
 
-def _sandbox_delete(name: str) -> None:
+def _sandbox_delete(name: str) -> bool:
     ok, msg = _sandbox_step(["delete", name], timeout=120.0)
     if not ok:
         sys.stderr.write("[executor] WARNING: sandbox delete failed (possible leak): %s\n" % msg)
+    return ok
+
+
+def _sandbox_progress_interval() -> float:
+    raw = (os.environ.get("MAC_OPENSHELL_PROGRESS_INTERVAL") or "5").strip()
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 5.0
+
+
+def _sandbox_progress_snapshot(
+    name: str, basename: str, workspace: Path
+) -> Optional[Dict[str, str]]:
+    sub = "%s/%s" % (_SANDBOX_WORKDIR, basename)
+    mapped_repo = _sandbox_path_for_workspace_child(
+        workspace, sub, os.environ.get("MAC_TASK_REPO_WORKTREE", "")
+    )
+    repo = mapped_repo or ""
+    base = os.environ.get("MAC_TASK_REPO_BASE_SHA", "").strip()
+    script = "\n".join(
+        [
+            "set -eu",
+            "repo=%s" % shlex.quote(repo),
+            "base=%s" % shlex.quote(base),
+            "head=",
+            "changed_count=0",
+            "changed_digest=",
+            'if [ -n "$repo" ] && [ -d "$repo" ]; then',
+            '  head="$(git -C "$repo" rev-parse HEAD 2>/dev/null || true)"',
+            '  changed="$( { git -C "$repo" status --porcelain 2>/dev/null; [ -n "$base" ] && git -C "$repo" diff --name-only "$base..HEAD" 2>/dev/null || true; } | sort -u )"',
+            '  changed_count="$(printf %s "$changed" | sed "/^$/d" | wc -l | tr -d " ")"',
+            '  changed_digest="$(printf %s "$changed" | sha256sum 2>/dev/null | cut -d" " -f1 || true)"',
+            "fi",
+            'printf "ready=1\\nhead=%%s\\nchanged_count=%%s\\nchanged_digest=%%s\\nmanifest=%%s\\n" "$head" "$changed_count" "$changed_digest" "$( [ -f %s/mac-evidence.json ] && echo 1 || echo 0 )"'
+            % shlex.quote(sub),
+        ]
+    )
+    ok, output = _sandbox_step(
+        [
+            "exec",
+            "--name",
+            name,
+            "--workdir",
+            sub,
+            "--timeout",
+            "15",
+            "--no-tty",
+            "--",
+            "bash",
+            "-lc",
+            script,
+        ],
+        timeout=30.0,
+    )
+    if not ok:
+        return None
+    snapshot: Dict[str, str] = {}
+    for line in output.splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key in {
+            "ready",
+            "head",
+            "changed_count",
+            "changed_digest",
+            "manifest",
+        }:
+            snapshot[key] = value.strip()
+    return snapshot if snapshot.get("ready") == "1" else None
+
+
+class _SandboxProgressMonitor:
+    """Transition-based observer of the real sandbox workspace."""
+
+    def __init__(self, name: str, basename: str, workspace: Path, task_id: Any) -> None:
+        self.name = name
+        self.basename = basename
+        self.workspace = workspace
+        self.task_id = str(task_id) if task_id else None
+        self.interval = _sandbox_progress_interval()
+        self.stop_event = threading.Event()
+        self.thread: Optional[threading.Thread] = None
+        self.ready = False
+        self.mutated = False
+        self.manifest_seen = False
+        self.last_head = ""
+        self.changed_file_count = 0
+        self.changed_file_digest = ""
+        self.stopped = False
+
+    def start(self) -> None:
+        if self.interval <= 0:
+            return
+        self.thread = threading.Thread(
+            target=self._loop,
+            name="mac-sandbox-progress-%s" % self.name,
+            daemon=True,
+        )
+        self.thread.start()
+
+    def _loop(self) -> None:
+        while not self.stop_event.wait(self.interval):
+            self.observe()
+
+    def observe(self) -> None:
+        snapshot = _sandbox_progress_snapshot(
+            self.name, self.basename, self.workspace
+        )
+        if snapshot is None:
+            return
+        if not self.ready:
+            self.ready = True
+            emit_telemetry(
+                "sandbox_ready",
+                task_id=self.task_id,
+                sandbox=self.name,
+                state="ready",
+            )
+        head = snapshot.get("head", "")
+        try:
+            changed_count = int(snapshot.get("changed_count") or 0)
+        except ValueError:
+            changed_count = 0
+        changed = changed_count > 0 or (
+            bool(head)
+            and bool(os.environ.get("MAC_TASK_REPO_BASE_SHA"))
+            and head != os.environ.get("MAC_TASK_REPO_BASE_SHA")
+        )
+        self.changed_file_count = changed_count
+        self.changed_file_digest = snapshot.get("changed_digest", "")
+        if changed and not self.mutated:
+            self.mutated = True
+            emit_telemetry(
+                "sandbox_first_mutation",
+                task_id=self.task_id,
+                sandbox=self.name,
+                state="sandbox_dirty",
+                changed_file_count=changed_count,
+                changed_file_digest=snapshot.get("changed_digest", ""),
+                head_sha=head,
+            )
+        if head and head != self.last_head:
+            self.last_head = head
+            emit_telemetry(
+                "sandbox_head_observed",
+                task_id=self.task_id,
+                sandbox=self.name,
+                head_sha=head,
+            )
+        if snapshot.get("manifest") == "1" and not self.manifest_seen:
+            self.manifest_seen = True
+            emit_telemetry(
+                "sandbox_manifest_observed",
+                task_id=self.task_id,
+                sandbox=self.name,
+            )
+
+    def stop(self) -> None:
+        if self.stopped:
+            return
+        self.stopped = True
+        if self.interval <= 0:
+            return
+        self.observe()
+        self.stop_event.set()
+        if self.thread is not None:
+            self.thread.join(timeout=min(2.0, self.interval + 0.5))
+        if not self.mutated:
+            emit_telemetry(
+                "sandbox_no_effect",
+                task_id=self.task_id,
+                level="warning",
+                sandbox=self.name,
+                state="sandbox_clean",
+            )
+
+    def evidence(self) -> Dict[str, object]:
+        return {
+            "ready_observed": self.ready,
+            "mutation_observed": self.mutated,
+            "manifest_observed": self.manifest_seen,
+            "head_sha": self.last_head,
+            "changed_file_count": self.changed_file_count,
+            "changed_file_digest": self.changed_file_digest,
+        }
 
 
 def _run_sandboxed(
@@ -2697,20 +2942,109 @@ def _run_sandboxed(
 ) -> Any:
     """Run the agent through the OpenShell sandbox lifecycle: create (upload the
     workspace + run the agent, keep) -> download results -> delete. The agent
-    runs confined; teardown ALWAYS happens (finally), even on failure."""
+    runs confined. Harvest is attempted before teardown on every exit path,
+    including runner exceptions and cancellation, so a useful partial patch or
+    evidence manifest is not destroyed with the sandbox."""
     _force_child_yolo_env()  # truly silent agent; OpenShell is the guardrail
     _ensure_landlock_or_fail()
     name = _sandbox_name()
     basename = _workspace_basename(workspace)
-    create_argv = _build_sandbox_create_argv(name, workspace, basename, agent_argv)
+    sandbox_workspace = "%s/%s" % (_SANDBOX_WORKDIR, basename)
+    runtime_files = _write_sandbox_runtime_files(workspace, sandbox_workspace)
+    try:
+        create_argv = _build_sandbox_create_argv(name, workspace, basename, agent_argv)
+    except Exception:
+        for path in runtime_files:
+            path.unlink(missing_ok=True)
+        raise
+    runner_completed = False
+    harvested = False
+    kept = _truthy(os.environ.get("MAC_OPENSHELL_KEEP"))
+    emit_telemetry(
+        "sandbox_started",
+        task_id=str(audit_id) if audit_id else None,
+        sandbox=name,
+        workspace=basename,
+    )
+    progress = _SandboxProgressMonitor(name, basename, workspace, audit_id)
+    progress.start()
     try:
         result = runner(create_argv, workspace, audit_id, opts)
-        _sandbox_run_repository_verification(name, basename, workspace, opts.get("task"))
-        _sandbox_download(name, basename, workspace)
+        runner_completed = True
+        progress.stop()
+        emit_telemetry(
+            "sandbox_agent_completed",
+            task_id=str(audit_id) if audit_id else None,
+            level="info" if int(getattr(result, "returncode", 1)) == 0 else "warning",
+            sandbox=name,
+            returncode=int(getattr(result, "returncode", 1)),
+        )
+        verification_expected = (
+            isinstance(opts.get("task"), dict)
+            and task_is_repo_coupled(opts["task"])
+            and bool(_repository_contract_test_command(opts["task"]))
+        )
+        if verification_expected:
+            emit_telemetry(
+                "sandbox_verification_started",
+                task_id=str(audit_id) if audit_id else None,
+                sandbox=name,
+            )
+        verification = _sandbox_run_repository_verification(
+            name, basename, workspace, opts.get("task")
+        )
+        if verification is not None:
+            emit_telemetry(
+                "sandbox_verification_completed",
+                task_id=str(audit_id) if audit_id else None,
+                level="info" if verification else "warning",
+                sandbox=name,
+                passed=verification,
+            )
         return result
     finally:
-        if not _truthy(os.environ.get("MAC_OPENSHELL_KEEP")):
-            _sandbox_delete(name)
+        active_error = sys.exc_info()[1]
+        progress.stop()
+        harvested = _sandbox_download(name, basename, workspace)
+        salvage = {
+            "schema": "mac.openshell_salvage.v1",
+            "sandbox": name,
+            "runner_completed": runner_completed,
+            "harvest_attempted": True,
+            "harvested": harvested,
+            "kept": kept,
+            "error": str(active_error) if active_error is not None else "",
+            "progress": progress.evidence(),
+            "at": utcnow(),
+        }
+        try:
+            (workspace / "openshell-salvage.json").write_text(
+                json.dumps(salvage, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            sys.stderr.write("[executor] WARNING: could not write sandbox salvage record: %s\n" % exc)
+        emit_telemetry(
+            "sandbox_harvested",
+            task_id=str(audit_id) if audit_id else None,
+            level="info" if harvested else "warning",
+            sandbox=name,
+            runner_completed=runner_completed,
+            harvested=harvested,
+        )
+        deleted = False
+        if not kept:
+            deleted = _sandbox_delete(name)
+            emit_telemetry(
+                "sandbox_deleted",
+                task_id=str(audit_id) if audit_id else None,
+                level="info" if deleted else "warning",
+                sandbox=name,
+                deleted=deleted,
+            )
+        for path in runtime_files:
+            path.unlink(missing_ok=True)
+        (workspace / ".mac-sandbox-repository-verify.sh").unlink(missing_ok=True)
 
 
 def _force_child_yolo_env() -> None:
@@ -2867,17 +3201,33 @@ def _coding_agent_preflight_timeout() -> float:
         return 180.0
 
 
-def _build_sandbox_probe_argv(name: str, agent_argv: List[str]) -> List[str]:
-    """A minimal ``openshell sandbox create`` argv that runs ``agent_argv`` under
-    the SAME policy + env-forwarding + create-args as a real task run, but with no
-    workspace upload — used only to verify the coding agent works in-sandbox."""
+def _build_sandbox_probe_argv(
+    name: str, agent_argv: List[str], private_dir: Path
+) -> List[str]:
+    """Build a credential-free process argv for the coding-agent probe."""
+    if "mac.agent_command" not in agent_argv:
+        raise ValueError("sandbox probe must use the private-file command wrapper")
     argv: List[str] = [_openshell_bin(), "sandbox", "create", "--no-auto-providers"]
     argv += ["--policy", _resolve_openshell_policy(), "--name", name]
-    argv += _openshell_env_flags()
     extra = (os.environ.get("MAC_OPENSHELL_CREATE_ARGS") or "").strip()
     if extra:
-        argv += shlex.split(extra)
-    argv += ["--", "bash", "-lc", "exec %s" % shlex.join(agent_argv)]
+        extra_argv = shlex.split(extra)
+        if "--env" in extra_argv or "--" in extra_argv:
+            raise ValueError("MAC_OPENSHELL_CREATE_ARGS may not contain --env or --")
+        argv += extra_argv
+    sandbox_dir = "/sandbox/%s" % private_dir.name
+    argv += ["--upload", "%s:/sandbox" % private_dir]
+    inner = "\n".join(
+        [
+            "cd %s" % shlex.quote(sandbox_dir),
+            "set -a",
+            ". ./.mac-openshell-env.sh",
+            "set +a",
+            "rm -f ./.mac-openshell-env.sh",
+            "exec %s" % shlex.join(agent_argv),
+        ]
+    )
+    argv += ["--", "bash", "-lc", inner]
     return argv
 
 
@@ -2900,11 +3250,28 @@ def _run_coding_agent_preflight(choice: Any) -> bool:
     from . import coding_agent as _ca
 
     name = "mac-codingcap-%s-%d" % (choice.agent, os.getpid())
-    probe_argv = _ca.coding_agent_argv(choice, _ca.PREFLIGHT_PROMPT)
-    try:
-        rc, out = _openshell_probe(_build_sandbox_probe_argv(name, probe_argv), timeout=_coding_agent_preflight_timeout())
-    finally:
-        _sandbox_step(["delete", name], timeout=60.0)
+    with tempfile.TemporaryDirectory(prefix="mac-coding-agent-probe-") as tmp:
+        private_dir = Path(tmp)
+        probe_argv = _ca.coding_agent_argv(choice, PROMPT_SENTINEL)
+        bundle = _write_agent_command_bundle(
+            private_dir, _ca.PREFLIGHT_PROMPT, probe_argv
+        )
+        _write_private_shell_env(
+            private_dir / ".mac-openshell-env.sh", _openshell_environment()
+        )
+        sandbox_dir = "/sandbox/%s" % private_dir.name
+        try:
+            rc, out = _openshell_probe(
+                _build_sandbox_probe_argv(
+                    name,
+                    bundle.argv(sandbox_workspace=sandbox_dir),
+                    private_dir,
+                ),
+                timeout=_coding_agent_preflight_timeout(),
+            )
+        finally:
+            bundle.cleanup()
+            _sandbox_step(["delete", name], timeout=60.0)
     ok = rc == 0 and _ca.PREFLIGHT_SENTINEL in out
     sys.stderr.write(
         "[executor] coding-agent sandbox preflight (%s): %s\n"
@@ -3232,10 +3599,28 @@ def _invoke_agent(
     # enablement is gated on `confined`, not `wrap`.
     wrap = _openshell_enabled()
     confined = wrap or _openshell_required_for_local_agent()
-    agent_argv = _agent_argv(prompt, workspace, confined=confined, task=opts.get("task"))
-    if wrap:
-        return _run_sandboxed(runner, agent_argv, workspace, audit_id, opts)
-    return runner(_unsandboxed_agent_argv(agent_argv), workspace, audit_id, opts)
+    agent_argv = _agent_argv(
+        PROMPT_SENTINEL, workspace, confined=confined, task=opts.get("task")
+    )
+    bundle = _write_agent_command_bundle(workspace, prompt, agent_argv)
+    try:
+        if wrap:
+            sandbox_workspace = "%s/%s" % (
+                _SANDBOX_WORKDIR,
+                _workspace_basename(workspace),
+            )
+            return _run_sandboxed(
+                runner,
+                bundle.argv(sandbox_workspace=sandbox_workspace),
+                workspace,
+                audit_id,
+                opts,
+            )
+        return runner(
+            _unsandboxed_agent_argv(bundle.argv()), workspace, audit_id, opts
+        )
+    finally:
+        bundle.cleanup()
 
 
 def _agent_timeout() -> Optional[float]:

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -54,6 +54,12 @@ from mac.codegraph_audit import (
 )
 from mac.hermes_adapter import MacApiClient, MacApiError
 from mac.hermes_config_surface import apply_hermes_surface_payload
+from mac.gitops import (
+    guarded_push,
+    resolve_canonical_publication_target,
+    validate_git_ref,
+    validate_git_remote_url,
+)
 
 
 JsonDict = Dict[str, Any]
@@ -64,14 +70,6 @@ SAFE_GIT_REF_RE = r"^[A-Za-z0-9][A-Za-z0-9._/\-]{0,127}$"
 SAFE_SYSTEMD_SERVICE_RE = r"^[A-Za-z0-9][A-Za-z0-9_.@:\-]{0,126}\.service$"
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
 GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
-# mac-raud: validate git remote URLs supplied by upstream evidence
-# before passing to ``git clone``. We accept https/http, ssh://, git://,
-# git@host:path forms; nothing that could be parsed as a flag.
-_GIT_REMOTE_URL_RE = re.compile(
-    r"^(?:https?://|ssh://|git://|file://|git@|/)[A-Za-z0-9._\-:/@%+~?=&]*$"
-)
-# Git ref name rules (simplified — see git-check-ref-format).
-_GIT_REF_RE = re.compile(r"^[A-Za-z0-9._/\-]+$")
 DEFAULT_COMMAND_INVENTORY_NAMES = (
     "bash",
     "codegraph",
@@ -92,27 +90,11 @@ DEFAULT_COMMAND_INVENTORY_INTERVAL_SECONDS = 300.0
 
 
 def _validate_git_remote_url(value: str) -> str:
-    """Reject git remote URLs that could smuggle argv flags or escape
-    the URL shape entirely (mac-raud).
-    """
-    if not value or value.startswith("-"):
-        raise ValueError("git remote URL is empty or looks like a flag: %r" % value)
-    if len(value) > 2048:
-        raise ValueError("git remote URL exceeds 2048 byte limit")
-    if not _GIT_REMOTE_URL_RE.match(value):
-        raise ValueError("git remote URL does not match a recognised scheme: %r" % value)
-    return value
+    return validate_git_remote_url(value)
 
 
 def _validate_git_ref(value: str) -> str:
-    """Reject git refs that could be confused with argv flags."""
-    if not value or value.startswith("-"):
-        raise ValueError("git ref is empty or looks like a flag: %r" % value)
-    if len(value) > 512:
-        raise ValueError("git ref exceeds 512 byte limit")
-    if not _GIT_REF_RE.match(value):
-        raise ValueError("git ref contains disallowed characters: %r" % value)
-    return value
+    return validate_git_ref(value)
 
 
 def _env_int(name: str, default: int) -> int:
@@ -2667,9 +2649,11 @@ class MacWorker:
                 "repository_source_path": str(source_root),
                 "repository_worktree": str(worktree_dir),
                 "repository_branch": branch,
+                "repository_lease_id": lease_id,
                 "repository_base_sha": base_sha,
                 "repository_local_prior_sha": local_prior_sha,
                 "repository_canonical_branch": canonical_branch,
+                "repository_canonical_remote_url": canonical_remote,
                 "repository_canonical_remote": canonical_remote_display,
                 "repository_ahead": ahead_count,
                 "repository_behind": behind_count,
@@ -2740,6 +2724,7 @@ class MacWorker:
         _validate_git_ref(default_branch)
 
         auth_url = _inject_git_remote_auth(remote_url)
+        remote_display = _redact_git_remote_auth(auth_url)
         clone_args = ["clone", "--depth=1", "--branch", default_branch, "--", auth_url, str(worktree_dir)]
         # ``git -C`` requires an existing directory; clone runs from the
         # parent so we use a separate code path (the helper expects the
@@ -2778,8 +2763,12 @@ class MacWorker:
             "repository_source_path": str(worktree_dir),
             "repository_worktree": str(worktree_dir),
             "repository_branch": branch,
+            "repository_lease_id": str(lease.get("id") or ""),
             "repository_base_sha": base_sha,
-            "repository_origin_remote": remote_url,
+            "repository_canonical_branch": default_branch,
+            "repository_canonical_remote_url": remote_url,
+            "repository_canonical_remote": remote_display,
+            "repository_origin_remote": remote_display,
         }
         self._observe_log(
             "worker.repository.worktree_prepared",
@@ -2987,13 +2976,11 @@ class MacWorker:
         (task_dir / "stdout.txt").write_text(execution.stdout, encoding="utf-8")
         (task_dir / "stderr.txt").write_text(execution.stderr, encoding="utf-8")
         if execution.succeeded:
-            finalized_missing_manifest = self._write_missing_repository_evidence_manifest(
+            self._write_missing_repository_evidence_manifest(
                 task_id,
                 task_dir,
                 execution,
             )
-            if not finalized_missing_manifest:
-                self._auto_publish_repository_worktree(task_id, task_dir)
         result_path = task_dir / "worker-result.json"
         result_path.write_text(
             json.dumps(
@@ -3242,10 +3229,39 @@ class MacWorker:
         repo["pushed"] = False
         if branch:
             repo["remote_ref"] = "refs/heads/%s" % branch
-        push_remote, push_remote_display = _repository_push_remote(task, context)
-        repo["push_remote"] = push_remote_display
+        canonical_remote = _repository_publication_remote(task, context)
+        canonical_branch = str(context.get("repository_canonical_branch") or "").strip()
+        prepared_base_sha = str(context.get("repository_base_sha") or "").strip()
+        repo["push_remote"] = _redact_git_remote_auth(
+            _inject_git_remote_auth(canonical_remote)
+        )
         codegraph = run_codegraph_audit(worktree, files_changed)
         repo["dirty"] = _repository_worktree_is_dirty(worktree)
+
+        publication_target = None
+        target_error = ""
+        try:
+            lease_id = str(context.get("repository_lease_id") or "").strip()
+            if not lease_id:
+                raise ValueError("repository context is missing repository_lease_id")
+            publication_target = resolve_canonical_publication_target(
+                worktree=worktree,
+                canonical_remote=canonical_remote,
+                canonical_branch=canonical_branch,
+                destination_branch=branch,
+                prepared_base_sha=prepared_base_sha,
+                isolation_key="%s-%s" % (task_id, lease_id),
+            )
+        except (OSError, ValueError) as exc:
+            target_error = str(exc)
+            repo["freshness"] = {
+                "ok": False,
+                "remote": repo["push_remote"],
+                "canonical_branch": canonical_branch,
+                "prepared_base_sha": prepared_base_sha,
+                "task_head_sha": repo["head_sha"],
+                "error": target_error,
+            }
 
         pushed = False
         push_item: Optional[JsonDict] = None
@@ -3261,36 +3277,29 @@ class MacWorker:
             problems.extend(prepush_problems)
             problems.append("repository evidence failed local contract checks; refusing to push")
         elif test_item.get("returncode") == 0:
-            if branch:
-                push = _run_git(worktree, ["push", push_remote, "HEAD:refs/heads/%s" % branch])
-                push_item = _process_check_item(
-                    "git push",
-                    push.returncode,
-                    command="git push %s HEAD:refs/heads/%s" % (push_remote_display, branch),
-                    stdout=_redact_git_remote_auth_in_text(push.stdout),
-                    stderr=_redact_git_remote_auth_in_text(push.stderr),
+            if publication_target is not None:
+                publication = guarded_push(publication_target)
+                display = (
+                    publication.target.remote_display
+                    if publication.target is not None
+                    else repo["push_remote"]
                 )
-                if push.returncode == 0:
-                    pushed = _repository_context_head_is_pushed(
-                        worktree,
-                        {
-                            "head_sha": _git_stdout(worktree, ["rev-parse", "HEAD"]),
-                            "remote_ref": "refs/heads/%s" % branch,
-                            "remote_url": push_remote,
-                        },
-                    )
-                    if not pushed:
-                        problems.append("repository push succeeded but remote HEAD verification failed")
-                else:
-                    problems.append(
-                        "repository push failed: %s"
-                        % (
-                            _redact_git_remote_auth_in_text((push.stderr or push.stdout or "").strip())
-                            or branch
-                        )
-                    )
+                repo["push_remote"] = display
+                if publication.canonical_tip_sha:
+                    repo["base_sha"] = publication.canonical_tip_sha
+                repo["freshness"] = publication.evidence()
+                push_item = _process_check_item(
+                    "guarded git push",
+                    0 if publication.ok and publication.remote_verified else 1,
+                    command="guarded git push %s HEAD:refs/heads/%s" % (display, branch),
+                    stdout=publication.push_stdout,
+                    stderr=publication.push_stderr or publication.error,
+                )
+                pushed = publication.ok and publication.remote_verified
+                if not pushed:
+                    problems.append("repository publication blocked: %s" % publication.error)
             else:
-                problems.append("repository context is missing repository_branch")
+                problems.append("repository publication target invalid: %s" % target_error)
         else:
             problems.append("repository contract test failed; refusing to push")
 
@@ -3467,96 +3476,6 @@ class MacWorker:
             command=command,
             stdout=proc.stdout,
             stderr=proc.stderr,
-        )
-
-    def _auto_publish_repository_worktree(self, task_id: str, task_dir: Path) -> None:
-        task = _task_payload_from_workspace(task_dir)
-        metadata = ensure_json_object(task.get("metadata"))
-        if not (
-            metadata.get("repository_auto_publish") is True
-            or metadata.get("auto_commit_repository") is True
-            or os.environ.get("MAC_WORKER_REPOSITORY_AUTO_PUBLISH", "").lower()
-            in {"1", "true", "yes"}
-        ):
-            return
-        context = _load_repository_context(task_dir)
-        if not context:
-            return
-        worktree = Path(str(context.get("repository_worktree") or "")).expanduser()
-        if not worktree.exists():
-            raise RuntimeError("repository auto-publish worktree missing: %s" % worktree)
-        branch = str(context.get("repository_branch") or "").strip()
-        if not branch:
-            raise RuntimeError("repository auto-publish missing repository_branch")
-
-        status = _run_git(worktree, ["status", "--porcelain"])
-        if status.returncode != 0:
-            raise RuntimeError(
-                "repository auto-publish status failed: %s"
-                % ((status.stderr or status.stdout or "").strip() or worktree)
-            )
-        if status.stdout.strip():
-            add = _run_git(worktree, ["add", "-A"])
-            if add.returncode != 0:
-                raise RuntimeError(
-                    "repository auto-publish add failed: %s"
-                    % ((add.stderr or add.stdout or "").strip() or worktree)
-                )
-            staged = _run_git(worktree, ["diff", "--cached", "--quiet"])
-            if staged.returncode == 1:
-                title = str(task.get("title") or task_id).strip() or task_id
-                commit = _run_git(
-                    worktree,
-                    ["commit", "-m", "MAC task %s: %s" % (task_id, title[:120])],
-                )
-                if commit.returncode != 0:
-                    raise RuntimeError(
-                        "repository auto-publish commit failed: %s"
-                        % ((commit.stderr or commit.stdout or "").strip() or worktree)
-                    )
-            elif staged.returncode != 0:
-                raise RuntimeError(
-                    "repository auto-publish staged diff failed: %s"
-                    % ((staged.stderr or staged.stdout or "").strip() or worktree)
-                )
-
-        files_changed = _repository_context_changed_files(worktree, context)
-        codegraph = run_codegraph_audit(worktree, files_changed)
-        if not codegraph_audit_passed(codegraph):
-            raise RuntimeError(
-                "repository auto-publish codegraph audit failed: %s"
-                % (codegraph.get("reason") or "unknown")
-            )
-        if _repository_worktree_is_dirty(worktree):
-            raise RuntimeError("repository auto-publish worktree dirty after codegraph audit")
-
-        push_remote, push_remote_display = _repository_push_remote(task, context)
-        push = _run_git(worktree, ["push", push_remote, "HEAD:refs/heads/%s" % branch])
-        if push.returncode != 0:
-            raise RuntimeError(
-                "repository auto-publish push failed: %s"
-                % (
-                    _redact_git_remote_auth_in_text((push.stderr or push.stdout or "").strip())
-                    or branch
-                )
-            )
-        head = _run_git(worktree, ["rev-parse", "HEAD"])
-        remote = _run_git(worktree, ["ls-remote", push_remote, "refs/heads/%s" % branch])
-        remote_sha = (remote.stdout.split() or [""])[0] if remote.returncode == 0 else ""
-        if head.returncode != 0 or not head.stdout.strip() or remote_sha != head.stdout.strip():
-            raise RuntimeError("repository auto-publish remote verification failed for %s" % branch)
-
-        self._observe_log(
-            "worker.repository.auto_published",
-            subject_type="task",
-            subject_id=task_id,
-            detail={
-                "repository_worktree": str(worktree),
-                "repository_branch": branch,
-                "head_sha": head.stdout.strip(),
-                "remote_ref": "refs/heads/%s" % branch,
-                "push_remote": push_remote_display,
-            },
         )
 
     def _execution_submission_problems(self, task_dir: Path, evidence: JsonDict) -> List[str]:
@@ -4395,6 +4314,7 @@ def _durable_evidence_artifacts(task_dir: Path, primary_result_path: Path) -> Li
         (task_dir / "stderr.txt", "stderr.txt", "stderr"),
         (task_dir / "mac-evidence.json", "mac-evidence.json", "verification_manifest"),
         (task_dir / "mac-sandbox-verification.json", "mac-sandbox-verification.json", "sandbox_verification"),
+        (task_dir / "openshell-salvage.json", "openshell-salvage.json", "sandbox_salvage"),
         (task_dir / "repository-worktree.json", "repository-worktree.json", "repository_context"),
         (task_dir / "executor-evidence.json", "executor-evidence.json", "review_context"),
         (task_dir / "executor-task.json", "executor-task.json", "review_context"),
@@ -4543,8 +4463,11 @@ def _repository_context_env(context: JsonDict) -> Dict[str, str]:
         "MAC_TASK_REPO_WORKTREE": context.get("repository_worktree"),
         "MAC_TASK_REPO_SOURCE": context.get("repository_source_path"),
         "MAC_TASK_REPO_BRANCH": context.get("repository_branch"),
+        "MAC_TASK_REPO_LEASE_ID": context.get("repository_lease_id"),
         "MAC_TASK_REPO_BASE_SHA": context.get("repository_base_sha"),
         "MAC_TASK_REPO_REMOTE": context.get("repository_origin_remote"),
+        "MAC_TASK_CANONICAL_REMOTE": context.get("repository_canonical_remote_url"),
+        "MAC_TASK_REPO_DEFAULT_BRANCH": context.get("repository_canonical_branch"),
     }
     return {key: str(value) for key, value in mapping.items() if value not in {None, ""}}
 
@@ -4742,9 +4665,29 @@ def _repository_contract_canonical_remote(task: JsonDict) -> str:
     return ""
 
 
+def _repository_publication_remote(task: JsonDict, context: Optional[JsonDict] = None) -> str:
+    """Return the explicit task/preparation canonical URL, without fallback.
+
+    The prepared context intentionally stores only a display-safe URL. Reading
+    the raw target from the task contract keeps credentials out of workspace
+    metadata while allowing the publication guard to resolve the exact remote.
+    """
+    canonical = _repository_contract_canonical_remote(task)
+    if canonical:
+        return canonical
+    metadata = task.get("metadata") if isinstance(task, dict) else {}
+    origin = metadata.get("origin") if isinstance(metadata, dict) else {}
+    if isinstance(origin, dict):
+        remote = str(origin.get("repository_url") or "").strip()
+        if remote:
+            return remote
+    if isinstance(context, dict):
+        return str(context.get("repository_canonical_remote_url") or "").strip()
+    return ""
+
+
 def _repository_push_remote(task: JsonDict, context: JsonDict) -> tuple[str, str]:
-    fallback = str(context.get("repository_origin_remote") or "").strip()
-    remote = _repository_contract_canonical_remote(task) or fallback or "origin"
+    remote = _repository_publication_remote(task, context)
     authed = _inject_git_remote_auth(remote)
     return authed, _redact_git_remote_auth(authed)
 

--- a/tests/test_agent_command.py
+++ b/tests/test_agent_command.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from mac import agent_command
+
+
+def _inputs(tmp_path: Path, argv: list[str], prompt: str) -> tuple[Path, Path]:
+    command = tmp_path / "command.json"
+    prompt_file = tmp_path / "prompt.txt"
+    command.write_text(json.dumps({"argv": argv}), encoding="utf-8")
+    prompt_file.write_text(prompt, encoding="utf-8")
+    return command, prompt_file
+
+
+def test_hermes_prompt_is_loaded_in_process_and_private_files_are_unlinked(
+    tmp_path: Path, monkeypatch
+) -> None:
+    prompt = "private task instructions"
+    command, prompt_file = _inputs(
+        tmp_path,
+        [
+            "/opt/mac-venv/bin/python",
+            "-m",
+            "hermes_cli.main",
+            "chat",
+            "--query",
+            agent_command.PROMPT_SENTINEL,
+            "--yolo",
+        ],
+        prompt,
+    )
+    seen: dict[str, object] = {}
+
+    def fake_run_module(name: str, *, run_name: str, alter_sys: bool) -> None:
+        seen.update(name=name, argv=list(sys.argv), run_name=run_name, alter_sys=alter_sys)
+
+    monkeypatch.setattr(agent_command.runpy, "run_module", fake_run_module)
+
+    assert agent_command.main(
+        ["--command-file", str(command), "--prompt-file", str(prompt_file)]
+    ) == 0
+    assert seen["name"] == "hermes_cli.main"
+    assert prompt in seen["argv"]
+    assert not command.exists()
+    assert not prompt_file.exists()
+
+
+def test_external_agent_receives_prompt_on_stdin_not_argv(
+    tmp_path: Path, monkeypatch
+) -> None:
+    prompt = "secret-free process list"
+    command, prompt_file = _inputs(
+        tmp_path,
+        ["claude", "--dangerously-skip-permissions", "-p", agent_command.PROMPT_SENTINEL],
+        prompt,
+    )
+    seen: dict[str, object] = {}
+
+    class _Completed:
+        returncode = 0
+
+    def fake_run(argv, *, input, text, check):
+        seen.update(argv=list(argv), input=input, text=text, check=check)
+        return _Completed()
+
+    monkeypatch.setattr(agent_command.subprocess, "run", fake_run)
+
+    assert agent_command.main(
+        ["--command-file", str(command), "--prompt-file", str(prompt_file)]
+    ) == 0
+    assert prompt not in seen["argv"]
+    assert seen["input"] == prompt
+    assert not command.exists()
+    assert not prompt_file.exists()

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -5,6 +5,8 @@ import re
 import subprocess
 import sys
 
+import pytest
+
 from mac.deploy_env import (
     ControlConfig,
     DEFAULT_WORKER_CAPABILITIES,
@@ -948,30 +950,54 @@ def test_env_writer_spoke_routes_via_hub_with_no_provider_keys(tmp_path):
     assert "nvapi-SECRET" not in "\n".join(out.values())
 
 
-def test_env_writer_spoke_without_hub_token_leaves_gateway_unconfigured(tmp_path):
-    # No configured hub token → MAC_WORKER_TOKEN degenerates to the local token.
-    out = _run_env_writer(
-        tmp_path, agent="natasha", hub_agent="rocky",
-        hub_url="http://hub.example:8789", hub_token="",
-        extra_env={**_ROUTER_ENV, "NVIDIA_API_KEY": ""},
-        existing_env_text=(
-            "OPENAI_BASE_URL=https://old.example/v1\n"
-            "OPENAI_API_KEY=OLD_OPENAI\n"
-            "MAC_HERMES_GATEWAY_BASE_URL=https://old.example/v1\n"
-            "MAC_HERMES_GATEWAY_API_KEY=OLD_GATEWAY\n"
-            "NVIDIA_API_KEY=OLD_NVIDIA\n"
-            "MAC_ROUTER_PROVIDERS=nvidia=https://old.example/v1,0,key=old\n"
-        ),
-    )
-    # do NOT point the gateway at the hub with a broken local-token credential
-    assert out.get("OPENAI_BASE_URL") != "http://hub.example:8789/v1"
-    local = out.get("MAC_API_TOKEN")
-    assert out.get("OPENAI_API_KEY") != local  # never the local token
-    assert out.get("MAC_HERMES_GATEWAY_API_KEY") != local
-    assert "OLD_OPENAI" not in out.values()
-    assert "OLD_GATEWAY" not in out.values()
-    assert "OLD_NVIDIA" not in out.values()
-    assert "MAC_ROUTER_PROVIDERS" not in out
+def test_env_writer_spoke_without_hub_token_fails_fast(tmp_path):
+    with pytest.raises(ValueError, match="hub-facing token distinct"):
+        _run_env_writer(
+            tmp_path, agent="natasha", hub_agent="rocky",
+            hub_url="http://hub.example:8789", hub_token="",
+            extra_env={**_ROUTER_ENV, "NVIDIA_API_KEY": ""},
+        )
+
+
+def test_env_writer_hub_without_providers_fails_fast(tmp_path):
+    with pytest.raises(ValueError, match="MAC_DEPLOY_ROUTER_PROVIDERS"):
+        _run_env_writer(
+            tmp_path, agent="rocky", hub_agent="rocky",
+            hub_url="http://127.0.0.1:8789", hub_token="HUBTOK",
+            extra_env={
+                "MAC_DEPLOY_ROUTER_BACKEND": "inproc",
+                "MAC_DEPLOY_ROUTER_PROVIDERS": "",
+            },
+        )
+
+
+def test_direct_fleet_deploy_loads_authoritative_env_before_defaults():
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+
+    load = '. "$DEPLOY_ENV_FILE"'
+    assert 'DEPLOY_ENV_FILE="${MAC_DEPLOY_ENV_FILE:-$HOME/.mac/.env}"' in script
+    assert load in script
+    assert script.index(load) < script.index('GIT_BRANCH="${MAC_DEPLOY_GIT_BRANCH:-main}"')
+
+
+def test_router_topology_preflight_runs_before_remote_mutation():
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    main_body = script.split("main() {", 1)[1].split("\n}\n\nmain", 1)[0]
+
+    assert "validate_router_topology_spec()" in script
+    validation = main_body.index('validate_router_topology_spec "$spec" "$hub_token"')
+    assert validation < main_body.index("install_reverse_tunnel_on_hub")
+    assert validation < main_body.index('deploy_host "$spec"')
+
+
+def test_agent_service_reads_worker_token_from_environment_not_process_argv():
+    script = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    wrapper = script.split("install_mac_agent_wrapper() {", 1)[1].split(
+        "\n}\n", 1
+    )[0]
+
+    assert ': "${MAC_WORKER_TOKEN:?MAC_WORKER_TOKEN is required}"' in wrapper
+    assert '--token "$MAC_WORKER_TOKEN"' not in wrapper
 
 
 def _extract_bash_fn(name):
@@ -1667,7 +1693,12 @@ def test_executor_prompt_includes_repository_runtime_contract():
     assert "origin.repository_path / $MAC_TASK_REPO_SOURCE as read-only" in script
     assert "bootstrap.command" in script
     assert "test.command" in script
-    assert "returncode=0, status=pass, result=passed" in script
+    assert ".mac-executor-policy.txt" in script
+    policy = (ROOT / "src" / "mac" / "executor-policy.txt").read_text(
+        encoding="utf-8"
+    )
+    assert policy.startswith("mac.executor_policy.v1")
+    assert "Write $MAC_TASK_WORKSPACE/mac-evidence.json" in policy
 
 
 def test_reviewer_prompt_includes_verdict_contract():

--- a/tests/test_gitops_publication_target.py
+++ b/tests/test_gitops_publication_target.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import json
+import subprocess
+from pathlib import Path
+
+import mac.gitops as gitops
+import pytest
+from mac.gitops import (
+    check_canonical_freshness,
+    guarded_push,
+    resolve_canonical_publication_target,
+)
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, str]:
+    origin = tmp_path / "origin.git"
+    canonical = tmp_path / "canonical.git"
+    _git(tmp_path, "init", "--bare", str(origin))
+    _git(tmp_path, "init", "--bare", str(canonical))
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(origin), str(work))
+    _git(work, "config", "user.email", "test@example.invalid")
+    _git(work, "config", "user.name", "test")
+    (work / "README.md").write_text("base\n", encoding="utf-8")
+    _git(work, "add", "README.md")
+    _git(work, "commit", "-m", "base")
+    _git(work, "branch", "-M", "main")
+    _git(work, "push", "origin", "main")
+    _git(work, "push", canonical.as_uri(), "main")
+    base = _git(work, "rev-parse", "HEAD").stdout.strip()
+    _git(work, "checkout", "-b", "task/change")
+    (work / "feature.py").write_text("print('feature')\n", encoding="utf-8")
+    _git(work, "add", "feature.py")
+    _git(work, "commit", "-m", "feature")
+    return origin, canonical, work, base
+
+
+def test_guarded_push_uses_checked_canonical_target_and_cleans_ref(tmp_path: Path) -> None:
+    origin, canonical, work, base = _fixture(tmp_path)
+
+    target = resolve_canonical_publication_target(
+        worktree=work,
+        canonical_remote=canonical.as_uri(),
+        canonical_branch="main",
+        destination_branch="task/change",
+        prepared_base_sha=base,
+        isolation_key="task-1-lease-1",
+    )
+    preflight = check_canonical_freshness(target)
+    result = guarded_push(target)
+
+    assert preflight.ok is True
+    assert result.ok is True
+    assert result.remote_verified is True
+    assert result.canonical_tip_sha == base
+    assert result.files_changed == ("feature.py",)
+    assert target.lock_path.name == "mac_prepare_worktree.lock"
+    assert target.task_head_sha == result.head_sha
+    assert _git(
+        tmp_path, "ls-remote", str(canonical), "refs/heads/task/change"
+    ).stdout.strip().startswith(result.head_sha)
+    assert _git(
+        tmp_path, "ls-remote", str(origin), "refs/heads/task/change"
+    ).stdout.strip() == ""
+    assert _git(work, "for-each-ref", "refs/mac/publication").stdout.strip() == ""
+
+
+def test_guarded_push_blocks_head_that_omits_new_canonical_tip(tmp_path: Path) -> None:
+    _origin, canonical, work, base = _fixture(tmp_path)
+    advance = tmp_path / "advance"
+    _git(tmp_path, "clone", str(canonical), str(advance))
+    _git(advance, "config", "user.email", "test@example.invalid")
+    _git(advance, "config", "user.name", "test")
+    _git(advance, "checkout", "main")
+    (advance / "canonical.py").write_text("# newer\n", encoding="utf-8")
+    _git(advance, "add", "canonical.py")
+    _git(advance, "commit", "-m", "advance canonical")
+    _git(advance, "push", "origin", "main")
+
+    target = resolve_canonical_publication_target(
+        worktree=work,
+        canonical_remote=canonical.as_uri(),
+        canonical_branch="main",
+        destination_branch="task/change",
+        prepared_base_sha=base,
+        isolation_key="task-stale-lease-1",
+    )
+    result = guarded_push(target)
+
+    assert result.ok is False
+    assert result.remote_verified is False
+    assert "not an ancestor" in result.error
+    assert _git(
+        tmp_path, "ls-remote", str(canonical), "refs/heads/task/change"
+    ).stdout.strip() == ""
+    assert _git(work, "for-each-ref", "refs/mac/publication").stdout.strip() == ""
+
+
+def test_freshness_check_requires_prepared_base_context(tmp_path: Path) -> None:
+    _origin, canonical, work, _base = _fixture(tmp_path)
+
+    with pytest.raises(ValueError, match="prepared repository base SHA is missing"):
+        resolve_canonical_publication_target(
+            worktree=work,
+            canonical_remote=canonical.as_uri(),
+            canonical_branch="main",
+            destination_branch="task/change",
+            prepared_base_sha="",
+            isolation_key="task-missing-context",
+        )
+
+
+def test_temporary_ref_cleanup_failure_blocks_push(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _origin, canonical, work, base = _fixture(tmp_path)
+    real_run_git = gitops._run_git
+
+    def fail_cleanup(worktree: Path, args: list[str]):
+        if args[:2] == ["update-ref", "-d"]:
+            return subprocess.CompletedProcess(
+                ["git", *args], 1, "", "simulated cleanup failure"
+            )
+        return real_run_git(worktree, args)
+
+    monkeypatch.setattr(gitops, "_run_git", fail_cleanup)
+
+    target = resolve_canonical_publication_target(
+        worktree=work,
+        canonical_remote=canonical.as_uri(),
+        canonical_branch="main",
+        destination_branch="task/change",
+        prepared_base_sha=base,
+        isolation_key="task-cleanup-failure",
+    )
+    result = guarded_push(target)
+
+    assert result.ok is False
+    assert "could not clean isolated canonical fetch ref" in result.error
+    assert _git(
+        tmp_path, "ls-remote", str(canonical), "refs/heads/task/change"
+    ).stdout.strip() == ""
+
+
+def test_publication_lock_failure_blocks_push(tmp_path: Path, monkeypatch) -> None:
+    _origin, canonical, work, base = _fixture(tmp_path)
+
+    def fail_lock(_file, operation: int) -> None:
+        if operation == gitops.fcntl.LOCK_EX:
+            raise OSError("simulated lock failure")
+
+    monkeypatch.setattr(gitops.fcntl, "flock", fail_lock)
+    target = resolve_canonical_publication_target(
+        worktree=work,
+        canonical_remote=canonical.as_uri(),
+        canonical_branch="main",
+        destination_branch="task/change",
+        prepared_base_sha=base,
+        isolation_key="task-lock-failure",
+    )
+
+    result = guarded_push(target)
+
+    assert result.ok is False
+    assert "could not acquire publication lock" in result.error
+    assert _git(
+        tmp_path, "ls-remote", str(canonical), "refs/heads/task/change"
+    ).stdout.strip() == ""
+
+
+def test_target_is_immutable_unique_and_secret_free(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _origin, _canonical, work, base = _fixture(tmp_path)
+    monkeypatch.setenv("GH_TOKEN", "publication-secret")
+    first = resolve_canonical_publication_target(
+        worktree=work,
+        canonical_remote="https://github.com/example/project.git",
+        canonical_branch="main",
+        destination_branch="task/change",
+        prepared_base_sha=base,
+        isolation_key="task-1-lease-1",
+    )
+    second = resolve_canonical_publication_target(
+        worktree=work,
+        canonical_remote="https://github.com/example/project.git",
+        canonical_branch="main",
+        destination_branch="task/change",
+        prepared_base_sha=base,
+        isolation_key="task-1-lease-2",
+    )
+
+    assert first.isolated_ref != second.isolated_ref
+    assert "publication-secret" not in repr(first)
+    evidence = gitops.CanonicalFreshnessResult(True, first).evidence()
+    assert "publication-secret" not in json.dumps(evidence)
+    assert evidence["remote"] == (
+        "https://x-access-token:<redacted>@github.com/example/project.git"
+    )
+    with pytest.raises(FrozenInstanceError):
+        first.canonical_branch = "other"  # type: ignore[misc]

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -20,7 +20,15 @@ import pytest
 
 from mac import task_executor as te
 
-_ARGV = ["/home/x/.mac/venv/bin/python", "-m", "hermes_cli.main", "chat", "--query", "do it", "--yolo"]
+_ARGV = [
+    "/opt/mac-venv/bin/python",
+    "-m",
+    "mac.agent_command",
+    "--command-file",
+    "/sandbox/task-7/.mac-agent-command.json",
+    "--prompt-file",
+    "/sandbox/task-7/.mac-agent-prompt",
+]
 
 _OPENSHELL_ENVS = [
     "MAC_OPENSHELL_SANDBOX",
@@ -32,6 +40,7 @@ _OPENSHELL_ENVS = [
     "MAC_OPENSHELL_ENV_PASSTHROUGH",
     "MAC_OPENSHELL_ALLOW_NO_LANDLOCK",
     "MAC_OPENSHELL_HOST_ALIAS",
+    "MAC_OPENSHELL_PROGRESS_INTERVAL",
     "MAC_HERMES_PYTHON",
     "MAC_ALLOW_UNSANDBOXED_YOLO",
     "HERMES_YOLO_MODE",
@@ -49,6 +58,7 @@ def _clean(monkeypatch, tmp_path):
     # Tests run on non-Landlock hosts (Mac/CI); bypass the kernel precheck so the
     # orchestration tests exercise the lifecycle. The precheck has its own tests.
     monkeypatch.setenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_PROGRESS_INTERVAL", "0")
     monkeypatch.setattr(te, "_merge_sandbox_download_tree", lambda download_root, workspace: None)
     yield
 
@@ -116,13 +126,16 @@ def test_enabled_default_off():
 # ---------------------------------------------------------------------------
 
 
-def test_invoke_unsandboxed_runs_plain_argv():
+def test_invoke_unsandboxed_uses_private_prompt_wrapper(tmp_path):
     r = FakeRunner()
-    te._invoke_agent(r, "do the thing", Path("/work/t"), "tid", {})
+    workspace = tmp_path / "t"
+    workspace.mkdir()
+    te._invoke_agent(r, "do the thing", workspace, "tid", {})
     assert len(r.calls) == 1
     argv = r.calls[0][0]
     assert "openshell" not in argv[0] and argv[0].endswith("python")
-    assert "--yolo" in argv
+    assert "mac.agent_command" in argv
+    assert "do the thing" not in argv
 
 
 # ---------------------------------------------------------------------------
@@ -177,18 +190,25 @@ def test_build_uploads_workspace_to_sandbox_root():
     assert "/work/task-7:/sandbox" in out
 
 
-def test_build_runs_agent_in_workspace_subdir_with_yolo():
+def test_build_runs_private_agent_wrapper_in_workspace_subdir():
     inner = _inner(_build("/work/task-7"))
     assert inner.startswith("cd /sandbox/task-7\n")
     assert "mac_sandbox_toolchain_setup" in inner
     assert "\nexec " in inner
-    assert "hermes_cli.main" in inner and "--yolo" in inner
+    assert "mac.agent_command" in inner
+    assert "hermes_cli.main" not in inner
 
 
-def test_build_repoints_workspace_env_into_sandbox():
-    out = _build("/work/task-7")
-    assert "MAC_TASK_WORKSPACE=/sandbox/task-7" in out
-    assert "MAC_TASK_FILE=/sandbox/task-7/task.json" in out
+def test_private_env_file_repoints_workspace_without_argv_exposure(tmp_path):
+    workspace = tmp_path / "task-7"
+    workspace.mkdir()
+    env_file, toolchain_file = te._write_sandbox_runtime_files(
+        workspace, "/sandbox/task-7"
+    )
+    content = env_file.read_text(encoding="utf-8")
+    assert "MAC_TASK_WORKSPACE=/sandbox/task-7" in content
+    assert "MAC_TASK_FILE=/sandbox/task-7/task.json" in content
+    assert toolchain_file.stat().st_mode & 0o777 == 0o700
 
 
 def test_build_separator_appears_once_before_command():
@@ -203,23 +223,26 @@ def test_build_bin_override(monkeypatch):
 
 
 def test_build_create_args_spliced(monkeypatch):
-    monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from img --upload /a:/b --env HOME=/tmp")
+    monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from img --upload /a:/b")
     out = _build()
-    for tok in ("--from", "img", "--upload", "/a:/b", "--env", "HOME=/tmp"):
+    for tok in ("--from", "img", "--upload", "/a:/b"):
         assert tok in out
         assert out.index(tok) < out.index("bash")
 
 
-def test_build_quotes_prompt_safely():
-    # A shell-hostile prompt must not be able to break out of the cd-wrapper.
-    argv = te._hermes_argv("do; rm -rf / # $(whoami)")
-    inner = _inner(_build(argv=argv))
-    # the dangerous text is single-quoted inside the exec'd command, not bare
-    assert "rm -rf /" not in inner.replace("'do; rm -rf / # $(whoami)'", "")
+def test_build_rejects_direct_prompt_bearing_agent_argv():
+    with pytest.raises(ValueError, match="private-file command wrapper"):
+        _build(argv=te._hermes_argv("do; rm -rf / # $(whoami)"))
+
+
+def test_build_rejects_env_values_in_extra_argv(monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_CREATE_ARGS", "--from img --env TOKEN=secret")
+    with pytest.raises(ValueError, match="may not contain --env"):
+        _build()
 
 
 # ---------------------------------------------------------------------------
-# env passthrough (forwarded into the sandbox via --env)
+# env passthrough (copied into the sandbox via a private file)
 # ---------------------------------------------------------------------------
 
 
@@ -227,19 +250,18 @@ def test_env_passthrough_only_set_vars(monkeypatch):
     monkeypatch.setenv("MAC_OPENSHELL_ENV_PASSTHROUGH", "FOO,BAR,FOO")
     monkeypatch.setenv("FOO", "fooval")
     monkeypatch.delenv("BAR", raising=False)
-    out = _build()
-    assert out.count("FOO=fooval") == 1
-    assert not any(tok.startswith("BAR=") for tok in out)
+    values = te._openshell_environment()
+    assert values == {"FOO": "fooval"}
 
 
 def test_env_passthrough_default_list_used(monkeypatch):
     monkeypatch.setenv("MAC_HUB_URL", "http://hub:8789")
-    assert "MAC_HUB_URL=http://hub:8789" in _build()
+    assert te._openshell_environment()["MAC_HUB_URL"] == "http://hub:8789"
 
 
 def test_env_passthrough_defaults_include_yolo_bypass(monkeypatch):
     monkeypatch.setenv("HERMES_YOLO_MODE", "1")
-    assert "HERMES_YOLO_MODE=1" in _build()
+    assert te._openshell_environment()["HERMES_YOLO_MODE"] == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -247,13 +269,21 @@ def test_env_passthrough_defaults_include_yolo_bypass(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_invoke_sandboxed_runs_full_lifecycle(monkeypatch):
+def test_invoke_sandboxed_runs_full_lifecycle(monkeypatch, tmp_path):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "sb1")
     steps = []
+    events = []
     monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (steps.append(args) or (True, "")))
+    monkeypatch.setattr(
+        te,
+        "emit_telemetry",
+        lambda event, **detail: events.append((event, detail)) or True,
+    )
     r = FakeRunner()
-    te._invoke_agent(r, "do it", Path("/work/task-7"), "tid", {})
+    workspace = tmp_path / "task-7"
+    workspace.mkdir()
+    te._invoke_agent(r, "do it", workspace, "tid", {})
     # 1 audited create call (runs the agent), then download + delete out-of-band
     assert len(r.calls) == 1
     create = r.calls[0][0]
@@ -261,24 +291,107 @@ def test_invoke_sandboxed_runs_full_lifecycle(monkeypatch):
     assert steps[0][:3] == ["download", "sb1", "/sandbox/task-7"]
     assert Path(steps[0][3]).name.startswith(".task-7-openshell-download-")
     assert steps[1] == ["delete", "sb1"]
+    salvage = (workspace / "openshell-salvage.json").read_text(encoding="utf-8")
+    assert '"harvested": true' in salvage
+    assert [event for event, _detail in events if event.startswith("sandbox_")] == [
+        "sandbox_started",
+        "sandbox_agent_completed",
+        "sandbox_harvested",
+        "sandbox_deleted",
+    ]
 
 
-def test_invoke_sandboxed_tears_down_on_agent_failure(monkeypatch):
+def test_sandbox_create_argv_is_small_and_contains_no_prompt_or_tokens(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_WORKER_TOKEN", "mac-super-secret-token")
+    monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (True, ""))
+    workspace = tmp_path / "task-large"
+    prompt = "private-task-prompt-" + ("x" * 25000)
+    runner = FakeRunner()
+
+    te._invoke_agent(runner, prompt, workspace, "tid", {})
+
+    create = runner.calls[0][0]
+    joined = " ".join(create)
+    assert "mac-super-secret-token" not in joined
+    assert "private-task-prompt" not in joined
+    assert "--env" not in create
+    assert len(joined) < 4000
+
+
+def test_progress_monitor_emits_state_transitions_from_sandbox_snapshot(
+    monkeypatch, tmp_path
+):
+    snapshots = iter(
+        [
+            {
+                "ready": "1",
+                "head": "a" * 40,
+                "changed_count": "0",
+                "changed_digest": "clean",
+                "manifest": "0",
+            },
+            {
+                "ready": "1",
+                "head": "b" * 40,
+                "changed_count": "2",
+                "changed_digest": "digest-2",
+                "manifest": "1",
+            },
+        ]
+    )
+    events = []
+    monkeypatch.setenv("MAC_OPENSHELL_PROGRESS_INTERVAL", "0")
+    monkeypatch.setenv("MAC_TASK_REPO_BASE_SHA", "a" * 40)
+    monkeypatch.setattr(
+        te, "_sandbox_progress_snapshot", lambda *args: next(snapshots)
+    )
+    monkeypatch.setattr(
+        te,
+        "emit_telemetry",
+        lambda event, **detail: events.append((event, detail)) or True,
+    )
+    monitor = te._SandboxProgressMonitor("sb", "task", tmp_path, "tid")
+
+    monitor.observe()
+    monitor.observe()
+
+    assert [event for event, _detail in events] == [
+        "sandbox_ready",
+        "sandbox_head_observed",
+        "sandbox_first_mutation",
+        "sandbox_head_observed",
+        "sandbox_manifest_observed",
+    ]
+    assert monitor.evidence()["changed_file_digest"] == "digest-2"
+    assert monitor.evidence()["manifest_observed"] is True
+
+
+def test_invoke_sandboxed_harvests_then_tears_down_on_agent_failure(monkeypatch, tmp_path):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "sb2")
     steps = []
     monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (steps.append(args[0]) or (True, "")))
+    workspace = tmp_path / "task-7"
+    workspace.mkdir()
     with pytest.raises(RuntimeError, match="agent boom"):
-        te._invoke_agent(FakeRunner(raises=True), "do it", Path("/work/task-7"), "tid", {})
-    assert "delete" in steps  # teardown still ran (finally)
+        te._invoke_agent(FakeRunner(raises=True), "do it", workspace, "tid", {})
+    assert steps[-2:] == ["download", "delete"]
+    assert '"runner_completed": false' in (
+        workspace / "openshell-salvage.json"
+    ).read_text(encoding="utf-8")
 
 
-def test_invoke_sandboxed_keep_skips_delete(monkeypatch):
+def test_invoke_sandboxed_keep_skips_delete(monkeypatch, tmp_path):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_KEEP", "1")
     steps = []
     monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (steps.append(args[0]) or (True, "")))
-    te._invoke_agent(FakeRunner(), "do it", Path("/work/task-7"), "tid", {})
+    workspace = tmp_path / "task-7"
+    workspace.mkdir()
+    te._invoke_agent(FakeRunner(), "do it", workspace, "tid", {})
     assert "download" in steps and "delete" not in steps
 
 
@@ -305,20 +418,20 @@ def test_unsandboxed_fail_closed_raises(monkeypatch):
         te._unsandboxed_agent_argv(te._hermes_argv("do the thing"))
 
 
-def test_invoke_unsandboxed_fail_closed_raises(monkeypatch):
+def test_invoke_unsandboxed_fail_closed_raises(monkeypatch, tmp_path):
     monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
     monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "0")
     with pytest.raises(RuntimeError, match="without an OpenShell sandbox"):
-        te._invoke_agent(FakeRunner(), "do it", Path("/work/t"), "tid", {})
+        te._invoke_agent(FakeRunner(), "do it", tmp_path / "t", "tid", {})
 
 
-def test_invoke_sandbox_overrides_failclosed_hatch(monkeypatch):
+def test_invoke_sandbox_overrides_failclosed_hatch(monkeypatch, tmp_path):
     # sandbox on -> safe regardless of the unsandboxed hatch (no raise)
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "0")
     monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (True, ""))
     r = FakeRunner()
-    te._invoke_agent(r, "do it", Path("/work/t"), "tid", {})
+    te._invoke_agent(r, "do it", tmp_path / "t", "tid", {})
     assert r.calls[0][0][0] == "openshell"
 
 
@@ -361,9 +474,9 @@ def test_env_flags_rewrite_loopback_urls(monkeypatch):
     monkeypatch.setenv("MAC_OPENSHELL_ENV_PASSTHROUGH", "MAC_HUB_URL,MAC_WORKER_TOKEN")
     monkeypatch.setenv("MAC_HUB_URL", "http://127.0.0.1:8789")
     monkeypatch.setenv("MAC_WORKER_TOKEN", "tok-127.0.0.1-abc")  # not a URL -> untouched
-    flags = te._openshell_env_flags()
-    assert "MAC_HUB_URL=http://host.openshell.internal:8789" in flags
-    assert "MAC_WORKER_TOKEN=tok-127.0.0.1-abc" in flags
+    values = te._openshell_environment()
+    assert values["MAC_HUB_URL"] == "http://host.openshell.internal:8789"
+    assert values["MAC_WORKER_TOKEN"] == "tok-127.0.0.1-abc"
 
 
 def test_repo_worktree_aliases_hermes_clone_path(monkeypatch):
@@ -383,43 +496,43 @@ def test_host_alias_override(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_landlock_precheck_fail_closed(monkeypatch):
+def test_landlock_precheck_fail_closed(monkeypatch, tmp_path):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.delenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", raising=False)
     monkeypatch.setattr(te, "_kernel_has_landlock", lambda: False)
-    with pytest.raises(RuntimeError, match="does not expose .*Landlock"):
-        te._invoke_agent(FakeRunner(), "do it", Path("/work/t"), "tid", {})
+    with pytest.raises(RuntimeError, match="Landlock"):
+        te._invoke_agent(FakeRunner(), "do it", tmp_path / "t", "tid", {})
 
 
-def test_landlock_precheck_passes_when_present(monkeypatch):
+def test_landlock_precheck_passes_when_present(monkeypatch, tmp_path):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.delenv("MAC_OPENSHELL_ALLOW_NO_LANDLOCK", raising=False)
     monkeypatch.setattr(te, "_kernel_has_landlock", lambda: True)
     monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (True, ""))
     r = FakeRunner()
-    te._invoke_agent(r, "do it", Path("/work/t"), "tid", {})
+    te._invoke_agent(r, "do it", tmp_path / "t", "tid", {})
     assert r.calls[0][0][:3] == ["openshell", "sandbox", "create"]
 
 
 # --- child HERMES_YOLO_MODE env (fixes the approval.py import-order freeze) ---
 
 
-def test_sets_child_yolo_env_when_sandboxed(monkeypatch):
+def test_sets_child_yolo_env_when_sandboxed(monkeypatch, tmp_path):
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: (True, ""))
-    te._invoke_agent(FakeRunner(), "x", Path("/work/t"), "tid", {})
+    te._invoke_agent(FakeRunner(), "x", tmp_path / "t", "tid", {})
     assert os.environ.get("HERMES_YOLO_MODE") == "1"
 
 
-def test_sets_child_yolo_env_when_unsandboxed_allowed(monkeypatch):
+def test_sets_child_yolo_env_when_unsandboxed_allowed(monkeypatch, tmp_path):
     monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
-    te._invoke_agent(FakeRunner(), "x", Path("/work/t"), "tid", {})
+    te._invoke_agent(FakeRunner(), "x", tmp_path / "t", "tid", {})
     assert os.environ.get("HERMES_YOLO_MODE") == "1"
 
 
-def test_failclosed_does_not_set_yolo_env(monkeypatch):
+def test_failclosed_does_not_set_yolo_env(monkeypatch, tmp_path):
     monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
     monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "0")
     with pytest.raises(RuntimeError):
-        te._invoke_agent(FakeRunner(), "x", Path("/work/t"), "tid", {})
+        te._invoke_agent(FakeRunner(), "x", tmp_path / "t", "tid", {})
     assert os.environ.get("HERMES_YOLO_MODE") != "1"

--- a/tests/test_tailscale_supervisord.py
+++ b/tests/test_tailscale_supervisord.py
@@ -55,6 +55,15 @@ def test_detect_supervisor_picks_supervisord_when_systemd_dir_absent():
     → must resolve to 'supervisord'.
     """
     fn = _extract("detect_supervisor")
+    # Keep the production default literal covered by the source assertion
+    # below, but make this behavioral test independent of the CI host's init
+    # system. GitHub's Linux runners do have /run/systemd/system, whereas the
+    # target container nodes intentionally do not.
+    fn = fn.replace(
+        "[ -d /run/systemd/system ]",
+        '[ -d "$SYSTEMD_RUNTIME_DIR" ]',
+        1,
+    )
     # Override PATH so that a fake 'systemctl' and 'supervisorctl' are found
     # but NOT launchctl, and /run/systemd/system does not exist.
     snippet = r"""
@@ -62,30 +71,19 @@ SUPERVISOR_KIND=auto
 %(fn)s
 
 PATH_OVERRIDE="$(mktemp -d)"
+SYSTEMD_RUNTIME_DIR="$PATH_OVERRIDE/missing-systemd-runtime"
 # Fake supervisorctl (present) and systemctl (present but no /run/systemd/system)
 printf '#!/bin/sh\nexit 0\n' > "$PATH_OVERRIDE/supervisorctl"
 printf '#!/bin/sh\nexit 0\n' > "$PATH_OVERRIDE/systemctl"
 chmod +x "$PATH_OVERRIDE/supervisorctl" "$PATH_OVERRIDE/systemctl"
 
-# Ensure /run/systemd/system definitely does not exist in our fake env by
-# using a temp dir that has no such path; override the check by injecting an
-# environment variable that the test shim honours.
+# The rewritten test-only path definitely does not exist.
 PATH="$PATH_OVERRIDE" SUPERVISOR_KIND=auto detect_supervisor
 """ % {"fn": fn}
-    # We can't easily mock [ -d /run/systemd/system ] in bash without rewriting
-    # the function.  Instead use a scratch PATH and verify behaviour directly:
-    # on the real test machine /run/systemd/system is absent (GKE container),
-    # so the real binary check will hit the supervisord branch when our fake
-    # supervisorctl is on PATH.
     result = _run_bash(snippet)
-    # If we're on a real GKE container the output should be supervisord
-    # (or launchd on macOS CI, which we accept as a valid non-systemd path).
-    # The important assertion is: it must NOT be systemd.
     assert result.returncode == 0, result.stderr
     supervisor = result.stdout.strip()
-    assert supervisor in {"supervisord", "launchd"}, (
-        "Expected non-systemd supervisor, got: %r" % supervisor
-    )
+    assert supervisor == "supervisord"
 
 
 def test_detect_supervisor_requires_systemd_dir_not_just_systemctl():

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -44,9 +44,8 @@ def test_build_task_prompt_injects_recalled_lessons():
     task = {"id": "t1", "title": "Do a thing", "project": "demo"}
     base = te.build_task_prompt(task, Path("/tmp/task.json"), lessons=[])
     assert "Lessons from prior runs" not in base
-    assert "verification.environment_delta" in base
-    assert "task-local .venv" in base
-    assert "shared Hermes/worker virtualenv" in base
+    assert ".mac-executor-policy.txt" in base
+    assert "verification.environment_delta" not in base
     with_lessons = te.build_task_prompt(task, Path("/tmp/task.json"), lessons=["push before reporting", "run the contract tests"])
     assert "Lessons from prior runs" in with_lessons
     assert "push before reporting" in with_lessons
@@ -61,6 +60,22 @@ def test_build_task_prompt_demands_autonomy():
     assert "never ask the operator for confirmation" in prompt
 
 
+def test_agent_bundle_materializes_owner_only_versioned_policy(tmp_path):
+    bundle = te._write_agent_command_bundle(
+        tmp_path,
+        "small prompt",
+        te._hermes_argv(te.PROMPT_SENTINEL),
+    )
+    try:
+        assert bundle.policy_file.stat().st_mode & 0o777 == 0o600
+        policy = bundle.policy_file.read_text(encoding="utf-8")
+        assert policy.startswith("mac.executor_policy.v1")
+        assert "verification.environment_delta" in policy
+        assert "small prompt" not in policy
+    finally:
+        bundle.cleanup()
+
+
 def test_build_task_prompt_warns_repo_tasks_away_from_operator_result():
     task = {
         "id": "t1",
@@ -70,8 +85,8 @@ def test_build_task_prompt_warns_repo_tasks_away_from_operator_result():
     }
     prompt = te.build_task_prompt(task, Path("/tmp/task.json"))
     assert "default to evidence_type=repo_change" in prompt
-    assert "Use operator_result only for tasks that are not tied to a repository contract" in prompt
-    assert "codegraph audit object" in prompt
+    assert "use operator_result only when no repository contract exists" in prompt
+    assert "Deterministic host code enforces tests, CodeGraph" in prompt
 
 
 def test_repository_contract_section_no_repository_is_a_failure():
@@ -115,10 +130,29 @@ def test_sandbox_create_maps_repo_worktree_env_inside_upload(tmp_path, monkeypat
     monkeypatch.setenv("MAC_TASK_REPO_BRANCH", "mac/test")
     monkeypatch.setattr(te, "_resolve_openshell_policy", lambda: "/policy.yaml")
 
-    argv = te._build_sandbox_create_argv("sb", workspace, "task", ["python", "-m", "agent"])
+    env_file, _toolchain_file = te._write_sandbox_runtime_files(
+        workspace, "/sandbox/task"
+    )
+    argv = te._build_sandbox_create_argv(
+        "sb",
+        workspace,
+        "task",
+        [
+            "python",
+            "-m",
+            "mac.agent_command",
+            "--command-file",
+            "/sandbox/task/command.json",
+            "--prompt-file",
+            "/sandbox/task/prompt.txt",
+        ],
+    )
 
-    assert "MAC_TASK_REPO_WORKTREE=/sandbox/task/repo-lease" in argv
-    assert "MAC_TASK_REPO_BRANCH=mac/test" in argv
+    private_env = env_file.read_text(encoding="utf-8")
+    assert "MAC_TASK_REPO_WORKTREE=/sandbox/task/repo-lease" in private_env
+    assert "MAC_TASK_REPO_BRANCH=mac/test" in private_env
+    assert str(repo) not in " ".join(argv)
+    assert "MAC_TASK_REPO_BRANCH=mac/test" not in " ".join(argv)
     assert "mac_sandbox_toolchain_setup" in argv[-1]
 
 
@@ -392,6 +426,7 @@ PY''',
 def test_sandboxed_repo_task_runs_verification_before_download(tmp_path, monkeypatch):
     workspace = tmp_path / "task"
     workspace.mkdir()
+    monkeypatch.setenv("MAC_OPENSHELL_PROGRESS_INTERVAL", "0")
     monkeypatch.setattr(te, "_resolve_openshell_policy", lambda: "/policy.yaml")
     monkeypatch.setattr(te, "_ensure_landlock_or_fail", lambda: None)
     monkeypatch.setattr(te, "_sandbox_name", lambda: "sb")
@@ -421,14 +456,28 @@ def test_sandboxed_repo_task_runs_verification_before_download(tmp_path, monkeyp
         },
     }
 
-    result = te._run_sandboxed(fake_runner, ["python", "-m", "agent"], workspace, "t1", {"task": task})
+    result = te._run_sandboxed(
+        fake_runner,
+        [
+            "python",
+            "-m",
+            "mac.agent_command",
+            "--command-file",
+            "/sandbox/task/command.json",
+            "--prompt-file",
+            "/sandbox/task/prompt.txt",
+        ],
+        workspace,
+        "t1",
+        {"task": task},
+    )
 
     assert result.returncode == 0
     assert steps[0][0] == "runner"
     assert steps[1][:2] == ["upload", "sb"]
     verify_script = Path(steps[1][2])
     assert verify_script.name == ".mac-sandbox-repository-verify.sh"
-    assert "mac-sandbox-verification.json" in verify_script.read_text(encoding="utf-8")
+    assert not verify_script.exists(), "executor-only verification script should be cleaned"
     assert steps[1][3] == "/sandbox/task/.mac-sandbox-repository-verify.sh"
     assert steps[2][:2] == ["exec", "--name"]
     assert steps[2][-2:] == ["bash", "/sandbox/task/.mac-sandbox-repository-verify.sh"]
@@ -694,7 +743,7 @@ def test_recall_falls_back_to_direct_memory_records(monkeypatch):
     # deployment_learning records so the very next task still gets hindsight.
     learning = json.dumps({
         "schema": "mac.deployment_learning.v1",
-        "task_title": "Earlier task",
+        "task_title": "Router deployment failure",
         "evidence_type": "repo_change",
         "outcome": "failure",
         "error_signature": "check:git_finalizer rc=1",
@@ -704,13 +753,28 @@ def test_recall_falls_back_to_direct_memory_records(monkeypatch):
         if path.startswith("/v1/memory/recall"):
             return []  # vector tier not populated yet
         return [
+            {
+                "record_type": "deployment_learning:demo",
+                "content": json.dumps(
+                    {
+                        "schema": "mac.deployment_learning.v1",
+                        "task_title": "Unrelated spreadsheet export",
+                        "outcome": "success",
+                    }
+                ),
+                "created_at": "2026-06-01T00:00:00Z",
+            },
             {"record_type": "deployment_learning:demo", "content": learning, "created_at": "2026-05-31T00:00:00Z"},
             {"record_type": "other", "content": "ignored", "created_at": "2026-05-31T01:00:00Z"},
         ]
 
     monkeypatch.setattr(te, "_hub_get", fake_get)
-    lessons = te.recall_deployment_lessons({"title": "Next task", "project": "demo"})
-    assert lessons == ["[failure] Earlier task (repo_change) — failed: check:git_finalizer rc=1"]
+    lessons = te.recall_deployment_lessons(
+        {"title": "Fix router deployment", "project": "demo"}
+    )
+    assert lessons == [
+        "[failure] Router deployment failure (repo_change) — failed: check:git_finalizer rc=1"
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -758,6 +822,18 @@ def _install_fake_codegraph(tmp_path: Path, monkeypatch) -> Path:
     )
     script.chmod(0o755)
     monkeypatch.setenv("MAC_CODEGRAPH_BIN", str(script))
+    # Finalizer tests model a worker-prepared repository context. The worker
+    # records the canonical base before the agent starts; make that contract
+    # explicit instead of relying on the old finalizer's implicit HEAD~1/main.
+    work = tmp_path / "work"
+    if work.is_dir():
+        for base_ref in ("main", "develop"):
+            base = _git(work, "rev-parse", "--verify", base_ref)
+            if base.returncode == 0 and base.stdout.strip():
+                monkeypatch.setenv("MAC_TASK_REPO_BASE_SHA", base.stdout.strip())
+                monkeypatch.setenv("MAC_TASK_REPO_DEFAULT_BRANCH", base_ref)
+                monkeypatch.setenv("MAC_TASK_REPO_LEASE_ID", "lease-test")
+                break
     return script
 
 
@@ -852,24 +928,6 @@ def test_git_finalizer_pushes_to_canonical_remote_when_origin_differs(tmp_path, 
         .stdout.strip()
         == ""
     )
-
-
-def test_repository_push_remote_uses_auth_but_reports_redacted(monkeypatch):
-    monkeypatch.setenv("GH_TOKEN", "secret-token")
-    task = {
-        "metadata": {
-            "origin": {
-                "repository_contract": {
-                    "canonical_remote_url": "https://github.com/org/repo.git",
-                },
-            },
-        },
-    }
-
-    remote, display = te._repository_push_remote(task, "origin")
-
-    assert remote == "https://x-access-token:secret-token@github.com/org/repo.git"
-    assert display == "https://x-access-token:<redacted>@github.com/org/repo.git"
 
 
 def test_git_finalizer_runs_contract_bootstrap_before_tests(tmp_path, monkeypatch):
@@ -1227,8 +1285,8 @@ def test_git_finalizer_uses_non_main_canonical_branch(tmp_path, monkeypatch):
     assert {item["name"]: item["status"] for item in manifest["checks"]}["git_finalizer"] == "pass"
 
 
-def test_git_finalizer_blocks_when_no_remote_context(tmp_path, monkeypatch):
-    """No canonical remote in contract or env: fetch attempt fails closed (no silent pass)."""
+def test_git_finalizer_blocks_when_canonical_remote_is_missing(tmp_path, monkeypatch):
+    """A named-origin guess cannot replace the prepared canonical target."""
     origin = tmp_path / "origin.git"
     _git(tmp_path, "init", "--bare", str(origin))
     work = tmp_path / "work"
@@ -1247,7 +1305,7 @@ def test_git_finalizer_blocks_when_no_remote_context(tmp_path, monkeypatch):
     ws.mkdir()
     _install_fake_codegraph(tmp_path, monkeypatch)
     monkeypatch.setenv("MAC_TASK_REPO_WORKTREE", str(work))
-    # No canonical_remote_url, no env override — finalizer must not silently pass.
+    # No canonical_remote_url or prepared canonical URL: fail closed.
     task = {
         "id": "t-no-remote",
         "metadata": {
@@ -1263,9 +1321,9 @@ def test_git_finalizer_blocks_when_no_remote_context(tmp_path, monkeypatch):
     te.run_deterministic_git_finalizer(ws, task)
 
     manifest = json.loads((ws / "mac-evidence.json").read_text(encoding="utf-8"))
-    # Without a resolvable canonical remote, the freshness check must fail closed.
     assert manifest["repo"]["pushed"] is False
     assert manifest["push"]["status"] == "skipped"
+    assert "remote URL" in manifest["freshness_error"]
     assert {item["name"]: item["status"] for item in manifest["checks"]}["git_finalizer"] == "fail"
 
 
@@ -1400,13 +1458,16 @@ def test_main_runs_records_telemetry_and_memory(tmp_path, monkeypatch):
     seen = {}
 
     def fake_runner(argv, cwd, task_id, metadata):
-        seen["prompt"] = argv[argv.index("--query") + 1]
+        prompt_file = Path(argv[argv.index("--prompt-file") + 1])
+        seen["prompt"] = prompt_file.read_text(encoding="utf-8")
+        seen["argv"] = list(argv)
         return _FakeResult(0, stdout="Produced the rollout plan and mapped the dependencies.\n")
 
     rc = te.main(runner=fake_runner)
     assert rc == 0
     # recalled lesson reached the prompt
     assert "push before reporting" in seen["prompt"]
+    assert "push before reporting" not in seen["argv"]
     # fallback wrote an unverified operator_result
     manifest = json.loads((ws / "mac-evidence.json").read_text())
     assert manifest["evidence_type"] == "operator_result"
@@ -1443,15 +1504,22 @@ def test_invoke_agent_routes_to_coding_agent_when_available(tmp_path, monkeypatc
 
     def fake_runner(argv, cwd, task_id, metadata):
         captured["argv"] = argv
+        command_file = Path(argv[argv.index("--command-file") + 1])
+        captured["agent_argv"] = json.loads(
+            command_file.read_text(encoding="utf-8")
+        )["argv"]
         return _FakeResult(0, stdout="done\n")
 
     te._invoke_agent(fake_runner, "fix the bug", tmp_path, "tid", {})
     argv = captured["argv"]
-    assert argv[0] == "/usr/local/bin/claude"
-    assert "-p" in argv and argv[-1] == "fix the bug"
-    assert "--dangerously-skip-permissions" in argv
+    agent_argv = captured["agent_argv"]
+    assert "mac.agent_command" in argv
+    assert "fix the bug" not in argv
+    assert agent_argv[0] == "/usr/local/bin/claude"
+    assert "-p" in agent_argv and agent_argv[-1] == te.PROMPT_SENTINEL
+    assert "--dangerously-skip-permissions" in agent_argv
     # Messaging MCP config was materialized in the workspace and wired in (Claude).
-    assert "--mcp-config" in argv
+    assert "--mcp-config" in agent_argv
     assert (tmp_path / ".mac-coding-agent-mcp.json").is_file()
 
 
@@ -1472,8 +1540,9 @@ def test_invoke_agent_falls_back_to_hermes_when_no_coding_agent(tmp_path, monkey
         "tid",
         {},
     )
-    # Fell back to the Hermes -> gateway argv.
-    assert "--query" in captured["argv"] and "hermes_cli.main" in captured["argv"]
+    # Fell back to Hermes, still behind the private-prompt wrapper.
+    assert "mac.agent_command" in captured["argv"]
+    assert "do it" not in captured["argv"]
 
 
 # ---------------------------------------------------------------------------
@@ -1633,10 +1702,14 @@ def test_preflight_passes_only_on_sentinel_and_always_deletes(monkeypatch):
     monkeypatch.setattr(te, "_sandbox_step", lambda args, *, timeout: deleted.append(args) or (True, ""))
     choice = ca.CodingAgentChoice(agent="claude", available=True, binary="/usr/bin/claude")
     assert te._run_coding_agent_preflight(choice) is True
-    # The probe ran the real CLI with the preflight prompt, inside `sandbox create`.
+    # The probe runs through private files: neither prompt nor underlying agent
+    # command/credentials appear in the host's long-lived create argv.
     assert "create" in seen["argv"]
     joined = " ".join(seen["argv"])
-    assert "/usr/bin/claude" in joined and ca.PREFLIGHT_SENTINEL in joined
+    assert "mac.agent_command" in joined
+    assert "/usr/bin/claude" not in joined
+    assert ca.PREFLIGHT_PROMPT not in joined
+    assert ca.PREFLIGHT_SENTINEL not in joined
     # The throwaway sandbox is always deleted.
     assert deleted and deleted[0][0] == "delete"
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1246,7 +1246,12 @@ def test_mac_worker_finalizes_missing_repository_manifest(tmp_path: Path):
 
 def test_mac_worker_blocks_publication_when_canonical_advances_after_preparation(
     tmp_path: Path,
+    monkeypatch,
 ):
+    monkeypatch.setattr(
+        "mac.worker.run_codegraph_audit",
+        lambda _worktree, files: _codegraph_fixture(list(files)),
+    )
     cp = ControlPlane.in_memory()
     agent = register_worker_fixture(cp)
     seed, repo = _git_fixture(tmp_path)
@@ -1281,7 +1286,13 @@ def test_mac_worker_blocks_publication_when_canonical_advances_after_preparation
     assert _git(repo, "ls-remote", "origin", manifest["repo"]["remote_ref"]) == ""
 
 
-def test_mac_worker_publishes_after_merging_new_canonical_tip(tmp_path: Path):
+def test_mac_worker_publishes_after_merging_new_canonical_tip(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr(
+        "mac.worker.run_codegraph_audit",
+        lambda _worktree, files: _codegraph_fixture(list(files)),
+    )
     cp = ControlPlane.in_memory()
     agent = register_worker_fixture(cp)
     seed, repo = _git_fixture(tmp_path)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -315,6 +315,16 @@ def test_mac_worker_submits_durable_evidence_artifacts(tmp_path: Path):
             ),
             encoding="utf-8",
         )
+        (task_dir / "openshell-salvage.json").write_text(
+            json.dumps(
+                {
+                    "schema": "mac.openshell_salvage.v1",
+                    "harvested": True,
+                    "progress": {"changed_file_digest": "sha256:test"},
+                }
+            ),
+            encoding="utf-8",
+        )
         return WorkerExecution(
             0,
             "captured output",
@@ -336,7 +346,14 @@ def test_mac_worker_submits_durable_evidence_artifacts(tmp_path: Path):
     evidence = cp.list_evidence(task.id)[0]
     index = evidence.metadata["durable_artifacts"]["artifacts"]
     by_name = {item["name"]: item for item in index}
-    assert {"worker-result.json", "stdout.txt", "stderr.txt", "mac-evidence.json"} <= set(by_name)
+    assert {
+        "worker-result.json",
+        "stdout.txt",
+        "stderr.txt",
+        "mac-evidence.json",
+        "openshell-salvage.json",
+    } <= set(by_name)
+    assert by_name["openshell-salvage.json"]["sha256"].startswith("sha256:")
     assert "content_base64" not in by_name["stdout.txt"]
     stdout_artifact = cp.get_evidence_artifact(evidence.id, by_name["stdout.txt"]["id"])
     stderr_artifact = cp.get_evidence_artifact(evidence.id, by_name["stderr.txt"]["id"])
@@ -1129,7 +1146,7 @@ def test_mac_worker_derives_repo_anchor_for_documentation_evidence(tmp_path: Pat
     assert repo_anchor["files_changed"] == ["docs/implementation-plan.md"]
 
 
-def test_mac_worker_auto_publishes_repository_worktree_when_enabled(tmp_path: Path):
+def test_mac_worker_finalizes_dirty_repository_despite_incomplete_manifest(tmp_path: Path):
     cp = ControlPlane.in_memory()
     agent = register_worker_fixture(cp)
     _seed, repo = _git_fixture(tmp_path)
@@ -1137,9 +1154,8 @@ def test_mac_worker_auto_publishes_repository_worktree_when_enabled(tmp_path: Pa
     _git(repo, "config", "user.name", "mac tests")
     metadata = _repository_task_metadata(repo)
     metadata["execution_contract"]["evidence_type"] = "documentation"
-    metadata["repository_auto_publish"] = True
     task = cp.create_task(
-        "Repository docs auto-publish task",
+        "Repository docs finalization task",
         required_capabilities=["python"],
         metadata=metadata,
     )
@@ -1228,6 +1244,81 @@ def test_mac_worker_finalizes_missing_repository_manifest(tmp_path: Path):
     )
 
 
+def test_mac_worker_blocks_publication_when_canonical_advances_after_preparation(
+    tmp_path: Path,
+):
+    cp = ControlPlane.in_memory()
+    agent = register_worker_fixture(cp)
+    seed, repo = _git_fixture(tmp_path)
+    task = cp.create_task(
+        "Repository task prepared on stale base",
+        required_capabilities=["python"],
+        metadata=_repository_task_metadata(repo),
+    )
+    client = TestClient(create_app(control_plane=cp))
+
+    def executor(task_payload: Dict[str, Any], _task_dir: Path) -> WorkerExecution:
+        worktree = Path(task_payload["metadata"]["runtime"]["repository_worktree"])
+        (worktree / "feature.py").write_text("feature\n", encoding="utf-8")
+        _commit_fixture_update(seed, "canonical advanced\n")
+        return WorkerExecution(0, "changed repo after canonical advanced", stdout="ok\n")
+
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=api_transport(client)),
+        agent.id,
+        tmp_path / "workspaces",
+        executor,
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+
+    result = worker.run_once()
+
+    assert result.status == "blocked"
+    manifest = cp.list_evidence(task.id)[0].metadata["verification"]
+    assert manifest["repo"]["pushed"] is False
+    assert manifest["repo"]["freshness"]["ok"] is False
+    assert "not an ancestor" in manifest["repo"]["freshness"]["error"]
+    assert _git(repo, "ls-remote", "origin", manifest["repo"]["remote_ref"]) == ""
+
+
+def test_mac_worker_publishes_after_merging_new_canonical_tip(tmp_path: Path):
+    cp = ControlPlane.in_memory()
+    agent = register_worker_fixture(cp)
+    seed, repo = _git_fixture(tmp_path)
+    task = cp.create_task(
+        "Repository task refreshes canonical base",
+        required_capabilities=["python"],
+        metadata=_repository_task_metadata(repo),
+    )
+    client = TestClient(create_app(control_plane=cp))
+
+    def executor(task_payload: Dict[str, Any], _task_dir: Path) -> WorkerExecution:
+        worktree = Path(task_payload["metadata"]["runtime"]["repository_worktree"])
+        _commit_fixture_update(seed, "canonical advanced\n")
+        _git(worktree, "fetch", "origin", "main")
+        _git(worktree, "merge", "--ff-only", "FETCH_HEAD")
+        (worktree / "feature.py").write_text("feature\n", encoding="utf-8")
+        return WorkerExecution(0, "merged canonical and changed repo", stdout="ok\n")
+
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=api_transport(client)),
+        agent.id,
+        tmp_path / "workspaces",
+        executor,
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+
+    result = worker.run_once()
+
+    assert result.status == "submitted_for_review"
+    manifest = cp.list_evidence(task.id)[0].metadata["verification"]
+    assert manifest["repo"]["pushed"] is True
+    assert manifest["repo"]["freshness"]["ok"] is True
+    assert manifest["repo"]["freshness"]["canonical_tip_sha"] == _git(
+        seed, "rev-parse", "HEAD"
+    )
+
+
 def test_mac_worker_does_not_push_invalid_finalized_repository_manifest(tmp_path: Path):
     cp = ControlPlane.in_memory()
     agent = register_worker_fixture(cp)
@@ -1287,7 +1378,6 @@ def test_mac_worker_fails_when_required_changed_files_are_missing(tmp_path: Path
         "README.md",
         "docs/demo-story.md",
     ]
-    metadata["repository_auto_publish"] = True
     task = cp.create_task(
         "Repository docs task with required files",
         required_capabilities=["python"],

--- a/tests/test_worker_remote_clone.py
+++ b/tests/test_worker_remote_clone.py
@@ -119,7 +119,11 @@ def test_remote_clone_happy_path_creates_branch(tmp_path: Path, monkeypatch: pyt
     assert ctx is not None
     assert ctx["schema"] == "mac.repository_task_worktree.v1"
     assert ctx["checkout_policy"] == "k8s_task_owned_clone"
-    assert ctx["repository_origin_remote"] == "https://gitea.omv.test/org/repo.git"
+    assert ctx["repository_origin_remote"] == (
+        "https://x-access-token:<redacted>@gitea.omv.test/org/repo.git"
+    )
+    assert ctx["repository_canonical_remote"] == ctx["repository_origin_remote"]
+    assert ctx["repository_canonical_branch"] == "main"
     assert ctx["repository_base_sha"] == "a" * 40
     assert ctx["repository_branch"].startswith("mac/")
 
@@ -486,9 +490,7 @@ def test_local_worktree_uses_fetched_canonical_head_not_stale_local(
     # Context must carry audit fields.
     assert ctx["repository_local_prior_sha"] == stale_sha
     assert ctx["repository_canonical_branch"] == "main"
-    # Canonical remote must be redacted (not a raw URL with credentials).
     assert ctx["repository_canonical_remote"] != ""
-    assert "x-access-token" not in str(ctx["repository_canonical_remote"])
     # ahead/behind must be structured integers.
     assert isinstance(ctx.get("repository_ahead"), int), "repository_ahead must be int"
     assert isinstance(ctx.get("repository_behind"), int), "repository_behind must be int"
@@ -951,6 +953,12 @@ def test_local_worktree_context_carries_redacted_remote_and_integer_audit_fields
     task_dir = tmp_path / "tasks" / "task-audit-ctx"
     task_dir.mkdir(parents=True)
 
+    test_token = "mac-hermetic-redaction-secret"
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITEA_TOKEN", raising=False)
+    monkeypatch.delenv("MAC_TASK_GIT_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", test_token)
+
     ctx = worker._prepare_repository_worktree(task, lease, task_dir)
     assert ctx is not None
     # canonical_remote must NOT be the literal placeholder '<remote>'.
@@ -958,8 +966,9 @@ def test_local_worktree_context_carries_redacted_remote_and_integer_audit_fields
         "canonical_remote must be a real redacted URL, not the placeholder '<remote>'"
     )
     # It must be a valid (possibly redacted) URL that doesn't leak raw credentials.
-    assert ctx["repository_canonical_remote"] != ""
-    assert "x-access-token" not in str(ctx["repository_canonical_remote"])
+    display = str(ctx["repository_canonical_remote"])
+    assert test_token not in display
+    assert "x-access-token:<redacted>@" in display
     # Audit fields.
     assert ctx["repository_local_prior_sha"] == prior_sha
     assert ctx["repository_canonical_branch"] == "main"


### PR DESCRIPTION
## Summary

- replace duplicate repository publication checks with one immutable canonical target, shared lock, isolated fetch ref, freshness proof, guarded push, and remote verification
- remove the dormant worker auto-publish compatibility path and fail closed when prepared repository context is incomplete
- keep prompts, fleet tokens, and large sandbox bootstrap bodies out of long-lived process argv; add versioned executor policy input
- add real OpenShell lifecycle progress, guaranteed harvest-before-delete, and durable salvage evidence
- validate hub/spoke router topology before local rendering or remote deployment mutation

## Validation

- `scripts/run-contract-tests.sh`: 2480 passed, 19 skipped; 83.84% coverage
- `codegraph sync` and `codegraph affected --stdin`: completed successfully
- shell syntax checks passed for all modified fleet scripts
- wheel build verified `mac/agent_command.py` and `mac/executor-policy.txt` are packaged

## Ledger tasks

- task_a23bc83b8b59488d810e67a64259adac
- task_69ccd2d991564527a4accf42681a52b7
- task_4682c3d0ea614f4e8b56f229858e4818
- task_71b2c56f1aea467a80aaeff59a89f730
- task_8bfb841cdcfd4907b5707b4f6ff123cf
- task_96582d89416941868e86e0560c33f73b
