### PR TITLE
MAC task task_aaa547bc8065463c88ada06a95855268: Repair environment prerequisites: Add disk space preflight check

### DIFF
--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -2515,7 +2515,23 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, RepoPrepMixin, RuntimeDepsMixi
             return True
         return False
 
+    _WORKSPACE_MIN_FREE_BYTES: int = 512 * 1024 * 1024
+
     def _prepare_task_workspace(self, task: JsonDict, lease: JsonDict) -> Path:
+        try:
+            check_path = self.workspace if self.workspace.exists() else self.workspace.parent
+            usage = shutil.disk_usage(check_path)
+            if usage.free < self._WORKSPACE_MIN_FREE_BYTES:
+                free_mb = usage.free // (1024 * 1024)
+                raise OSError(
+                    28,
+                    "Not enough disk space to prepare task workspace "
+                    "(%d MiB free, need %d MiB)"
+                    % (free_mb, self._WORKSPACE_MIN_FREE_BYTES // (1024 * 1024)),
+                    str(self.workspace),
+                )
+        except OSError:
+            raise
         task_dir = self.workspace / _safe_path_component(task["id"])
         task_dir.mkdir(parents=True, exist_ok=True)
         repository_context = self._prepare_repository_worktree(task, lease, task_dir)

--- a/tests/test_worker_misc_edges.py
+++ b/tests/test_worker_misc_edges.py
@@ -481,3 +481,55 @@ def test_sandbox_verification_item_hub_verify_non_dict_json_returns_deferred(tmp
     assert item is not None
     assert worker._is_hub_verify_deferred_item(item)
 
+
+
+def test_prepare_task_workspace_raises_when_disk_space_below_minimum(
+    tmp_path, monkeypatch
+) -> None:
+    """_prepare_task_workspace raises OSError when free disk space is insufficient."""
+    from collections import namedtuple
+
+    DiskUsage = namedtuple("usage", ["total", "used", "free"])
+    fake_usage = DiskUsage(total=10 * 1024**3, used=9 * 1024**3, free=100 * 1024**2)
+    monkeypatch.setattr("mac.worker.shutil.disk_usage", lambda _path: fake_usage)
+
+    instance = _worker(tmp_path)
+    task = {"id": "task_disk_check", "project": "mac", "metadata": {}}
+    lease = {"id": "lease_disk_check", "agent_id": "agent_test"}
+
+    with pytest.raises(OSError) as exc_info:
+        instance._prepare_task_workspace(task, lease)
+
+    assert "Not enough disk space" in str(exc_info.value)
+    assert "100" in str(exc_info.value)
+    assert "512" in str(exc_info.value)
+
+
+def test_prepare_task_workspace_proceeds_when_disk_space_sufficient(
+    tmp_path, monkeypatch
+) -> None:
+    """_prepare_task_workspace does not raise when disk space exceeds minimum."""
+    from collections import namedtuple
+
+    DiskUsage = namedtuple("usage", ["total", "used", "free"])
+    free_bytes = 2 * 1024**3
+    fake_usage = DiskUsage(total=10 * 1024**3, used=8 * 1024**3, free=free_bytes)
+    monkeypatch.setattr("mac.worker.shutil.disk_usage", lambda _path: fake_usage)
+
+    prepared_dirs = []
+
+    def fake_prepare_repo(task, lease, task_dir):
+        prepared_dirs.append(task_dir)
+        return None
+
+    instance = _worker(tmp_path)
+    monkeypatch.setattr(instance, "_prepare_repository_worktree", fake_prepare_repo)
+    monkeypatch.setattr(instance, "_is_onboarding_task", lambda _task: False)
+
+    task = {"id": "task_disk_ok", "project": "mac", "metadata": {}}
+    lease = {"id": "lease_disk_ok", "agent_id": "agent_test"}
+
+    result = instance._prepare_task_workspace(task, lease)
+
+    assert result.exists()
+    assert len(prepared_dirs) == 1


### PR DESCRIPTION
Repair environment prerequisite for parent tasks that failed with "No space left on device".

Adds a disk space preflight check to `_prepare_task_workspace` that raises a clear `OSError` (errno 28) before attempting to create the workspace directory when free disk space is below 512 MiB. This converts opaque `worker_exception` failures into diagnostic messages.

**Files changed:**
- `src/mac/worker.py`: `_WORKSPACE_MIN_FREE_BYTES` class constant and disk usage check
- `tests/test_worker_misc_edges.py`: two new tests for the disk space guard

**Contract verification:** 5954 passed, 21 skipped; coverage 92.87%/84.15%

Task: task_aaa547bc8065463c88ada06a95855268  
Agent: agent_rocky  
Base SHA: 1870189bf6ac2bf6afe26cd25d7280aa8a64a9f4  
Head SHA: 0b29d3b40f8ee69a13ec80ab7ac5133947bfe6d9