### PR TITLE
Keep failure output, stop false recovery telemetry, and survive fleet re-keys

### DIFF
--- a/src/mac/fleet_release_epoch_service.py
+++ b/src/mac/fleet_release_epoch_service.py
@@ -1778,9 +1778,16 @@ class FleetReleaseEpochService:
                     conn.execute(
                         "UPDATE agents SET "
                         "attestation_key_prev_ciphertext = attestation_key_ciphertext, "
+                        "attestation_key_history_ciphertext = ?, "
                         "attestation_key_ciphertext = ?, "
                         "attestation_key_rotated_at = ?, updated_at = ? WHERE id = ?",
                         (
+                            # A release rotates the whole fleet at once. Keeping
+                            # only one prior generation meant two releases put
+                            # in-flight review evidence permanently out of reach.
+                            self.control_plane._attestation_history_after_rotation(
+                                agent_id, rotated_at=now, conn=conn
+                            ),
                             self.control_plane.secrets._encrypt(candidate_key),
                             now,
                             now,

--- a/src/mac/harness_recovery_reflex.py
+++ b/src/mac/harness_recovery_reflex.py
@@ -147,7 +147,7 @@ def choose_remediation(
 def try_recovery(
     attempt_state: JsonDict,
     failure_info: str,
-    dispatch: Callable[[str, JsonDict], Any],
+    dispatch: Optional[Callable[[str, JsonDict], Any]],
     observe: Callable[[str, str, str], None],
     *,
     llm_fn: Optional[Callable[[str], str]] = None,
@@ -164,7 +164,10 @@ def try_recovery(
         Human-readable description of the failure being triaged.
     dispatch:
         Callable ``(action: str, context: dict) -> Any``.  The reflex calls
-        this to execute the chosen remediation action.
+        this to execute the chosen remediation action.  Pass ``None`` when the
+        caller only wants the retry/escalate decision and has no remediation
+        dispatcher wired: the reflex then says so in the log instead of
+        claiming it dispatched something.
     observe:
         Callable ``(step: str, choice: str, result: str) -> None``.  Called
         once per ``try_recovery`` invocation for observability.
@@ -174,8 +177,9 @@ def try_recovery(
     Returns
     -------
     (recovered, choice, log_message) : tuple[bool, str, str]
-        ``recovered`` – True when the reflex dispatched a recovery action and
-        believes it has a chance of succeeding; False on limit/escalation.
+        ``recovered`` – True when the caller should retry the failed step
+        (a remediation was dispatched, or none was wired and the reflex chose
+        to retry anyway); False on limit/escalation/dispatch failure.
         ``choice``    – The chosen :class:`RemediationChoice` value string.
         ``log_message`` – A brief human-readable explanation.
     """
@@ -199,13 +203,24 @@ def try_recovery(
         return False, choice, log_message
 
     # --- Dispatch the chosen remediation ---
-    try:
-        dispatch(choice, {"failure_info": failure_info, "attempt": count})
-        log_message = "dispatched %s (attempt %d)" % (choice, count + 1)
+    # A caller with no remediation dispatcher still gets the retry decision,
+    # but must not be told a remediation ran. This log is what operators — and
+    # this fleet's own agents — read to judge whether recovery works, so a
+    # false "dispatched" here is worse than no record at all.
+    if dispatch is None:
+        log_message = (
+            "chose %s; no remediation dispatcher wired - retrying without "
+            "remediation (attempt %d)" % (choice, count + 1)
+        )
         recovered = True
-    except Exception as exc:  # noqa: BLE001
-        log_message = "dispatch(%s) failed: %s" % (choice, exc)
-        recovered = False
+    else:
+        try:
+            dispatch(choice, {"failure_info": failure_info, "attempt": count})
+            log_message = "dispatched %s (attempt %d)" % (choice, count + 1)
+            recovered = True
+        except Exception as exc:  # noqa: BLE001
+            log_message = "dispatch(%s) failed: %s" % (choice, exc)
+            recovered = False
 
     attempt_state["recovery_count"] = count + 1
     attempt_state["recovery_log"] = log + [log_message]

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -15377,6 +15377,90 @@ class ControlPlane:
         except Exception:  # noqa: BLE001 - a corrupt prev key shouldn't crash review
             return None
 
+    ATTESTATION_KEY_HISTORY_LIMIT = 5
+
+    def _agent_attestation_history_keys(self, agent_id: str) -> List[str]:
+        """Decrypted attestation keys retired before the immediate previous one.
+
+        A fleet release rotates every participating agent at once
+        (fleet_release_epoch_service). With only ``prev`` retained, two
+        releases put in-flight review evidence permanently out of reach and the
+        task parks in waiting_for_verifiable_evidence with no diagnosis --
+        observed live 2026-07-30, when one release orphaned 66 tasks.
+        """
+
+        row = self.store.query_one(
+            "SELECT attestation_key_history_ciphertext FROM agents WHERE id = ?",
+            (agent_id,),
+        )
+        if row is None:
+            return []
+        try:
+            raw = row["attestation_key_history_ciphertext"]
+        except (KeyError, IndexError):  # column predates this build
+            return []
+        if not raw:
+            return []
+        keys: List[str] = []
+        for item in json_loads(raw, []) or []:
+            if not isinstance(item, Mapping):
+                continue
+            ciphertext = item.get("ciphertext")
+            if not ciphertext:
+                continue
+            try:
+                keys.append(self.secrets._decrypt(str(ciphertext)))
+            except Exception:  # noqa: BLE001 - one corrupt entry must not hide the rest
+                continue
+        return keys
+
+    def _attestation_history_after_rotation(
+        self, agent_id: str, *, rotated_at: str, conn: Any = None
+    ) -> str:
+        """Push the outgoing key onto a bounded, timestamped key history."""
+
+        reader = conn if conn is not None else self.store
+        row = reader.execute(
+            "SELECT attestation_key_ciphertext, attestation_key_history_ciphertext "
+            "FROM agents WHERE id = ?",
+            (agent_id,),
+        ).fetchone()
+        outgoing = None
+        history = []
+        if row is not None:
+            try:
+                outgoing = row["attestation_key_ciphertext"]
+            except (KeyError, IndexError):
+                outgoing = None
+            try:
+                history = list(json_loads(row["attestation_key_history_ciphertext"], []) or [])
+            except (KeyError, IndexError):
+                history = []
+        if outgoing:
+            history.insert(0, {"ciphertext": outgoing, "rotated_at": rotated_at})
+        return json_dumps(history[: self.ATTESTATION_KEY_HISTORY_LIMIT])
+
+    def _verify_manifest_against_retained_keys(
+        self,
+        signed_by: str,
+        manifest: Mapping[str, Any],
+        signature: str,
+    ) -> bool:
+        """Try every retained generation for this signer.
+
+        Only keys this hub already holds for that agent are tried, so this
+        widens how long a signature stays verifiable without widening who is
+        allowed to sign.
+        """
+
+        prev_key = self._agent_attestation_prev_key(signed_by)
+        candidates = [prev_key] if prev_key is not None else []
+        candidates.extend(self._agent_attestation_history_keys(signed_by))
+        for candidate in candidates:
+            if verify_verification_manifest_signature(candidate, manifest, signature):
+                return True
+        return False
+
     def rotate_agent_attestation_key(self, agent_id: str) -> str:
         """Rotate and return the cleartext HMAC key for one agent.
 
@@ -15409,12 +15493,21 @@ class ControlPlane:
                 """
                 UPDATE agents
                 SET attestation_key_prev_ciphertext = attestation_key_ciphertext,
+                    attestation_key_history_ciphertext = ?,
                     attestation_key_ciphertext = ?,
                     attestation_key_rotated_at = ?,
                     updated_at = ?
                 WHERE id = ?
                 """,
-                (self.secrets._encrypt(key), now, now, agent_id),
+                (
+                    self._attestation_history_after_rotation(
+                        agent_id, rotated_at=now, conn=conn
+                    ),
+                    self.secrets._encrypt(key),
+                    now,
+                    now,
+                    agent_id,
+                ),
             )
         return key
 
@@ -15543,12 +15636,21 @@ class ControlPlane:
                 """
                 UPDATE agents
                 SET attestation_key_prev_ciphertext = attestation_key_ciphertext,
+                    attestation_key_history_ciphertext = ?,
                     attestation_key_ciphertext = ?,
                     attestation_key_rotated_at = ?,
                     updated_at = ?
                 WHERE id = ?
                 """,
-                (self.secrets._encrypt(key), now, now, agent_id),
+                (
+                    self._attestation_history_after_rotation(
+                        agent_id, rotated_at=now, conn=conn
+                    ),
+                    self.secrets._encrypt(key),
+                    now,
+                    now,
+                    agent_id,
+                ),
             )
             self._record_agent_lifecycle_event(
                 conn,
@@ -25549,11 +25651,9 @@ class ControlPlane:
                 except ValueError:
                     predates = False
                 if predates:
-                    prev_key = self._agent_attestation_prev_key(signed_by)
-                    if prev_key is not None:
-                        rotated_ok = verify_verification_manifest_signature(
-                            prev_key, manifest, signature
-                        )
+                    rotated_ok = self._verify_manifest_against_retained_keys(
+                        signed_by, manifest, signature
+                    )
             if not rotated_ok:
                 return {
                     "valid": False,
@@ -26708,11 +26808,9 @@ class ControlPlane:
                         predates_rotation = False
                 prev_ok = False
                 if predates_rotation:
-                    prev_key = self._agent_attestation_prev_key(signed_by)
-                    if prev_key is not None:
-                        prev_ok = verify_verification_manifest_signature(
-                            prev_key, manifest, signature
-                        )
+                    prev_ok = self._verify_manifest_against_retained_keys(
+                        signed_by, manifest, signature
+                    )
                 if not prev_ok:
                     if predates_rotation:
                         # Rotated, and the retained previous key is absent

--- a/src/mac/store.py
+++ b/src/mac/store.py
@@ -6800,6 +6800,17 @@ class SQLiteStore:
             "attestation_key_prev_ciphertext",
             "attestation_key_prev_ciphertext TEXT",
         )
+        # A fleet release rotates every participating agent's attestation key
+        # (fleet_release_epoch_service). Retaining only ONE prior generation
+        # meant two releases orphaned every in-flight review: the evidence was
+        # signed under a key the hub could no longer reach, so the task parked
+        # in waiting_for_verifiable_evidence forever. Keep a bounded, stamped
+        # history so verification can reach the key that was active at signing.
+        self._ensure_column(
+            "agents",
+            "attestation_key_history_ciphertext",
+            "attestation_key_history_ciphertext TEXT",
+        )
         self._ensure_column(
             "fleet_release_epoch_agents",
             "prior_report_executor_projection_sha256",

--- a/src/mac/store_postgres.py
+++ b/src/mac/store_postgres.py
@@ -298,6 +298,11 @@ class PostgresStore:
             "attestation_key_prev_ciphertext TEXT",
         )
         self.ensure_column(
+            "agents",
+            "attestation_key_history_ciphertext",
+            "attestation_key_history_ciphertext TEXT",
+        )
+        self.ensure_column(
             "fleet_release_epoch_agents",
             "prior_report_executor_projection_sha256",
             "prior_report_executor_projection_sha256 TEXT",

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -1280,12 +1280,10 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                     _step = "worktree_preparation"
                 _wt_dir = self.workspace / _safe_path_component(task_id)
                 _wt_dir.mkdir(parents=True, exist_ok=True)
-                def _noop_dispatch(_action, _ctx):
-                    pass
                 _recovered, _choice, _msg = _hrr.try_recovery(
                     attempt_state,
                     str(_prep_exc),
-                    _noop_dispatch,
+                    None,  # no remediation dispatcher wired
                     lambda _s, _c, _r: self._emit_recovery_observability(
                         task_id, _s, _c, _r
                     ),
@@ -1333,12 +1331,10 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
             )
             if not execution.succeeded and _boot_failed:
                 _boot_info = "bootstrap failed: %s" % (_bootstrap_meta.get("error") or _bootstrap_meta.get("status") or "unknown")
-                def _noop_dispatch_b(_action, _ctx):
-                    pass
                 _b_recovered, _b_choice, _b_msg = _hrr.try_recovery(
                     attempt_state,
                     _boot_info,
-                    _noop_dispatch_b,
+                    None,  # no remediation dispatcher wired
                     lambda _s, _c, _r: self._emit_recovery_observability(
                         task_id, _s, _c, _r
                     ),
@@ -1420,6 +1416,11 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                                 "manual_repair_required": True,
                                 "evidence_id": evidence.get("id"),
                                 "problems": submission_problems,
+                                # Without this the ledger records only
+                                # "transition supplied no stdout, stderr,
+                                # output, log, or tail field" and the failure
+                                # is undiagnosable after the fact.
+                                "output_tail": _executor_output_tail(execution),
                             },
                         },
                     )
@@ -1524,6 +1525,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                     "detail": {
                         "reason": "executor_timeout",
                         "manual_repair_required": True,
+                        "output_tail": _executor_output_tail(execution),
                         "timeout_seconds": exc.timeout,
                         "process_tree_terminated": True,
                         "evidence_id": evidence.get("id") if evidence else None,
@@ -4294,12 +4296,10 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                 if not pushed:
                     _push_fail_info = "repository publication blocked: %s" % publication.error
                     if attempt_state is not None:
-                        def _noop_dispatch_p(_action, _ctx):
-                            pass
                         _p_recovered, _p_choice, _p_msg = _hrr.try_recovery(
                             attempt_state,
                             _push_fail_info,
-                            _noop_dispatch_p,
+                            None,  # no remediation dispatcher wired
                             lambda _s, _c, _r: self._emit_recovery_observability(
                                 task_id, _s, _c, _r
                             ),
@@ -7401,6 +7401,26 @@ def _truncate_process_text(value: str, limit: int = 4000) -> str:
     tail = limit - head
     marker = "\n… [%d chars omitted] …\n" % (len(text) - head - tail)
     return text[:head] + marker + text[-tail:]
+
+
+def _executor_output_tail(execution: "WorkerExecution") -> str:
+    """Bounded stderr+stdout for a failure transition detail.
+
+    ``_diagnostic_output_tail`` (services.py) reads only the transition detail,
+    so any failure path that omits this records "transition supplied no stdout,
+    stderr, output, log, or tail field" and cannot be diagnosed from the ledger.
+    """
+
+    return _truncate_process_text(
+        "\n".join(
+            part
+            for part in (
+                getattr(execution, "stderr", ""),
+                getattr(execution, "stdout", ""),
+            )
+            if str(part or "").strip()
+        )
+    )
 
 
 def _executor_failure_transition_detail(

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -9546,7 +9546,7 @@ def test_claim_task_enforces_tenant_policy_as_explicit_chokepoint(cp):
         cp.claim_task(task.id, worker.id)
 
 
-def test_attestation_single_rotation_verifies_double_rotation_errors(cp):
+def test_attestation_rotation_tolerated_within_retained_key_history(cp):
     """mac-s2vz followup: a SINGLE attestation-key rotation (e.g. an agent
     re-keyed after a redeploy) must NOT invalidate a verdict signed beforehand
     — the retained previous key verifies it, so review publication proceeds.
@@ -9583,17 +9583,32 @@ def test_attestation_single_rotation_verifies_double_rotation_errors(cp):
     assert not any("rotated" in p or "does not verify" in p for p in problems), \
         "a single rotation must not invalidate a pre-rotation verdict; got: %s" % problems
 
-    # A second rotation drops the previous key: the verdict is now genuinely
-    # unrecoverable and the clear recovery error surfaces.
-    cp.rotate_agent_attestation_key(reviewer.id)
+    # A fleet release rotates every agent at once, so "survives exactly one
+    # rotation" was not enough: two releases orphaned 66 in-flight reviews on
+    # 2026-07-30. Retained generations must keep the verdict verifiable.
+    for _ in range(cp.ATTESTATION_KEY_HISTORY_LIMIT - 1):
+        cp.rotate_agent_attestation_key(reviewer.id)
     _verdict2, problems2 = cp._find_review_verdict_evidence(
         task.id, reviewer.id,
         executor_evidence_id=evidence.id,
         verdict_evidence_id=verdict_id,
         not_before=review.created_at,
     )
-    assert any("rotated" in p for p in problems2), \
-        "expected clear rotation error after the prev key is gone, got: %s" % problems2
+    assert not any("rotated" in p or "does not verify" in p for p in problems2), \
+        "retained key history must survive a fleet-wide re-key; got: %s" % problems2
+
+    # Past the retention bound the key really is gone, and the clear
+    # rotation error must still surface rather than a vague failure.
+    for _ in range(3):
+        cp.rotate_agent_attestation_key(reviewer.id)
+    _verdict3, problems3 = cp._find_review_verdict_evidence(
+        task.id, reviewer.id,
+        executor_evidence_id=evidence.id,
+        verdict_evidence_id=verdict_id,
+        not_before=review.created_at,
+    )
+    assert any("rotated" in p for p in problems3), \
+        "expected clear rotation error once history is exhausted, got: %s" % problems3
 
 
 def test_executor_evidence_verifies_via_prev_key_after_rotation(cp):
@@ -9617,8 +9632,15 @@ def test_executor_evidence_verifies_via_prev_key_after_rotation(cp):
     assert cp._assess_default_review_evidence(task, evidence)["valid"] is True, \
         "executor evidence must verify via the retained previous key after one rotation"
 
-    # A second rotation drops the previous key -> now genuinely unverifiable.
-    cp.rotate_agent_attestation_key(worker.id)
+    # ...and so must a fleet-wide re-key, which rotates every agent at once.
+    for _ in range(cp.ATTESTATION_KEY_HISTORY_LIMIT - 1):
+        cp.rotate_agent_attestation_key(worker.id)
+    assert cp._assess_default_review_evidence(task, evidence)["valid"] is True, \
+        "retained key history must keep bound executor evidence verifiable"
+
+    # Past the retention bound the signature is genuinely unrecoverable.
+    for _ in range(3):
+        cp.rotate_agent_attestation_key(worker.id)
     result = cp._assess_default_review_evidence(task, evidence)
     assert result["valid"] is False and result["reason"] == "signature_invalid"
 

--- a/tests/test_harness_recovery_reflex.py
+++ b/tests/test_harness_recovery_reflex.py
@@ -674,3 +674,45 @@ class TestRecoveryOnNonStandardPrepFailure:
         assert calls["n"] == 2
         # The task proceeds past prep (no longer wedged on the prep failure).
         assert result.status != "no_task"
+
+
+def test_try_recovery_without_dispatcher_does_not_claim_it_dispatched(monkeypatch):
+    """A caller with no remediation dispatcher must not get a 'dispatched' log.
+
+    The worker passes None at every call site; recording "dispatched <action>"
+    there made recovery_log report repairs that never happened, which is the
+    signal operators and this fleet's own agents read to judge fleet health.
+    """
+
+    monkeypatch.setenv("MAC_RECOVERY_REFLEX_ENABLED", "1")
+    state: dict = {}
+    seen = []
+    recovered, choice, message = try_recovery(
+        state,
+        "worktree preparation exploded",
+        None,
+        lambda step, ch, res: seen.append((step, ch, res)),
+        llm_fn=lambda _prompt: "retry_fetch",
+    )
+
+    assert recovered is True  # the retry decision is still honoured
+    assert "dispatched" not in message
+    assert "no remediation dispatcher wired" in message
+    assert state["recovery_count"] == 1
+    assert seen and "dispatched" not in seen[0][2]
+
+
+def test_try_recovery_with_dispatcher_still_reports_dispatch(monkeypatch):
+    monkeypatch.setenv("MAC_RECOVERY_REFLEX_ENABLED", "1")
+    calls = []
+    recovered, choice, message = try_recovery(
+        {},
+        "boom",
+        lambda action, ctx: calls.append((action, ctx)),
+        lambda *_: None,
+        llm_fn=lambda _prompt: "retry_fetch",
+    )
+
+    assert recovered is True
+    assert calls, "a real dispatcher must still be invoked"
+    assert message.startswith("dispatched ")


### PR DESCRIPTION
Three fixes found while recovering the 2026-07-30/31 fleet standstill.

## 1. Attestation key history (the one that froze 66 reviews)

A fleet release rotates every participating agent's attestation key in one transaction. Verification retained exactly **one** prior generation, so evidence signed more than one release ago became unverifiable — the bound review target failed `_assess_default_review_evidence` on every sweep and the task parked in `waiting_for_verifiable_evidence` forever.

Epoch `718406262ed585ca` committed `2026-07-30T10:52:48.671185Z` and stamped that exact timestamp on all 8 live agents. All 66 tasks then in REVIEWING had evidence signed before it.

Now keeps a bounded (5), timestamped history of retired keys. Only widens *how long* a signature stays verifiable, never *who* may sign — the candidate set is exactly the keys the hub already holds for that agent. Past the bound, the clear "key was rotated" error still surfaces.

## 2. Failure output is retained

`verification_contract_failed` and `executor_timeout` omitted stdout/stderr, so `_diagnostic_output_tail` — which reads only the transition detail — recorded *"transition supplied no stdout, stderr, output, log, or tail field"*. That reason is stamped on **1,464 of 1,488** failure records on the live hub. For the timeout path the data was already in scope three lines above the detail that dropped it.

## 3. The recovery reflex stops claiming repairs it never made

`try_recovery` logged `"dispatched <action>"` and set `recovered=True` whenever the dispatch callable didn't raise; all three worker call sites passed a `pass`-bodied no-op. The retry/escalate decision is real and is kept — only the claim was false. `dispatch` may now be `None` and the log says so.

Severity note: `MAC_RECOVERY_REFLEX_ENABLED` is unset in production, so this path does not currently execute. Latent, armed for whoever enables the flag.

## Tests

A test asserting the old rotation behaviour is rewritten — it pinned the defect. `1355 passed` across attestation/evidence/review/store/migration; `507 passed` control-plane + review + release-epoch; `1504 passed` worker/recovery/evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)