### PR TITLE
Verification diagnosability: keep failure tails, fit real budgets, flag old git

### DIFF
--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -33,6 +33,22 @@ git config --global user.name "mac contract tests" >/dev/null 2>&1 || true
 # throwaway hermetic HOME, so the wildcard is scoped to this run only.
 git config --global --add safe.directory '*' >/dev/null 2>&1 || true
 
+# The merge-gate suite (and the production merge queue) uses
+# `git merge-tree --write-tree`, added in git 2.38. On an older git the
+# git-publication/merge-queue tests fail with an opaque rc=129 — lead the log
+# with the actual cause so a fleet host running distro git (e.g. 2.34 on the
+# GKE pod image) is diagnosable from the first line of the failure output.
+_git_ver="$(git version 2>/dev/null | sed -E 's/^git version ([0-9]+)\.([0-9]+).*/\1 \2/')"
+if [ -n "${_git_ver}" ]; then
+    set -- ${_git_ver}
+    if [ "${1:-0}" -lt 2 ] || { [ "${1:-0}" -eq 2 ] && [ "${2:-0}" -lt 38 ]; }; then
+        echo "run-contract-tests.sh: WARNING: $(git version) < 2.38 —" \
+             "merge-gate tests (and the production merge queue) WILL fail;" \
+             "upgrade git on this host" >&2
+    fi
+    set --
+fi
+
 # Resolve a usable interpreter instead of assuming a repo-local .venv. Local
 # dev / bare-metal hosts have .venv; the OpenShell task sandbox ships the mac
 # runtime at /opt/mac-venv and has no .venv (a missing .venv/bin/python is

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -1179,11 +1179,11 @@ def _repository_bootstrap_timeout() -> float:
     raw = (
         os.environ.get("MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT")
         or os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT")
-        or "600"
+        or "1800"
     )
     try:
         value = float(raw)
-        return value if value > 0 else 600.0
+        return value if value > 0 else 1800.0
     except ValueError:
         return 600.0
 
@@ -1394,7 +1394,8 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
     tests = None
     if test_cmd:
         tr = subprocess.run(
-            ["bash", "-lc", test_cmd], cwd=str(worktree_path), capture_output=True, text=True, check=False, timeout=600
+            ["bash", "-lc", test_cmd], cwd=str(worktree_path), capture_output=True, text=True, check=False,
+            timeout=float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800") or "1800")
         )
         tail = (tr.stdout or "") + "\n" + (tr.stderr or "")
         import re as _re
@@ -1685,7 +1686,8 @@ def run_deterministic_review_verdict(task_workspace: Path, task: Dict[str, Any],
             bootstrap = _run_repository_bootstrap_if_needed(review_worktree_path, task)
             test_cmd = (_repository_contract_test_command(task) or "scripts/run-contract-tests.sh").strip()
             tr = subprocess.run(
-                ["bash", "-lc", test_cmd], cwd=str(review_worktree_path), capture_output=True, text=True, check=False, timeout=600
+                ["bash", "-lc", test_cmd], cwd=str(review_worktree_path), capture_output=True, text=True, check=False,
+                timeout=float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800") or "1800")
             )
             bootstrap_ok = bootstrap is None or bootstrap.get("returncode") == 0
             codegraph = run_codegraph_audit(review_worktree_path, exec_repo.get("files_changed") or [])
@@ -2686,10 +2688,10 @@ if bootstrap_command:
             timeout = float(
                 os.environ.get("MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT")
                 or os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT")
-                or "600"
+                or "1800"
             )
         except ValueError:
-            timeout = 600.0
+            timeout = 1800.0
         returncode, stdout, stderr, timed_out = run_bounded_bash(bootstrap_command, timeout)
         bootstrap = {
             "command": bootstrap_command,
@@ -2735,9 +2737,9 @@ elif bootstrap is not None and bootstrap.get("returncode") != 0:
 else:
     started = time.time()
     try:
-        timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "600") or "600")
+        timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800") or "1800")
     except ValueError:
-        timeout = 600.0
+        timeout = 1800.0
     returncode, stdout, stderr, timed_out = run_bounded_bash(command, timeout)
     payload = {
         "schema": "mac.sandbox_verification.v1",
@@ -3074,9 +3076,9 @@ def _sandbox_run_repository_verification(
         sys.stderr.write("[executor] WARNING: sandbox repository verification upload failed: %s\n" % msg)
         return False
     try:
-        timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "600"))
+        timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800"))
     except ValueError:
-        timeout = 600.0
+        timeout = 1800.0
     ok, msg = _sandbox_step(
         [
             "exec",

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -3611,9 +3611,14 @@ class MacWorker:
                 "stderr": "repository contract test.command is missing",
             }
         try:
-            timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "600"))
+            # 600s fit the bare suite (~7 min), but verification may now
+            # bootstrap the repo .venv first (pip install -e .[dev]) on hosts
+            # whose interpreter can't run the suite — bootstrap + suite blows
+            # a 600s budget and the kill landed mid-run with rc 124/1 and a
+            # truncated log, indistinguishable from a test failure.
+            timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800"))
         except ValueError:
-            timeout = 600.0
+            timeout = 1800.0
         try:
             proc = subprocess.run(
                 ["bash", "-lc", command],
@@ -5567,7 +5572,20 @@ def _run_git(repo: Path, args: List[str]) -> subprocess.CompletedProcess[str]:
 
 
 def _truncate_process_text(value: str, limit: int = 4000) -> str:
-    return str(value or "")[:limit]
+    """Bound process output for evidence, keeping head AND tail.
+
+    The tail is where the diagnosis lives — pytest prints its failure summary
+    last — and the previous head-only cut made every long verification failure
+    undiagnosable from the ledger (observed live: a suite that died after the
+    4000-char mark left only passing '[ 12%]' progress lines in evidence,
+    everywhere, including the workspace copy)."""
+    text = str(value or "")
+    if len(text) <= limit:
+        return text
+    head = max(0, limit // 4)
+    tail = limit - head
+    marker = "\n… [%d chars omitted] …\n" % (len(text) - head - tail)
+    return text[:head] + marker + text[-tail:]
 
 
 def _env_truthy(value: Optional[str]) -> bool:

--- a/tests/test_worker_misc_edges.py
+++ b/tests/test_worker_misc_edges.py
@@ -316,3 +316,19 @@ def test_required_changed_file_collection_and_problems() -> None:
         task, {"repo": {"files_changed": ["src/a.py"]}}
     )
     assert "README.md" in problems[0]
+
+
+def test_truncate_process_text_keeps_the_failure_tail() -> None:
+    # pytest prints its failure summary LAST; a head-only cut made every long
+    # verification failure undiagnosable from the ledger (observed live).
+    from mac.worker import _truncate_process_text
+
+    text = ("x" * 10000) + "\nFAILED tests/test_thing.py::test_case - boom\n1 failed"
+    out = _truncate_process_text(text, limit=4000)
+    assert len(out) < 4200  # bounded (marker adds a few chars)
+    assert out.startswith("x")                      # head kept for context
+    assert "chars omitted" in out                   # explicit gap marker
+    assert "FAILED tests/test_thing.py" in out      # the diagnosis survives
+    assert out.endswith("1 failed")
+    # Short output passes through untouched.
+    assert _truncate_process_text("all good", limit=4000) == "all good"


### PR DESCRIPTION
Post-mortem fixes from the overnight fleet-task runs — the failures were real but undiagnosable:

1. **Evidence kept the wrong 4000 chars.** `_truncate_process_text` head-truncated process output; pytest prints failures last, so every long verification failure persisted only passing progress lines — everywhere, including workspace evidence. Now head + tail with an omission marker (regression test included).
2. **600s watchdogs kill legitimate runs.** Verification can now bootstrap the repo `.venv` before the suite; bootstrap + suite exceeds 10 min on fleet hosts and the kill was indistinguishable from a test failure. All contract-test timeout sites now default to 1800s (env-overridable via `MAC_WORKER_REPOSITORY_TEST_TIMEOUT`).
3. **git < 2.38 now announces itself.** The merge gate needs `git merge-tree --write-tree`; distro git 2.34 on the GKE pod image failed 8 merge-gate/publication tests with opaque rc=129. The contract script now leads with a clear WARNING. (Ops side: worker1/worker2 upgraded to git 2.54; bullwinkle/natasha/rocky already ≥2.43; jordanh-gke pending — SSH path flaky, retry loop running.)

Contract suite: 4324 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)