### PR TITLE
Outcome-grounded learning loop: verdict lessons, curation fork, content search

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -6136,6 +6136,7 @@ def create_app(
         until: Optional[str] = Query(default=None, description="ISO-8601 upper bound on created_at (inclusive)"),
         limit: Optional[int] = Query(default=None, ge=1, description="Maximum number of records to return"),
         order: str = Query(default="asc", description="Sort order: asc (oldest first) or desc (newest first)"),
+        content_contains: Optional[str] = Query(default=None, description="Case-insensitive substring match on record content"),
     ) -> List[Dict[str, Any]]:
         return [
             record.to_dict()
@@ -6150,6 +6151,7 @@ def create_app(
                 until=until,
                 limit=limit,
                 order=order,
+                content_contains=content_contains,
             )
         ]
 

--- a/src/mac/memory_service.py
+++ b/src/mac/memory_service.py
@@ -108,6 +108,7 @@ class MemoryService:
         until: Optional[str] = None,
         limit: Optional[int] = None,
         order: str = "asc",
+        content_contains: Optional[str] = None,
     ) -> List[MemoryRecord]:
         """Query memory records with operator-grade filters.
 
@@ -136,6 +137,9 @@ class MemoryService:
             Maximum number of records to return.  ``None`` returns all.
         order:
             ``"asc"`` (oldest first, default) or ``"desc"`` (newest first).
+        content_contains:
+            Case-insensitive substring match against record content (how an
+            agent finds prior lessons about e.g. "merge-tree" or a host name).
         """
         clauses: List[str] = []
         params: List[Any] = []
@@ -163,6 +167,12 @@ class MemoryService:
         if until:
             clauses.append("created_at <= ?")
             params.append(until)
+        if content_contains:
+            # Case-insensitive substring match on record content. Deliberately
+            # LIKE, not FTS: works identically on SQLite and Postgres stores at
+            # this table's scale, and stays honest about what it is.
+            clauses.append("LOWER(content) LIKE ?")
+            params.append("%" + str(content_contains).lower() + "%")
         sql = "SELECT * FROM memory_records"
         if clauses:
             sql += " WHERE " + " AND ".join(clauses)

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -4,6 +4,7 @@ import base64
 import binascii
 import fnmatch
 import hashlib
+import json
 import logging
 import os
 import re
@@ -10799,12 +10800,58 @@ class ControlPlane:
             },
             actor,
         )
+        # Ground truth into memory: publication is the strongest outcome signal
+        # the pipeline produces, and until now it never became a lesson (the
+        # executor's deployment_learning writeback happens BEFORE review).
+        self._record_review_outcome_lesson(
+            task_id, outcome="approved_published", detail="published to %s" % publication.target
+        )
         return {
             "task_id": task_id,
             "status": "published",
             "review_id": review.id,
             "publication_id": publication.id,
         }
+
+    def _record_review_outcome_lesson(
+        self, task_id: str, *, outcome: str, detail: str
+    ) -> None:
+        """Distill a review-stage outcome into a ``deployment_learning`` memory
+        record (best-effort; never breaks the workflow).
+
+        Emitted with schema ``mac.deployment_learning.v1`` so the executor's
+        existing ``recall_deployment_lessons`` surfaces it to the NEXT task on
+        the project with zero reader changes — the fleet learns from verdicts,
+        not just from its own exit codes."""
+        try:
+            task = self.get_task(task_id)
+            project = str(task.project or "") or "unknown"
+            content = {
+                "schema": "mac.deployment_learning.v1",
+                "task_id": task_id,
+                "task_title": task.title,
+                "project": project,
+                "repository": "",
+                "evidence_type": "review_verdict",
+                "outcome": outcome,
+                "signals": {"stage": "hub_review"},
+                "error_signature": ("" if outcome == "approved_published" else str(detail)[:200]),
+                "detail": str(detail)[:300],
+                "at": utcnow(),
+            }
+            self.add_memory(
+                task_id,
+                "project",
+                project,
+                "deployment_learning:%s" % project,
+                json.dumps(content, sort_keys=True, separators=(",", ":")),
+                None,
+                "hub-review-workflow",
+            )
+        except Exception:  # noqa: BLE001 - lessons are advisory, workflow is not.
+            logging.getLogger("mac.review_lessons").warning(
+                "could not record review outcome lesson for %s", task_id, exc_info=True
+            )
 
     # Secrets boundary: thin facade over ``self.secrets``. New code should
     # call ``cp.secrets.<method>`` directly.
@@ -12965,6 +13012,12 @@ class ControlPlane:
             {"review_id": review.id, "verdict": verdict, "returncode": returncode,
              "reviewer_agent_id": review.reviewer_agent_id}, actor,
         )
+        if verdict == "rejected":
+            self._record_review_outcome_lesson(
+                task.id,
+                outcome="review_rejected",
+                detail=str(manifest.get("feedback") or "hub contract verification failed")[:300],
+            )
         # The verdict is the event that unlocks the next stage (publish on
         # approval / feedback on rejection) — advance now, not on the next sweep.
         self._nudge_review_workflow(task.id)

--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -957,6 +957,97 @@ def record_deployment_learning(task: Dict[str, Any], outcome: Dict[str, Any]) ->
     return _hub_post("/memory", build_learning_record(task, outcome))
 
 
+_LESSON_CURATION_PROMPT = """You are the fleet's lesson curator. A task just finished; distill what the NEXT agent working on this project should know.
+
+Task: {title}
+Outcome: {outcome} (evidence_type={evidence_type})
+Signals: {signals}
+Failure hint: {error_signature}
+
+Write 1-3 lessons, ONE PER LINE, no bullets or numbering. Each lesson must be a single self-contained sentence under 250 characters stating a reusable, project-specific fact or pitfall (environment quirks, commands that worked/failed, gotchas). Ground every lesson in the outcome above - do not speculate. If nothing generalizes beyond this one task, output exactly: NOTHING
+"""
+
+
+def curate_lessons_from_outcome(
+    task: Dict[str, Any], outcome: Dict[str, Any]
+) -> List[str]:
+    """LLM-curated lessons from a finished run (the Hermes background-review
+    pattern, made outcome-grounded and fleet-shared).
+
+    Hermes forks an LLM every N iterations to journal into per-host text files
+    with no outcome signal; here the fork runs ONCE per task, is shown the
+    VERIFIED outcome (tests/push/checks signals), and its lessons land in the
+    HUB memory service as ``mac.deployment_learning.v1`` records - recalled by
+    every agent on the project via the existing lesson recall, and promoted to
+    the vector tier by the nap consolidator. Opt-in via
+    MAC_LESSON_CURATION_ENABLED; router endpoint from
+    MAC_ROUTER_URL/OPENAI_BASE_URL (the eval runner's seam). Best-effort: any
+    failure returns [] and the run's outcome is unaffected."""
+    if str(os.environ.get("MAC_LESSON_CURATION_ENABLED") or "").strip().lower() not in {
+        "1", "true", "yes", "on",
+    }:
+        return []
+    router_url = str(
+        os.environ.get("MAC_ROUTER_URL")
+        or os.environ.get("MAC_ROUTER_INTERNAL_URL")
+        or os.environ.get("OPENAI_BASE_URL")
+        or ""
+    ).strip()
+    model = str(
+        os.environ.get("MAC_LESSON_CURATION_MODEL")
+        or os.environ.get("MAC_TASK_MODEL")
+        or os.environ.get("MAC_HERMES_GATEWAY_MODEL")
+        or ""
+    ).strip()
+    if not router_url or not model:
+        return []
+    try:
+        from mac.eval_runner import router_model_caller
+
+        prompt = _LESSON_CURATION_PROMPT.format(
+            title=str(task.get("title") or "")[:200],
+            outcome=outcome.get("outcome"),
+            evidence_type=outcome.get("evidence_type"),
+            signals=json.dumps(outcome.get("signals") or {}, sort_keys=True)[:400],
+            error_signature=str(outcome.get("error_signature") or "none")[:200],
+        )
+        caller = router_model_caller(
+            router_url, token=str(os.environ.get("MAC_API_TOKEN") or "")
+        )
+        answer, _cites, _ms = caller(model, prompt, "")
+    except Exception:  # noqa: BLE001 - curation is advisory.
+        return []
+    lessons: List[str] = []
+    for line in str(answer or "").splitlines():
+        text = line.strip().strip("-*\u2022 ").strip()
+        if not text or text.upper() == "NOTHING":
+            continue
+        lessons.append(text[:250])
+        if len(lessons) >= 3:
+            break
+    return lessons
+
+
+def record_curated_lessons(task: Dict[str, Any], outcome: Dict[str, Any]) -> int:
+    """Persist LLM-curated lessons as deployment-learning records (best-effort).
+    Returns the number recorded."""
+    lessons = curate_lessons_from_outcome(task, outcome)
+    recorded = 0
+    for lesson in lessons:
+        payload = build_learning_record(
+            task,
+            {
+                "evidence_type": outcome.get("evidence_type"),
+                "outcome": outcome.get("outcome"),
+                "signals": {**(outcome.get("signals") or {}), "curated": True},
+                "error_signature": lesson,
+            },
+        )
+        if _hub_post("/memory", payload):
+            recorded += 1
+    return recorded
+
+
 def classify_outcome(task_workspace: Path, task: Dict[str, Any], returncode: int) -> Dict[str, Any]:
     """Derive a compact, recall-friendly outcome from the final evidence
     manifest (read from disk) + the executor return code."""
@@ -4508,6 +4599,7 @@ def _run_executor(
             signals=outcome["signals"],
         )
         record_deployment_learning(task, outcome)
+        record_curated_lessons(task, outcome)
 
     sys.stdout.write(result.stdout)
     sys.stderr.write(result.stderr)

--- a/tests/test_outcome_grounded_lessons.py
+++ b/tests/test_outcome_grounded_lessons.py
@@ -1,0 +1,110 @@
+"""Outcome-grounded learning loop (B from the Hermes evaluation):
+review verdicts become recallable lessons, curation is LLM-forked but
+outcome-grounded, and memory content is searchable."""
+
+from __future__ import annotations
+
+import json
+
+import mac.task_executor as te
+from mac.services import ControlPlane
+
+
+def _cp() -> ControlPlane:
+    return ControlPlane.in_memory()
+
+
+def test_review_outcome_lesson_lands_in_deployment_learning(monkeypatch):
+    cp = _cp()
+    task = cp.create_task("Fix the thing", required_capabilities=["python"],
+                          metadata={"publication_target": "test://x"})
+    cp._record_review_outcome_lesson(
+        task.id, outcome="review_rejected", detail="hub contract verification failed: 1 failed"
+    )
+    records = cp.search_memory(record_type_prefix="deployment_learning")
+    assert len(records) == 1
+    content = json.loads(records[0].content)
+    # Emitted in the executor's recall schema so recall_deployment_lessons
+    # surfaces it to the next task with zero reader changes.
+    assert content["schema"] == "mac.deployment_learning.v1"
+    assert content["outcome"] == "review_rejected"
+    assert "verification failed" in content["error_signature"]
+    assert records[0].created_by == "hub-review-workflow"
+
+
+def test_review_outcome_lesson_never_breaks_workflow(monkeypatch):
+    cp = _cp()
+    # Nonexistent task -> get_task raises inside -> swallowed, no exception out.
+    cp._record_review_outcome_lesson("task_missing", outcome="approved_published", detail="x")
+
+
+def test_memory_search_content_contains():
+    cp = _cp()
+    task = cp.create_task("T", required_capabilities=["python"])
+    cp.add_memory(task.id, "project", "mac", "deployment_learning:mac",
+                  json.dumps({"error_signature": "git merge-tree needs 2.38"}), None, "t")
+    cp.add_memory(task.id, "project", "mac", "deployment_learning:mac",
+                  json.dumps({"error_signature": "unrelated"}), None, "t")
+    hits = cp.search_memory(content_contains="MERGE-TREE")
+    assert len(hits) == 1 and "merge-tree" in hits[0].content
+    assert len(cp.search_memory(content_contains="nomatchxyz")) == 0
+
+
+def test_curation_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("MAC_LESSON_CURATION_ENABLED", raising=False)
+    assert te.curate_lessons_from_outcome({"title": "t"}, {"outcome": "success"}) == []
+
+
+def test_curation_parses_lessons_and_caps(monkeypatch):
+    monkeypatch.setenv("MAC_LESSON_CURATION_ENABLED", "1")
+    monkeypatch.setenv("MAC_ROUTER_URL", "http://router.test/v1")
+    monkeypatch.setenv("MAC_LESSON_CURATION_MODEL", "test-model")
+
+    def fake_caller_factory(url, token=""):
+        def call(model, question, context):
+            assert model == "test-model"
+            assert "Outcome: failure" in question
+            return ("- lesson one about the venv\nNOTHING\nlesson two\nlesson three\nlesson four", [], 5.0)
+        return call
+
+    import mac.eval_runner as er
+    monkeypatch.setattr(er, "router_model_caller", fake_caller_factory)
+    lessons = te.curate_lessons_from_outcome(
+        {"title": "t", "metadata": {}},
+        {"outcome": "failure", "evidence_type": "repo_change",
+         "signals": {"tests": "fail"}, "error_signature": "boom"},
+    )
+    assert lessons == ["lesson one about the venv", "lesson two", "lesson three"]
+
+
+def test_curation_nothing_and_errors_yield_empty(monkeypatch):
+    monkeypatch.setenv("MAC_LESSON_CURATION_ENABLED", "1")
+    monkeypatch.setenv("MAC_ROUTER_URL", "http://router.test/v1")
+    monkeypatch.setenv("MAC_LESSON_CURATION_MODEL", "m")
+    import mac.eval_runner as er
+    monkeypatch.setattr(er, "router_model_caller",
+                        lambda url, token="": lambda m, q, c: ("NOTHING", [], 1.0))
+    assert te.curate_lessons_from_outcome({"title": "t"}, {"outcome": "success"}) == []
+    def raising_factory(url, token=""):
+        def call(m, q, c):
+            raise ConnectionError("router down")
+        return call
+    monkeypatch.setattr(er, "router_model_caller", raising_factory)
+    assert te.curate_lessons_from_outcome({"title": "t"}, {"outcome": "success"}) == []
+
+
+def test_record_curated_lessons_posts_learning_records(monkeypatch):
+    monkeypatch.setattr(te, "curate_lessons_from_outcome",
+                        lambda task, outcome: ["use the ppa git", "bootstrap needs --venv-only"])
+    posted = []
+    monkeypatch.setattr(te, "_hub_post", lambda path, payload: posted.append((path, payload)) or True)
+    n = te.record_curated_lessons(
+        {"id": "task_x", "title": "T", "metadata": {}},
+        {"outcome": "failure", "evidence_type": "repo_change", "signals": {"tests": "fail"}},
+    )
+    assert n == 2
+    assert all(p[0] == "/memory" for p in posted)
+    contents = [json.loads(p[1]["content"]) for p in posted]
+    assert contents[0]["error_signature"] == "use the ppa git"
+    assert all(c["signals"]["curated"] is True for c in contents)
+    assert all(c["schema"] == "mac.deployment_learning.v1" for c in contents)


### PR DESCRIPTION
Implements option B from the hermes-agent evaluation: Hermes's learning-loop *patterns* adopted into MAC's hub-side loop, gaining the one thing Hermes lacks — **outcome grounding**.

1. **Review verdicts become lessons** (deterministic): publication and hub-verify rejection now emit `mac.deployment_learning.v1` records — picked up by the existing `recall_deployment_lessons` with zero reader changes. The fleet learns from signed verdicts, not just its own exit codes.
2. **LLM curation fork** (opt-in via `MAC_LESSON_CURATION_ENABLED`): once per finished task, shown the verified outcome signals, writes ≤3 distilled lessons to the hub memory service (fleet-shared, vs Hermes's per-host 2200-char text file with no outcome signal).
3. **Memory content search**: `content_contains` filter on `search_memory` + `GET /memory` (honest LIKE, portable across SQLite/Postgres).

Tests cover: verdict-lesson schema/recall-compatibility, workflow never breaks on lesson failure, content search, curation disabled-by-default/parse-cap/NOTHING/error paths, curated-record posting.

Contract suite: 4383 passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)