### PR TITLE
Progress-based verification watchdog + event-driven review advancement

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -2833,6 +2833,11 @@ def _start_hub_tick_loop(app: FastAPI, cp: ControlPlane) -> None:
         interval = 0.0
     if interval <= 0:
         return
+    # Event-driven review advancement rides the same gate as the tick: on the
+    # hub, review-stage transitions fire the moment their triggering event
+    # lands (submit_for_review, hub verdict) instead of waiting for the next
+    # sweep; the periodic tick below remains the fallback for anything missed.
+    cp.enable_event_driven_review_advance()
     try:
         stale_after = int(float((os.environ.get("MAC_HUB_TICK_STALE_AFTER_SECONDS") or "300").strip()))
     except ValueError:

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -4,6 +4,7 @@ import base64
 import binascii
 import fnmatch
 import hashlib
+import logging
 import os
 import re
 import shutil
@@ -1164,6 +1165,63 @@ class ControlPlane:
             get_environment=self.deploy.get_environment,
             current_deployment=self.deploy.current_deployment,
         )
+        # Event-driven review advancement (opt-in; enabled by the hub's tick
+        # wiring). Review-stage transitions used to wait for the next periodic
+        # sweep, so every hop of work -> verify -> publish paid up to a full
+        # tick interval of latency. When enabled, the moment an advancing event
+        # lands (submit_for_review, a recorded hub verdict) the task is nudged
+        # onto a queue consumed by a daemon thread; the periodic sweep remains
+        # as the fallback. None (default) = disabled: CLI invocations and tests
+        # never spawn the thread.
+        self._advance_queue: Optional[Any] = None
+        self._advance_queued: set = set()
+        self._advance_state_lock = threading.Lock()
+
+    def enable_event_driven_review_advance(self) -> None:
+        """Start the review-advance nudge consumer (idempotent).
+
+        Called from the hub's self-drive wiring only — the same gate that owns
+        the periodic tick — so stateless replicas, the CLI, and the test suite
+        never spawn a competing advancer."""
+        import queue as _queue
+
+        with self._advance_state_lock:
+            if self._advance_queue is not None:
+                return
+            q: "_queue.Queue[str]" = _queue.Queue()
+            self._advance_queue = q
+
+        def _consume() -> None:
+            while True:
+                task_id = q.get()
+                with self._advance_state_lock:
+                    self._advance_queued.discard(task_id)
+                try:
+                    self.advance_default_review_workflow(
+                        task_id, actor="event-driven-review"
+                    )
+                except Exception:  # noqa: BLE001 - the advancer must never die; the sweep is the fallback.
+                    logging.getLogger("mac.review_advance").warning(
+                        "event-driven review advance failed for %s", task_id, exc_info=True
+                    )
+
+        threading.Thread(
+            target=_consume, name="mac-review-advance", daemon=True
+        ).start()
+
+    def _nudge_review_workflow(self, task_id: str) -> None:
+        """Queue an immediate workflow advance for ``task_id``.
+
+        No-op unless event-driven advancement is enabled; de-duplicates so a
+        burst of events for one task costs one advance."""
+        q = self._advance_queue
+        if q is None or not task_id:
+            return
+        with self._advance_state_lock:
+            if task_id in self._advance_queued:
+                return
+            self._advance_queued.add(task_id)
+        q.put(task_id)
 
     @classmethod
     def in_memory(cls) -> "ControlPlane":
@@ -6256,6 +6314,9 @@ class ControlPlane:
             {},
             drain_outbox=drain_outbox,
         )
+        # Event, not sweep: start the review workflow the moment work is
+        # submitted instead of waiting up to a full tick interval.
+        self._nudge_review_workflow(task_id)
         return reviewed
 
     def _require_review_ready(self, task: Task) -> Evidence:
@@ -12670,6 +12731,9 @@ class ControlPlane:
             {"review_id": review.id, "verdict": verdict, "returncode": returncode,
              "reviewer_agent_id": review.reviewer_agent_id}, actor,
         )
+        # The verdict is the event that unlocks the next stage (publish on
+        # approval / feedback on rejection) — advance now, not on the next sweep.
+        self._nudge_review_workflow(task.id)
         return evidence
 
     def _default_review_for_task(self, task_id: str) -> Optional[Review]:

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -543,6 +543,93 @@ def _run_captured(argv: List[str], cwd: Path, timeout: Optional[float]):
     return subprocess.CompletedProcess(argv, proc.returncode, out, err)
 
 
+def run_with_stall_watchdog(
+    argv: List[str],
+    cwd: Path,
+    *,
+    stall_timeout: Optional[float] = None,
+    hard_timeout: Optional[float] = None,
+) -> "subprocess.CompletedProcess[str]":
+    """Run a command, killing it only when it STOPS MAKING PROGRESS.
+
+    Total-runtime budgets on verification commands have a long history of
+    going stale: every time legitimate work grows (a venv bootstrap, a bigger
+    suite), the constant kills healthy runs mid-flight, indistinguishable from
+    real failures. A progress-based watchdog ends that lineage: the child is
+    killed when it emits NO output for ``stall_timeout`` seconds (a genuinely
+    hung process goes quiet; a slow suite keeps printing progress). The
+    ``hard_timeout`` ceiling remains as a backstop against pathological
+    always-printing loops. Either kill takes the whole process group
+    (start_new_session), same as ``_run_captured``, and returns rc 124 with an
+    explicit marker appended to stderr instead of raising — callers treat it
+    as a failed check with a diagnosable reason.
+
+    Defaults: MAC_TEST_STALL_TIMEOUT (300s) / MAC_WORKER_REPOSITORY_TEST_TIMEOUT
+    (1800s).
+    """
+    import signal
+
+    def _env_float(name: str, fallback: float) -> float:
+        try:
+            value = float(os.environ.get(name, "") or fallback)
+            return value if value > 0 else fallback
+        except ValueError:
+            return fallback
+
+    stall = stall_timeout if stall_timeout is not None else _env_float("MAC_TEST_STALL_TIMEOUT", 300.0)
+    hard = hard_timeout if hard_timeout is not None else _env_float("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", 1800.0)
+
+    proc = subprocess.Popen(
+        argv,
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    chunks: Dict[str, List[bytes]] = {"out": [], "err": []}
+    last_activity = [time.monotonic()]
+
+    def _drain(stream, key: str) -> None:
+        for chunk in iter(lambda: stream.read1(65536), b""):
+            chunks[key].append(chunk)
+            last_activity[0] = time.monotonic()
+        stream.close()
+
+    readers = [
+        threading.Thread(target=_drain, args=(proc.stdout, "out"), daemon=True),
+        threading.Thread(target=_drain, args=(proc.stderr, "err"), daemon=True),
+    ]
+    for r in readers:
+        r.start()
+
+    started = time.monotonic()
+    kill_reason = ""
+    while True:
+        if proc.poll() is not None:
+            break
+        now = time.monotonic()
+        if now - last_activity[0] > stall:
+            kill_reason = "stalled: no output for %.0fs (MAC_TEST_STALL_TIMEOUT)" % stall
+        elif now - started > hard:
+            kill_reason = "exceeded hard ceiling of %.0fs (MAC_WORKER_REPOSITORY_TEST_TIMEOUT)" % hard
+        if kill_reason:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except (AttributeError, ProcessLookupError, PermissionError, OSError):
+                proc.kill()
+            break
+        time.sleep(min(1.0, stall / 10.0))
+    proc.wait()
+    for r in readers:
+        r.join(timeout=10.0)
+    out = b"".join(chunks["out"]).decode("utf-8", errors="replace")
+    err = b"".join(chunks["err"]).decode("utf-8", errors="replace")
+    if kill_reason:
+        err = (err + "\n" if err else "") + "run_with_stall_watchdog: killed — %s" % kill_reason
+        return subprocess.CompletedProcess(argv, 124, out, err)
+    return subprocess.CompletedProcess(argv, proc.returncode, out, err)
+
+
 def run_audited_command(argv: List[str], cwd: Path, task_id, metadata: Dict[str, Any]):
     command_id = command_audit_id()
     agent_id = local_agent_id()
@@ -1393,10 +1480,9 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
     test_cmd = (_repository_contract_test_command(task) or "scripts/run-contract-tests.sh").strip()
     tests = None
     if test_cmd:
-        tr = subprocess.run(
-            ["bash", "-lc", test_cmd], cwd=str(worktree_path), capture_output=True, text=True, check=False,
-            timeout=float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800") or "1800")
-        )
+        # Progress-based: kills on output stall, not on a total-runtime guess
+        # that goes stale every time legitimate work grows.
+        tr = run_with_stall_watchdog(["bash", "-lc", test_cmd], worktree_path)
         tail = (tr.stdout or "") + "\n" + (tr.stderr or "")
         import re as _re
 
@@ -1685,10 +1771,7 @@ def run_deterministic_review_verdict(task_workspace: Path, task: Dict[str, Any],
         if ck.returncode == 0 and checked_out_head == exec_head:
             bootstrap = _run_repository_bootstrap_if_needed(review_worktree_path, task)
             test_cmd = (_repository_contract_test_command(task) or "scripts/run-contract-tests.sh").strip()
-            tr = subprocess.run(
-                ["bash", "-lc", test_cmd], cwd=str(review_worktree_path), capture_output=True, text=True, check=False,
-                timeout=float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800") or "1800")
-            )
+            tr = run_with_stall_watchdog(["bash", "-lc", test_cmd], review_worktree_path)
             bootstrap_ok = bootstrap is None or bootstrap.get("returncode") == 0
             codegraph = run_codegraph_audit(review_worktree_path, exec_repo.get("files_changed") or [])
             integration = _cooperative_integration_check(task, review_worktree_path)

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -3611,34 +3611,14 @@ class MacWorker:
                 "stderr": "repository contract test.command is missing",
             }
         try:
-            # 600s fit the bare suite (~7 min), but verification may now
-            # bootstrap the repo .venv first (pip install -e .[dev]) on hosts
-            # whose interpreter can't run the suite — bootstrap + suite blows
-            # a 600s budget and the kill landed mid-run with rc 124/1 and a
-            # truncated log, indistinguishable from a test failure.
-            timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800"))
-        except ValueError:
-            timeout = 1800.0
-        try:
-            proc = subprocess.run(
-                ["bash", "-lc", command],
-                cwd=str(worktree),
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            stdout = exc.stdout if isinstance(exc.stdout, str) else ""
-            stderr = exc.stderr if isinstance(exc.stderr, str) else ""
-            return {
-                "name": "repository contract test",
-                "command": command,
-                "returncode": 124,
-                "status": "fail",
-                "stdout": _truncate_process_text(stdout),
-                "stderr": _truncate_process_text(stderr or "test command timed out"),
-            }
+            # Progress-based watchdog: kills only when the command stops
+            # emitting output (MAC_TEST_STALL_TIMEOUT, default 300s), with
+            # MAC_WORKER_REPOSITORY_TEST_TIMEOUT (1800s) as a hard backstop.
+            # Total-runtime constants kept going stale as legitimate work grew
+            # (venv bootstrap + suite) and killed healthy runs mid-flight.
+            from mac.task_executor import run_with_stall_watchdog
+
+            proc = run_with_stall_watchdog(["bash", "-lc", command], worktree)
         except Exception as exc:  # noqa: BLE001 - report as verification failure.
             return {
                 "name": "repository contract test",

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -9706,3 +9706,37 @@ def test_hub_verify_sandbox_command_whitelists_uploaded_repo_for_git(cp, monkeyp
     # confusing test failures.
     assert "rev-parse --is-inside-work-tree" in inner
     assert "not a usable git repo after upload" in inner
+
+
+def test_event_driven_advance_reviews_without_tick(cp, monkeypatch):
+    """With the event-driven advancer enabled (hub wiring), submitting work
+    for review triggers the workflow immediately — no periodic sweep needed.
+    Previously every stage waited up to a full MAC_HUB_TICK_INTERVAL_SECONDS."""
+    import time as _time
+
+    monkeypatch.setenv("MAC_REVIEW_HUB_VERIFY", "1")
+    worker, reviewer, task, evidence = _setup_hubverify_task(
+        cp, lambda remote, branch, head, cmd: (0, "all passed"),
+    )
+    # _setup_hubverify_task already called submit_for_review BEFORE the
+    # advancer existed; enable it and nudge as submit_for_review now does.
+    cp.enable_event_driven_review_advance()
+    cp._nudge_review_workflow(task.id)
+
+    deadline = _time.monotonic() + 10.0
+    while _time.monotonic() < deadline:
+        if cp.get_task(task.id).state == TaskState.COMPLETED.value:
+            break
+        _time.sleep(0.05)
+    # verdict recording re-nudges, so review AND publication complete without
+    # any cp.tick()/advance call from a sweep.
+    assert cp.get_task(task.id).state == TaskState.COMPLETED.value
+    reviews = cp.list_reviews(task.id)
+    assert reviews and reviews[0].status == ReviewStatus.APPROVED.value
+
+
+def test_nudge_is_noop_when_advancer_disabled(cp):
+    """CLI/test constructions never spawn the advancer thread; nudges are free."""
+    assert cp._advance_queue is None
+    cp._nudge_review_workflow("task_whatever")  # must not raise or spawn
+    assert cp._advance_queue is None

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -2379,3 +2379,44 @@ def test_main_emits_plan_decomposed_telemetry(tmp_path, monkeypatch):
     # children were posted
     assert captured_children.get("task_id") == "t_plan"
     assert len(captured_children.get("children", [])) == 3
+
+
+# --------------------------------------------------------------------------- #
+# run_with_stall_watchdog: progress-based, not total-runtime-based
+# --------------------------------------------------------------------------- #
+
+
+def test_stall_watchdog_kills_silent_hang_quickly(tmp_path):
+    # A hung process goes quiet; the watchdog kills on output stall — long
+    # before any total-runtime budget — with an explicit diagnosable marker.
+    import time as _time
+    start = _time.monotonic()
+    r = te.run_with_stall_watchdog(
+        ["bash", "-c", "echo working; sleep 60"], tmp_path,
+        stall_timeout=1.0, hard_timeout=120.0,
+    )
+    assert r.returncode == 124
+    assert "stalled: no output" in r.stderr
+    assert "working" in r.stdout            # pre-hang output preserved
+    assert _time.monotonic() - start < 20   # killed on stall, not after 60s
+
+
+def test_stall_watchdog_lets_slow_but_chatty_work_finish(tmp_path):
+    # Steady progress output means NO kill even when total runtime exceeds the
+    # stall window — the exact scenario stale total-runtime budgets murdered.
+    r = te.run_with_stall_watchdog(
+        ["bash", "-c", "for i in 1 2 3 4 5 6; do echo tick $i; sleep 0.5; done; echo done"],
+        tmp_path, stall_timeout=1.5, hard_timeout=120.0,
+    )
+    assert r.returncode == 0
+    assert "done" in r.stdout
+
+
+def test_stall_watchdog_hard_ceiling_stops_chatty_loops(tmp_path):
+    # The backstop: a pathological always-printing loop still dies at the ceiling.
+    r = te.run_with_stall_watchdog(
+        ["bash", "-c", "while true; do echo spin; sleep 0.2; done"], tmp_path,
+        stall_timeout=5.0, hard_timeout=2.0,
+    )
+    assert r.returncode == 124
+    assert "hard ceiling" in r.stderr


### PR DESCRIPTION
Answers the "why does the git history keep bumping timeouts" architectural review.

## 1. Watchdogs now measure progress, not elapsed time
`run_with_stall_watchdog()` kills verification commands on **output stall** (`MAC_TEST_STALL_TIMEOUT`, 300s) instead of a total-runtime constant that goes stale whenever legitimate work grows (last night: venv bootstrap + suite vs a 600s budget). The total ceiling survives only as a backstop for always-printing loops. Group-kill, rc 124, explicit reason in stderr. Wired into all three contract-test sites.

## 2. Review workflow advances on events, not sweeps
`submit_for_review` and hub-verdict recording nudge a dedupe'd in-process queue; a daemon thread advances that task immediately, so work → verify → publish chains through without paying up to a full `MAC_HUB_TICK_INTERVAL_SECONDS` per stage. The periodic sweep remains as fallback. The advancer starts only under the hub tick's gate — CLI/tests/stateless replicas never spawn it.

## Verification
- Stall-kill in seconds with diagnosable marker; slow-but-chatty work survives past the stall window; hard ceiling stops infinite printers.
- Full review→publish completes with **zero** sweep ticks in test.
- Contract suite: 4329 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)