### PR TITLE
Pin every capacity input in the hardware schema contract test

### DIFF
--- a/tests/test_roles_service.py
+++ b/tests/test_roles_service.py
@@ -160,13 +160,23 @@ def test_machine_hardware_satisfies_handles_accelerators_and_tags():
     assert any("tags" in r for r in reasons) or any("accelerator" in r for r in reasons)
 
 
-def test_detected_hardware_shape_satisfies_allocator_contract(monkeypatch):
+def test_detected_hardware_shape_satisfies_allocator_contract(monkeypatch, tmp_path):
     """The self-report schema and allocator matcher must share field names."""
     import mac.hardware as hw
 
     monkeypatch.setattr(hw.platform, "system", lambda: "Linux")
     monkeypatch.setattr(hw.platform, "machine", lambda: "x86_64")
     monkeypatch.setattr(hw.os, "cpu_count", lambda: 32)
+    # detect_hardware() reports SANDBOX-EFFECTIVE capacity (ed60d3cd): it takes
+    # the minimum of os.cpu_count, scheduler affinity and the cgroup cpuset.
+    # Stubbing only os.cpu_count left the host's real affinity leaking in, so
+    # this schema-contract test failed on any Linux runner with < 16 CPUs --
+    # invisible on macOS, which has no sched_getaffinity, and rarely selected
+    # by the impact map. Pin every input so the contract is host-independent.
+    monkeypatch.setattr(
+        hw.os, "sched_getaffinity", lambda _pid: set(range(32)), raising=False
+    )
+    monkeypatch.setattr(hw, "_CGROUP_ROOT", tmp_path / "no-cgroup")
     monkeypatch.setattr(hw, "_cpu_model", lambda: "AMD EPYC")
     monkeypatch.setattr(hw, "_memory_mb", lambda: 65536)
     monkeypatch.setattr(


### PR DESCRIPTION
## A host-dependent assertion in a test that claims to be synthetic

`test_detected_hardware_shape_satisfies_allocator_contract` stubs `os.cpu_count → 32`, then asserts the detected shape satisfies a role needing 16 CPUs. Its docstring says it only checks *"the self-report schema and allocator matcher must share field names."*

But since `ed60d3cd`, `detect_hardware()` reports **sandbox-effective** capacity — `min(os.cpu_count, sched_getaffinity, cgroup cpuset)`. Affinity and cgroup were never stubbed, so the host's real CPU count leaks in.

macOS has no `sched_getaffinity`, so it's invisible locally. On a 4-CPU Linux runner effective capacity collapses to 4 and the assertion fails. Verified directly:

```
with affinity=4  -> 4
with affinity=32 -> 32
```

## Why it matters now

It has been failing on CI Linux runners since `ed60d3cd` and stayed hidden because the impact map rarely selects this file. It surfaced only because editing `resolve-impacted-tests.py` forced a full selection — and it **blocks `mainline`, which gates the OpenShell runtime image publish**, which is what every worker needs to advance past `718406262`.

## Fix

Stub affinity and point `_CGROUP_ROOT` at a nonexistent path, so the contract is host-independent. **Production behaviour untouched** — honouring cgroup limits is correct and is the entire point of `ed60d3cd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)