### PR TITLE
Extract TicketingCoordinator from ControlPlane (god-object, first delegation)

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -111,6 +111,7 @@ from mac.repository_hygiene import (
     repository_ref_lifecycle_for_transition,
 )
 from mac.reconciliation import ReconciliationCoordinator
+from mac.ticketing_service import TicketingCoordinator
 from mac.agent_state_service import AgentStateService
 from mac.agentbus_control import (
     ARTIFACT_PUBLISH_CONTENT_TYPE,
@@ -1087,6 +1088,9 @@ class ControlPlane:
             get_agent=self.get_agent,
             get_task=self.get_task,
         )
+        # Ticketing detection + one-way conversion, delegated off the god-object
+        # (task_bf0d1f01). ControlPlane keeps thin shims below for compatibility.
+        self.ticketing = TicketingCoordinator(self)
         self.notifiers = NotifierService(
             self.store,
             list_agents=self.list_agents,
@@ -8592,36 +8596,9 @@ class ControlPlane:
     # future ticketing system plugs in the same way.
 
     def detect_ticketing(self, repo_path: str) -> JsonDict:
-        """Report which ticketing sources a repo has + whether a one-way
-        ledger import should be offered (foreign source present, no local
-        .tickets/ compatibility mirror). Read-only. Emits a
-        ``ticketing.conversion_available`` observation the hub's hermes agent
-        can surface to the user."""
-        from pathlib import Path as _Path
-        from mac.ticketing import detect_ticketing as _detect
-
-        detection = _detect(_Path(repo_path))
-        if detection.needs_conversion:
-            self.record_log(
-                "ticketing.conversion_available",
-                layer="control_plane",
-                source="ticketing",
-                level="info",
-                subject_type="environment",
-                subject_id=str(repo_path),
-                detail={
-                    "schema": "mac.ticketing_conversion.v1",
-                    "conversion_from": detection.conversion_from,
-                    "message": detection.message,
-                    "prompt": (
-                        "Repo %s has a '%s' ticket source but no local .tickets "
-                        "compatibility mirror. Import it one-way into the MAC "
-                        "task ledger?"
-                        % (repo_path, detection.conversion_from)
-                    ),
-                },
-            )
-        return detection.to_dict()
+        # Delegated to TicketingCoordinator (task_bf0d1f01). Thin shim kept for
+        # API/call-site compatibility.
+        return self.ticketing.detect_ticketing(repo_path)
 
     def convert_ticketing_source(
         self,
@@ -8631,32 +8608,10 @@ class ControlPlane:
         actor: str = "hermes",
         dry_run: bool = False,
     ) -> JsonDict:
-        """Run the one-way conversion of a detected foreign source (e.g. beads)
-        into MAC ledger tasks plus optional local compatibility files. Hermes
-        calls this only after the user agrees. Never writes back to the foreign
-        source."""
-        from pathlib import Path as _Path
-        from mac.ticketing import detect_ticketing as _detect, connector_for
-
-        detection = _detect(_Path(repo_path))
-        if not detection.needs_conversion or not detection.conversion_from:
-            return {"status": "no_conversion_needed", "detection": detection.to_dict()}
-        connector = connector_for(detection.conversion_from)
-        if connector is None:
-            return {"status": "unknown_connector", "detection": detection.to_dict()}
-        report = connector.convert(
-            _Path(repo_path), project=project, cp=None if dry_run else self, actor=actor, dry_run=dry_run
+        # Delegated to TicketingCoordinator (task_bf0d1f01).
+        return self.ticketing.convert_ticketing_source(
+            repo_path, project=project, actor=actor, dry_run=dry_run
         )
-        self.record_log(
-            "ticketing.converted",
-            layer="control_plane",
-            source="ticketing",
-            level="info",
-            subject_type="environment",
-            subject_id=str(repo_path),
-            detail={"schema": "mac.ticketing_conversion.v1", "from": detection.conversion_from, "report": report},
-        )
-        return {"status": "converted", "from": detection.conversion_from, "report": report}
 
     # -- Fleet awareness (fleet-01/02) --------------------------------------
 

--- a/src/mac/ticketing_service.py
+++ b/src/mac/ticketing_service.py
@@ -1,0 +1,104 @@
+"""Ticketing detection + one-way conversion, extracted from ``ControlPlane``.
+
+``ControlPlane`` is a ~13.9k-line, 400+-method god-object. It already composes
+~22 focused sub-services; the debt the architecture review flagged is that
+cohesive domain clusters kept accreting as methods on the god-object instead of
+being delegated to services. This module extracts the ticketing cluster
+(``detect_ticketing`` / ``convert_ticketing_source``) as the first of that
+follow-on delegation, establishing the pattern (a small service holding a
+control-plane reference; the god-object keeps thin delegation shims for API
+compatibility). See ``task_bf0d1f01`` for the full extraction plan.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from mac.models import JsonDict
+
+
+class TicketingCoordinator:
+    """Detects foreign ticket sources in a repo and runs the one-way import
+    into the MAC ledger. Never writes back to the foreign source."""
+
+    def __init__(self, control_plane: Any) -> None:
+        # Held for record_log telemetry and to hand the connector a control
+        # plane for ledger writes during conversion.
+        self._cp = control_plane
+
+    def detect_ticketing(self, repo_path: str) -> JsonDict:
+        """Report which ticketing sources a repo has + whether a one-way ledger
+        import should be offered (foreign source present, no local .tickets
+        compatibility mirror). Read-only. Emits a
+        ``ticketing.conversion_available`` observation the hub's hermes agent
+        can surface to the user."""
+        from mac.ticketing import detect_ticketing as _detect
+
+        detection = _detect(Path(repo_path))
+        if detection.needs_conversion:
+            self._cp.record_log(
+                "ticketing.conversion_available",
+                layer="control_plane",
+                source="ticketing",
+                level="info",
+                subject_type="environment",
+                subject_id=str(repo_path),
+                detail={
+                    "schema": "mac.ticketing_conversion.v1",
+                    "conversion_from": detection.conversion_from,
+                    "message": detection.message,
+                    "prompt": (
+                        "Repo %s has a '%s' ticket source but no local .tickets "
+                        "compatibility mirror. Import it one-way into the MAC "
+                        "task ledger?"
+                        % (repo_path, detection.conversion_from)
+                    ),
+                },
+            )
+        return detection.to_dict()
+
+    def convert_ticketing_source(
+        self,
+        repo_path: str,
+        *,
+        project: str,
+        actor: str = "hermes",
+        dry_run: bool = False,
+    ) -> JsonDict:
+        """Run the one-way conversion of a detected foreign source (e.g. beads)
+        into MAC ledger tasks plus optional local compatibility files. Hermes
+        calls this only after the user agrees. Never writes back to the foreign
+        source."""
+        from mac.ticketing import connector_for, detect_ticketing as _detect
+
+        detection = _detect(Path(repo_path))
+        if not detection.needs_conversion or not detection.conversion_from:
+            return {"status": "no_conversion_needed", "detection": detection.to_dict()}
+        connector = connector_for(detection.conversion_from)
+        if connector is None:
+            return {"status": "unknown_connector", "detection": detection.to_dict()}
+        report = connector.convert(
+            Path(repo_path),
+            project=project,
+            cp=None if dry_run else self._cp,
+            actor=actor,
+            dry_run=dry_run,
+        )
+        self._cp.record_log(
+            "ticketing.converted",
+            layer="control_plane",
+            source="ticketing",
+            level="info",
+            subject_type="environment",
+            subject_id=str(repo_path),
+            detail={
+                "schema": "mac.ticketing_conversion.v1",
+                "from": detection.conversion_from,
+                "report": report,
+            },
+        )
+        return {"status": "converted", "from": detection.conversion_from, "report": report}
+
+
+__all__ = ["TicketingCoordinator"]

--- a/tests/test_ticketing_service.py
+++ b/tests/test_ticketing_service.py
@@ -1,0 +1,46 @@
+"""TicketingCoordinator extraction: delegation + behavior preservation."""
+
+from __future__ import annotations
+
+from mac.services import ControlPlane
+from mac.ticketing_service import TicketingCoordinator
+
+
+def test_control_plane_composes_ticketing_coordinator():
+    cp = ControlPlane.in_memory()
+    assert isinstance(cp.ticketing, TicketingCoordinator)
+
+
+def test_detect_ticketing_on_empty_repo(tmp_path):
+    cp = ControlPlane.in_memory()
+    result = cp.detect_ticketing(str(tmp_path))
+    # No foreign source present -> no conversion offered; still a well-formed dict.
+    assert isinstance(result, dict)
+    assert result.get("needs_conversion") in (False, None)
+
+
+def test_detect_ticketing_shim_delegates(tmp_path):
+    cp = ControlPlane.in_memory()
+    sentinel = {"delegated": True}
+    cp.ticketing.detect_ticketing = lambda repo_path: sentinel  # type: ignore[assignment]
+    assert cp.detect_ticketing(str(tmp_path)) is sentinel
+
+
+def test_convert_ticketing_source_shim_delegates(tmp_path):
+    cp = ControlPlane.in_memory()
+    captured = {}
+
+    def _fake(repo_path, *, project, actor="hermes", dry_run=False):
+        captured.update(repo_path=repo_path, project=project, actor=actor, dry_run=dry_run)
+        return {"status": "ok"}
+
+    cp.ticketing.convert_ticketing_source = _fake  # type: ignore[assignment]
+    out = cp.convert_ticketing_source(str(tmp_path), project="mac", dry_run=True)
+    assert out == {"status": "ok"}
+    assert captured == {"repo_path": str(tmp_path), "project": "mac", "actor": "hermes", "dry_run": True}
+
+
+def test_convert_no_conversion_needed_on_empty_repo(tmp_path):
+    cp = ControlPlane.in_memory()
+    out = cp.convert_ticketing_source(str(tmp_path), project="mac", dry_run=True)
+    assert out["status"] in ("no_conversion_needed", "unknown_connector")


### PR DESCRIPTION
First increment against the `ControlPlane` god-object (review finding H1; ~13.9k lines / 400+ methods). The class already composes ~22 focused sub-services; the debt is that cohesive domain clusters kept accreting as methods on the god-object instead of being delegated. This establishes the follow-on delegation pattern with a clean, conflict-free cluster.

## What
- `src/mac/ticketing_service.py`: `TicketingCoordinator` holds a control-plane reference and owns `detect_ticketing` + `convert_ticketing_source` (one-way import of foreign ticket sources into the ledger). `ControlPlane` composes it as `self.ticketing` and keeps thin delegation shims for API/call-site compatibility. **Pure extraction — behavior unchanged.**

## Why this cluster
Cohesive, delegates to the already-clean `ticketing.py` module, and touched by no open PR (minimizes merge conflict). The **bulk of H1** — finishing delegation of the larger non-delegated clusters (review/publication, project-repository, heartbeat side-effects) — is best sequenced **after** the current PRs merge to avoid `services.py` conflicts; the plan stays tracked in `task_bf0d1f01`.

## Verification
5 new tests (composition, delegation shims, empty-repo behavior) + existing `test_ticketing.py` unchanged and green; full contract suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)