### PR TITLE
Give unscoped work a real project so it can be counted and paused

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -997,6 +997,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_SCIENTIFIC_OPTIMIZER_MIN_BASELINE_TASKS` | str | consumer-defined | scientific-optimizer | Scientific Optimizer setting: scientific optimizer min baseline tasks. |
 | `MAC_SCIENTIFIC_OPTIMIZER_MIN_SAMPLES_PER_ARM` | str | consumer-defined | scientific-optimizer | Scientific Optimizer setting: scientific optimizer min samples per arm. |
 | `MAC_SCIENTIFIC_OPTIMIZER_OUTCOME_HORIZON_SECONDS` | int | consumer-defined | scientific-optimizer | Scientific Optimizer setting: scientific optimizer outcome horizon seconds. |
+| `MAC_SCOPE_UNPROJECTED_TASKS` | str | consumer-defined | core | Core setting: scope unprojected tasks. |
 | `MAC_SECRET_KEY` | str | consumer-defined | core | Core setting: secret key. |
 | `MAC_SECRET_VAULT_TOKEN` | str | consumer-defined | core | Core setting: secret vault token. |
 | `MAC_SECRET_VAULT_URL` | str | consumer-defined | core | Core setting: secret vault url. |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -11810,6 +11810,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: scope unprojected tasks.",
+    "family": "core",
+    "name": "MAC_SCOPE_UNPROJECTED_TASKS",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: secret key.",
     "family": "core",
     "name": "MAC_SECRET_KEY",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1285,6 +1285,15 @@ def _repository_contract_root(repo_path: Path) -> Path:
 
 _ONBOARDING_REMOTE_URL_RE = re.compile(r"^(https://|git@|ssh://|git://)\S+$")
 DEFAULT_PROJECT_BRANCH = "main"
+# Work with no product repository still needs a scope. A NULL project is not a
+# semantic -- it is an escape hatch: task_lifecycle's gate reads
+# `project_registered = task.project is None or project_record is not None`, so
+# an unscoped task bypasses BOTH the registered-project requirement and the
+# operator dispatch_paused switch. It is also invisible to every per-project
+# view and report. Giving fleet-maintenance work a real, registered project
+# makes it countable, reportable and -- most importantly -- pausable, which is
+# the only lever that can stop self-generated work crowding out product work.
+FLEET_MAINTENANCE_PROJECT = "fleet-maintenance"
 
 
 def _normalize_onboarding_remote_url(value: str) -> str:
@@ -4427,6 +4436,52 @@ class ControlPlane:
 
     # Task ledger
 
+    def _ensure_fleet_maintenance_project(self) -> None:
+        """Idempotently register the reserved scope for unscoped work.
+
+        The projects table needs only a name, so this does not go through
+        register_project (which is Git-backed and mints a contract-authoring
+        task). Failure is swallowed: a task must still be creatable if the
+        registry write races or the column set predates this.
+        """
+
+        try:
+            existing = self.store.query_one(
+                "SELECT id FROM projects WHERE name = ?", (FLEET_MAINTENANCE_PROJECT,)
+            )
+            if existing is not None:
+                return
+            now = utcnow()
+            self.store.execute(
+                "INSERT INTO projects (id, name, description, metadata, status, "
+                "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(name) DO NOTHING",
+                (
+                    new_id("proj"),
+                    FLEET_MAINTENANCE_PROJECT,
+                    "Fleet self-maintenance: work with no product repository. "
+                    "Pause this project to stop the fleet generating and running "
+                    "work about itself.",
+                    json_dumps({"fleet_maintenance": True}),
+                    "active",
+                    now,
+                    now,
+                ),
+            )
+        except Exception:  # noqa: BLE001 - never block task creation on this
+            return
+
+    def _resolve_task_project(self, project: Optional[str]) -> Optional[str]:
+        """Every task gets a scope; unscoped work lands in fleet-maintenance."""
+
+        resolved = str(project or "").strip()
+        if resolved:
+            return resolved
+        if not _truthy_env("MAC_SCOPE_UNPROJECTED_TASKS", "1"):
+            return None
+        self._ensure_fleet_maintenance_project()
+        return FLEET_MAINTENANCE_PROJECT
+
     def _apply_project_task_defaults(
         self,
         project: Optional[str],
@@ -5239,6 +5294,7 @@ class ControlPlane:
 
         now = utcnow()
         state = TaskState.WAITING.value if dep_ids else TaskState.OPEN.value
+        project = self._resolve_task_project(project)
         task_capabilities, task_metadata = self._apply_project_task_defaults(
             project,
             requested_capabilities,

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -16139,3 +16139,57 @@ def test_dependency_reconcile_outbox_row_is_idempotent(cp):
     cp._resolve_waiting_dependents_of(dep.id, "failed", "outbox")
 
     assert cp.get_task(downstream.id).state == first == "blocked"
+
+
+def test_unscoped_task_lands_in_a_real_pausable_project(cp):
+    """A NULL project is an escape hatch, not a semantic.
+
+    task_lifecycle gates on
+    `project_registered = task.project is None or project_record is not None`,
+    so an unscoped task bypasses BOTH the registered-project requirement and
+    the operator dispatch_paused switch, and is invisible to every per-project
+    view. Fleet self-work needs a real scope so it can be counted and paused.
+    """
+    from mac.services import FLEET_MAINTENANCE_PROJECT
+
+    task = cp.create_task("adjudicate something about an agent")
+
+    assert task.project == FLEET_MAINTENANCE_PROJECT
+    record = cp.get_project_record(FLEET_MAINTENANCE_PROJECT)
+    assert record is not None and record.status == "active"
+
+
+def test_pausing_fleet_maintenance_stops_self_work_dispatching(cp):
+    """The point of the scope: one switch stops self-generated work.
+
+    Previously impossible -- an unscoped task passed project_active
+    unconditionally, so there was nothing to pause.
+    """
+    from mac.services import FLEET_MAINTENANCE_PROJECT
+
+    register_agent(cp, "w", ["python"])
+    # A task naming an UNREGISTERED project is not dispatchable, while a NULL
+    # project was -- the asymmetry this change removes. Register the product
+    # scope so the comparison is about the pause, not registration.
+    cp._ensure_fleet_maintenance_project()
+    cp.store.execute(
+        "INSERT INTO projects (id, name, description, metadata, status, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("proj_product", "mac", "", "{}", "active", "2026-01-01T00:00:00+00:00",
+         "2026-01-01T00:00:00+00:00"),
+    )
+    product = cp.create_task("real product work", project="mac", required_capabilities=["python"])
+    self_work = cp.create_task("adjudicate agent state", required_capabilities=["python"])
+    assert self_work.project == FLEET_MAINTENANCE_PROJECT
+
+    cp.set_project_dispatch(FLEET_MAINTENANCE_PROJECT, paused=True, actor="operator")
+
+    explained = cp.explain_task_dispatch(self_work.id)
+    assert explained["task_ready"] is False, explained["task_reasons"]
+    # Product work is unaffected.
+    assert cp.explain_task_dispatch(product.id)["task_ready"] is True
+
+
+def test_explicit_project_is_never_overridden(cp):
+    task = cp.create_task("scoped work", project="nanolang")
+    assert task.project == "nanolang"


### PR DESCRIPTION
## "No project" is a hole, not a semantic

`task_lifecycle` gates on:

```python
project_registered = task.project is None or project_record is not None
project_active = project_registered and (project_record is None or ...)
```

An unscoped task passes **both unconditionally** — exempt from the registered-project requirement *and* from the operator `dispatch_paused` switch, and invisible to every per-project view.

The asymmetry is what makes it a bug rather than a convention: **a task naming an *unregistered* project is not dispatchable, while a task naming *no* project is.**

## The targeting consequence

In the last 24h the fleet created **73 unscoped root tasks**, each fanning out ~4.6× through decomposition (755 children from 163 parents), while `nanolang` — the only project currently landing commits — received 6 roots. The entire live review queue was unscoped, including real product work ("AI Slicer 5/9a: shape-spec schema…") that simply lost its attribution.

Project inheritance through decomposition already works correctly (243 NULL→NULL, 383 mac→mac), so this originates **entirely at the root**.

## The change

Unscoped work is routed to a reserved, registered `fleet-maintenance` project. The `projects` table needs only a name, so this doesn't go through `register_project` (Git-backed, mints a contract-authoring task). Explicitly supplied projects are never overridden; `MAC_SCOPE_UNPROJECTED_TASKS=0` restores the old behaviour.

**Deliberately not a cap.** It gives the lever that didn't exist: pause `fleet-maintenance` and self-generated work stops dispatching while product work is untouched — steering instead of guessing a threshold.

Existing NULL-project tasks are untouched; this changes creation only.

`2189 passed, 4 skipped`; dead-code gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)