### PR TITLE
Record review rejections as durable project lessons (close the learn-from-bad gap)

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -10377,6 +10377,17 @@ class ControlPlane:
                     },
                     actor,
                 )
+                # Distill the rejection into a durable, project-scoped lesson so
+                # the next execution run on this project recalls it (the review
+                # branch never wrote a deployment_learning record, so rejected
+                # work taught the fleet nothing — a real learn-from-bad gap).
+                self._record_project_failure_lesson(
+                    task_id,
+                    evidence_type="review_verdict",
+                    error_signature="review_rejected",
+                    signals={"review_rejected": True, "problems": list(verdict_problems or [])[:5]},
+                    evidence_id=verdict_evidence.id,
+                )
             else:
                 review = self.submit_review(
                     review.id,
@@ -13526,6 +13537,65 @@ class ControlPlane:
             subject_id=task_id,
             detail={"actor": actor, **detail},
         )
+
+    def _record_project_failure_lesson(
+        self,
+        task_id: str,
+        *,
+        evidence_type: str,
+        error_signature: str,
+        signals: Optional[JsonDict] = None,
+        evidence_id: Optional[str] = None,
+    ) -> None:
+        """Persist a hub-side, project-scoped ``mac.deployment_learning.v1``
+        failure lesson so the next execution run on this project recalls it.
+
+        The executor records deployment lessons for failed *runs*, but review
+        rejections and hub-side terminal failures produced no lesson — so the
+        fleet never learned from rejected or force-failed work. The record
+        shape matches the executor's ``build_learning_record`` so
+        ``recall_deployment_lessons`` renders and injects it unchanged.
+        Best-effort: telemetry-only, never breaks the caller.
+        """
+        try:
+            task = self.get_task(task_id)
+        except Exception:  # noqa: BLE001 - lesson recording must not break the workflow.
+            return
+        try:
+            project = self._hermes_task_project_key(task) or (task.project or "unassigned")
+            metadata = ensure_json_object(task.metadata)
+            origin = metadata.get("origin") if isinstance(metadata, dict) else {}
+            repo_name = str(origin.get("repository_name") or "") if isinstance(origin, dict) else ""
+            content = {
+                "schema": "mac.deployment_learning.v1",
+                "task_id": task.id,
+                "task_title": task.title,
+                "project": project,
+                "repository": repo_name,
+                "evidence_type": evidence_type,
+                "outcome": "failure",
+                "signals": signals or {},
+                "error_signature": error_signature or "",
+                "at": utcnow(),
+            }
+            self.add_memory(
+                task_id=task.id,
+                subject_type="project",
+                subject_id=project,
+                # Matches the executor's DEPLOYMENT_LEARNING_PREFIX contract so
+                # recall_deployment_lessons (which filters by this record_type
+                # prefix + project) picks it up.
+                record_type="deployment_learning:%s" % project,
+                content=json_dumps(content),
+                evidence_id=evidence_id,
+                created_by="mac-hub-review",
+            )
+        except Exception:  # noqa: BLE001 - best-effort durable learning.
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "could not record project failure lesson for %s", task_id, exc_info=True
+            )
 
     def _set_agent_idle(self, agent_id: str, conn: Any = None) -> None:
         now = utcnow()

--- a/tests/test_learning_loop.py
+++ b/tests/test_learning_loop.py
@@ -1,0 +1,67 @@
+"""Learning-loop hardening: review rejections become durable project lessons."""
+
+from __future__ import annotations
+
+import json
+
+from mac.services import ControlPlane
+
+from mac.task_executor import _format_learning_content
+
+
+def _cp(tmp_path=None) -> ControlPlane:
+    return ControlPlane.in_memory()
+
+
+def _lessons(cp, project):
+    """Deployment-learning records for a project (what recall reads)."""
+    out = []
+    for rec in cp.search_memory(subject_type="project", subject_id=project):
+        if str(rec.record_type or "").startswith("deployment_learning"):
+            out.append(rec)
+    return out
+
+
+def test_records_review_rejection_lesson(tmp_path):
+    cp = _cp(tmp_path)
+    cp.create_project("mac")
+    task = cp.create_task("Do the thing", project="mac")
+
+    cp._record_project_failure_lesson(
+        task.id,
+        evidence_type="review_verdict",
+        error_signature="review_rejected",
+        signals={"review_rejected": True, "problems": ["missing tests", "lint fail"]},
+    )
+
+    lessons = _lessons(cp, "mac")
+    assert len(lessons) == 1
+    content = json.loads(lessons[0].content)
+    assert content["schema"] == "mac.deployment_learning.v1"
+    assert content["outcome"] == "failure"
+    assert content["error_signature"] == "review_rejected"
+    assert content["project"] == "mac"
+    assert content["task_id"] == task.id
+    # The record must be renderable by the recall path into a one-line lesson.
+    rendered = _format_learning_content(lessons[0].content)
+    assert rendered and "review_rejected" in rendered
+
+
+def test_record_type_matches_recall_contract(tmp_path):
+    # recall_deployment_lessons filters by record_type prefix + project; the
+    # hub-written record must use the same "deployment_learning:<project>" shape.
+    cp = _cp(tmp_path)
+    cp.create_project("proj-x")
+    task = cp.create_task("t", project="proj-x")
+    cp._record_project_failure_lesson(task.id, evidence_type="review_verdict",
+                                      error_signature="review_rejected")
+    lessons = _lessons(cp, "proj-x")
+    assert lessons and lessons[0].record_type == "deployment_learning:proj-x"
+
+
+def test_lesson_recording_is_best_effort_on_unknown_task(tmp_path):
+    cp = _cp(tmp_path)
+    # Must not raise for a nonexistent task (telemetry-only, never breaks review).
+    cp._record_project_failure_lesson("task_does_not_exist",
+                                      evidence_type="review_verdict",
+                                      error_signature="review_rejected")


### PR DESCRIPTION
## Why
The executor records deployment lessons for failed *runs*, but review **rejection** verdicts produced no lesson (the review branch wrote none) — so rejected work taught the fleet nothing. That's the "learn from bad" gap the audit flagged.

## What
- `_record_project_failure_lesson` (hub-side): writes a `mac.deployment_learning.v1` failure record whose shape matches the executor's `build_learning_record`, and whose `record_type` (`deployment_learning:<project>`) matches the contract `recall_deployment_lessons` filters on — so the next execution run on the project recalls and injects it. Best-effort / telemetry-only; never breaks the review workflow.
- Wired into the default-review rejection path: a rejection records `outcome=failure`, `error_signature=review_rejected`, and the verdict problems.

The recall side already consumes `deployment_learning` records, so recording the rejection closes the loop end to end.

## Verification
3 unit tests (record shape, recall-contract `record_type`, best-effort on unknown task, renderable one-line lesson); full contract suite green.

Part of `task_741b6a30`. Remaining sub-items in that ticket (nap-consolidation not depending on a manually-installed timer; real embed backend vs. hash stub) are deploy-config, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)