### PR TITLE
Let refresh-source adopt the published runtime digest for its target revision

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -698,6 +698,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_OPENCLAW_VERIFY_STARTUP_INTERVAL` | int | consumer-defined | openclaw-runtime | Openclaw Runtime setting: openclaw verify startup interval. |
 | `MAC_OPENCLAW_VERIFY_STARTUP_TIMEOUT` | int | consumer-defined | openclaw-runtime | Openclaw Runtime setting: openclaw verify startup timeout. |
 | `MAC_OPENCLAW_WORKSPACE` | str | consumer-defined | openclaw-runtime | Openclaw Runtime setting: openclaw workspace. |
+| `MAC_OPENSHELL_ADOPT_PUBLISHED_RUNTIME` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell adopt published runtime. |
 | `MAC_OPENSHELL_ALLOW_CODEX_FILE_AUTH` | bool | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell allow codex file auth. |
 | `MAC_OPENSHELL_ALLOW_NO_LANDLOCK` | bool | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell allow no landlock. |
 | `MAC_OPENSHELL_BIN` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell bin. |

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -80,6 +80,10 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         "tests/test_fleet_node_prior_topology.py",
         "tests/test_fleet_node_supervisord_lifecycle.py",
         "tests/test_fleet_skills.py",
+        # Covers the worker side of the runtime-marker contract this installer
+        # writes: a change to how the markers are produced must run the tests
+        # that decide whether a worker may adopt them.
+        "tests/test_worker_control_edges.py",
         "tests/test_gateway_serving_openclaw_agent_probe_soft.py",
         "tests/test_gateway_serving_worker_selftest_soft_agent_probe.py",
         "tests/test_gatewayless_worker_selftest_crash.py",

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -8293,6 +8293,17 @@
   },
   {
     "default": null,
+    "description": "Openshell Sandbox setting: openshell adopt published runtime.",
+    "family": "openshell-sandbox",
+    "name": "MAC_OPENSHELL_ADOPT_PUBLISHED_RUNTIME",
+    "retired": false,
+    "sources": [
+      "src/mac/worker.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Openshell Sandbox setting: openshell allow codex file auth.",
     "family": "openshell-sandbox",
     "name": "MAC_OPENSHELL_ALLOW_CODEX_FILE_AUTH",

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -3313,6 +3313,114 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
             "stderr": (completed.stderr or "")[-1000:],
         }
 
+    def _adopt_published_runtime_image(
+        self, after_sha: str, *, previous_ref: str, marked_sha: str
+    ) -> Optional[JsonDict]:
+        """Pin this node to the published runtime digest for ``after_sha``.
+
+        Returns the rebuild record on success, or ``None`` to leave the caller
+        on its existing fail-closed path. Adoption is deliberately narrow: only
+        a digest CI published for this exact revision at the repository-owned
+        GHCR path is accepted, the image must pull before either marker moves,
+        and both markers are written together so a partial adoption cannot
+        leave the node claiming a revision it cannot run.
+        """
+
+        if not _env_truthy(os.environ.get("MAC_OPENSHELL_ADOPT_PUBLISHED_RUNTIME", "1")):
+            return None
+        target_ref = _published_runtime_image_ref(after_sha)
+        if not target_ref:
+            return None
+        docker = _resolve_openshell_docker_bin()
+        if not docker:
+            return None
+        try:
+            pulled = subprocess.run(
+                [docker, "pull", target_ref],
+                capture_output=True,
+                text=True,
+                timeout=1800,
+                check=False,
+            )
+        except Exception as exc:  # noqa: BLE001 - a pull failure is not fatal here
+            self._observe_log(
+                "worker.openshell.managed_image_adoption_failed",
+                level="warning",
+                subject_type="agent",
+                subject_id=self.agent_id,
+                detail={
+                    "reason": "published runtime digest could not be pulled",
+                    "runtime_image_ref": target_ref,
+                    "error_type": type(exc).__name__,
+                    "after_sha": after_sha,
+                },
+            )
+            return None
+        if pulled.returncode != 0:
+            self._observe_log(
+                "worker.openshell.managed_image_adoption_failed",
+                level="warning",
+                subject_type="agent",
+                subject_id=self.agent_id,
+                detail={
+                    "reason": "published runtime digest could not be pulled",
+                    "runtime_image_ref": target_ref,
+                    "stderr": _truncate_process_text(pulled.stderr or "", limit=800),
+                    "after_sha": after_sha,
+                },
+            )
+            return None
+        ref_file = Path(
+            os.environ.get("MAC_OPENSHELL_RUNTIME_IMAGE_REF_FILE")
+            or mac_paths.mac_home() / "openshell" / "runtime-image-ref"
+        ).expanduser()
+        sha_file = Path(
+            os.environ.get("MAC_OPENSHELL_IMAGE_SOURCE_SHA_FILE")
+            or mac_paths.mac_home() / "openshell" / "image-source-sha"
+        ).expanduser()
+        try:
+            ref_file.parent.mkdir(parents=True, exist_ok=True)
+            # Write the image first: a node that names an image it has pulled
+            # but an older source SHA is merely stale, which is recoverable.
+            # The reverse would claim a revision whose runtime is absent.
+            _atomic_write_text(ref_file, target_ref + "\n")
+            _atomic_write_text(sha_file, after_sha + "\n")
+        except OSError as exc:
+            self._observe_log(
+                "worker.openshell.managed_image_adoption_failed",
+                level="error",
+                subject_type="agent",
+                subject_id=self.agent_id,
+                detail={
+                    "reason": "runtime markers could not be written",
+                    "runtime_image_ref": target_ref,
+                    "error_type": type(exc).__name__,
+                    "after_sha": after_sha,
+                },
+            )
+            return None
+        self._observe_log(
+            "worker.openshell.managed_image_adopted",
+            level="info",
+            subject_type="agent",
+            subject_id=self.agent_id,
+            detail={
+                "reason": "adopted the published runtime digest for the target revision",
+                "runtime_image_ref": target_ref,
+                "previous_runtime_image_ref": previous_ref,
+                "previous_marked_sha": marked_sha,
+                "after_sha": after_sha,
+            },
+        )
+        return {
+            "status": "managed_image_adopted",
+            "runtime_image_ref": target_ref,
+            "previous_runtime_image_ref": previous_ref,
+            "marked_sha": after_sha,
+            "previous_marked_sha": marked_sha,
+            "after_sha": after_sha,
+        }
+
     def _maybe_rebuild_openshell_image_after_update(
         self, repo: Path, before_sha: str, after_sha: str
     ) -> Optional[JsonDict]:
@@ -3367,10 +3475,21 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                     },
                 )
                 return {"status": "managed_image_invalid", "marker": str(managed_ref_file)}
-            # A published runtime is bound to one exact source revision. Source
-            # adoption must wait for a fleet deploy carrying the corresponding
-            # new digest; rebuilding this tag locally would silently destroy the
-            # single-image identity required by synchronized execution.
+            # A published runtime is bound to one exact source revision, and
+            # rebuilding this tag locally would destroy the single-image
+            # identity synchronized execution depends on. But CI publishes a
+            # digest for every commit on main, so the corresponding image
+            # usually already exists -- the node simply had no way to adopt it,
+            # and `mac fleet refresh-source` could therefore never advance a
+            # digest-managed worker to ANY new commit without a full deploy.
+            # Adopt the canonical published digest for the target revision;
+            # fall back to the previous fail-closed behaviour when there is
+            # none.
+            adopted = self._adopt_published_runtime_image(
+                after_sha, previous_ref=managed_ref, marked_sha=marked_sha
+            )
+            if adopted is not None:
+                return adopted
             self._observe_log(
                 "worker.openshell.managed_image_stale",
                 level="error",
@@ -7532,6 +7651,60 @@ def _extract_marked_summary(text: str) -> str:
 #: Path (relative to the self-update repo root) of the OpenShell sandbox image
 #: build recipe.
 _OPENSHELL_CONTAINERFILE_RELPATH = "deploy/openshell/mac-hermes.Containerfile"
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write a marker file so a crash cannot leave it half-written."""
+
+    temporary = path.with_name("%s.tmp.%d" % (path.name, os.getpid()))
+    temporary.write_text(text, encoding="utf-8")
+    temporary.chmod(0o600)
+    os.replace(temporary, path)
+
+
+_OPENSHELL_RUNTIME_REPO = "ghcr.io/jordanhubbard/mac-openshell-runtime"
+_OPENSHELL_RUNTIME_DIGEST_RE = re.compile(
+    r"ghcr\.io/jordanhubbard/mac-openshell-runtime@sha256:[0-9a-f]{64}"
+)
+
+
+def _published_runtime_image_ref(source_sha: str) -> Optional[str]:
+    """Resolve the immutable digest CI published for one exact source revision.
+
+    CI publishes ``<repo>:git-<sha>`` for every commit on main. Reading that
+    tag back as a digest is what lets a worker adopt the canonical image for a
+    target revision without a full fleet deploy. Only the repository-owned
+    GHCR path is accepted, and only as a digest: a tag is mutable, and a
+    locally built image would break the single-image identity that
+    synchronized execution depends on.
+    """
+
+    if not re.fullmatch(r"[0-9a-f]{40}", str(source_sha or "")):
+        return None
+    docker = _resolve_openshell_docker_bin()
+    if not docker:
+        return None
+    tag = "%s:git-%s" % (_OPENSHELL_RUNTIME_REPO, source_sha)
+    for argv in (
+        [docker, "buildx", "imagetools", "inspect", "--format", "{{.Manifest.Digest}}", tag],
+        [docker, "manifest", "inspect", "--verbose", tag],
+    ):
+        try:
+            completed = subprocess.run(
+                argv, capture_output=True, text=True, timeout=180, check=False
+            )
+        except Exception:  # noqa: BLE001 - registry probing must never raise here
+            continue
+        if completed.returncode != 0:
+            continue
+        text = (completed.stdout or "").strip()
+        match = re.search(r"sha256:[0-9a-f]{64}", text)
+        if not match:
+            continue
+        candidate = "%s@%s" % (_OPENSHELL_RUNTIME_REPO, match.group(0))
+        if _OPENSHELL_RUNTIME_DIGEST_RE.fullmatch(candidate):
+            return candidate
+    return None
 
 
 def _resolve_openshell_docker_bin() -> Optional[str]:

--- a/tests/test_worker_control_edges.py
+++ b/tests/test_worker_control_edges.py
@@ -642,3 +642,125 @@ def test_repo_update_service_restart_results(monkeypatch, tmp_path) -> None:
         "restart_services": ["one.service"],
     })
     assert result["status"] == "service_restart_error"
+
+
+_ADOPT_SHA_OLD = "a" * 40
+_ADOPT_SHA_NEW = "b" * 40
+_ADOPT_DIGEST = "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "c" * 64
+_ADOPT_PREV = "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "d" * 64
+
+
+def _managed_markers(monkeypatch, tmp_path):
+    source_marker = tmp_path / "image-source-sha"
+    managed_marker = tmp_path / "runtime-image-ref"
+    source_marker.write_text(_ADOPT_SHA_OLD + "\n")
+    managed_marker.write_text(_ADOPT_PREV + "\n")
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_REBUILD_ON_SOURCE_UPDATE", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_IMAGE_SOURCE_SHA_FILE", str(source_marker))
+    monkeypatch.setenv("MAC_OPENSHELL_RUNTIME_IMAGE_REF_FILE", str(managed_marker))
+    return source_marker, managed_marker
+
+
+def test_managed_image_adopts_the_published_digest_for_the_target_revision(
+    monkeypatch, tmp_path
+) -> None:
+    """refresh-source must be able to advance a digest-managed worker.
+
+    Only fleet-node-install.sh ever wrote these markers, so `mac fleet
+    refresh-source` could not move a worker to ANY new commit without a full
+    deploy -- every pod sat five commits behind main for two days.
+    """
+    instance = _instance(tmp_path)
+    source_marker, managed_marker = _managed_markers(monkeypatch, tmp_path)
+    monkeypatch.setattr(worker, "_published_runtime_image_ref", lambda sha: _ADOPT_DIGEST)
+    monkeypatch.setattr(worker, "_resolve_openshell_docker_bin", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(
+        worker.subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+
+    result = instance._maybe_rebuild_openshell_image_after_update(
+        tmp_path, _ADOPT_SHA_OLD, _ADOPT_SHA_NEW
+    )
+
+    assert result["status"] == "managed_image_adopted"
+    assert result["runtime_image_ref"] == _ADOPT_DIGEST
+    assert managed_marker.read_text().strip() == _ADOPT_DIGEST
+    assert source_marker.read_text().strip() == _ADOPT_SHA_NEW
+
+
+def test_managed_image_stays_stale_when_nothing_is_published(monkeypatch, tmp_path) -> None:
+    """Fail-closed is preserved: no published digest, no adoption."""
+    instance = _instance(tmp_path)
+    source_marker, managed_marker = _managed_markers(monkeypatch, tmp_path)
+    monkeypatch.setattr(worker, "_published_runtime_image_ref", lambda sha: None)
+
+    result = instance._maybe_rebuild_openshell_image_after_update(
+        tmp_path, _ADOPT_SHA_OLD, _ADOPT_SHA_NEW
+    )
+
+    assert result["status"] == "managed_image_stale"
+    assert managed_marker.read_text().strip() == _ADOPT_PREV
+    assert source_marker.read_text().strip() == _ADOPT_SHA_OLD
+
+
+def test_managed_image_does_not_move_markers_when_the_pull_fails(
+    monkeypatch, tmp_path
+) -> None:
+    """A node must never claim a revision whose runtime it could not fetch."""
+    instance = _instance(tmp_path)
+    source_marker, managed_marker = _managed_markers(monkeypatch, tmp_path)
+    monkeypatch.setattr(worker, "_published_runtime_image_ref", lambda sha: _ADOPT_DIGEST)
+    monkeypatch.setattr(worker, "_resolve_openshell_docker_bin", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(
+        worker.subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=1, stdout="", stderr="denied"),
+    )
+
+    result = instance._maybe_rebuild_openshell_image_after_update(
+        tmp_path, _ADOPT_SHA_OLD, _ADOPT_SHA_NEW
+    )
+
+    assert result["status"] == "managed_image_stale"
+    assert managed_marker.read_text().strip() == _ADOPT_PREV
+    assert source_marker.read_text().strip() == _ADOPT_SHA_OLD
+
+
+def test_managed_image_adoption_can_be_disabled(monkeypatch, tmp_path) -> None:
+    instance = _instance(tmp_path)
+    _managed_markers(monkeypatch, tmp_path)
+    monkeypatch.setenv("MAC_OPENSHELL_ADOPT_PUBLISHED_RUNTIME", "0")
+    monkeypatch.setattr(worker, "_published_runtime_image_ref", lambda sha: _ADOPT_DIGEST)
+
+    result = instance._maybe_rebuild_openshell_image_after_update(
+        tmp_path, _ADOPT_SHA_OLD, _ADOPT_SHA_NEW
+    )
+
+    assert result["status"] == "managed_image_stale"
+
+
+def test_published_runtime_ref_only_accepts_repository_owned_digests(
+    monkeypatch, tmp_path
+) -> None:
+    """A mutable tag or a foreign registry must never be adopted."""
+    monkeypatch.setattr(worker, "_resolve_openshell_docker_bin", lambda: "/usr/bin/docker")
+
+    # Non-40-hex revision: never probe the registry at all.
+    assert worker._published_runtime_image_ref("not-a-sha") is None
+
+    # Registry returns something without a digest -> no adoption.
+    monkeypatch.setattr(
+        worker.subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="latest", stderr=""),
+    )
+    assert worker._published_runtime_image_ref(_ADOPT_SHA_NEW) is None
+
+    # A real digest resolves to the repository-owned immutable reference.
+    monkeypatch.setattr(
+        worker.subprocess, "run",
+        lambda *a, **k: SimpleNamespace(returncode=0, stdout="sha256:" + "e" * 64, stderr=""),
+    )
+    assert worker._published_runtime_image_ref(_ADOPT_SHA_NEW) == (
+        "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "e" * 64
+    )


### PR DESCRIPTION
## The design gap

`mac fleet refresh-source` exists to move a worker's source forward and **could not do it.**

A digest-managed node pins `openshell/runtime-image-ref` and `openshell/image-source-sha`, and refuses any source whose SHA differs from the marked one. Only `deploy/fleet-node-install.sh` ever wrote those markers, and it is reachable solely through the full fleet deploy.

Because the marker is keyed on the **source SHA** rather than on whether the image content changed, *every* commit makes a worker stale — so `refresh-source` could never advance a worker to any new revision at all. All five pods sat at `718406262` for two days behind a command whose stated purpose was to update them.

## Why adopting is safe

The old code's comment says rebuilding the tag locally "would silently destroy the single-image identity required by synchronized execution." That is true of a **local build** — and not true of the digest CI already publishes for every commit on main. The corresponding image usually exists; the node just had no way to adopt it.

All workers adopting revision X converge on the same published digest, so single-image identity is **preserved**, not weakened.

## Narrow by construction

- only a digest resolved from the repository-owned GHCR path for that exact revision (`git-<sha>` → immutable digest); a mutable tag, foreign registry, or non-40-hex revision is never probed or accepted
- the image must **pull** before either marker moves
- markers written atomically, **image first** — a node naming a pulled image with an older SHA is merely stale and recoverable; the reverse claims a revision whose runtime is absent
- no published digest, failed pull, or unwritable marker → the previous fail-closed path is unchanged (rollback, `managed_image_stale`)
- `MAC_OPENSHELL_ADOPT_PUBLISHED_RUNTIME=0` restores the old behaviour

The pre-existing `test_digest_managed_openshell_image_never_rebuilds_locally` passes **unmodified**.

`2138 passed, 6 skipped`. Env registry regenerated; `test_worker_control_edges.py` registered against `deploy/fleet-node-install.sh` in `PATH_TEST_CONTRACTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)