### PR TITLE
MAC task task_00673d196a254f2493318a664f487b16: Add CLI test for fleet soul-audit and list_dir edge-case coverage

### DIFF
--- a/tests/cli/test_cli_operational_paths.py
+++ b/tests/cli/test_cli_operational_paths.py
@@ -375,3 +375,57 @@ def test_sender_agent_id_requires_explicit_control_identity(monkeypatch):
         cli._sender_agent_id(SimpleNamespace(sender_agent_id=None))
     monkeypatch.setenv("MAC_WORKER_AGENT_ID", "agent_worker")
     assert cli._sender_agent_id(SimpleNamespace(sender_agent_id=None)) == "agent_worker"
+
+
+def test_fleet_soul_audit_happy_path(tmp_path, monkeypatch, capsys):
+    from mac import soul_snapshot
+
+    registry = _registry(tmp_path)
+
+    audit_result = {
+        "schema": "mac.hermes_salvage_audit.v1",
+        "agent": "rocky",
+        "target": "mac@source",
+        "audited_at": "20260101T000000Z",
+        "files": ["SOUL.md", "USER.md"],
+        "file_count": 2,
+        "error": None,
+    }
+    monkeypatch.setattr(soul_snapshot, "hermes_salvage_audit", lambda *_a, **_kw: audit_result)
+
+    result = cli.main(
+        [
+            "fleet",
+            "soul-audit",
+            "--agent",
+            "rocky",
+            "--fleet",
+            "source",
+            "--fleets-config",
+            str(registry),
+        ]
+    )
+    assert result == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["agent"] == "rocky"
+
+
+def test_fleet_soul_audit_unknown_agent_raises(tmp_path, monkeypatch):
+    from mac import soul_snapshot
+
+    registry = _registry(tmp_path)
+
+    with pytest.raises(SystemExit, match="not found in fleet"):
+        cli.main(
+            [
+                "fleet",
+                "soul-audit",
+                "--agent",
+                "no-such-agent",
+                "--fleet",
+                "source",
+                "--fleets-config",
+                str(registry),
+            ]
+        )

--- a/tests/test_soul_snapshot_edges.py
+++ b/tests/test_soul_snapshot_edges.py
@@ -177,3 +177,23 @@ def test_ssh_transport_list_dir_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     transport = snapshot.SSHTransport()
     monkeypatch.setattr(snapshot.subprocess, "run", lambda *a, **kw: _result(0, ""))
     assert transport.list_dir("host") == []
+
+
+def test_ssh_transport_list_dir_skips_blank_lines(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_dir silently skips empty/blank lines in find output (line 181 branch)."""
+    transport = snapshot.SSHTransport()
+    # Include a blank line and a whitespace-only line mixed with real paths
+    output = "/home/agent/.hermes/SOUL.md\n\n  \n/home/agent/.hermes/USER.md\n"
+    monkeypatch.setattr(snapshot.subprocess, "run", lambda *a, **kw: _result(0, output))
+    paths = transport.list_dir("host")
+    assert paths == ["SOUL.md", "USER.md"]
+
+
+def test_ssh_transport_list_dir_passthrough_without_hermes_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """list_dir passes through a path unchanged when the .hermes/ prefix is absent (line 187 branch)."""
+    transport = snapshot.SSHTransport()
+    # A path that does not contain the '.hermes/' substring at all
+    output = "/some/other/path/file.txt\n"
+    monkeypatch.setattr(snapshot.subprocess, "run", lambda *a, **kw: _result(0, output))
+    paths = transport.list_dir("host")
+    assert paths == ["/some/other/path/file.txt"]


### PR DESCRIPTION
Adds CLI test for fleet soul-audit and list_dir edge-case coverage.

Tests added:
- tests/test_soul_snapshot_edges.py (edge-case coverage)
- tests/cli/test_cli_operational_paths.py (CLI operational paths)

All 21 targeted tests pass.