### PR TITLE
Contract-test bootstrap fallback + hardware in agent list lines

### DIFF
--- a/scripts/bootstrap-project.py
+++ b/scripts/bootstrap-project.py
@@ -26,6 +26,12 @@ def run(command: list[str]) -> None:
 
 
 def main() -> int:
+    # --venv-only: build just the .venv (pip install -e .[dev]) without the
+    # dev-workflow tool checks. git/gh serve the human dev loop; verification
+    # hosts (worker venvs, sandboxes) need only the venv, and requiring gh
+    # there blocked contract-test bootstrap on the GKE pods.
+    venv_only = "--venv-only" in sys.argv[1:]
+    required = ("python3",) if venv_only else REQUIRED_COMMANDS
     if not (ROOT / "pyproject.toml").exists():
         print("bootstrap-project.py must be run from a mac checkout", file=sys.stderr)
         return 2
@@ -36,7 +42,7 @@ def main() -> int:
             file=sys.stderr,
         )
         return 2
-    missing = [command for command in REQUIRED_COMMANDS if shutil.which(command) is None]
+    missing = [command for command in required if shutil.which(command) is None]
     if missing:
         print(
             "missing required command(s): %s" % ", ".join(missing),

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -51,6 +51,33 @@ if [ -z "${PY}" ]; then
     echo "run-contract-tests.sh: no python interpreter found (.venv, /opt/mac-venv, or PATH)" >&2
     exit 1
 fi
+
+# The resolved interpreter must actually carry the suite's toolchain: the dev
+# extras (coverage, pytest) AND the project deps. A worker host's PATH python
+# is its runtime venv — mac's runtime deps but no dev extras — and verification
+# there died with "No module named coverage" (observed live on the GKE pods,
+# blocking every repo-change task); a dev host's bare python3 can have the
+# opposite hole (global pytest/coverage, no project deps). Probe both classes
+# cheaply; when the interpreter can't run the suite and the repo ships its
+# bootstrap, build the hermetic .venv the execution contract already promises.
+_py_can_run_suite() {
+    "$1" -m coverage --version >/dev/null 2>&1 \
+        && "$1" -m pytest --version >/dev/null 2>&1 \
+        && "$1" -c "import cryptography, fastapi, yaml" >/dev/null 2>&1
+}
+if ! _py_can_run_suite "$PY"; then
+    if [ ! -x ".venv/bin/python" ] && [ -f "scripts/bootstrap-project.py" ]; then
+        echo "run-contract-tests.sh: $PY cannot run the suite; bootstrapping .venv" >&2
+        "$PY" scripts/bootstrap-project.py --venv-only >&2
+    fi
+    if [ -x ".venv/bin/python" ] && _py_can_run_suite ".venv/bin/python"; then
+        PY=".venv/bin/python"
+    else
+        echo "run-contract-tests.sh: no interpreter can run the suite (tried $PY and .venv;" \
+             "need coverage+pytest+project deps)" >&2
+        exit 1
+    fi
+fi
 export PATH="$(cd "$(dirname "$PY")" && pwd):${PATH}"
 
 if [ "$#" -eq 0 ]; then

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -99,6 +99,35 @@ def _trunc(text: Any, n: int = 72) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+def _agent_hw_summary(d: dict) -> str:
+    """Compact measured-hardware string for an agent line, from the
+    ``resources.hardware`` block the agent reports at registration/heartbeat
+    (``mac.hardware.v1``). "-" when the agent hasn't reported hardware."""
+    res = d.get("resources")
+    hw = (res.get("hardware") or {}) if isinstance(res, dict) else {}
+    if not isinstance(hw, dict) or not hw:
+        return "-"
+    bits = []
+    if hw.get("os"):
+        bits.append("%s/%s" % (hw.get("os"), hw.get("arch") or "?"))
+    if hw.get("cpu_count"):
+        bits.append("%sc" % hw.get("cpu_count"))
+    if hw.get("memory_mb"):
+        bits.append("%dG" % round(float(hw["memory_mb"]) / 1024))
+    gpu = hw.get("gpu") or {}
+    name = str(gpu.get("name") or "").replace("NVIDIA ", "").replace("GeForce ", "")
+    name = name.replace(" Server Edition", "").replace("Apple ", "")
+    if name:
+        vram = gpu.get("vram_mb")
+        bits.append(name + (" %dG" % round(float(vram) / 1024) if vram else ""))
+    accel = hw.get("accelerator")
+    # cuda is implied by an NVIDIA gpu name; spell out anything else (metal),
+    # or cuda with no name to identify the accelerator at all.
+    if accel and (accel != "cuda" or not name):
+        bits.append(str(accel))
+    return " ".join(bits) or "-"
+
+
 def _one_liner(value: Any) -> str:
     """A single compact line for one record (task / agent / generic dict)."""
     d = _unwrap(value)
@@ -117,9 +146,10 @@ def _one_liner(value: Any) -> str:
         )
     if "status" in d and ("name" in d or "current_task_id" in d or "capabilities" in d):
         cur = d.get("current_task_id")
-        return "%-16s %-9s %s" % (
+        return "%-16s %-9s %-28s %s" % (
             d.get("name") or ident,
             d.get("status", "?"),
+            _agent_hw_summary(d),
             ("▶ " + str(cur)) if cur else "idle",
         )
     scal = [

--- a/tests/cli/test_cli_text_output.py
+++ b/tests/cli/test_cli_text_output.py
@@ -28,6 +28,34 @@ def test_agent_one_liner():
     assert "idle" in out
 
 
+def test_agent_one_liner_shows_measured_hardware():
+    # Agents report resources.hardware (mac.hardware.v1) at registration; the
+    # human list line surfaces it so operators see real HW without --json.
+    agents = [
+        {"name": "bullwinkle", "status": "idle", "current_task_id": None,
+         "resources": {"hardware": {
+             "os": "linux", "arch": "x86_64", "cpu_count": 32, "memory_mb": 188647,
+             "accelerator": "cuda",
+             "gpu": {"name": "NVIDIA GeForce RTX 5090", "vram_mb": 32607}}}},
+        {"name": "rocky", "status": "busy", "current_task_id": "task_1",
+         "resources": {"hardware": {
+             "os": "darwin", "arch": "arm64", "cpu_count": 12, "memory_mb": 65536,
+             "accelerator": "metal", "gpu": {"name": "Apple M4 Pro"}}}},
+    ]
+    lines = cli._render_text(agents).splitlines()
+    assert "linux/x86_64" in lines[0] and "32c" in lines[0]
+    assert "184G" in lines[0] and "RTX 5090 32G" in lines[0]
+    assert "cuda" not in lines[0]  # implied by the NVIDIA gpu name
+    assert "darwin/arm64" in lines[1] and "M4 Pro" in lines[1] and "metal" in lines[1]
+    assert "▶ task_1" in lines[1]
+
+
+def test_agent_one_liner_without_hardware_shows_dash():
+    out = cli._render_text([{"name": "x", "status": "idle", "current_task_id": None}])
+    assert out.startswith("x")
+    assert "-" in out.split()
+
+
 def test_task_show_wrapper_is_compact():
     detail = {
         "task": {"id": "task_x", "state": "completed", "project": "mac", "title": "T", "attempt_count": 1},


### PR DESCRIPTION
Two fixes surfaced while shepherding the fleet's fix tasks:

## Worker verification died on the pods: "No module named coverage"
`run-contract-tests.sh`'s PATH-python fallback resolves the worker's runtime venv — mac's runtime deps but no dev extras. (A dev host's bare python3 has the opposite hole: global pytest/coverage, no project deps — reproduced both.) The script now probes whether the resolved interpreter can actually run the suite (coverage + pytest + project-dep proxy imports) and, when it can't, builds the hermetic `.venv` the execution contract already promises. `bootstrap-project.py` gains `--venv-only` (venv build without the git/gh dev-workflow checks — requiring `gh` blocked bootstrap on the pods). Verified in a pod simulation: bare interpreter, no gh, no `.venv` → bootstraps and passes.

## `mac agent list` now shows measured hardware
Agents already report `resources.hardware` (mac.hardware.v1) at registration; the human line now renders it:
```
bullwinkle       idle      linux/x86_64 32c 184G RTX 5090 32G   idle
natasha          idle      linux/aarch64 20c 122G GB10          idle
rocky            busy      darwin/arm64 12c 64G M4 Pro metal    ▶ task_939ff6…
```
cuda is implied by an NVIDIA gpu name; other accelerators (metal) are spelled out; agents with no report show `-`.

## Verification
Full contract suite: 4315 passed, 19 skipped. New tests for the agent-line rendering; pod-sim exercised the bootstrap path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)