### PR TITLE
Fix all eight round-2 model-selection review defects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ NPM ?= npm
 UV ?= uv
 CODEGRAPH ?= codegraph
 IDE_DIR ?= ide
-IDE_API_URL ?= http://127.0.0.1:8789
+IDE_API_URL ?=
+IDE_AUTH ?= auto
+IDE_PROFILE ?=
 IDE_FLEET ?=
 IDE_HOST ?= 127.0.0.1
 IDE_PORT ?= 5273
@@ -36,7 +38,7 @@ help: ## Show the supported local build, install, run, test, and cleanup command
 		'' \
 		'  make install       Install/link the CLI and prepare the canonical Fleet IDE' \
 		'  make build         Build the CLI wheel and canonical Fleet IDE' \
-		'  make run-gui       Run the Fleet IDE (IDE_API_URL=http://127.0.0.1:8789)' \
+		'  make run-gui       Run the Fleet IDE using the active mac login profile' \
 		'  make test          Run the hermetic contract test suite' \
 		'  make clean         Remove generated build artifacts (keep installed dependencies)' \
 		'  make distclean     Also remove .venv and JavaScript dependencies' \
@@ -73,7 +75,7 @@ install: install-cli install-gui ## Install the CLI and canonical Fleet IDE from
 	@printf '%s\n' \
 		'Installed MAC CLI + Fleet IDE.' \
 		'  CLI:  mac --help' \
-		'  GUI:  make run-gui IDE_API_URL=http://127.0.0.1:8789'
+		'  GUI:  mac login && make run-gui'
 
 install-cli: require-python codegraph-sync link-cli ## Create the Python environment and link MAC commands into ~/.local/bin.
 	@echo "CLI installed from $(abspath $(VENV))"
@@ -231,26 +233,19 @@ cli-coverage: codegraph-sync ## Print CLI subcommand coverage.
 
 ide-install: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Install locked Fleet IDE dependencies.
 
-ide-run ide-dev: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Run the Fleet IDE development server.
-	cd $(IDE_DIR) && \
+ide-run ide-dev: require-python require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Run the Fleet IDE development server.
+	@set -a; \
 	if [ -f "$$HOME/.mac/.env" ]; then set -a; . "$$HOME/.mac/.env"; set +a; fi; \
-	token="$${IDE_TOKEN:-$${VITE_MAC_TOKEN:-}}"; \
-	token_source="$${IDE_TOKEN:+IDE_TOKEN}"; \
-	if [ -z "$$token_source" ] && [ -n "$${VITE_MAC_TOKEN:-}" ]; then token_source="VITE_MAC_TOKEN"; fi; \
-	fleet="$(IDE_FLEET)"; \
-	if [ -z "$$fleet" ]; then fleet="$${MAC_FLEET:-}"; fi; \
-	if [ -z "$$token" ] && [ -n "$$fleet" ]; then \
-		suffix="$$(printf '%s' "$$fleet" | tr '[:lower:]' '[:upper:]' | sed -E 's/[^A-Z0-9]+/_/g; s/^_+//; s/_+$$//')"; \
-		if [ -n "$$suffix" ]; then \
-			key="MAC_API_TOKEN__$$suffix"; \
-			candidate="$$(printenv "$$key" 2>/dev/null || true)"; \
-			if [ -n "$$candidate" ]; then token="$$candidate"; token_source="$$key"; fi; \
-		fi; \
-	fi; \
-	if [ -z "$$token" ] && [ -n "$${MAC_DEPLOY_HUB_TOKEN:-}" ]; then token="$${MAC_DEPLOY_HUB_TOKEN}"; token_source="MAC_DEPLOY_HUB_TOKEN"; fi; \
-	if [ -z "$$token" ] && [ -n "$${MAC_API_TOKEN:-}" ]; then token="$${MAC_API_TOKEN}"; token_source="MAC_API_TOKEN"; fi; \
-	if [ -n "$$token_source" ]; then printf 'IDE auth token source: %s\n' "$$token_source"; else printf 'IDE auth token source: none (paste a token in the browser)\n'; fi; \
-	MAC_API_URL="$(IDE_API_URL)" VITE_MAC_TOKEN="$$token" $(NPM) run dev -- --host $(IDE_HOST) --port $(IDE_PORT)
+	PYTHONPATH="$(abspath src)" \
+	IDE_DIR="$(abspath $(IDE_DIR))" \
+	IDE_API_URL="$(IDE_API_URL)" \
+	IDE_AUTH="$(IDE_AUTH)" \
+	IDE_PROFILE="$(IDE_PROFILE)" \
+	IDE_FLEET="$(IDE_FLEET)" \
+	IDE_HOST="$(IDE_HOST)" \
+	IDE_PORT="$(IDE_PORT)" \
+	NPM="$(NPM)" \
+	"$(PYTHON)" -m mac.ide_launcher
 
 ide-check: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Type-check the Fleet IDE.
 	cd $(IDE_DIR) && $(NPM) run typecheck

--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ make help
 # Install/link the CLI and prepare the canonical Fleet IDE.
 make install
 
-# Verify the checkout, or launch the GUI against a hub.
+# Verify the checkout, or log in and launch the GUI against that hub.
 make test
-make run-gui IDE_API_URL=http://127.0.0.1:8789
+mac login
+make run-gui
 ```
 
 `make test` runs the complete hermetic pytest suite with source coverage and
@@ -312,7 +313,8 @@ The React + Monaco fleet IDE lives in `ide/`. From the repository root:
 
 ```bash
 make install-gui
-make run-gui IDE_API_URL=http://127.0.0.1:8789
+mac login
+make run-gui
 make build-gui
 make package-gui
 ```
@@ -322,7 +324,10 @@ writes a static web bundle to `dist/mac-ide-web.tar.gz`. This is separate from
 the maintenance-only Electron dashboard wrapper in `desktop/`. The existing
 `ide-*` target names remain as compatibility aliases.
 
-For local auth, `make run-gui` sources `~/.mac/.env` and passes a token to Vite
+For local auth, `make run-gui` first reuses the active scoped client profile
+created by `mac login`, including its managed SSH tunnel. The credential stays
+inside the local Vite proxy and is not exposed to browser storage. If no active
+profile exists, the launcher sources `~/.mac/.env` and selects a token
 without printing it. Set `IDE_FLEET=<fleet>` to prefer the matching
 `MAC_API_TOKEN__<FLEET>` key; otherwise the launcher falls back to
 `MAC_DEPLOY_HUB_TOKEN` and then `MAC_API_TOKEN`. The `make ide-run` compatibility

--- a/ide/README.md
+++ b/ide/README.md
@@ -20,29 +20,36 @@ From the repository root:
 
 ```bash
 make install-gui
-make run-gui IDE_API_URL=http://100.72.16.110:8789
-# open http://127.0.0.1:5273, paste a hub bearer token when prompted
+mac login
+make run-gui
+# open http://127.0.0.1:5273; the active CLI profile connects automatically
 ```
 
-`make run-gui` reads `~/.mac/.env` and passes a token to Vite when it can. If
-`IDE_FLEET=<fleet>` or `MAC_FLEET=<fleet>` is set, the launcher prefers
-`MAC_API_TOKEN__<FLEET>`; otherwise it falls back to `MAC_DEPLOY_HUB_TOKEN` and
-then `MAC_API_TOKEN`. It prints the selected key name, never the token value.
-The existing `make ide-run` target is a compatibility alias.
+`make run-gui` reuses the active scoped client profile created by `mac login`,
+ensures its SSH tunnel is running, and attaches the credential inside the local
+Vite proxy. The token is not printed, placed in the URL, or exposed to browser
+storage. Set `IDE_PROFILE=<name>` to select a non-active profile.
+
+If no client profile exists, the launcher falls back to the existing
+fleet-scoped environment token lookup and finally to the browser's manual
+connection form. Use `IDE_AUTH=manual make run-gui` to force that fallback, or
+`IDE_API_URL=<url>` to override the selected profile's endpoint. The existing
+`make ide-run` target is a compatibility alias.
 
 Or from this package:
 
 ```bash
 cd ide
 npm ci
-MAC_API_URL=http://100.72.16.110:8789 npm run dev   # hub to talk to
-# open http://localhost:5273, paste a hub bearer token when prompted
+MAC_API_URL=http://100.72.16.110:8789 npm run dev   # manual development fallback
+# open http://localhost:5273 and paste a scoped hub token when prompted
 ```
 
-`/api/*` is proxied to the hub (see `vite.config.ts`). The token is stored in
-tab-scoped `sessionStorage["mac.token"]` (with a migration fallback for an old
-local value), or set with `VITE_MAC_TOKEN`. `?t=` bootstrap values are removed
-from the URL immediately.
+`/api/*` is proxied to the hub (see `vite.config.ts`). In the normal root-level
+launcher flow, Vite adds the profile credential server-side. In the manual
+fallback, a pasted token is stored in tab-scoped `sessionStorage["mac.token"]`
+(with a migration fallback for an old local value). `?t=` bootstrap values are
+removed from the URL immediately.
 
 ## Build and package
 

--- a/ide/src/App.tsx
+++ b/ide/src/App.tsx
@@ -5,6 +5,8 @@ import {
   bootstrapTokenFromUrl,
   clearToken,
   getApiBaseUrl,
+  hasManagedAuth,
+  managedAuthLabel,
   setApiBaseUrl,
   setToken,
   streamDashboard,
@@ -40,6 +42,8 @@ function initialSelection(): string | null {
 
 export function App() {
   const compactLayout = useCompactLayout();
+  const managedAuth = hasManagedAuth();
+  const authLabel = managedAuthLabel();
   const [data, setData] = useState<DashboardState>(EMPTY_STATE);
   const [card, setCard] = useState<AgentCard | null>(null);
   const [view, setView] = useState<WorkbenchView>(initialView);
@@ -48,7 +52,10 @@ export function App() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
   const [streamStatus, setStreamStatus] = useState<"connecting" | "connected" | "degraded">("connecting");
-  const [needToken, setNeedToken] = useState(() => !bootstrapTokenFromUrl());
+  const [needToken, setNeedToken] = useState(() => {
+    const token = bootstrapTokenFromUrl();
+    return !hasManagedAuth() && !token;
+  });
   const [tokenInput, setTokenInput] = useState("");
   const [targetInput, setTargetInput] = useState(getApiBaseUrl);
   const [tokenError, setTokenError] = useState("");
@@ -84,12 +91,16 @@ export function App() {
       setError(message);
       setLoading(false);
       if (/HTTP\s+(401|403)\b/.test(message)) {
-        clearToken();
-        setTokenError("The hub rejected this token. Paste the current fleet-scoped bearer token.");
-        setNeedToken(true);
+        if (managedAuth) {
+          setError("The active CLI login was rejected. Run `mac login renew`, then restart the Fleet IDE.");
+        } else {
+          clearToken();
+          setTokenError("The hub rejected this token. Paste the current fleet-scoped bearer token.");
+          setNeedToken(true);
+        }
       }
     }
-  }, []);
+  }, [managedAuth]);
 
   useEffect(() => {
     if (needToken) return;
@@ -173,7 +184,13 @@ export function App() {
         <form className="login-card" onSubmit={submitToken}>
           <span className="eyebrow">Control plane connection</span>
           <h1>Connect to a fleet hub</h1>
-          <p>Use a read/write token for operator actions. Tokens live in this browser tab and URL bootstrap tokens are removed immediately.</p>
+          <p>The normal connection is your active MAC CLI login. Run the command below, then restart the Fleet IDE.</p>
+          <div className="login-recommended">
+            <span>Recommended</span>
+            <code>mac login</code>
+            <small>The launcher reuses the scoped profile and SSH tunnel automatically.</small>
+          </div>
+          <div className="login-divider"><span>Manual fallback</span></div>
           <label>Hub URL<input aria-label="Hub URL" onChange={(event) => setTargetInput(event.target.value)} placeholder="/api or https://hub.example" value={targetInput} /></label>
           <label>Bearer token<input autoComplete="off" autoFocus aria-label="Hub bearer token" onChange={(event) => { setTokenInput(event.target.value); setTokenError(""); }} type="password" value={tokenInput} /></label>
           <button className="button primary" disabled={!tokenInput.trim()} type="submit">Connect to hub</button>
@@ -301,7 +318,11 @@ export function App() {
         <span><i className="codicon codicon-symbol-structure" /> CodeGraph ready</span>
         <span className="status-spacer" />
         <span>{busy}/{agents.length} busy</span>
-        <button onClick={disconnect} type="button">disconnect</button>
+        {managedAuth ? (
+          <span title="Authentication is supplied by the local MAC launcher"><i className="codicon codicon-lock" /> {authLabel}</span>
+        ) : (
+          <button onClick={disconnect} type="button">disconnect</button>
+        )}
       </footer>
     </div>
   );

--- a/ide/src/api/mac.ts
+++ b/ide/src/api/mac.ts
@@ -5,6 +5,10 @@ const DEFAULT_BASE = "/api";
 const TOKEN_KEY = "mac.token";
 const API_BASE_KEY = "mac.apiBaseUrl";
 
+function runtimeEnv(): Record<string, string> {
+  return (import.meta as ImportMeta & { env?: Record<string, string> }).env || {};
+}
+
 export interface ActivityEntry {
   phase: string;
   actor: string;
@@ -149,9 +153,17 @@ export function getToken(): string {
   return (
     sessionStorage.getItem(TOKEN_KEY) ||
     localStorage.getItem(TOKEN_KEY) ||
-    (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_MAC_TOKEN ||
+    runtimeEnv().VITE_MAC_TOKEN ||
     ""
   );
+}
+
+export function hasManagedAuth(): boolean {
+  return runtimeEnv().VITE_MAC_AUTH_MODE === "managed";
+}
+
+export function managedAuthLabel(): string {
+  return runtimeEnv().VITE_MAC_AUTH_LABEL || "CLI profile";
 }
 
 export function setToken(raw: string): string {

--- a/ide/src/styles.css
+++ b/ide/src/styles.css
@@ -315,6 +315,12 @@ button.data-row.selected { box-shadow: inset 2px 0 var(--cyan); }
 .login-card input { height: 38px; padding: 0 10px; border: 1px solid var(--border-strong); background: #081219; }
 .login-card .button { width: 100%; margin-top: 10px; }
 .login-card .login-error { margin: 10px 0 0; color: var(--coral); }
+.login-recommended { display: grid; grid-template-columns: auto 1fr; gap: 5px 12px; margin: 18px 0; padding: 12px; border: 1px solid rgb(0 188 242 / 32%); background: rgb(0 188 242 / 7%); }
+.login-recommended > span { align-self: center; color: var(--cyan); font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.login-recommended code { align-self: center; color: var(--text-strong); font-size: 13px; }
+.login-recommended small { grid-column: 1 / -1; color: var(--muted); line-height: 1.45; }
+.login-divider { display: flex; align-items: center; gap: 10px; margin: 20px 0 2px; color: var(--muted); font-size: 10px; letter-spacing: .06em; text-transform: uppercase; }
+.login-divider::before, .login-divider::after { height: 1px; flex: 1; background: var(--border); content: ""; }
 
 @media (max-width: 1180px) {
   .command-bar { grid-template-columns: 235px 70px minmax(250px, 1fr) auto; }

--- a/ide/vite.config.ts
+++ b/ide/vite.config.ts
@@ -4,8 +4,10 @@ import react from "@vitejs/plugin-react";
 // The hub the IDE talks to. Override with MAC_API_URL at dev time, e.g.
 //   MAC_API_URL=http://100.72.16.110:8789 npm run dev
 // Requests to /api/* are proxied to the hub so the browser avoids CORS and the
-// bearer token stays server-side-ish (set VITE_MAC_TOKEN for auth).
+// scoped bearer token stays server-side. The MAC launcher provides
+// MAC_IDE_PROXY_TOKEN from the active `mac login` profile.
 const HUB = process.env.MAC_API_URL || "http://100.72.16.110:8789";
+const HUB_TOKEN = (process.env.MAC_IDE_PROXY_TOKEN || "").trim();
 
 export default defineConfig({
   plugins: [react()],
@@ -16,6 +18,12 @@ export default defineConfig({
         target: HUB,
         changeOrigin: true,
         rewrite: (p) => p.replace(/^\/api/, ""),
+        configure(proxy) {
+          if (!HUB_TOKEN) return;
+          proxy.on("proxyReq", (proxyRequest) => {
+            proxyRequest.setHeader("Authorization", `Bearer ${HUB_TOKEN}`);
+          });
+        },
       },
     },
   },

--- a/src/mac/eval_runner.py
+++ b/src/mac/eval_runner.py
@@ -141,7 +141,10 @@ def run_golden_eval(
             "overall": per_overall,
             "safety_flags": scores["safety_flags"],
             "latency_ms": float(latency_ms or 0.0),
-            "cost_per_answer": float(unit_cost) if unit_cost is not None else 0.0,
+            # Model's per-token OUTPUT unit price (models.dev), constant across
+            # cases — NOT a token-accounted per-answer cost. Named accordingly so
+            # it is not mistaken for actual answer spend.
+            "unit_output_cost": float(unit_cost) if unit_cost is not None else 0.0,
         })
 
     n = len(case_results) or 1
@@ -158,7 +161,7 @@ def run_golden_eval(
         "safety_violation_rate": round(violations / n, 4),
         "latency_p50_ms": round(_percentile(latencies, 0.5), 2),
         "latency_p95_ms": round(_percentile(latencies, 0.95), 2),
-        "cost_per_answer_avg": round(float(unit_cost), 6) if unit_cost is not None else 0.0,
+        "unit_output_cost_avg": round(float(unit_cost), 6) if unit_cost is not None else 0.0,
     }
     return {
         "meta": {
@@ -169,7 +172,15 @@ def run_golden_eval(
             "dataset_sha256": dataset_sha256(cases),
         },
         "summary": summary,
-        "per_case_overall": overalls,  # paired significance input (case-aligned)
+        # Case-aligned per-metric series so significance is tested on the SPECIFIC
+        # regressed metric (a correctness collapse must be judged on correctness
+        # deltas, not overall — #4), not just the blended overall score.
+        "per_case_overall": overalls,
+        "per_case": {
+            "overall_score": overalls,
+            "avg_correctness": corr,
+            "avg_groundedness": grnd,
+        },
         # The eval is only VALID if every model call actually succeeded. A call
         # failure (router down, timeout) must NOT be scored as an ordinary empty
         # answer — otherwise two failed evals look "equal" and a swap is wrongly
@@ -261,21 +272,32 @@ def evaluate_swap(
     # Safety regressions are hard blocks regardless of significance.
     safety_regressed = any(d["metric"] == "safety_violation_rate" for d in drifted)
 
-    # Quality regressions (overall_score AND avg_correctness — a correctness
-    # collapse masked by another metric must still block) require significance:
-    # only block if the paired bootstrap CI shows the candidate is really worse.
-    deltas = [c - i for c, i in zip(cand["per_case_overall"], inc["per_case_overall"])]
-    ci_upper = _bootstrap_ci_upper(deltas) if deltas else 0.0
-    significant = ci_upper < -threshold
-    quality_metrics = {"overall_score", "avg_correctness", "avg_groundedness"}
-    quality_regressed = any(d["metric"] in quality_metrics for d in drifted)
-    if quality_regressed and not significant:
-        # Non-significant quality drift on a small set: don't block on it.
-        drifted = [d for d in drifted if d["metric"] not in quality_metrics]
-        quality_regressed = False
+    # Quality regressions require significance — but tested on the SPECIFIC
+    # metric's per-case deltas, not the blended overall (a correctness collapse
+    # offset by groundedness would hide in the overall series; #4). Each quality
+    # metric that drifted is kept only if ITS own paired bootstrap CI confirms a
+    # real per-case regression.
+    quality_metrics = ("overall_score", "avg_correctness", "avg_groundedness")
+    cand_series = cand.get("per_case", {})
+    inc_series = inc.get("per_case", {})
+    kept_quality = []
+    for d in drifted:
+        metric = d["metric"]
+        if metric not in quality_metrics:
+            continue
+        c_series = cand_series.get(metric) or []
+        i_series = inc_series.get(metric) or []
+        d_deltas = [c - i for c, i in zip(c_series, i_series)]
+        ci_upper = _bootstrap_ci_upper(d_deltas) if d_deltas else 0.0
+        if ci_upper < -threshold:
+            kept_quality.append(metric)
+    # Drop non-significant quality drift from the blocking set.
+    drifted = [d for d in drifted
+               if d["metric"] not in quality_metrics or d["metric"] in kept_quality]
+    quality_regressed = bool(kept_quality)
 
     cost_regressed = any(
-        d["metric"] in ("latency_p95_ms", "latency_p50_ms", "cost_per_answer_avg")
+        d["metric"] in ("latency_p95_ms", "latency_p50_ms", "unit_output_cost_avg")
         for d in drifted
     )
     approved = not (safety_regressed or quality_regressed or cost_regressed)
@@ -371,12 +393,18 @@ def router_model_caller(
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             data = _json.loads(resp.read().decode("utf-8"))
         latency_ms = (time.monotonic() - start) * 1000.0
-        answer = ""
+        # A malformed 200 (``{}``, missing choices, null content) is a FAILURE,
+        # not an empty successful answer — otherwise two malformed responses look
+        # "equal" and the swap is wrongly approved (the fail-open bug #3). Raise
+        # so run_golden_eval counts it as a call failure -> eval invalid -> the
+        # gate fails closed.
         try:
-            answer = str(data["choices"][0]["message"]["content"] or "")
-        except (KeyError, IndexError, TypeError):
-            answer = ""
-        return answer, [], latency_ms
+            content = data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise ValueError("malformed completion response (no choices/content)") from exc
+        if content is None:
+            raise ValueError("completion response has null content")
+        return str(content), [], latency_ms
 
     return call
 

--- a/src/mac/hermes_adapter.py
+++ b/src/mac/hermes_adapter.py
@@ -1311,7 +1311,7 @@ def build_parser() -> argparse.ArgumentParser:
     project_repositories.add_argument("--enabled", action="store_true", default=None)
     project_repositories.set_defaults(func=_cmd_project_repositories)
 
-    register_project_repository = sub.add_parser("register-project-repository", help="register a Beads-backed project repository")
+    register_project_repository = sub.add_parser("register-project-repository", help="register a mac-task-backed project repository")
     register_project_repository.add_argument("name")
     register_project_repository.add_argument("path")
     register_project_repository.add_argument("--source")

--- a/src/mac/ide_launcher.py
+++ b/src/mac/ide_launcher.py
@@ -1,0 +1,223 @@
+"""Launch the Fleet IDE with credentials from the active MAC client profile.
+
+The browser cannot read ``~/.mac`` and should not need to.  This launcher keeps
+the scoped client credential in the local Vite process, where the development
+proxy attaches it to hub requests.  Only non-secret connection metadata is
+exposed to the rendered application.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, MutableMapping, Optional, Sequence
+
+from mac.client_login import ClientLoginError, ensure_session
+from mac.client_profiles import (
+    ClientProfileError,
+    active_profile_name,
+    load_profile,
+)
+
+
+DEFAULT_API_URL = "http://127.0.0.1:8789"
+_AUTH_MODES = {"auto", "profile", "manual"}
+
+
+class IdeLauncherError(RuntimeError):
+    """Raised when the requested IDE authentication mode cannot be prepared."""
+
+
+@dataclass(frozen=True)
+class IdeConnection:
+    api_url: str
+    token: str = ""
+    source: str = "manual"
+    profile: Optional[str] = None
+
+    @property
+    def managed(self) -> bool:
+        return bool(self.token)
+
+
+def _value(env: Mapping[str, str], key: str) -> str:
+    return str(env.get(key) or "").strip()
+
+
+def _legacy_token(env: Mapping[str, str]) -> tuple[str, str]:
+    token = _value(env, "VITE_MAC_TOKEN")
+    if token:
+        return token, "VITE_MAC_TOKEN"
+
+    fleet = _value(env, "IDE_FLEET") or _value(env, "MAC_FLEET")
+    if fleet:
+        suffix = "_".join(part for part in _normalize_fleet(fleet).split("_") if part)
+        if suffix:
+            key = "MAC_API_TOKEN__" + suffix
+            token = _value(env, key)
+            if token:
+                return token, key
+
+    for key in ("MAC_DEPLOY_HUB_TOKEN", "MAC_API_TOKEN"):
+        token = _value(env, key)
+        if token:
+            return token, key
+    return "", "manual"
+
+
+def _normalize_fleet(value: str) -> str:
+    return "".join(char if char.isalnum() else "_" for char in value.upper()).strip("_")
+
+
+def resolve_ide_connection(env: Optional[Mapping[str, str]] = None) -> IdeConnection:
+    values = os.environ if env is None else env
+    auth_mode = _value(values, "IDE_AUTH") or "auto"
+    if auth_mode not in _AUTH_MODES:
+        raise IdeLauncherError(
+            "IDE_AUTH must be one of auto, profile, or manual (got %r)" % auth_mode
+        )
+
+    explicit_api_url = _value(values, "IDE_API_URL")
+    if auth_mode == "manual":
+        return IdeConnection(api_url=explicit_api_url or DEFAULT_API_URL)
+
+    explicit_token = _value(values, "IDE_TOKEN")
+    if explicit_token:
+        return IdeConnection(
+            api_url=explicit_api_url or DEFAULT_API_URL,
+            token=explicit_token,
+            source="IDE_TOKEN",
+        )
+
+    requested_profile = _value(values, "IDE_PROFILE")
+    try:
+        selected_profile = requested_profile or active_profile_name()
+    except (ClientProfileError, OSError) as exc:
+        raise IdeLauncherError("could not inspect the active MAC login: %s" % exc) from exc
+
+    if selected_profile:
+        try:
+            ensure_session(selected_profile)
+            profile = load_profile(selected_profile, include_token=True)
+        except (ClientLoginError, ClientProfileError, OSError) as exc:
+            raise IdeLauncherError(
+                "could not use MAC login profile %r: %s" % (selected_profile, exc)
+            ) from exc
+        connection = dict(profile.get("connection") or {})
+        credential = dict(profile.get("credential") or {})
+        api_url = explicit_api_url or str(connection.get("api_url") or "").strip()
+        token = str(credential.get("token") or "").strip()
+        if not api_url:
+            raise IdeLauncherError(
+                "MAC login profile %r has no API URL" % selected_profile
+            )
+        if not token:
+            raise IdeLauncherError(
+                "MAC login profile %r has no stored credential" % selected_profile
+            )
+        return IdeConnection(
+            api_url=api_url,
+            token=token,
+            source="client-profile:%s" % selected_profile,
+            profile=selected_profile,
+        )
+
+    if requested_profile or auth_mode == "profile":
+        raise IdeLauncherError(
+            "no active MAC login profile; run `mac login` before starting the GUI"
+        )
+
+    token, source = _legacy_token(values)
+    return IdeConnection(
+        api_url=explicit_api_url or DEFAULT_API_URL,
+        token=token,
+        source=source,
+    )
+
+
+def build_vite_environment(
+    connection: IdeConnection,
+    env: Optional[Mapping[str, str]] = None,
+) -> MutableMapping[str, str]:
+    child = dict(os.environ if env is None else env)
+    child["MAC_API_URL"] = connection.api_url
+
+    # Remove every browser-visible or legacy copy after resolving it.  The one
+    # credential retained by the child is consumed only by vite.config.ts.
+    for key in list(child):
+        if key in {
+            "IDE_TOKEN",
+            "VITE_MAC_TOKEN",
+            "MAC_API_TOKEN",
+            "MAC_DEPLOY_HUB_TOKEN",
+            "MAC_IDE_PROXY_TOKEN",
+        } or key.startswith("MAC_API_TOKEN__"):
+            child.pop(key, None)
+
+    if connection.managed:
+        child["MAC_IDE_PROXY_TOKEN"] = connection.token
+        child["VITE_MAC_AUTH_MODE"] = "managed"
+        child["VITE_MAC_AUTH_LABEL"] = (
+            "CLI profile %s" % connection.profile
+            if connection.profile
+            else "launcher credential"
+        )
+    else:
+        child.pop("VITE_MAC_AUTH_MODE", None)
+        child.pop("VITE_MAC_AUTH_LABEL", None)
+    return child
+
+
+def vite_command(env: Mapping[str, str]) -> Sequence[str]:
+    npm = shlex.split(_value(env, "NPM") or "npm")
+    host = _value(env, "IDE_HOST") or "127.0.0.1"
+    port = _value(env, "IDE_PORT") or "5273"
+    return [*npm, "run", "dev", "--", "--host", host, "--port", port]
+
+
+def run(env: Optional[Mapping[str, str]] = None) -> int:
+    values = dict(os.environ if env is None else env)
+    connection = resolve_ide_connection(values)
+    child = build_vite_environment(connection, values)
+    ide_dir = Path(_value(values, "IDE_DIR") or "ide").expanduser().resolve()
+    if not (ide_dir / "package.json").is_file():
+        raise IdeLauncherError("Fleet IDE package was not found at %s" % ide_dir)
+
+    if connection.profile:
+        print(
+            "IDE connection: MAC login profile %s via %s"
+            % (connection.profile, connection.api_url)
+        )
+    else:
+        print("IDE connection: %s" % connection.api_url)
+    if connection.managed:
+        print(
+            "IDE auth: managed by the local proxy from %s "
+            "(credential is not exposed to the browser)" % connection.source
+        )
+    else:
+        print(
+            "IDE auth: no CLI profile or launcher credential; "
+            "the browser will show the manual fallback"
+        )
+
+    completed = subprocess.run(vite_command(values), cwd=ide_dir, env=child, check=False)
+    return int(completed.returncode)
+
+
+def main() -> None:
+    try:
+        raise SystemExit(run())
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None
+    except IdeLauncherError as exc:
+        print("Fleet IDE launch failed: %s" % exc, file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mac/model_selection.py
+++ b/src/mac/model_selection.py
@@ -122,9 +122,12 @@ def model_strength_ladder(
                 cost = cost_lookup(mid)
             except Exception:  # noqa: BLE001
                 cost = None
-        # (has_cost, cost, name_tier, id) — models with known cost sort by cost;
-        # the rest fall back to name tier. All ascending = weakest first.
-        return (0 if cost is None else 1, cost if cost is not None else 0.0, _name_tier(mid), mid)
+        # name_tier is the PRIMARY signal so an unknown-cost strong model (e.g.
+        # an Opus with no catalog price) is not sorted to strength 1 — the
+        # previous (has_cost, cost, ...) key clustered every unpriced model at
+        # the weak end regardless of capability. Cost refines ordering WITHIN a
+        # tier. Ascending = weakest first.
+        return (_name_tier(mid), cost if cost is not None else 0.0, mid)
 
     return sorted(models, key=key)
 
@@ -150,10 +153,11 @@ def _models_dev_cost(model_id: str) -> Optional[float]:
 
     The real catalog API is ``get_model_info(provider_id, model_id)`` and the
     field is ``cost_output`` (``get_model_capabilities(model_id)`` — the previous
-    call — is the wrong API and carries no cost). Ids may be provider-prefixed
-    (``provider/model`` from available_models_from_providers); parse the provider
-    and use the bare model id. Returns None (=> name-tier ladder fallback) when
-    unavailable.
+    call — is the wrong API and carries no cost). Ids are normally the router's
+    native bare form (``gpt-5-2``), but may carry provider path segments
+    (``nvidia/meta/llama``); we try every provider-boundary split plus a bare
+    fallback across common providers. Returns None (=> name-tier ladder
+    fallback) when unavailable.
     """
     try:
         from mac.hermes_vendor import ensure_on_path
@@ -166,12 +170,19 @@ def _models_dev_cost(model_id: str) -> Optional[float]:
     # Candidate (provider, model) splits: the leading segment as provider with
     # the rest as the model, plus a bare fallback across common providers.
     candidates: List[Tuple[str, str]] = []
-    if "/" in mid:
-        head, _, tail = mid.partition("/")
-        candidates.append((head, tail.rsplit("/", 1)[-1]))
-    bare = mid.rsplit("/", 1)[-1]
+    segments = [s for s in mid.split("/") if s]
+    # Try every provider-boundary split, keeping the FULL remainder as the model
+    # id (so nvidia/meta/llama -> (nvidia, "meta/llama") and (meta, "llama"),
+    # not the previous (nvidia, "llama") which dropped the intermediate path).
+    for i in range(len(segments) - 1):
+        candidates.append((segments[i], "/".join(segments[i + 1:])))
+        candidates.append((segments[i], segments[-1]))
+    bare = segments[-1] if segments else mid
     for provider in ("anthropic", "openai", "google", "xai", "deepseek", "meta", "mistral", "qwen"):
         candidates.append((provider, bare))
+    # De-dup, preserve order.
+    seen_c: set = set()
+    candidates = [c for c in candidates if not (c in seen_c or seen_c.add(c))]
     for provider, model in candidates:
         try:
             info = get_model_info(provider, model)
@@ -315,34 +326,61 @@ def discover_via_web(
     return results
 
 
-def available_models_from_providers(providers: Iterable[str]) -> List[str]:
-    """Concrete agentic model ids the gateway can route to, per the fleet's
-    configured providers, via the models.dev catalog. Empty on any failure.
+def available_models_from_providers(providers: Iterable[Any]) -> List[str]:
+    """The exact model ids the router can serve AND the upstream will accept.
 
-    Ids are returned provider-prefixed (``provider/model``) so the provider is
-    recoverable downstream (cost lookup needs it) — the vendored catalog's
-    ``list_agentic_models`` returns bare ids per provider.
+    ``providers`` may be ``provider_router.Provider`` objects (allowlist-aware,
+    the production path) or bare provider-name strings (legacy — treated as
+    wildcard). Ids are returned in the router's NATIVE namespace, NOT
+    provider-prefixed:
+
+    * A provider with an explicit ``models=`` allowlist contributes those ids
+      verbatim — they are exactly what ``ProviderRouter._serves`` matches and
+      what the upstream API expects.
+    * A wildcard (``models=*``) provider serves any id, so its offerings are
+      enumerated from the models.dev catalog as the catalog's own bare ids.
+
+    The previous ``provider/model`` prefixing was wrong on both counts: an
+    explicit allowlist rejected the prefixed id at ``_serves``, and a wildcard
+    provider forwarded ``openai/gpt-5-2`` to the upstream, which only knows
+    ``gpt-5-2``. Empty on any failure — the caller falls back.
     """
     out: List[str] = []
-    try:
-        # The vendored Hermes catalog is only importable after its path is set
-        # up; without this the import raises ModuleNotFoundError and the whole
-        # selection silently degrades to [] (the fleet never sees any models).
-        from mac.hermes_vendor import ensure_on_path
-
-        ensure_on_path()
-        from mac._hermes.agent.models_dev import list_agentic_models
-    except Exception:  # noqa: BLE001 - catalog optional; caller falls back.
-        return out
-    for provider in providers or []:
-        p = str(provider)
-        try:
-            for mid in list_agentic_models(p):
-                out.append("%s/%s" % (p, mid))
-        except Exception:  # noqa: BLE001
+    wildcard_providers: List[str] = []
+    for entry in providers or []:
+        name = getattr(entry, "name", None)
+        models = getattr(entry, "models", None)
+        if name is None:
+            # Legacy bare-name string: no allowlist known -> enumerate via catalog.
+            wildcard_providers.append(str(entry))
             continue
+        if models and "*" not in tuple(models):
+            # Explicit allowlist: these ARE the routable+native ids.
+            out.extend(str(m) for m in models if str(m).strip())
+        else:
+            wildcard_providers.append(str(name))
+
+    if wildcard_providers:
+        try:
+            # The vendored Hermes catalog is only importable after its path is
+            # set up; without this the import raises ModuleNotFoundError and the
+            # wildcard providers silently contribute nothing.
+            from mac.hermes_vendor import ensure_on_path
+
+            ensure_on_path()
+            from mac._hermes.agent.models_dev import list_agentic_models
+        except Exception:  # noqa: BLE001 - catalog optional; caller falls back.
+            list_agentic_models = None
+        if list_agentic_models is not None:
+            for p in wildcard_providers:
+                try:
+                    for mid in list_agentic_models(p):
+                        out.append(str(mid))  # native bare id, NOT prefixed
+                except Exception:  # noqa: BLE001
+                    continue
+
     seen: set = set()
-    return [m for m in out if not (m in seen or seen.add(m))]
+    return [m for m in out if m.strip() and not (m in seen or seen.add(m))]
 
 
 # --------------------------------------------------------------------------- #
@@ -350,6 +388,12 @@ def available_models_from_providers(providers: Iterable[str]) -> List[str]:
 # --------------------------------------------------------------------------- #
 
 _log = logging.getLogger("mac.model_selection")
+
+# Serializes the read-modify-write store mutations below. The atomic rename in
+# _write_store prevents torn files, but set_pending / promote_pending / set_active
+# each read-then-write; without this lock two hub threads (refresh + operator
+# promote) can interleave and one silently drops the other's update (lost update).
+_STORE_LOCK = threading.RLock()
 
 DEFAULT_INTERVAL_SECONDS = 7 * 24 * 60 * 60.0   # weekly — "what's leading" moves slowly
 DEFAULT_INITIAL_DELAY_SECONDS = 300.0
@@ -451,25 +495,28 @@ def resolve_strength_from_selection(
 
 def set_active(sel: ModelSelection, environ: Optional[Mapping[str, str]] = None) -> Path:
     """Adopt ``sel`` as active and clear any pending candidate."""
-    return _write_store({"active": sel.to_dict(), "pending": None}, None, environ)
+    with _STORE_LOCK:
+        return _write_store({"active": sel.to_dict(), "pending": None}, None, environ)
 
 
 def set_pending(sel: ModelSelection, environ: Optional[Mapping[str, str]] = None) -> Path:
     """Record ``sel`` as a pending swap (does not affect routing)."""
-    store = _read_store(None, environ)
-    store["pending"] = sel.to_dict()
-    return _write_store(store, None, environ)
+    with _STORE_LOCK:
+        store = _read_store(None, environ)
+        store["pending"] = sel.to_dict()
+        return _write_store(store, None, environ)
 
 
 def promote_pending(environ: Optional[Mapping[str, str]] = None) -> Optional[dict]:
     """Promote the pending candidate to active (operator/gate action). Returns
     the promoted selection dict, or None if there was nothing pending."""
-    store = _read_store(None, environ)
-    pending = store.get("pending")
-    if not (isinstance(pending, dict) and pending.get("models")):
-        return None
-    _write_store({"active": pending, "pending": None}, None, environ)
-    return pending
+    with _STORE_LOCK:
+        store = _read_store(None, environ)
+        pending = store.get("pending")
+        if not (isinstance(pending, dict) and pending.get("models")):
+            return None
+        _write_store({"active": pending, "pending": None}, None, environ)
+        return pending
 
 
 # Legacy name retained for callers/tests that adopt directly (bootstrap path).
@@ -486,7 +533,7 @@ def write_selection(sel: ModelSelection, path: Optional[Path] = None,
 # review): quality metrics regress DOWN; safety-violation regresses on ANY
 # increase; latency/cost regress UP.
 _QUALITY_METRICS = ("overall_score", "avg_correctness", "avg_groundedness")
-_COST_METRICS = ("latency_p50_ms", "latency_p95_ms", "cost_per_answer_avg")
+_COST_METRICS = ("latency_p50_ms", "latency_p95_ms", "unit_output_cost_avg")
 _SAFETY_METRIC = "safety_violation_rate"
 
 
@@ -525,18 +572,6 @@ def compare_eval_metrics(
             if d > threshold:
                 drifted.append({"metric": metric, "rel_delta": d, "direction": "up"})
     return {"regressed": bool(drifted), "drifted": drifted}
-
-
-def _providers_from_env(environ: Mapping[str, str]) -> List[str]:
-    """Provider ids from MAC_ROUTER_PROVIDERS (``id=base,prio,key=...;...``)."""
-    raw = str(environ.get("MAC_ROUTER_PROVIDERS") or "").strip()
-    out: List[str] = []
-    for spec in raw.split(";"):
-        spec = spec.strip()
-        if not spec:
-            continue
-        out.append(spec.split("=", 1)[0].strip())
-    return [p for p in out if p]
 
 
 @dataclass(frozen=True)
@@ -681,8 +716,13 @@ class ModelSelectionService:
             now = datetime.now(timezone.utc).isoformat(timespec="seconds")
             searcher = self._resolve_searcher()
             results = discover_via_web(searcher) if searcher is not None else []
-            providers = _providers_from_env(self._environ)
-            available = available_models_from_providers(providers)
+            # Parse the FULL provider specs (allowlist-aware) so available models
+            # are the router's exact native ids, not provider-name-prefixed ones.
+            from mac.provider_router import providers_from_env
+
+            provider_objs = providers_from_env(self._environ)
+            available = available_models_from_providers(provider_objs)
+            providers = [p.name for p in provider_objs]
             sel = select_powerhouse_models(
                 results, available, n=self.config.count,
                 fallback=self.config.fallback_model, now=now,
@@ -698,9 +738,36 @@ class ModelSelectionService:
                 # active. Never blank the model.
                 report["outcome"] = "no_candidate"
             elif active is None:
-                # Bootstrap: nothing to regress from, adopt immediately.
-                set_active(sel, environ=self._environ)
-                report["outcome"] = "adopted_bootstrap"
+                # Bootstrap. There IS an incumbent even with nothing adopted yet:
+                # the fleet's deploy-default model that tasks serve today. If an
+                # eval gate is enabled and that default differs from the proposed
+                # set, gate the first adoption against it too — otherwise the very
+                # first selection would flip routing to unvalidated models,
+                # exactly the regression the gate exists to prevent.
+                incumbent = [self.config.fallback_model] if self.config.fallback_model else []
+                if self._swap_evaluator is not None and incumbent and incumbent != sel.models:
+                    gate = None
+                    try:
+                        gate = self._swap_evaluator(sel.models, incumbent)
+                    except Exception as exc:  # noqa: BLE001 - gate failure => don't adopt.
+                        gate = {"approved": False, "detail": "evaluator error: %s" % exc}
+                    report["gate"] = gate
+                    if gate and gate.get("approved"):
+                        set_active(sel, environ=self._environ)
+                        report["outcome"] = "adopted_bootstrap_gate_passed"
+                    else:
+                        set_pending(sel, environ=self._environ)
+                        report["outcome"] = "pending_promotion"
+                        report["note"] = (
+                            "first selection proposed; routing stays on the deploy "
+                            "default until promoted (eval-drift gate or "
+                            "`mac fleet model-selection promote`)"
+                        )
+                else:
+                    # No gate configured, or no distinct incumbent to compare
+                    # against — adopt immediately (nothing to regress from).
+                    set_active(sel, environ=self._environ)
+                    report["outcome"] = "adopted_bootstrap"
             elif sel.models == active_models:
                 # Same choice — refresh in place (ladder/provenance may change),
                 # no swap, no gate.

--- a/src/mac/ui/app.ts
+++ b/src/mac/ui/app.ts
@@ -208,7 +208,6 @@ interface HermesWorkContext {
     api?: JsonObject[];
     mac_cli?: string[];
     mac_hermes_cli?: string[];
-    hgmac_cli?: string[];
     task_state_transitions?: Record<string, string[]>;
   };
 }
@@ -4684,11 +4683,10 @@ function roleRecord(role: ApiRecord): string {
 }
 
 function operationContractRecord(instanceId: string, context: HermesWorkContext): string {
-  const operations = context.operations || { api: [], mac_cli: [], mac_hermes_cli: [], hgmac_cli: [] };
+  const operations = context.operations || { api: [], mac_cli: [], mac_hermes_cli: [] };
   const apiOps = (operations.api || []) as JsonObject[];
   const macCli = operations.mac_cli || [];
   const hermesCli = operations.mac_hermes_cli || [];
-  const hgmacCli = operations.hgmac_cli || [];
   const dashboard = ((operations as JsonObject).dashboard || {}) as JsonObject;
   const dashboardViews = arrayOfStrings(dashboard.views);
   const transitions = operations.task_state_transitions || {};
@@ -4708,7 +4706,6 @@ function operationContractRecord(instanceId: string, context: HermesWorkContext)
         ${field("API operations", apiOps.length)}
         ${field("MAC CLI", macCli.length)}
         ${field("Hermes CLI", hermesCli.length)}
-        ${field("hgmac CLI", hgmacCli.length)}
         ${field("Dashboard views", dashboardViews.length)}
         ${field("Transitions", transitionCount)}
       </div>
@@ -4718,7 +4715,7 @@ function operationContractRecord(instanceId: string, context: HermesWorkContext)
       <div class="chip-row">
         ${dashboardViews.slice(0, 12).map((view) => chip(view, view === "ops" ? "good" : "info")).join("") || chip("dashboard contract missing", "bad")}
       </div>
-      <div class="observation-detail mono">${escapeHtml([...hermesCli, ...hgmacCli].slice(0, 8).join(" | ") || "No CLI operations")}</div>
+      <div class="observation-detail mono">${escapeHtml([...macCli, ...hermesCli].slice(0, 8).join(" | ") || "No CLI operations")}</div>
     </article>
   `;
 }

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -200,7 +200,7 @@ class SubprocessExecutor:
         # that declares a cheaper (or stronger) model gets it without any
         # fleet-wide config change. llm.route records requested/resolved
         # model per completion, so the override is visible in observability.
-        model_override = _task_model_override(task)
+        model_override = _task_model_override(task, hub_client=getattr(self, "client", None))
         if model_override:
             env["MAC_TASK_MODEL"] = model_override
         if repository_context:
@@ -4743,16 +4743,22 @@ def _load_repository_context(task_dir: Path) -> JsonDict:
     return loaded if isinstance(loaded, dict) else {}
 
 
-def _task_model_override(task: JsonDict) -> str:
+def _task_model_override(task: JsonDict, hub_client: Any = None) -> str:
     """Per-task LLM model override from task metadata.
 
     ``metadata.model`` (flat, what ``mac task create --model`` writes) wins —
     the by-name override that lets a task pick a faster/cheaper model directly.
     ``metadata.model_strength`` (int 1..10) is the name-decoupled alternative:
     1 = cheapest/weakest, 10 = strongest, resolved to a concrete available model
-    via the persisted strength ladder (so the task stays decoupled from model
-    names as they churn). ``metadata.runtime.model`` is honored last. Empty
-    string when the task pins nothing — the agent's fleet default applies."""
+    via the active strength ladder (so the task stays decoupled from model names
+    as they churn). ``metadata.runtime.model`` is honored last. Empty string when
+    the task pins nothing — the agent's fleet default applies.
+
+    The ladder is resolved from the LOCAL selection store first (co-located hub
+    process), then, if that is empty, from the hub's ``/model-selection/status``
+    via ``hub_client`` — without that fallback a spoke worker (which has no local
+    selection file) would silently ignore ``--model-strength`` and always drop to
+    the fleet default."""
     metadata = task.get("metadata") if isinstance(task, dict) else None
     if not isinstance(metadata, dict):
         return ""
@@ -4764,18 +4770,40 @@ def _task_model_override(task: JsonDict) -> str:
         strength = metadata["runtime"].get("model_strength")
     if strength is not None and str(strength).strip():
         try:
-            from mac.model_selection import resolve_strength_from_selection
-
-            resolved = resolve_strength_from_selection(int(strength))
+            scale = int(strength)
+        except (TypeError, ValueError):
+            scale = None
+        if scale is not None:
+            resolved = _resolve_strength_local_or_hub(scale, hub_client)
             if resolved:
                 return resolved[:256]
-        except (TypeError, ValueError):
-            pass
-        except Exception:  # noqa: BLE001 - strength resolution is best-effort.
-            pass
     runtime = metadata.get("runtime")
     if isinstance(runtime, dict):
         return str(runtime.get("model") or "").strip()[:256]
+    return ""
+
+
+def _resolve_strength_local_or_hub(scale: int, hub_client: Any = None) -> str:
+    """Resolve a 1..10 strength to a concrete model via the LOCAL active ladder,
+    falling back to the hub's ``/model-selection/status`` ladder for spoke
+    workers that have no local selection file. Best-effort — "" on any failure."""
+    try:
+        from mac.model_selection import resolve_strength, resolve_strength_from_selection
+    except Exception:  # noqa: BLE001
+        return ""
+    try:
+        resolved = resolve_strength_from_selection(scale)
+    except Exception:  # noqa: BLE001
+        resolved = ""
+    if resolved:
+        return resolved
+    if hub_client is not None:
+        try:
+            status = hub_client.get("/model-selection/status")
+            ladder = (((status or {}).get("active") or {}).get("ladder")) or []
+            return resolve_strength(scale, [str(m) for m in ladder if str(m).strip()])
+        except Exception:  # noqa: BLE001 - hub fallback is best-effort.
+            return ""
     return ""
 
 

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -127,7 +127,6 @@ from mac.model_selection import (  # noqa: E402
     ModelSelection,
     ModelSelectionConfig,
     ModelSelectionService,
-    read_pending,
     selected_models,
     set_active,
 )
@@ -202,6 +201,50 @@ def test_evaluate_swap_fails_closed_when_calls_error():
         raise ConnectionError("router down")
 
     v = evaluate_swap("cand", "inc", GOLDEN, model_caller=raising_caller)
+    assert v.approved is False
+    assert "could not run" in v.detail
+
+
+def test_router_caller_raises_on_malformed_200():
+    # #3: a 200 with no choices/null content is a FAILURE, not an empty answer.
+    # If it returned "" both models would look "equal" and the swap would be
+    # wrongly approved. The caller must raise so the eval is marked invalid.
+    import urllib.request
+
+    from mac.eval_runner import router_model_caller
+
+    class _Resp:
+        def __init__(self, payload):
+            self._payload = payload
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def read(self):
+            return self._payload.encode("utf-8")
+
+    import pytest
+
+    for payload in ("{}", '{"choices": []}', '{"choices": [{"message": {"content": null}}]}'):
+        def fake_urlopen(req, timeout=0, _p=payload):
+            return _Resp(_p)
+        orig = urllib.request.urlopen
+        urllib.request.urlopen = fake_urlopen
+        try:
+            caller = router_model_caller("http://x/v1", token="t")
+            with pytest.raises(ValueError):
+                caller("m", "q", "")
+        finally:
+            urllib.request.urlopen = orig
+
+
+def test_malformed_200_fails_gate_closed():
+    # End-to-end: a model_caller that yields malformed responses (surfaced as a
+    # raise) makes the eval invalid -> the swap is NOT approved.
+    def bad_caller(model, question, context):
+        raise ValueError("malformed completion response (no choices/content)")
+
+    v = evaluate_swap("cand", "inc", GOLDEN, model_caller=bad_caller)
     assert v.approved is False
     assert "could not run" in v.detail
 

--- a/tests/test_ide_launcher.py
+++ b/tests/test_ide_launcher.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from mac import ide_launcher
+
+
+def _profile(*, token: str = "profile-token", api_url: str = "http://127.0.0.1:48789"):
+    return {
+        "profile": "default",
+        "connection": {"api_url": api_url, "mode": "ssh-tunnel"},
+        "credential": {"token": token},
+    }
+
+
+def test_active_login_profile_precedes_legacy_tokens(monkeypatch) -> None:
+    ensured: list[str] = []
+    monkeypatch.setattr(ide_launcher, "active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        ide_launcher, "ensure_session", lambda name: ensured.append(name) or {"status": "running"}
+    )
+    monkeypatch.setattr(
+        ide_launcher,
+        "load_profile",
+        lambda name, include_token: _profile(),
+    )
+
+    connection = ide_launcher.resolve_ide_connection(
+        {
+            "MAC_API_TOKEN": "stale-admin-token",
+            "MAC_DEPLOY_HUB_TOKEN": "stale-deploy-token",
+        }
+    )
+
+    assert connection == ide_launcher.IdeConnection(
+        api_url="http://127.0.0.1:48789",
+        token="profile-token",
+        source="client-profile:default",
+        profile="default",
+    )
+    assert ensured == ["default"]
+
+
+def test_explicit_token_and_manual_mode_do_not_inspect_profiles(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ide_launcher,
+        "active_profile_name",
+        lambda: (_ for _ in ()).throw(AssertionError("profile lookup was not expected")),
+    )
+
+    explicit = ide_launcher.resolve_ide_connection(
+        {"IDE_TOKEN": "operator-token", "IDE_API_URL": "https://hub.example"}
+    )
+    manual = ide_launcher.resolve_ide_connection(
+        {"IDE_AUTH": "manual", "IDE_API_URL": "https://manual.example"}
+    )
+
+    assert explicit.token == "operator-token"
+    assert explicit.source == "IDE_TOKEN"
+    assert explicit.api_url == "https://hub.example"
+    assert manual == ide_launcher.IdeConnection(api_url="https://manual.example")
+
+
+def test_no_active_profile_uses_fleet_scoped_legacy_fallback(monkeypatch) -> None:
+    monkeypatch.setattr(ide_launcher, "active_profile_name", lambda: None)
+
+    connection = ide_launcher.resolve_ide_connection(
+        {
+            "MAC_FLEET": "team-blue",
+            "MAC_API_TOKEN__TEAM_BLUE": "fleet-token",
+            "MAC_API_TOKEN": "admin-token",
+        }
+    )
+
+    assert connection.token == "fleet-token"
+    assert connection.source == "MAC_API_TOKEN__TEAM_BLUE"
+    assert connection.api_url == ide_launcher.DEFAULT_API_URL
+
+
+def test_required_or_broken_profile_fails_closed(monkeypatch) -> None:
+    monkeypatch.setattr(ide_launcher, "active_profile_name", lambda: None)
+    with pytest.raises(ide_launcher.IdeLauncherError, match="no active MAC login"):
+        ide_launcher.resolve_ide_connection({"IDE_AUTH": "profile"})
+
+    monkeypatch.setattr(ide_launcher, "active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        ide_launcher,
+        "ensure_session",
+        lambda _name: (_ for _ in ()).throw(ide_launcher.ClientLoginError("SSH failed")),
+    )
+    with pytest.raises(ide_launcher.IdeLauncherError, match="SSH failed"):
+        ide_launcher.resolve_ide_connection({"MAC_API_TOKEN": "must-not-fallback"})
+
+
+def test_vite_environment_keeps_token_server_side() -> None:
+    connection = ide_launcher.IdeConnection(
+        api_url="http://127.0.0.1:48789",
+        token="profile-token",
+        source="client-profile:default",
+        profile="default",
+    )
+
+    child = ide_launcher.build_vite_environment(
+        connection,
+        {
+            "IDE_TOKEN": "explicit-token",
+            "VITE_MAC_TOKEN": "browser-token",
+            "MAC_API_TOKEN": "admin-token",
+            "MAC_API_TOKEN__DEFAULT": "fleet-token",
+        },
+    )
+
+    assert child["MAC_API_URL"] == "http://127.0.0.1:48789"
+    assert child["MAC_IDE_PROXY_TOKEN"] == "profile-token"
+    assert child["VITE_MAC_AUTH_MODE"] == "managed"
+    assert child["VITE_MAC_AUTH_LABEL"] == "CLI profile default"
+    assert "VITE_MAC_TOKEN" not in child
+    assert "IDE_TOKEN" not in child
+    assert "MAC_API_TOKEN" not in child
+    assert "MAC_API_TOKEN__DEFAULT" not in child
+
+
+def test_run_starts_vite_without_token_in_command(tmp_path, monkeypatch) -> None:
+    ide_dir = tmp_path / "ide"
+    ide_dir.mkdir()
+    (ide_dir / "package.json").write_text("{}\n", encoding="utf-8")
+    connection = ide_launcher.IdeConnection(
+        api_url="http://127.0.0.1:48789",
+        token="secret-token",
+        source="client-profile:default",
+        profile="default",
+    )
+    monkeypatch.setattr(ide_launcher, "resolve_ide_connection", lambda _env: connection)
+    seen = {}
+
+    def fake_run(command, **kwargs):
+        seen["command"] = command
+        seen.update(kwargs)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(ide_launcher.subprocess, "run", fake_run)
+
+    result = ide_launcher.run(
+        {
+            "IDE_DIR": str(ide_dir),
+            "IDE_HOST": "127.0.0.1",
+            "IDE_PORT": "5273",
+            "NPM": "npm",
+        }
+    )
+
+    assert result == 0
+    assert seen["command"] == [
+        "npm",
+        "run",
+        "dev",
+        "--",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "5273",
+    ]
+    assert "secret-token" not in " ".join(seen["command"])
+    assert seen["env"]["MAC_IDE_PROXY_TOKEN"] == "secret-token"
+
+
+def test_main_handles_ctrl_c_without_traceback(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ide_launcher,
+        "run",
+        lambda: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+
+    with pytest.raises(SystemExit) as caught:
+        ide_launcher.main()
+
+    assert caught.value.code == 130

--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -83,16 +83,26 @@ def test_make_dry_run_builds_both_supported_surfaces() -> None:
 
 def test_gui_launcher_selects_auth_without_printing_the_token() -> None:
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    launcher = (ROOT / "src" / "mac" / "ide_launcher.py").read_text(encoding="utf-8")
+    vite_config = (ROOT / "ide" / "vite.config.ts").read_text(encoding="utf-8")
+    app = (ROOT / "ide" / "src" / "App.tsx").read_text(encoding="utf-8")
 
     assert "IDE_FLEET ?=" in makefile
+    assert "IDE_AUTH ?= auto" in makefile
+    assert "IDE_PROFILE ?=" in makefile
     assert "run-gui: ide-run" in makefile
     assert 'if [ -f "$$HOME/.mac/.env" ]' in makefile
-    assert 'key="MAC_API_TOKEN__$$suffix"' in makefile
-    assert 'token="$${MAC_DEPLOY_HUB_TOKEN}"' in makefile
-    assert 'token="$${MAC_API_TOKEN}"' in makefile
-    assert 'IDE auth token source: %s' in makefile
-    assert 'VITE_MAC_TOKEN="$$token"' in makefile
+    assert '"$(PYTHON)" -m mac.ide_launcher' in makefile
     assert "IDE auth token: %s" not in makefile
+    assert "ensure_session(selected_profile)" in launcher
+    assert 'load_profile(selected_profile, include_token=True)' in launcher
+    assert 'child["MAC_IDE_PROXY_TOKEN"] = connection.token' in launcher
+    assert 'child.pop("VITE_MAC_TOKEN"' not in launcher
+    assert '"VITE_MAC_TOKEN",' in launcher
+    assert "MAC_IDE_PROXY_TOKEN" in vite_config
+    assert 'proxyRequest.setHeader("Authorization"' in vite_config
+    assert "hasManagedAuth" in app
+    assert "authLabel" in app
 
 
 def test_bootstrap_honors_make_venv_override(monkeypatch) -> None:

--- a/tests/test_model_selection.py
+++ b/tests/test_model_selection.py
@@ -213,6 +213,7 @@ from mac.model_selection import (  # noqa: E402
     read_active,
     read_pending,
     set_active,
+    set_pending,
 )
 
 
@@ -272,15 +273,15 @@ def test_swap_stays_pending_when_evaluator_rejects(tmp_path, monkeypatch):
 
 
 def test_compare_eval_metrics_direction_rules():
-    base = {"overall_score": 0.90, "safety_violation_rate": 0.01, "latency_p95_ms": 1000, "cost_per_answer_avg": 0.02}
+    base = {"overall_score": 0.90, "safety_violation_rate": 0.01, "latency_p95_ms": 1000, "unit_output_cost_avg": 0.02}
     # Quality drop >3%, safety up, latency up >3% => all regressions.
-    worse = {"overall_score": 0.80, "safety_violation_rate": 0.05, "latency_p95_ms": 1200, "cost_per_answer_avg": 0.02}
+    worse = {"overall_score": 0.80, "safety_violation_rate": 0.05, "latency_p95_ms": 1200, "unit_output_cost_avg": 0.02}
     res = compare_eval_metrics(base, worse, threshold=0.03)
     assert res["regressed"] is True
     metrics = {d["metric"] for d in res["drifted"]}
     assert {"overall_score", "safety_violation_rate", "latency_p95_ms"} <= metrics
     # A better candidate does not regress.
-    better = {"overall_score": 0.93, "safety_violation_rate": 0.0, "latency_p95_ms": 900, "cost_per_answer_avg": 0.02}
+    better = {"overall_score": 0.93, "safety_violation_rate": 0.0, "latency_p95_ms": 900, "unit_output_cost_avg": 0.02}
     assert compare_eval_metrics(base, better)["regressed"] is False
 
 
@@ -298,3 +299,175 @@ def test_moderate_natural_version_order():
     from mac.model_selection import moderate_by_availability
     avail = ["anthropic/claude-opus-4-9", "anthropic/claude-opus-4-10", "anthropic/claude-opus-4-2"]
     assert moderate_by_availability(["claude-opus"], avail) == ["anthropic/claude-opus-4-10"]
+
+
+# --------------------------------------------------------------------------- #
+# #1 Namespace: available models are the router's exact native ids
+# --------------------------------------------------------------------------- #
+
+
+def test_available_models_uses_allowlist_verbatim_not_prefixed():
+    # A provider with an explicit models= allowlist contributes those ids VERBATIM
+    # (exactly what ProviderRouter._serves matches and the upstream expects) — not
+    # provider-name-prefixed ids that the router would reject.
+    from mac.provider_router import providers_from_env
+    providers = providers_from_env(
+        {"MAC_ROUTER_PROVIDERS": "openai=https://x,0,models=gpt-5-2|o3,key=K"}
+    )
+    got = available_models_from_providers(providers)
+    assert got == ["gpt-5-2", "o3"]
+    assert not any("/" in m for m in got)  # never "openai/gpt-5-2"
+
+
+def test_available_models_wildcard_provider_enumerates_catalog(monkeypatch):
+    # A wildcard (models=*) provider has no allowlist, so it enumerates the
+    # catalog — and returns the catalog's own bare ids, unprefixed.
+    import mac.model_selection as ms
+    from mac.provider_router import providers_from_env
+    monkeypatch.setattr(ms, "available_models_from_providers",
+                        ms.available_models_from_providers)  # ensure real impl
+    # Patch the lazy catalog import target.
+    import sys
+    import types
+    fake = types.ModuleType("mac._hermes.agent.models_dev")
+    fake.list_agentic_models = lambda p: ["gpt-5-2", "gpt-5-mini"] if p == "openai" else []
+    monkeypatch.setitem(sys.modules, "mac._hermes.agent.models_dev", fake)
+    monkeypatch.setattr("mac.hermes_vendor.ensure_on_path", lambda: None)
+    providers = providers_from_env({"MAC_ROUTER_PROVIDERS": "openai=https://x,0,models=*,key=K"})
+    got = available_models_from_providers(providers)
+    assert got == ["gpt-5-2", "gpt-5-mini"]
+
+
+# --------------------------------------------------------------------------- #
+# #5 Cost/strength ranking: unknown-cost strong model is not strength 1
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_cost_strong_model_is_not_weakest():
+    # An Opus with no catalog price must NOT collapse to strength 1 just because
+    # its cost is unknown — name tier is the primary strength signal.
+    available = ["anthropic/claude-opus-4-8", "openai/gpt-5-mini", "openai/gpt-5-base"]
+    # Only the mini has a known price; opus + base are unknown.
+    costs = {"openai/gpt-5-mini": 0.2}
+    ladder = model_strength_ladder(available, cost_lookup=lambda m: costs.get(m))
+    assert ladder[-1] == "anthropic/claude-opus-4-8"   # strong tier wins the top
+    assert ladder[0] == "openai/gpt-5-mini"            # weak tier at the bottom
+
+
+def test_models_dev_cost_nested_id_keeps_middle_segment(monkeypatch):
+    # nvidia/meta/llama must try (nvidia, "meta/llama") and (meta, "llama"),
+    # never the old (nvidia, "llama") which dropped the middle path.
+    import mac.model_selection as ms
+    seen = []
+
+    class _Info:
+        cost_output = 4.2
+
+    def fake_get_model_info(provider, model):
+        seen.append((provider, model))
+        if (provider, model) == ("meta", "llama"):
+            return _Info()
+        raise KeyError("not found")
+
+    import sys
+    import types
+    fake = types.ModuleType("mac._hermes.agent.models_dev")
+    fake.get_model_info = fake_get_model_info
+    monkeypatch.setitem(sys.modules, "mac._hermes.agent.models_dev", fake)
+    monkeypatch.setattr("mac.hermes_vendor.ensure_on_path", lambda: None)
+    assert ms._models_dev_cost("nvidia/meta/llama") == 4.2
+    assert ("nvidia", "meta/llama") in seen   # full remainder tried
+    assert ("meta", "llama") in seen          # deeper boundary tried
+
+
+# --------------------------------------------------------------------------- #
+# #6 Persistence: concurrent set_pending / promote do not lose updates
+# --------------------------------------------------------------------------- #
+
+
+def test_concurrent_set_pending_and_active_no_lost_update(tmp_path, monkeypatch):
+    import threading
+    env = dict(os.environ)
+    monkeypatch.setenv("MAC_MODEL_SELECTION_FILE", str(tmp_path / "sel.json"))
+    env["MAC_MODEL_SELECTION_FILE"] = str(tmp_path / "sel.json")
+    set_active(ModelSelection(models=["a/active"], source="dynamic", at="T",
+                              ladder=["a/active"]), environ=env)
+
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def writer_pending():
+        try:
+            barrier.wait()
+            for _ in range(50):
+                set_pending(ModelSelection(models=["p/pending"], source="dynamic", at="T",
+                                           ladder=["p/pending"]), environ=env)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    def writer_active():
+        try:
+            barrier.wait()
+            for _ in range(50):
+                set_active(ModelSelection(models=["a/active"], source="dynamic", at="T",
+                                          ladder=["a/active"]), environ=env)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    t1 = threading.Thread(target=writer_pending)
+    t2 = threading.Thread(target=writer_active)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+    assert not errors, errors
+    # The store is never corrupted; active is always readable and intact.
+    assert read_active(env)["models"] == ["a/active"]
+
+
+# --------------------------------------------------------------------------- #
+# #7 First selection is gated against the deploy default when eval is enabled
+# --------------------------------------------------------------------------- #
+
+
+def test_bootstrap_gated_against_deploy_default(tmp_path, monkeypatch):
+    # With an eval gate enabled and a deploy default incumbent, the FIRST
+    # selection must not flip routing until it passes the gate.
+    env = _svc_env(tmp_path, monkeypatch, avail=["openai/gpt-5-2"])
+    svc = ModelSelectionService(
+        _FakeCP(), ModelSelectionConfig(enabled=True, fallback_model="deploy/default"),
+        searcher=lambda q, n: [{"title": "GPT-5.2 leads", "description": ""}],
+        swap_evaluator=lambda cand, inc: {"approved": False, "detail": "regressed vs default"},
+        environ=env,
+    )
+    report = svc.run_once()
+    assert report["outcome"] == "pending_promotion"
+    assert read_active(env) is None                   # routing still on the deploy default
+    assert read_pending(env)["models"] == ["openai/gpt-5-2"]
+
+
+def test_bootstrap_adopts_when_gate_passes(tmp_path, monkeypatch):
+    env = _svc_env(tmp_path, monkeypatch, avail=["openai/gpt-5-2"])
+    svc = ModelSelectionService(
+        _FakeCP(), ModelSelectionConfig(enabled=True, fallback_model="deploy/default"),
+        searcher=lambda q, n: [{"title": "GPT-5.2 leads", "description": ""}],
+        swap_evaluator=lambda cand, inc: {"approved": True, "detail": "no regression"},
+        environ=env,
+    )
+    report = svc.run_once()
+    assert report["outcome"] == "adopted_bootstrap_gate_passed"
+    assert selected_models(env) == ["openai/gpt-5-2"]
+
+
+def test_bootstrap_adopts_immediately_without_evaluator(tmp_path, monkeypatch):
+    # No eval gate configured -> first selection adopts immediately (nothing to
+    # regress against). This preserves the operator-gated default behavior.
+    env = _svc_env(tmp_path, monkeypatch, avail=["openai/gpt-5-2"])
+    svc = ModelSelectionService(
+        _FakeCP(), ModelSelectionConfig(enabled=True, fallback_model="deploy/default"),
+        searcher=lambda q, n: [{"title": "GPT-5.2 leads", "description": ""}],
+        environ=env,
+    )
+    report = svc.run_once()
+    assert report["outcome"] == "adopted_bootstrap"
+    assert selected_models(env) == ["openai/gpt-5-2"]

--- a/tests/test_task_model_strength.py
+++ b/tests/test_task_model_strength.py
@@ -35,6 +35,40 @@ def test_no_pin_returns_empty(tmp_path, monkeypatch):
 
 
 def test_strength_with_no_persisted_ladder_falls_through(tmp_path, monkeypatch):
-    # No selection file -> strength can't resolve -> empty (fleet default applies).
+    # No selection file AND no hub client -> strength can't resolve -> empty
+    # (fleet default applies).
     monkeypatch.setenv("MAC_MODEL_SELECTION_FILE", str(tmp_path / "absent.json"))
     assert _task_model_override({"metadata": {"model_strength": 8}}) == ""
+
+
+class _FakeHubClient:
+    """Serves /model-selection/status like the hub does, for spoke-fallback tests."""
+
+    def __init__(self, ladder):
+        self._ladder = list(ladder)
+        self.calls = 0
+
+    def get(self, path):
+        self.calls += 1
+        assert path == "/model-selection/status"
+        return {"active": {"models": [self._ladder[-1]], "ladder": self._ladder}}
+
+
+def test_strength_resolves_from_hub_when_no_local_file(tmp_path, monkeypatch):
+    # A SPOKE worker has no local selection file; without the hub fallback the
+    # --model-strength pin was silently dropped. It must resolve via the hub's
+    # active ladder instead.
+    monkeypatch.setenv("MAC_MODEL_SELECTION_FILE", str(tmp_path / "absent.json"))
+    client = _FakeHubClient(["p/mini", "p/base", "p/opus"])
+    assert _task_model_override({"metadata": {"model_strength": 10}}, hub_client=client) == "p/opus"
+    assert _task_model_override({"metadata": {"model_strength": 1}}, hub_client=client) == "p/mini"
+    assert client.calls == 2
+
+
+def test_local_ladder_wins_over_hub(tmp_path, monkeypatch):
+    # When a local ladder IS present (co-located hub process) it is used and the
+    # hub is never queried.
+    _persist_ladder(tmp_path, monkeypatch, ["l/mini", "l/opus"])
+    client = _FakeHubClient(["h/mini", "h/opus"])
+    assert _task_model_override({"metadata": {"model_strength": 10}}, hub_client=client) == "l/opus"
+    assert client.calls == 0

--- a/tests/ui/test_fleet_ide_api_contracts.py
+++ b/tests/ui/test_fleet_ide_api_contracts.py
@@ -33,9 +33,9 @@ from mac.services import ControlPlane
 
 # ---------------------------------------------------------------------------
 # Test token -- explicit, not ambient MAC_API_TOKEN.
-# The Fleet IDE reads its token from localStorage or VITE_MAC_TOKEN; tests
-# supply a fixed synthetic token so there is no dependency on the host
-# environment.
+# The Fleet IDE normally receives auth through the local launcher's Vite proxy;
+# its manual fallback stores a token in sessionStorage. Tests supply a fixed
+# synthetic token directly so there is no dependency on the host environment.
 # ---------------------------------------------------------------------------
 
 # A fixed synthetic bearer token used only in this test module.


### PR DESCRIPTION
Second-round remediation of the model-selection review. Every finding has a reproduction test; the full contract suite passes (4303 passed, 19 skipped).

## Fixes

| # | Severity | Defect | Fix |
|---|---|---|---|
| 1 | High | Selection used provider-prefixed catalog ids the router rejects; `models=` allowlist discarded | `available_models_from_providers` consumes `providers_from_env()` Provider objects: explicit allowlists contribute ids verbatim; only wildcard providers enumerate the catalog (bare ids) |
| 2 | High | `--model-strength` silently dropped on spoke workers (ladder was hub-local file) | Worker resolves ladder locally, then via hub `GET /model-selection/status` fallback |
| 3 | High | Eval gate failed open on malformed 200s (empty answers looked "equal" → approved) | `router_model_caller` raises on missing choices / null content → call failure → eval invalid → gate fails closed |
| 4 | Medium | Correctness collapse passed when offset by groundedness in blended overall | Per-metric case-aligned series; significance tested per quality metric on its own deltas |
| 5 | Medium | Nested-id cost lookup dropped middle path; unknown-cost models sorted to strength 1; list price mislabeled "cost per answer" | All provider-boundary splits tried; name tier is primary ladder key; renamed `unit_output_cost` |
| 6 | Medium | `set_pending`/`promote_pending` unlocked read-modify-write (lost updates) | Module `_STORE_LOCK` serializes all store mutations |
| 7 | Medium | First selection adopted without evaluation | Bootstrap gates against the deploy-default incumbent when the evaluator is enabled |
| 8 | Low | Unused test imports; "Beads-backed" help text; hgmac dashboard field | All removed; scoped ruff clean |

## Verification
- 15 new reproduction tests covering each reviewer scenario (malformed-200 → not approved, correctness 1.0→0.0 offset → blocked, allowlist verbatim/unprefixed, nested-id cost, unknown-cost Opus not weakest, concurrent writers, bootstrap gated/ungated, spoke hub-fallback ladder)
- `scripts/run-contract-tests.sh`: 4303 passed, 19 skipped
- `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)