### PR TITLE
Model-selection hardening: fail-closed eval gate, real deployment seams, opt-in

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ Think of MAC as a project office for AI workers:
   production.
 - Rollout: the controlled movement of a version through environments.
 - Eval: a measured check used to prevent regressions.
-- Secret: a credential or token, routed through TokenHub in fleet deployments.
+- Secret: a credential or token, resolved through the in-mac LLM router in fleet deployments (the standalone TokenHub is retired).
 - Qdrant: shared vector memory service for recall across agents.
 - Firecrawl: web research service used by agents for search, scrape, and crawl.
 - AgentBus: typed agent-to-agent content streams.
@@ -333,13 +333,13 @@ http://127.0.0.1:8789/ui
 In another terminal, inspect the same state through the hub CLI:
 
 ```bash
-uv run hgmac --url http://127.0.0.1:8789 projects list
-uv run hgmac --url http://127.0.0.1:8789 tasks list
+mac --hub-url http://127.0.0.1:8789 project list
+mac --hub-url http://127.0.0.1:8789 task list
 ```
 
-If you configured `MAC_API_TOKEN`, pass it with `--token` or store it in the
-`hgmac` config file. With no API token configured, the local development API is
-open on localhost.
+If you configured `MAC_API_TOKEN`, pass it with `--token`. With no API token
+configured, the local development API is open on localhost. (The legacy `hgmac`
+binary is gone — all of its functionality lives under `mac` now.)
 
 ## Split A Large Task
 
@@ -347,10 +347,15 @@ If an agent claims a task and decides it is too large, it should add child tasks
 instead of trying to finish everything in one step. The parent task becomes
 blocked until the children complete.
 
+Child tasks are added via the API (`POST /tasks/{id}/children`) — an executing
+agent typically emits a `plan_steps` list in its evidence and the executor
+posts the children automatically (auto-decompose); the Hermes adapter exposes
+`mac-hermes add-child-task` for the same. For example, over the API:
+
 ```bash
-uv run hgmac --url http://127.0.0.1:8789 tasks add-child task_... \
-  --title "Write the first draft" \
-  --description "Produce the first small deliverable."
+curl -sX POST http://127.0.0.1:8789/tasks/task_.../children \
+  -H 'Content-Type: application/json' \
+  -d '{"children":[{"title":"Write the first draft","description":"Produce the first small deliverable."}]}'
 ```
 
 This is the same idea used in systems such as Jira: large work is represented by

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -989,8 +989,35 @@ The delivered-nudge cap prevents an unparseable or crashing reviewer from
 spinning forever. It does not currently learn general executor/harness
 failures as reviewer-routing exclusions; track and repair those separately.
 
+## Dynamic model selection (opt-in, hub only)
+
+The hub can periodically pick the fleet's "powerhouse" models from a web search
+of what's currently leading, moderated by what the gateway can actually route,
+instead of a hard-coded pin. It is **opt-in and advisory** today — a selection
+is surfaced via `GET /model-selection/status` and a *swap* is recorded pending
+(routing does not change) until promoted, so it cannot regress the fleet. Not
+enabled by default: a production-readiness gap remains (the selection namespace
+does not yet match the router's routable model namespace, and the per-worker
+strength ladder is not distributed from the hub — tracked follow-up).
+
+Environment variables (hub):
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `MAC_MODEL_SELECT_ENABLED` | off | Run the weekly selection refresher. |
+| `MAC_MODEL_SELECT_INTERVAL_SECONDS` | 604800 | Refresh cadence. |
+| `MAC_MODEL_SELECTION_FILE` | `$MAC_HOME/model-selection.json` | Where the active/pending selection + strength ladder are persisted. |
+| `MAC_MODEL_SWAP_EVAL_ENABLED` | off | Auto-gate a swap on a golden-set eval-drift check (adopt only if no regression); otherwise swaps stay pending for `mac fleet model-selection promote`. |
+| `MAC_MODEL_SWAP_EVAL_GOLDEN_SET` | built-in floor set | Path to a JSONL golden set of eval cases. |
+
+Per task, `--model <name>` pins a model by name and `--model-strength 1..10`
+pins by capability (resolved via the strength ladder; **hub agent only** until
+ladder distribution lands).
+
 ## Known limitations
 
+- Dynamic model selection is advisory/opt-in and not yet wired to control
+  deployed routing (namespace + ladder-distribution gaps); see above.
 - SQLite topology is single-writer. Use the Kubernetes + Postgres
   topology for multi-replica deployments.
 - No built-in TLS. Put a reverse proxy in front.

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -860,6 +860,12 @@ def build_mac_env(
         # route (vs a hard-coded pin). Falls back to the configured default on
         # any discovery failure, so enabling it by default is safe.
         values.setdefault("MAC_MODEL_SELECT_ENABLED", "1")
+        # mac-model-select: gate model SWAPS on an automated golden-set eval so a
+        # newly-"leading" model is adopted only if it doesn't regress quality/
+        # safety on our tasks. Uses the hub's local router (OPENAI_BASE_URL) —
+        # no extra URL to configure. Fully safe: if the eval can't run, the swap
+        # stays pending for operator promotion (routing never changes blindly).
+        values.setdefault("MAC_MODEL_SWAP_EVAL_ENABLED", "1")
     _apply_router(values, cfg, env)
     _apply_home_channel(values, cfg)
     return values

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -855,17 +855,14 @@ def build_mac_env(
         # a no-op for every project that has not opted in via
         # metadata["backlog_grooming"], so enabling it by default is safe.
         values.setdefault("MAC_BACKLOG_GROOM_ENABLED", "1")
-        # mac-model-select: periodically choose the fleet's powerhouse models
-        # from a web search of what's leading, moderated by what the gateway can
-        # route (vs a hard-coded pin). Falls back to the configured default on
-        # any discovery failure, so enabling it by default is safe.
-        values.setdefault("MAC_MODEL_SELECT_ENABLED", "1")
-        # mac-model-select: gate model SWAPS on an automated golden-set eval so a
-        # newly-"leading" model is adopted only if it doesn't regress quality/
-        # safety on our tasks. Uses the hub's local router (OPENAI_BASE_URL) —
-        # no extra URL to configure. Fully safe: if the eval can't run, the swap
-        # stays pending for operator promotion (routing never changes blindly).
-        values.setdefault("MAC_MODEL_SWAP_EVAL_ENABLED", "1")
+        # mac-model-select: dynamic powerhouse-model selection is OPT-IN, not
+        # default-on. It is not yet production-ready: the selection namespace
+        # (bare models.dev ids) does not match the router's routable namespace,
+        # so a selection cannot yet safely control routing, and the per-worker
+        # strength ladder is not distributed from the hub. Until those are closed
+        # (tracked follow-up) selection stays advisory (observable via
+        # /model-selection/status) and the eval-swap gate is operator-driven.
+        # Operators opt in with MAC_MODEL_SELECT_ENABLED / MAC_MODEL_SWAP_EVAL_ENABLED.
     _apply_router(values, cfg, env)
     _apply_home_channel(values, cfg)
     return values

--- a/src/mac/eval_runner.py
+++ b/src/mac/eval_runner.py
@@ -122,14 +122,15 @@ def run_golden_eval(
         except Exception:  # noqa: BLE001
             unit_cost = None
     case_results: List[Dict[str, Any]] = []
+    call_failures = 0
     for case in cases:
         question = str(case.get("question") or "")
         context = str(case.get("context") or "")
         try:
             answer, citations, latency_ms = model_caller(model_id, question, context)
-        except Exception as exc:  # noqa: BLE001 - a failed call scores as worst-case.
+        except Exception:  # noqa: BLE001 - record the failure; the eval is invalid.
             answer, citations, latency_ms = "", [], 0.0
-            _ = exc
+            call_failures += 1
         scores = score_case(case, answer, list(citations or []))
         per_overall = round(0.5 * scores["correctness"] + 0.5 * scores["groundedness"], 4)
         case_results.append({
@@ -169,6 +170,12 @@ def run_golden_eval(
         },
         "summary": summary,
         "per_case_overall": overalls,  # paired significance input (case-aligned)
+        # The eval is only VALID if every model call actually succeeded. A call
+        # failure (router down, timeout) must NOT be scored as an ordinary empty
+        # answer — otherwise two failed evals look "equal" and a swap is wrongly
+        # approved. evaluate_swap fails closed on an invalid eval.
+        "call_failures": call_failures,
+        "valid": call_failures == 0 and len(case_results) > 0,
     }
 
 
@@ -235,32 +242,45 @@ def evaluate_swap(
 
     cand = run_golden_eval(candidate_model, cases, model_caller=model_caller, cost_lookup=cost_lookup)
     inc = run_golden_eval(incumbent_model, cases, model_caller=model_caller, cost_lookup=cost_lookup)
+
+    # FAIL CLOSED: if either eval could not actually run (a model call failed —
+    # router down, timeout), we have no evidence the candidate is safe, so we do
+    # NOT approve. The swap stays pending. (A failed call is not an "empty
+    # answer that ties" — that was the fail-open bug.)
+    if not cand.get("valid") or not inc.get("valid"):
+        return SwapVerdict(
+            approved=False,
+            detail="eval could not run (candidate_failures=%d, incumbent_failures=%d) — staying pending"
+            % (cand.get("call_failures", -1), inc.get("call_failures", -1)),
+            candidate_summary=cand["summary"], incumbent_summary=inc["summary"],
+        )
+
     cmp = compare_eval_metrics(inc["summary"], cand["summary"], threshold=threshold)
     drifted = list(cmp["drifted"])
 
     # Safety regressions are hard blocks regardless of significance.
     safety_regressed = any(d["metric"] == "safety_violation_rate" for d in drifted)
 
-    # For overall-score quality regression, require significance: only block if
-    # we're confident (bootstrap CI upper bound still below -threshold) the
-    # candidate is really worse per-case.
-    quality_regressed = any(d["metric"] == "overall_score" for d in drifted)
-    significant = False
-    if quality_regressed:
-        deltas = [c - i for c, i in zip(cand["per_case_overall"], inc["per_case_overall"])]
-        ci_upper = _bootstrap_ci_upper(deltas)
-        significant = ci_upper < -threshold
-        if not significant:
-            # Drop the non-significant overall-score drift from the blocking set.
-            drifted = [d for d in drifted if d["metric"] != "overall_score"]
+    # Quality regressions (overall_score AND avg_correctness — a correctness
+    # collapse masked by another metric must still block) require significance:
+    # only block if the paired bootstrap CI shows the candidate is really worse.
+    deltas = [c - i for c, i in zip(cand["per_case_overall"], inc["per_case_overall"])]
+    ci_upper = _bootstrap_ci_upper(deltas) if deltas else 0.0
+    significant = ci_upper < -threshold
+    quality_metrics = {"overall_score", "avg_correctness", "avg_groundedness"}
+    quality_regressed = any(d["metric"] in quality_metrics for d in drifted)
+    if quality_regressed and not significant:
+        # Non-significant quality drift on a small set: don't block on it.
+        drifted = [d for d in drifted if d["metric"] not in quality_metrics]
+        quality_regressed = False
 
-    approved = not (safety_regressed or (quality_regressed and significant) or
-                    any(d["metric"] in ("latency_p95_ms", "latency_p50_ms", "cost_per_answer_avg")
-                        for d in drifted))
-    if approved:
-        detail = "no significant regression vs incumbent"
-    else:
-        detail = "regressed: " + ", ".join(sorted({d["metric"] for d in drifted}))
+    cost_regressed = any(
+        d["metric"] in ("latency_p95_ms", "latency_p50_ms", "cost_per_answer_avg")
+        for d in drifted
+    )
+    approved = not (safety_regressed or quality_regressed or cost_regressed)
+    detail = ("no significant regression vs incumbent" if approved
+              else "regressed: " + ", ".join(sorted({d["metric"] for d in drifted})))
     return SwapVerdict(
         approved=approved, detail=detail, drifted=drifted,
         candidate_summary=cand["summary"], incumbent_summary=inc["summary"],

--- a/src/mac/eval_runner.py
+++ b/src/mac/eval_runner.py
@@ -329,7 +329,13 @@ def router_model_caller(
     import json as _json
     import urllib.request
 
+    # Normalize so it works whether the configured URL already includes the
+    # OpenAI ``/v1`` suffix (the hub sets OPENAI_BASE_URL to ``.../v1``) or not.
     base = router_url.rstrip("/")
+    if base.endswith("/v1"):
+        completions_url = base + "/chat/completions"
+    else:
+        completions_url = base + "/v1/chat/completions"
 
     def call(model_id: str, question: str, context: str) -> Tuple[str, List[str], float]:
         messages = []
@@ -340,7 +346,7 @@ def router_model_caller(
         headers = {"Content-Type": "application/json"}
         if token:
             headers["Authorization"] = "Bearer %s" % token
-        req = urllib.request.Request(base + "/v1/chat/completions", data=body, headers=headers, method="POST")
+        req = urllib.request.Request(completions_url, data=body, headers=headers, method="POST")
         start = time.monotonic()
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = _json.loads(resp.read().decode("utf-8"))
@@ -370,11 +376,21 @@ def build_swap_evaluator(
     env = os.environ if environ is None else environ
     if str(env.get("MAC_MODEL_SWAP_EVAL_ENABLED") or "").strip().lower() not in {"1", "true", "yes", "on"}:
         return None
-    router_url = str(env.get("MAC_ROUTER_URL") or env.get("MAC_ROUTER_INTERNAL_URL") or "").strip()
+    # Reuse the hub's already-wired local router endpoint (OPENAI_BASE_URL points
+    # at the in-mac router's /v1) so no separate URL needs configuring; a
+    # dedicated MAC_ROUTER_(INTERNAL_)URL still wins if set.
+    router_url = str(
+        env.get("MAC_ROUTER_URL")
+        or env.get("MAC_ROUTER_INTERNAL_URL")
+        or env.get("OPENAI_BASE_URL")
+        or ""
+    ).strip()
     if not router_url:
         return None
     cases = load_golden_set(str(env.get("MAC_MODEL_SWAP_EVAL_GOLDEN_SET") or ""))
-    token = str(env.get("MAC_ROUTER_TOKEN") or env.get("MAC_API_TOKEN") or "").strip()
+    token = str(
+        env.get("MAC_ROUTER_TOKEN") or env.get("MAC_API_TOKEN") or env.get("OPENAI_API_KEY") or ""
+    ).strip()
     caller = router_model_caller(router_url, token=token)
 
     def _cost(model_id: str):

--- a/src/mac/model_selection.py
+++ b/src/mac/model_selection.py
@@ -27,9 +27,16 @@ adding a new family here just lets discovery see it.
 
 from __future__ import annotations
 
+import copy
+import json
+import logging
+import os
 import re
+import threading
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 # Recognition registry: canonical family -> regex matching how it's written on
 # the web AND (loosely) how its concrete model ids look. This only lets the
@@ -139,17 +146,41 @@ def resolve_strength(scale: int, ladder: Sequence[str]) -> str:
 
 
 def _models_dev_cost(model_id: str) -> Optional[float]:
-    """Output cost per token for a concrete model id via models.dev, or None."""
-    try:
-        from mac._hermes.agent.models_dev import get_model_capabilities  # type: ignore
+    """Output cost per token for a model id via models.dev, or None.
 
-        info = get_model_capabilities(model_id)
+    The real catalog API is ``get_model_info(provider_id, model_id)`` and the
+    field is ``cost_output`` (``get_model_capabilities(model_id)`` — the previous
+    call — is the wrong API and carries no cost). Ids may be provider-prefixed
+    (``provider/model`` from available_models_from_providers); parse the provider
+    and use the bare model id. Returns None (=> name-tier ladder fallback) when
+    unavailable.
+    """
+    try:
+        from mac.hermes_vendor import ensure_on_path
+
+        ensure_on_path()
+        from mac._hermes.agent.models_dev import get_model_info  # type: ignore
     except Exception:  # noqa: BLE001
         return None
-    for attr in ("output_cost", "cost_output", "output_price"):
-        val = getattr(info, attr, None)
-        if isinstance(val, (int, float)):
-            return float(val)
+    mid = str(model_id)
+    # Candidate (provider, model) splits: the leading segment as provider with
+    # the rest as the model, plus a bare fallback across common providers.
+    candidates: List[Tuple[str, str]] = []
+    if "/" in mid:
+        head, _, tail = mid.partition("/")
+        candidates.append((head, tail.rsplit("/", 1)[-1]))
+    bare = mid.rsplit("/", 1)[-1]
+    for provider in ("anthropic", "openai", "google", "xai", "deepseek", "meta", "mistral", "qwen"):
+        candidates.append((provider, bare))
+    for provider, model in candidates:
+        try:
+            info = get_model_info(provider, model)
+        except Exception:  # noqa: BLE001
+            info = None
+        if info is not None:
+            val = getattr(info, "cost_output", None)
+            if isinstance(val, (int, float)):
+                return float(val)
     return None
 
 
@@ -190,9 +221,9 @@ def moderate_by_availability(
     model id for it. Families with no available model are dropped — that is the
     'moderate by what the gateway/CLI actually has' constraint.
 
-    'Best' within a family = the available id whose family matches, preferring
-    the lexically-greatest id (later versions/snapshots sort higher) so we pick
-    the newest available of the leading family.
+    'Best' within a family = the newest available id, by a NATURAL version sort
+    (numeric segments compared as integers) so ``claude-opus-4-10`` beats
+    ``claude-opus-4-9`` — a lexical sort would wrongly prefer 4-9.
     """
     by_family: Dict[str, List[str]] = {}
     for mid in available_models or []:
@@ -203,8 +234,15 @@ def moderate_by_availability(
     for family in leading_families:
         candidates = by_family.get(family)
         if candidates:
-            chosen.append(sorted(candidates)[-1])
+            chosen.append(max(candidates, key=_version_key))
     return chosen
+
+
+def _version_key(model_id: str):
+    """Natural-order key: split into numeric and non-numeric runs so numeric
+    segments compare as integers (4-10 > 4-9), not lexically."""
+    parts = re.findall(r"\d+|\D+", str(model_id))
+    return [(1, int(p)) if p.isdigit() else (0, p) for p in parts]
 
 
 def select_powerhouse_models(
@@ -279,18 +317,30 @@ def discover_via_web(
 
 def available_models_from_providers(providers: Iterable[str]) -> List[str]:
     """Concrete agentic model ids the gateway can route to, per the fleet's
-    configured providers, via the models.dev catalog. Empty on any failure."""
+    configured providers, via the models.dev catalog. Empty on any failure.
+
+    Ids are returned provider-prefixed (``provider/model``) so the provider is
+    recoverable downstream (cost lookup needs it) — the vendored catalog's
+    ``list_agentic_models`` returns bare ids per provider.
+    """
     out: List[str] = []
     try:
+        # The vendored Hermes catalog is only importable after its path is set
+        # up; without this the import raises ModuleNotFoundError and the whole
+        # selection silently degrades to [] (the fleet never sees any models).
+        from mac.hermes_vendor import ensure_on_path
+
+        ensure_on_path()
         from mac._hermes.agent.models_dev import list_agentic_models
     except Exception:  # noqa: BLE001 - catalog optional; caller falls back.
         return out
     for provider in providers or []:
+        p = str(provider)
         try:
-            out.extend(list_agentic_models(str(provider)))
+            for mid in list_agentic_models(p):
+                out.append("%s/%s" % (p, mid))
         except Exception:  # noqa: BLE001
             continue
-    # De-dup, preserve order.
     seen: set = set()
     return [m for m in out if not (m in seen or seen.add(m))]
 
@@ -298,15 +348,6 @@ def available_models_from_providers(providers: Iterable[str]) -> List[str]:
 # --------------------------------------------------------------------------- #
 # Persistence + periodic refresher
 # --------------------------------------------------------------------------- #
-
-import copy
-import json
-import logging
-import os
-import threading
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Mapping
 
 _log = logging.getLogger("mac.model_selection")
 
@@ -347,11 +388,24 @@ def _read_store(path: Optional[Path], environ: Optional[Mapping[str, str]]) -> d
 
 
 def _write_store(store: dict, path: Optional[Path], environ: Optional[Mapping[str, str]]) -> Path:
+    import os as _os
+    import tempfile as _tempfile
+
     p = path if path is not None else selection_file_path(environ)
     p.parent.mkdir(parents=True, exist_ok=True)
-    tmp = p.with_suffix(p.suffix + ".tmp")
-    tmp.write_text(json.dumps(store, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    tmp.replace(p)  # atomic
+    # Unique temp in the same dir (not a fixed ``.tmp``) so a concurrent refresh
+    # and promote can't clobber each other's temp mid-write; the rename is atomic.
+    fd, tmp_name = _tempfile.mkstemp(dir=str(p.parent), prefix=p.name + ".", suffix=".tmp")
+    try:
+        with _os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(store, indent=2, sort_keys=True) + "\n")
+        _os.replace(tmp_name, str(p))  # atomic
+    except BaseException:
+        try:
+            _os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
     return p
 
 

--- a/src/mac/router_app.py
+++ b/src/mac/router_app.py
@@ -44,7 +44,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from typing import Any, Callable, Dict, Iterable, Iterator, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Tuple
 
 from fastapi import Body, Request
 

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -50,7 +50,6 @@ from mac.env_config import resolve_hub_agent
 from mac.codegraph_audit import (
     codegraph_audit_check,
     codegraph_audit_manifest_problems,
-    codegraph_audit_passed,
     run_codegraph_audit,
 )
 from mac.fleet_learning import (

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -166,3 +166,28 @@ def test_service_builds_no_evaluator_when_disabled(tmp_path, monkeypatch):
     monkeypatch.delenv("MAC_MODEL_SWAP_EVAL_ENABLED", raising=False)
     svc = ModelSelectionService(_FakeCP(), ModelSelectionConfig(enabled=True), environ=dict(os.environ))
     assert svc._swap_evaluator is None
+
+
+def test_builder_uses_openai_base_url_when_enabled(monkeypatch):
+    # The hub wires OPENAI_BASE_URL to its local router; the builder should use
+    # it (no dedicated router var needed) and produce a live evaluator.
+    from mac.eval_runner import build_swap_evaluator
+    env = {"MAC_MODEL_SWAP_EVAL_ENABLED": "1",
+           "OPENAI_BASE_URL": "http://127.0.0.1:8789/v1",
+           "MAC_API_TOKEN": "t"}
+    ev = build_swap_evaluator(env)
+    assert ev is not None
+    # Missing model args -> not approved, no network call.
+    assert ev([], ["inc"]) == {"approved": False, "detail": "missing candidate/incumbent model"}
+
+
+def test_builder_none_without_router_url(monkeypatch):
+    from mac.eval_runner import build_swap_evaluator
+    assert build_swap_evaluator({"MAC_MODEL_SWAP_EVAL_ENABLED": "1"}) is None
+
+
+def test_deploy_env_enables_swap_eval_on_hub():
+    from mac import deploy_env as de
+    # Grep the source: the hub block sets MAC_MODEL_SWAP_EVAL_ENABLED.
+    src = open(de.__file__, encoding="utf-8").read()
+    assert 'values.setdefault("MAC_MODEL_SWAP_EVAL_ENABLED", "1")' in src

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -186,8 +186,34 @@ def test_builder_none_without_router_url(monkeypatch):
     assert build_swap_evaluator({"MAC_MODEL_SWAP_EVAL_ENABLED": "1"}) is None
 
 
-def test_deploy_env_enables_swap_eval_on_hub():
+def test_deploy_env_does_not_default_enable_model_selection():
+    # Model selection is OPT-IN until production-ready (namespace/distribution
+    # gaps): deploy must NOT default-enable it.
     from mac import deploy_env as de
-    # Grep the source: the hub block sets MAC_MODEL_SWAP_EVAL_ENABLED.
     src = open(de.__file__, encoding="utf-8").read()
-    assert 'values.setdefault("MAC_MODEL_SWAP_EVAL_ENABLED", "1")' in src
+    assert 'setdefault("MAC_MODEL_SELECT_ENABLED", "1")' not in src
+    assert 'setdefault("MAC_MODEL_SWAP_EVAL_ENABLED", "1")' not in src
+
+
+def test_evaluate_swap_fails_closed_when_calls_error():
+    # The fail-open bug: a router outage made both evals empty -> "equal" ->
+    # approved. Now a call that raises marks the eval invalid -> NOT approved.
+    def raising_caller(model, question, context):
+        raise ConnectionError("router down")
+
+    v = evaluate_swap("cand", "inc", GOLDEN, model_caller=raising_caller)
+    assert v.approved is False
+    assert "could not run" in v.detail
+
+
+def test_evaluate_swap_blocks_correctness_collapse():
+    # Correctness 100% -> 0% across many cases must block even if other metrics
+    # look fine (previously only overall_score was checked).
+    cases = [{"id": "c%d" % i, "question": "q%d" % i, "expected_points": ["target%d" % i]}
+             for i in range(12)]
+    answers = {
+        "inc": {"q%d" % i: ("target%d is the answer" % i, [], 10.0) for i in range(12)},
+        "cand": {"q%d" % i: ("completely wrong", [], 10.0) for i in range(12)},
+    }
+    v = evaluate_swap("cand", "inc", cases, model_caller=lambda m, q, c: answers[m][q])
+    assert v.approved is False

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -291,3 +291,10 @@ def test_safety_regresses_on_any_increase():
 
 
 import os  # noqa: E402
+
+
+def test_moderate_natural_version_order():
+    # 4-10 is newer than 4-9; a lexical sort would wrongly pick 4-9.
+    from mac.model_selection import moderate_by_availability
+    avail = ["anthropic/claude-opus-4-9", "anthropic/claude-opus-4-10", "anthropic/claude-opus-4-2"]
+    assert moderate_by_availability(["claude-opus"], avail) == ["anthropic/claude-opus-4-10"]


### PR DESCRIPTION
A review found the model-selection work (merged #198 + the unpushed wire-live branch) passed unit tests only because they injected fakes and bypassed the real deployment seams. This fixes the concrete safety/correctness bugs — verified against the real seams — and makes the feature **safe-by-default (opt-in)** until the remaining architectural gaps land (`task_61baf40a`).

## Fixed
- **Fail-open eval gate → fail-closed.** A model-call exception became an empty answer, so two failed evals looked "equal" and a swap was *approved* (router-down ⇒ auto-swap). `run_golden_eval` now records `call_failures`/`valid`; `evaluate_swap` refuses to approve when either eval couldn't run. (Verified: a raising caller ⇒ `approved=False`.)
- **Catalog never loaded in prod.** Importing vendored `models_dev` without `hermes_vendor.ensure_on_path()` raised `ModuleNotFoundError`, swallowed to `availability=[]`. Now calls it first. (Verified: `[]` before, real models after.)
- **Wrong cost API.** Now `get_model_info(provider, model).cost_output`; available ids are provider-prefixed so the provider is recoverable.
- **Correctness collapse** (100%→0% masked by another metric) now blocks.
- **Natural version order** (`4-10` > `4-9`; was lexical).
- **Persistence race** → atomic `mkstemp` write (was a fixed `.tmp`).
- **Ruff clean** (E402 imports, `router_app` `List`, removed an unused worker import).
- **Docs**: getting-started's broken `hgmac`/`--url`/TokenHub commands fixed; opt-in model-selection env vars + limitations documented in production-deployment.

## Made safe-by-default (opt-in)
Deploy no longer default-enables `MAC_MODEL_SELECT_ENABLED` / `MAC_MODEL_SWAP_EVAL_ENABLED`. Dynamic selection stays **advisory** (observable via `/model-selection/status`; swaps pending until promoted) — it does **not** control routing yet, because the selection namespace (bare `models.dev` ids) doesn't match the router's routable namespace and the strength ladder isn't distributed to spokes.

## Deferred with a ticket (`task_61baf40a`) — explicitly not fixed here
Namespace coherence (selection↔router↔CLI), routing precedence, hub-distributed strength ladder for spokes, token-accounted cost + citations, and the remaining `hermes-integration.md`/IDE-README doc cleanup. Forcing routing precedence before namespace coherence would route to invalid models — worse than advisory.

The most dangerous combo (enabled + fail-open) only ever existed on the **unpushed** wire-live branch; it never reached main. This supersedes it.

## Verification
Fail-closed on call error, correctness-collapse blocks, natural version order, opt-in (deploy does not default-enable), plus the full contract suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)