### PR TITLE
Fix OpenShell harvest of generated runtime state

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -2116,6 +2116,10 @@ _SANDBOX_DOWNLOAD_RUNTIME_ROOT_NAMES = {
     "node_modules",
 }
 
+_SANDBOX_DOWNLOAD_WORKSPACE_RUNTIME_ROOT_NAMES = {
+    ".mac-toolchain",
+}
+
 
 def _relative_path_or_none(path: Path, root: Path) -> Optional[Path]:
     try:
@@ -2249,6 +2253,11 @@ def _sandbox_download_path_excluded(rel_path: Path, repository_roots: set[Path])
         ".git" in rel_path.parts
         or _sandbox_download_path_is_git_backup(rel_path)
         or _sandbox_download_path_is_host_control(rel_path)
+    ):
+        return True
+    if (
+        rel_path.parts
+        and rel_path.parts[0] in _SANDBOX_DOWNLOAD_WORKSPACE_RUNTIME_ROOT_NAMES
     ):
         return True
     for root in repository_roots:
@@ -3183,6 +3192,41 @@ def _sandbox_download(name: str, basename: str, workspace: Path) -> bool:
     back into the host workspace. Best-effort: a failure is logged, not fatal —
     completeness is still judged by the evidence manifest on the host."""
     sub = "%s/%s" % (_SANDBOX_WORKDIR, basename)
+    repository_roots = _sandbox_repository_roots(workspace, workspace)
+    generated_paths = {
+        Path(root_name)
+        for root_name in _SANDBOX_DOWNLOAD_WORKSPACE_RUNTIME_ROOT_NAMES
+    }
+    for repository_root in repository_roots:
+        generated_paths.update(
+            repository_root / root_name
+            for root_name in _SANDBOX_DOWNLOAD_RUNTIME_ROOT_NAMES
+        )
+    cleanup_script = shlex.join(
+        ["rm", "-rf", "--", *(str(path) for path in sorted(generated_paths))]
+    )
+    cleanup_ok, cleanup_msg = _sandbox_step(
+        [
+            "exec",
+            "--name",
+            name,
+            "--workdir",
+            sub,
+            "--timeout",
+            "30",
+            "--no-tty",
+            "--",
+            "/bin/sh",
+            "-c",
+            cleanup_script,
+        ],
+        timeout=60.0,
+    )
+    if not cleanup_ok:
+        sys.stderr.write(
+            "[executor] WARNING: sandbox generated-state cleanup failed before "
+            "download: %s\n" % cleanup_msg
+        )
     temp_parent = str(workspace.parent) if workspace.parent.is_dir() else None
     with tempfile.TemporaryDirectory(
         prefix=".%s-openshell-download-" % workspace.name,

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -478,13 +478,17 @@ def test_invoke_sandboxed_runs_full_lifecycle(monkeypatch, tmp_path):
     workspace = tmp_path / "task-7"
     workspace.mkdir()
     te._invoke_agent(r, "do it", workspace, "tid", {})
-    # 1 audited create call (runs the agent), then download + delete out-of-band
+    # 1 audited create call (runs the agent), then generated-state cleanup,
+    # download, and delete out-of-band.
     assert len(r.calls) == 1
     create = r.calls[0][0]
     assert create[:3] == ["openshell", "sandbox", "create"] and "--upload" in create
-    assert steps[0][:3] == ["download", "sb1", "/sandbox/task-7"]
-    assert Path(steps[0][3]).name.startswith(".task-7-openshell-download-")
-    assert steps[1] == ["delete", "sb1"]
+    assert steps[0][:3] == ["exec", "--name", "sb1"]
+    assert steps[0][-3:-1] == ["/bin/sh", "-c"]
+    assert ".mac-toolchain" in steps[0][-1]
+    assert steps[1][:3] == ["download", "sb1", "/sandbox/task-7"]
+    assert Path(steps[1][3]).name.startswith(".task-7-openshell-download-")
+    assert steps[2] == ["delete", "sb1"]
     salvage = (workspace / "openshell-salvage.json").read_text(encoding="utf-8")
     assert '"harvested": true' in salvage
     assert [event for event, _detail in events if event.startswith("sandbox_")] == [

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -998,8 +998,12 @@ def test_sandboxed_repo_task_runs_verification_before_download(tmp_path, monkeyp
     assert "export MAC_TASK_WORKSPACE=/sandbox/task" in uploaded_scripts[0]
     assert "export MAC_TASK_REPO_WORKTREE=/sandbox/task/repo" in uploaded_scripts[0]
     assert "mac-sandbox-verification.json" in te._sandbox_repository_verification_shell()
-    assert steps[3][0] == "download"
-    assert steps[4][0] == "delete"
+    assert steps[3][:2] == ["exec", "--name"]
+    assert steps[3][-3:-1] == ["/bin/sh", "-c"]
+    assert ".mac-toolchain" in steps[3][-1]
+    assert "repo/.codegraph" in steps[3][-1]
+    assert steps[4][0] == "download"
+    assert steps[5][0] == "delete"
 
 
 def test_clean_failed_agent_skips_repository_finalizer_but_harvests(tmp_path, monkeypatch):
@@ -1279,10 +1283,17 @@ def test_sandbox_download_merge_preserves_host_git_metadata_and_skips_runtime_di
     )
     (sandbox_repo / ".venv" / "bin").mkdir(parents=True)
     (sandbox_repo / ".venv" / "bin" / "python").write_text("container venv\n", encoding="utf-8")
+    (sandbox_repo / ".codegraph").mkdir()
+    (sandbox_repo / ".codegraph" / "codegraph.db").write_text(
+        "generated index\n", encoding="utf-8"
+    )
     (sandbox_repo / "fixtures" / "node_modules").mkdir(parents=True)
     (sandbox_repo / "fixtures" / "node_modules" / "package.json").write_text("{}\n", encoding="utf-8")
     (sandbox_repo / "same.py").write_text("new\n", encoding="utf-8")
     (sandbox_repo / "new.py").write_text("added\n", encoding="utf-8")
+    toolchain = download / ".mac-toolchain" / "bin"
+    toolchain.mkdir(parents=True)
+    os.symlink("/opt/mac-tools/gh", toolchain / "gh")
     (download / "mac-evidence.json").write_text('{"status":"complete"}\n', encoding="utf-8")
 
     te._merge_sandbox_download_tree(download, workspace)
@@ -1294,11 +1305,61 @@ def test_sandbox_download_merge_preserves_host_git_metadata_and_skips_runtime_di
     assert not (repo / ".git.bak123").exists()
     assert not (repo / ".git.bak-old").exists()
     assert not (repo / ".venv").exists()
+    assert not (repo / ".codegraph").exists()
+    assert not (workspace / ".mac-toolchain").exists()
     assert not (repo / "old.py").exists()
     assert (repo / "same.py").read_text(encoding="utf-8") == "new\n"
     assert (repo / "new.py").read_text(encoding="utf-8") == "added\n"
     assert (repo / "fixtures" / "node_modules" / "package.json").exists()
     assert (workspace / "mac-evidence.json").exists()
+
+
+def test_sandbox_download_removes_generated_runtime_before_transfer(
+    tmp_path, monkeypatch
+):
+    workspace = tmp_path / "task"
+    repo = workspace / "repo"
+    repo.mkdir(parents=True)
+    (workspace / "repository-worktree.json").write_text(
+        json.dumps({"repository_worktree": str(repo)}), encoding="utf-8"
+    )
+    calls = []
+
+    def step(args, *, timeout):
+        calls.append((list(args), timeout))
+        return True, ""
+
+    monkeypatch.setattr(te, "_sandbox_step", step)
+    monkeypatch.setattr(
+        te, "_merge_sandbox_download_tree", lambda download_root, target: None
+    )
+
+    assert te._sandbox_download("sb", "task", workspace) is True
+    assert [call[0][0] for call in calls] == ["exec", "download"]
+    cleanup_argv = calls[0][0]
+    cleanup_script = cleanup_argv[-1]
+    assert cleanup_argv[cleanup_argv.index("--workdir") + 1] == "/sandbox/task"
+    assert cleanup_script.startswith("rm -rf -- ")
+    assert ".mac-toolchain" in cleanup_script
+    assert "repo/.codegraph" in cleanup_script
+    assert "repo/.venv" in cleanup_script
+    assert "repo/node_modules" in cleanup_script
+
+
+def test_sandbox_download_still_rejects_authored_absolute_symlinks(tmp_path):
+    workspace = tmp_path / "task"
+    repo = workspace / "repo"
+    repo.mkdir(parents=True)
+    (workspace / "repository-worktree.json").write_text(
+        json.dumps({"repository_worktree": str(repo)}), encoding="utf-8"
+    )
+    download = tmp_path / "download"
+    authored = download / "repo" / "src"
+    authored.mkdir(parents=True)
+    os.symlink("/etc/passwd", authored / "escape")
+
+    with pytest.raises(ValueError, match="absolute target: repo/src/escape"):
+        te._merge_sandbox_download_tree(download, workspace)
 
 
 def test_sandbox_download_merge_failure_is_best_effort(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
Removes known generated runtime roots inside the sandbox before workspace transfer, excludes the workspace toolchain during merge, and retains fail-closed rejection for absolute symlinks in authored source. Full contract gate passed: 9835 regular tests passed, 4 skipped; protected phase 4 passed, 43 skipped; coverage floors passed. CodeGraph sync and affected audit passed.