### PR TITLE
Typed env-config module; retire the dead MAC_BEADS_BRIDGE_HUB_AGENT fallback

### DIFF
--- a/src/mac/env_config.py
+++ b/src/mac/env_config.py
@@ -1,0 +1,112 @@
+"""Central, typed access to ``MAC_*`` configuration.
+
+The fleet reads ~350 distinct ``MAC_*`` environment variables ad hoc across many
+modules — with no single catalog, no validation, and dead-named legacy
+fallbacks. The starkest example the architecture review flagged:
+``MAC_BEADS_BRIDGE_HUB_AGENT`` — named after the *removed* beads subsystem —
+still terminated several hub-agent resolution chains, silently steering
+autonomous review-advance and notifier-drain toward a var no current deployment
+sets under that name.
+
+This module is the consolidation point: typed accessors with validation, and
+documented resolvers for multi-variable fallback chains so a legacy name can be
+retired in ONE place instead of N. It is introduced as a foundation and adopted
+incrementally; new config reads should go through here rather than calling
+``os.environ.get`` inline.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Mapping, Optional
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+def _env(environ: Optional[Mapping[str, str]]) -> Mapping[str, str]:
+    return os.environ if environ is None else environ
+
+
+def env_str(name: str, default: str = "", *, environ: Optional[Mapping[str, str]] = None) -> str:
+    """Return the trimmed value of ``name``, or ``default`` if unset/blank."""
+    value = _env(environ).get(name)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return default
+
+
+def env_bool(name: str, default: bool = False, *, environ: Optional[Mapping[str, str]] = None) -> bool:
+    """Parse a boolean flag. Unset/blank → ``default``; unrecognized → ``default``."""
+    raw = _env(environ).get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    token = str(raw).strip().lower()
+    if token in _TRUTHY:
+        return True
+    if token in _FALSY:
+        return False
+    return default
+
+
+def env_int(
+    name: str,
+    default: int,
+    *,
+    minimum: Optional[int] = None,
+    maximum: Optional[int] = None,
+    environ: Optional[Mapping[str, str]] = None,
+) -> int:
+    """Parse an int with optional clamping. Unset/blank/invalid → ``default`` (then clamped)."""
+    raw = str(_env(environ).get(name) or "").strip()
+    try:
+        value = int(raw) if raw else default
+    except ValueError:
+        value = default
+    if minimum is not None:
+        value = max(minimum, value)
+    if maximum is not None:
+        value = min(maximum, value)
+    return value
+
+
+def resolve_env_chain(
+    *names: str,
+    default: str = "",
+    environ: Optional[Mapping[str, str]] = None,
+) -> str:
+    """First non-empty value among ``names`` (in priority order), else ``default``.
+
+    Centralizes multi-variable fallback chains so a dead-named legacy variable
+    can be retired in one place.
+    """
+    env = _env(environ)
+    for name in names:
+        value = env.get(name)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return default
+
+
+def resolve_hub_agent(
+    *names: str,
+    environ: Optional[Mapping[str, str]] = None,
+) -> str:
+    """Resolve which agent acts as the hub for a heartbeat-driven side effect.
+
+    Callers pass the applicable variables in priority order (e.g.
+    ``MAC_NOTIFIER_DRAIN_HUB_AGENT`` then ``MAC_REVIEW_TICK_HUB_AGENT``, or
+    ``MAC_SHARED_SERVICES_MANAGER_AGENT``). ``MAC_BEADS_BRIDGE_HUB_AGENT`` — the
+    removed beads subsystem's name — is deliberately NOT consulted; set one of
+    the current variables instead.
+    """
+    return resolve_env_chain(*names, environ=environ)
+
+
+__all__ = [
+    "env_str",
+    "env_bool",
+    "env_int",
+    "resolve_env_chain",
+    "resolve_hub_agent",
+]

--- a/src/mac/hermes_startup.py
+++ b/src/mac/hermes_startup.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from mac.agent_provider import resolve_agent_provider
+from mac.env_config import resolve_hub_agent
 from mac.hermes_runtime import RUNTIME_CONTEXT_SCHEMA
 
 
@@ -771,9 +772,7 @@ def _qdrant_memory_report(hermes_home: Path) -> Dict[str, Any]:
         "endpoint_source": endpoint_source,
         "api_key_present": bool(api_key),
         "role": os.environ.get("MAC_QDRANT_MEMORY_ROLE", "shared_level2"),
-        "manager_agent": os.environ.get("MAC_SHARED_SERVICES_MANAGER_AGENT")
-        or os.environ.get("MAC_BEADS_BRIDGE_HUB_AGENT")
-        or "",
+        "manager_agent": resolve_hub_agent("MAC_SHARED_SERVICES_MANAGER_AGENT"),
         "topology": topology,
         "collection_count": None,
         "warning": "",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -110,6 +110,7 @@ from mac.repository_hygiene import (
     normalize_cancellation_detail,
     repository_ref_lifecycle_for_transition,
 )
+from mac.env_config import resolve_hub_agent
 from mac.reconciliation import ReconciliationCoordinator
 from mac.agent_state_service import AgentStateService
 from mac.agentbus_control import (
@@ -7946,13 +7947,10 @@ class ControlPlane:
         """
         if not _truthy_env("MAC_NOTIFIER_DRAIN_ON_HEARTBEAT", "1"):
             return
-        hub_agent = os.environ.get(
+        hub_agent = resolve_hub_agent(
             "MAC_NOTIFIER_DRAIN_HUB_AGENT",
-            os.environ.get(
-                "MAC_REVIEW_TICK_HUB_AGENT",
-                os.environ.get("MAC_BEADS_BRIDGE_HUB_AGENT", ""),
-            ),
-        ).strip()
+            "MAC_REVIEW_TICK_HUB_AGENT",
+        )
         if not hub_agent:
             return
         if agent.name != hub_agent and agent.id != hub_agent:
@@ -7991,10 +7989,7 @@ class ControlPlane:
     def _maybe_advance_reviews_on_heartbeat(self, agent: Agent) -> None:
         if not _truthy_env("MAC_REVIEW_TICK_ON_HEARTBEAT", "1"):
             return
-        hub_agent = os.environ.get(
-            "MAC_REVIEW_TICK_HUB_AGENT",
-            os.environ.get("MAC_BEADS_BRIDGE_HUB_AGENT", ""),
-        ).strip()
+        hub_agent = resolve_hub_agent("MAC_REVIEW_TICK_HUB_AGENT")
         if not hub_agent:
             return
         if agent.name != hub_agent and agent.id != hub_agent:

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -46,6 +46,7 @@ from mac.agentbus_control import (
     REPO_UPDATE_TOPIC,
     debug_terminal_output_payload,
 )
+from mac.env_config import resolve_hub_agent
 from mac.codegraph_audit import (
     codegraph_audit_check,
     codegraph_audit_manifest_problems,
@@ -5729,11 +5730,7 @@ def _ensure_worker_fleet_membership(
     if not tenant_id:
         return
     fleet_name = _fleet_name_from_env(tenant_id)
-    shared_services_manager = (
-        os.environ.get("MAC_SHARED_SERVICES_MANAGER_AGENT")
-        or os.environ.get("MAC_BEADS_BRIDGE_HUB_AGENT")
-        or ""
-    ).strip()
+    shared_services_manager = resolve_hub_agent("MAC_SHARED_SERVICES_MANAGER_AGENT")
     metadata = {
         "source": "mac-agent",
         "fleet": fleet_name,

--- a/tests/test_env_config.py
+++ b/tests/test_env_config.py
@@ -1,0 +1,53 @@
+"""Tests for the typed MAC_* config accessors (env-config-registry foundation)."""
+
+from __future__ import annotations
+
+from mac.env_config import (
+    env_bool,
+    env_int,
+    env_str,
+    resolve_env_chain,
+    resolve_hub_agent,
+)
+
+
+def test_env_str():
+    e = {"A": "  hi  ", "B": "  "}
+    assert env_str("A", environ=e) == "hi"
+    assert env_str("B", "def", environ=e) == "def"
+    assert env_str("MISSING", "def", environ=e) == "def"
+
+
+def test_env_bool():
+    for token in ("1", "true", "TRUE", "yes", "on"):
+        assert env_bool("F", environ={"F": token}) is True
+    for token in ("0", "false", "no", "off"):
+        assert env_bool("F", True, environ={"F": token}) is False
+    assert env_bool("F", True, environ={}) is True          # unset -> default
+    assert env_bool("F", True, environ={"F": "garbage"}) is True  # invalid -> default
+
+
+def test_env_int_and_clamp():
+    assert env_int("N", 5, environ={}) == 5
+    assert env_int("N", 5, environ={"N": "12"}) == 12
+    assert env_int("N", 5, environ={"N": "nope"}) == 5
+    assert env_int("N", 5, minimum=0, maximum=10, environ={"N": "99"}) == 10
+    assert env_int("N", 5, minimum=3, environ={"N": "1"}) == 3
+
+
+def test_resolve_env_chain_priority():
+    e = {"SECOND": "b", "THIRD": "c"}
+    assert resolve_env_chain("FIRST", "SECOND", "THIRD", environ=e) == "b"
+    assert resolve_env_chain("X", "Y", default="fallback", environ=e) == "fallback"
+    # blank values are skipped
+    assert resolve_env_chain("BLANK", "SECOND", environ={"BLANK": "  ", "SECOND": "b"}) == "b"
+
+
+def test_resolve_hub_agent_ignores_removed_beads_var():
+    # The removed beads subsystem's var must NOT resolve a hub agent.
+    e = {"MAC_BEADS_BRIDGE_HUB_AGENT": "old-beads-agent"}
+    assert resolve_hub_agent("MAC_SHARED_SERVICES_MANAGER_AGENT", environ=e) == ""
+    assert resolve_hub_agent("MAC_REVIEW_TICK_HUB_AGENT", environ=e) == ""
+    # A current var resolves normally.
+    e2 = {"MAC_REVIEW_TICK_HUB_AGENT": "rocky"}
+    assert resolve_hub_agent("MAC_REVIEW_TICK_HUB_AGENT", environ=e2) == "rocky"


### PR DESCRIPTION
First increment toward consolidating the ~350-var `MAC_*` config surface (review finding H2). Adds a single typed-access point and retires the starkest footgun it named.

## What
- `src/mac/env_config.py`: typed accessors (`env_str`/`env_bool`/`env_int` with clamping) + `resolve_env_chain`/`resolve_hub_agent` for multi-variable fallback chains, so a legacy name can be retired in **one** place. Adopted incrementally.
- **Retired `MAC_BEADS_BRIDGE_HUB_AGENT`** — named after the *removed* beads subsystem — which still terminated the hub-agent resolution chains in `services.py` (×2), `worker.py`, and `hermes_startup.py`, silently steering autonomous review-advance / notifier-drain toward a var no current deployment sets. The chains now resolve via the current vars (which the deploy already sets).

**Scope note:** this is a foundation + footgun fix, not the full 350-var migration (that stays `task_ebb40ea9`); modules adopt `env_config` incrementally.

## Verification
5 unit tests (accessors, chain priority, and that the removed beads var no longer resolves a hub agent); full contract suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)