### PR TITLE
Hermetic forge tokens: one leaked GITHUB_TOKEN failed every fleet-host verification

### DIFF
--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -10,6 +10,12 @@ unset "${!MAC_@}"
 unset "${!QDRANT_@}"
 unset "${!SLACK_@}"
 unset "${!TOKENHUB_@}"
+# Git-forge credentials: worker hosts MUST carry these to publish, but
+# gitops.token_for_host() consults them, so a live GH_TOKEN/GITHUB_TOKEN
+# changes inject_git_remote_auth() behavior under test — one leaked token
+# failed test_ref_host_token_auth_and_redaction_edges on every fleet host
+# while the same suite passed on tokenless dev machines and hub sandboxes.
+unset GH_TOKEN GITHUB_TOKEN GITEA_TOKEN GIT_TOKEN
 
 # Hermetic HOME: unsetting env vars is not enough — a deployed host also carries
 # real fleet config under ~/.hermes, ~/.mac and ~/.config, which leaked into

--- a/tests/test_gitops_edges.py
+++ b/tests/test_gitops_edges.py
@@ -36,6 +36,12 @@ def _target(tmp_path: Path, **extra):
 
 
 def test_ref_host_token_auth_and_redaction_edges(monkeypatch) -> None:
+    # Hermetic under bare pytest too: a fleet host's real forge token changes
+    # inject_git_remote_auth() outcomes below (observed live — this single
+    # failure blocked every worker-host verification while the same suite
+    # passed on tokenless dev machines and hub sandboxes).
+    for var in ("GH_TOKEN", "GITHUB_TOKEN", "GITEA_TOKEN", "GIT_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
     with pytest.raises(ValueError, match="exceeds"):
         gitops.validate_git_ref("x" * 513)
     for ref in ("/bad", "bad/", "bad.", "bad..ref", "bad//ref", "bad.lock"):


### PR DESCRIPTION
With evidence tails preserved (#206), the real blocker became visible: **exactly one test** failing on an otherwise-green suite on every worker host — `test_ref_host_token_auth_and_redaction_edges`.

`gitops.token_for_host()` consults `GH_TOKEN`/`GITHUB_TOKEN`, which worker hosts must export to publish; the test asserts tokenless `inject_git_remote_auth()` behavior; the contract script unsets `MAC_*` etc. but not forge tokens. Dev machines and hub-verify sandboxes are tokenless — the suite was green everywhere the operator looked. Reproduced locally with `GITHUB_TOKEN=x` → same single failure (1 failed, 4332 passed).

Fix at both layers: the script's hermetic unset now includes `GH_TOKEN GITHUB_TOKEN GITEA_TOKEN GIT_TOKEN`, and the test monkeypatch-deletes them for bare-pytest hermeticity. Verified both ways.

🤖 Generated with [Claude Code](https://claude.com/claude-code)