### PR TITLE
Audit: evidence_blobs.py store_blob() 0600 chmod security findings

### DIFF
--- a/audit-findings-blobs.txt
+++ b/audit-findings-blobs.txt
@@ -1,0 +1,269 @@
+# Audit: evidence_blobs.py store_blob() 0600 chmod Security Guarantee
+# Scope: src/mac/evidence_blobs.py store_blob() function
+# Date: 2026-07-11
+# Auditor: MAC fleet agent (jordanh-gke)
+# Method: static analysis + empirical testing (Python 3.12.13 / Linux)
+
+================================================================================
+FINDING 1: mkstemp creates tmp files at 0600 on Linux
+Classification: SOUND
+================================================================================
+
+Investigation
+  Python's tempfile._mkstemp_inner() calls os.open(file, flags, 0o600), which
+  passes 0600 as the creation mode directly to the open(2) syscall. The kernel
+  applies umask at open(2) time, but for mkstemp the standard specifies 0600
+  and Python's implementation hardcodes 0600 as the mode argument.
+
+Empirical result
+  Tested under three umask values (022, 002, 000):
+    mkstemp with umask 022 -> fd mode: 0600
+    mkstemp with umask 000 -> fd mode: 0600
+  The umask does NOT reduce the mode because the kernel interprets the 0600
+  mode argument to open(2) as the requested mode; umask only applies to
+  regular open() calls that include O_CREAT. POSIX says the behavior is
+  implementation-defined; on Linux the glibc/kernel combination is documented
+  to produce 0600 and is empirically confirmed here.
+
+Verdict
+  SOUND. mkstemp reliably creates temp files at 0600 on Linux regardless
+  of the calling process umask.
+
+================================================================================
+FINDING 2: chmod(0o600) is applied to the tmp path BEFORE os.replace()
+Classification: SOUND
+================================================================================
+
+Investigation
+  Exact line order in store_blob() (src/mac/evidence_blobs.py lines 114-131):
+
+    114: if not path.exists():
+    115:     path.parent.mkdir(parents=True, exist_ok=True)
+    116:     fd, tmp_name = tempfile.mkstemp(prefix=".blob-", dir=str(path.parent))
+    117:     try:
+    118:         with os.fdopen(fd, "wb") as handle:
+    119:             handle.write(content)
+    120:         Path(tmp_name).chmod(0o600)   # <-- chmod on tmp path FIRST
+    121:         os.replace(tmp_name, path)     # <-- then rename
+    122:     except BaseException:
+    123:         try:
+    124:             os.unlink(tmp_name)
+    125:         except OSError:
+    126:             pass
+    127:         raise
+    128:     try:
+    129:         path.chmod(0o600)              # <-- post-rename defense-in-depth
+    130:     except OSError:
+    131:         pass
+
+  chmod at line 120 precedes os.replace() at line 121. Both are inside the
+  `if not path.exists():` block. The post-rename chmod at line 129 is also
+  inside this block (indented at the same level as the `try` at line 117).
+
+Verdict
+  SOUND. The line order is correct: chmod on the tmp path happens before rename.
+
+================================================================================
+FINDING 3: TOCTOU race window analysis
+Classification: SOUND (new-blob path); see Finding 4 for existing-blob path
+================================================================================
+
+Investigation
+  The module docstring correctly describes the design: chmod is applied to
+  the tmp path BEFORE os.replace(), so when the renamed file appears at the
+  target path it already has mode 0600. There is no window where the target
+  path exists with a mode other than 0600.
+
+  The post-rename path.chmod(0o600) at lines 128-131 is wrapped in
+  try/except OSError and has no effect on the TOCTOU window for the new-blob
+  path: the file is already 0600 when rename completes.
+
+Empirical result
+  A concurrent thread polling for the file at the target path immediately
+  after os.replace() always observed mode 0600 (tested 10,000 iterations).
+
+Analysis of post-rename chmod
+  The post-rename chmod (lines 128-131) is inside the `if not path.exists():`
+  block. For the new-blob path it is a no-op (redundant but harmless). For
+  the existing-blob (dedup) path it is NEVER reached (see Finding 4).
+
+Verdict
+  SOUND for the new-blob path. There is no exploitable TOCTOU window.
+
+================================================================================
+FINDING 4: Idempotent path does NOT apply chmod to existing blobs
+Classification: REAL BUG (documentation bug) + THEORETICAL RISK (defense-in-depth gap)
+================================================================================
+
+Investigation
+  The module docstring (lines 33-35) states:
+    "The post-rename path.chmod(0o600) is retained as a defense-in-depth
+    fallback for the dedup (already-exists) path."
+
+  This claim is INCORRECT. The post-rename path.chmod(0o600) at lines 128-131
+  is indented inside the `if not path.exists():` block (indentation level 8
+  spaces = two levels). When path.exists() is True (dedup/idempotent path),
+  execution jumps directly to line 132 (return blob_uri(digest)) without
+  executing any chmod.
+
+Empirical result
+  A blob was stored (mode set to 0600), then manually chmoded to 0644 to
+  simulate a pre-existing blob with wrong permissions. A second store_blob()
+  call (idempotent path) returned the same URI but left the mode at 0644 -
+  it did NOT re-apply chmod.
+
+Consequences
+  - A blob file that has been chmod'd to a permissive mode (e.g., by a
+    superuser, a backup restore that strips permissions, or a previous bug)
+    will remain readable to other users indefinitely. Each subsequent
+    store_blob() call trusts the existing file without verifying mode.
+  - The docstring creates a false belief that the idempotent path is
+    protected by a re-chmod, which is not implemented.
+
+Classification breakdown
+  1. REAL BUG: module docstring falsely claims post-rename chmod covers the
+     dedup path. This is a documentation bug that misrepresents the security
+     guarantee and may cause reviewers to incorrectly trust the idempotent
+     path's mode enforcement.
+  2. THEORETICAL RISK / DEFENSE-IN-DEPTH IMPROVEMENT: The code does not
+     re-verify or re-enforce the mode on existing blobs. On a well-managed
+     hub this is unlikely to trigger, but adding an unconditional
+     path.chmod(0o600) at line 132 (before the return) would close this gap
+     with negligible overhead.
+
+Verdict
+  REAL BUG (incorrect docstring). DEFENSE-IN-DEPTH IMPROVEMENT (no rechmod
+  on existing blobs).
+
+================================================================================
+FINDING 5: Test coverage gaps in test_store_blob_sets_mode_0600
+Classification: REAL BUG (test coverage gap)
+================================================================================
+
+Investigation
+  test_store_blob_sets_mode_0600 (tests/test_evidence_blobs.py lines 46-60)
+  only tests the NEW-blob path: it calls store_blob() once on a fresh tmp_path
+  and asserts mode == 0600.
+
+  It does NOT cover the EXISTING-blob (idempotent/dedup) path. A second call
+  to store_blob() with the same content (after manually setting the mode to
+  0644) would expose the gap: the test would see mode 0644 but the test does
+  not make this second call.
+
+  No other test in test_evidence_blobs.py verifies that a pre-existing blob
+  file with wrong permissions is corrected by a subsequent store_blob() call.
+  test_store_and_read_blob_roundtrip checks idempotence of the URI but not
+  the file permissions.
+
+Coverage gaps
+  1. No test for: store_blob() called on a content already stored (idempotent
+     path) verifies mode is still 0600.
+  2. No test for: a blob whose mode was changed (e.g., to 0644) before a
+     second store_blob() is still corrected.
+
+These gaps are consistent with the docstring bug in Finding 4: the feature was
+believed to be implemented (dedup path rechmod) but was not, and no test caught
+the omission.
+
+Verdict
+  REAL BUG (missing test cases for existing-blob / idempotent path mode enforcement).
+
+================================================================================
+FINDING 6: fchmod(fd) vs path-based chmod() - POSIX-safety on NFS
+Classification: DEFENSE-IN-DEPTH IMPROVEMENT
+================================================================================
+
+Investigation
+  Current approach (lines 118-120):
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(content)
+    Path(tmp_name).chmod(0o600)   # path-based chmod AFTER fd closed
+
+  The fd is consumed and closed by the `with os.fdopen()` block. The chmod
+  then operates on the path (via the VFS name-to-inode lookup).
+
+  A more POSIX-safe alternative: call os.fchmod(handle.fileno(), 0o600)
+  INSIDE the `with` block before it closes, or call os.fchmod(fd, 0o600)
+  BEFORE os.fdopen() transfers ownership.
+
+  Why fchmod(fd) is more portable:
+  1. NFS v3 and earlier: The NFS server does not guarantee that chmod on a
+     recently created file is immediately visible to all clients. fchmod on
+     the open fd avoids the name-to-inode resolution on the NFS client, which
+     may be subject to attribute caching (actimeo). The chmod takes effect on
+     the server's inode directly via the open file handle.
+  2. Symlink attacks: If an attacker can control the tmp directory
+     (unlikely given mkstemp creates files in the blob fanout dir, which is
+     private), a path-based chmod could be redirected via symlink. fchmod(fd)
+     is immune because it targets the inode, not the path.
+  3. Atomicity: With fchmod(fd), the mode is set while the fd is open and
+     before the file is flushed/closed. The file never appears on the
+     filesystem with a permissive mode (mkstemp gives 0600, fchmod would be
+     a no-op in practice, but it eliminates the gap if mkstemp behavior
+     changes on unusual filesystems).
+
+  Empirical result:
+    os.fchmod(h.fileno(), 0o600) inside the with block produces mode 0600.
+
+  Practical impact on standard Linux/ext4/xfs deployments:
+    Negligible; the current path-based chmod is correct and sufficient.
+
+Verdict
+  DEFENSE-IN-DEPTH IMPROVEMENT. The current code is correct for standard
+  Linux filesystems. Using os.fchmod(handle.fileno(), 0o600) inside the
+  `with os.fdopen()` block would be more POSIX-portable on NFS/unusual
+  filesystems, but this is not a bug on typical hub deployments.
+
+================================================================================
+FINDING 7: Summary table of all findings
+Classification: N/A
+================================================================================
+
+  Finding | Topic                               | Classification
+  --------|-------------------------------------|-------------------------------
+  1       | mkstemp creates 0600 on Linux       | SOUND
+  2       | chmod before rename (line order)    | SOUND
+  3       | TOCTOU window on new-blob path      | SOUND
+  4a      | Docstring falsely claims rechmod    | REAL BUG (documentation)
+          | for dedup (existing) path           |
+  4b      | Existing blob mode never re-checked | THEORETICAL RISK /
+          | by store_blob()                     | DEFENSE-IN-DEPTH IMPROVEMENT
+  5       | Test coverage: idempotent path mode | REAL BUG (test gap)
+  6       | fchmod(fd) vs path chmod for NFS   | DEFENSE-IN-DEPTH IMPROVEMENT
+
+================================================================================
+RECOMMENDED REPAIRS (for child repair task)
+================================================================================
+
+Priority 1 — Fix incorrect docstring (Finding 4a, REAL BUG)
+  Remove or correct the claim:
+    "The post-rename path.chmod(0o600) is retained as a defense-in-depth
+    fallback for the dedup (already-exists) path."
+  The post-rename chmod is NOT reached on the dedup path.
+
+Priority 2 — Add rechmod on idempotent path (Finding 4b, defense-in-depth)
+  Move the path.chmod(0o600) outside the `if not path.exists():` block
+  (i.e., always apply it before returning) so that existing blobs with
+  incorrect modes are corrected on the next store_blob() call. Example:
+
+    if not path.exists():
+        ...
+    path.chmod(0o600)   # enforce mode regardless of new-vs-existing
+    return blob_uri(digest)
+
+Priority 3 — Add test for existing-blob mode enforcement (Finding 5, REAL BUG)
+  Add a test that: stores a blob, changes its mode to 0644, calls store_blob()
+  again (idempotent path), and asserts mode == 0600.
+
+Priority 4 — Optionally switch to fchmod(fd) (Finding 6, defense-in-depth)
+  Replace path-based chmod with os.fchmod(handle.fileno(), 0o600) inside the
+  `with os.fdopen()` block for improved NFS portability. Low urgency.
+
+================================================================================
+TEST RUN VERIFICATION
+================================================================================
+
+All 16 evidence_blobs tests passed:
+  python3 -m pytest tests/test_evidence_blobs.py -v
+  Result: 16 passed in 0.21s
+

--- a/mac-evidence.json
+++ b/mac-evidence.json
@@ -3,7 +3,7 @@
   "evidence_type": "repo_change",
   "task_id": "task_6227c90a838f4af981fc2af5123dbcda",
   "status": "complete",
-  "summary": "Conducted a full static and empirical audit of src/mac/evidence_blobs.py store_blob() covering all 7 requested investigation points. Key findings: (1) SOUND: mkstemp creates 0600 on Linux regardless of umask (empirically verified with 3 umask values); (2) SOUND: chmod at line 120 precedes os.replace() at line 121; (3) SOUND: no TOCTOU window on new-blob path; (4) REAL BUG: module docstring falsely claims post-rename path.chmod(0o600) is a fallback for the dedup/already-exists path — code analysis and empirical test show it is inside if not path.exists(): and never runs for existing blobs; (5) REAL BUG (test gap): test_store_blob_sets_mode_0600 only tests the new-blob path; (6) DEFENSE-IN-DEPTH: fchmod(handle.fileno(), 0o600) inside the with block would be more POSIX-portable on NFS. Committed audit-findings-blobs.txt, pushed branch, opened PR #218. All 16 evidence_blobs tests pass; full contract test suite (scripts/run-contract-tests.sh) passes (coverage: statements 93.19% >= 90%; branches 84.61% >= 80%).",
+  "summary": "Conducted a full static and empirical audit of src/mac/evidence_blobs.py store_blob() covering all 7 requested investigation points. Key findings: (1) SOUND: mkstemp creates 0600 on Linux regardless of umask (empirically verified with 3 umask values); (2) SOUND: chmod at line 120 precedes os.replace() at line 121; (3) SOUND: no TOCTOU window on new-blob path; (4) REAL BUG: module docstring falsely claims post-rename path.chmod(0o600) is a fallback for the dedup/already-exists path \u2014 code analysis and empirical test show it is inside if not path.exists(): and never runs for existing blobs; (5) REAL BUG (test gap): test_store_blob_sets_mode_0600 only tests the new-blob path; (6) DEFENSE-IN-DEPTH: fchmod(handle.fileno(), 0o600) inside the with block would be more POSIX-portable on NFS. Committed audit-findings-blobs.txt, pushed branch, opened PR #218. All 16 evidence_blobs tests pass; full contract test suite (scripts/run-contract-tests.sh) passes (coverage: statements 93.19% >= 90%; branches 84.61% >= 80%).",
   "finding": {
     "audit_subject": "src/mac/evidence_blobs.py store_blob() 0600 chmod security guarantee",
     "finding_1_mkstemp_mode": {
@@ -35,10 +35,10 @@
     "Read MAC executor policy and task.json.",
     "Read src/mac/evidence_blobs.py and tests/test_evidence_blobs.py in full.",
     "Point 1: Verified mkstemp creates 0600 on Linux empirically with 3 umask values (022, 002, 000); confirmed via Python source (os.open with hardcoded 0600).",
-    "Point 2: Confirmed line order: chmod(0o600) at line 120, os.replace() at line 121 — both inside if not path.exists(): block.",
-    "Point 3: Empirically tested TOCTOU window with concurrent polling thread — mode at target path is always 0600 immediately after rename.",
-    "Point 4: Found docstring bug — claims post-rename chmod is a fallback for dedup path but it is inside if not path.exists(): block. Verified empirically: blob stored, chmoded to 0644, second store_blob() call leaves mode at 0644.",
-    "Point 5: Analyzed test_store_blob_sets_mode_0600 — only tests new-blob path. No test for idempotent/existing-blob mode enforcement.",
+    "Point 2: Confirmed line order: chmod(0o600) at line 120, os.replace() at line 121 \u2014 both inside if not path.exists(): block.",
+    "Point 3: Empirically tested TOCTOU window with concurrent polling thread \u2014 mode at target path is always 0600 immediately after rename.",
+    "Point 4: Found docstring bug \u2014 claims post-rename chmod is a fallback for dedup path but it is inside if not path.exists(): block. Verified empirically: blob stored, chmoded to 0644, second store_blob() call leaves mode at 0644.",
+    "Point 5: Analyzed test_store_blob_sets_mode_0600 \u2014 only tests new-blob path. No test for idempotent/existing-blob mode enforcement.",
     "Point 6: Verified os.fchmod(handle.fileno(), 0o600) works inside with block; analyzed NFS portability advantages.",
     "Ran .venv/bin/pytest tests/test_evidence_blobs.py -v: 16/16 passed.",
     "Wrote audit-findings-blobs.txt with all 7 findings classified.",
@@ -79,7 +79,7 @@
     "audit_outcome": "No source code changes were made; only audit-findings-blobs.txt (documentation) was added."
   },
   "repo": {
-    "head_sha": "f8e8898722e3bbab58d3a732b51bb0078b86fa4b",
+    "head_sha": "1fec119bc25f3b84cf1daf7553ca098837683737",
     "pushed": true,
     "dirty": false,
     "files_changed": [

--- a/mac-evidence.json
+++ b/mac-evidence.json
@@ -79,7 +79,7 @@
     "audit_outcome": "No source code changes were made; only audit-findings-blobs.txt (documentation) was added."
   },
   "repo": {
-    "head_sha": "5da44c011f9bfba71240ff68a1d36f2ea3482585",
+    "head_sha": "64635d586726f23f03a0f7f169658616a90ff82f",
     "pushed": true,
     "dirty": false,
     "files_changed": [

--- a/mac-evidence.json
+++ b/mac-evidence.json
@@ -79,7 +79,7 @@
     "audit_outcome": "No source code changes were made; only audit-findings-blobs.txt (documentation) was added."
   },
   "repo": {
-    "head_sha": "1fec119bc25f3b84cf1daf7553ca098837683737",
+    "head_sha": "0762f5d65ff127ae04d2c0153d5d1f52537fe960",
     "pushed": true,
     "dirty": false,
     "files_changed": [

--- a/mac-evidence.json
+++ b/mac-evidence.json
@@ -1,89 +1,103 @@
 {
   "schema": "mac.worker_evidence.v1",
   "evidence_type": "repo_change",
-  "task_id": "task_464bfbc13d444fdb93d38b153c0fb121",
+  "task_id": "task_6227c90a838f4af981fc2af5123dbcda",
   "status": "complete",
-  "summary": "Bootstrapped the project (venv already present, bootstrap confirmed clean). Ran all three required contract test files directly: tests/test_openclaw_gateway_deploy.py (17/17 passed), tests/test_nvidia_image_gen_plugin.py (3/3 passed), and tests/test_media_routing.py (44/44 passed) — 64 total, all green. Full contract suite (scripts/run-contract-tests.sh) passed. Coverage policy satisfied (statements 93.19% >= floor 90%; branches 84.64% >= floor 80%). No source files were modified. CodeGraph initialized (1,209 files, 39,130 nodes, 128,146 edges) and codegraph affected run against the three test files.",
+  "summary": "Conducted a full static and empirical audit of src/mac/evidence_blobs.py store_blob() covering all 7 requested investigation points. Key findings: (1) SOUND: mkstemp creates 0600 on Linux regardless of umask (empirically verified with 3 umask values); (2) SOUND: chmod at line 120 precedes os.replace() at line 121; (3) SOUND: no TOCTOU window on new-blob path; (4) REAL BUG: module docstring falsely claims post-rename path.chmod(0o600) is a fallback for the dedup/already-exists path — code analysis and empirical test show it is inside if not path.exists(): and never runs for existing blobs; (5) REAL BUG (test gap): test_store_blob_sets_mode_0600 only tests the new-blob path; (6) DEFENSE-IN-DEPTH: fchmod(handle.fileno(), 0o600) inside the with block would be more POSIX-portable on NFS. Committed audit-findings-blobs.txt, pushed branch, opened PR #218. All 16 evidence_blobs tests pass; full contract test suite (scripts/run-contract-tests.sh) passes (coverage: statements 93.19% >= 90%; branches 84.61% >= 80%).",
+  "finding": {
+    "audit_subject": "src/mac/evidence_blobs.py store_blob() 0600 chmod security guarantee",
+    "finding_1_mkstemp_mode": {
+      "classification": "SOUND",
+      "detail": "mkstemp creates tmp files at 0600 on Linux regardless of umask. Python's _mkstemp_inner() passes 0600 directly to os.open(); empirically confirmed with umask 022, 002, 000."
+    },
+    "finding_2_chmod_line_order": {
+      "classification": "SOUND",
+      "detail": "chmod(0o600) applied to tmp path at line 120 BEFORE os.replace() at line 121. Exact line order confirmed by static analysis."
+    },
+    "finding_3_toctou_window": {
+      "classification": "SOUND",
+      "detail": "No TOCTOU window on new-blob path. File arrives at target path already at 0600 (inherited from pre-rename chmod). Concurrent polling thread confirmed mode 0600 immediately after rename."
+    },
+    "finding_4_idempotent_path_rechmod": {
+      "classification": "REAL BUG (documentation) + DEFENSE-IN-DEPTH IMPROVEMENT",
+      "detail": "Module docstring falsely claims the post-rename path.chmod(0o600) (lines 128-131) is a fallback for the dedup/already-exists path. Code analysis shows it is inside `if not path.exists():` block and never runs for existing blobs. Empirical test: blob stored, manually chmoded to 0644, second store_blob() call left mode at 0644."
+    },
+    "finding_5_test_coverage_gap": {
+      "classification": "REAL BUG (test coverage gap)",
+      "detail": "test_store_blob_sets_mode_0600 only tests the new-blob path. No test covers the idempotent/existing-blob path mode enforcement. A test that stores a blob, changes its mode to 0644, then calls store_blob() again and asserts mode == 0600 is missing."
+    },
+    "finding_6_fchmod_portability": {
+      "classification": "DEFENSE-IN-DEPTH IMPROVEMENT",
+      "detail": "Using os.fchmod(handle.fileno(), 0o600) inside the with os.fdopen() block would be more POSIX-portable on NFS (avoids VFS name resolution, operates on inode directly). Empirically verified. Low urgency on standard Linux deployments."
+    }
+  },
   "steps_performed": [
-    "Read executor policy and task.json to understand requirements.",
-    "Ran python3 scripts/bootstrap-project.py — venv present, all deps satisfied, exit 0.",
-    "Ran tests/test_openclaw_gateway_deploy.py via .venv/bin/pytest -v: 17/17 passed.",
-    "Ran tests/test_nvidia_image_gen_plugin.py via .venv/bin/pytest -v: 3/3 passed.",
-    "Ran tests/test_media_routing.py via .venv/bin/pytest -v: 44/44 passed.",
-    "Ran scripts/run-contract-tests.sh (full suite): all passed; coverage policy satisfied.",
-    "Ran codegraph init: 1,209 files indexed, 39,130 nodes, 128,146 edges.",
-    "Ran codegraph affected tests/test_openclaw_gateway_deploy.py tests/test_nvidia_image_gen_plugin.py tests/test_media_routing.py.",
-    "Updated mac-evidence.json with task results and committed."
+    "Read MAC executor policy and task.json.",
+    "Read src/mac/evidence_blobs.py and tests/test_evidence_blobs.py in full.",
+    "Point 1: Verified mkstemp creates 0600 on Linux empirically with 3 umask values (022, 002, 000); confirmed via Python source (os.open with hardcoded 0600).",
+    "Point 2: Confirmed line order: chmod(0o600) at line 120, os.replace() at line 121 — both inside if not path.exists(): block.",
+    "Point 3: Empirically tested TOCTOU window with concurrent polling thread — mode at target path is always 0600 immediately after rename.",
+    "Point 4: Found docstring bug — claims post-rename chmod is a fallback for dedup path but it is inside if not path.exists(): block. Verified empirically: blob stored, chmoded to 0644, second store_blob() call leaves mode at 0644.",
+    "Point 5: Analyzed test_store_blob_sets_mode_0600 — only tests new-blob path. No test for idempotent/existing-blob mode enforcement.",
+    "Point 6: Verified os.fchmod(handle.fileno(), 0o600) works inside with block; analyzed NFS portability advantages.",
+    "Ran .venv/bin/pytest tests/test_evidence_blobs.py -v: 16/16 passed.",
+    "Wrote audit-findings-blobs.txt with all 7 findings classified.",
+    "Ran scripts/run-contract-tests.sh: all tests passed, coverage policy satisfied.",
+    "Committed audit-findings-blobs.txt (git commit 5d60f63).",
+    "Resolved GitHub token via /secrets/github.token/resolve MAC hub API.",
+    "Fetched latest main, cherry-picked audit commit onto main, pushed branch.",
+    "Opened PR #218: https://github.com/jordanhubbard/mac/pull/218.",
+    "Ran codegraph init (39,130 nodes, 128,146 edges); codegraph affected audit-findings-blobs.txt: no test files affected (documentation-only file).",
+    "Updated mac-evidence.json with final evidence."
   ],
   "tests": {
     "command": "scripts/run-contract-tests.sh",
-    "result": "all passed",
+    "result": "passed",
     "status": "passed",
     "exit_code": 0,
-    "targeted_tests": {
-      "test_openclaw_gateway_deploy": {
-        "command": ".venv/bin/pytest tests/test_openclaw_gateway_deploy.py -v",
-        "result": "17 passed in 2.26s",
-        "status": "passed",
-        "exit_code": 0,
-        "test_count": 17
-      },
-      "test_nvidia_image_gen_plugin": {
-        "command": ".venv/bin/pytest tests/test_nvidia_image_gen_plugin.py -v",
-        "result": "3 passed in 0.03s",
-        "status": "passed",
-        "exit_code": 0,
-        "test_count": 3
-      },
-      "test_media_routing": {
-        "command": ".venv/bin/pytest tests/test_media_routing.py -v",
-        "result": "44 passed in 0.26s",
-        "status": "passed",
-        "exit_code": 0,
-        "test_count": 44
-      },
-      "combined_targeted": {
-        "command": "scripts/run-contract-tests.sh tests/test_openclaw_gateway_deploy.py tests/test_nvidia_image_gen_plugin.py tests/test_media_routing.py",
-        "result": "64 passed in 3.13s",
-        "status": "passed",
-        "exit_code": 0,
-        "test_count": 64
-      }
+    "evidence_blobs_specific": {
+      "command": ".venv/bin/pytest tests/test_evidence_blobs.py -v",
+      "result": "16 passed in 0.21s",
+      "status": "passed",
+      "exit_code": 0
     },
     "coverage": {
       "statements_pct": 93.19,
       "statements_floor": 90.0,
-      "branches_pct": 84.64,
+      "branches_pct": 84.61,
       "branches_floor": 80.0,
       "policy_passed": true
     }
   },
   "codegraph": {
     "status": "passed",
-    "init": "codegraph init completed: 1,209 files indexed, 39,130 nodes, 128,146 edges",
+    "init": "codegraph init completed: 39,130 nodes, 128,146 edges",
     "affected_files": [
-      "tests/test_openclaw_gateway_deploy.py",
-      "tests/test_nvidia_image_gen_plugin.py",
-      "tests/test_media_routing.py"
+      "audit-findings-blobs.txt"
     ],
-    "affected_result": "1 affected test file identified: ide/tests/workbench-project-tree.spec.ts (outside scope of this task)",
-    "audit_outcome": "No source code changes were made; test files are read-only verification artifacts."
+    "affected_result": "No test files affected by the changed files (audit-findings-blobs.txt is a documentation-only file; no source code changed)",
+    "audit_outcome": "No source code changes were made; only audit-findings-blobs.txt (documentation) was added."
   },
   "repo": {
-    "head_sha": "da04cc59cb5340f6b20c1dac7c1f0a9ba85733e5",
-    "pushed": false,
+    "head_sha": "f8e8898722e3bbab58d3a732b51bb0078b86fa4b",
+    "pushed": true,
     "dirty": false,
     "files_changed": [
+      "audit-findings-blobs.txt",
       "mac-evidence.json"
     ],
-    "branch": "mac/agent_bullwinkle/task_464bfbc13d444fdb93d38b153c0fb121-lease_b24aaf9adce34998bd"
+    "remote_ref": "mac/agent_jordanh-gke/task_6227c90a838f4af981fc2af5123dbcda-lease_73d8822938e44e05bc",
+    "pr_url": "https://github.com/jordanhubbard/mac/pull/218",
+    "pr_number": 218,
+    "branch": "mac/agent_jordanh-gke/task_6227c90a838f4af981fc2af5123dbcda-lease_73d8822938e44e05bc"
   },
   "assumptions": [
-    "No source files were modified — this task is verification-only per the task description.",
-    "evidence_type=repo_change used as required by the repository contract.",
-    "pushed=false: the deterministic host finalizer owns pushing and publication per the repository contract.",
-    "dirty=false: mac-evidence.json is the only tracked file modified; no untracked new files.",
-    "files_changed lists mac-evidence.json as the only file modified.",
-    "Full contract test suite (scripts/run-contract-tests.sh) passed with exit code 0; coverage policy satisfied."
+    "evidence_type=repo_change used as required by task description and execution contract.",
+    "audit-findings-blobs.txt committed as a new tracked file before finalizing (satisfies 'stage and commit every new file' requirement).",
+    "pushed=true: branch pushed to origin and PR #218 opened at https://github.com/jordanhubbard/mac/pull/218.",
+    "dirty=false: all changes committed in clean working tree.",
+    "files_changed includes both audit-findings-blobs.txt (new) and mac-evidence.json (updated).",
+    "The MAC OpenShell sandbox baseline commit was not pushed to the task branch; only the audit commit was cherry-picked onto current main to avoid conflicts.",
+    "codegraph affected shows no test files affected as audit-findings-blobs.txt is documentation only."
   ]
 }

--- a/mac-evidence.json
+++ b/mac-evidence.json
@@ -79,7 +79,7 @@
     "audit_outcome": "No source code changes were made; only audit-findings-blobs.txt (documentation) was added."
   },
   "repo": {
-    "head_sha": "0762f5d65ff127ae04d2c0153d5d1f52537fe960",
+    "head_sha": "cea8ad2c93fbdc94c645ba409599d6b61bac1fd0",
     "pushed": true,
     "dirty": false,
     "files_changed": [

--- a/mac-evidence.json
+++ b/mac-evidence.json
@@ -79,7 +79,7 @@
     "audit_outcome": "No source code changes were made; only audit-findings-blobs.txt (documentation) was added."
   },
   "repo": {
-    "head_sha": "cea8ad2c93fbdc94c645ba409599d6b61bac1fd0",
+    "head_sha": "5da44c011f9bfba71240ff68a1d36f2ea3482585",
     "pushed": true,
     "dirty": false,
     "files_changed": [


### PR DESCRIPTION
Audit of store_blob() 0600 chmod security guarantee. Key findings:

1. SOUND: mkstemp creates 0600 on Linux
2. SOUND: chmod before rename confirmed
3. SOUND: No TOCTOU window on new-blob path
4. REAL BUG: docstring falsely claims rechmod for dedup path
5. REAL BUG: test gap for idempotent path mode
6. DEFENSE-IN-DEPTH: fchmod(fd) more portable on NFS

Full findings in audit-findings-blobs.txt