### PR TITLE
Stop re-embedding observability detail into action_events

### DIFF
--- a/src/mac/action_event_service.py
+++ b/src/mac/action_event_service.py
@@ -188,7 +188,6 @@ class ActionEventService:
         conn: Any,
         event: ObservabilityEvent,
     ) -> Optional[ActionEvent]:
-        detail = ensure_json_object(event.detail)
         actor = str(event.source or "mac")
         outcome = "success"
         if event.level in {"error", "critical"}:
@@ -205,6 +204,17 @@ class ActionEventService:
             subject_id=event.subject_id,
             outcome=outcome,
             severity=event.level,
+            # AMANALAP ("as little as necessary"): store only a REFERENCE to the
+            # source observability row, never a re-embedded copy of its `detail`
+            # blob. The full detail already lives in observability_events.detail
+            # under the same telemetry retention window and is recoverable by
+            # joining on observability_id. Re-embedding it here made
+            # action_events a duplicate superset of observability_events — the
+            # firehose that grew the hub mac.db to 16GB. No reader extracts
+            # action_events.attributes.detail: OTLP export (_otel_attributes)
+            # projects typed columns only, and dream_scanner also scans
+            # observability_events directly, so dropping the copy loses no
+            # signal while halving this table's write volume and row size.
             attributes={
                 "schema": ACTION_EVENT_SCHEMA,
                 "observability_id": event.id,
@@ -214,7 +224,6 @@ class ActionEventService:
                 "source": event.source,
                 "value": event.value,
                 "unit": event.unit,
-                "detail": detail,
             },
             redaction_state="redacted",
             conn=conn,

--- a/tests/test_action_event_obs_projection.py
+++ b/tests/test_action_event_obs_projection.py
@@ -1,0 +1,79 @@
+"""The observability -> action_events projection must store only a REFERENCE
+to the source observability row, not a re-embedded copy of its `detail` blob.
+
+Re-embedding `detail` made action_events a duplicate superset of
+observability_events and was the write firehose that grew the hub mac.db to
+16GB. These tests pin the deduplicated contract: the projected action event
+keeps `observability_id` (so the detail is recoverable by join) but drops the
+blob, and the source detail still lives in observability_events.
+"""
+
+from __future__ import annotations
+
+from mac.services import ControlPlane
+
+
+def _project(cp: ControlPlane, obs):
+    """Return the action_event projected from an observability event."""
+    events = cp.list_action_events(action_type="observability", limit=50)
+    match = [e for e in events if e.attributes.get("observability_id") == obs.id]
+    assert len(match) == 1, "expected exactly one projected action_event"
+    return match[0]
+
+
+def test_projection_stores_reference_not_reembedded_detail() -> None:
+    cp = ControlPlane.in_memory()
+    obs = cp.record_observation(
+        kind="log",
+        name="worker.test",
+        layer="worker",
+        source="worker-1",
+        level="info",
+        detail={"secret_shaped": "x" * 512, "phase": "gate"},
+    )
+
+    action = _project(cp, obs)
+
+    # The reference is present; the blob is not.
+    assert action.attributes.get("observability_id") == obs.id
+    assert "detail" not in action.attributes
+    # Cheap scalar dimensions readers filter on are retained.
+    assert action.attributes.get("layer") == "worker"
+    assert action.attributes.get("kind") == "log"
+
+
+def test_source_detail_remains_recoverable_via_observability_row() -> None:
+    cp = ControlPlane.in_memory()
+    obs = cp.record_observation(
+        kind="metric",
+        name="executor.duration",
+        layer="executor",
+        source="worker-2",
+        value=46200.0,
+        unit="ms",
+        detail={"clone_ms": 1200, "test_ms": 45000},
+    )
+
+    action = _project(cp, obs)
+    ref = action.attributes["observability_id"]
+
+    # Joining back on the reference recovers the full detail — nothing lost.
+    source = [o for o in cp.list_observability(limit=50) if o.id == ref]
+    assert len(source) == 1
+    assert source[0].detail == {"clone_ms": 1200, "test_ms": 45000}
+
+
+def test_error_level_projects_failure_outcome_without_detail() -> None:
+    cp = ControlPlane.in_memory()
+    obs = cp.record_observation(
+        kind="log",
+        name="executor.crash",
+        layer="executor",
+        source="worker-3",
+        level="error",
+        detail={"traceback": "boom" * 100},
+    )
+
+    action = _project(cp, obs)
+    assert action.outcome == "failure"
+    assert "detail" not in action.attributes


### PR DESCRIPTION
## Problem

The observability → `action_events` projection re-embedded the **full `detail` blob** of every observability event into `action_events.attributes`. That made `action_events` a duplicate superset of `observability_events` — the write firehose that grew the hub `mac.db` to 16 GB and wedged the control plane.

Retention wiring + index reduction (`6f716c60`) bounded the *growth*, but the duplication itself remained: a mere ~2.5-day window still costs ~5 GB live because every telemetry row is written twice.

## Fix

`project_observability` now stores only the **`observability_id` reference** (plus the cheap scalar dimensions readers filter on), not the blob. The full detail already lives in `observability_events.detail` under the same telemetry retention window and is recoverable by join.

**Verified no reader depends on the copy:**
- OTLP export (`_otel_attributes`) projects typed columns only — never `attributes.detail`.
- `dream_scanner` also scans `observability_events` directly, so the failure signal survives (and it's an orphan module per the audit anyway).
- API list/dashboard pass `to_dict()` through, but nothing consumes the re-embedded blob; `observability_id` remains for recovery.

Roughly halves this table's write volume and row size at the source, so the bounded steady-state is far smaller.

## Tests

New `tests/test_action_event_obs_projection.py` (3 tests): projection keeps `observability_id` but drops `detail`; source detail stays recoverable via the obs row; error level still projects `failure`. Full dream_scanner + relay-observability reader suites (69 tests) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)