### PR TITLE
Lesson curation v2: dedup against existing lessons

### DIFF
--- a/src/mac/task_executor.py
+++ b/src/mac/task_executor.py
@@ -964,7 +964,10 @@ Outcome: {outcome} (evidence_type={evidence_type})
 Signals: {signals}
 Failure hint: {error_signature}
 
-Write 1-3 lessons, ONE PER LINE, no bullets or numbering. Each lesson must be a single self-contained sentence under 250 characters stating a reusable, project-specific fact or pitfall (environment quirks, commands that worked/failed, gotchas). Ground every lesson in the outcome above - do not speculate. If nothing generalizes beyond this one task, output exactly: NOTHING
+The project already knows these lessons:
+{existing}
+
+Write 1-3 NEW lessons, ONE PER LINE, no bullets or numbering. Each lesson must be a single self-contained sentence under 250 characters stating a reusable, project-specific fact or pitfall (environment quirks, commands that worked/failed, gotchas). Ground every lesson in the outcome above - do not speculate. Do NOT restate or rephrase anything the project already knows; only add what is genuinely novel. If nothing NEW generalizes beyond this one task, output exactly: NOTHING
 """
 
 
@@ -1004,7 +1007,15 @@ def curate_lessons_from_outcome(
     try:
         from mac.eval_runner import router_model_caller
 
+        # Show the curator what the project already knows (v2 dedup): the first
+        # live batch re-derived the same pushed=false insight across three
+        # failures. Best-effort — recall failure just means an empty list.
+        try:
+            existing = recall_deployment_lessons(task, limit=8)
+        except Exception:  # noqa: BLE001
+            existing = []
         prompt = _LESSON_CURATION_PROMPT.format(
+            existing="\n".join("- " + l for l in existing) or "- (none yet)",
             title=str(task.get("title") or "")[:200],
             outcome=outcome.get("outcome"),
             evidence_type=outcome.get("evidence_type"),

--- a/tests/test_outcome_grounded_lessons.py
+++ b/tests/test_outcome_grounded_lessons.py
@@ -108,3 +108,26 @@ def test_record_curated_lessons_posts_learning_records(monkeypatch):
     assert contents[0]["error_signature"] == "use the ppa git"
     assert all(c["signals"]["curated"] is True for c in contents)
     assert all(c["schema"] == "mac.deployment_learning.v1" for c in contents)
+
+
+def test_curation_prompt_includes_existing_lessons_for_dedup(monkeypatch):
+    # v2: the curator sees what the project already knows and is told to add
+    # only novel lessons (first live batch re-derived one insight three times).
+    monkeypatch.setenv("MAC_LESSON_CURATION_ENABLED", "1")
+    monkeypatch.setenv("MAC_ROUTER_URL", "http://router.test/v1")
+    monkeypatch.setenv("MAC_LESSON_CURATION_MODEL", "m")
+    monkeypatch.setattr(te, "recall_deployment_lessons",
+                        lambda task, limit=8: ["pushed=false means the delivery step failed"])
+    captured = {}
+
+    def factory(url, token=""):
+        def call(model, question, context):
+            captured["q"] = question
+            return ("NOTHING", [], 1.0)
+        return call
+
+    import mac.eval_runner as er
+    monkeypatch.setattr(er, "router_model_caller", factory)
+    te.curate_lessons_from_outcome({"title": "t", "metadata": {}}, {"outcome": "failure"})
+    assert "pushed=false means the delivery step failed" in captured["q"]
+    assert "genuinely novel" in captured["q"]


### PR DESCRIPTION
First live batch validated outcome grounding (six lessons, zero hallucinated) but re-derived one insight three times. The curator now sees the project's existing lessons and adds only what's novel.

Contract suite: green (see commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)