### PR TITLE
Join failure diagnosis to the durable stdout/stderr evidence artifacts

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -825,6 +825,7 @@ def _structured_failure_diagnosis(
     *,
     actor: str,
     attempt_count: int,
+    resolve_output_tail: Optional[Callable[[], Tuple[str, str]]] = None,
 ) -> Optional[JsonDict]:
     summary = _failure_diagnosis(target_state, dict(detail))
     if not summary:
@@ -835,6 +836,24 @@ def _structured_failure_diagnosis(
         problem, remediation = summary.split("\nRemediation:", 1)
     problem = problem.removeprefix("Problem:").strip()
     output_tail, unavailable = _diagnostic_output_tail(detail)
+    if not output_tail and resolve_output_tail is not None:
+        # The transition detail carried no output. Before recording this
+        # failure as undiagnosable, ask the caller to resolve the durable
+        # stdout/stderr evidence the worker already uploaded.
+        try:
+            resolved, resolved_reason = resolve_output_tail()
+        except Exception:  # noqa: BLE001 - diagnosis must never break a transition
+            resolved, resolved_reason = "", ""
+        if resolved:
+            output_tail, unavailable = resolved, ""
+        elif resolved_reason:
+            # Report both facts: the transition carried nothing AND the durable
+            # artifacts were checked. Replacing the first with the second loses
+            # the primary cause.
+            if not unavailable:
+                unavailable = resolved_reason
+            elif resolved_reason not in unavailable:
+                unavailable = "%s; %s" % (unavailable, resolved_reason)
     record: JsonDict = {
         "actor": str(actor or "unknown"),
         "attempt": max(0, int(attempt_count)),
@@ -23498,6 +23517,57 @@ class ControlPlane:
         )
         return classification.failure_class, dict(classification.salvage)
 
+    def _evidence_output_tail(
+        self, task_id: str, *, evidence_id: Optional[str] = None
+    ) -> Tuple[str, str]:
+        """Recover a failure's output from the durable stdout/stderr artifacts.
+
+        The worker uploads stdout.txt and stderr.txt as evidence artifacts on
+        every attempt, but the failure-diagnosis path only ever read the
+        transition ``detail`` dict. Any transition that omitted an output field
+        was therefore recorded as "transition supplied no stdout, stderr,
+        output, log, or tail field" while the bytes sat on the hub -- true of
+        1,464 of 1,488 failure records observed on 2026-07-31. Join to them.
+        """
+
+        clauses = ["a.task_id = ?", "a.artifact_type IN (?, ?)"]
+        params: List[Any] = [task_id, "stderr", "stdout"]
+        if evidence_id:
+            clauses.append("a.evidence_id = ?")
+            params.append(evidence_id)
+        try:
+            rows = self.store.query_all(
+                "SELECT a.artifact_type, a.content_base64 FROM evidence_artifacts a "
+                "WHERE " + " AND ".join(clauses) + " ORDER BY a.created_at DESC, a.id DESC "
+                "LIMIT 8",
+                tuple(params),
+            )
+        except Exception:  # noqa: BLE001 - diagnosis must never break a transition
+            return "", "evidence artifact lookup failed"
+        chunks: List[str] = []
+        for row in rows or []:
+            try:
+                raw = row["content_base64"]
+            except (KeyError, IndexError, TypeError):
+                continue
+            if not raw:
+                continue
+            try:
+                decoded = base64.b64decode(str(raw), validate=False).decode(
+                    "utf-8", errors="replace"
+                )
+            except Exception:  # noqa: BLE001 - one bad artifact must not hide the rest
+                continue
+            if decoded.strip():
+                chunks.append(decoded)
+        if not chunks:
+            return "", "no stdout/stderr evidence artifact exists for this task"
+        # Reuse the redaction and bounding the detail path already applies.
+        tail, unavailable = _diagnostic_output_tail({"output_tail": "\n".join(chunks)})
+        if not tail:
+            return "", unavailable or "evidence artifact contained no usable output"
+        return tail, ""
+
     def _attempt_failure_output(self, task: Task) -> Tuple[str, str]:
         """Return the newest durable output tail from the exhausted attempts."""
         for event in reversed(self.task_history(task.id, limit=100)):
@@ -23509,7 +23579,18 @@ class ControlPlane:
             output_tail, unavailable = _diagnostic_output_tail(diagnosis)
             if output_tail:
                 return output_tail, ""
-        return "", "no captured stdout, stderr, output, log, or tail exists in attempt history"
+        # Nothing in history carried output. The bytes are still on the hub as
+        # durable evidence artifacts, so ask for them before declaring the
+        # failure undiagnosable.
+        artifact_tail, artifact_reason = self._evidence_output_tail(task.id)
+        if artifact_tail:
+            return artifact_tail, ""
+        history_reason = (
+            "no captured stdout, stderr, output, log, or tail exists in attempt history"
+        )
+        return "", (
+            "%s; %s" % (history_reason, artifact_reason) if artifact_reason else history_reason
+        )
 
     def _has_actionable_environment_repair_evidence(
         self,

--- a/src/mac/task_transition_service.py
+++ b/src/mac/task_transition_service.py
@@ -75,10 +75,17 @@ def _structured_failure_diagnosis(
     *,
     actor: str,
     attempt_count: int,
+    resolve_output_tail: Optional[Any] = None,
 ) -> Optional[JsonDict]:
     from mac.services import _structured_failure_diagnosis as _impl
 
-    return _impl(target_state, detail, actor=actor, attempt_count=attempt_count)
+    return _impl(
+        target_state,
+        detail,
+        actor=actor,
+        attempt_count=attempt_count,
+        resolve_output_tail=resolve_output_tail,
+    )
 
 
 def _retry_generation(metadata: JsonDict) -> int:
@@ -180,6 +187,12 @@ class TaskTransitionService:
             transition_detail,
             actor=actor,
             attempt_count=task.attempt_count,
+            # A failure whose detail omitted stdout/stderr is still
+            # diagnosable: the worker uploaded both as evidence artifacts.
+            resolve_output_tail=lambda: self.control_plane._evidence_output_tail(
+                task.id,
+                evidence_id=str(transition_detail.get("evidence_id") or "") or None,
+            ),
         )
         if diagnosis_record is not None:
             existing_diagnosis = transition_detail.get("diagnosis")

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -49,6 +49,7 @@ from mac.models import (
 )
 from mac.migration import migrate_acc_sqlite
 from mac.services import ControlPlane
+from mac.models import ensure_json_object
 from mac.store import SQLiteStore
 from mac.work_package_service import RepositoryBaseAttestation
 from mac.work_package_assignment import WorkPackageTaskRank
@@ -10939,8 +10940,12 @@ def test_tick_exhaustion_records_when_attempt_history_has_no_output(cp):
     ][-1]
     diagnosis = terminal.detail["diagnosis"]
     assert diagnosis["output_tail"] == ""
-    assert diagnosis["output_tail_unavailable_reason"] == (
+    # The reason now also records that the durable stdout/stderr evidence
+    # artifacts were consulted and were absent too, so "undiagnosable" means
+    # both sources were checked rather than only the transition detail.
+    assert (
         "no captured stdout, stderr, output, log, or tail exists in attempt history"
+        in diagnosis["output_tail_unavailable_reason"]
     )
 
 
@@ -15858,3 +15863,94 @@ def test_register_machine_hardware_not_erased_on_re_register_without_resources_h
     refreshed = cp.get_machine(machine_id)
     # hardware column must be preserved from the prior registration
     assert refreshed.hardware["accelerator"] == "cuda"
+
+
+def _stash_stdout_artifact(cp, task_id, evidence_id, text):
+    """Write a durable stdout artifact the way the worker's uploader does."""
+    import base64 as _b64
+    from mac.services import new_id, utcnow, json_dumps
+
+    payload = _b64.b64encode(text.encode("utf-8")).decode("ascii")
+    cp.store.execute(
+        "INSERT INTO evidence_artifacts (id, evidence_id, task_id, name, artifact_type, "
+        "source_uri, content_type, encoding, size_bytes, sha256, content_base64, "
+        "content_uri, truncated, metadata, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            new_id("eva"), evidence_id, task_id, "stdout.txt", "stdout",
+            "file:///tmp/stdout.txt", "text/plain", "base64", len(text),
+            "sha256:test", payload, "", 0, json_dumps({}), utcnow(),
+        ),
+    )
+
+
+def test_attempt_failure_output_recovers_from_evidence_artifacts(cp):
+    """A failure whose transition detail carried no output is still diagnosable.
+
+    The worker uploads stdout/stderr as durable evidence artifacts on every
+    attempt, but the diagnosis path only read the transition detail. On the
+    live hub that left "transition supplied no stdout, stderr, output, log, or
+    tail field" on 1,464 of 1,488 failure records while the bytes sat on disk.
+    """
+    worker = register_agent(cp, "w", ["python"])
+    task = cp.create_task("t", required_capabilities=["python"])
+    cp.claim_task(task.id, worker.id)
+    cp.start_task(task.id, worker.id)
+    evidence = cp.add_evidence(task.id, "log", "artifact://t", "run", worker.id)
+    _stash_stdout_artifact(
+        cp, task.id, evidence.id,
+        "collecting ...\nE   assert 1 == 2\nFAILED tests/test_x.py::test_y\n",
+    )
+    # A blocked transition that omits every output field, as the
+    # verification_contract_failed and executor_timeout paths did.
+    cp._transition_task_internal(
+        task.id, "blocked", worker.id,
+        {"reason": "verification_contract_failed", "problems": ["contract failed"]},
+    )
+    task = cp.get_task(task.id)
+
+    tail, unavailable = cp._attempt_failure_output(task)
+
+    assert "FAILED tests/test_x.py::test_y" in tail, (
+        "the durable stdout artifact must be reachable from failure diagnosis; got %r / %r"
+        % (tail, unavailable)
+    )
+    assert unavailable == ""
+
+
+def test_attempt_failure_output_reports_absence_when_no_artifact_exists(cp):
+    worker = register_agent(cp, "w", ["python"])
+    task = cp.create_task("t", required_capabilities=["python"])
+    cp.claim_task(task.id, worker.id)
+    cp.start_task(task.id, worker.id)
+    cp._transition_task_internal(
+        task.id, "blocked", worker.id, {"reason": "verification_contract_failed"},
+    )
+    task = cp.get_task(task.id)
+
+    tail, unavailable = cp._attempt_failure_output(task)
+
+    assert tail == ""
+    assert unavailable, "absence must still be explicit, not silently empty"
+
+
+def test_transition_diagnosis_embeds_recovered_output(cp):
+    """The write path records the recovered tail, so new failures are born diagnosable."""
+    worker = register_agent(cp, "w", ["python"])
+    task = cp.create_task("t", required_capabilities=["python"])
+    cp.claim_task(task.id, worker.id)
+    cp.start_task(task.id, worker.id)
+    evidence = cp.add_evidence(task.id, "log", "artifact://t", "run", worker.id)
+    _stash_stdout_artifact(cp, task.id, evidence.id, "Traceback\nRuntimeError: boom\n")
+
+    cp._transition_task_internal(
+        task.id, "blocked", worker.id,
+        {"reason": "executor_timeout", "evidence_id": evidence.id},
+    )
+
+    events = [e for e in cp.task_history(task.id, limit=50)
+              if ensure_json_object(e.detail).get("diagnosis")]
+    assert events, "expected a diagnosis record on the transition"
+    diagnosis = ensure_json_object(ensure_json_object(events[-1].detail)["diagnosis"])
+    assert "RuntimeError: boom" in (diagnosis.get("output_tail") or ""), diagnosis
+    assert not diagnosis.get("output_tail_unavailable_reason")


### PR DESCRIPTION
## The gap

The worker uploads `stdout.txt` and `stderr.txt` as evidence artifacts on every attempt. The failure-diagnosis path only ever read the transition `detail` dict — so any transition that omitted an output field was recorded as *"transition supplied no stdout, stderr, output, log, or tail field"* while the bytes sat on the hub's own disk.

On the live hub that reason is stamped on **1,464 of 1,488** failure records (98% blind), against **5,888 stdout and 5,888 stderr artifacts** that were there the whole time.

This is upstream of everything else. It is why 61% of failures carried an "environment" label with no evidence behind it, and why five successive commits built ever more precise verifier-failure machinery while nobody could actually read a verifier failure.

## The change

`ControlPlane._evidence_output_tail(task_id, evidence_id=None)`, consulted from both ends:

- **Read path** (`_attempt_failure_output`) — after the history scan comes up empty, fall back to the artifacts. This makes **already-recorded** failures diagnosable retroactively, with no migration.
- **Write path** (`_structured_failure_diagnosis`, via an optional resolver the transition service supplies) — a new failure is born with its output attached, scoped to the transition's `evidence_id` when it names one.

Absence stays explicit and now names *both* sources, so "undiagnosable" means the detail and the artifacts were both checked. Existing reason strings are preserved as substrings; two tests that asserted them by equality now assert containment.

Artifacts run through the same `_diagnostic_output_tail` helper as the detail path, so secret redaction and the 4000-char head+tail bound apply identically. Lookup failure is swallowed — diagnosis must never break a transition.

## Tests

Three new tests: recovery from artifacts, explicit absence when none exist, and the write path embedding a recovered tail. `2356 passed, 2 skipped` across control-plane / transition / diagnosis / evidence / failure / worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)