### PR TITLE
Reconcile dependents of an in-transaction terminal transition; teach the audit its own joins

### DIFF
--- a/src/mac/task_ledger_audit.py
+++ b/src/mac/task_ledger_audit.py
@@ -986,6 +986,37 @@ def _root_failure_reason(history: Sequence[Mapping[str, Any]], current_reason: s
     return current_reason
 
 
+def _dependency_join_policy_of(task: Mapping[str, Any]) -> str:
+    """The join this task's dependencies are evaluated under.
+
+    Mirrors ControlPlane._dependency_join_policy: cooperative integration
+    parents default to ``all_settled``, everything else to ``all_success``.
+    """
+
+    metadata = _mapping(task.get("metadata"))
+    policy = _mapping(metadata.get("dependency_policy"))
+    coordination = _mapping(metadata.get("coordination"))
+    declared = _text(policy.get("join")) or _text(coordination.get("join_policy"))
+    if declared:
+        return declared
+    if _text(coordination.get("mode")) == "cooperative_integration":
+        return "all_settled"
+    return "all_success"
+
+
+def _is_supervised_dependency_block(task: Mapping[str, Any]) -> bool:
+    """True when this task carries the spec's prescribed supervised outcome.
+
+    docs/task-dependency-semantics.md: an ordinary dependent of a terminal
+    prerequisite "become[s] blocked with reason=dependencies_incomplete,
+    preserving their work and provenance". That is the DESIGNED steady state,
+    not a contradiction to repair.
+    """
+
+    resolution = _mapping(_mapping(task.get("metadata")).get("dependency_resolution"))
+    return _text(resolution.get("status")) == "unsatisfied"
+
+
 def _assessment(
     row: Mapping[str, Any],
     raw_history: Sequence[Mapping[str, Any]],
@@ -1138,10 +1169,19 @@ def _assessment(
             findings.append("waiting_with_all_dependencies_completed")
             verdict = "contradiction"
             action = "reopen_stranded_waiting_task"
-        elif int(dependencies.get("terminal_blocker_count") or 0):
+        elif int(dependencies.get("terminal_blocker_count") or 0) and (
+            _dependency_join_policy_of(task) != "all_settled"
+        ):
             findings.append("waiting_on_failed_cancelled_or_missing_dependency")
             verdict = "contradiction"
             action = "repair_terminal_dependency_or_cancel_with_replacement"
+        elif int(dependencies.get("terminal_blocker_count") or 0):
+            # all_settled: a terminal prerequisite IS settled. A cooperative
+            # integration parent waiting here is holding for its remaining
+            # children, which is the documented design, not a defect.
+            findings.append("waiting_on_settled_dependency_under_all_settled_join")
+            verdict = "active_valid"
+            action = "await_remaining_children"
         elif int(dependencies.get("cycle_count") or 0):
             findings.append("waiting_dependency_cycle")
             verdict = "contradiction"
@@ -1161,6 +1201,16 @@ def _assessment(
             findings.append("blocked_with_all_dependencies_completed")
             verdict = "contradiction"
             action = "reopen_stranded_blocked_task"
+        elif int(dependencies.get("terminal_blocker_count") or 0) and (
+            _is_supervised_dependency_block(task)
+        ):
+            # docs/task-dependency-semantics.md prescribes exactly this state
+            # for an ordinary dependent of a terminal prerequisite: blocked,
+            # preserved and diagnosable. Reporting it as a contradiction led
+            # operators to cancel the work the spec says to preserve.
+            findings.append("blocked_by_supervised_terminal_dependency")
+            verdict = "active_valid"
+            action = "await_repair_or_replacement"
         elif int(dependencies.get("terminal_blocker_count") or 0):
             findings.append("blocked_by_failed_cancelled_or_missing_dependency")
             verdict = "contradiction"

--- a/src/mac/task_transition_service.py
+++ b/src/mac/task_transition_service.py
@@ -509,6 +509,28 @@ class TaskTransitionService:
                 apply_transition(transaction)
         else:
             apply_transition(conn)
+            if target in {TaskState.FAILED.value, TaskState.CANCELLED.value}:
+                # The caller owns this transaction, so dependency
+                # reconciliation cannot run here: it opens transactions of its
+                # own and must not observe a terminal state that has not
+                # committed yet. The conn-is-None path calls
+                # _resolve_waiting_dependents_of directly after commit; this
+                # path had no equivalent and simply skipped it, so every
+                # in-transaction cancel left its waiting dependents with no
+                # dependency_resolution record, no BLOCKED transition and no
+                # observation -- silently unrunnable forever. workflow_runtime
+                # cancels exactly this way. Hand the work to the outbox, which
+                # already exists to run post-commit side effects in order.
+                self.control_plane.task_ledger.enqueue_outbox(
+                    conn,
+                    task_id=task_id,
+                    event_type="dependency.reconcile",
+                    actor=actor,
+                    from_state=task.state,
+                    to_state=target,
+                    detail=detail or {},
+                    created_at=now,
+                )
             transitioned_row = conn.execute(
                 "SELECT * FROM tasks WHERE id = ?", (task_id,)
             ).fetchone()
@@ -831,6 +853,15 @@ class TaskTransitionService:
             self.control_plane._task_outbox_drain_lock.release()
 
     def _process_task_transition_outbox_item(self, item: TaskTransitionOutbox) -> None:
+        if item.event_type == "dependency.reconcile":
+            # Post-commit half of an in-transaction terminal transition. Safe to
+            # repeat: _resolve_waiting_dependents_of skips any dependent that is
+            # no longer WAITING, so a redelivered row is a no-op.
+            if item.to_state in {TaskState.FAILED.value, TaskState.CANCELLED.value}:
+                self.control_plane._resolve_waiting_dependents_of(
+                    item.task_id, item.to_state or "", item.actor or "outbox"
+                )
+            return
         if item.event_type == "task.lifecycle":
             task = self.control_plane.get_task(item.task_id)
             metadata = ensure_json_object(task.metadata)

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -16088,3 +16088,54 @@ def test_tick_survives_a_failing_stranding_detector(cp, monkeypatch):
     result = cp.tick(limit=0)
 
     assert isinstance(result, dict)
+
+
+def test_in_transaction_cancel_still_reconciles_its_dependents(cp):
+    """A terminal transition inside a caller transaction must not strand deps.
+
+    _transition_task_impl returns before the reconciler when conn is not None,
+    so an in-transaction cancel left every waiting dependent with no
+    dependency_resolution record, no BLOCKED transition and no observation --
+    silently unrunnable forever. workflow_runtime.py cancels exactly this way.
+    """
+    dep = cp.create_task("dep", required_capabilities=["python"])
+    downstream = cp.create_task(
+        "downstream", required_capabilities=["python"], dependencies=[dep.id]
+    )
+    assert cp.get_task(downstream.id).state == "waiting"
+
+    # Cancel the prerequisite the way workflow_runtime does: inside a
+    # transaction the caller owns.
+    with cp.store.transaction() as conn:
+        cp._transition_task_in_transaction(
+            conn, dep.id, "cancelled", "workflow", {"reason": "run cancelled"}
+        )
+    cp.drain_task_transition_outbox(task_id=dep.id, limit=20)
+
+    resolved = cp.get_task(downstream.id)
+    record = ensure_json_object(
+        ensure_json_object(resolved.metadata).get("dependency_resolution")
+    )
+    assert resolved.state == "blocked", (
+        "dependent must be supervised, not left waiting; got %s" % resolved.state
+    )
+    assert record.get("status") == "unsatisfied", record
+
+
+def test_dependency_reconcile_outbox_row_is_idempotent(cp):
+    """Redelivery must be a no-op, not a second supervision pass."""
+    dep = cp.create_task("dep", required_capabilities=["python"])
+    downstream = cp.create_task(
+        "downstream", required_capabilities=["python"], dependencies=[dep.id]
+    )
+    with cp.store.transaction() as conn:
+        cp._transition_task_in_transaction(
+            conn, dep.id, "failed", "workflow", {"reason": "boom"}
+        )
+    cp.drain_task_transition_outbox(task_id=dep.id, limit=20)
+    first = cp.get_task(downstream.id).state
+
+    # Replay the same side effect.
+    cp._resolve_waiting_dependents_of(dep.id, "failed", "outbox")
+
+    assert cp.get_task(downstream.id).state == first == "blocked"

--- a/tests/test_task_ledger_audit.py
+++ b/tests/test_task_ledger_audit.py
@@ -896,3 +896,74 @@ def test_dependency_cycle_is_not_reported_as_valid_blocking():
         assert row["dependencies"]["cycle_count"] == 1
         assert row["assessment"]["verdict"] == "contradiction"
         assert "blocked_by_dependency_cycle" in row["assessment"]["findings"]
+
+
+def _assess(state, *, metadata=None, terminal_blockers=1, incomplete=1, count=1):
+    from mac.task_ledger_audit import _assessment
+
+    return _assessment(
+        {
+            "task": {"id": "task_x", "state": state, "metadata": metadata or {}},
+            "history": {},
+            "evidence": {},
+            "repository": {},
+            "dependencies": {
+                "count": count,
+                "incomplete_count": incomplete,
+                "terminal_blocker_count": terminal_blockers,
+                "cycle_count": 0,
+            },
+        },
+        [],
+        {},
+    )
+
+
+def test_supervised_blocked_dependent_is_not_a_contradiction():
+    """docs/task-dependency-semantics.md prescribes exactly this state.
+
+    An ordinary dependent of a terminal prerequisite "become[s] blocked with
+    reason=dependencies_incomplete, preserving their work and provenance".
+    The audit reported it as a contradiction whose action was to repair or
+    cancel -- i.e. it told operators to destroy the work the spec preserves.
+    """
+    result = _assess(
+        "blocked",
+        metadata={
+            "dependency_resolution": {
+                "schema": "mac.dependency_resolution.v1",
+                "status": "unsatisfied",
+            }
+        },
+    )
+
+    assert result["verdict"] == "active_valid", result
+    assert "blocked_by_supervised_terminal_dependency" in result["findings"]
+
+
+def test_unsupervised_blocked_terminal_dependency_is_still_a_contradiction():
+    """Without the supervised record it is genuinely stranded."""
+    result = _assess("blocked")
+
+    assert result["verdict"] == "contradiction"
+    assert "blocked_by_failed_cancelled_or_missing_dependency" in result["findings"]
+
+
+def test_all_settled_parent_waiting_on_a_terminal_child_is_valid():
+    """Under all_settled a terminal prerequisite IS settled, so a cooperative
+    integration parent waiting here is holding for its remaining children."""
+    result = _assess(
+        "waiting",
+        metadata={"coordination": {"mode": "cooperative_integration"}},
+    )
+
+    assert result["verdict"] == "active_valid", result
+    assert "waiting_on_settled_dependency_under_all_settled_join" in result["findings"]
+
+
+def test_all_success_parent_waiting_on_a_terminal_child_is_a_contradiction():
+    """The default join can never accept a terminal dependency."""
+    result = _assess("waiting")
+
+    assert result["verdict"] == "contradiction"
+    assert "waiting_on_failed_cancelled_or_missing_dependency" in result["findings"]


### PR DESCRIPTION
The last two lifecycle-spec violations.

## V2 — in-transaction terminal transitions stranded their dependents

`_transition_task_impl` returns from the `conn is not None` branch **before** reaching `_resolve_waiting_dependents_of`. So every in-transaction cancel left its waiting dependents with no `dependency_resolution` record, no BLOCKED transition, and no observation — silently unrunnable, and invisible to the unblock sweep because their dependency can never satisfy the join.

`workflow_runtime.py:488` cancels exactly this way, so **every workflow-run cancellation orphaned its downstream tasks.**

The reconciler can't simply be called there — it opens transactions of its own and must not observe a terminal state that hasn't committed. Instead it enqueues a `dependency.reconcile` row on the transition outbox, which already exists to run ordered post-commit side effects. Redelivery is safe (`_resolve_waiting_dependents_of` skips any dependent no longer WAITING). The `conn is None` path keeps its direct call, so its timing is unchanged.

Test proves it: with the fix reverted, the dependent is left in `waiting`.

## V4b — the audit didn't know about dependency joins

It reported **both** of the spec's prescribed healthy steady states as contradictions needing repair:

- a supervised BLOCKED dependent carrying `dependency_resolution.status=unsatisfied` — which the spec prescribes as the outcome that *"preserv[es] their work and provenance"* — was reported as `blocked_by_failed_cancelled_or_missing_dependency`, action **"repair or cancel with replacement"**;
- a cooperative integration parent WAITING under `all_settled`, where a terminal prerequisite **is** settled, was reported as `waiting_on_failed_cancelled_or_missing_dependency`.

An operator acting on that output would cancel exactly the work the spec exists to preserve. Both now resolve to `active_valid`. The genuinely stranded cases — no supervised record, or an `all_success` join that can never accept a terminal dependency — still report `contradiction`, unchanged.

`1494 passed, 2 skipped`; dead-code gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)