### PR TITLE
Schedule the stranding detector, drop stale dependency records, correct a docstring

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -1054,6 +1054,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_TASK_EXECUTOR_SCRIPT` | str | consumer-defined | task-execution | Task Execution setting: task executor script. |
 | `MAC_TASK_EXECUTOR_TIMEOUT_SECONDS` | int | consumer-defined | task-execution | Task Execution setting: task executor timeout seconds. |
 | `MAC_TASK_FILE` | str | consumer-defined | task-execution | Task Execution setting: task file. |
+| `MAC_TASK_FLOW_TICK_SINCE_HOURS` | str | consumer-defined | task-execution | Task Execution setting: task flow tick since hours. |
 | `MAC_TASK_GIT_TOKEN` | str | consumer-defined | task-execution | Task Execution setting: task git token. |
 | `MAC_TASK_ID` | str | consumer-defined | task-execution | Task Execution setting: task id. |
 | `MAC_TASK_MAX_ITERATIONS` | str | consumer-defined | task-execution | Task Execution setting: task max iterations. |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -12498,6 +12498,17 @@
   },
   {
     "default": null,
+    "description": "Task Execution setting: task flow tick since hours.",
+    "family": "task-execution",
+    "name": "MAC_TASK_FLOW_TICK_SINCE_HOURS",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Task Execution setting: task git token.",
     "family": "task-execution",
     "name": "MAC_TASK_GIT_TOKEN",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -341,6 +341,12 @@ def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
     return max(minimum, value)
 
 
+def _task_flow_tick_since_hours() -> int:
+    """Lookback for the scheduled stranding sweep."""
+
+    return _env_int("MAC_TASK_FLOW_TICK_SINCE_HOURS", 24, minimum=1)
+
+
 def _agent_quarantine_threshold() -> int:
     return _env_int("MAC_AGENT_QUARANTINE_THRESHOLD", 2, minimum=1)
 
@@ -10934,14 +10940,22 @@ class ControlPlane:
         actor: str,
         reason: Optional[str] = None,
     ) -> Task:
-        """Operator override: mark a task COMPLETED regardless of its current
-        state or review status.
+        """Operator override: mark a task COMPLETED from any state, subject to
+        one remaining gate.
 
         For reconciling work done out-of-band (e.g. a task whose change merged
         via a PR) or recovering a task stranded in a terminal state where the
-        normal review→publish path can no longer run. This deliberately bypasses
-        the review/evidence completion gate, so it records who forced it, the
-        prior state, and why. Recovery counterpart to :meth:`reopen_task`.
+        normal review→publish path can no longer run. It deliberately bypasses
+        both the review/evidence completion gate and ``validate_transition`` --
+        the recovery case is precisely ``failed -> completed``, which
+        ``TASK_TRANSITIONS`` forbids -- so it records who forced it, the prior
+        state, and why. Recovery counterpart to :meth:`reopen_task`.
+
+        NOT bypassed: a repo-coupled task still has to satisfy
+        :meth:`_require_canonical_integration_proof`, so forcing one complete
+        without a canonical integration record raises. Only report deliverables
+        and tasks without a repository execution contract complete
+        unconditionally.
         """
         task = self.get_task(task_id)
         # get_task accepts unambiguous display prefixes, but every mutation and
@@ -18808,6 +18822,28 @@ class ControlPlane:
             tenant_id=None,
             allow_blocking_hub_verify=False,
         )
+        # Stranding episodes were only ever created inside task_flow.report(),
+        # whose callers are the CLI, the HTTP route and two facades -- no
+        # scheduler. docs/task-throughput-observability.md describes an episode
+        # that "opens once per task/attempt/stage and is updated until progress
+        # resolves it", but nothing opened one unless a human ran
+        # `mac task throughput`. On 2026-07-31 the detector had 312 unresolved
+        # episodes and had not run for 30 hours while the fleet was stalled.
+        # Drive it from the hub's own clock so the detector observes the fleet
+        # rather than the operator.
+        try:
+            self.task_flow.report(
+                project=None,
+                since_hours=_task_flow_tick_since_hours(),
+                refresh_limit=limit_value,
+            )
+        except Exception as exc:  # noqa: BLE001 - diagnostics must never stop the tick.
+            self.record_log(
+                "task_flow.tick_failed",
+                layer="control_plane",
+                level="warning",
+                detail={"error": str(exc)[:500]},
+            )
         # Desired-source holds must land before dispatch.  Otherwise a stale
         # idle node can acquire new work in the same tick that notices drift.
         try:
@@ -23457,6 +23493,10 @@ class ControlPlane:
             TaskState.FAILED.value,
             TaskState.CANCELLED.value,
         }:
+            # Both are terminal: no retry proceeds from either. The spec's
+            # "executor failures that may still retry ... continue to hold the
+            # integration parent" is about a BLOCKED child awaiting retry,
+            # which is handled below by requiring the supervised record.
             return True
         dependency_resolution = ensure_json_object(
             ensure_json_object(metadata).get("dependency_resolution")

--- a/src/mac/task_transition_service.py
+++ b/src/mac/task_transition_service.py
@@ -311,6 +311,14 @@ class TaskTransitionService:
                 "retry_excluded_agent_ids",
                 "retry_failure_fingerprint",
                 "retry_failure_kind",
+                # A dependency_resolution record describes ONE unsatisfied
+                # prerequisite episode. Left behind across a reopen it makes
+                # _dependency_state_satisfies_join count this task as
+                # "settled" the next time it blocks -- for any reason at all,
+                # including a plain executor failure the spec says must hold
+                # the integration parent. The episode ended when the task was
+                # reopened; the record must end with it.
+                "dependency_resolution",
             ):
                 candidate_metadata.pop(key, None)
             metadata_changed = True

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -16024,3 +16024,67 @@ def test_heartbeat_does_not_release_an_operator_hold(cp):
     held = cp.get_agent(agent.id)
     assert held.dispatch_hold is True
     assert "operator" in (held.dispatch_hold_reason or "")
+
+
+def test_all_settled_still_settles_a_cancelled_child(cp):
+    """Cancellation is terminal with no retry, so it settles immediately."""
+    child = cp.create_task("child", required_capabilities=["python"])
+    parent = cp.create_task(
+        "parent",
+        required_capabilities=["python"],
+        dependencies=[child.id],
+        metadata={"dependency_policy": {"join": "all_settled"}},
+    )
+    cp._transition_task_internal(child.id, "cancelled", "operator", {"reason": "no longer needed"})
+
+    assert cp._dependencies_satisfied(cp.get_task(parent.id)) is True
+
+
+def test_reopen_clears_a_stale_dependency_resolution_record(cp):
+    """The record describes one episode; it must not outlive the reopen.
+
+    Left behind, it made a later block for an unrelated reason count as
+    "settled" and released the integration parent.
+    """
+    task = cp.create_task("t", required_capabilities=["python"])
+    cp.update_task(
+        task.id,
+        metadata={"dependency_resolution": {"schema": "mac.dependency_resolution.v1",
+                                            "status": "unsatisfied"}},
+        actor="operator",
+    )
+    cp._transition_task_internal(task.id, "failed", "operator", {"reason": "boom"})
+    cp.reopen_task(task.id, "operator", "retry")
+
+    assert "dependency_resolution" not in ensure_json_object(cp.get_task(task.id).metadata)
+
+
+def test_tick_runs_the_stranding_detector(cp, monkeypatch):
+    """Stranding episodes were only created inside task_flow.report(), whose
+    callers were the CLI, the HTTP route and two facades -- no scheduler. The
+    documented "opens once per task/attempt/stage" episode therefore never
+    opened unless a human ran `mac task throughput`; on 2026-07-31 the detector
+    had 312 unresolved episodes and had not run in 30 hours."""
+    calls = []
+    original = cp.task_flow.report
+
+    def _spy(**kwargs):
+        calls.append(kwargs)
+        return original(**kwargs)
+
+    monkeypatch.setattr(cp.task_flow, "report", _spy)
+    cp.tick(limit=0)
+
+    assert calls, "the hub tick must drive the stranding detector"
+    assert calls[0].get("since_hours")
+
+
+def test_tick_survives_a_failing_stranding_detector(cp, monkeypatch):
+    """Diagnostics must never be able to stop lease maintenance or dispatch."""
+    def _boom(**_kwargs):
+        raise RuntimeError("detector exploded")
+
+    monkeypatch.setattr(cp.task_flow, "report", _boom)
+    result = cp.tick(limit=0)
+
+    assert isinstance(result, dict)


### PR DESCRIPTION
Three spec-conformance fixes from the lifecycle audit — and one deliberate non-fix.

## 1. The stranding detector now runs on the hub's clock

`docs/task-throughput-observability.md` describes an episode that *"opens once per task/attempt/stage and is updated until progress resolves it"*. Episodes were only ever created inside `task_flow.report()`, whose callers are the CLI, the HTTP route and two facades — **no scheduler**. Nothing opened one unless a human ran `mac task throughput`.

On 2026-07-31 the detector held **312 unresolved episodes and had not run for 30 hours** — straight through the 18-hour fleet standstill it exists to detect. Now driven from `tick()`, wrapped so a diagnostic failure can never stop lease maintenance or dispatch.

## 2. An operator reopen clears `dependency_resolution`

That record describes **one** unsatisfied-prerequisite episode, and `_dependency_state_satisfies_join` treats a BLOCKED child carrying `status=unsatisfied` as settled. Left behind across a reopen, it made the task count as settled the next time it blocked **for any reason at all** — including a plain executor failure — releasing an integration parent over work that had not settled.

## 3. `force_complete_task` docstring corrected

It claimed "regardless of its current state or review status". It also enforces `_require_canonical_integration_proof`, so a repo-coupled task cannot be forced complete without a canonical integration record. Bypassing `validate_transition` is deliberate — the recovery case is exactly `failed -> completed`, which `TASK_TRANSITIONS` forbids — and now says so.

## Deliberately NOT changed

The audit read *"executor failures that may still retry … continue to hold the integration parent"* as requiring a FAILED dependency with retry budget to block an `all_settled` join. **Read in full, that paragraph is about BLOCKED children**, which the predicate already handles by requiring the supervised record. `FAILED` is terminal; no retry proceeds from it.

Implementing the audit's reading broke **8 existing tests** that correctly encode confluence across terminal event orders. Reverted; a comment now records why the branch is right as written.

`1332 passed`; dead-code gate clean; env registry regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)