### PR TITLE
Stop the self-healing sentinel filing work about agents that have no host

### DIFF
--- a/src/mac/self_healing.py
+++ b/src/mac/self_healing.py
@@ -488,6 +488,27 @@ class SelfHealingSentinel:
         "updated", "no_update", "skipped", "deferred", "rolled_back", "error",
     )
 
+    @staticmethod
+    def _agent_has_no_worker_process(agent: Any) -> bool:
+        """True for hub-driven virtual agents that have no host of their own.
+
+        agent_operator and the hub_verify review verifier are registered with
+        ``resources.virtual = True`` (services.py registers both). They are
+        offline by construction: there is no worker process to heartbeat and no
+        checkout to pin. Both detectors below flagged them anyway, and each
+        finding fans out into a diagnose -> remediate -> verify chain aimed at a
+        host that does not exist. That is a self-sustaining task generator: on
+        2026-07-31 these chains were a visible share of 283 unscoped tasks.
+
+        ServiceLayer._agent_is_virtual exists for exactly this, but it takes an
+        id and re-fetches; the sentinel already holds the agent rows.
+        """
+
+        resources = getattr(agent, "resources", None)
+        if isinstance(resources, Mapping):
+            return bool(resources.get("virtual"))
+        return False
+
     def _check_fleet_pin_divergence(self) -> List[Finding]:
         """A heartbeating agent whose repo-update trail lags the fleet's
         newest application is running stale code with a wedged agentbus
@@ -516,6 +537,8 @@ class SelfHealingSentinel:
             agent_id = str(getattr(agent, "id", "") or "")
             if getattr(agent, "dispatch_hold", False):
                 continue
+            if self._agent_has_no_worker_process(agent):
+                continue  # no checkout to pin
             last_seen = _parse_ts(getattr(agent, "last_seen_at", None))
             if last_seen is None or (now - last_seen).total_seconds() > self.config.agent_silence_seconds:
                 continue  # not heartbeating -> _check_agent_unhealthy owns it
@@ -568,6 +591,8 @@ class SelfHealingSentinel:
         for agent in self.control_plane.list_agents():
             if getattr(agent, "dispatch_hold", False):
                 continue  # deliberately benched; stuck_quarantine covers auto-holds
+            if self._agent_has_no_worker_process(agent):
+                continue  # offline by construction, not a fault
             agent_id = str(getattr(agent, "id", "") or "")
             last_seen = _parse_ts(getattr(agent, "last_seen_at", None))
             age = None if last_seen is None else (now - last_seen).total_seconds()

--- a/tests/test_self_healing.py
+++ b/tests/test_self_healing.py
@@ -654,3 +654,45 @@ def test_run_once_report_carries_budget_and_capped_count(cp, monkeypatch):
     assert report["budget"] == 1
     assert report["filed_count"] == 1
     assert report["capped_count"] == 2
+
+
+def _virtual_agent(agent_id="agent_operator", **over):
+    from types import SimpleNamespace
+
+    base = dict(
+        id=agent_id,
+        dispatch_hold=False,
+        last_seen_at=None,
+        health_status="healthy",
+        status="offline",
+        resources={"virtual": True, "operator_persona": True},
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_virtual_agents_are_not_flagged_unhealthy():
+    """agent_operator and the hub_verify reviewer are offline by construction.
+
+    Both are registered with resources.virtual=True and have no worker process,
+    so the detector flagged them forever and every finding fanned out into a
+    diagnose -> remediate -> verify chain aimed at a host that does not exist.
+    """
+    from mac.self_healing import SelfHealingSentinel
+
+    assert SelfHealingSentinel._agent_has_no_worker_process(_virtual_agent()) is True
+
+
+def test_real_workers_are_still_flagged():
+    from mac.self_healing import SelfHealingSentinel
+
+    real = _virtual_agent("agent_rocky", resources={"machine": "puck"})
+    assert SelfHealingSentinel._agent_has_no_worker_process(real) is False
+
+
+def test_missing_resources_does_not_exempt_an_agent():
+    """Fail closed: an agent with no resources is a real worker, not virtual."""
+    from mac.self_healing import SelfHealingSentinel
+
+    bare = _virtual_agent("agent_x", resources=None)
+    assert SelfHealingSentinel._agent_has_no_worker_process(bare) is False


### PR DESCRIPTION
## A self-sustaining task generator

`agent_operator` and the `hub_verify` review verifier are registered with `resources.virtual=True` and have **no worker process**: offline by construction, no checkout to pin.

Both sentinel detectors flagged them anyway — `_check_agent_unhealthy` trips on `status == "offline"`, `_check_fleet_pin_divergence` on a missing repo_update trail — and every finding fans out into a diagnose → remediate → verify chain aimed at a host that does not exist.

Triaging the 283 unscoped non-terminal tasks turned up whole clusters of exactly this shape:

- *"Ground-truth agent_operator class/host/heartbeat"*
- *"Diagnose agent_da539e43 host/service state"*
- *"Remediate agent_operator healthy/offline invariant"*

None can ever succeed, and each spawns repair and verification children of its own.

## The fix

`ServiceLayer._agent_is_virtual` already exists for this exact distinction — *"hub-driven virtual agents that have no worker process of their own"* — but takes an id and re-fetches. The sentinel already holds the rows, so this adds a local predicate over `agent.resources` and skips them in both checks.

**Fails closed**: an agent whose resources are absent or unparseable is treated as a real worker and still checked.

`1013 passed, 3 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)