### PR TITLE
Pin init.defaultBranch in hermetic test HOME; pin peer-clone branch

### DIFF
--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -30,6 +30,12 @@ export HOME="$_MAC_TEST_HOME"
 export XDG_CONFIG_HOME="$_MAC_TEST_HOME/.config"
 git config --global user.email "mac-contract-tests@example.invalid" >/dev/null 2>&1 || true
 git config --global user.name "mac contract tests" >/dev/null 2>&1 || true
+# Stock git defaults new repos to `master`; most dev machines set
+# init.defaultBranch=main in their user gitconfig, which this hermetic HOME
+# deliberately hides. Pin it so tests that build repos behave identically on
+# dev machines and fleet sandboxes (a bare-canonical clone checked out nothing
+# on stock git and failed two publication tests only on fleet hosts).
+git config --global init.defaultBranch main >/dev/null 2>&1 || true
 # The suite has tests that shell out to git (git ls-files, etc.). When the repo
 # is a clone owned by a different uid than the test runner — e.g. the hub
 # verifier uploads a clone into an OpenShell sandbox run as the `sandbox` user —

--- a/tests/test_gitops_publication_target.py
+++ b/tests/test_gitops_publication_target.py
@@ -221,7 +221,12 @@ def test_target_is_immutable_unique_and_secret_free(
 def _advance_canonical(tmp_path: Path, canonical: Path, filename: str, content: str) -> str:
     """Land a new commit on the canonical branch (simulates a peer publishing)."""
     other = tmp_path / ("peer-" + filename.replace("/", "-"))
-    _git(tmp_path, "clone", canonical.as_uri(), str(other))
+    # --branch main: the bare canonical's HEAD symref still points at the
+    # host git's init.defaultBranch (master on stock git), so a default clone
+    # checks out nothing and the peer's commit lands on the wrong branch —
+    # failed only on fleet sandboxes, passed on dev machines whose gitconfig
+    # sets init.defaultBranch=main.
+    _git(tmp_path, "clone", "--branch", "main", canonical.as_uri(), str(other))
     _git(other, "config", "user.email", "peer@example.invalid")
     _git(other, "config", "user.name", "peer")
     (other / filename).write_text(content, encoding="utf-8")


### PR DESCRIPTION
The #203 sync tests failed only on fleet sandboxes: stock git defaults to `master`, the bare-canonical fixture's HEAD symref pointed at a nonexistent branch, a default clone checked out nothing, and the peer's commit landed on `master` → `push origin main` → "src refspec main does not match any". Dev machines pass because their gitconfig sets `init.defaultBranch=main` — precisely the config the hermetic HOME hides.

Fix: seed `init.defaultBranch=main` in the script's hermetic HOME + `--branch main` on the fixture's peer clone. Reproduced and verified both ways with `GIT_CONFIG_*` forcing `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)