### PR TITLE
Return the artifact that was written, not the one it replaced

### DIFF
--- a/src/mac/deploy_service.py
+++ b/src/mac/deploy_service.py
@@ -191,7 +191,16 @@ class DeployService:
                         existing_row["id"],
                     ),
                 )
-                return self.get_artifact(existing_row["id"])
+                # Read back on the transaction's OWN connection. get_artifact()
+                # borrows a different pooled connection, which on Postgres
+                # cannot see this not-yet-committed UPDATE -- so the caller was
+                # handed the pre-update row while the database held the new
+                # one. SQLite never showed it (one serialized connection), so
+                # POST /artifacts returned stale uri/signers in production only.
+                updated_row = conn.execute(
+                    "SELECT * FROM artifacts WHERE id = ?", (existing_row["id"],)
+                ).fetchone()
+                return self._artifact_from_row(updated_row)
             # No existing row inside the same transaction → insert.
             artifact_id = new_id("art")
             conn.execute(

--- a/tests/test_postgres_live.py
+++ b/tests/test_postgres_live.py
@@ -1860,3 +1860,40 @@ def test_postgres_supervised_dependencies_are_non_cascading(postgres_store) -> N
         TaskState.FAILED.value,
         TaskState.BLOCKED.value,
     }
+
+
+def test_re_registering_an_artifact_returns_what_it_just_wrote(postgres_store) -> None:
+    """register_artifact must not hand back the row it just replaced.
+
+    The augment path opens a transaction, UPDATEs the existing row, then read
+    the artifact back. That read borrowed a *different* pooled connection,
+    which cannot see the not-yet-committed UPDATE -- so on Postgres the caller
+    received the pre-update uri and signers while the database held the new
+    ones. POST /artifacts served that stale row in production.
+
+    SQLite could never catch this: one serialized connection sees its own
+    uncommitted writes, so the whole suite agreed with an engine the fleet
+    does not run.
+    """
+    cp = ControlPlane(postgres_store, secret_key=_CONTROL_PLANE_TEST_SECRET)
+    first = cp.register_artifact(
+        kind="image",
+        digest="sha256:staleread",
+        uri="artifact://registry/mac:1.0",
+        created_by="ci",
+        signers=["ci"],
+    )
+    second = cp.register_artifact(
+        kind="image",
+        digest="sha256:staleread",
+        uri="artifact://registry/mac:1.0-public",
+        created_by="ci",
+        signers=["release"],
+    )
+
+    assert second.id == first.id
+    # What the caller is handed must equal what was committed.
+    assert second.uri == "artifact://registry/mac:1.0-public"
+    assert second.signers == ["ci", "release"]
+    committed = cp.get_artifact(first.id)
+    assert (second.uri, second.signers) == (committed.uri, committed.signers)


### PR DESCRIPTION
## The bug

`register_artifact`'s augment path opens a transaction, `UPDATE`s the existing row, then reads the artifact back with `get_artifact()`. That read borrows a **different connection from the pool**, which on Postgres cannot see the not-yet-committed `UPDATE`.

The caller gets the pre-update row:

```
returned uri:  artifact://registry/mac:1.0          <- stale
committed uri: artifact://registry/mac:1.0-public   <- what's actually stored
returned sign: ['ci']
committed sig: ['ci', 'release']
```

The data commits correctly; what's wrong is what `POST /artifacts` hands back. Production only, since the fleet runs Postgres.

## Why no test caught it

SQLite has one serialized connection and sees its own uncommitted writes, so the entire suite agreed with an engine the fleet does not run. This surfaced while pointing the suite at Postgres.

The regression test is marked `postgres` and I verified it fails without the fix:

```
E         + artifact://registry/mac:1.0
FAILED tests/test_postgres_live.py::test_re_registering_an_artifact_returns_what_it_just_wrote
```

## Scope

Reading back on the transaction's own connection is the narrow fix. I swept `src/mac` for the same shape (`with self.store.transaction()` ... `return self.get_*()`) — this was the only occurrence.

## Testing

`10067 passed` on the default suite, plus the new Postgres regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)