### PR TITLE
Give work that needs an answer somewhere to wait

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -332,11 +332,11 @@ options:
 ```console
 $ mac task --help
 usage: mac task [-h]
-                {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
+                {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,answer,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
                 ...
 
 positional arguments:
-  {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
+  {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,answer,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
     list                list tasks (default: short ids; use --full-ids for
                         scripts)
     show                show task state, activity, diagnoses, and compact
@@ -357,6 +357,10 @@ positional arguments:
                         requires a reason
     cancel              actively cancel a task, revoke its lease, and abort a
                         running worker executor
+    ask                 park a task on an unanswered human question (not a
+                        failure; never reaped)
+    answer              answer a parked task's question and return it to the
+                        dispatch pool
     reopen              recovery: return a stuck/terminal task
                         (failed/cancelled/blocked) to OPEN for retry or
                         reconciliation

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -340,6 +340,8 @@ request and response definitions.
 | `GET` | `/tasks/{task_id}` | Get Task |
 | `PUT` | `/tasks/{task_id}` | Update Task |
 | `POST` | `/tasks/{task_id}/activity` | Append Task Activity |
+| `POST` | `/tasks/{task_id}/answer` | Answer Task |
+| `POST` | `/tasks/{task_id}/ask` | Ask Task |
 | `GET` | `/tasks/{task_id}/break-glass-authorizations` | List Break Glass Authorizations |
 | `POST` | `/tasks/{task_id}/break-glass-authorizations` | Authorize Break Glass |
 | `POST` | `/tasks/{task_id}/children` | Add Child Tasks |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -874,6 +874,17 @@ class TaskRecoveryRequest(BaseModel):
     reason: Optional[str] = None
 
 
+class TaskAskRequest(BaseModel):
+    questions: List[Any]
+    actor: str
+    why: Optional[str] = None
+
+
+class TaskAnswerRequest(BaseModel):
+    answer: str
+    actor: str
+
+
 class EvidenceCreate(BaseModel):
     kind: str
     uri: str
@@ -2233,7 +2244,7 @@ def _required_scope(method: str, path: str) -> Optional[str]:
         # `write` token can't flush every reviewable task to
         # COMPLETED on demand. mac-iez.
         return "admin"
-    if re.match(r"^/tasks/[^/]+/(force-complete|reopen|release)$", path):
+    if re.match(r"^/tasks/[^/]+/(force-complete|reopen|release|ask|answer)$", path):
         # These recovery/control-plane endpoints bypass normal worker flow or
         # make held work dispatchable. They must never be available to an
         # ordinary task writer.
@@ -6240,6 +6251,31 @@ def create_app(
         # Recovery: return a stuck/terminal task (failed/cancelled/blocked) to
         # OPEN so it can be retried or reconciled. Counterpart to force-complete.
         return cp.reopen_task(task_id, body.actor, body.reason).to_dict()
+
+    @app.post("/tasks/{task_id}/ask")
+    def ask_task(
+        task_id: str,
+        body: TaskAskRequest,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.require_admin()
+        # Park the task on an unanswered human question. Not a failure: the
+        # work is still wanted, so no sweeper or reaper may collect it and its
+        # attempt budget is left untouched until someone answers.
+        return cp.request_task_input(
+            task_id, body.questions, body.actor, why=body.why or ""
+        ).to_dict()
+
+    @app.post("/tasks/{task_id}/answer")
+    def answer_task(
+        task_id: str,
+        body: TaskAnswerRequest,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.require_admin()
+        # Answering returns held work to the dispatch pool, so it carries the
+        # same authority as reopen/release.
+        return cp.answer_task_input(task_id, body.answer, body.actor).to_dict()
 
     @app.post("/tasks/{task_id}/force-complete")
     def force_complete_task(

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -2029,6 +2029,29 @@ def cmd_task_close(args: argparse.Namespace) -> None:
     _print(result)
 
 
+def cmd_task_ask(args: argparse.Namespace) -> None:
+    """Park a task on an unanswered human question.
+
+    This is deliberately NOT a failure. The work is still wanted; it just
+    cannot proceed until a person answers. Tasks parked here are excluded
+    from every sweeper and reaper, so they wait indefinitely rather than
+    being retried into the ground or retired as bad work.
+    """
+    cp = _plane(args)
+    questions = [{"question": q} for q in (args.question or []) if str(q or "").strip()]
+    result = cp.request_task_input(
+        args.task_id, questions, args.actor, why=args.why or ""
+    )
+    _print(result)
+
+
+def cmd_task_answer(args: argparse.Namespace) -> None:
+    """Answer a parked task's question and return it to the dispatch pool."""
+    cp = _plane(args)
+    result = cp.answer_task_input(args.task_id, args.answer, args.actor)
+    _print(result)
+
+
 def cmd_task_cancel(args: argparse.Namespace) -> None:
     """Actively cancel a task and revoke any live worker assignment.
 
@@ -6438,6 +6461,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="delay before an eligible managed ref may be pruned (default: 7)",
     )
     _set(cmd_task_cancel, cancel)
+
+    ask = task.add_parser(
+        "ask",
+        help="park a task on an unanswered human question (not a failure; never reaped)",
+    )
+    ask.add_argument("task_id")
+    ask.add_argument(
+        "--question",
+        action="append",
+        required=True,
+        help="a question that must be answered before work can continue (repeatable)",
+    )
+    ask.add_argument("--why", default="", help="why the answer is needed")
+    ask.add_argument("--actor", default="human")
+    _set(cmd_task_ask, ask)
+
+    answer = task.add_parser(
+        "answer",
+        help="answer a parked task's question and return it to the dispatch pool",
+    )
+    answer.add_argument("task_id")
+    answer.add_argument("--answer", required=True, help="the answer to record")
+    answer.add_argument("--actor", default="human")
+    _set(cmd_task_answer, answer)
 
     reopen = task.add_parser(
         "reopen",

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -695,6 +695,23 @@ class RemoteDispatch:
         body = _drop_none({"actor": actor, "reason": reason})
         return _Dictish(self._post("/tasks/%s/reopen" % quote(task_id, safe=""), body))
 
+    def request_task_input(
+        self,
+        task_id: str,
+        questions: Any,
+        actor: str,
+        *,
+        why: str = "",
+    ) -> _Dictish:
+        body = _drop_none(
+            {"questions": list(questions or []), "actor": actor, "why": why or None}
+        )
+        return _Dictish(self._post("/tasks/%s/ask" % quote(task_id, safe=""), body))
+
+    def answer_task_input(self, task_id: str, answer: str, actor: str) -> _Dictish:
+        body = {"answer": answer, "actor": actor}
+        return _Dictish(self._post("/tasks/%s/answer" % quote(task_id, safe=""), body))
+
     def force_complete_task(
         self,
         task_id: str,

--- a/src/mac/models.py
+++ b/src/mac/models.py
@@ -114,6 +114,7 @@ class TaskState(StrEnum):
     CLAIMED = "claimed"
     RUNNING = "running"
     NEEDS_REVIEW = "needs_review"
+    NEEDS_INPUT = "needs_input"
     REVIEWING = "reviewing"
     COMPLETED = "completed"
     FAILED = "failed"
@@ -599,8 +600,60 @@ def report_repository_context_execution_contract(
     return contract
 
 
+NEEDS_INPUT_SCHEMA = "mac.task_needs_input.v1"
+
+
+def normalize_needs_input_detail(detail: Optional[Mapping[str, Any]]) -> JsonDict:
+    """Validate the durable contract for parking a task on a human question.
+
+    The point of the state is that it is *actionable*: an operator must be able
+    to see what is being asked without reading the transcript. So at least one
+    non-empty question is required, and each is normalized to
+    ``{"question": str, "why": str, "options": [str]}``. ``why`` and ``options``
+    are optional but preserved -- an agent that can say "I need X because Y, and
+    the plausible answers are A or B" turns a stall into a decision.
+
+    Refusing an empty payload is the whole safeguard. Without it this state
+    degrades into a second ``blocked``: somewhere work goes to be forgotten.
+    """
+
+    normalized = dict(detail or {})
+    raw = normalized.get("questions")
+    if isinstance(raw, (str, bytes)):
+        raw = [raw]
+    questions: List[JsonDict] = []
+    for item in list(raw or []):
+        if isinstance(item, Mapping):
+            text = str(item.get("question") or item.get("text") or "").strip()
+            why = str(item.get("why") or item.get("context") or "").strip()
+            options = [
+                str(opt).strip()
+                for opt in list(item.get("options") or [])
+                if str(opt).strip()
+            ]
+        else:
+            text, why, options = str(item or "").strip(), "", []
+        if not text:
+            continue
+        entry: JsonDict = {"question": text[:2000]}
+        if why:
+            entry["why"] = why[:2000]
+        if options:
+            entry["options"] = options[:12]
+        questions.append(entry)
+    if not questions:
+        raise ValidationError(
+            "needs_input requires at least one non-empty question; a task parked "
+            "for unstated reasons is indistinguishable from a stalled one"
+        )
+    normalized["schema"] = NEEDS_INPUT_SCHEMA
+    normalized["questions"] = questions[:20]
+    return normalized
+
+
 TASK_TRANSITIONS = {
     TaskState.OPEN.value: {
+        TaskState.NEEDS_INPUT.value,
         TaskState.WAITING.value,
         TaskState.BLOCKED.value,
         TaskState.CLAIMED.value,
@@ -608,18 +661,21 @@ TASK_TRANSITIONS = {
         TaskState.FAILED.value,
     },
     TaskState.WAITING.value: {
+        TaskState.NEEDS_INPUT.value,
         TaskState.OPEN.value,
         TaskState.BLOCKED.value,
         TaskState.CANCELLED.value,
         TaskState.FAILED.value,
     },
     TaskState.BLOCKED.value: {
+        TaskState.NEEDS_INPUT.value,
         TaskState.OPEN.value,
         TaskState.WAITING.value,
         TaskState.CANCELLED.value,
         TaskState.FAILED.value,
     },
     TaskState.CLAIMED.value: {
+        TaskState.NEEDS_INPUT.value,
         TaskState.WAITING.value,
         TaskState.BLOCKED.value,
         TaskState.OPEN.value,
@@ -628,6 +684,7 @@ TASK_TRANSITIONS = {
         TaskState.CANCELLED.value,
     },
     TaskState.RUNNING.value: {
+        TaskState.NEEDS_INPUT.value,
         TaskState.WAITING.value,
         TaskState.BLOCKED.value,
         TaskState.NEEDS_REVIEW.value,
@@ -636,6 +693,7 @@ TASK_TRANSITIONS = {
         TaskState.CANCELLED.value,
     },
     TaskState.NEEDS_REVIEW.value: {
+        TaskState.NEEDS_INPUT.value,
         TaskState.WAITING.value,
         TaskState.BLOCKED.value,
         TaskState.REVIEWING.value,
@@ -644,12 +702,22 @@ TASK_TRANSITIONS = {
         TaskState.CANCELLED.value,
     },
     TaskState.REVIEWING.value: {
+        TaskState.NEEDS_INPUT.value,
         TaskState.WAITING.value,
         TaskState.BLOCKED.value,
         TaskState.OPEN.value,
         TaskState.RUNNING.value,
         TaskState.COMPLETED.value,
         TaskState.FAILED.value,
+        TaskState.CANCELLED.value,
+    },
+    # A task parked on a human question leaves only when a human acts:
+    # answered (-> OPEN, re-dispatchable) or abandoned (-> CANCELLED).
+    # FAILED is deliberately absent: waiting on an answer is not a failed
+    # attempt, and treating it as one is exactly how desired work got
+    # classified as bad work and retired.
+    TaskState.NEEDS_INPUT.value: {
+        TaskState.OPEN.value,
         TaskState.CANCELLED.value,
     },
     TaskState.COMPLETED.value: set(),

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -10888,6 +10888,61 @@ class ControlPlane:
             conn=None,
         )
 
+    def request_task_input(
+        self,
+        task_id: str,
+        questions: Sequence[Any],
+        actor: str,
+        *,
+        why: str = "",
+        drain_outbox: bool = True,
+    ) -> Task:
+        """Park a task on an unanswered human question.
+
+        This is NOT a failure path. The work is still wanted; it simply cannot
+        proceed until a person answers. Parked tasks are excluded from every
+        sweeper, reaper, and dispatch pass, so they wait indefinitely instead
+        of burning their attempt budget on a blocker no code path can clear.
+
+        An agent that discovers mid-flight that it needs an answer reaches this
+        state through the ordinary lease-fenced worker transition. This trusted
+        entry point exists for operators parking a task they do not hold.
+        """
+        detail: JsonDict = {"questions": list(questions or [])}
+        if str(why or "").strip():
+            detail["why"] = why
+        return self._transition_task_internal(
+            task_id,
+            TaskState.NEEDS_INPUT.value,
+            actor,
+            detail,
+            drain_outbox=drain_outbox,
+        )
+
+    def answer_task_input(
+        self,
+        task_id: str,
+        answer: str,
+        actor: str,
+        *,
+        drain_outbox: bool = True,
+    ) -> Task:
+        """Answer a parked task's question and return it to the dispatch pool.
+
+        The outstanding question set is folded into ``needs_input_history``
+        alongside the answer, so what was asked stays auditable next to what
+        was decided.
+        """
+        if not str(answer or "").strip():
+            raise ValidationError("an answer is required to release a parked task")
+        return self._transition_task_internal(
+            task_id,
+            TaskState.OPEN.value,
+            actor,
+            {"answer": answer, "reason": "human answered outstanding question"},
+            drain_outbox=drain_outbox,
+        )
+
     def _transition_task_internal(
         self,
         task_id: str,

--- a/src/mac/store.py
+++ b/src/mac/store.py
@@ -1363,7 +1363,7 @@ class SQLiteStore:
                 FOR EACH ROW
                 WHEN NEW.state NOT IN (
                     'open', 'waiting', 'blocked', 'claimed', 'running',
-                    'needs_review', 'reviewing', 'completed',
+                    'needs_review', 'reviewing', 'needs_input', 'completed',
                     'failed', 'cancelled'
                 )
                 BEGIN
@@ -1374,7 +1374,7 @@ class SQLiteStore:
                 FOR EACH ROW
                 WHEN NEW.state NOT IN (
                     'open', 'waiting', 'blocked', 'claimed', 'running',
-                    'needs_review', 'reviewing', 'completed',
+                    'needs_review', 'reviewing', 'needs_input', 'completed',
                     'failed', 'cancelled'
                 )
                 BEGIN
@@ -6741,9 +6741,11 @@ class SQLiteStore:
             self._conn.commit()
 
     def _migrate(self) -> None:
-        # Dependency waits are intentionally distinct from actionable blocks.
-        # Recreate these triggers because IF NOT EXISTS cannot update the enum
-        # on databases created before the WAITING state was introduced.
+        # Dependency waits are intentionally distinct from actionable blocks,
+        # and a task parked on an unanswered human question is distinct from
+        # both. Recreate these triggers because IF NOT EXISTS cannot update the
+        # enum on databases created before the WAITING and NEEDS_INPUT states
+        # were introduced.
         self._conn.executescript(
             """
             DROP TRIGGER IF EXISTS trg_tasks_state_enum_ins;
@@ -6753,7 +6755,8 @@ class SQLiteStore:
             FOR EACH ROW
             WHEN NEW.state NOT IN (
                 'open', 'waiting', 'blocked', 'claimed', 'running',
-                'needs_review', 'reviewing', 'completed', 'failed', 'cancelled'
+                'needs_review', 'reviewing', 'needs_input', 'completed',
+                'failed', 'cancelled'
             )
             BEGIN
                 SELECT RAISE(ABORT, 'invalid task state');
@@ -6763,7 +6766,8 @@ class SQLiteStore:
             FOR EACH ROW
             WHEN NEW.state NOT IN (
                 'open', 'waiting', 'blocked', 'claimed', 'running',
-                'needs_review', 'reviewing', 'completed', 'failed', 'cancelled'
+                'needs_review', 'reviewing', 'needs_input', 'completed',
+                'failed', 'cancelled'
             )
             BEGIN
                 SELECT RAISE(ABORT, 'invalid task state');

--- a/src/mac/task_ledger_audit.py
+++ b/src/mac/task_ledger_audit.py
@@ -1252,6 +1252,14 @@ def _assessment(
             verdict = "active_valid"
             if _bool(metadata.get("no_dispatch")):
                 findings.append("open_task_is_intentionally_held")
+    elif state == "needs_input":
+        # Parked on an unanswered human question. This is a legitimate resting
+        # place, not a contradiction: the ledger is correct and the task is
+        # waiting on a person, so no automated repair applies. Surfaced as a
+        # finding so it still shows up in backlog reports rather than going
+        # quiet, but never as reaper bait.
+        verdict = "active_valid"
+        findings.append("task_awaiting_human_input")
     elif state in _ACTIVE_STATES:
         leased_until = _parse_time(task.get("leased_until"))
         if state in {"claimed", "running"} and leased_until and leased_until <= datetime.now(timezone.utc):

--- a/src/mac/task_transition_service.py
+++ b/src/mac/task_transition_service.py
@@ -41,6 +41,7 @@ from mac.models import (
     ValidationError,
     ensure_json_object,
     json_dumps,
+    normalize_needs_input_detail,
     utcnow,
     validate_transition,
 )
@@ -182,6 +183,11 @@ class TaskTransitionService:
             # failure accounting by supplying an arbitrary generation.
             transition_detail["retry_generation"] = current_retry_generation
             transition_detail = _normalize_blocked_detail(transition_detail)
+        if target == TaskState.NEEDS_INPUT.value:
+            # Parking work on a human question REQUIRES stating the question.
+            # Enforced at the single chokepoint every transition passes
+            # through, so no caller can park a task on an unstated blocker.
+            transition_detail = normalize_needs_input_detail(transition_detail)
         diagnosis_record = _structured_failure_diagnosis(
             target,
             transition_detail,
@@ -338,6 +344,35 @@ class TaskTransitionService:
             )
             candidate_metadata["activity"] = activity[-24:]
             metadata_changed = True
+        if target == TaskState.NEEDS_INPUT.value:
+            candidate_metadata["needs_input"] = {
+                "schema": transition_detail["schema"],
+                "questions": transition_detail["questions"],
+                "asked_by": str(actor or "")[:120],
+                "asked_at": now,
+                "from_state": task.state,
+            }
+            metadata_changed = True
+        elif task.state == TaskState.NEEDS_INPUT.value:
+            # Leaving the state: fold the outstanding questions into history so
+            # the answer stays auditable next to what was asked, then clear it.
+            outstanding = ensure_json_object(candidate_metadata.get("needs_input"))
+            if outstanding:
+                answered = dict(outstanding)
+                answered["answered_by"] = str(actor or "")[:120]
+                answered["answered_at"] = now
+                answered["answer"] = str(
+                    (transition_detail or {}).get("answer")
+                    or (transition_detail or {}).get("reason")
+                    or ""
+                )[:2000]
+                answered["resolved_to"] = target
+                history = candidate_metadata.get("needs_input_history")
+                if not isinstance(history, list):
+                    history = []
+                candidate_metadata["needs_input_history"] = (history + [answered])[-20:]
+                candidate_metadata.pop("needs_input", None)
+                metadata_changed = True
         if review_ready_evidence is not None:
             candidate_metadata["review_target"] = {
                 "executor_evidence_id": review_ready_evidence.id,

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -2569,8 +2569,15 @@ def test_fastapi_exposes_dashboard_read_models_and_redacts_secret_values():
     assert "project_summaries" in state
     assert "swarm_summary" in state
     assert "fleets" in state
-    unassigned = next(item for item in state["project_summaries"] if item["project"] == "unassigned")
-    assert unassigned["ready_count"] == 1
+    # Work filed without a project is no longer invisible: it is scoped to
+    # fleet-maintenance so it can be counted, reported on, and paused like any
+    # other project. The old "unassigned" bucket no longer collects anything.
+    unscoped = next(
+        item
+        for item in state["project_summaries"]
+        if item["project"] == "fleet-maintenance"
+    )
+    assert unscoped["ready_count"] == 1
     assert state["swarm_summary"]["agent_total"] == 1
     assert "memory_records" in state
     assert "nap_schedules" in state

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -4161,3 +4161,59 @@ def test_report_task_with_registered_project_stays_operator_result_via_api(tmp_p
     assert persisted["type"] == "operator_directive"
     assert persisted["evidence_type"] == "operator_result"
     assert persisted["repository_required"] is False
+
+
+def test_needs_input_round_trip_and_privilege_boundary():
+    """Parking and answering are admin-only, and survive the HTTP round trip.
+
+    Answering returns held work to the dispatch pool, which is the same
+    authority as reopen/release -- an ordinary `write` token must not have it.
+    """
+    client = TestClient(
+        create_app(
+            control_plane=ControlPlane.in_memory(),
+            auth_tokens={"writer": ["write"], "admin": ["admin"]},
+        )
+    )
+    writer = {"Authorization": "Bearer writer"}
+    admin = {"Authorization": "Bearer admin"}
+
+    task = client.post(
+        "/tasks", headers=writer, json={"title": "ambiguous work"}
+    ).json()
+
+    # An ordinary writer may neither park work nor release it.
+    assert client.post(
+        "/tasks/%s/ask" % task["id"],
+        headers=writer,
+        json={"actor": "writer", "questions": [{"question": "which db?"}]},
+    ).status_code == 403
+
+    parked = client.post(
+        "/tasks/%s/ask" % task["id"],
+        headers=admin,
+        json={"actor": "operator", "questions": [{"question": "which db?"}]},
+    )
+    assert parked.status_code == 200, parked.text
+    assert parked.json()["state"] == "needs_input"
+
+    # A question is mandatory: parking on an unstated blocker is refused.
+    assert client.post(
+        "/tasks/%s/ask" % task["id"],
+        headers=admin,
+        json={"actor": "operator", "questions": []},
+    ).status_code == 400
+
+    assert client.post(
+        "/tasks/%s/answer" % task["id"],
+        headers=writer,
+        json={"actor": "writer", "answer": "postgres"},
+    ).status_code == 403
+
+    answered = client.post(
+        "/tasks/%s/answer" % task["id"],
+        headers=admin,
+        json={"actor": "operator", "answer": "postgres"},
+    )
+    assert answered.status_code == 200, answered.text
+    assert answered.json()["state"] == "open"

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -689,6 +689,13 @@ network_policies:
     ctx["transition_task_id"] = transition_task["id"]
     ctx["transition_lease_id"] = transition_lease.id
     ctx["reopen_task_id"] = task("route reopen task")["id"]
+    ctx["ask_task_id"] = task("route ask task")["id"]
+    answer_task = task("route answer task")
+    # Answering only applies to a task already parked on a question.
+    cp.request_task_input(
+        answer_task["id"], [{"question": "route coverage question?"}], "operator"
+    )
+    ctx["answer_task_id"] = answer_task["id"]
     ctx["force_complete_task_id"] = task("route force-complete task")["id"]
     ctx["claim_task_id"] = task("route claim task")["id"]
     ctx["claim_next_task_id"] = task("route claim-next task")["id"]
@@ -1292,6 +1299,8 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("DELETE", "/tasks/{task_id}"): {"task_id": "delete_task_id"},
         ("POST", "/tasks/{task_id}/transition"): {"task_id": "transition_task_id"},
         ("POST", "/tasks/{task_id}/reopen"): {"task_id": "reopen_task_id"},
+        ("POST", "/tasks/{task_id}/ask"): {"task_id": "ask_task_id"},
+        ("POST", "/tasks/{task_id}/answer"): {"task_id": "answer_task_id"},
         ("POST", "/tasks/{task_id}/force-complete"): {"task_id": "force_complete_task_id"},
         ("POST", "/tasks/{task_id}/claim"): {"task_id": "claim_task_id"},
         ("POST", "/tasks/{task_id}/start"): {"task_id": "start_task_id"},
@@ -1731,6 +1740,15 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
         ("POST", "/tasks/{task_id}/reopen"): {
             "actor": "operator",
             "reason": "route coverage reopen",
+        },
+        ("POST", "/tasks/{task_id}/ask"): {
+            "actor": "operator",
+            "questions": [{"question": "which database?"}],
+            "why": "route coverage ask",
+        },
+        ("POST", "/tasks/{task_id}/answer"): {
+            "actor": "operator",
+            "answer": "route coverage answer",
         },
         ("POST", "/tasks/{task_id}/force-complete"): {
             "actor": "operator",

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -486,9 +486,20 @@ def test_task_create_explicit_project_overrides_cwd(tmp_path, monkeypatch):
     assert task["project"] == "chosen"
 
 
-def test_task_create_empty_project_means_none(tmp_path, monkeypatch):
-    # Explicit --project '' opts out of the cwd default (never silently inferred).
+def test_task_create_empty_project_opts_out_of_cwd_inference(tmp_path, monkeypatch):
+    # Explicit --project '' opts out of the cwd default (never silently
+    # inferred). It does not produce an unscoped task: work with no project of
+    # its own is scoped to fleet-maintenance so it stays countable.
     monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "inferred-proj")
+    rc, task = _run(tmp_path, "task", "create", "No project", "--project", "")
+    assert rc == 0
+    assert task["project"] == "fleet-maintenance"
+
+
+def test_task_create_can_opt_out_of_project_scoping_entirely(tmp_path, monkeypatch):
+    """The fleet-maintenance default is a policy, and policies can be disabled."""
+    monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "inferred-proj")
+    monkeypatch.setenv("MAC_SCOPE_UNPROJECTED_TASKS", "0")
     rc, task = _run(tmp_path, "task", "create", "No project", "--project", "")
     assert rc == 0
     assert task["project"] is None
@@ -518,7 +529,11 @@ def test_task_ready_scopes_to_cwd_project(tmp_path, monkeypatch):
     assert {"alpha", "beta"} <= {t["project"] for t in everything}
 
 
-def test_task_why_unclaimed_reports_authoritative_reason(tmp_path):
+def test_task_why_unclaimed_reports_authoritative_reason(tmp_path, monkeypatch):
+    # Pin the inferred project rather than relying on the checkout being named
+    # "mac": agents are required to work from git worktrees, whose directory
+    # names differ, and an unpinned cwd made this pass or fail by location.
+    monkeypatch.setattr("mac.cli._default_project_from_cwd", lambda: "mac")
     _run(tmp_path, "project", "create", "mac", "--active")
     rc, task = _run(tmp_path, "task", "create", "Explain unclaimed")
     assert rc == 0

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -882,3 +882,54 @@ def test_mac_cli_secret_set_and_list_redacts_value(tmp_path):
     assert rc == 0
     for s in secrets:
         assert s.get("value", "***REDACTED***") != "never-reveal-this"
+
+
+def test_task_ask_parks_the_task_on_a_stated_question(tmp_path):
+    """`mac task ask` parks work on a human question instead of failing it."""
+    rc, task = _run(tmp_path, "task", "create", "Ambiguous work")
+    assert rc == 0
+
+    rc, parked = _run(
+        tmp_path,
+        "task",
+        "ask",
+        task["id"],
+        "--question",
+        "which database?",
+        "--question",
+        "which region?",
+        "--why",
+        "the spec names neither",
+    )
+    assert rc == 0
+    assert parked["state"] == "needs_input"
+    payload = parked["metadata"]["needs_input"]
+    assert [q["question"] for q in payload["questions"]] == [
+        "which database?",
+        "which region?",
+    ]
+    assert payload["asked_by"] == "human"
+
+
+def test_task_answer_returns_a_parked_task_to_the_pool(tmp_path):
+    rc, task = _run(tmp_path, "task", "create", "Ambiguous work")
+    assert rc == 0
+    _run(tmp_path, "task", "ask", task["id"], "--question", "which database?")
+
+    rc, answered = _run(
+        tmp_path,
+        "task",
+        "answer",
+        task["id"],
+        "--answer",
+        "postgres",
+        "--actor",
+        "jordan",
+    )
+    assert rc == 0
+    assert answered["state"] == "open"
+    # Cleared as outstanding, retained as history next to its answer.
+    assert "needs_input" not in answered["metadata"]
+    record = answered["metadata"]["needs_input_history"][-1]
+    assert record["answer"] == "postgres"
+    assert record["answered_by"] == "jordan"

--- a/tests/test_task_needs_input_state.py
+++ b/tests/test_task_needs_input_state.py
@@ -1,0 +1,152 @@
+"""A task waiting on a human question is parked, not failed.
+
+Before NEEDS_INPUT existed, a task that could not proceed without an answer
+had nowhere correct to sit. It went to BLOCKED or FAILED, where the retry
+machinery burned its attempt budget re-running work whose blocker no code
+path could clear, and the reaper eventually retired it as bad work. Desired
+work got classified as failed work purely because there was no state meaning
+"a person needs to answer something".
+
+NEEDS_INPUT is that state. The properties that make it safe:
+
+* entering it REQUIRES stating the question (no unstated blockers),
+* it leaves only to OPEN (answered) or CANCELLED (abandoned) -- never FAILED,
+* no sweeper, reaper, or dispatcher touches it, so it waits indefinitely.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mac.models import TaskState, TransitionError, ValidationError
+from mac.services import ControlPlane
+
+
+@pytest.fixture
+def cp():
+    return ControlPlane.in_memory()
+
+
+def _park(cp, task, questions=("which database?",), actor="human"):
+    return cp.request_task_input(
+        task.id, [{"question": q} for q in questions], actor
+    )
+
+
+def test_parking_requires_a_stated_question(cp):
+    task = cp.create_task("ambiguous work")
+    with pytest.raises(ValidationError):
+        cp.request_task_input(task.id, [], "human")
+    with pytest.raises(ValidationError):
+        cp.request_task_input(task.id, [{"question": "  "}], "human")
+    # The rejected attempts must not have moved the task.
+    assert cp.get_task(task.id).state == TaskState.OPEN.value
+
+
+def test_parking_records_the_question_and_who_asked(cp):
+    task = cp.create_task("ambiguous work")
+    parked = _park(cp, task, questions=("which database?", "which region?"))
+
+    assert parked.state == TaskState.NEEDS_INPUT.value
+    payload = parked.metadata["needs_input"]
+    assert [q["question"] for q in payload["questions"]] == [
+        "which database?",
+        "which region?",
+    ]
+    assert payload["asked_by"] == "human"
+    assert payload["asked_at"]
+    assert payload["from_state"] == TaskState.OPEN.value
+
+
+def test_answering_returns_the_task_to_the_dispatch_pool(cp):
+    task = cp.create_task("ambiguous work")
+    _park(cp, task)
+    answered = cp.answer_task_input(task.id, "postgres, us-west", "jordan")
+
+    assert answered.state == TaskState.OPEN.value
+    # The outstanding question is cleared, but preserved next to its answer.
+    assert "needs_input" not in answered.metadata
+    record = answered.metadata["needs_input_history"][-1]
+    assert record["answer"] == "postgres, us-west"
+    assert record["answered_by"] == "jordan"
+    assert record["resolved_to"] == TaskState.OPEN.value
+    assert [q["question"] for q in record["questions"]] == ["which database?"]
+
+
+def test_a_parked_task_cannot_be_failed(cp):
+    """The whole point: waiting on an answer is not a failed attempt.
+
+    Asserted against the *trusted* internal path, because that is the one
+    every sweeper and reaper uses. An untrusted caller is already refused
+    earlier for lack of a lease, which proves less.
+    """
+    task = cp.create_task("ambiguous work")
+    _park(cp, task)
+    for target in (
+        TaskState.FAILED.value,
+        TaskState.BLOCKED.value,
+        TaskState.RUNNING.value,
+        TaskState.COMPLETED.value,
+        TaskState.WAITING.value,
+    ):
+        with pytest.raises(TransitionError):
+            cp._transition_task_internal(task.id, target, "sweeper", {"reason": "x"})
+    assert cp.get_task(task.id).state == TaskState.NEEDS_INPUT.value
+
+
+def test_a_parked_task_may_be_abandoned_by_a_human(cp):
+    task = cp.create_task("ambiguous work")
+    _park(cp, task)
+    cancelled = cp.close_task(
+        task.id,
+        TaskState.CANCELLED.value,
+        "human",
+        {"reason": "requirement withdrawn", "disposition": "not_applicable"},
+    )
+    assert cancelled.state == TaskState.CANCELLED.value
+
+
+def test_a_parked_task_is_never_dispatched(cp):
+    """It must not be handed to a worker while the question is outstanding."""
+    task = cp.create_task("ambiguous work", required_capabilities=["python"])
+    machine = cp.register_machine("host", resources={"cpu": 4, "memory_gb": 8})
+    worker = cp.register_agent(machine.id, "worker", capabilities=["python"])
+    _park(cp, task)
+
+    assert task.id not in {t.id for t in cp.ready_tasks()}
+    with pytest.raises((ValidationError, Exception)):
+        cp.claim_task(task.id, worker.id)
+    assert cp.get_task(task.id).state == TaskState.NEEDS_INPUT.value
+
+
+def test_the_ledger_audit_does_not_call_it_a_contradiction(cp):
+    """A parked task is a legitimate resting place, not state corruption.
+
+    It previously fell through to `unknown_task_state`/`repair_task_state`,
+    which is precisely how an automated repair pass would have collected it.
+    """
+    from mac.task_ledger_audit import _assessment
+
+    verdict = _assessment(
+        {"task": {"id": "t1", "state": TaskState.NEEDS_INPUT.value, "metadata": {}}},
+        [],
+        {},
+    )
+    assert verdict["verdict"] == "active_valid"
+    assert "task_awaiting_human_input" in verdict["findings"]
+    assert "unknown_task_state" not in verdict["findings"]
+
+
+def test_it_is_reachable_from_every_state_where_a_question_can_arise(cp):
+    """An agent discovers it needs an answer mid-flight, not just at pickup."""
+    from mac.models import TASK_TRANSITIONS
+
+    for origin in (
+        TaskState.OPEN,
+        TaskState.WAITING,
+        TaskState.BLOCKED,
+        TaskState.CLAIMED,
+        TaskState.RUNNING,
+        TaskState.NEEDS_REVIEW,
+        TaskState.REVIEWING,
+    ):
+        assert TaskState.NEEDS_INPUT.value in TASK_TRANSITIONS[origin.value], origin


### PR DESCRIPTION
## Problem

A task that could not proceed without a human answer had nowhere correct to sit. It went to `BLOCKED` or `FAILED`, where the retry machinery burned its attempt budget re-running work whose blocker no code path could clear, and the reaper eventually retired it.

That is how the isaacsim7-poc tasks died: **15 of 23 retired with retry budget still remaining**, every one labelled `work` — desired work classified as bad work purely because no state meant *"a person needs to answer something"*.

## The state

- **Entering it requires stating the question.** Validation sits at the single transition chokepoint (`_transition_task_impl`), so no caller can park work on an unstated blocker.
- **It leaves only to `OPEN` (answered) or `CANCELLED` (abandoned).** `FAILED` is deliberately unreachable — waiting on an answer is not a failed attempt. A *trusted* sweeper gets a `TransitionError` for trying, which is the property the test asserts (an untrusted caller is refused earlier for lack of a lease, which proves less).
- **No sweeper or reaper collects it.** All of them enumerate their states explicitly, so they already exclude it. The one real gap was the ledger audit, which fell through to `unknown_task_state`/`repair_task_state` — precisely how an automated repair pass would have swept it up. It now reads `active_valid` with a `task_awaiting_human_input` finding, so a parked task stays visible in backlog reports without being reaper bait.

## Surfaces

An agent that discovers mid-flight that it needs an answer reaches the state through the ordinary lease-fenced worker transition, from any of the seven non-terminal states.

Operators get `mac task ask` / `mac task answer`, routed through a trusted control-plane path (`request_task_input` / `answer_task_input`) with `RemoteDispatch` + API equivalents, so it works in hub mode. Answering returns held work to the dispatch pool, so it sits behind the same admin gate as `reopen`/`release`. The outstanding question set is folded into `needs_input_history` with the answer, keeping what was asked auditable next to what was decided.

SQLite's state triggers reject any state not in their literal enum, so they are extended too; the migration already recreates them unconditionally at startup. Postgres stores state as text and needs no change.

## Testing

`10056 passed`. Three failures are **pre-existing on this branch** and unrelated (verified by re-running them with these changes stashed) — they are regressions from the earlier project-inference work:

- `test_fastapi_exposes_dashboard_read_models_and_redacts_secret_values`
- `test_task_create_empty_project_means_none`
- `test_task_why_unclaimed_reports_authoritative_reason`

New coverage: state machine, payload validation, park/answer round trip, sweeper-cannot-fail-it, audit classification, CLI, and an HTTP round trip asserting the `write`-token privilege boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)