### PR TITLE
Classify failures on cause, retry by default, and show every dead letter

### DIFF
--- a/src/mac/attempt_failure_classifier.py
+++ b/src/mac/attempt_failure_classifier.py
@@ -154,16 +154,68 @@ def _merge_salvage(target: JsonDict, source: Mapping[str, Any]) -> None:
         target.setdefault(key, value)
 
 
+# Fields that describe WHY a transition happened. Captured process output is
+# deliberately excluded: a pytest log routinely contains "timeout" or "no such
+# file or directory", and matching markers against it reclassifies a genuine
+# work failure as environment or scope.
+_CLASSIFIABLE_DETAIL_KEYS = (
+    "failure_class",
+    "reason",
+    "error",
+    "disposition",
+    "failure",
+)
+_OUTPUT_KEYS = frozenset(
+    {
+        "output_tail",
+        "stdout",
+        "stderr",
+        "stdout_tail",
+        "stderr_tail",
+        "output",
+        "log_tail",
+        "logs",
+        "output_tail_unavailable_reason",
+    }
+)
+
+
+def _diagnosis_reason(value: Any) -> str:
+    """The diagnosis' own verdict, without the process output it now carries."""
+
+    if isinstance(value, Mapping):
+        return " ".join(
+            str(value.get(key) or "")
+            for key in ("failure", "problem", "remediation")
+        )
+    return str(value or "")
+
+
 def _detail_reason(detail: Mapping[str, Any]) -> str:
     parts = []
-    for key in ("failure_class", "reason", "error", "diagnosis", "disposition"):
+    for key in _CLASSIFIABLE_DETAIL_KEYS:
         parts.append(str(detail.get(key) or ""))
+    parts.append(_diagnosis_reason(detail.get("diagnosis")))
     problems = detail.get("problems")
     if isinstance(problems, list):
         parts.extend(str(item) for item in problems)
     else:
         parts.append(str(problems or ""))
     return " ".join(parts).lower()
+
+
+def _classifiable_detail(detail: Mapping[str, Any]) -> JsonDict:
+    """Drop captured process output before the detail is flattened for matching."""
+
+    trimmed: JsonDict = {}
+    for key, value in detail.items():
+        if key in _OUTPUT_KEYS:
+            continue
+        if key == "diagnosis":
+            trimmed[key] = _diagnosis_reason(value)
+            continue
+        trimmed[key] = value
+    return trimmed
 
 
 def _has_marker(blob: str, marker: str) -> bool:
@@ -178,7 +230,13 @@ def _class_from_history(events: Iterable[Any]) -> str:
     for event in events:
         detail = _event_detail(event)
         event_type = _event_type(event).lower()
-        blob = " ".join([event_type, _detail_reason(detail), _compact_text(detail)])
+        blob = " ".join(
+            [
+                event_type,
+                _detail_reason(detail),
+                _compact_text(_classifiable_detail(detail)),
+            ]
+        )
         if (
             "superseded" in blob
             or "duplicate" in blob
@@ -233,8 +291,12 @@ def _class_from_history(events: Iterable[Any]) -> str:
                 "lease_expired",
                 "lease expired",
                 "agent went offline",
-                "worker_exception",
-                "executor_failed",
+                # "worker_exception" and "executor_failed" used to live here.
+                # worker.py stamps executor_failed on EVERY non-zero executor
+                # exit -- including a correct "the agent's tests failed" -- so
+                # matching them classified real work failures as environment
+                # and made the ledger's 61% environment rate an artifact of the
+                # classifier reading its own transport label.
                 "could not clone",
                 "authentication failed",
                 "permission denied",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -647,7 +647,14 @@ def _blocked_attempt_retry_kind(value: Any) -> str:
         return "transient"
     if detail.get("manual_repair_required") is True:
         return "non_retryable"
-    return "non_retryable"
+    # Unrecognised failures consume the retry budget they were granted rather
+    # than bypassing it. Bad work is still stopped by the deterministic marker
+    # list above, by an explicit manual_repair_required, by the repeated-
+    # fingerprint gate, and by max_attempts. Returning "non_retryable" here
+    # meant an infrastructure failure where the model never ran went terminal
+    # at attempt 1 of 3 -- and, because attempt_count increments at claim time,
+    # it burned an attempt for a sandbox that never started.
+    return "transient"
 
 
 def _blocked_attempt_failure_fingerprint(value: Any) -> str:
@@ -10681,7 +10688,11 @@ class ControlPlane:
         cursor: Optional[str] = None,
     ) -> JsonDict:
         limit_value = max(1, min(int(limit), 1000))
-        clauses = ["state = ?", "attempt_count >= max_attempts"]
+        # Every FAILED task is a dead letter. Requiring an exhausted attempt
+        # budget hid the largest failure population from the surface built to
+        # surface failures: a task killed by the retry verdict goes terminal
+        # with attempt_count=1 against max_attempts=3, so it never matched.
+        clauses = ["state = ?"]
         params: List[Any] = [TaskState.FAILED.value]
         if tenant_id is not None:
             clauses.append(

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -1524,7 +1524,10 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                     "lease_id": lease_id,
                     "detail": {
                         "reason": "executor_timeout",
-                        "manual_repair_required": True,
+                        # The hub classifies; the worker cannot know whether an
+                        # operator must intervene. Declaring it here forced
+                        # non_retryable and skipped the retry budget entirely.
+                        "manual_repair_required": False,
                         "output_tail": _executor_output_tail(execution),
                         "timeout_seconds": exc.timeout,
                         "process_tree_terminated": True,
@@ -1589,7 +1592,9 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                         "lease_id": lease_id,
                         "detail": {
                             "reason": "worker_exception",
-                            "manual_repair_required": True,
+                            # Same: an unexpected worker exception is not
+                            # self-evidently operator-actionable.
+                            "manual_repair_required": False,
                             "error": str(exc),
                             "exception_type": exc_type,
                             "output_tail": tb_text,

--- a/tests/test_attempt_failure_classifier.py
+++ b/tests/test_attempt_failure_classifier.py
@@ -89,7 +89,15 @@ def test_attempt_failure_classifier_superseded_preempts_environment():
     assert result.failure_class == "superseded"
 
 
-def test_attempt_failure_classifier_classifies_executor_failed_as_environment():
+def test_bare_executor_failed_is_not_an_environment_verdict():
+    """``executor_failed`` is a transport label, not a cause.
+
+    worker.py stamps it on EVERY non-zero executor exit, including a correct
+    "the agent's tests failed". Treating it as an environment marker made 61%
+    of the live ledger's failures "environment" with no evidence behind it --
+    the classifier reading its own input field.
+    """
+
     result = classify_attempt_failure(
         [
             {
@@ -102,10 +110,53 @@ def test_attempt_failure_classifier_classifies_executor_failed_as_environment():
         ]
     )
 
+    assert result.failure_class != "environment"
+
+
+def test_executor_failed_with_a_real_environment_signal_still_classifies():
+    """The label is not the signal; an actual cause in a structured field is."""
+
+    result = classify_attempt_failure(
+        [
+            {
+                "event_type": "task.transitioned",
+                "detail": {
+                    "reason": "executor_failed",
+                    "error": "connection refused talking to the sandbox host",
+                },
+            }
+        ]
+    )
+
     assert result.failure_class == "environment"
 
 
-def test_attempt_failure_classifier_executor_failed_in_mixed_history():
+def test_captured_test_output_does_not_drive_classification():
+    """Real pytest output reaches the detail now that diagnosis joins to the
+    durable stdout/stderr artifacts. It must not be matched for markers: a
+    failing test log routinely prints "no such file or directory"."""
+
+    result = classify_attempt_failure(
+        [
+            {
+                "event_type": "task.transitioned",
+                "detail": {
+                    "reason": "verification_contract_failed",
+                    "problems": ["contract verification failed"],
+                    "output_tail": (
+                        "E   FileNotFoundError: no such file or directory: 'x.txt'\n"
+                        "E   assert 1 == 2\n"
+                        "FAILED tests/test_x.py::test_y\n"
+                    ),
+                },
+            }
+        ]
+    )
+
+    assert result.failure_class != "environment"
+
+
+def test_bare_executor_failed_in_mixed_history_still_salvages():
     result = classify_attempt_failure(
         [
             {
@@ -123,11 +174,14 @@ def test_attempt_failure_classifier_executor_failed_in_mixed_history():
         ]
     )
 
-    assert result.failure_class == "environment"
+    assert result.failure_class != "environment"
+    # Salvage is independent of classification and must still be collected.
     assert result.salvage.get("pushed_branch") == "mac/agent/task"
 
 
-def test_attempt_failure_classifier_classifies_worker_exception_as_environment():
+def test_bare_worker_exception_is_not_an_environment_verdict():
+    """Also a transport label: it says the worker raised, not why."""
+
     result = classify_attempt_failure(
         [
             {
@@ -140,7 +194,7 @@ def test_attempt_failure_classifier_classifies_worker_exception_as_environment()
         ]
     )
 
-    assert result.failure_class == "environment"
+    assert result.failure_class != "environment"
 
 
 def test_attempt_failure_classifier_classifies_network_error_as_environment():

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -11137,7 +11137,7 @@ def test_tick_exhausted_executor_failed_creates_environment_repair_task(cp):
         task.id,
         TaskState.BLOCKED.value,
         "worker",
-        {"reason": "executor_failed", "manual_repair_required": True, "returncode": 1},
+        {"error": "/usr/bin/python: command not found in the sandbox", "reason": "executor_failed", "manual_repair_required": True, "returncode": 1},
     )
     cp.store.execute(
         "UPDATE tasks SET attempt_count = ?, updated_at = ? WHERE id = ?",
@@ -11171,7 +11171,7 @@ def test_tick_exhausted_worker_exception_creates_environment_repair_task(cp):
         task.id,
         TaskState.BLOCKED.value,
         "worker",
-        {"reason": "worker_exception", "failure": "worker_exception"},
+        {"error": "/usr/bin/python: command not found in the sandbox", "reason": "worker_exception", "failure": "worker_exception"},
     )
     cp.store.execute(
         "UPDATE tasks SET attempt_count = ?, updated_at = ? WHERE id = ?",
@@ -11204,7 +11204,7 @@ def test_tick_exhausted_environment_failure_resets_attempt_count_to_zero(cp):
         task.id,
         TaskState.BLOCKED.value,
         "worker",
-        {"reason": "worker_exception"},
+        {"error": "/usr/bin/python: command not found in the sandbox", "reason": "worker_exception"},
     )
     cp.store.execute(
         "UPDATE tasks SET attempt_count = ?, updated_at = ? WHERE id = ?",
@@ -11262,7 +11262,7 @@ def test_tick_exhausted_environment_repair_task_title_and_description(cp):
         task.id,
         TaskState.BLOCKED.value,
         "worker",
-        {"reason": "worker_exception"},
+        {"error": "/usr/bin/python: command not found in the sandbox", "reason": "worker_exception"},
     )
     cp.store.execute(
         "UPDATE tasks SET attempt_count = ?, updated_at = ? WHERE id = ?",
@@ -11290,7 +11290,7 @@ def test_tick_exhausted_environment_repair_task_idempotent(cp):
         task.id,
         TaskState.BLOCKED.value,
         "worker",
-        {"reason": "worker_exception"},
+        {"error": "/usr/bin/python: command not found in the sandbox", "reason": "worker_exception"},
     )
     cp.store.execute(
         "UPDATE tasks SET attempt_count = ?, updated_at = ? WHERE id = ?",
@@ -11413,7 +11413,7 @@ def test_tick_exhausted_environment_failure_does_not_set_contract_repair_status(
         task.id,
         TaskState.BLOCKED.value,
         "worker",
-        {"reason": "worker_exception", "failure": "worker_exception"},
+        {"error": "/usr/bin/python: command not found in the sandbox", "reason": "worker_exception", "failure": "worker_exception"},
     )
     cp.store.execute(
         "UPDATE tasks SET attempt_count = ?, updated_at = ? WHERE id = ?",
@@ -15341,9 +15341,15 @@ def test_tick_injects_plan_first_on_timeout_blocked_attempt(cp, timeout_reason):
     assert any(event.name == "task.auto_reopened" for event in observations)
 
 
-def test_tick_stops_non_timeout_executor_failure_without_plan_first(cp):
+def test_tick_retries_non_timeout_executor_failure_without_plan_first(cp):
     """Non-timeout block reasons (executor_failed, etc.) must NOT set plan_first —
-    only agent-run-timeout failures trigger the decomposition redirect."""
+    only agent-run-timeout failures trigger the decomposition redirect.
+
+    An unrecognised executor failure now consumes its retry budget instead of
+    going terminal at attempt 1: the worker stamps ``executor_failed`` on every
+    non-zero exit, so treating it as a stop verdict retired tasks that had
+    never really been attempted.
+    """
     task = cp.create_task("executor-failed task", required_capabilities=["python"])
     cp._transition_task_internal(
         task.id,
@@ -15359,7 +15365,10 @@ def test_tick_stops_non_timeout_executor_failure_without_plan_first(cp):
     cp.tick(limit=0)
 
     stopped = cp.get_task(task.id)
-    assert stopped.state == TaskState.FAILED.value
+    assert stopped.state == TaskState.OPEN.value, (
+        "budget remains (attempt 1 of %s); the attempt must be retried"
+        % stopped.max_attempts
+    )
     assert stopped.dependencies == []
     assert "environment_repair_task_id" not in stopped.metadata
     from mac.models import ensure_json_object


### PR DESCRIPTION
Three changes that only make sense together, now that failure diagnosis actually reaches the captured output (#241).

## 1. Classify on cause, not on the transport label

`worker.py` stamps `reason="executor_failed"` on **every** non-zero executor exit — including a correct *"the agent's tests failed"* — and the classifier listed that literal as an ENVIRONMENT marker.

That is why **912 of 1,488** recent failures (61%) carried `failure_class=environment` while a keyword scan of all 912 diagnoses found **zero** mentions of sandbox, openshell, network, auth or toolchain. The rate was the classifier reading its own input field.

The second half — building the match blob from cause-bearing fields only — became urgent rather than cosmetic the moment #241 landed: real pytest logs now reach the detail, and a failing test log routinely prints `no such file or directory` or `timeout`. Matching over it would have reclassified genuine work failures as environment/scope. **The fix for blindness would have manufactured a new lie.**

## 2. Unrecognised failures consume their retry budget

`_blocked_attempt_retry_kind` ended in `return "non_retryable"`, so anything unmatched went terminal regardless of attempts remaining. Since `attempt_count` increments at **claim** time, an infrastructure failure where the model never ran burned an attempt and then retired the task at 1 of 3. Both live blocker tasks examined on 2026-07-31 died exactly that way — at 2/3 and 2/5.

Bad work is still stopped by the deterministic markers, explicit `manual_repair_required`, the repeated-fingerprint gate, and `max_attempts`. The worker also stops declaring `manual_repair_required` on `executor_timeout`/`worker_exception` — it cannot know whether an operator must intervene. `verification_contract_failed` keeps it: that *is* a work verdict.

## 3. Every FAILED task is a dead letter

`list_dead_letters_page` required `attempt_count >= max_attempts`, so tasks killed by the retry verdict never appeared. The largest failure population was invisible on the surface built to surface failures — which is why this went unnoticed for weeks.

## Tests

Ten tests asserted the old behaviour and were **rewritten rather than worked around**: three pinned the transport label as an environment verdict, six drove the environment-repair path from that bare label and now supply a real cause, one asserted an unrecognised executor failure stops at attempt 1 (its no-`plan_first` intent preserved).

`3276 passed, 2 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)