### PR TITLE
Seed run-gui hub prompt default from ~/.mac/fleets.yaml

### DIFF
--- a/src/mac/ide_launcher.py
+++ b/src/mac/ide_launcher.py
@@ -312,6 +312,59 @@ def _api_url_for_hub_target(raw: str, *, default_port: int) -> str:
     return "http://%s:%d" % (host, port)
 
 
+def _fleet_prompt_default(env: Mapping[str, str]) -> "tuple[str, int]":
+    """Best-effort hub URL + control port from ``~/.mac/fleets.yaml``.
+
+    A managed login profile's ``api_url`` is an ephemeral loopback SSH-tunnel
+    port that changes every launch, so it is a poor prompt default and forces
+    the operator to re-enter the real hub each time. The fleet registry already
+    records the canonical hub, so we seed the prompt from it: honour
+    ``IDE_FLEET``/``MAC_FLEET`` when set, otherwise use the registry's default
+    fleet. Any problem (no registry, unset ``hub_url``, parse error, multiple
+    fleets with no default) yields ``("", 0)`` so the caller falls back to the
+    profile/tunnel default and the prompt still works. The path is resolved from
+    the caller-supplied ``env`` (via ``MAC_FLEETS_CONFIG``) so tests stay
+    hermetic; only when that is unset do we read the real ``~/.mac`` location.
+    """
+
+    try:
+        from mac.fleet_ssh import (
+            fleet_entries,
+            load_fleet_config,
+            resolve_fleet_key,
+        )
+    except Exception:
+        return ("", 0)
+
+    explicit = _value(env, "MAC_FLEETS_CONFIG")
+    path = (
+        Path(explicit).expanduser()
+        if explicit
+        else Path.home() / ".mac" / "fleets.yaml"
+    )
+    if not path.is_file():
+        return ("", 0)
+    fleet = _value(env, "IDE_FLEET") or _value(env, "MAC_FLEET")
+    try:
+        config = load_fleet_config(str(path))
+        entry = fleet_entries(config)[resolve_fleet_key(config, fleet or None)]
+    except Exception:
+        return ("", 0)
+
+    raw = str(entry.get("hub_url") or "").strip()
+    if not raw:
+        return ("", 0)
+    try:
+        api_url = _validated_api_url(raw)
+    except IdeLauncherError:
+        return ("", 0)
+    try:
+        port = int(entry.get("control_port") or 0)
+    except (TypeError, ValueError):
+        port = 0
+    return (api_url, port if 1 <= port <= 65535 else 0)
+
+
 def prompt_for_ide_connection(
     connection: IdeConnection,
     env: Optional[Mapping[str, str]] = None,
@@ -322,9 +375,12 @@ def prompt_for_ide_connection(
     """Let an interactive operator select the hub before Vite starts.
 
     Explicit ``IDE_API_URL`` values and non-interactive launches remain
-    prompt-free. Bare hosts use the hub's remote API port rather than the
-    profile's ephemeral local tunnel port. The selected URL still flows through
-    Vite's local proxy, so a managed profile token never enters browser storage.
+    prompt-free. The prompt default is seeded from ``~/.mac/fleets.yaml`` (the
+    canonical hub) when available, falling back to the profile connection; this
+    means pressing Enter reaches the real hub instead of a stale loopback tunnel
+    port. Bare hosts use the hub's remote API port rather than the profile's
+    ephemeral local tunnel port. The selected URL still flows through Vite's
+    local proxy, so a managed profile token never enters browser storage.
     """
 
     values = os.environ if env is None else env
@@ -334,27 +390,36 @@ def prompt_for_ide_connection(
     if not should_prompt:
         return connection
 
+    default = connection
+    fleet_url, fleet_port = _fleet_prompt_default(values)
+    if fleet_url:
+        default = replace(
+            connection,
+            api_url=fleet_url,
+            hub_port=fleet_port or connection.hub_port,
+        )
+
     read = input if input_fn is None else input_fn
     while True:
         try:
             entered = read(
                 "Target hub host or IP "
                 "[Enter keeps %s; direct port %d]: "
-                % (connection.api_url, connection.hub_port)
+                % (default.api_url, default.hub_port)
             ).strip()
         except EOFError:
-            return connection
+            return default
         if not entered:
-            return connection
+            return default
         try:
             api_url = _api_url_for_hub_target(
                 entered,
-                default_port=connection.hub_port,
+                default_port=default.hub_port,
             )
         except IdeLauncherError as exc:
             print("Invalid hub target: %s" % exc, file=sys.stderr)
             continue
-        return replace(connection, api_url=api_url)
+        return replace(default, api_url=api_url)
 
 
 def build_vite_environment(

--- a/tests/test_ide_launcher.py
+++ b/tests/test_ide_launcher.py
@@ -7,6 +7,10 @@ import pytest
 
 from mac import ide_launcher
 
+# Point the fleet-registry lookup at a path that does not exist so prompt tests
+# stay hermetic regardless of the developer's real ``~/.mac/fleets.yaml``.
+_NO_FLEETS = {"MAC_FLEETS_CONFIG": "/nonexistent/mac-fleets.yaml"}
+
 
 def _profile(*, token: str = "profile-token", api_url: str = "http://127.0.0.1:48789"):
     return {
@@ -200,7 +204,7 @@ def test_interactive_prompt_selects_hub_without_changing_managed_auth() -> None:
 
     selected = ide_launcher.prompt_for_ide_connection(
         connection,
-        {},
+        _NO_FLEETS,
         interactive=True,
         input_fn=lambda prompt: prompts.append(prompt) or "192.0.2.10",
     )
@@ -218,6 +222,96 @@ def test_interactive_prompt_selects_hub_without_changing_managed_auth() -> None:
     )
 
 
+def _write_fleets(tmp_path, *, hub_url: str, control_port: int = 8789):
+    path = tmp_path / "fleets.yaml"
+    path.write_text(
+        "version: 1\n"
+        "fleets:\n"
+        "  rocky:\n"
+        "    default: true\n"
+        "    hub_url: %s\n"
+        "    control_port: %d\n" % (hub_url, control_port),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_prompt_default_seeds_hub_from_fleets_registry(tmp_path) -> None:
+    """The prompt default (and Enter) must come from ~/.mac/fleets.yaml, not the
+    profile's ephemeral loopback tunnel port."""
+    fleets = _write_fleets(tmp_path, hub_url="http://100.72.16.110:8789")
+    connection = ide_launcher.IdeConnection(
+        api_url="http://127.0.0.1:48789",  # stale per-launch SSH-tunnel port
+        token="profile-token",
+        source="client-profile:default",
+        profile="default",
+        hub_port=48789,
+    )
+    prompts: list[str] = []
+
+    # Pressing Enter accepts the fleet hub, preserving the managed token.
+    selected = ide_launcher.prompt_for_ide_connection(
+        connection,
+        {"MAC_FLEETS_CONFIG": str(fleets)},
+        interactive=True,
+        input_fn=lambda prompt: prompts.append(prompt) or "",
+    )
+    assert prompts == [
+        "Target hub host or IP "
+        "[Enter keeps http://100.72.16.110:8789; direct port 8789]: "
+    ]
+    assert selected == ide_launcher.IdeConnection(
+        api_url="http://100.72.16.110:8789",
+        token="profile-token",
+        source="client-profile:default",
+        profile="default",
+        hub_port=8789,
+    )
+
+
+def test_prompt_bare_host_uses_fleet_control_port(tmp_path) -> None:
+    fleets = _write_fleets(
+        tmp_path, hub_url="http://100.72.16.110:9443", control_port=9443
+    )
+    connection = ide_launcher.IdeConnection(
+        api_url="http://127.0.0.1:48789", hub_port=48789
+    )
+
+    selected = ide_launcher.prompt_for_ide_connection(
+        connection,
+        {"MAC_FLEETS_CONFIG": str(fleets)},
+        interactive=True,
+        input_fn=lambda _prompt: "hub.internal",
+    )
+
+    assert selected.api_url == "http://hub.internal:9443"
+
+
+def test_prompt_falls_back_when_fleet_hub_url_missing(tmp_path) -> None:
+    fleets = tmp_path / "fleets.yaml"
+    fleets.write_text(
+        "version: 1\nfleets:\n  rocky:\n    default: true\n    control_port: 8789\n",
+        encoding="utf-8",
+    )
+    connection = ide_launcher.IdeConnection(
+        api_url="http://127.0.0.1:48789", hub_port=8789
+    )
+    prompts: list[str] = []
+
+    selected = ide_launcher.prompt_for_ide_connection(
+        connection,
+        {"MAC_FLEETS_CONFIG": str(fleets)},
+        interactive=True,
+        input_fn=lambda prompt: prompts.append(prompt) or "",
+    )
+
+    assert prompts == [
+        "Target hub host or IP "
+        "[Enter keeps http://127.0.0.1:48789; direct port 8789]: "
+    ]
+    assert selected is connection
+
+
 def test_hub_prompt_retries_invalid_url_and_skips_explicit_or_noninteractive(
     capsys,
 ) -> None:
@@ -226,7 +320,7 @@ def test_hub_prompt_retries_invalid_url_and_skips_explicit_or_noninteractive(
 
     selected = ide_launcher.prompt_for_ide_connection(
         connection,
-        {},
+        _NO_FLEETS,
         interactive=True,
         input_fn=lambda _prompt: next(answers),
     )
@@ -236,7 +330,7 @@ def test_hub_prompt_retries_invalid_url_and_skips_explicit_or_noninteractive(
     assert (
         ide_launcher.prompt_for_ide_connection(
             connection,
-            {"IDE_API_URL": "http://explicit.example:8789"},
+            {**_NO_FLEETS, "IDE_API_URL": "http://explicit.example:8789"},
             interactive=True,
             input_fn=lambda _prompt: (_ for _ in ()).throw(
                 AssertionError("unexpected prompt")
@@ -247,7 +341,7 @@ def test_hub_prompt_retries_invalid_url_and_skips_explicit_or_noninteractive(
     assert (
         ide_launcher.prompt_for_ide_connection(
             connection,
-            {},
+            _NO_FLEETS,
             interactive=False,
             input_fn=lambda _prompt: (_ for _ in ()).throw(
                 AssertionError("unexpected prompt")
@@ -268,7 +362,7 @@ def test_hub_prompt_retries_invalid_url_and_skips_explicit_or_noninteractive(
 def test_hub_prompt_accepts_explicit_ports_and_urls(entered, expected) -> None:
     selected = ide_launcher.prompt_for_ide_connection(
         ide_launcher.IdeConnection(api_url=ide_launcher.DEFAULT_API_URL),
-        {},
+        _NO_FLEETS,
         interactive=True,
         input_fn=lambda _prompt: entered,
     )


### PR DESCRIPTION
## Problem

`make run-gui` prompted for the hub with the login profile's `api_url` as the default. For a managed profile that value is an **ephemeral loopback SSH-tunnel port** that changes every launch — so the default never matched the real hub, and the operator had to look up and re-type the hub IP each time (this is the "it forgets the hub IP" symptom).

## Fix

`~/.mac/fleets.yaml` already records the canonical hub. Seed the prompt default from it:

- New `_fleet_prompt_default(env)` reads the fleet registry — honouring `IDE_FLEET`/`MAC_FLEET`, else the `default: true` fleet — and returns its `hub_url` + `control_port`.
- Any problem (no registry, missing `hub_url`, parse error, ambiguous fleet) returns `("", 0)` so it **falls back to the old profile default** — no regression.
- Pressing **Enter** now reaches the real hub (e.g. `http://100.72.16.110:8789`) with the managed token preserved; a bare host uses the fleet's `control_port`. Explicit `IDE_API_URL` still wins (precedence unchanged).
- The registry path resolves from the caller-supplied `env` (`MAC_FLEETS_CONFIG`) so tests stay hermetic; production reads `~/.mac/fleets.yaml`.

## Tests

`tests/test_ide_launcher.py`: 18/18 pass, incl. 3 new (fleet-seeded default, bare-host-uses-fleet-port, fallback-when-hub_url-missing). Existing prompt tests made hermetic so they don't pick up a developer's real `fleets.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)