### PR TITLE
Remove unreachable raise that has blocked every runtime image publish

### DIFF
--- a/src/mac/dreaming/engine.py
+++ b/src/mac/dreaming/engine.py
@@ -416,13 +416,13 @@ def _retrying(caller: ModelCaller, *, budget: float) -> ModelCaller:
     def call(model_id: str, question: str, context: str):
         started = time.monotonic()
         attempt = 0
-        last: Optional[BaseException] = None
+        # The loop only ever exits by returning the result or re-raising, so
+        # there is no fall-through path and no need to retain the last error.
         while True:
             attempt += 1
             try:
                 return caller(model_id, question, context)
             except Exception as exc:  # noqa: BLE001 - classified below
-                last = exc
                 if not _is_transient(exc):
                     raise
                 elapsed = time.monotonic() - started
@@ -432,7 +432,6 @@ def _retrying(caller: ModelCaller, *, budget: float) -> ModelCaller:
                 if elapsed + delay >= budget:
                     raise
                 time.sleep(delay)
-        raise last  # pragma: no cover - loop only exits via return/raise
 
     return call
 


### PR DESCRIPTION
## The one-line failure that closed the fleet's deployment path

`scripts/dead-code-check.sh` has failed on `main` since `920ffb96` (2026-07-29). `dreaming/engine.py`'s retry wrapper ends in `raise last` after a `while True` whose only exits are `return` and `raise` — the author's own `# pragma: no cover` says exactly that.

That is not cosmetic. The image job declares:

```yaml
openshell-runtime-image:
  needs: [dead-code, mainline, compatibility, postgres-contract, publication-scope]
```

A failing `dead-code` gate ⇒ **no runtime image published**. Workers refuse source whose runtime digest is unpublished — a canary `mac fleet refresh-source` rolled itself back with `status: managed_image_stale`, `summary: "source update required a new published runtime digest"`.

So every worker has been pinned at `718406262` for two days, and **no worker-side code change could reach the fleet at all**.

Found by canarying a single worker instead of refreshing the whole fleet.

## Change

Drop the unreachable statement and the `last` variable it was the sole reader of. Behaviour unchanged — the loop cannot fall through.

`dead-code-check: clean`. 93 dreaming tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)