### PR TITLE
Whitelist uploaded repos for git inside verification sandboxes

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -569,6 +569,21 @@ REPOSITORY_CONTRACT_FILES = (
 )
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
 _GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+# Sandbox git preflight for hub verification. The repo is tar-uploaded into the
+# sandbox, so its files can be owned by a different uid than the user running
+# the tests (HOME=/tmp guarantees no .gitconfig safe.directory whitelist).
+# Without this, git refuses the uploaded repo ("dubious ownership") and the
+# contract tests that run `git` against the checkout itself fail — rejecting
+# work whose tests pass everywhere else. GIT_CONFIG_* env (not --global) so the
+# whitelist reaches every git subprocess the suite spawns without a writable
+# HOME; the rev-parse probe distinguishes a lost-.git upload from a test
+# failure with an unmistakable message and exit code.
+_HUB_VERIFY_GIT_PREFLIGHT = (
+    "export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0='*'; "
+    "git -C /sandbox/repo rev-parse --is-inside-work-tree >/dev/null 2>&1 || "
+    "{ echo 'hub verify: /sandbox/repo is not a usable git repo after upload"
+    " (missing .git or git unavailable)'; exit 97; }; "
+)
 # mac-5xwh: bd issue ids look like ``<prefix>-<slug>`` where the slug
 # may itself contain dashes (e.g. ``mac-defer-claim``). Reject anything
 # that could be misread as a CLI flag (leading ``-``) or that contains
@@ -12541,7 +12556,10 @@ class ControlPlane:
                 "--name", name, "--from", image, "--env", "HOME=/tmp",
                 "--upload", "%s:%s" % (str(tmp / "repo"), "/sandbox"),
                 "--", "bash", "-c",
-                "cd /sandbox/repo && %s" % (test_command or "scripts/run-contract-tests.sh"),
+                "%scd /sandbox/repo && %s" % (
+                    _HUB_VERIFY_GIT_PREFLIGHT,
+                    test_command or "scripts/run-contract-tests.sh",
+                ),
             ]
             try:
                 proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -2825,6 +2825,13 @@ def _build_sandbox_create_argv(
             ". ./.mac-sandbox-toolchain.sh",
             "rm -f ./.mac-sandbox-toolchain.sh",
             "mac_sandbox_toolchain_setup || true",
+            # The workspace is tar-uploaded, so its files can be owned by a
+            # different uid than the sandbox user; without a safe.directory
+            # whitelist every git command against uploaded paths dies with
+            # "dubious ownership" (the sandbox is single-purpose and isolated,
+            # so trusting all paths inside it is safe). Env form, not --global,
+            # so it reaches every git subprocess regardless of HOME.
+            "export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0='*'",
             # A host git worktree stores `.git` as a pointer into a host-only
             # common directory.  That pointer is invalid after OpenShell uploads
             # the workspace, and host credentials/remotes must not be copied

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -9672,3 +9672,37 @@ def test_hub_verify_inflight_guard_prevents_concurrent_runs(cp, monkeypatch):
     result = cp._run_hub_review_verification(task, review, evidence, "test")
     assert result is None
     assert calls == []
+
+
+def test_hub_verify_sandbox_command_whitelists_uploaded_repo_for_git(cp, monkeypatch):
+    """The tar-uploaded repo can be owned by a different uid than the sandbox
+    user, and HOME=/tmp means no safe.directory whitelist exists — without the
+    preflight, the contract tests that run git against the checkout itself die
+    with "dubious ownership" and good work is rejected (observed live: exactly
+    the 4 git-at-ROOT tests failed while ~4290 passed)."""
+    import subprocess as _subprocess
+
+    from mac import services as services_mod
+
+    captured = []
+
+    def fake_run(argv, **kwargs):
+        captured.append(list(argv))
+        return _subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(services_mod.subprocess, "run", fake_run)
+    rc, out = cp._hub_verify_run_contract_test(
+        "git@github.com:org/repo.git", "task/branch", "a" * 40, ""
+    )
+    assert rc == 0
+    create = next(a for a in captured if "create" in a and "--upload" in a)
+    inner = create[create.index("-c") + 1]
+    # Whitelist reaches every git subprocess the suite spawns (env form, not
+    # --global), and it precedes the test command.
+    assert "GIT_CONFIG_KEY_0=safe.directory" in inner
+    assert "GIT_CONFIG_VALUE_0='*'" in inner
+    assert inner.index("safe.directory") < inner.index("cd /sandbox/repo")
+    # Lost-.git uploads fail fast with a distinguishable message, not 4
+    # confusing test failures.
+    assert "rev-parse --is-inside-work-tree" in inner
+    assert "not a usable git repo after upload" in inner

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -204,6 +204,21 @@ def test_build_runs_private_agent_wrapper_in_workspace_subdir():
     assert "hermes_cli.main" not in inner
 
 
+def test_build_whitelists_uploaded_paths_for_git():
+    # The workspace is tar-uploaded, so its files can be owned by a different
+    # uid than the sandbox user; without a safe.directory whitelist every git
+    # command against uploaded paths dies with "dubious ownership" — including
+    # the contract tests the agent runs before declaring done (observed live:
+    # workers failed verification on the only 4 tests that run git against the
+    # checkout, then correctly refused to push).
+    inner = _inner(_build("/work/task-7"))
+    assert "GIT_CONFIG_KEY_0=safe.directory" in inner
+    assert "GIT_CONFIG_VALUE_0='*'" in inner
+    # Must be in force before the git snapshot section AND the agent exec.
+    assert inner.index("safe.directory") < inner.index('init -q')
+    assert inner.index("safe.directory") < inner.index("\nexec ")
+
+
 def test_private_env_file_repoints_workspace_without_argv_exposure(tmp_path):
     workspace = tmp_path / "task-7"
     workspace.mkdir()


### PR DESCRIPTION
Fixes the root cause that stalled 4 of 7 fleet tasks on 2026-07-03 (tracked as `task_cb9ba647`).

## Problem
Verification sandboxes tar-upload the repo/workspace, so its files can be owned by a different uid than the test-running user; the hub verifier also sets `HOME=/tmp`, so no `safe.directory` whitelist can exist. git refuses the uploaded repo ("dubious ownership"), failing **exactly the 4 contract tests that run git against the checkout itself** (`test_fleet_samples.py` ×3, `test_docs_no_operator_identity.py`) while ~4290 others pass. Observed live: both hub review verifications rejected good pushed work, and two workers failed pre-push verification and correctly refused to push.

## Fix
- **Hub verifier** (`services._hub_verify_run_contract_test`): preflight exports `GIT_CONFIG_COUNT/KEY_0/VALUE_0` with `safe.directory '*'` (env form → reaches every git subprocess regardless of HOME), then probes `git -C /sandbox/repo rev-parse --is-inside-work-tree` and exits 97 with a clear "not a usable git repo after upload" message if `.git` was lost — infra failures can no longer masquerade as test failures.
- **Executor sandbox** (`task_executor._build_sandbox_create_argv`): same whitelist exported in the inner script before the git snapshot section and the agent exec.

## Verification
- New tests exercise the REAL argv construction (not the `_hub_verify_runner` test hook) and assert the whitelist precedes the test command / git usage.
- Full contract suite: 4293 passed, 19 skipped.

## Deploy note
The hub runs its deployed copy of `services.py` — after merge, the hub on puck needs a redeploy for the reviewer path; workers pick it up with their next code refresh. Then the two rejected tasks can re-verify and the two blocked ones can retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)