### PR TITLE
Reclaim same-lease worktree debris instead of wedging the task

### DIFF
--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -2669,10 +2669,25 @@ class MacWorker:
             branch = _task_worktree_branch(self.agent_id, str(task.get("id") or ""), str(lease.get("id") or ""))
             worktree_dir = task_dir / ("repo-" + _safe_path_component(str(lease.get("id") or "lease")))
             if worktree_dir.exists():
+                # The directory is lease-scoped and leases are exclusive, so an
+                # existing dir here is OUR OWN debris from an interrupted prior
+                # run of this same assignment (worker restart mid-attempt) —
+                # not a foreign process to protect. Hard-failing here wedged
+                # tasks every time a worker restarted while executing
+                # (observed live: worker_exception -> blocked after each fleet
+                # deploy). The ledger is canonical and the worktree is
+                # attempt-local scratch: clean deterministically and re-prepare.
                 existing_head = _run_git(worktree_dir, ["rev-parse", "HEAD"])
                 if existing_head.returncode == 0 and existing_head.stdout.strip():
-                    raise RuntimeError(
-                        "repository task worktree already exists for this lease: %s" % worktree_dir
+                    self._observe_log(
+                        "worker.repository.stale_lease_worktree_reclaimed",
+                        subject_type="task",
+                        subject_id=str(task.get("id") or ""),
+                        detail={
+                            "worktree": str(worktree_dir),
+                            "stale_head": existing_head.stdout.strip(),
+                            "lease_id": str(lease.get("id") or ""),
+                        },
                     )
                 shutil.rmtree(worktree_dir)
             # mac-3qv6: prune any orphaned worktree registration in
@@ -2683,7 +2698,10 @@ class MacWorker:
 
             add = _run_git(
                 source_root,
-                ["worktree", "add", "-b", branch, str(worktree_dir), base_sha],
+                # -B (not -b): the branch may survive from a reclaimed
+                # interrupted run of this same lease; force-reset it to the
+                # fresh base rather than failing on "branch already exists".
+                ["worktree", "add", "-B", branch, str(worktree_dir), base_sha],
             )
             if add.returncode != 0:
                 raise RuntimeError(

--- a/tests/test_worker_misc_edges.py
+++ b/tests/test_worker_misc_edges.py
@@ -332,3 +332,4 @@ def test_truncate_process_text_keeps_the_failure_tail() -> None:
     assert out.endswith("1 failed")
     # Short output passes through untouched.
     assert _truncate_process_text("all good", limit=4000) == "all good"
+

--- a/tests/test_worker_remote_clone.py
+++ b/tests/test_worker_remote_clone.py
@@ -1374,3 +1374,40 @@ def test_repo_snapshot_falls_back_to_origin_remote_when_no_canonical() -> None:
         "repository_origin_remote": "https://github.com/org/repo.git",
     }
     assert _repository_context_repo_snapshot(context)["remote_url"] == "https://github.com/org/repo.git"
+
+
+def test_local_worktree_same_lease_debris_is_reclaimed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A worktree dir left by an interrupted prior run of the SAME lease is our
+    own debris (leases are exclusive) — preparation must reclaim it and
+    re-prepare, not raise. Hard-failing wedged tasks (worker_exception ->
+    blocked) after every mid-attempt worker restart, observed live on every
+    fleet deploy that restarted agents while they executed."""
+    monkeypatch.delenv("MAC_TASK_WORKTREE_SKIP_FETCH", raising=False)
+    _origin, _seed, work, sha = _make_local_git_fixture(tmp_path)
+
+    worker = _make_worker(tmp_path)
+    task = _repo_task_local(str(work))
+    lease = {"id": "lease-restart-test"}
+    task_dir = tmp_path / "tasks" / "task-restart"
+    task_dir.mkdir(parents=True)
+
+    first = worker._prepare_repository_worktree(task, lease, task_dir)
+    assert first is not None
+    stale_dir = Path(first["repository_worktree"])
+    assert stale_dir.exists()
+    # Leave debris behind (simulates the worker dying mid-attempt) and make it
+    # distinguishable from a fresh checkout.
+    (stale_dir / "half-done.txt").write_text("in progress\n", encoding="utf-8")
+
+    second = worker._prepare_repository_worktree(task, lease, task_dir)
+    assert second is not None, "same-lease debris must be reclaimed, not fatal"
+    fresh_dir = Path(second["repository_worktree"])
+    assert fresh_dir == stale_dir
+    assert not (fresh_dir / "half-done.txt").exists(), "reclaim must re-prepare cleanly"
+    head = _subprocess.run(
+        ["git", "-C", str(fresh_dir), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    assert head == sha


### PR DESCRIPTION
A worktree dir named for the **current** lease is the worker's own debris from an interrupted prior run (leases are exclusive). The old guard hard-failed on it, so any worker restart mid-attempt (fleet deploys, self-updates) wedged the task with `worker_exception → blocked` — observed live; one host accumulated five stale worktrees in a day.

Fix: log `worker.repository.stale_lease_worktree_reclaimed`, remove, re-prepare; `git worktree add -B` force-resets the surviving branch. Regression test drives the real preparation path twice with the same lease.

Contract suite: 4344 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)