### PR TITLE
Fail closed per task, not per round, on an unparseable dependency join

### DIFF
--- a/src/mac/task_lifecycle.py
+++ b/src/mac/task_lifecycle.py
@@ -617,15 +617,27 @@ class DispatchService:
             dependency_rows_by_task.setdefault(str(row["task_id"]), []).append(row)
         dependency_ready: Dict[str, bool] = {}
         for task in tasks:
-            join = self.control_plane._dependency_join_policy(task)
-            dependency_ready[task.id] = all(
-                self.control_plane._dependency_state_satisfies_join(
-                    str(row["dependency_state"]),
-                    json_loads(row["dependency_metadata"], {}),
-                    join,
+            # Fail closed for the ONE offending task, never for the round.
+            # _dependency_join_policy raises ValidationError on an unrecognised
+            # metadata.dependency_policy.join, which is writable through the
+            # ordinary update_task surface. The single-task snapshot path
+            # already guards this (see dependencies_satisfied above); the bulk
+            # path added for round performance did not, so one malformed task
+            # aborted _allocation_v2_inputs and halted dispatch fleet-wide,
+            # while `mac task ready` -- which takes the guarded path -- still
+            # looked healthy.
+            try:
+                join = self.control_plane._dependency_join_policy(task)
+                dependency_ready[task.id] = all(
+                    self.control_plane._dependency_state_satisfies_join(
+                        str(row["dependency_state"]),
+                        json_loads(row["dependency_metadata"], {}),
+                        join,
+                    )
+                    for row in dependency_rows_by_task.get(task.id, ())
                 )
-                for row in dependency_rows_by_task.get(task.id, ())
-            )
+            except (NotFoundError, TransitionError, ValidationError):
+                dependency_ready[task.id] = False
 
         now = utcnow()
         break_glass_by_task: Dict[str, Any] = {}

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -15963,3 +15963,32 @@ def test_transition_diagnosis_embeds_recovered_output(cp):
     diagnosis = ensure_json_object(ensure_json_object(events[-1].detail)["diagnosis"])
     assert "RuntimeError: boom" in (diagnosis.get("output_tail") or ""), diagnosis
     assert not diagnosis.get("output_tail_unavailable_reason")
+
+
+def test_one_malformed_dependency_policy_cannot_halt_the_whole_round(cp):
+    """A single unparseable join policy must not abort dispatch fleet-wide.
+
+    _dependency_join_policy raises ValidationError on an unrecognised
+    metadata.dependency_policy.join, which is writable through the ordinary
+    update_task surface. The bulk snapshot path used by every dispatch round
+    called it unguarded, so one bad task raised out of _allocation_v2_inputs
+    and no agent could be assigned anything -- while `mac task ready`, which
+    takes the guarded single-task path, still reported the fleet healthy.
+    """
+    worker = register_agent(cp, "w", ["python"])
+    good = cp.create_task("good", required_capabilities=["python"])
+    poison = cp.create_task("poison", required_capabilities=["python"])
+    cp.update_task(
+        poison.id,
+        metadata={"dependency_policy": {"join": "any_success"}},
+        actor="operator",
+    )
+
+    # The round must still run and must still place the healthy task.
+    assignment = cp.dispatch_once(lease_seconds=300)
+
+    assert assignment is not None, "one malformed task must not starve the round"
+    assert cp.get_task(good.id).state in {"claimed", "running"}
+    # The offending task fails closed rather than being dispatched.
+    assert cp.get_task(poison.id).state == "open"
+    del worker


### PR DESCRIPTION
## One malformed task could halt the entire fleet

`_dependency_join_policy` raises `ValidationError` for any `metadata.dependency_policy.join` outside `{all_success, all_settled}` — and that metadata is writable through the ordinary `update_task` surface.

The **single-task** snapshot path has always guarded this: `_v2_snapshot_task` wraps `_dependencies_satisfied` in `except (NotFoundError, TransitionError, ValidationError)` and marks that one task not-ready. The **bulk** path added later for round performance did not, and `_allocation_v2_inputs` passes its result in as `dependencies_satisfied_override` — bypassing the guarded branch entirely.

So one malformed OPEN task raised out of the snapshot builder and **no agent could be assigned anything, fleet-wide**, for as long as that task existed. Neither `_dispatch_batch_impl` nor the claim-next path isolates it.

The symptom is especially misleading: `mac task ready` and `explain_task_dispatch` take the *guarded* path, so they keep reporting a healthy ready list while nothing dispatches — the exact shape of a multi-hour standstill with no visible cause.

## Test proves the regression

With the guard reverted:
```
E  mac.models.ValidationError: unsupported dependency join policy 'any_success' for task task_8edc7e01…
FAILED test_one_malformed_dependency_policy_cannot_halt_the_whole_round
```
With it: the healthy task is still placed, the offending task stays `open`.

`2092 passed, 3 skipped` across control-plane / dispatch / lifecycle / allocator / dependency suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)