### PR TITLE
Dream-log merge: embedding + hub-served `mac dream import-logs`

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1849,6 +1849,15 @@ class NapCycle(BaseModel):
     qdrant_url: Optional[str] = None
 
 
+class DreamImportLogs(BaseModel):
+    dream_logs_dir: Optional[str] = None
+    agent_id: Optional[str] = None
+    created_by: str = "dream-log-import"
+    embed: bool = True
+    dry_run: bool = False
+    qdrant_url: Optional[str] = None
+
+
 class NapConsolidate(BaseModel):
     since: Optional[str] = None
     nap_run_id: Optional[str] = None
@@ -7061,6 +7070,22 @@ def create_app(
             vector_writer=vector_writer,
             embed_into_medium=body.embed_into_medium,
             emit_dream_artifacts=body.emit_dream_artifacts,
+        )
+
+    @app.post("/dream/import-logs")
+    def import_dream_logs(body: DreamImportLogs) -> Dict[str, Any]:
+        vector_writer = _vector_writer_for_memory(
+            cp,
+            enabled=body.embed and not body.dry_run,
+            qdrant_url=body.qdrant_url,
+        )
+        return cp.import_dream_logs(
+            dream_logs_dir=body.dream_logs_dir,
+            agent_id=body.agent_id,
+            created_by=body.created_by,
+            embed=body.embed,
+            vector_writer=vector_writer,
+            dry_run=body.dry_run,
         )
 
     @app.post("/agents/{agent_id}/nap-consolidate")

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -4514,6 +4514,23 @@ def cmd_memory_recall_dreams(args: argparse.Namespace) -> None:
     _print(cp.recall_dream_artifacts(args.query, **kwargs))
 
 
+def cmd_dream_import_logs(args: argparse.Namespace) -> None:
+    """Merge the gateway's orphaned ~/.hermes/dream_logs reports into durable
+    memory (record_type dream:imported_report), embedding each so it is
+    retrievable via dream recall. Idempotent; dedups on findings."""
+    cp = _plane(args)
+    kwargs = {
+        "dream_logs_dir": getattr(args, "dream_logs_dir", None),
+        "agent_id": getattr(args, "agent_id", None),
+        "embed": not args.no_embed,
+        "dry_run": args.dry_run,
+    }
+    qdrant_url = getattr(args, "qdrant_url", None)
+    if qdrant_url:
+        kwargs["qdrant_url"] = qdrant_url
+    _print(cp.import_dream_logs(**kwargs))
+
+
 def cmd_nap_cycle(args: argparse.Namespace) -> None:
     """mem-08 autonomy: begin + consolidate + complete in one shot."""
     from mac.dispatch import RemoteDispatch
@@ -7372,6 +7389,35 @@ def build_parser() -> argparse.ArgumentParser:
     mood_history.add_argument("agent_id")
     mood_history.add_argument("--limit", type=int, default=50)
     _set(cmd_mood_history, mood_history)
+
+    dream = sub.add_parser(
+        "dream",
+        help="dream-cycle learning maintenance",
+    ).add_subparsers(dest="dream_command", required=True)
+    dream_import = dream.add_parser(
+        "import-logs",
+        help="merge orphaned ~/.hermes/dream_logs reports into durable memory",
+    )
+    dream_import.add_argument(
+        "--dream-logs-dir",
+        default=None,
+        help="source dir (default: $HERMES_HOME/dream_logs)",
+    )
+    dream_import.add_argument(
+        "--agent-id", default=None, help="attribute imported dreams to this agent"
+    )
+    dream_import.add_argument("--qdrant-url", default=None)
+    dream_import.add_argument(
+        "--no-embed",
+        action="store_true",
+        help="skip vector embedding (imported dreams won't be recall-eligible)",
+    )
+    dream_import.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be imported without writing",
+    )
+    _set(cmd_dream_import_logs, dream_import)
 
     nap = sub.add_parser(
         "nap",

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -1763,6 +1763,31 @@ class RemoteDispatch:
             self._post("/agents/%s/nap-cycle" % quote(agent_id, safe=""), body)
         )
 
+    def import_dream_logs(
+        self,
+        *,
+        dream_logs_dir: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        created_by: str = "dream-log-import",
+        embed: bool = True,
+        dry_run: bool = False,
+        qdrant_url: Optional[str] = None,
+        vector_writer: Any = None,
+    ) -> _Dictish:
+        if vector_writer is not None:
+            raise DispatchError("hub mode builds the dream vector writer on the hub")
+        body = _drop_none(
+            {
+                "dream_logs_dir": dream_logs_dir,
+                "agent_id": agent_id,
+                "created_by": created_by,
+                "embed": embed,
+                "dry_run": dry_run,
+                "qdrant_url": qdrant_url,
+            }
+        )
+        return _Dictish(self._post("/dream/import-logs", body))
+
     def consolidate_nap(
         self,
         agent_id: str,

--- a/src/mac/dream_log_import.py
+++ b/src/mac/dream_log_import.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from mac import mac_paths
-from mac.models import json_dumps
+from mac.models import MacMemoryTier, json_dumps
 
 IMPORT_SCHEMA = "mac.dream_log_import.v1"
 IMPORTED_RECORD_TYPE = "dream:imported_report"
@@ -124,12 +124,16 @@ def import_dream_logs(
     dream_logs_dir: Optional[Path] = None,
     agent_id: Optional[str] = None,
     created_by: str = DEFAULT_CREATED_BY,
+    vector_writer: Optional[Any] = None,
     dry_run: bool = False,
 ) -> Dict[str, Any]:
     """Consolidate ``$HERMES_HOME/dream_logs/*.md`` into durable memory.
 
-    ``cp`` is a ControlPlane. Returns a stable report dict. When ``dry_run`` is
-    set, nothing is written — the report shows what *would* be imported.
+    ``cp`` is a ControlPlane. When ``vector_writer`` is provided, each imported
+    memory is also embedded into the medium tier so it is retrievable via
+    ``recall_dream_artifacts`` (dream memories that are not embedded never
+    surface in vector recall — the whole point of the merge). Returns a stable
+    report dict. When ``dry_run`` is set, nothing is written.
     """
     directory = Path(dream_logs_dir) if dream_logs_dir is not None else mac_paths.dream_logs_dir()
     report: Dict[str, Any] = {
@@ -137,6 +141,7 @@ def import_dream_logs(
         "source_dir": str(directory),
         "scanned": 0,
         "imported": 0,
+        "embedded": 0,
         "skipped_empty": 0,
         "skipped_duplicate": 0,
         "dry_run": dry_run,
@@ -192,4 +197,16 @@ def import_dream_logs(
             continue
         report["imported"] += 1
         report["imported_ids"].append(memory.id)
+        if vector_writer is not None:
+            try:
+                vector_writer.embed_memory(
+                    memory.id,
+                    tier=MacMemoryTier.MEDIUM.value,
+                    created_by=created_by,
+                )
+                report["embedded"] += 1
+            except Exception as exc:  # noqa: BLE001 - memory persists even if embed fails
+                report["errors"].append(
+                    {"file": path.name, "phase": "embed", "error": str(exc)}
+                )
     return report

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -17102,6 +17102,46 @@ class ControlPlane:
             hits = [hit for hit in hits if _confidence_score(hit) >= floor]
         return hits[: max(1, int(limit))]
 
+    def import_dream_logs(
+        self,
+        *,
+        dream_logs_dir: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        created_by: str = "dream-log-import",
+        embed: bool = True,
+        qdrant_url: Optional[str] = None,
+        vector_writer: Optional[Any] = None,
+        dry_run: bool = False,
+    ) -> JsonDict:
+        """Merge the gateway's orphaned ``~/.hermes/dream_logs`` reports into
+        durable ``memory_records`` (record_type ``dream:imported_report``).
+
+        No first-party reader consumes ``dream_logs`` today, so that learning
+        never reached MAC's durable store; this consolidates it. Each imported
+        memory is ``subject_type='dream'`` and, when ``embed`` is set and a
+        Qdrant URL is configured, is embedded into the medium tier so it becomes
+        retrievable via :meth:`recall_dream_artifacts`. Idempotent; dedups on
+        findings. Returns the importer's stable report dict.
+        """
+        from pathlib import Path as _Path
+
+        from mac import dream_log_import as _dli
+
+        if embed and vector_writer is None and not dry_run:
+            url = _configured_qdrant_url(qdrant_url)
+            if url:
+                from mac.vector_writer_service import VectorWriterService
+
+                vector_writer = VectorWriterService(memory=self.memory, qdrant_url=url)
+        return _dli.import_dream_logs(
+            self,
+            dream_logs_dir=_Path(dream_logs_dir) if dream_logs_dir else None,
+            agent_id=agent_id,
+            created_by=created_by,
+            vector_writer=vector_writer,
+            dry_run=dry_run,
+        )
+
     def run_nap_cycle(
         self,
         agent_id: str,

--- a/tests/test_dream_log_import.py
+++ b/tests/test_dream_log_import.py
@@ -121,6 +121,44 @@ def test_dry_run_writes_nothing(tmp_path):
     assert len(rows) == 0
 
 
+class _FakeWriter:
+    def __init__(self, fail=False):
+        self.calls = []
+        self.fail = fail
+
+    def embed_memory(self, memory_id, *, tier, created_by):
+        self.calls.append((memory_id, tier, created_by))
+        if self.fail:
+            raise RuntimeError("qdrant down")
+
+
+def test_import_embeds_each_memory_when_writer_provided(tmp_path):
+    cp = ControlPlane.in_memory()
+    d = _write_logs(tmp_path)
+    writer = _FakeWriter()
+    report = dream_log_import.import_dream_logs(cp, dream_logs_dir=d, vector_writer=writer)
+    assert report["imported"] == 1
+    assert report["embedded"] == 1
+    assert len(writer.calls) == 1
+    assert writer.calls[0][1] == "medium"  # MEDIUM tier
+
+
+def test_embed_failure_keeps_the_memory(tmp_path):
+    cp = ControlPlane.in_memory()
+    d = _write_logs(tmp_path)
+    report = dream_log_import.import_dream_logs(
+        cp, dream_logs_dir=d, vector_writer=_FakeWriter(fail=True)
+    )
+    assert report["imported"] == 1
+    assert report["embedded"] == 0
+    assert any(e.get("phase") == "embed" for e in report["errors"])
+    rows = cp.store.query_all(
+        "SELECT id FROM memory_records WHERE record_type = ?",
+        (dream_log_import.IMPORTED_RECORD_TYPE,),
+    )
+    assert len(rows) == 1  # memory persists even though embedding failed
+
+
 def test_missing_directory_is_reported_not_raised(tmp_path):
     cp = ControlPlane.in_memory()
     report = dream_log_import.import_dream_logs(cp, dream_logs_dir=tmp_path / "nope")


### PR DESCRIPTION
Makes the orphaned-dream-log merge usable and runs it through hub authority.

- Importer gains optional `vector_writer`; each imported `dream:imported_report` memory is embedded into the medium tier (idempotent) so it surfaces via `recall_dream_artifacts` (`subject_type='dream'`). Embed failure never loses the memory.
- `ControlPlane.import_dream_logs` builds the writer from the hub's Qdrant config (mirrors `recall_dream_artifacts`/`run_nap_cycle`).
- Hub-served path (single writer, hub authority): `POST /dream/import-logs`, `RemoteDispatch.import_dream_logs`, and `mac dream import-logs [--dream-logs-dir] [--agent-id] [--no-embed] [--dry-run] [--qdrant-url]`.

All new code resolves paths via `mac_paths` (guard clean). Full gate green; app builds with the route; 162 nap/dream/vector suites + new embed tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)