### PR TITLE
Honor fleet validation env files

### DIFF
--- a/src/mac/fleet_setup.py
+++ b/src/mac/fleet_setup.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from mac.fleet_deploy import normalize_ssh_target
+from mac.fleet_env import parse_env_file
 from mac.providers import ROUTER_PROVIDERS, router_secret_name
 
 SETUP_SPEC_SCHEMA = "mac.fleet_setup.v1"
@@ -83,9 +84,15 @@ def build_setup_plan(
     """Build a machine-readable setup plan from a declarative spec.
 
     The returned object intentionally contains no side effects. Callers decide
-    whether to write files, dry-run, validate only, or deploy.
+    whether to write files, dry-run, validate only, or deploy. Values from
+    ``env_file`` fill gaps in the effective environment; an explicit ``env``
+    mapping (or the live process environment when ``env`` is omitted) wins so
+    a caller can intentionally override persisted operator configuration.
     """
-    env_map = dict(os.environ if env is None else env)
+    env_map: Dict[str, str] = {}
+    if env_file is not None:
+        env_map.update(parse_env_file(Path(env_file).expanduser()))
+    env_map.update(os.environ if env is None else env)
     errors: List[str] = []
     warnings: List[str] = []
     schema = str(spec.get("schema") or "").strip()

--- a/tests/test_fleet_setup.py
+++ b/tests/test_fleet_setup.py
@@ -106,19 +106,56 @@ def test_declarative_webdav_enabled_without_dns_name_fails(tmp_path):
 
 
 def test_declarative_setup_plan_reports_missing_provider_env(tmp_path):
+    env_file = tmp_path / ".env"
     plan = build_setup_plan(
         _spec(),
         root=ROOT,
         fleets_config=tmp_path / "fleets.yaml",
-        env_file=tmp_path / ".env",
+        env_file=env_file,
         env={},
     )
 
+    assert not env_file.exists()
     assert plan["status"] == "fail"
     assert plan["required_env"] == ["NVIDIA_API_KEY"]
     env_check = [check for check in plan["checks"] if check["name"] == "env.required"][0]
     assert env_check["status"] == "fail"
     assert "NVIDIA_API_KEY" in env_check["detail"]
+
+
+def test_declarative_setup_plan_reads_required_provider_from_env_file(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("NVIDIA_API_KEY=env-file-secret\n", encoding="utf-8")
+
+    plan = build_setup_plan(
+        _spec(),
+        root=ROOT,
+        fleets_config=tmp_path / "fleets.yaml",
+        env_file=env_file,
+        env={},
+    )
+
+    assert plan["status"] == "pass"
+    assert plan["env_values"]["NVIDIA_API_KEY"] == "env-file-secret"
+    rendered = json.dumps(public_plan(plan))
+    assert "env-file-secret" not in rendered
+    assert public_plan(plan)["env_values"]["NVIDIA_API_KEY"] == "<set>"
+
+
+def test_live_environment_overrides_persisted_env_file(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("NVIDIA_API_KEY=persisted-secret\n", encoding="utf-8")
+    monkeypatch.setenv("NVIDIA_API_KEY", "live-secret")
+
+    plan = build_setup_plan(
+        _spec(),
+        root=ROOT,
+        fleets_config=tmp_path / "fleets.yaml",
+        env_file=env_file,
+    )
+
+    assert plan["status"] == "pass"
+    assert plan["env_values"]["NVIDIA_API_KEY"] == "live-secret"
 
 
 def test_setup_fleet_spec_mode_writes_registry_and_env(tmp_path):
@@ -160,8 +197,11 @@ def test_setup_fleet_spec_mode_writes_registry_and_env(tmp_path):
 
 def test_mac_fleet_doctor_prints_llm_setup_report(tmp_path):
     spec_path = tmp_path / "fleet.yaml"
+    env_file = tmp_path / ".env"
     spec_path.write_text(yaml.safe_dump(_spec()), encoding="utf-8")
-    env = {**os.environ, "NVIDIA_API_KEY": "nv-secret"}
+    env_file.write_text("NVIDIA_API_KEY=doctor-file-secret\n", encoding="utf-8")
+    env = dict(os.environ)
+    env.pop("NVIDIA_API_KEY", None)
 
     result = subprocess.run(
         [
@@ -176,7 +216,7 @@ def test_mac_fleet_doctor_prints_llm_setup_report(tmp_path):
             "--fleets-config",
             str(tmp_path / "fleets.yaml"),
             "--env-file",
-            str(tmp_path / ".env"),
+            str(env_file),
         ],
         cwd=ROOT,
         env=env,
@@ -191,6 +231,44 @@ def test_mac_fleet_doctor_prints_llm_setup_report(tmp_path):
     assert report["status"] == "pass"
     assert report["hub"] == "horde-hub"
     assert any(check["name"] == "router.providers" for check in report["checks"])
+
+
+def test_mac_fleet_validate_reads_and_redacts_env_file(tmp_path):
+    spec_path = tmp_path / "fleet.yaml"
+    env_file = tmp_path / ".env"
+    spec_path.write_text(yaml.safe_dump(_spec()), encoding="utf-8")
+    env_file.write_text("NVIDIA_API_KEY=validate-file-secret\n", encoding="utf-8")
+    env = dict(os.environ)
+    env.pop("NVIDIA_API_KEY", None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mac.cli",
+            "--json",
+            "fleet",
+            "validate",
+            "--spec",
+            str(spec_path),
+            "--fleets-config",
+            str(tmp_path / "fleets.yaml"),
+            "--env-file",
+            str(env_file),
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "validate-file-secret" not in result.stdout
+    assert "validate-file-secret" not in result.stderr
+    report = json.loads(result.stdout)
+    assert report["status"] == "pass"
+    assert report["env_values"]["NVIDIA_API_KEY"] == "<set>"
 
 
 def test_spec_path_materializes_default_model_never_blank(tmp_path):


### PR DESCRIPTION
Fixes task_3f03037f22af4c6bb61c484efc170fd0. Parse the selected fleet env file in the shared setup planner, preserve live/explicit environment precedence, and cover validate/doctor behavior plus redaction. Verification: scripts/run-contract-tests.sh (2492 passed, 19 skipped); CodeGraph sync and affected audit passed.