### PR TITLE
Honor canonical clone remotes and repair task claims

### DIFF
--- a/deploy/codex-runner/mac-task-executor-opencode-build
+++ b/deploy/codex-runner/mac-task-executor-opencode-build
@@ -88,6 +88,7 @@ PROMPT="Task ${MAC_TASK_ID}"
 REPO_URL=""
 REPO_BRANCH="main"
 PROJECT=""
+REPO_ERROR=""
 if [ -n "${MAC_URL}" ] && [ -n "${MAC_TASK_ID}" ] && [ -n "${MAC_WORKER_TOKEN}" ]; then
     task_json="$(curl -fsS --config - \
         "${MAC_URL}/tasks/${MAC_TASK_ID}" 2>/dev/null <<CURL || true
@@ -96,7 +97,7 @@ CURL
 )"
     if [ -n "${task_json}" ]; then
         eval "$(printf '%s' "${task_json}" | python3 -c '
-import json, shlex, sys
+import json, shlex, sys, urllib.parse
 
 def render_feedback(task):
     meta = task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
@@ -137,13 +138,69 @@ if feedback:
     prompt = prompt + "\n\n" + feedback
 print("PROMPT=%s" % shlex.quote(prompt))
 print("PROJECT=%s" % shlex.quote(t.get("project") or ""))
-origin = (t.get("metadata") or {}).get("origin") or {}
-print("REPO_URL=%s" % shlex.quote(origin.get("repository_url") or ""))
+meta = (t.get("metadata") or {})
+origin = meta.get("origin") or {}
+
+def nested_dict(root, *path):
+    node = root
+    for key in path:
+        if not isinstance(node, dict):
+            return {}
+        node = node.get(key)
+    return node if isinstance(node, dict) else {}
+
+repo_url = str(origin.get("repository_url") or "").strip()
+repo_source = "origin.repository_url"
+if not repo_url:
+    contracts = [
+        nested_dict(meta, "execution_contract", "repository_contract"),
+        nested_dict(meta, "origin", "repository_contract"),
+        nested_dict(meta, "repository_contract"),
+    ]
+    for contract in contracts:
+        repo_url = str(contract.get("canonical_remote_url") or "").strip()
+        if repo_url:
+            repo_source = "repository contract canonical_remote_url"
+            break
+
+def valid_repo_url(value):
+    if not value or value.startswith("-") or len(value) > 2048:
+        return False
+    if any(char.isspace() for char in value):
+        return False
+    if value.startswith("/"):
+        return True
+    if value.startswith("git@"):
+        return ":" in value.partition("@")[2]
+    try:
+        parsed = urllib.parse.urlsplit(value)
+    except ValueError:
+        return False
+    if parsed.scheme == "file":
+        return bool(parsed.path)
+    if parsed.scheme not in {"http", "https", "ssh", "git"} or not parsed.hostname:
+        return False
+    if parsed.scheme in {"http", "https"} and parsed.username:
+        return False
+    return True
+
+repo_error = ""
+if repo_url and not valid_repo_url(repo_url):
+    repo_error = (
+        "%s is invalid (value redacted); expected a supported git remote "
+        "without embedded credentials" % repo_source
+    )
+    repo_url = ""
+print("REPO_URL=%s" % shlex.quote(repo_url))
+print("REPO_ERROR=%s" % shlex.quote(repo_error))
 print("REPO_BRANCH=%s" % shlex.quote(origin.get("default_branch") or "main"))
 print("CHECKOUT_BRANCH=%s" % shlex.quote(origin.get("checkout_branch") or ""))
-meta = (t.get("metadata") or {})
 print("SKIP_PR_OPEN=%s" % ("true" if meta.get("skip_pr_open") else ""))
 ' || true)"
+    fi
+    if [ -n "${REPO_ERROR}" ]; then
+        echo "[FATAL] ${REPO_ERROR}" >&2
+        exit 2
     fi
     # If task didn't carry the repo URL, fall back to project metadata. GET /projects/{name} returns a wrapper {project, summary, record, tasks,...}; the project record (with its metadata) is nested under `record`.
     if [ -z "${REPO_URL}" ] && [ -n "${PROJECT}" ]; then

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -280,14 +280,17 @@ class RemoteDispatch:
         lease_seconds: Optional[int] = None,
         sync_beads: Optional[bool] = None,
     ) -> tuple:  # type: ignore[type-arg]
-        body = _drop_none(
+        # The hub endpoint models these as query parameters. ``sync_beads`` is
+        # intentionally local-only; remote claims always use the hub's
+        # one-way-migration-safe behavior.
+        path = "/tasks/%s/claim" % quote(task_id, safe="")
+        path += _query(
             {
                 "agent_id": agent_id,
                 "lease_seconds": lease_seconds,
-                "sync_beads": sync_beads,
             }
         )
-        resp = self._post("/tasks/%s/claim" % quote(task_id, safe=""), body)
+        resp = self._post(path)
         task_payload = resp.get("task") if isinstance(resp, dict) else None
         lease_payload = resp.get("lease") if isinstance(resp, dict) else None
         return _Dictish(task_payload or {}), _Dictish(lease_payload or {})

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -2355,8 +2355,8 @@ class MacWorker:
             candidate = self._resolve_repository_source_path(origin)
             if candidate.exists():
                 local_source = candidate
-        remote_url = self._resolve_repository_remote_url(origin)
         if local_source is None:
+            remote_url = self._resolve_repository_remote_url(task, origin)
             if remote_url:
                 return self._prepare_repository_worktree_from_remote(
                     task, lease, task_dir, origin, remote_url
@@ -2374,7 +2374,8 @@ class MacWorker:
                 )
             raise RuntimeError(
                 "repository task origin has neither a local repository_path "
-                "nor a repository_url (or MAC_TASK_REPO_URL env)"
+                "nor a repository_url, repository contract canonical_remote_url, "
+                "or MAC_TASK_REPO_URL env"
             )
         source = local_source
 
@@ -2680,19 +2681,31 @@ class MacWorker:
                 return candidate
         return Path(str(origin.get("repository_path") or "")).expanduser()
 
-    def _resolve_repository_remote_url(self, origin: JsonDict) -> str:
-        """Return the remote clone URL for the K8s clone path, or "".
+    def _resolve_repository_remote_url(self, task: JsonDict, origin: JsonDict) -> str:
+        """Return the remote clone URL for a worker without a local source.
 
-        The task ``origin.repository_url`` takes precedence; if the task
-        does not carry one, ``MAC_TASK_REPO_URL`` from the environment is
-        consulted (the K8s Job pod injects this). Empty string means
-        "no remote URL available."""
+        An explicit ``origin.repository_url`` is the task-level override. The
+        durable repository contract is next, followed by the legacy
+        ``MAC_TASK_REPO_URL`` runtime fallback. Empty string means no remote is
+        available. Invalid values fail closed without echoing possible secrets.
+        """
         raw = str(origin.get("repository_url") or "").strip()
+        source = "origin.repository_url"
+        if not raw:
+            raw = _repository_contract_canonical_remote(task)
+            source = "repository contract canonical_remote_url"
         if not raw:
             raw = os.environ.get("MAC_TASK_REPO_URL", "").strip()
+            source = "MAC_TASK_REPO_URL"
         if not raw:
             return ""
-        return _validate_git_remote_url(raw)
+        try:
+            return _validate_git_remote_url(raw)
+        except ValueError:
+            raise ValueError(
+                "%s is invalid (value redacted); expected a supported git remote "
+                "without embedded credentials" % source
+            ) from None
 
     def _prepare_repository_worktree_from_remote(
         self,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -663,7 +663,7 @@ def test_remote_dispatch_task_show_via_cli(monkeypatch):
 
 
 def test_remote_dispatch_task_claim_returns_task_and_lease(monkeypatch):
-    """`task claim` reads `task` and `lease.id` from a two-field response."""
+    """`task claim` sends the API's query contract and reads its response."""
     import io
     import json as _json
     import sys
@@ -710,6 +710,75 @@ def test_remote_dispatch_task_claim_returns_task_and_lease(monkeypatch):
     # cli.cmd_task_claim builds {"task": ..., "lease_id": lease.id if lease else None}
     assert body["task"]["id"] == "task_xyz"
     assert body["lease_id"] == "lease_42"
+    method, url, request_body, _token = fake.calls[0]
+    from urllib.parse import parse_qs, urlsplit
+
+    assert method == "POST"
+    assert urlsplit(url).path == "/tasks/task_xyz/claim"
+    assert parse_qs(urlsplit(url).query) == {"agent_id": ["agent_natasha"]}
+    assert request_body == {}
+
+
+def test_remote_cli_task_claim_matches_live_api_and_persists_lease(monkeypatch):
+    """Exercise the documented CLI through RemoteDispatch and the real API."""
+    import json as _json
+    from urllib.parse import urlsplit
+
+    from fastapi.testclient import TestClient
+
+    from mac.api import create_app
+    from mac.cli import main
+    from mac.http_client import HubClient
+    from mac.services import ControlPlane
+
+    monkeypatch.delenv("MAC_DB", raising=False)
+    monkeypatch.setenv("MAC_DEPLOY_ENV_FILE", "/dev/null")
+    plane = ControlPlane.in_memory()
+    machine = plane.register_machine("claim-host")
+    agent = plane.register_agent(machine.id, "claim-worker", capabilities=["python"])
+    task = plane.create_task("claim through remote CLI", required_capabilities=["python"])
+    api = TestClient(create_app(control_plane=plane))
+
+    def api_transport(method, url, body, _token):
+        parts = urlsplit(url)
+        target = parts.path + (("?" + parts.query) if parts.query else "")
+        response = api.request(method, target, json=body)
+        assert response.status_code == 200, response.text
+        return response.json()
+
+    original_init = HubClient.__init__
+    monkeypatch.setattr(
+        HubClient,
+        "__init__",
+        lambda self, base_url, *, token=None, transport=None: original_init(
+            self, base_url, token=token, transport=api_transport
+        ),
+    )
+
+    output = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = output
+    try:
+        rc = main(
+            [
+                "--hub-url",
+                "http://hub.example:8789",
+                "task",
+                "claim",
+                task.id,
+                agent.id,
+            ]
+        )
+    finally:
+        sys.stdout = old_stdout
+
+    assert rc == 0
+    result = _json.loads(output.getvalue())
+    assert result["task"]["state"] == "claimed"
+    assert result["task"]["owner_agent_id"] == agent.id
+    lease = plane.get_lease(result["lease_id"])
+    assert lease.task_id == task.id
+    assert lease.agent_id == agent.id
 
 
 def test_remote_dispatch_nap_cycle_via_cli_uses_hub_writer(monkeypatch):

--- a/tests/test_opencode_build_executor.py
+++ b/tests/test_opencode_build_executor.py
@@ -474,6 +474,80 @@ def _findings_by_kind(manifest: dict) -> Dict[str, dict]:
     return out
 
 
+def test_k8s_executor_uses_contract_remote_when_registered_path_is_hub_only(
+    tmp_path: Path,
+) -> None:
+    bindir = tmp_path / "bin"
+    canonical = "https://github.com/NVIDIA-dev/ova.git"
+    contract = {
+        "schema": "mac.repository_contract.v1",
+        "canonical_remote_url": canonical,
+    }
+    _make_fake_bin(
+        bindir,
+        opencode_stdout=json.dumps({"type": "step_finish", "reason": "stop"}) + "\n",
+        task_metadata={
+            "origin": {
+                "repository_path": "/hub-only/src/ova",
+                "repository_contract": contract,
+            },
+            "execution_contract": {
+                "type": "repository",
+                "repository_contract": contract,
+            },
+        },
+    )
+    manifest_path = tmp_path / "mac-evidence.json"
+
+    result = _run_build(bindir=bindir, manifest_path=manifest_path)
+
+    assert result.returncode == 0, result.stderr
+    assert manifest_path.exists()
+    assert "REPO_URL:         %s" % canonical in result.stdout
+    assert "git clone --depth=1 --branch=main %s" % canonical in result.stdout
+
+
+def test_k8s_executor_rejects_invalid_contract_remote_without_leaking_secret(
+    tmp_path: Path,
+) -> None:
+    bindir = tmp_path / "bin"
+    redaction_marker = "test-only-redaction-marker"
+    credential_url = (
+        "https://"
+        + "operator:"
+        + redaction_marker
+        + "@"
+        + "github.com/NVIDIA-dev/ova.git"
+    )
+    _make_fake_bin(
+        bindir,
+        opencode_stdout="",
+        task_metadata={
+            "origin": {
+                "repository_path": "/hub-only/src/ova",
+                "repository_contract": {"schema": "mac.repository_contract.v1"},
+            },
+            "execution_contract": {
+                "type": "repository",
+                "repository_contract": {
+                    "schema": "mac.repository_contract.v1",
+                    "canonical_remote_url": credential_url,
+                },
+            },
+        },
+    )
+    manifest_path = tmp_path / "mac-evidence.json"
+
+    result = _run_build(bindir=bindir, manifest_path=manifest_path)
+
+    assert result.returncode == 2
+    assert "repository contract canonical_remote_url is invalid" in result.stderr
+    assert redaction_marker not in result.stdout
+    assert redaction_marker not in result.stderr
+    assert "git clone" not in result.stdout
+    assert not manifest_path.exists()
+
+
 def test_captures_stdout_stderr_head_tail_and_event_summary(tmp_path: Path) -> None:
     bindir = tmp_path / "bin"
     # Build a JSON-lines stream using the REAL opencode event shapes:

--- a/tests/test_worker_remote_clone.py
+++ b/tests/test_worker_remote_clone.py
@@ -143,6 +143,99 @@ def test_remote_clone_happy_path_creates_branch(tmp_path: Path, monkeypatch: pyt
     assert checkout_calls[0]["args"][1] == "-b"
 
 
+def test_remote_clone_uses_contract_when_registered_path_is_hub_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worker = _make_worker(tmp_path)
+    fake = _FakeGit(head_sha="c" * 40)
+    monkeypatch.setattr("mac.worker._run_git_in", fake.run_git_in)
+    monkeypatch.setattr("mac.worker._run_git", fake.run_git)
+    monkeypatch.delenv("MAC_TASK_REPO_URL", raising=False)
+
+    canonical = "https://github.com/NVIDIA-dev/ova.git"
+    task = _repo_task(repository_path="/hub-only/src/ova")
+    task["metadata"]["origin"]["repository_name"] = "ova"
+    task["metadata"]["origin"]["repository_contract"]["project"] = "ova"
+    task["metadata"]["execution_contract"]["repository_contract"] = {
+        "schema": "mac.repository_contract.v1",
+        "canonical_remote_url": canonical,
+    }
+    lease = {"id": "lease-contract"}
+    task_dir = tmp_path / "tasks" / "task-contract"
+    task_dir.mkdir(parents=True)
+
+    ctx = worker._prepare_repository_worktree(task, lease, task_dir)
+
+    assert ctx is not None
+    assert ctx["checkout_policy"] == "k8s_task_owned_clone"
+    assert ctx["repository_declared_path"] == "/hub-only/src/ova"
+    assert ctx["repository_canonical_remote_url"] == canonical
+    assert fake.calls[0]["args"][-2].endswith("github.com/NVIDIA-dev/ova.git")
+
+
+def test_remote_clone_explicit_origin_url_overrides_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worker = _make_worker(tmp_path)
+    fake = _FakeGit()
+    monkeypatch.setattr("mac.worker._run_git_in", fake.run_git_in)
+    monkeypatch.setattr("mac.worker._run_git", fake.run_git)
+    monkeypatch.delenv("MAC_TASK_REPO_URL", raising=False)
+
+    explicit = "https://gitea.omv.test/org/override.git"
+    task = _repo_task(
+        repository_url=explicit,
+        repository_path="/hub-only/src/repo",
+    )
+    task["metadata"]["origin"]["repository_name"] = "external-repo"
+    task["metadata"]["origin"]["repository_contract"]["project"] = "external-repo"
+    task["metadata"]["execution_contract"]["repository_contract"] = {
+        "schema": "mac.repository_contract.v1",
+        "canonical_remote_url": "https://github.com/org/canonical.git",
+    }
+    lease = {"id": "lease-override"}
+    task_dir = tmp_path / "tasks" / "task-override"
+    task_dir.mkdir(parents=True)
+
+    ctx = worker._prepare_repository_worktree(task, lease, task_dir)
+
+    assert ctx is not None
+    assert ctx["repository_canonical_remote_url"] == explicit
+
+
+def test_remote_clone_invalid_contract_url_fails_closed_without_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worker = _make_worker(tmp_path)
+    fake = _FakeGit()
+    monkeypatch.setattr("mac.worker._run_git_in", fake.run_git_in)
+    monkeypatch.setattr("mac.worker._run_git", fake.run_git)
+    monkeypatch.delenv("MAC_TASK_REPO_URL", raising=False)
+
+    redaction_marker = "test-only-redaction-marker"
+    credential_url = (
+        "https://" + "operator:" + redaction_marker + "@" + "github.com/org/repo.git"
+    )
+    task = _repo_task(repository_path="/hub-only/src/repo")
+    task["metadata"]["origin"]["repository_name"] = "external-repo"
+    task["metadata"]["origin"]["repository_contract"]["project"] = "external-repo"
+    task["metadata"]["execution_contract"]["repository_contract"] = {
+        "schema": "mac.repository_contract.v1",
+        "canonical_remote_url": credential_url,
+    }
+    lease = {"id": "lease-invalid-contract"}
+    task_dir = tmp_path / "tasks" / "task-invalid-contract"
+    task_dir.mkdir(parents=True)
+
+    with pytest.raises(ValueError) as raised:
+        worker._prepare_repository_worktree(task, lease, task_dir)
+
+    message = str(raised.value)
+    assert "repository contract canonical_remote_url is invalid" in message
+    assert redaction_marker not in message
+    assert fake.calls == []
+
+
 def test_remote_clone_prefers_local_path_when_both_present(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Fixes task_3e1a5a7fb53d4cd4903380e16182ab76 and task_b41c1629af324525be3adcb55dcc5eb0. Workers now fall back from a hub-only registered path to the repository contract canonical remote with explicit origin URL precedence and secret-safe validation; the K8s executor follows the same contract. Remote task claims now encode agent_id and lease_seconds as the API query contract requires, with a real CLI-to-FastAPI lease/ownership regression. Verification: 2498 passed, 19 skipped; focused 70 passed; CodeGraph sync, affected, and impact audits passed.