### PR TITLE
Home-consolidation Phase 0 sweep: route all home paths through mac_paths

### DIFF
--- a/src/mac/acp/backend.py
+++ b/src/mac/acp/backend.py
@@ -39,6 +39,8 @@ import threading
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence
 
+from mac import mac_paths
+
 from .protocol import StopReason
 from .server import PromptTurn, _prompt_text
 
@@ -70,7 +72,7 @@ def default_argv(prompt: str) -> List[str]:
 
     wrapper = (
         os.environ.get("MAC_OPENCLAW_AGENT_BIN")
-        or str(Path.home() / ".mac" / "bin" / "openclaw-agent")
+        or str(mac_paths.mac_home() / "bin" / "openclaw-agent")
     )
     return [
         wrapper,

--- a/src/mac/acp/permission.py
+++ b/src/mac/acp/permission.py
@@ -43,6 +43,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from mac import mac_paths
+
 
 __all__ = [
     "PermissionDecision",
@@ -195,7 +197,7 @@ def load_openshell_policy(path: Optional[str] = None) -> Optional[Dict[str, Any]
         if explicit:
             candidate = Path(explicit)
         else:
-            candidate = Path.home() / ".mac" / "openshell-policy.yaml"
+            candidate = mac_paths.mac_home() / "openshell-policy.yaml"
 
     try:
         if not candidate.is_file():

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
 
+from mac import mac_paths
 from mac.migration import import_jsonl, migrate_acc_sqlite
 from mac.models import MACError, REPORT_DELIVERABLE, normalize_deliverable_kind, parse_time, utcnow
 from mac.repository_hygiene import (
@@ -560,7 +561,7 @@ def _local_ledger_notice_payload() -> Optional[Dict[str, Any]]:
     except (LocalLedgerMigrationError, OSError, sqlite3.Error) as exc:
         return {
             "status": "inspection_failed",
-            "source_db": str(Path.home() / ".mac" / "mac.db"),
+            "source_db": str(mac_paths.mac_home() / "mac.db"),
             "message": str(exc),
             "next_command": "mac migrate local-ledger",
         }
@@ -3567,7 +3568,7 @@ def cmd_fleet_refresh_context(args: argparse.Namespace) -> None:
     snapshot = plane.fleet_snapshot(exclude_agent_id=agent)
     markdown = getattr(args, "markdown", None) or _os.environ.get(
         "MAC_HERMES_RUNTIME_CONTEXT_MARKDOWN"
-    ) or str(_Path.home() / ".hermes" / "mac-runtime-context.md")
+    ) or str(mac_paths.gateway_home() / "mac-runtime-context.md")
     path = _Path(markdown)
     refresh_fleet_section(path, render_fleet_section(snapshot))
 
@@ -6754,7 +6755,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     fleet_ssh_spec.add_argument("--agent", help="agent name (default: fleet hub_agent)")
     fleet_ssh_spec.add_argument(
-        "--fleets-config", default=str(Path.home() / ".mac" / "fleets.yaml")
+        "--fleets-config", default=str(mac_paths.fleets_config())
     )
     fleet_ssh_spec.add_argument("--ssh-port", type=int)
     fleet_ssh_spec.add_argument(
@@ -6812,7 +6813,7 @@ def build_parser() -> argparse.ArgumentParser:
     fleet_soul_pull.add_argument("--fleet", help="fleet name (default: first in fleets.yaml)")
     fleet_soul_pull.add_argument("--into", required=True, help="destination directory for the snapshot")
     fleet_soul_pull.add_argument(
-        "--fleets-config", default=str(Path.home() / ".mac" / "fleets.yaml")
+        "--fleets-config", default=str(mac_paths.fleets_config())
     )
     fleet_soul_pull.add_argument(
         "--memory-checksum", action="store_true",
@@ -6837,7 +6838,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     fleet_soul_push.add_argument("--fleet", help="fleet name (default: snapshot manifest)")
     fleet_soul_push.add_argument(
-        "--fleets-config", default=str(Path.home() / ".mac" / "fleets.yaml")
+        "--fleets-config", default=str(mac_paths.fleets_config())
     )
     _set(cmd_fleet_soul_push, fleet_soul_push)
 
@@ -6848,7 +6849,7 @@ def build_parser() -> argparse.ArgumentParser:
     fleet_soul_audit.add_argument("--agent", required=True, help="agent name to audit")
     fleet_soul_audit.add_argument("--fleet", help="fleet name (default: first in fleets.yaml)")
     fleet_soul_audit.add_argument(
-        "--fleets-config", default=str(Path.home() / ".mac" / "fleets.yaml")
+        "--fleets-config", default=str(mac_paths.fleets_config())
     )
     _set(cmd_fleet_soul_audit, fleet_soul_audit)
 
@@ -6895,11 +6896,11 @@ def build_parser() -> argparse.ArgumentParser:
     fleet_validate.add_argument("--spec", required=True)
     fleet_validate.add_argument(
         "--fleets-config",
-        default=str(Path.home() / ".mac" / "fleets.yaml"),
+        default=str(mac_paths.fleets_config()),
     )
     fleet_validate.add_argument(
         "--env-file",
-        default=str(Path.home() / ".mac" / ".env"),
+        default=str(mac_paths.deploy_env_file()),
     )
     _set(cmd_fleet_validate_setup, fleet_validate)
 
@@ -6944,11 +6945,11 @@ def build_parser() -> argparse.ArgumentParser:
     fleet_doctor.add_argument("--spec", required=True)
     fleet_doctor.add_argument(
         "--fleets-config",
-        default=str(Path.home() / ".mac" / "fleets.yaml"),
+        default=str(mac_paths.fleets_config()),
     )
     fleet_doctor.add_argument(
         "--env-file",
-        default=str(Path.home() / ".mac" / ".env"),
+        default=str(mac_paths.deploy_env_file()),
     )
     _set(cmd_fleet_doctor_setup, fleet_doctor)
 
@@ -6965,12 +6966,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     fleet_sync_token.add_argument(
         "--fleets-config",
-        default=str(Path.home() / ".mac" / "fleets.yaml"),
+        default=str(mac_paths.fleets_config()),
         help="path to fleets.yaml (default ~/.mac/fleets.yaml)",
     )
     fleet_sync_token.add_argument(
         "--env-file",
-        default=str(Path.home() / ".mac" / ".env"),
+        default=str(mac_paths.deploy_env_file()),
         help="client env file to update (default ~/.mac/.env)",
     )
     _set(cmd_fleet_sync_token, fleet_sync_token)
@@ -7013,7 +7014,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     fleet_creds_sync.add_argument(
         "--fleets-config",
-        default=str(Path.home() / ".mac" / "fleets.yaml"),
+        default=str(mac_paths.fleets_config()),
         help="path to fleets.yaml (default ~/.mac/fleets.yaml)",
     )
     fleet_creds_sync.add_argument(
@@ -7105,12 +7106,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     fleet_rotate_token.add_argument(
         "--fleets-config",
-        default=str(Path.home() / ".mac" / "fleets.yaml"),
+        default=str(mac_paths.fleets_config()),
         help="path to fleets.yaml (default ~/.mac/fleets.yaml)",
     )
     fleet_rotate_token.add_argument(
         "--env-file",
-        default=str(Path.home() / ".mac" / ".env"),
+        default=str(mac_paths.deploy_env_file()),
         help="client env file to update (default ~/.mac/.env)",
     )
     _set(cmd_fleet_rotate_token, fleet_rotate_token)
@@ -8523,12 +8524,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     migrate_local_ledger.add_argument(
         "--source-db",
-        default=str(Path.home() / ".mac" / "mac.db"),
+        default=str(mac_paths.mac_home() / "mac.db"),
         help="isolated local SQLite ledger (default: ~/.mac/mac.db)",
     )
     migrate_local_ledger.add_argument(
         "--archive-dir",
-        default=str(Path.home() / ".mac" / "archive"),
+        default=str(mac_paths.archive_dir()),
         help="directory for the verified database archive and manifest",
     )
     migrate_local_ledger.add_argument(

--- a/src/mac/client_principals.py
+++ b/src/mac/client_principals.py
@@ -20,6 +20,8 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Iterable, Iterator, List, Mapping, Optional, Tuple
 
 
@@ -60,7 +62,7 @@ def _parse_timestamp(value: Any) -> Optional[datetime]:
 
 
 def mac_home() -> Path:
-    return Path(os.environ.get("MAC_HOME") or (Path.home() / ".mac")).expanduser()
+    return mac_paths.mac_home()
 
 
 def default_registry_path() -> Path:

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -53,6 +53,8 @@ import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 from urllib.parse import quote, urlencode
 
@@ -2808,7 +2810,11 @@ def _maybe_print_local_banner(db_path: str) -> None:
 
 
 def _canonical_client_db_path() -> Path:
-    return (Path.home() / ".mac" / "mac.db").expanduser().resolve()
+    # Canonical = the DEFAULT local client DB location, deliberately MAC_DB-
+    # AGNOSTIC (the hub/MAC_DB case is handled separately by
+    # _is_hub_authority_db). Honors MAC_HOME only, so it stays a stable
+    # comparison target even when MAC_DB points elsewhere.
+    return (mac_paths.mac_home() / "mac.db").expanduser().resolve()
 
 
 def _is_canonical_client_db(db_path: str) -> bool:
@@ -3033,8 +3039,7 @@ def _resolve_client_profile(args: Any, env: Dict[str, str]) -> Optional[Dict[str
 
 
 def _fleets_config_path() -> Path:
-    override = os.environ.get("MAC_FLEETS_CONFIG")
-    return Path(override) if override else (Path.home() / ".mac" / "fleets.yaml")
+    return mac_paths.fleets_config()
 
 
 def _load_fleets_yaml() -> Dict[str, Any]:
@@ -3102,7 +3107,7 @@ def _load_dotenv_into(env: Dict[str, str]) -> None:
     a shell would, rather than landing as a bogus ``export MAC_API_TOKEN`` key
     or a value with stray quotes.
     """
-    path = Path(os.environ.get("MAC_DEPLOY_ENV_FILE") or (Path.home() / ".mac" / ".env"))
+    path = mac_paths.deploy_env_file()
     if not path.is_file():
         return
     try:

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -67,6 +67,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
+from mac import mac_paths
 from mac import relay_observability
 from mac.agent_command import PROMPT_SENTINEL
 from mac.models import (
@@ -664,7 +665,7 @@ def _resolve_openshell_policy() -> str:
         if not Path(explicit).is_file():
             raise FileNotFoundError("MAC_OPENSHELL_POLICY=%r but no such file" % explicit)
         return explicit
-    deployed = Path.home() / ".mac" / "openshell-policy.yaml"
+    deployed = mac_paths.mac_home() / "openshell-policy.yaml"
     if deployed.is_file():
         return str(deployed)
     bundled = _bundled_default_policy()
@@ -1736,7 +1737,7 @@ _MANAGED_OPENSHELL_RUNTIME_REF_RE = _re.compile(
 def _managed_openshell_runtime_image_ref() -> str:
     """Return the deployment-pinned OpenShell image, or fail closed."""
 
-    mac_home = Path(os.environ.get("MAC_HOME") or Path.home() / ".mac").expanduser()
+    mac_home = mac_paths.mac_home()
     path = Path(
         env_str("MAC_OPENSHELL_RUNTIME_IMAGE_REF_FILE")
         or mac_home / "openshell" / "runtime-image-ref"
@@ -3743,7 +3744,7 @@ def _prepare_host_break_glass_environment(
     configured = env_str("MAC_BREAK_GLASS_HOST_PATH")
     candidates = [
         *(configured.split(os.pathsep) if configured else []),
-        str(Path.home() / ".mac" / "bin"),
+        str(mac_paths.mac_home() / "bin"),
         str(Path.home() / ".local" / "bin"),
         "/opt/homebrew/bin",
         "/opt/local/bin",

--- a/src/mac/fleet_creds.py
+++ b/src/mac/fleet_creds.py
@@ -35,6 +35,8 @@ import shlex
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Callable, Dict, List, Optional, Tuple
 
 from mac.fleet_env import scoped_var, set_env_key
@@ -118,7 +120,7 @@ def _fleets_config_path(path: Optional[str] = None) -> Path:
     env = os.environ.get("MAC_FLEETS_CONFIG")
     if env:
         return Path(env).expanduser()
-    return Path.home() / ".mac" / "fleets.yaml"
+    return mac_paths.fleets_config()
 
 
 def load_fleets_config(path: Optional[str] = None) -> dict:
@@ -210,7 +212,7 @@ def sync_token(
             "the hub uses only MAC_API_TOKENS — rotate-token --prune to reduce to one)"
             % hub.target
         )
-    env_file = Path(env_path).expanduser() if env_path else (Path.home() / ".mac" / ".env")
+    env_file = Path(env_path).expanduser() if env_path else mac_paths.deploy_env_file()
     key = scoped_var("MAC_API_TOKEN", fleet)
     changed = set_env_key(env_file, key, token)
     return {
@@ -312,7 +314,7 @@ def rotate_token(
     hub = hub_ssh(config, fleet)
     cur_single, cur_tokens = read_hub_auth(hub, runner=runner)
     registry = normalize_registry(cur_single, cur_tokens)
-    env_file = Path(env_path).expanduser() if env_path else (Path.home() / ".mac" / ".env")
+    env_file = Path(env_path).expanduser() if env_path else mac_paths.deploy_env_file()
     key = scoped_var("MAC_API_TOKEN", fleet)
     restart_cmd = restart_command(hub)
 

--- a/src/mac/fleet_ssh.py
+++ b/src/mac/fleet_ssh.py
@@ -19,6 +19,8 @@ import os
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from mac.fleet_deploy import parse_ssh_target
@@ -282,7 +284,7 @@ def load_fleet_config(path: Optional[str] = None) -> Dict[str, Any]:
     target = Path(
         path
         or os.environ.get("MAC_FLEETS_CONFIG")
-        or (Path.home() / ".mac" / "fleets.yaml")
+        or mac_paths.fleets_config()
     ).expanduser()
     if not target.is_file():
         raise FleetSshError("fleets config not found: %s" % target)

--- a/src/mac/hermes_chat_config.py
+++ b/src/mac/hermes_chat_config.py
@@ -32,6 +32,8 @@ import os
 import re
 import shlex
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Dict, List, Optional
 
 # Explicit provider timeouts stamped into the deployed `custom` provider block.
@@ -372,9 +374,9 @@ def main(argv: object = None) -> int:
     parser = argparse.ArgumentParser(prog="python -m mac.hermes_chat_config")
     parser.add_argument(
         "--hermes-home",
-        default=os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes"),
+        default=str(mac_paths.gateway_home()),
     )
-    parser.add_argument("--mac-env", default=str(Path.home() / ".mac" / "mac.env"))
+    parser.add_argument("--mac-env", default=str(mac_paths.mac_env_file()))
     ns = parser.parse_args(argv)
     result = sync(Path(ns.hermes_home), Path(ns.mac_env))
     # Never print key material — only booleans/keys/counts.

--- a/src/mac/hermes_config_surface.py
+++ b/src/mac/hermes_config_surface.py
@@ -17,6 +17,8 @@ import re
 import tempfile
 from copy import deepcopy
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 import yaml
@@ -75,7 +77,7 @@ _RUNTIME_FIELDS = (
 
 
 def hermes_home() -> Path:
-    return Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes").expanduser()
+    return mac_paths.gateway_home()
 
 
 def registry_path() -> Path:
@@ -83,7 +85,7 @@ def registry_path() -> Path:
         os.environ.get("MAC_FLEETS_CONFIG")
         or os.environ.get("MAC_DEPLOY_FLEETS_CONFIG")
         or os.environ.get("MAC_DEPLOY_FLEET_REGISTRY")
-        or str(Path.home() / ".mac" / "fleets.yaml")
+        or str(mac_paths.fleets_config())
     )
     return Path(raw).expanduser()
 

--- a/src/mac/hermes_gateway.py
+++ b/src/mac/hermes_gateway.py
@@ -18,6 +18,8 @@ import os
 import shlex
 import sys
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Callable, List, Optional
 
 
@@ -62,7 +64,7 @@ def _resolve_gateway_policy() -> str:
         if not Path(explicit).is_file():
             raise FileNotFoundError("MAC_OPENSHELL_GATEWAY_POLICY=%r but no such file" % explicit)
         return explicit
-    deployed = Path.home() / ".mac" / "openshell-gateway-policy.yaml"
+    deployed = mac_paths.mac_home() / "openshell-gateway-policy.yaml"
     if deployed.is_file():
         return str(deployed)
     bundled = Path(__file__).resolve().parent / "openshell" / "gateway-default-policy.yaml"

--- a/src/mac/hermes_home_audit.py
+++ b/src/mac/hermes_home_audit.py
@@ -16,10 +16,10 @@ disk.
 
 Usage::
 
-    from pathlib import Path
+    from mac import mac_paths
     from mac.hermes_home_audit import audit_hermes_home
 
-    report = audit_hermes_home(Path.home() / ".hermes")
+    report = audit_hermes_home(mac_paths.gateway_home())
 """
 
 from __future__ import annotations

--- a/src/mac/hermes_runtime.py
+++ b/src/mac/hermes_runtime.py
@@ -7,6 +7,8 @@ import re
 import time
 import urllib.parse
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Optional
 
 import yaml
@@ -299,7 +301,7 @@ def _webdav_publish_method() -> Dict[str, Any]:
     publish_dir = (
         os.environ.get("MAC_PUBLISH_DIR")
         or os.environ.get("MAC_WEBDAV_ROOT")
-        or str(Path.home() / ".mac" / "public-artifacts")
+        or str(mac_paths.mac_home() / "public-artifacts")
     )
     return {
         "enabled": True,
@@ -993,8 +995,8 @@ def _main(argv: Optional[list[str]] = None) -> int:
     parser.add_argument("--agent-name", default=os.environ.get("AGENT") or os.environ.get("MAC_WORKER_AGENT_NAME", "agent"))
     parser.add_argument("--fleet-name", default=os.environ.get("FLEET_NAME", "mac"))
     parser.add_argument("--mac-url", default=os.environ.get("MAC_HUB_URL") or os.environ.get("MAC_URL", ""))
-    parser.add_argument("--hermes-home", default=os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
-    parser.add_argument("--mac-home", default=os.environ.get("MAC_HOME", str(Path.home() / ".mac")))
+    parser.add_argument("--hermes-home", default=str(mac_paths.gateway_home()))
+    parser.add_argument("--mac-home", default=str(mac_paths.mac_home()))
     parser.add_argument("--tenant-id", default=os.environ.get("MAC_FLEET_TENANT_ID"))
     parser.add_argument("--persona-id", default=os.environ.get("MAC_HERMES_PERSONA_ID"))
     parser.add_argument("--hermes-instance-id", default=os.environ.get("MAC_HERMES_INSTANCE_ID"))

--- a/src/mac/ide_launcher.py
+++ b/src/mac/ide_launcher.py
@@ -17,6 +17,8 @@ import sys
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Callable, MutableMapping, Optional, Sequence
 from urllib.parse import urlsplit
 
@@ -340,7 +342,7 @@ def _fleet_prompt_default(env: Mapping[str, str]) -> "tuple[str, int]":
     path = (
         Path(explicit).expanduser()
         if explicit
-        else Path.home() / ".mac" / "fleets.yaml"
+        else mac_paths.fleets_config()
     )
     if not path.is_file():
         return ("", 0)

--- a/src/mac/ledger_backup.py
+++ b/src/mac/ledger_backup.py
@@ -38,6 +38,8 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+from mac import mac_paths
 from typing import List, Optional
 
 SNAPSHOT_MANIFEST_SCHEMA = "mac.ledger_snapshot.v1"
@@ -175,12 +177,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(prog="python -m mac.ledger_backup")
     parser.add_argument(
         "--db",
-        default=os.environ.get("MAC_DB") or str(Path.home() / ".mac" / "mac.db"),
+        default=str(mac_paths.ledger_db()),
     )
     parser.add_argument(
         "--out",
         default=os.environ.get("MAC_LEDGER_BACKUP_DIR")
-        or str(Path.home() / ".mac" / "backups"),
+        or str(mac_paths.backups_dir()),
     )
     parser.add_argument("--keep-last", type=int, default=DEFAULT_KEEP_LAST)
     parser.add_argument("--sync-cmd", default=None)

--- a/src/mac/ledger_backup_scheduler.py
+++ b/src/mac/ledger_backup_scheduler.py
@@ -21,6 +21,8 @@ import os
 import threading
 from dataclasses import dataclass
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Mapping, Optional
 
 from mac import ledger_backup
@@ -43,7 +45,7 @@ def _default_db_path(env: Mapping[str, str]) -> str:
     raw = str(env.get("MAC_DB") or "").strip()
     if raw:
         return raw
-    return str(Path(env.get("MAC_HOME") or Path.home() / ".mac") / "mac.db")
+    return str(Path(env.get("MAC_HOME") or mac_paths.mac_home()) / "mac.db")
 
 
 @dataclass(frozen=True)
@@ -67,7 +69,7 @@ class LedgerBackupConfig:
             except ValueError:
                 return default
 
-        default_home = env.get("MAC_HOME") or str(Path.home() / ".mac")
+        default_home = env.get("MAC_HOME") or str(mac_paths.mac_home())
         return cls(
             # Default-ON, but a non-hub role should not back up.
             enabled=(

--- a/src/mac/local_ledger_migration.py
+++ b/src/mac/local_ledger_migration.py
@@ -8,6 +8,8 @@ import tempfile
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Protocol, Tuple
 
 from mac.models import MACError, TERMINAL_TASK_STATES, TaskState
@@ -120,11 +122,13 @@ class LocalLedgerRetirementResult:
 
 
 def default_local_db_path() -> Path:
-    return Path.home() / ".mac" / "mac.db"
+    # The default LOCAL ledger location (~/.mac/mac.db), MAC_DB-agnostic — an
+    # explicit --source-db is used when migrating a non-default file.
+    return mac_paths.mac_home() / "mac.db"
 
 
 def default_archive_dir() -> Path:
-    return Path.home() / ".mac" / "archive"
+    return mac_paths.archive_dir()
 
 
 def _utcnow() -> str:

--- a/src/mac/model_selection.py
+++ b/src/mac/model_selection.py
@@ -36,6 +36,8 @@ import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from mac import models_catalog
@@ -390,7 +392,7 @@ def selection_file_path(environ: Optional[Mapping[str, str]] = None) -> Path:
     if configured:
         return Path(configured).expanduser()
     home = str(env.get("MAC_HOME") or "").strip()
-    base = Path(home).expanduser() if home else Path.home() / ".mac"
+    base = Path(home).expanduser() if home else mac_paths.mac_home()
     return base / "model-selection.json"
 
 

--- a/src/mac/models_catalog.py
+++ b/src/mac/models_catalog.py
@@ -24,6 +24,8 @@ import time
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
@@ -131,7 +133,7 @@ def _cache_path() -> Path:
     if configured:
         return Path(configured).expanduser()
     home = str(os.environ.get("MAC_HOME") or "").strip()
-    base = Path(home).expanduser() if home else Path.home() / ".mac"
+    base = Path(home).expanduser() if home else mac_paths.mac_home()
     return base / "models-dev-cache.json"
 
 

--- a/src/mac/openshell_reconcile.py
+++ b/src/mac/openshell_reconcile.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
 import yaml
@@ -24,10 +26,7 @@ def default_policy_path() -> Path:
 
 
 def default_fleets_path() -> Path:
-    import os
-
-    override = os.environ.get("MAC_FLEETS_CONFIG")
-    return Path(override).expanduser() if override else Path.home() / ".mac" / "fleets.yaml"
+    return mac_paths.fleets_config()
 
 
 def _to_dict(value: Any) -> Dict[str, Any]:

--- a/src/mac/openshell_service.py
+++ b/src/mac/openshell_service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import hashlib
 import os
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, List, Optional
 
 import yaml
@@ -490,7 +492,7 @@ class OpenShellService:
         explicit = os.environ.get("MAC_OPENSHELL_POLICY")
         if explicit and Path(explicit).is_file():
             return Path(explicit)
-        deployed = Path.home() / ".mac" / "openshell-policy.yaml"
+        deployed = mac_paths.mac_home() / "openshell-policy.yaml"
         if deployed.is_file():
             return deployed
         bundled = Path(__file__).resolve().parent / "openshell" / "default-policy.yaml"

--- a/src/mac/openshell_supervisor.py
+++ b/src/mac/openshell_supervisor.py
@@ -15,6 +15,8 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Iterable, List, Optional, Sequence
 
 from mac.openshell_runtime import base_agent_name, openshell_required_for_identity
@@ -63,7 +65,7 @@ def default_policy_path(agent_id: str) -> Path:
     explicit = os.environ.get("MAC_OPENSHELL_POLICY")
     if explicit:
         return Path(explicit).expanduser()
-    return Path.home() / ".mac" / "openshell" / ("%s-policy.yaml" % base_agent_name(agent_id))
+    return mac_paths.mac_home() / "openshell" / ("%s-policy.yaml" % base_agent_name(agent_id))
 
 
 def default_child_argv() -> List[str]:

--- a/src/mac/webdav_server.py
+++ b/src/mac/webdav_server.py
@@ -11,6 +11,8 @@ import urllib.parse
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Optional
 
 
@@ -320,7 +322,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Serve public-read MAC artifacts from a hub publish directory.")
     parser.add_argument("--host", default=os.environ.get("MAC_WEBDAV_BIND_ADDR", "127.0.0.1"))
     parser.add_argument("--port", type=int, default=int(os.environ.get("MAC_WEBDAV_PORT", "80")))
-    parser.add_argument("--root", default=os.environ.get("MAC_WEBDAV_ROOT", str(Path.home() / ".mac" / "public-artifacts")))
+    parser.add_argument("--root", default=os.environ.get("MAC_WEBDAV_ROOT", str(mac_paths.mac_home() / "public-artifacts")))
     parser.add_argument("--public-prefix", default=os.environ.get("MAC_WEBDAV_PUBLIC_PATH", DEFAULT_PUBLIC_PREFIX))
     parser.add_argument(
         "--max-upload-bytes",

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -27,6 +27,8 @@ import traceback
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Callable, Dict, List, Mapping, Optional
 from urllib.parse import quote, urlencode
 
@@ -1829,7 +1831,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         if channel_type not in {"", "hermes", "slack"} and target_type != "slack":
             return {"status": "skipped", "sent": 0, "skipped": 1, "failed": 0}
 
-        hermes_home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+        hermes_home = mac_paths.gateway_home()
         accounts = _load_slack_accounts(hermes_home)
         home_channels = _load_slack_home_channels(hermes_home)
         if not accounts or not home_channels:
@@ -1911,7 +1913,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         identity = os.environ.get("MAC_OPENCLAW_PUBLIC_IDENTITY", "").strip()
         message_bin = Path(
             os.environ.get("MAC_OPENCLAW_MESSAGE_BIN")
-            or Path.home() / ".mac" / "bin" / "openclaw-message"
+            or mac_paths.mac_home() / "bin" / "openclaw-message"
         )
         if not identity or not message_bin.is_file():
             return
@@ -2011,7 +2013,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         identity = os.environ.get("MAC_OPENCLAW_PUBLIC_IDENTITY", "").strip()
         message_bin = Path(
             os.environ.get("MAC_OPENCLAW_MESSAGE_BIN")
-            or Path.home() / ".mac" / "bin" / "openclaw-message"
+            or mac_paths.mac_home() / "bin" / "openclaw-message"
         )
         if not identity or not message_bin.is_file():
             return
@@ -3034,9 +3036,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         ).strip()
         if configured:
             return Path(configured).expanduser()
-        mac_home = Path(
-            os.environ.get("MAC_HOME") or Path.home() / ".mac"
-        ).expanduser()
+        mac_home = mac_paths.mac_home()
         return mac_home / "repo-update-dispatch-blocked.json"
 
     def _write_repo_update_dispatch_blocker(
@@ -3103,9 +3103,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
     def _managed_openshell_source_update_guard(
         self, *, current_sha: str, target_sha: str
     ) -> Optional[JsonDict]:
-        mac_home = Path(
-            os.environ.get("MAC_HOME") or Path.home() / ".mac"
-        ).expanduser()
+        mac_home = mac_paths.mac_home()
         runtime_ref_file = Path(
             os.environ.get("MAC_OPENSHELL_RUNTIME_IMAGE_REF_FILE")
             or mac_home / "openshell" / "runtime-image-ref"
@@ -3217,7 +3215,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
             return None
         marker = Path(
             os.environ.get("MAC_OPENSHELL_IMAGE_SOURCE_SHA_FILE")
-            or Path(os.environ.get("MAC_HOME") or Path.home() / ".mac")
+            or mac_paths.mac_home()
             / "openshell"
             / "image-source-sha"
         ).expanduser()
@@ -3229,7 +3227,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
             return None
         managed_ref_file = Path(
             os.environ.get("MAC_OPENSHELL_RUNTIME_IMAGE_REF_FILE")
-            or Path(os.environ.get("MAC_HOME") or Path.home() / ".mac")
+            or mac_paths.mac_home()
             / "openshell"
             / "runtime-image-ref"
         ).expanduser()
@@ -5447,7 +5445,7 @@ def _hermes_media_cache_dirs() -> List[Path]:
         or os.environ.get("MAC_HERMES_HOME")
         or ""
     ).strip()
-    base = Path(home).expanduser() if home else Path.home() / ".hermes"
+    base = Path(home).expanduser() if home else mac_paths.gateway_home()
     cache = base / "cache"
     return [cache / "images", cache / "audio", cache / "video"]
 
@@ -5827,11 +5825,11 @@ def _repository_source_candidates(origin: JsonDict, self_update_repo: Path) -> L
         if ".mac" in parts:
             idx = parts.index(".mac")
             suffix = Path(*parts[idx + 1 :]) if idx + 1 < len(parts) else Path()
-            candidates.append(Path.home() / ".mac" / suffix)
+            candidates.append(mac_paths.mac_home() / suffix)
 
     repository_name = str(origin.get("repository_name") or "").strip()
     if repository_name:
-        candidates.append(Path.home() / ".mac" / "src" / _safe_path_component(repository_name))
+        candidates.append(mac_paths.mac_home() / "src" / _safe_path_component(repository_name))
 
     source = str(origin.get("source") or "").strip()
     contract = origin.get("repository_contract")
@@ -7460,7 +7458,7 @@ def _register_runtime_identity_for_worker(
         or os.environ.get("MAC_WORKER_PERSONA_ID")
         or _stable_id("persona", agent_name)
     )
-    hermes_home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+    hermes_home = mac_paths.gateway_home()
     fleet_name = (
         os.environ.get("MAC_FLEET_NAME")
         or os.environ.get("FLEET_NAME")
@@ -7520,7 +7518,7 @@ def _local_fleet_registry_path() -> Path:
     return Path(
         os.environ.get("MAC_FLEETS_CONFIG")
         or os.environ.get("MAC_DEPLOY_FLEETS_CONFIG")
-        or Path.home() / ".mac" / "fleets.yaml"
+        or mac_paths.fleets_config()
     ).expanduser()
 
 

--- a/src/mac/worker_credentials.py
+++ b/src/mac/worker_credentials.py
@@ -29,6 +29,8 @@ import tempfile
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from mac.client_principals import (
@@ -184,7 +186,7 @@ def default_policy_path() -> Path:
     configured = os.environ.get("MAC_WORKER_CREDENTIAL_POLICY_FILE")
     if configured:
         return Path(configured).expanduser()
-    mac_home = Path(os.environ.get("MAC_HOME") or (Path.home() / ".mac")).expanduser()
+    mac_home = mac_paths.mac_home()
     return mac_home / "worker-credential-policy.json"
 
 

--- a/src/mac/worker_directable.py
+++ b/src/mac/worker_directable.py
@@ -24,6 +24,8 @@ import os
 import re
 import subprocess
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, Optional
 from urllib.parse import quote, urlencode
 
@@ -502,7 +504,7 @@ class DirectableMixin:
         timeout_s = _bounded_float(os.environ.get("MAC_DIRECTABLE_TIMEOUT"), 1.0, 600.0, 120.0)
         agent_bin = Path(
             os.environ.get("MAC_OPENCLAW_AGENT_BIN")
-            or Path.home() / ".mac" / "bin" / "openclaw-agent"
+            or mac_paths.mac_home() / "bin" / "openclaw-agent"
         )
         safe_slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", (sender or stream_id)).strip("-")
         session_id = "mac-peer-%s" % (safe_slug or self.agent_id)

--- a/src/mac/worker_reflect.py
+++ b/src/mac/worker_reflect.py
@@ -15,6 +15,8 @@ import os
 import re
 import subprocess
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict
 from urllib.parse import quote, urlencode
 
@@ -153,7 +155,7 @@ class ReflectMixin:
         timeout_s = _bounded_float(os.environ.get("MAC_REFLECT_TIMEOUT"), 1.0, 600.0, 120.0)
         agent_bin = Path(
             os.environ.get("MAC_OPENCLAW_AGENT_BIN")
-            or Path.home() / ".mac" / "bin" / "openclaw-agent"
+            or mac_paths.mac_home() / "bin" / "openclaw-agent"
         )
         safe_stream = re.sub(r"[^A-Za-z0-9_.-]+", "-", stream_id).strip("-")
         session_id = "mac-reflect-%s" % (safe_stream or self.agent_id)

--- a/src/mac/worker_runtime_deps.py
+++ b/src/mac/worker_runtime_deps.py
@@ -20,6 +20,8 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+
+from mac import mac_paths
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -42,7 +44,7 @@ class RuntimeDepsMixin:
     """
 
     def _mac_home(self) -> Path:
-        return Path(os.environ.get("MAC_HOME") or (Path.home() / ".mac"))
+        return mac_paths.mac_home()
 
     def _agent_venv_python(self) -> str:
         py = self._mac_home() / "venv" / "bin" / "python"

--- a/tests/test_mac_paths_no_hardcode.py
+++ b/tests/test_mac_paths_no_hardcode.py
@@ -18,17 +18,8 @@ _SRC = Path(__file__).resolve().parent.parent / "src" / "mac"
 _PATTERN = re.compile(r"""home\(\)\s*/\s*["']\.(mac|hermes)["']""")
 
 # Modules that still contain a legacy literal (Phase 0 baseline; only shrink).
-_BASELINE = {
-    "acp/backend.py", "acp/permission.py", "cli.py", "client_principals.py",
-    "dispatch.py", "executor_sandbox.py", "fleet_creds.py", "fleet_ssh.py",
-    "hermes_chat_config.py", "hermes_config_surface.py", "hermes_gateway.py",
-    "hermes_home_audit.py", "hermes_runtime.py", "ide_launcher.py",
-    "ledger_backup_scheduler.py", "ledger_backup.py", "local_ledger_migration.py",
-    "model_selection.py", "models_catalog.py", "openshell_reconcile.py",
-    "openshell_service.py", "openshell_supervisor.py", "webdav_server.py",
-    "worker_credentials.py", "worker_directable.py", "worker_reflect.py",
-    "worker_runtime_deps.py", "worker.py",
-}
+# Every site has been routed through mac.mac_paths, so the baseline is empty.
+_BASELINE = set()
 
 
 def _offenders():


### PR DESCRIPTION
Completes Phase 0 of the home-consolidation program (`docs/home-consolidation.md`, `task_18e7714e`): routes **all 71** hard-coded `~/.mac`/`~/.hermes` literals across 28 first-party `src/mac` modules through `mac.mac_paths`, and **empties the ratchet baseline** so any new hard-coded home literal now fails the build.

**Behavior-preserving:** with env unset (production) every resolver returns exactly the old path; `MAC_HOME`/`HERMES_HOME` now relocate everything together — the leaky knob is closed.

**Semantic care:** four "canonical/default *local* db" sites (`_canonical_client_db_path`, `default_local_db_path`, cli `--source-db`/`source_db`) resolve to `mac_home()/"mac.db"` — deliberately `MAC_DB`-agnostic — not `ledger_db()`, so the canonical-client-db comparison (`dispatch.protected_authority`) stays a stable target while `MAC_DB` points elsewhere (the hub/`MAC_DB` case is handled separately by `_is_hub_authority_db`). Every other site uses the dedicated env-honoring resolver.

**Verified:** full contract gate green; guard (empty baseline) + 105 focused path-resolution tests + import smoke across all 29 touched modules. `client_principals.mac_home()` now delegates to `mac_paths` (single source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)