### PR TITLE
Rebase task worktrees onto the advanced canonical tip before verification

### DIFF
--- a/src/mac/gitops.py
+++ b/src/mac/gitops.py
@@ -11,7 +11,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass, field as dataclass_field
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 from urllib.parse import quote as _quote, urlparse, urlsplit, urlunsplit
 
 
@@ -543,6 +543,57 @@ def _canonical_freshness_locked(
         push_stderr=redact_git_remote_auth_in_text(pushed.stderr or ""),
         remote_verified=True,
     )
+
+
+def sync_worktree_with_canonical(
+    worktree: Path, canonical_remote: str, canonical_branch: str
+) -> Dict[str, str]:
+    """Rebase the task worktree onto the advanced canonical tip BEFORE the
+    contract test runs, so the suite validates the projected published tree.
+
+    Fleet agents race each other to one canonical branch; without this, every
+    task slower than its peers dies at the publication freshness gate
+    ("canonical tip … is not an ancestor of task HEAD") after an hour of good
+    work. A CLEAN rebase only: conflicts abort (`git rebase --abort`), the work
+    stays intact, and the existing freshness gate then reports its precise
+    error for a human/agent to resolve. Callers must have committed all local
+    changes first (both finalizers auto-commit before verification) and must
+    re-read HEAD when status == "rebased".
+    """
+    remote = str(canonical_remote or "").strip()
+    branch = str(canonical_branch or "").strip() or "main"
+    if not remote:
+        return {"status": "skipped", "reason": "no canonical remote"}
+    authed = inject_git_remote_auth(remote)
+    fetch = _run_git(worktree, ["fetch", "--no-tags", authed, branch])
+    if fetch.returncode != 0:
+        return {
+            "status": "fetch_failed",
+            "reason": redact_git_remote_auth_in_text(
+                _git_failure(fetch, "non-zero exit")
+            )[:500],
+        }
+    tip_res = _run_git(worktree, ["rev-parse", "--verify", "FETCH_HEAD^{commit}"])
+    tip = tip_res.stdout.strip()
+    if tip_res.returncode != 0 or not _GIT_SHA_RE.fullmatch(tip):
+        return {"status": "fetch_failed", "reason": "FETCH_HEAD did not resolve to a commit"}
+    if _run_git(worktree, ["merge-base", "--is-ancestor", tip, "HEAD"]).returncode == 0:
+        return {"status": "fresh", "canonical_tip": tip}
+    rebase = _run_git(
+        worktree,
+        ["-c", "user.email=mac-fleet@nvidia.com", "-c", "user.name=MAC fleet",
+         "rebase", tip],
+    )
+    if rebase.returncode != 0:
+        _run_git(worktree, ["rebase", "--abort"])
+        return {
+            "status": "conflict",
+            "canonical_tip": tip,
+            "reason": redact_git_remote_auth_in_text(
+                ((rebase.stderr or rebase.stdout) or "rebase failed").strip()
+            )[:500],
+        }
+    return {"status": "rebased", "canonical_tip": tip}
 
 
 def check_canonical_freshness(

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -85,6 +85,7 @@ from mac.gitops import (
     check_canonical_freshness,
     guarded_push,
     resolve_canonical_publication_target,
+    sync_worktree_with_canonical,
 )
 from mac.openshell_runtime import (
     openshell_required_for_local_agent as _openshell_required_for_local_agent,
@@ -1366,6 +1367,19 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
         )
     head_sha = _git(["rev-parse", "HEAD"], worktree_path).stdout.strip()
     branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], worktree_path).stdout.strip() or "HEAD"
+    # Rebase onto the advanced canonical tip BEFORE the contract test runs, so
+    # the suite validates the projected published tree. Fleet agents race each
+    # other to one canonical branch; a task that took an hour almost always
+    # finds main moved, and without this it dies at the publication freshness
+    # gate after all its work passed. Clean rebases only — a conflict aborts
+    # and the existing gate reports its precise error.
+    canonical_sync = sync_worktree_with_canonical(
+        worktree_path,
+        _repository_publication_remote(task),
+        _repository_contract_canonical_branch(task),
+    )
+    if canonical_sync.get("status") == "rebased":
+        head_sha = _git(["rev-parse", "HEAD"], worktree_path).stdout.strip()
     # Purge synced build artifacts before the host build. The agent built in the
     # task SANDBOX (e.g. Linux); those object files / binaries sync back into this
     # worktree, but this finalizer runs on the EXECUTOR HOST, which may be a
@@ -1513,6 +1527,7 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
             "dirty": bool(final_status),
             "files_changed": files_changed,
             "freshness": (publication or freshness).evidence(),
+            "canonical_sync": canonical_sync,
         },
         "codegraph": codegraph,
         # mac-wjy3: verification.tests is the CANONICAL list of test-result

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -65,6 +65,7 @@ from mac.hermes_config_surface import apply_hermes_surface_payload
 from mac.gitops import (
     guarded_push,
     resolve_canonical_publication_target,
+    sync_worktree_with_canonical,
     validate_git_ref,
     validate_git_remote_url,
 )
@@ -3377,6 +3378,16 @@ class MacWorker:
         branch = str(context.get("repository_branch") or "").strip()
         problems: List[str] = []
         self._commit_dirty_repository_worktree(task_id, task, worktree, problems)
+        # Rebase onto the advanced canonical tip BEFORE the contract test runs,
+        # so the suite validates the projected published tree (fleet agents
+        # race each other to one canonical branch; without this a slow task
+        # dies at the freshness gate after all its work passed). Clean rebases
+        # only — conflicts abort and the freshness gate reports precisely.
+        canonical_sync = sync_worktree_with_canonical(
+            worktree,
+            _repository_publication_remote(task, context),
+            str(context.get("repository_canonical_branch") or "").strip(),
+        )
         files_changed = _repository_context_changed_files(worktree, context)
 
         test_command = _repository_contract_test_command(task)
@@ -3387,6 +3398,7 @@ class MacWorker:
         repo["dirty"] = _repository_worktree_is_dirty(worktree)
         repo["files_changed"] = files_changed
         repo["pushed"] = False
+        repo["canonical_sync"] = canonical_sync
         if branch:
             repo["remote_ref"] = "refs/heads/%s" % branch
         canonical_remote = _repository_publication_remote(task, context)

--- a/tests/test_gitops_publication_target.py
+++ b/tests/test_gitops_publication_target.py
@@ -211,3 +211,75 @@ def test_target_is_immutable_unique_and_secret_free(
     )
     with pytest.raises(FrozenInstanceError):
         first.canonical_branch = "other"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# sync_worktree_with_canonical: pre-test rebase onto the advanced canonical tip
+# --------------------------------------------------------------------------- #
+
+
+def _advance_canonical(tmp_path: Path, canonical: Path, filename: str, content: str) -> str:
+    """Land a new commit on the canonical branch (simulates a peer publishing)."""
+    other = tmp_path / ("peer-" + filename.replace("/", "-"))
+    _git(tmp_path, "clone", canonical.as_uri(), str(other))
+    _git(other, "config", "user.email", "peer@example.invalid")
+    _git(other, "config", "user.name", "peer")
+    (other / filename).write_text(content, encoding="utf-8")
+    _git(other, "add", filename)
+    _git(other, "commit", "-m", "peer change: %s" % filename)
+    _git(other, "push", "origin", "main")
+    return _git(other, "rev-parse", "HEAD").stdout.strip()
+
+
+def test_sync_worktree_rebases_onto_advanced_canonical(tmp_path: Path) -> None:
+    # A peer published to canonical while the task worked. Without the sync the
+    # freshness gate rejects ("canonical tip is not an ancestor of task HEAD");
+    # with it the worktree rebases cleanly and publication proceeds.
+    origin, canonical, work, base = _fixture(tmp_path)
+    tip = _advance_canonical(tmp_path, canonical, "peer.txt", "peer\n")
+
+    result = gitops.sync_worktree_with_canonical(work, canonical.as_uri(), "main")
+    assert result["status"] == "rebased"
+    assert result["canonical_tip"] == tip
+    # The canonical tip is now an ancestor of HEAD and the task's work survives.
+    _git(work, "merge-base", "--is-ancestor", tip, "HEAD")
+    assert (work / "feature.py").exists() and (work / "peer.txt").exists()
+
+    target = resolve_canonical_publication_target(
+        worktree=work,
+        canonical_remote=canonical.as_uri(),
+        canonical_branch="main",
+        destination_branch="task/change",
+        prepared_base_sha=base,
+        isolation_key="task-1-lease-1",
+    )
+    assert check_canonical_freshness(target).ok
+
+
+def test_sync_worktree_fresh_when_canonical_unmoved(tmp_path: Path) -> None:
+    origin, canonical, work, base = _fixture(tmp_path)
+    result = gitops.sync_worktree_with_canonical(work, canonical.as_uri(), "main")
+    assert result["status"] == "fresh"
+    head_before = _git(work, "rev-parse", "HEAD").stdout.strip()
+    assert head_before  # HEAD untouched by a fresh sync
+
+
+def test_sync_worktree_conflict_aborts_and_preserves_work(tmp_path: Path) -> None:
+    # The peer landed a CONFLICTING edit. The sync must not leave a rebase in
+    # progress or lose the task's commits — abort, report, let the freshness
+    # gate fail with its precise error.
+    origin, canonical, work, base = _fixture(tmp_path)
+    _advance_canonical(tmp_path, canonical, "feature.py", "print('peer conflicting')\n")
+    head_before = _git(work, "rev-parse", "HEAD").stdout.strip()
+
+    result = gitops.sync_worktree_with_canonical(work, canonical.as_uri(), "main")
+    assert result["status"] == "conflict"
+    assert _git(work, "rev-parse", "HEAD").stdout.strip() == head_before
+    assert not (work / ".git" / "rebase-merge").exists()
+    assert not (work / ".git" / "rebase-apply").exists()
+    assert _git(work, "status", "--porcelain").stdout.strip() == ""
+
+
+def test_sync_worktree_no_remote_is_skipped(tmp_path: Path) -> None:
+    origin, canonical, work, base = _fixture(tmp_path)
+    assert gitops.sync_worktree_with_canonical(work, "", "main")["status"] == "skipped"

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -1239,11 +1239,12 @@ def test_git_finalizer_blocks_when_canonical_fetch_fails(tmp_path, monkeypatch):
     assert {item["name"]: item["status"] for item in manifest["checks"]}["git_finalizer"] == "fail"
 
 
-def test_git_finalizer_blocks_unrebased_task_head(tmp_path, monkeypatch):
-    """A task branch that diverges from canonical (omits new canonical commits) is blocked."""
+def test_git_finalizer_auto_rebases_clean_canonical_advance(tmp_path, monkeypatch):
+    """Canonical advanced cleanly under the task -> the finalizer rebases BEFORE
+    the contract test and publishes (previously this blocked with "canonical tip
+    is not an ancestor", killing every task slower than its fleet peers)."""
     origin, canonical, work, main_sha = _setup_two_repo_worktree(tmp_path)
-    # Advance canonical with a new commit AFTER the task branch was created.
-    # Push a new commit directly to canonical that the task branch does NOT have.
+    # Advance canonical with a NON-conflicting commit AFTER the task branch was created.
     advance_dir = tmp_path / "advance"
     _git(tmp_path, "clone", canonical.as_uri(), str(advance_dir))
     _git(advance_dir, "config", "user.email", "t@t")
@@ -1252,6 +1253,7 @@ def test_git_finalizer_blocks_unrebased_task_head(tmp_path, monkeypatch):
     _git(advance_dir, "add", "-A")
     _git(advance_dir, "commit", "-m", "advance canonical")
     _git(advance_dir, "push", "origin", "main")
+    new_canonical_sha = _git(advance_dir, "rev-parse", "HEAD").stdout.strip()
 
     ws = tmp_path / "ws"
     ws.mkdir()
@@ -1273,7 +1275,49 @@ def test_git_finalizer_blocks_unrebased_task_head(tmp_path, monkeypatch):
     te.run_deterministic_git_finalizer(ws, task)
 
     manifest = json.loads((ws / "mac-evidence.json").read_text(encoding="utf-8"))
-    assert manifest["repo"]["pushed"] is False, "stale task HEAD must not be pushed"
+    assert manifest["repo"]["canonical_sync"]["status"] == "rebased"
+    assert manifest["repo"]["canonical_sync"]["canonical_tip"] == new_canonical_sha
+    assert manifest["repo"]["pushed"] is True, "cleanly rebased task HEAD must publish"
+    assert manifest["repo"]["base_sha"] == new_canonical_sha
+    assert {item["name"]: item["status"] for item in manifest["checks"]}["git_finalizer"] == "pass"
+
+
+def test_git_finalizer_blocks_conflicting_canonical_advance(tmp_path, monkeypatch):
+    """Canonical advanced with a CONFLICTING edit -> the sync aborts its rebase
+    and the freshness gate still fails closed (no auto-merge of conflicts)."""
+    origin, canonical, work, main_sha = _setup_two_repo_worktree(tmp_path)
+    advance_dir = tmp_path / "advance"
+    _git(tmp_path, "clone", canonical.as_uri(), str(advance_dir))
+    _git(advance_dir, "config", "user.email", "t@t")
+    _git(advance_dir, "config", "user.name", "t")
+    # The task worktree also writes feature.py -> guaranteed rebase conflict.
+    (advance_dir / "feature.py").write_text("print('peer conflicting')\n", encoding="utf-8")
+    _git(advance_dir, "add", "-A")
+    _git(advance_dir, "commit", "-m", "conflicting canonical advance")
+    _git(advance_dir, "push", "origin", "main")
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    _install_fake_codegraph(tmp_path, monkeypatch)
+    monkeypatch.setenv("MAC_TASK_REPO_WORKTREE", str(work))
+    task = {
+        "id": "t-conflict",
+        "metadata": {
+            "publication_target": "git://main",
+            "origin": {
+                "repository_contract": {
+                    "canonical_remote_url": canonical.as_uri(),
+                    "test": {"command": "true"},
+                }
+            },
+        },
+    }
+
+    te.run_deterministic_git_finalizer(ws, task)
+
+    manifest = json.loads((ws / "mac-evidence.json").read_text(encoding="utf-8"))
+    assert manifest["repo"]["canonical_sync"]["status"] == "conflict"
+    assert manifest["repo"]["pushed"] is False, "conflicting task HEAD must not be pushed"
     assert manifest["push"]["status"] == "skipped"
     assert manifest["push"]["reason"] == "canonical freshness check failed"
     assert "freshness_error" in manifest

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1503,10 +1503,14 @@ def test_mac_worker_finalizes_missing_repository_manifest(tmp_path: Path):
     )
 
 
-def test_mac_worker_blocks_publication_when_canonical_advances_after_preparation(
+def test_mac_worker_auto_rebases_when_canonical_advances_cleanly(
     tmp_path: Path,
     monkeypatch,
 ):
+    """Canonical advanced (non-conflicting) while the task worked -> the
+    finalizer rebases BEFORE the contract test and publishes. Previously this
+    blocked with "canonical tip is not an ancestor", killing every task slower
+    than its fleet peers."""
     monkeypatch.setattr(
         "mac.worker.run_codegraph_audit",
         lambda _worktree, files: _codegraph_fixture(list(files)),
@@ -1537,8 +1541,57 @@ def test_mac_worker_blocks_publication_when_canonical_advances_after_preparation
 
     result = worker.run_once()
 
+    assert result.status == "submitted_for_review"
+    manifest = cp.list_evidence(task.id)[0].metadata["verification"]
+    assert manifest["repo"]["canonical_sync"]["status"] == "rebased"
+    assert manifest["repo"]["pushed"] is True
+    assert manifest["repo"]["freshness"]["ok"] is True
+    # The rebased HEAD contains the canonical advance and the task's work.
+    assert manifest["repo"]["freshness"]["canonical_tip_sha"] == _git(
+        seed, "rev-parse", "HEAD"
+    )
+
+
+def test_mac_worker_blocks_publication_on_conflicting_canonical_advance(
+    tmp_path: Path,
+    monkeypatch,
+):
+    """A CONFLICTING canonical advance must still fail closed: the sync aborts
+    its rebase (work intact) and the freshness gate reports precisely."""
+    monkeypatch.setattr(
+        "mac.worker.run_codegraph_audit",
+        lambda _worktree, files: _codegraph_fixture(list(files)),
+    )
+    cp = ControlPlane.in_memory()
+    agent = register_worker_fixture(cp)
+    seed, repo = _git_fixture(tmp_path)
+    task = cp.create_task(
+        "Repository task conflicting with canonical advance",
+        required_capabilities=["python"],
+        metadata=_repository_task_metadata(repo),
+    )
+    client = TestClient(create_app(control_plane=cp))
+
+    def executor(task_payload: Dict[str, Any], _task_dir: Path) -> WorkerExecution:
+        worktree = Path(task_payload["metadata"]["runtime"]["repository_worktree"])
+        # Both sides edit README.md -> guaranteed rebase conflict.
+        (worktree / "README.md").write_text("task edit\n", encoding="utf-8")
+        _commit_fixture_update(seed, "canonical advanced\n")
+        return WorkerExecution(0, "conflicting repo change", stdout="ok\n")
+
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=api_transport(client)),
+        agent.id,
+        tmp_path / "workspaces",
+        executor,
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+
+    result = worker.run_once()
+
     assert result.status == "blocked"
     manifest = cp.list_evidence(task.id)[0].metadata["verification"]
+    assert manifest["repo"]["canonical_sync"]["status"] == "conflict"
     assert manifest["repo"]["pushed"] is False
     assert manifest["repo"]["freshness"]["ok"] is False
     assert "not an ancestor" in manifest["repo"]["freshness"]["error"]


### PR DESCRIPTION
Third and final infra defect blocking the fleet's fix tasks: with six agents publishing to one canonical branch, any task slower than its peers found main moved by push time and died at the freshness gate ("canonical tip is not an ancestor of task HEAD") — after its full contract suite passed.

## Fix
New `gitops.sync_worktree_with_canonical()`: fetch canonical tip → no-op if already an ancestor → otherwise attempt a **clean rebase only** (conflicts abort with work intact; the freshness gate then fails closed with its precise error). Called from **both finalizers** (worker + task_executor) **before** the contract test, so the suite validates the projected published tree — and the hub review verification still re-tests the pushed branch downstream. Outcome recorded as `repo.canonical_sync` in evidence.

## Tests
- New gitops tests: clean rebase, fresh no-op, conflict abort (no rebase-in-progress, HEAD unchanged, worktree clean), no-remote skip — against real git repos.
- Behavior tests updated on both paths: clean advance → auto-rebase + publish; conflicting advance → fail closed.
- Full contract suite: 4323 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)