### PR TITLE
Hub verify: upload the repo as one tar file — OpenShell drops .git in transit

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -12772,6 +12772,20 @@ class ControlPlane:
                 return 1, "hub verify clone failed: %s" % _gitops.redact_git_remote_auth_in_text(
                     (clone.stderr or clone.stdout or "").strip()
                 )[-800:]
+            # Upload ONE tar file and extract inside the sandbox. Uploading the
+            # directory tree loses .git in transit (OpenShell's upload drops
+            # it), which failed every git-at-checkout contract test — and, once
+            # the exit-97 probe landed, every verify outright with
+            # "/sandbox/repo is not a usable git repo after upload". A single
+            # archive survives any upload path verbatim, .git included.
+            tar = subprocess.run(
+                ["tar", "czf", str(tmp / "repo.tgz"), "-C", str(tmp), "repo"],
+                capture_output=True, text=True, timeout=120, check=False,
+            )
+            if tar.returncode != 0:
+                return 1, "hub verify tar failed: %s" % (
+                    (tar.stderr or tar.stdout or "").strip()
+                )[-800:]
             subprocess.run([openshell, "sandbox", "delete", name],
                            capture_output=True, text=True, timeout=60, check=False)
             argv = [openshell, "sandbox", "create", "--no-auto-providers"]
@@ -12779,9 +12793,9 @@ class ControlPlane:
                 argv += ["--policy", policy]
             argv += [
                 "--name", name, "--from", image, "--env", "HOME=/tmp",
-                "--upload", "%s:%s" % (str(tmp / "repo"), "/sandbox"),
+                "--upload", "%s:%s" % (str(tmp / "repo.tgz"), "/sandbox"),
                 "--", "bash", "-c",
-                "%scd /sandbox/repo && %s" % (
+                "cd /sandbox && tar xzf repo.tgz && %scd /sandbox/repo && %s" % (
                     _HUB_VERIFY_GIT_PREFLIGHT,
                     test_command or "scripts/run-contract-tests.sh",
                 ),

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -9746,13 +9746,17 @@ def test_hub_verify_sandbox_command_whitelists_uploaded_repo_for_git(cp, monkeyp
     assert rc == 0
     create = next(a for a in captured if "create" in a and "--upload" in a)
     inner = create[create.index("-c") + 1]
+    # The repo travels as ONE tar file (OpenShell directory upload drops .git)
+    # and is extracted inside the sandbox before anything else.
+    upload = create[create.index("--upload") + 1]
+    assert upload.endswith("repo.tgz:/sandbox")
+    assert inner.startswith("cd /sandbox && tar xzf repo.tgz && ")
     # Whitelist reaches every git subprocess the suite spawns (env form, not
     # --global), and it precedes the test command.
     assert "GIT_CONFIG_KEY_0=safe.directory" in inner
     assert "GIT_CONFIG_VALUE_0='*'" in inner
     assert inner.index("safe.directory") < inner.index("cd /sandbox/repo")
-    # Lost-.git uploads fail fast with a distinguishable message, not 4
-    # confusing test failures.
+    # Lost-.git uploads still fail fast with a distinguishable message.
     assert "rev-parse --is-inside-work-tree" in inner
     assert "not a usable git repo after upload" in inner
 


### PR DESCRIPTION
Closes the original hub-review mystery, definitively identified by the #201 exit-97 probe: **OpenShell's directory upload loses `.git`**, so `/sandbox/repo` was never a git repository. Two agent branches that passed local verification and pushed were being rejected by this alone.

Fix: tar the shallow clone on the hub → upload the single archive → extract inside the sandbox before the git preflight + contract test. Proven live in a real sandbox on the hub (`rev-parse` + `ls-files` work post-extract, `TAR-UPLOAD-OK`).

Contract suite: 4368 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)