### PR TITLE
Treat advisory startup degradation as dispatch ready in the allocator

### DIFF
--- a/src/mac/allocator.py
+++ b/src/mac/allocator.py
@@ -163,10 +163,24 @@ class AllocationAgent:
             if str(project)
         )
         health = str(value("health_status", "") or "").lower()
+        # An advisory startup self-test can report ``degraded`` while proving it
+        # has no blocking problems. deploy-mac-fleet.sh (release_health_ready)
+        # and ControlPlane._advisory_health_dispatch_ready both treat that as
+        # dispatch-ready; disagreeing here would let the hub offer an agent that
+        # the policy layer then refuses, once per round, forever.
+        startup = resources.get("startup_self_test")
+        advisory_ready = bool(
+            health == "degraded"
+            and isinstance(startup, Mapping)
+            and startup.get("schema") == "mac.agent_startup_self_test.v1"
+            and startup.get("agent_id") == str(value("id"))
+            and startup.get("status") == "degraded"
+            and startup.get("blocking_problems") == []
+        )
         return cls(
             id=str(value("id")),
             online=bool(online),
-            healthy=health == "healthy",
+            healthy=health == "healthy" or advisory_ready,
             dispatch_held=bool(value("dispatch_hold", False)),
             machine_trusted=bool(machine_trusted),
             capacity=int(capacity),

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -24579,17 +24579,51 @@ class ControlPlane:
             return False
         return bool(ensure_json_object(rec.metadata).get("dispatch_paused"))
 
+    @staticmethod
+    def _advisory_health_dispatch_ready(agent: Agent) -> bool:
+        """Accept health that is safe for coding-task dispatch.
+
+        A gateway/model probe may report a degraded startup self-test while
+        also proving that it has no blocking problems. ``deploy-mac-fleet.sh``
+        already releases such an agent (``release_health_ready``); the
+        allocator has to agree, or an advisory condition — an OpenClaw probe
+        that cannot find a stale sandbox, say — benches an otherwise idle,
+        authenticated worker, and does it to every worker at once.
+        """
+
+        if agent.health_status == HealthStatus.HEALTHY.value:
+            return True
+        if agent.health_status != HealthStatus.DEGRADED.value:
+            return False
+        startup = ensure_json_object(
+            ensure_json_object(agent.resources).get("startup_self_test")
+        )
+        return bool(
+            startup.get("schema") == "mac.agent_startup_self_test.v1"
+            and startup.get("agent_id") == agent.id
+            and startup.get("status") == HealthStatus.DEGRADED.value
+            and startup.get("blocking_problems") == []
+        )
+
     def _available_agents(self) -> List[Agent]:
+        # Health is filtered in Python rather than SQL: the advisory verdict
+        # lives inside the resources JSON, whose accessors differ per backend.
         rows = self.store.query_all(
             """
             SELECT a.* FROM agents a
             JOIN machines m ON m.id = a.machine_id
-            WHERE a.status IN (?, ?) AND a.health_status = ? AND m.trusted = 1
+            WHERE a.status IN (?, ?) AND a.health_status IN (?, ?) AND m.trusted = 1
             ORDER BY a.last_seen_at DESC, a.id
             """,
-            (AgentStatus.IDLE.value, AgentStatus.BUSY.value, HealthStatus.HEALTHY.value),
+            (
+                AgentStatus.IDLE.value,
+                AgentStatus.BUSY.value,
+                HealthStatus.HEALTHY.value,
+                HealthStatus.DEGRADED.value,
+            ),
         )
-        return [self._agent_from_row(row) for row in rows]
+        agents = [self._agent_from_row(row) for row in rows]
+        return [agent for agent in agents if self._advisory_health_dispatch_ready(agent)]
 
     def _coordination_related_task_ids(self, task: Task) -> set[str]:
         """Return the durable task family used for cooperative separation."""
@@ -24691,7 +24725,7 @@ class ControlPlane:
             return "agent_deleted"
         if agent.status not in {AgentStatus.IDLE.value, AgentStatus.BUSY.value}:
             return "agent_status_unavailable"
-        if agent.health_status != HealthStatus.HEALTHY.value:
+        if not self._advisory_health_dispatch_ready(agent):
             return "agent_health_unavailable"
         if not self.directives.agent_policy_ready(agent.id):
             return "directive_policy_unacknowledged"
@@ -24774,7 +24808,7 @@ class ControlPlane:
             return "agent_deleted"
         if agent.status not in {AgentStatus.IDLE.value, AgentStatus.BUSY.value}:
             return "agent_status_unavailable"
-        if agent.health_status != HealthStatus.HEALTHY.value:
+        if not self._advisory_health_dispatch_ready(agent):
             return "agent_health_unavailable"
         # MacWorker owns one synchronous executor, and allocator-v2 snapshots
         # deliberately expose exactly one slot.  Do not reinterpret a
@@ -24985,7 +25019,7 @@ class ControlPlane:
             return False, "agent_dispatch_held"
         if agent.status not in {AgentStatus.IDLE.value, AgentStatus.BUSY.value}:
             return False, "agent_status_unavailable"
-        if agent.health_status != HealthStatus.HEALTHY.value:
+        if not self._advisory_health_dispatch_ready(agent):
             return False, "agent_health_unavailable"
         if not self.directives.agent_policy_ready(agent.id):
             return False, "directive_policy_unacknowledged"

--- a/tests/test_authoritative_allocator.py
+++ b/tests/test_authoritative_allocator.py
@@ -390,3 +390,67 @@ def test_round_completion_hook_runs_once_and_cannot_invalidate_leases():
     assert observed == ["round"]
     assert result.assigned_count == 1
     assert result.completion_hook_error == "RuntimeError:telemetry unavailable"
+
+
+def _agent_with_startup_self_test(startup, *, health_status="degraded", agent_id="worker"):
+    return AllocationAgent.from_hub_record(
+        {
+            "id": agent_id,
+            "health_status": health_status,
+            "capabilities": ["python"],
+            "resources": {"startup_self_test": startup},
+        },
+        online=True,
+        capacity=1,
+        active_leases=0,
+        machine_trusted=True,
+    )
+
+
+def _advisory_startup(agent_id="worker", blocking=()):
+    return {
+        "schema": "mac.agent_startup_self_test.v1",
+        "agent_id": agent_id,
+        "status": "degraded",
+        "blocking_problems": list(blocking),
+        "non_blocking_problems": ["OpenClaw agent self-test exited 1"],
+    }
+
+
+def test_advisory_startup_degradation_is_dispatch_ready():
+    """A degraded self-test with no blocking problems must still dispatch.
+
+    deploy-mac-fleet.sh already releases this agent (release_health_ready);
+    when the allocator disagreed, one failed OpenClaw probe benched the whole
+    fleet while the ledger still reported free capacity.
+    """
+
+    worker = _agent_with_startup_self_test(_advisory_startup())
+    assert worker.healthy is True
+
+    result = AuthoritativeAllocator().allocate_round(
+        [task("task", required_capabilities=frozenset({"python"}))],
+        [worker],
+        lambda proposal: ClaimCommit.success({"lease_id": "lease-1"}),
+        round_id="round",
+    )
+    assert result.assigned_count == 1
+
+
+def test_blocking_startup_problems_are_not_dispatch_ready():
+    worker = _agent_with_startup_self_test(
+        _advisory_startup(blocking=["qdrant_shared_memory unreachable"])
+    )
+    assert worker.healthy is False
+
+
+def test_advisory_startup_verdict_for_another_agent_is_ignored():
+    worker = _agent_with_startup_self_test(_advisory_startup(agent_id="someone-else"))
+    assert worker.healthy is False
+
+
+def test_unhealthy_agent_stays_ineligible():
+    worker = _agent_with_startup_self_test(
+        _advisory_startup(), health_status="unhealthy"
+    )
+    assert worker.healthy is False


### PR DESCRIPTION
## Problem

`deploy/deploy-mac-fleet.sh` already knows this rule: `release_health_ready` (707444e9) releases an agent whose startup self-test reports `degraded` while proving `blocking_problems == []`. The allocator never learned it — `_available_agents` and the claim-time re-checks all required `health_status == "healthy"`.

Observed in production 2026-07-30/31: every agent reported `degraded` because the OpenClaw self-test exits 1 with `"sandbox not found"` — a **non_blocking_problem** — and the hub dispatched nothing for 17 hours while its own telemetry still reported free capacity.

## Change

Apply the same predicate at all four task-dispatch decision points so the snapshot, the pure allocator policy, and the two transactional re-checks cannot disagree. A disagreement here does not fail loudly: the allocator proposes an agent the claim transaction then refuses, once per round, indefinitely.

Service-role claim eligibility (`_agent_service_claim_eligibility_reason`) is deliberately untouched — that gate is about service roles, not coding-task dispatch.

## Safety

Blocking problems, an unhealthy agent, and a verdict stamped for a different `agent_id` all remain ineligible. Four new tests cover those cases.

`1207 passed, 6 skipped` across the dispatch/allocator/claim/lifecycle suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)