### PR TITLE
Run the test suite on Postgres, and fix what that exposed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,15 @@ jobs:
         run: uv python install 3.11
       - name: Sync dependencies
         run: uv sync --extra dev --python 3.11
+      - name: Start test PostgreSQL
+        # The suite runs against Postgres because the fleet does. Provisioned
+        # with the same script developers use, rather than a service container,
+        # because max_locks_per_transaction is a postmaster setting: applying
+        # the full DDL per test schema exhausts the default 64 under parallel
+        # workers and the run dies with "out of shared memory".
+        run: |
+          eval "$(scripts/start-test-postgres.sh)"
+          echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run affected, public-contract, and process-E2E sanity scope
         run: scripts/run-sanity-tests.sh --base origin/${{ github.base_ref }}
 
@@ -61,6 +70,15 @@ jobs:
         run: uv python install 3.11
       - name: Sync dependencies
         run: uv sync --extra dev --python 3.11
+      - name: Start test PostgreSQL
+        # The suite runs against Postgres because the fleet does. Provisioned
+        # with the same script developers use, rather than a service container,
+        # because max_locks_per_transaction is a postmaster setting: applying
+        # the full DDL per test schema exhausts the default 64 under parallel
+        # workers and the run dies with "out of shared memory".
+        run: |
+          eval "$(scripts/start-test-postgres.sh)"
+          echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run impact-selected diff coverage gate (full on unsafe resolution)
         env:
           MAC_TEST_SELECT_BASE: ${{ github.event.before }}
@@ -86,6 +104,15 @@ jobs:
         run: uv python install 3.12
       - name: Sync dependencies
         run: uv sync --extra dev --python 3.12
+      - name: Start test PostgreSQL
+        # The suite runs against Postgres because the fleet does. Provisioned
+        # with the same script developers use, rather than a service container,
+        # because max_locks_per_transaction is a postmaster setting: applying
+        # the full DDL per test schema exhausts the default 64 under parallel
+        # workers and the run dies with "out of shared memory".
+        run: |
+          eval "$(scripts/start-test-postgres.sh)"
+          echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run secondary-version public/process compatibility slice
         run: scripts/run-compatibility-tests.sh
 
@@ -142,6 +169,15 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
       - name: Sync dependencies
         run: uv sync --extra dev --python ${{ matrix.python-version }}
+      - name: Start test PostgreSQL
+        # The suite runs against Postgres because the fleet does. Provisioned
+        # with the same script developers use, rather than a service container,
+        # because max_locks_per_transaction is a postmaster setting: applying
+        # the full DDL per test schema exhausts the default 64 under parallel
+        # workers and the run dies with "out of shared memory".
+        run: |
+          eval "$(scripts/start-test-postgres.sh)"
+          echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run full scheduled matrix
         run: scripts/run-contract-tests.sh
       - name: Prove historical fault detection
@@ -165,6 +201,15 @@ jobs:
         run: uv python install 3.11
       - name: Sync dependencies
         run: uv sync --extra dev --python 3.11
+      - name: Start test PostgreSQL
+        # The suite runs against Postgres because the fleet does. Provisioned
+        # with the same script developers use, rather than a service container,
+        # because max_locks_per_transaction is a postmaster setting: applying
+        # the full DDL per test schema exhausts the default 64 under parallel
+        # workers and the run dies with "out of shared memory".
+        run: |
+          eval "$(scripts/start-test-postgres.sh)"
+          echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Measure per-test contribution and rebuild the impact map
         env:
           MAC_TEST_PORTFOLIO: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
         # workers and the run dies with "out of shared memory".
         run: |
           eval "$(scripts/start-test-postgres.sh)"
+          # eval of a script that died leaves this empty and the step green,
+          # which then fails much later as "MAC_TEST_PG_URL is unset".
+          if [ -z "${MAC_TEST_PG_URL:-}" ]; then
+            echo "::error::start-test-postgres.sh produced no DSN" >&2
+            exit 1
+          fi
           echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run affected, public-contract, and process-E2E sanity scope
         run: scripts/run-sanity-tests.sh --base origin/${{ github.base_ref }}
@@ -78,6 +84,12 @@ jobs:
         # workers and the run dies with "out of shared memory".
         run: |
           eval "$(scripts/start-test-postgres.sh)"
+          # eval of a script that died leaves this empty and the step green,
+          # which then fails much later as "MAC_TEST_PG_URL is unset".
+          if [ -z "${MAC_TEST_PG_URL:-}" ]; then
+            echo "::error::start-test-postgres.sh produced no DSN" >&2
+            exit 1
+          fi
           echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run impact-selected diff coverage gate (full on unsafe resolution)
         env:
@@ -112,6 +124,12 @@ jobs:
         # workers and the run dies with "out of shared memory".
         run: |
           eval "$(scripts/start-test-postgres.sh)"
+          # eval of a script that died leaves this empty and the step green,
+          # which then fails much later as "MAC_TEST_PG_URL is unset".
+          if [ -z "${MAC_TEST_PG_URL:-}" ]; then
+            echo "::error::start-test-postgres.sh produced no DSN" >&2
+            exit 1
+          fi
           echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run secondary-version public/process compatibility slice
         run: scripts/run-compatibility-tests.sh
@@ -177,6 +195,12 @@ jobs:
         # workers and the run dies with "out of shared memory".
         run: |
           eval "$(scripts/start-test-postgres.sh)"
+          # eval of a script that died leaves this empty and the step green,
+          # which then fails much later as "MAC_TEST_PG_URL is unset".
+          if [ -z "${MAC_TEST_PG_URL:-}" ]; then
+            echo "::error::start-test-postgres.sh produced no DSN" >&2
+            exit 1
+          fi
           echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run full scheduled matrix
         run: scripts/run-contract-tests.sh
@@ -209,6 +233,12 @@ jobs:
         # workers and the run dies with "out of shared memory".
         run: |
           eval "$(scripts/start-test-postgres.sh)"
+          # eval of a script that died leaves this empty and the step green,
+          # which then fails much later as "MAC_TEST_PG_URL is unset".
+          if [ -z "${MAC_TEST_PG_URL:-}" ]; then
+            echo "::error::start-test-postgres.sh produced no DSN" >&2
+            exit 1
+          fi
           echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Measure per-test contribution and rebuild the impact map
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,13 +142,22 @@ run `git status` first to see whose work is present.
 
 ## Build & Test
 
-_Add your build and test commands here_
+The test suite runs against **PostgreSQL**, not SQLite, because that is what the
+fleet runs. Start one and export the DSN before running tests:
 
 ```bash
-# Example:
-# npm install
-# npm test
+eval "$(scripts/start-test-postgres.sh)"   # finds a local server or starts a container
+uv run --extra dev pytest -q -n 8          # full suite (~10 min)
+scripts/run-contract-tests.sh              # the gate CI runs
 ```
+
+`start-test-postgres.sh` sets `max_locks_per_transaction=1024`. Each test gets
+its own schema and applying the full DDL takes one lock per object in a single
+transaction, so at Postgres' default of 64 a parallel run fails with "out of
+shared memory" rather than anything that looks like a test failure.
+
+Without `MAC_TEST_PG_URL` the suite fails fast with instructions rather than
+skipping, because a suite that silently covers nothing is worse than a red one.
 
 ## Architecture Overview
 

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -1080,6 +1080,12 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_TEST_COVERAGE` | str | consumer-defined | core | Core setting: test coverage. |
 | `MAC_TEST_DISABLE_GROUPS` | str | consumer-defined | core | Core setting: test disable groups. |
 | `MAC_TEST_JOBS` | str | 2 | core | Core setting: test jobs. |
+| `MAC_TEST_PG_CONTAINER` | str | consumer-defined | core | Core setting: test pg container. |
+| `MAC_TEST_PG_DB` | str | consumer-defined | core | Core setting: test pg db. |
+| `MAC_TEST_PG_IMAGE` | str | consumer-defined | core | Core setting: test pg image. |
+| `MAC_TEST_PG_MAX_LOCKS` | str | consumer-defined | core | Core setting: test pg max locks. |
+| `MAC_TEST_PG_PORT` | int | consumer-defined | core | Core setting: test pg port. |
+| `MAC_TEST_PG_URL` | str | consumer-defined | core | Core setting: test pg url. |
 | `MAC_TEST_PORTFOLIO` | str | consumer-defined | core | Core setting: test portfolio. |
 | `MAC_TEST_PORTFOLIO_OUTPUT` | str | consumer-defined | core | Core setting: test portfolio output. |
 | `MAC_TEST_REBUILD_MAP` | bool | consumer-defined | core | Core setting: test rebuild map. |

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -68,6 +68,11 @@ _MAC_TEST_REBUILD_MAP_REQUESTED="${MAC_TEST_REBUILD_MAP:-0}"
 # the interpreter that resolves, instead of a real host /opt/mac-venv silently
 # winning and running the whole suite. Empty/unset => the /opt/mac-venv default.
 _MAC_CONTRACT_RUNTIME_VENV_REQUESTED="${MAC_CONTRACT_RUNTIME_VENV:-}"
+# The suite runs against Postgres, so its DSN must survive the MAC_* sweep --
+# it is test configuration, not inherited fleet configuration. Without this the
+# sweep silently removes it and every test fails with "MAC_TEST_PG_URL is
+# unset", pointing at the CI provisioning step rather than at this line.
+_MAC_TEST_PG_URL_REQUESTED="${MAC_TEST_PG_URL:-}"
 _MAC_COVERAGE_DIR=""
 
 # Fleet executors inherit deployment/task environment. Keep repository tests
@@ -85,6 +90,9 @@ unset "${!TOKENHUB_@}"
 # failed test_ref_host_token_auth_and_redaction_edges on every fleet host
 # while the same suite passed on tokenless dev machines and hub sandboxes.
 unset GH_TOKEN GITHUB_TOKEN GITEA_TOKEN GIT_TOKEN
+if [ -n "$_MAC_TEST_PG_URL_REQUESTED" ]; then
+    export MAC_TEST_PG_URL="$_MAC_TEST_PG_URL_REQUESTED"
+fi
 # Pytest configuration belongs to this repository and the explicit arguments
 # passed to this runner.  In particular, an inherited ``-n auto`` must not make
 # the protected process/container phase concurrent after the runner separates

--- a/scripts/start-test-postgres.sh
+++ b/scripts/start-test-postgres.sh
@@ -38,13 +38,17 @@ if command -v pg_isready >/dev/null 2>&1 && pg_isready -h 127.0.0.1 -p "$PORT" >
 fi
 
 # 3. Otherwise run one in a container.
-for engine in podman docker; do
+for engine in docker podman; do
   if command -v "$engine" >/dev/null 2>&1 && "$engine" info >/dev/null 2>&1; then
     if ! "$engine" inspect "$CONTAINER" >/dev/null 2>&1; then
-      "$engine" run -d --name "$CONTAINER" \
+      if ! run_log=$("$engine" run -d --name "$CONTAINER" \
         -e POSTGRES_PASSWORD=test -e POSTGRES_DB="$DB" \
         -p "$PORT:5432" "$IMAGE" \
-        -c max_locks_per_transaction="$LOCKS" >/dev/null
+        -c max_locks_per_transaction="$LOCKS" 2>&1); then
+        echo "error: $engine could not start $CONTAINER:" >&2
+        echo "$run_log" >&2
+        continue
+      fi
     else
       "$engine" start "$CONTAINER" >/dev/null 2>&1 || true
     fi
@@ -55,8 +59,9 @@ for engine in podman docker; do
       fi
       sleep 1
     done
-    echo "error: $CONTAINER did not become ready in 60s" >&2
-    exit 1
+    echo "error: $CONTAINER did not become ready in 60s ($engine)" >&2
+    "$engine" logs "$CONTAINER" >&2 2>/dev/null || true
+    "$engine" rm -f "$CONTAINER" >/dev/null 2>&1 || true
   fi
 done
 

--- a/scripts/start-test-postgres.sh
+++ b/scripts/start-test-postgres.sh
@@ -10,7 +10,14 @@ set -euo pipefail
 DB="${MAC_TEST_PG_DB:-mac_test}"
 CONTAINER="${MAC_TEST_PG_CONTAINER:-mac-test-postgres}"
 PORT="${MAC_TEST_PG_PORT:-5432}"
-IMAGE="${MAC_TEST_PG_IMAGE:-docker.io/library/postgres:17}"
+# Match the server major to the installed client. pg_dump refuses to dump a
+# server newer than itself ("aborting because of server version mismatch"), so
+# a pinned postgres:17 breaks the backup drill on any host whose client is
+# older -- which includes the GitHub runners.
+if [ -z "${MAC_TEST_PG_IMAGE:-}" ] && command -v pg_dump >/dev/null 2>&1; then
+  _client_major=$(pg_dump --version | grep -oE '[0-9]+' | head -1)
+fi
+IMAGE="${MAC_TEST_PG_IMAGE:-docker.io/library/postgres:${_client_major:-17}}"
 # Each test gets its own schema, and applying the full DDL takes one lock per
 # object in a single transaction. At the 64 default, parallel workers exhaust
 # the lock table and the suite fails with "out of shared memory" rather than

--- a/scripts/start-test-postgres.sh
+++ b/scripts/start-test-postgres.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Start (or find) a Postgres for the test suite and print the DSN to stdout.
+#
+# The suite runs against Postgres because the fleet does; see
+# src/mac/test_support.py for why an engine-accurate suite is not optional.
+#
+# Usage:  eval "$(scripts/start-test-postgres.sh)"
+set -euo pipefail
+
+DB="${MAC_TEST_PG_DB:-mac_test}"
+CONTAINER="${MAC_TEST_PG_CONTAINER:-mac-test-postgres}"
+PORT="${MAC_TEST_PG_PORT:-5432}"
+IMAGE="${MAC_TEST_PG_IMAGE:-docker.io/library/postgres:17}"
+# Each test gets its own schema, and applying the full DDL takes one lock per
+# object in a single transaction. At the 64 default, parallel workers exhaust
+# the lock table and the suite fails with "out of shared memory" rather than
+# anything resembling a test failure.
+LOCKS="${MAC_TEST_PG_MAX_LOCKS:-1024}"
+
+emit() { echo "export MAC_TEST_PG_URL=$1"; }
+
+# 1. Already configured -- respect it.
+if [ -n "${MAC_TEST_PG_URL:-}" ]; then
+  emit "$MAC_TEST_PG_URL"
+  exit 0
+fi
+
+# 2. A server already listening locally (brew services, a running container).
+if command -v pg_isready >/dev/null 2>&1 && pg_isready -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1; then
+  createdb -h 127.0.0.1 -p "$PORT" "$DB" 2>/dev/null || true
+  current=$(psql -h 127.0.0.1 -p "$PORT" -d "$DB" -tAc "show max_locks_per_transaction" 2>/dev/null || echo 0)
+  if [ "${current:-0}" -lt "$LOCKS" ]; then
+    echo "warning: max_locks_per_transaction=$current (< $LOCKS); a parallel run may fail with 'out of shared memory'." >&2
+    echo "         psql -d $DB -c 'ALTER SYSTEM SET max_locks_per_transaction = $LOCKS;' && restart postgres" >&2
+  fi
+  emit "postgresql://$(whoami)@127.0.0.1:$PORT/$DB"
+  exit 0
+fi
+
+# 3. Otherwise run one in a container.
+for engine in podman docker; do
+  if command -v "$engine" >/dev/null 2>&1 && "$engine" info >/dev/null 2>&1; then
+    if ! "$engine" inspect "$CONTAINER" >/dev/null 2>&1; then
+      "$engine" run -d --name "$CONTAINER" \
+        -e POSTGRES_PASSWORD=test -e POSTGRES_DB="$DB" \
+        -p "$PORT:5432" "$IMAGE" \
+        -c max_locks_per_transaction="$LOCKS" >/dev/null
+    else
+      "$engine" start "$CONTAINER" >/dev/null 2>&1 || true
+    fi
+    for _ in $(seq 1 60); do
+      if "$engine" exec "$CONTAINER" pg_isready -U postgres >/dev/null 2>&1; then
+        emit "postgresql://postgres:test@127.0.0.1:$PORT/$DB"
+        exit 0
+      fi
+      sleep 1
+    done
+    echo "error: $CONTAINER did not become ready in 60s" >&2
+    exit 1
+  fi
+done
+
+echo "error: no local Postgres and no usable container engine (tried podman, docker)." >&2
+echo "Start Docker/Podman, or 'brew services start postgresql@17'." >&2
+exit 1

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -12895,6 +12895,7 @@
     "retired": false,
     "sources": [
       "scripts/start-test-postgres.sh",
+      "src/mac/services.py",
       "src/mac/test_support.py"
     ],
     "type": "str"

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -12894,6 +12894,7 @@
     "name": "MAC_TEST_PG_URL",
     "retired": false,
     "sources": [
+      "scripts/run-contract-tests.sh",
       "scripts/start-test-postgres.sh",
       "src/mac/services.py",
       "src/mac/test_support.py"

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -12834,6 +12834,73 @@
   },
   {
     "default": null,
+    "description": "Core setting: test pg container.",
+    "family": "core",
+    "name": "MAC_TEST_PG_CONTAINER",
+    "retired": false,
+    "sources": [
+      "scripts/start-test-postgres.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test pg db.",
+    "family": "core",
+    "name": "MAC_TEST_PG_DB",
+    "retired": false,
+    "sources": [
+      "scripts/start-test-postgres.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test pg image.",
+    "family": "core",
+    "name": "MAC_TEST_PG_IMAGE",
+    "retired": false,
+    "sources": [
+      "scripts/start-test-postgres.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test pg max locks.",
+    "family": "core",
+    "name": "MAC_TEST_PG_MAX_LOCKS",
+    "retired": false,
+    "sources": [
+      "scripts/start-test-postgres.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test pg port.",
+    "family": "core",
+    "name": "MAC_TEST_PG_PORT",
+    "retired": false,
+    "sources": [
+      "scripts/start-test-postgres.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test pg url.",
+    "family": "core",
+    "name": "MAC_TEST_PG_URL",
+    "retired": false,
+    "sources": [
+      "scripts/start-test-postgres.sh",
+      "src/mac/test_support.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: test portfolio.",
     "family": "core",
     "name": "MAC_TEST_PORTFOLIO",

--- a/src/mac/data/postgres/schema.sql
+++ b/src/mac/data/postgres/schema.sql
@@ -426,6 +426,15 @@ CREATE TABLE IF NOT EXISTS agents (
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS instance_kind TEXT NOT NULL
     DEFAULT 'static' CHECK (instance_kind IN ('static', 'fungible'));
 CREATE INDEX IF NOT EXISTS idx_agents_status_health ON agents (status, health_status);
+-- Ephemeral/decommissioned agents are tombstoned (deleted_at set), never
+-- purged, so the table grows without bound. The default /agents listing
+-- filters deleted_at IS NULL and sorts by name,id; without this partial index
+-- that is a full scan plus a sort over every tombstone, which is where the
+-- ~1s /agents latency for 8 live agents came from. SQLite has had this index
+-- since the deleted_at migration; the Postgres port never got it, so the
+-- backend the fleet actually runs kept paying the cost.
+CREATE INDEX IF NOT EXISTS idx_agents_live_name
+    ON agents (name, id) WHERE deleted_at IS NULL;
 
 -- Hub-authoritative per-worker identities. Only a SHA-256 bearer hash is
 -- persisted; raw tokens exist solely in one-time install manifests and at the
@@ -2546,6 +2555,9 @@ CREATE TRIGGER trg_evidence_attempt_verification_identity
 CREATE OR REPLACE FUNCTION trg_evidence_attempt_verifications_immutable()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'attempt verification receipts are immutable';
+    END IF;
     RAISE EXCEPTION 'attempt verification receipts are append-only';
 END;
 $$ LANGUAGE plpgsql;
@@ -3030,6 +3042,9 @@ CREATE TRIGGER trg_work_package_expiry_repair_authority
 CREATE OR REPLACE FUNCTION trg_work_package_expiry_repairs_immutable()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'lease-expiry repair receipts are immutable';
+    END IF;
     RAISE EXCEPTION 'lease-expiry repair receipts are append-only';
 END;
 $$ LANGUAGE plpgsql;
@@ -3829,7 +3844,10 @@ CREATE OR REPLACE FUNCTION trg_work_package_controller_station_lifecycle()
 RETURNS trigger AS $$
 BEGIN
     IF TG_OP IN ('UPDATE', 'DELETE') THEN
-        RAISE EXCEPTION 'controller station receipts are append-only';
+        IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'controller station receipts are immutable';
+    END IF;
+    RAISE EXCEPTION 'controller station receipts are append-only';
     END IF;
     IF NEW.station_kind = 'integration' THEN
         IF NOT EXISTS (
@@ -4696,6 +4714,9 @@ CREATE TABLE IF NOT EXISTS telemetry_data_migrations (
 CREATE OR REPLACE FUNCTION trg_telemetry_data_migration_append_only()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'telemetry data migrations are immutable';
+    END IF;
     RAISE EXCEPTION 'telemetry data migrations are append-only';
 END;
 $$ LANGUAGE plpgsql;
@@ -4718,6 +4739,9 @@ CREATE TABLE IF NOT EXISTS schema_migration_receipts (
 CREATE OR REPLACE FUNCTION trg_schema_migration_receipt_append_only()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'schema migration receipts are immutable';
+    END IF;
     RAISE EXCEPTION 'schema migration receipts are append-only';
 END;
 $$ LANGUAGE plpgsql;
@@ -4741,6 +4765,9 @@ CREATE TABLE IF NOT EXISTS execution_cohort_configurations (
 CREATE OR REPLACE FUNCTION trg_execution_cohort_configuration_append_only()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'execution cohort configurations are immutable';
+    END IF;
     RAISE EXCEPTION 'execution cohort configurations are append-only';
 END;
 $$ LANGUAGE plpgsql;
@@ -4827,6 +4854,9 @@ CREATE INDEX IF NOT EXISTS idx_execution_cohort_route
 CREATE OR REPLACE FUNCTION trg_execution_cohort_append_only()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'execution cohort assignments are immutable';
+    END IF;
     RAISE EXCEPTION 'execution cohort assignments are append-only';
 END;
 $$ LANGUAGE plpgsql;
@@ -4920,6 +4950,9 @@ CREATE INDEX IF NOT EXISTS idx_work_package_station_attempts_status
 CREATE OR REPLACE FUNCTION trg_work_package_station_attempt_append_only()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'work-package station attempts are immutable';
+    END IF;
     RAISE EXCEPTION 'work-package station attempts are append-only';
 END;
 $$ LANGUAGE plpgsql;
@@ -4965,6 +4998,9 @@ CREATE INDEX IF NOT EXISTS idx_work_package_controller_outcomes_status
 CREATE OR REPLACE FUNCTION trg_work_package_controller_outcome_append_only()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'work-package controller outcomes are immutable';
+    END IF;
     RAISE EXCEPTION 'work-package controller outcomes are append-only';
 END;
 $$ LANGUAGE plpgsql;
@@ -5007,6 +5043,9 @@ CREATE INDEX IF NOT EXISTS idx_work_package_finalization_outcomes_package
 CREATE OR REPLACE FUNCTION trg_work_package_finalization_outcome_append_only()
 RETURNS trigger AS $$
 BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'work-package finalization outcomes are immutable';
+    END IF;
     RAISE EXCEPTION 'work-package finalization outcomes are append-only';
 END;
 $$ LANGUAGE plpgsql;

--- a/src/mac/scientific_optimizer.py
+++ b/src/mac/scientific_optimizer.py
@@ -1812,7 +1812,14 @@ class ScientificOptimizerService:
             "SELECT id, updated_at FROM tasks WHERE project = ? "
             "AND state IN ('completed', 'failed', 'cancelled') "
             "AND json_extract(metadata, '$.execution_contract.type') = 'repository' "
-            "AND COALESCE(json_extract(metadata, '$.optimizer_exempt'), 0) != 1 "
+            # json_extract disagrees across backends for JSON booleans: SQLite
+            # yields 1/0, Postgres yields 'true'/'false'. Comparing to the
+            # integer 1 worked on SQLite and made this whole query fail on
+            # Postgres with "COALESCE types text and integer cannot be
+            # matched", so the optimizer could not sample anything in
+            # production. Compare as text, accepting both spellings.
+            "AND COALESCE(CAST(json_extract(metadata, '$.optimizer_exempt') AS TEXT), '') "
+            "NOT IN ('1', 'true') "
             "AND COALESCE(json_extract(metadata, '$.origin.type'), '') "
             "NOT IN ('scientific_optimizer', 'backlog_grooming') "
             "ORDER BY COALESCE(completed_at, updated_at) DESC, id LIMIT ?",

--- a/src/mac/service_role_service.py
+++ b/src/mac/service_role_service.py
@@ -89,19 +89,36 @@ class ServiceRoleService:
         return self._role_from_row(row)
 
     def get_role_by_slug(self, slug: str, *, tenant_id: Optional[str] = None) -> ServiceRole:
-        row = self.store.query_one(
-            "SELECT * FROM service_roles WHERE slug = ? AND tenant_id IS ?",
-            (slug, tenant_id),
-        )
+        # ``tenant_id IS ?`` is a SQLite null-safe comparison; Postgres rejects
+        # it outright ("syntax error at or near $N"). Split into IS NULL / = ?,
+        # matching provisioning_service and workflow_service.
+        if tenant_id is None:
+            row = self.store.query_one(
+                "SELECT * FROM service_roles WHERE slug = ? AND tenant_id IS NULL",
+                (slug,),
+            )
+        else:
+            row = self.store.query_one(
+                "SELECT * FROM service_roles WHERE slug = ? AND tenant_id = ?",
+                (slug, tenant_id),
+            )
         if row is None:
             raise NotFoundError("service role %r not found" % slug)
         return self._role_from_row(row)
 
     def desired_services(self, *, tenant_id: Optional[str] = None) -> List[ServiceRole]:
-        rows = self.store.query_all(
-            "SELECT * FROM service_roles WHERE enabled = 1 AND (tenant_id IS ? OR tenant_id IS NULL)",
-            (tenant_id,),
-        )
+        # Same split as get_role_by_slug. With no tenant the second disjunct
+        # already covers it, so the clause collapses to IS NULL.
+        if tenant_id is None:
+            rows = self.store.query_all(
+                "SELECT * FROM service_roles WHERE enabled = 1 AND tenant_id IS NULL"
+            )
+        else:
+            rows = self.store.query_all(
+                "SELECT * FROM service_roles WHERE enabled = 1 "
+                "AND (tenant_id = ? OR tenant_id IS NULL)",
+                (tenant_id,),
+            )
         return [self._role_from_row(r) for r in rows]
 
     # --- claims (leased holders) ---------------------------------------

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -2290,7 +2290,17 @@ class ControlPlane:
 
     @classmethod
     def in_memory(cls) -> "ControlPlane":
-        return cls(SQLiteStore(":memory:"), secret_key="test-key-with-enough-entropy-32+chars")
+        """A throwaway control plane for tests, on its own Postgres schema.
+
+        Named for the in-memory SQLite it used to return. The fleet runs on
+        Postgres, and a suite that agrees with SQLite instead of with
+        production licenses deploys it cannot justify -- NEEDS_INPUT shipped a
+        task state every SQLite test accepted and the live Postgres trigger
+        rejected. Isolation is per-schema; see mac.test_support.
+        """
+        from mac.test_support import ephemeral_control_plane
+
+        return ephemeral_control_plane()
 
     def _resolved_json_column(
         self,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -2290,17 +2290,33 @@ class ControlPlane:
 
     @classmethod
     def in_memory(cls) -> "ControlPlane":
-        """A throwaway control plane for tests, on its own Postgres schema.
+        """A throwaway control plane.
 
-        Named for the in-memory SQLite it used to return. The fleet runs on
-        Postgres, and a suite that agrees with SQLite instead of with
+        With MAC_TEST_PG_URL set, this is a fresh PostgreSQL schema. The fleet
+        runs on Postgres, and a suite that agrees with SQLite instead of with
         production licenses deploys it cannot justify -- NEEDS_INPUT shipped a
         task state every SQLite test accepted and the live Postgres trigger
-        rejected. Isolation is per-schema; see mac.test_support.
-        """
-        from mac.test_support import ephemeral_control_plane
+        rejected. See mac.test_support.
 
-        return ephemeral_control_plane()
+        Without it, this falls back to in-memory SQLite, because build-time
+        tooling calls this too (generate-docs-reference.py builds the OpenAPI
+        reference from a live app; project_inception needs a scratch plane) and
+        generating documentation should not require a database.
+
+        That fallback is NOT a way for the suite to run on SQLite:
+        tests/conftest.py refuses to run at all unless MAC_TEST_PG_URL is set,
+        so the choice is never made silently on a developer's machine.
+        """
+        import os
+
+        if os.environ.get("MAC_TEST_PG_URL", "").strip():
+            from mac.test_support import ephemeral_control_plane
+
+            return ephemeral_control_plane()
+        return cls(
+            SQLiteStore(":memory:"),
+            secret_key="test-key-with-enough-entropy-32+chars",
+        )
 
     def _resolved_json_column(
         self,

--- a/src/mac/store.py
+++ b/src/mac/store.py
@@ -24,6 +24,9 @@ from typing import (
 )
 
 
+from mac.store_helpers import StoreHelpersMixin
+
+
 def _utcnow_iso() -> str:
     from datetime import datetime, timezone
 
@@ -310,6 +313,34 @@ class Store(Protocol):
     ) -> list: ...
     def backend_identity(self) -> "dict[str, Any]": ...
 
+    # Higher-level helpers, implemented once in StoreHelpersMixin. Declared
+    # here so a backend that lacks one fails the protocol check instead of
+    # raising AttributeError at the first request that needs it.
+    def upsert_human(self, *args: Any, **kwargs: Any) -> None: ...
+    def get_human(self, human_id: str) -> Optional[Any]: ...
+    def get_human_by_username(self, username: str) -> Optional[Any]: ...
+    def list_humans(self, *, group: Optional[str] = None) -> list: ...
+    def delete_human(self, human_id: str) -> bool: ...
+    def set_pipeline_cursor(self, scope: str, name: str, value: Any) -> None: ...
+    def get_pipeline_cursor(
+        self, scope: str, name: str, default: Any = None
+    ) -> Any: ...
+    def upsert_task_flow_span(self, *args: Any, **kwargs: Any) -> None: ...
+    def upsert_task_completion(self, *args: Any, **kwargs: Any) -> None: ...
+    def get_task_completion(self, *args: Any, **kwargs: Any) -> Optional[Any]: ...
+    def list_task_flow_spans_by_task(self, *args: Any, **kwargs: Any) -> list: ...
+    def list_task_flow_spans_by_project(self, *args: Any, **kwargs: Any) -> list: ...
+    def query_task_flow_stage_aggregates(self, *args: Any, **kwargs: Any) -> list: ...
+    def record_fleet_release_admission_episode(
+        self, *args: Any, **kwargs: Any
+    ) -> None: ...
+    def get_fleet_release_admission_episode(
+        self, *args: Any, **kwargs: Any
+    ) -> Optional[Any]: ...
+    def list_fleet_release_admission_episodes(
+        self, *args: Any, **kwargs: Any
+    ) -> list: ...
+
 
 def make_store_from_env(
     sqlite_path: Optional[str] = None,
@@ -363,7 +394,7 @@ def make_store_from_env(
     return SQLiteStore(path, initialize_schema=initialize_schema)
 
 
-class SQLiteStore:
+class SQLiteStore(StoreHelpersMixin):
     """Durable SQLite backing store for the control plane.
 
     Server startup uses the default ``initialize_schema=True`` to create and
@@ -511,56 +542,6 @@ class SQLiteStore:
             "in_memory": path == ":memory:",
         }
 
-    # Durable pipeline resume cursors (task_repair_d771f872). Opaque,
-    # bounded JSON documents keyed by a stable (scope, name). Used by the
-    # work-package pipeline controller and the repository ref reconciler so a
-    # hub restart resumes from its last bookmark instead of rescanning.
-    PIPELINE_CURSOR_MAX_BYTES = 65536
-
-    def set_pipeline_cursor(self, scope: str, name: str, value: Any) -> None:
-        import json as _json
-
-        scope_value = str(scope or "").strip()
-        name_value = str(name or "").strip()
-        if not scope_value or not name_value:
-            raise ValueError("pipeline cursor scope and name are required")
-        encoded = _json.dumps(value, sort_keys=True, separators=(",", ":"))
-        if len(encoded.encode("utf-8")) > self.PIPELINE_CURSOR_MAX_BYTES:
-            raise ValueError(
-                "pipeline cursor value exceeds %d bytes"
-                % self.PIPELINE_CURSOR_MAX_BYTES
-            )
-        now = _utcnow_iso()
-        with self._lock:
-            self._conn.execute(
-                """
-                INSERT INTO pipeline_cursors (scope, name, value, updated_at)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT(scope, name) DO UPDATE SET
-                    value = excluded.value,
-                    updated_at = excluded.updated_at
-                """,
-                (scope_value, name_value, encoded, now),
-            )
-
-    def get_pipeline_cursor(self, scope: str, name: str, default: Any = None) -> Any:
-        import json as _json
-
-        scope_value = str(scope or "").strip()
-        name_value = str(name or "").strip()
-        if not scope_value or not name_value:
-            return default
-        with self._lock:
-            row = self._conn.execute(
-                "SELECT value FROM pipeline_cursors WHERE scope = ? AND name = ?",
-                (scope_value, name_value),
-            ).fetchone()
-        if row is None:
-            return default
-        try:
-            return _json.loads(row["value"])
-        except (TypeError, ValueError):
-            return default
 
     def _migrate_execution_cohort_route_contract(self) -> None:
         """Upgrade the preliminary cohort route CHECK without losing receipts.
@@ -7287,442 +7268,3 @@ class SQLiteStore:
         if column not in columns:
             self._conn.execute("ALTER TABLE %s ADD COLUMN %s" % (table, definition))
 
-    # ------------------------------------------------------------------
-    # Human principals CRUD helpers
-    # ------------------------------------------------------------------
-    # These helpers mirror the style of the rest of SQLiteStore: callers
-    # are responsible for JSON-serialising / deserialising list fields.
-    # ``groups`` is stored as a JSON array text column.  The upsert also
-    # reconciles the ``human_groups`` membership table so both the denorm
-    # JSON column and the normalised table stay in sync.
-    # ------------------------------------------------------------------
-
-    def upsert_human(
-        self,
-        human_id: str,
-        username: str,
-        *,
-        email: Optional[str] = None,
-        github_login: Optional[str] = None,
-        display_name: Optional[str] = None,
-        groups: Optional[list] = None,
-        created_at: str,
-        updated_at: str,
-    ) -> None:
-        """Insert or replace a human row and reconcile group membership."""
-        import json as _json
-
-        groups_json = _json.dumps(sorted(set(groups or [])))
-        self.execute(
-            """
-            INSERT INTO humans (id, username, email, github_login, display_name,
-                                groups, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(id) DO UPDATE SET
-                username     = excluded.username,
-                email        = excluded.email,
-                github_login = excluded.github_login,
-                display_name = excluded.display_name,
-                groups       = excluded.groups,
-                updated_at   = excluded.updated_at
-            """,
-            (
-                human_id,
-                username,
-                email,
-                github_login,
-                display_name,
-                groups_json,
-                created_at,
-                updated_at,
-            ),
-        )
-        # Reconcile human_groups: remove rows no longer in the groups list,
-        # then insert any new ones (idempotent via INSERT OR IGNORE).
-        current_groups = sorted(set(groups or []))
-        self.execute(
-            "DELETE FROM human_groups WHERE human_id = ?", (human_id,)
-        )
-        for group_name in current_groups:
-            self.execute(
-                """
-                INSERT OR IGNORE INTO human_groups (id, human_id, group_name, created_at)
-                VALUES (?, ?, ?, ?)
-                """,
-                (
-                    "hg_%s_%s" % (human_id, group_name),
-                    human_id,
-                    group_name,
-                    created_at,
-                ),
-            )
-
-    def get_human(self, human_id: str) -> Optional[Any]:
-        """Return the human row for ``human_id``, or None if not found."""
-        return self.query_one(
-            "SELECT * FROM humans WHERE id = ?", (human_id,)
-        )
-
-    def get_human_by_username(self, username: str) -> Optional[Any]:
-        """Return the human row for ``username``, or None if not found."""
-        return self.query_one(
-            "SELECT * FROM humans WHERE username = ?", (username,)
-        )
-
-    def list_humans(self, *, group: Optional[str] = None) -> list:
-        """Return all humans, optionally filtered by group membership."""
-        if group is not None:
-            return self.query_all(
-                """
-                SELECT h.* FROM humans h
-                INNER JOIN human_groups hg ON hg.human_id = h.id
-                WHERE hg.group_name = ?
-                ORDER BY h.username
-                """,
-                (group,),
-            )
-        return self.query_all("SELECT * FROM humans ORDER BY username")
-
-    def delete_human(self, human_id: str) -> bool:
-        """Delete a human by id; returns True if a row was deleted."""
-        cursor = self.execute(
-            "DELETE FROM humans WHERE id = ?", (human_id,)
-        )
-        return cursor.rowcount > 0
-
-    # -- Task-flow analytics helpers -------------------------------------
-    #
-    # Read/write helpers for task_flow_spans and task_completions. Writes
-    # accept an optional open ``conn`` so callers can participate in an
-    # existing transaction (matching observability_service.insert_observation);
-    # when ``conn`` is None the helper runs on the store's own connection.
-    # UPSERT semantics make a recompute over historical rows idempotent.
-
-    @staticmethod
-    def _executor(conn: Optional[Any], store: "SQLiteStore") -> Any:
-        """Return the object to execute SQL on: the passed conn or the store."""
-        return conn if conn is not None else store
-
-    def upsert_task_flow_span(
-        self,
-        *,
-        span_id: str,
-        task_id: str,
-        project: str,
-        attempt: int,
-        stage: str,
-        started_at: str,
-        ended_at: Optional[str],
-        duration_seconds: Optional[float],
-        outcome: str,
-        metadata_json: str = "{}",
-        created_at: str,
-        updated_at: str,
-        conn: Optional[Any] = None,
-    ) -> None:
-        """Insert or update a task-flow span, keyed on (task_id, attempt, stage).
-
-        A recompute over historical transitions calls this with the same key and
-        the row is updated in place (no duplicate append). ``created_at`` is
-        preserved on conflict; only mutable fields are refreshed.
-        """
-        executor = self._executor(conn, self)
-        executor.execute(
-            """
-            INSERT INTO task_flow_spans (
-                id, task_id, project, attempt, stage, started_at, ended_at,
-                duration_seconds, outcome, metadata, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(task_id, attempt, stage) DO UPDATE SET
-                project          = excluded.project,
-                started_at       = excluded.started_at,
-                ended_at         = excluded.ended_at,
-                duration_seconds = excluded.duration_seconds,
-                outcome          = excluded.outcome,
-                metadata         = excluded.metadata,
-                updated_at       = excluded.updated_at
-            """,
-            (
-                span_id, task_id, project, attempt, stage, started_at,
-                ended_at, duration_seconds, outcome, metadata_json,
-                created_at, updated_at,
-            ),
-        )
-
-    def upsert_task_completion(
-        self,
-        *,
-        completion_id: str,
-        task_id: str,
-        project: str,
-        attempt: int,
-        started_at: str,
-        ended_at: Optional[str],
-        duration_seconds: Optional[float],
-        outcome: str,
-        publication_sha: Optional[str] = None,
-        main_sha: Optional[str] = None,
-        route_count: int = 0,
-        token_count: int = 0,
-        cost_count: float = 0.0,
-        review_count: int = 0,
-        rebase_count: int = 0,
-        test_count: int = 0,
-        per_stage_durations_json: str = "{}",
-        metadata_json: str = "{}",
-        created_at: str,
-        updated_at: str,
-        conn: Optional[Any] = None,
-    ) -> None:
-        """Insert or update a task-completion summary, keyed on (task_id, attempt).
-
-        A recompute over historical task_history / reviews / publications calls
-        this with the same key so the summary is updated in place rather than
-        appended. ``created_at`` is preserved on conflict.
-        """
-        executor = self._executor(conn, self)
-        executor.execute(
-            """
-            INSERT INTO task_completions (
-                id, task_id, project, attempt, started_at, ended_at,
-                duration_seconds, outcome, publication_sha, main_sha,
-                route_count, token_count, cost_count, review_count,
-                rebase_count, test_count, per_stage_durations, metadata,
-                created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(task_id, attempt) DO UPDATE SET
-                project             = excluded.project,
-                started_at          = excluded.started_at,
-                ended_at            = excluded.ended_at,
-                duration_seconds    = excluded.duration_seconds,
-                outcome             = excluded.outcome,
-                publication_sha     = excluded.publication_sha,
-                main_sha            = excluded.main_sha,
-                route_count         = excluded.route_count,
-                token_count         = excluded.token_count,
-                cost_count          = excluded.cost_count,
-                review_count        = excluded.review_count,
-                rebase_count        = excluded.rebase_count,
-                test_count          = excluded.test_count,
-                per_stage_durations = excluded.per_stage_durations,
-                metadata            = excluded.metadata,
-                updated_at          = excluded.updated_at
-            """,
-            (
-                completion_id, task_id, project, attempt, started_at,
-                ended_at, duration_seconds, outcome, publication_sha, main_sha,
-                route_count, token_count, cost_count, review_count,
-                rebase_count, test_count, per_stage_durations_json,
-                metadata_json, created_at, updated_at,
-            ),
-        )
-
-    def list_task_flow_spans_by_task(
-        self, task_id: str, *, attempt: Optional[int] = None
-    ) -> list:
-        """Return spans for a task, optionally filtered to a single attempt.
-
-        Ordered by attempt then started_at so a caller sees stage progression.
-        """
-        if attempt is not None:
-            return self.query_all(
-                """
-                SELECT * FROM task_flow_spans
-                WHERE task_id = ? AND attempt = ?
-                ORDER BY started_at, stage
-                """,
-                (task_id, attempt),
-            )
-        return self.query_all(
-            """
-            SELECT * FROM task_flow_spans
-            WHERE task_id = ?
-            ORDER BY attempt, started_at, stage
-            """,
-            (task_id,),
-        )
-
-    def list_task_flow_spans_by_project(
-        self,
-        project: str,
-        *,
-        stage: Optional[str] = None,
-        since: Optional[str] = None,
-        until: Optional[str] = None,
-    ) -> list:
-        """Return spans for a project, optionally narrowed by stage/time window."""
-        clauses = ["project = ?"]
-        params: list = [project]
-        if stage is not None:
-            clauses.append("stage = ?")
-            params.append(stage)
-        if since is not None:
-            clauses.append("started_at >= ?")
-            params.append(since)
-        if until is not None:
-            clauses.append("started_at < ?")
-            params.append(until)
-        sql = (
-            "SELECT * FROM task_flow_spans WHERE "
-            + " AND ".join(clauses)
-            + " ORDER BY started_at, task_id, stage"
-        )
-        return self.query_all(sql, tuple(params))
-
-    def get_task_completion(
-        self, task_id: str, attempt: int
-    ) -> Optional[Any]:
-        """Return the completion summary for a task attempt, or None."""
-        return self.query_one(
-            "SELECT * FROM task_completions WHERE task_id = ? AND attempt = ?",
-            (task_id, attempt),
-        )
-
-    def query_task_flow_stage_aggregates(
-        self,
-        *,
-        project: Optional[str] = None,
-        since: Optional[str] = None,
-        until: Optional[str] = None,
-    ) -> list:
-        """Aggregate stage durations over a window for KPI reporting.
-
-        Returns one row per stage with count, average, and total completed
-        duration. Only closed spans (duration_seconds NOT NULL) contribute so a
-        still-open stage does not skew the averages. Optionally scoped to a
-        project and a [since, until) start-time window.
-        """
-        clauses = ["duration_seconds IS NOT NULL"]
-        params: list = []
-        if project is not None:
-            clauses.append("project = ?")
-            params.append(project)
-        if since is not None:
-            clauses.append("started_at >= ?")
-            params.append(since)
-        if until is not None:
-            clauses.append("started_at < ?")
-            params.append(until)
-        sql = (
-            "SELECT stage, "
-            "COUNT(*) AS span_count, "
-            "AVG(duration_seconds) AS avg_duration_seconds, "
-            "SUM(duration_seconds) AS total_duration_seconds "
-            "FROM task_flow_spans WHERE "
-            + " AND ".join(clauses)
-            + " GROUP BY stage ORDER BY stage"
-        )
-        return self.query_all(sql, tuple(params))
-
-    def record_fleet_release_admission_episode(
-        self,
-        *,
-        episode_id: str,
-        barrier_resource_digest: str,
-        owner_kind: str,
-        waiter_kind: str,
-        wait_started_at: str,
-        outcome: str,
-        created_at: str,
-        updated_at: str,
-        project: Optional[str] = None,
-        owner_id: Optional[str] = None,
-        waiter_id: Optional[str] = None,
-        waiting_publishers: int = 0,
-        waiting_epoch_openers: int = 0,
-        queue_depth: int = 0,
-        wait_ended_at: Optional[str] = None,
-        wait_seconds: Optional[float] = None,
-        metadata_json: str = "{}",
-        conn: Optional[Any] = None,
-    ) -> None:
-        """Persist one fair-admission contention episode for the publication barrier.
-
-        Records queue depth (waiting publishers / epoch openers), the wait
-        window, the current barrier owner (publisher vs epoch opener plus its
-        identifier), and the episode outcome. Keyed on ``episode_id`` so an
-        observability layer that refreshes the same episode as it closes calls
-        this with the same id and the row is updated in place rather than
-        appended. Side-effect-free beyond the write.
-        """
-        executor = self._executor(conn, self)
-        executor.execute(
-            """
-            INSERT INTO fleet_release_admission_episodes (
-                id, project, barrier_resource_digest, owner_kind, owner_id,
-                waiter_kind, waiter_id, waiting_publishers,
-                waiting_epoch_openers, queue_depth, wait_started_at,
-                wait_ended_at, wait_seconds, outcome, metadata,
-                created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(id) DO UPDATE SET
-                project                = excluded.project,
-                barrier_resource_digest = excluded.barrier_resource_digest,
-                owner_kind             = excluded.owner_kind,
-                owner_id               = excluded.owner_id,
-                waiter_kind            = excluded.waiter_kind,
-                waiter_id              = excluded.waiter_id,
-                waiting_publishers     = excluded.waiting_publishers,
-                waiting_epoch_openers  = excluded.waiting_epoch_openers,
-                queue_depth            = excluded.queue_depth,
-                wait_started_at        = excluded.wait_started_at,
-                wait_ended_at          = excluded.wait_ended_at,
-                wait_seconds           = excluded.wait_seconds,
-                outcome                = excluded.outcome,
-                metadata               = excluded.metadata,
-                updated_at             = excluded.updated_at
-            """,
-            (
-                episode_id, project, barrier_resource_digest, owner_kind,
-                owner_id, waiter_kind, waiter_id, waiting_publishers,
-                waiting_epoch_openers, queue_depth, wait_started_at,
-                wait_ended_at, wait_seconds, outcome, metadata_json,
-                created_at, updated_at,
-            ),
-        )
-
-    def get_fleet_release_admission_episode(
-        self, episode_id: str
-    ) -> Optional[Any]:
-        """Return a single admission episode by id, or None."""
-        return self.query_one(
-            "SELECT * FROM fleet_release_admission_episodes WHERE id = ?",
-            (episode_id,),
-        )
-
-    def list_fleet_release_admission_episodes(
-        self,
-        *,
-        project: Optional[str] = None,
-        barrier_resource_digest: Optional[str] = None,
-        since: Optional[str] = None,
-        until: Optional[str] = None,
-        limit: Optional[int] = None,
-    ) -> list:
-        """Return admission episodes, most recent first, optionally narrowed.
-
-        Filters are additive: ``project`` and/or ``barrier_resource_digest``
-        scope the barrier, and ``[since, until)`` bounds the creation time.
-        """
-        clauses: list = []
-        params: list = []
-        if project is not None:
-            clauses.append("project = ?")
-            params.append(project)
-        if barrier_resource_digest is not None:
-            clauses.append("barrier_resource_digest = ?")
-            params.append(barrier_resource_digest)
-        if since is not None:
-            clauses.append("created_at >= ?")
-            params.append(since)
-        if until is not None:
-            clauses.append("created_at < ?")
-            params.append(until)
-        sql = "SELECT * FROM fleet_release_admission_episodes"
-        if clauses:
-            sql += " WHERE " + " AND ".join(clauses)
-        sql += " ORDER BY created_at DESC, id DESC"
-        if limit is not None:
-            sql += " LIMIT ?"
-            params.append(int(limit))
-        return self.query_all(sql, tuple(params))

--- a/src/mac/store_helpers.py
+++ b/src/mac/store_helpers.py
@@ -1,0 +1,552 @@
+"""Store helpers shared by every backend.
+
+These are the higher-level persistence helpers -- human principals, pipeline
+resume cursors, task-flow analytics, fleet-release admission episodes -- that
+sit above the seven primitives in the `Store` protocol.
+
+They live here because they used to live on SQLiteStore alone. Nothing
+required PostgresStore to have them and the protocol did not declare them, so
+`isinstance(postgres_store, Store)` passed while sixteen methods were simply
+absent from the backend the fleet actually runs. `GET /humans` returned 500 in
+production for as long as that was true.
+
+Every method below is written against `execute` / `query_one` / `query_all`,
+which both backends implement (Postgres translates SQLite-shaped SQL
+internally), so one definition serves both and the two cannot drift again.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+
+def _utcnow_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+class StoreHelpersMixin:
+    """Backend-neutral persistence helpers layered on the `Store` primitives."""
+
+    @contextmanager
+    def foreign_keys_suspended(self) -> "Iterator[Any]":
+        """Yield an executor that is not enforcing foreign keys. Fixtures only.
+
+        Some tests need a row whose parents are irrelevant to what is being
+        tested -- a finalization outcome used to check export *filtering*, say,
+        whose real parent chain runs through batches, landing receipts,
+        repositories, and certifications. Building all of that would test the
+        fixture rather than the filter.
+
+        Yields the executor to use rather than suspending enforcement globally,
+        because on Postgres the setting is per-session and every store.execute()
+        borrows a different pooled connection -- a `SET` on one of them does
+        nothing for the next. Callers MUST use the yielded object.
+        """
+        backend = str(self.backend_identity().get("backend") or "").lower()
+        if backend == "postgres":
+            with self.transaction() as conn:
+                conn.execute("SET LOCAL session_replication_role = replica")
+                yield conn
+        else:
+            # SQLite ignores this pragma inside a transaction, so it is set on
+            # the store's own connection and the store is the executor.
+            self.execute("PRAGMA foreign_keys = OFF")
+            try:
+                yield self
+            finally:
+                self.execute("PRAGMA foreign_keys = ON")
+
+    # Durable pipeline resume cursors (task_repair_d771f872). Opaque,
+    # bounded JSON documents keyed by a stable (scope, name). Used by the
+    # work-package pipeline controller and the repository ref reconciler so a
+    # hub restart resumes from its last bookmark instead of rescanning.
+    PIPELINE_CURSOR_MAX_BYTES = 65536
+
+    def set_pipeline_cursor(self, scope: str, name: str, value: Any) -> None:
+        import json as _json
+
+        scope_value = str(scope or "").strip()
+        name_value = str(name or "").strip()
+        if not scope_value or not name_value:
+            raise ValueError("pipeline cursor scope and name are required")
+        encoded = _json.dumps(value, sort_keys=True, separators=(",", ":"))
+        if len(encoded.encode("utf-8")) > self.PIPELINE_CURSOR_MAX_BYTES:
+            raise ValueError(
+                "pipeline cursor value exceeds %d bytes"
+                % self.PIPELINE_CURSOR_MAX_BYTES
+            )
+        now = _utcnow_iso()
+        self.execute(
+            """
+            INSERT INTO pipeline_cursors (scope, name, value, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(scope, name) DO UPDATE SET
+                value = excluded.value,
+                updated_at = excluded.updated_at
+            """,
+            (scope_value, name_value, encoded, now),
+        )
+
+    def get_pipeline_cursor(self, scope: str, name: str, default: Any = None) -> Any:
+        import json as _json
+
+        scope_value = str(scope or "").strip()
+        name_value = str(name or "").strip()
+        if not scope_value or not name_value:
+            return default
+        row = self.query_one(
+            "SELECT value FROM pipeline_cursors WHERE scope = ? AND name = ?",
+            (scope_value, name_value),
+        )
+        if row is None:
+            return default
+        try:
+            return _json.loads(row["value"])
+        except (TypeError, ValueError):
+            return default
+
+    # ------------------------------------------------------------------
+    # Human principals CRUD helpers
+    # ------------------------------------------------------------------
+    # These helpers mirror the style of the rest of SQLiteStore: callers
+    # are responsible for JSON-serialising / deserialising list fields.
+    # ``groups`` is stored as a JSON array text column.  The upsert also
+    # reconciles the ``human_groups`` membership table so both the denorm
+    # JSON column and the normalised table stay in sync.
+    # ------------------------------------------------------------------
+
+    def upsert_human(
+        self,
+        human_id: str,
+        username: str,
+        *,
+        email: Optional[str] = None,
+        github_login: Optional[str] = None,
+        display_name: Optional[str] = None,
+        groups: Optional[list] = None,
+        created_at: str,
+        updated_at: str,
+    ) -> None:
+        """Insert or replace a human row and reconcile group membership."""
+        import json as _json
+
+        groups_json = _json.dumps(sorted(set(groups or [])))
+        self.execute(
+            """
+            INSERT INTO humans (id, username, email, github_login, display_name,
+                                groups, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                username     = excluded.username,
+                email        = excluded.email,
+                github_login = excluded.github_login,
+                display_name = excluded.display_name,
+                groups       = excluded.groups,
+                updated_at   = excluded.updated_at
+            """,
+            (
+                human_id,
+                username,
+                email,
+                github_login,
+                display_name,
+                groups_json,
+                created_at,
+                updated_at,
+            ),
+        )
+        # Reconcile human_groups: remove rows no longer in the groups list,
+        # then insert any new ones. ON CONFLICT DO NOTHING rather than SQLite's
+        # INSERT OR IGNORE, which Postgres rejects outright -- shared helpers
+        # must be written in SQL both backends accept.
+        current_groups = sorted(set(groups or []))
+        self.execute(
+            "DELETE FROM human_groups WHERE human_id = ?", (human_id,)
+        )
+        for group_name in current_groups:
+            self.execute(
+                """
+                INSERT INTO human_groups (id, human_id, group_name, created_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT DO NOTHING
+                """,
+                (
+                    "hg_%s_%s" % (human_id, group_name),
+                    human_id,
+                    group_name,
+                    created_at,
+                ),
+            )
+
+    def get_human(self, human_id: str) -> Optional[Any]:
+        """Return the human row for ``human_id``, or None if not found."""
+        return self.query_one(
+            "SELECT * FROM humans WHERE id = ?", (human_id,)
+        )
+
+    def get_human_by_username(self, username: str) -> Optional[Any]:
+        """Return the human row for ``username``, or None if not found."""
+        return self.query_one(
+            "SELECT * FROM humans WHERE username = ?", (username,)
+        )
+
+    def list_humans(self, *, group: Optional[str] = None) -> list:
+        """Return all humans, optionally filtered by group membership."""
+        if group is not None:
+            return self.query_all(
+                """
+                SELECT h.* FROM humans h
+                INNER JOIN human_groups hg ON hg.human_id = h.id
+                WHERE hg.group_name = ?
+                ORDER BY h.username
+                """,
+                (group,),
+            )
+        return self.query_all("SELECT * FROM humans ORDER BY username")
+
+    def delete_human(self, human_id: str) -> bool:
+        """Delete a human by id; returns True if a row was deleted."""
+        cursor = self.execute(
+            "DELETE FROM humans WHERE id = ?", (human_id,)
+        )
+        return cursor.rowcount > 0
+
+    # -- Task-flow analytics helpers -------------------------------------
+    #
+    # Read/write helpers for task_flow_spans and task_completions. Writes
+    # accept an optional open ``conn`` so callers can participate in an
+    # existing transaction (matching observability_service.insert_observation);
+    # when ``conn`` is None the helper runs on the store's own connection.
+    # UPSERT semantics make a recompute over historical rows idempotent.
+
+    @staticmethod
+    def _executor(conn: Optional[Any], store: Any) -> Any:
+        """Return the object to execute SQL on: the passed conn or the store."""
+        return conn if conn is not None else store
+
+    def upsert_task_flow_span(
+        self,
+        *,
+        span_id: str,
+        task_id: str,
+        project: str,
+        attempt: int,
+        stage: str,
+        started_at: str,
+        ended_at: Optional[str],
+        duration_seconds: Optional[float],
+        outcome: str,
+        metadata_json: str = "{}",
+        created_at: str,
+        updated_at: str,
+        conn: Optional[Any] = None,
+    ) -> None:
+        """Insert or update a task-flow span, keyed on (task_id, attempt, stage).
+
+        A recompute over historical transitions calls this with the same key and
+        the row is updated in place (no duplicate append). ``created_at`` is
+        preserved on conflict; only mutable fields are refreshed.
+        """
+        executor = self._executor(conn, self)
+        executor.execute(
+            """
+            INSERT INTO task_flow_spans (
+                id, task_id, project, attempt, stage, started_at, ended_at,
+                duration_seconds, outcome, metadata, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(task_id, attempt, stage) DO UPDATE SET
+                project          = excluded.project,
+                started_at       = excluded.started_at,
+                ended_at         = excluded.ended_at,
+                duration_seconds = excluded.duration_seconds,
+                outcome          = excluded.outcome,
+                metadata         = excluded.metadata,
+                updated_at       = excluded.updated_at
+            """,
+            (
+                span_id, task_id, project, attempt, stage, started_at,
+                ended_at, duration_seconds, outcome, metadata_json,
+                created_at, updated_at,
+            ),
+        )
+
+    def upsert_task_completion(
+        self,
+        *,
+        completion_id: str,
+        task_id: str,
+        project: str,
+        attempt: int,
+        started_at: str,
+        ended_at: Optional[str],
+        duration_seconds: Optional[float],
+        outcome: str,
+        publication_sha: Optional[str] = None,
+        main_sha: Optional[str] = None,
+        route_count: int = 0,
+        token_count: int = 0,
+        cost_count: float = 0.0,
+        review_count: int = 0,
+        rebase_count: int = 0,
+        test_count: int = 0,
+        per_stage_durations_json: str = "{}",
+        metadata_json: str = "{}",
+        created_at: str,
+        updated_at: str,
+        conn: Optional[Any] = None,
+    ) -> None:
+        """Insert or update a task-completion summary, keyed on (task_id, attempt).
+
+        A recompute over historical task_history / reviews / publications calls
+        this with the same key so the summary is updated in place rather than
+        appended. ``created_at`` is preserved on conflict.
+        """
+        executor = self._executor(conn, self)
+        executor.execute(
+            """
+            INSERT INTO task_completions (
+                id, task_id, project, attempt, started_at, ended_at,
+                duration_seconds, outcome, publication_sha, main_sha,
+                route_count, token_count, cost_count, review_count,
+                rebase_count, test_count, per_stage_durations, metadata,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(task_id, attempt) DO UPDATE SET
+                project             = excluded.project,
+                started_at          = excluded.started_at,
+                ended_at            = excluded.ended_at,
+                duration_seconds    = excluded.duration_seconds,
+                outcome             = excluded.outcome,
+                publication_sha     = excluded.publication_sha,
+                main_sha            = excluded.main_sha,
+                route_count         = excluded.route_count,
+                token_count         = excluded.token_count,
+                cost_count          = excluded.cost_count,
+                review_count        = excluded.review_count,
+                rebase_count        = excluded.rebase_count,
+                test_count          = excluded.test_count,
+                per_stage_durations = excluded.per_stage_durations,
+                metadata            = excluded.metadata,
+                updated_at          = excluded.updated_at
+            """,
+            (
+                completion_id, task_id, project, attempt, started_at,
+                ended_at, duration_seconds, outcome, publication_sha, main_sha,
+                route_count, token_count, cost_count, review_count,
+                rebase_count, test_count, per_stage_durations_json,
+                metadata_json, created_at, updated_at,
+            ),
+        )
+
+    def list_task_flow_spans_by_task(
+        self, task_id: str, *, attempt: Optional[int] = None
+    ) -> list:
+        """Return spans for a task, optionally filtered to a single attempt.
+
+        Ordered by attempt then started_at so a caller sees stage progression.
+        """
+        if attempt is not None:
+            return self.query_all(
+                """
+                SELECT * FROM task_flow_spans
+                WHERE task_id = ? AND attempt = ?
+                ORDER BY started_at, stage
+                """,
+                (task_id, attempt),
+            )
+        return self.query_all(
+            """
+            SELECT * FROM task_flow_spans
+            WHERE task_id = ?
+            ORDER BY attempt, started_at, stage
+            """,
+            (task_id,),
+        )
+
+    def list_task_flow_spans_by_project(
+        self,
+        project: str,
+        *,
+        stage: Optional[str] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+    ) -> list:
+        """Return spans for a project, optionally narrowed by stage/time window."""
+        clauses = ["project = ?"]
+        params: list = [project]
+        if stage is not None:
+            clauses.append("stage = ?")
+            params.append(stage)
+        if since is not None:
+            clauses.append("started_at >= ?")
+            params.append(since)
+        if until is not None:
+            clauses.append("started_at < ?")
+            params.append(until)
+        sql = (
+            "SELECT * FROM task_flow_spans WHERE "
+            + " AND ".join(clauses)
+            + " ORDER BY started_at, task_id, stage"
+        )
+        return self.query_all(sql, tuple(params))
+
+    def get_task_completion(
+        self, task_id: str, attempt: int
+    ) -> Optional[Any]:
+        """Return the completion summary for a task attempt, or None."""
+        return self.query_one(
+            "SELECT * FROM task_completions WHERE task_id = ? AND attempt = ?",
+            (task_id, attempt),
+        )
+
+    def query_task_flow_stage_aggregates(
+        self,
+        *,
+        project: Optional[str] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+    ) -> list:
+        """Aggregate stage durations over a window for KPI reporting.
+
+        Returns one row per stage with count, average, and total completed
+        duration. Only closed spans (duration_seconds NOT NULL) contribute so a
+        still-open stage does not skew the averages. Optionally scoped to a
+        project and a [since, until) start-time window.
+        """
+        clauses = ["duration_seconds IS NOT NULL"]
+        params: list = []
+        if project is not None:
+            clauses.append("project = ?")
+            params.append(project)
+        if since is not None:
+            clauses.append("started_at >= ?")
+            params.append(since)
+        if until is not None:
+            clauses.append("started_at < ?")
+            params.append(until)
+        sql = (
+            "SELECT stage, "
+            "COUNT(*) AS span_count, "
+            "AVG(duration_seconds) AS avg_duration_seconds, "
+            "SUM(duration_seconds) AS total_duration_seconds "
+            "FROM task_flow_spans WHERE "
+            + " AND ".join(clauses)
+            + " GROUP BY stage ORDER BY stage"
+        )
+        return self.query_all(sql, tuple(params))
+
+    def record_fleet_release_admission_episode(
+        self,
+        *,
+        episode_id: str,
+        barrier_resource_digest: str,
+        owner_kind: str,
+        waiter_kind: str,
+        wait_started_at: str,
+        outcome: str,
+        created_at: str,
+        updated_at: str,
+        project: Optional[str] = None,
+        owner_id: Optional[str] = None,
+        waiter_id: Optional[str] = None,
+        waiting_publishers: int = 0,
+        waiting_epoch_openers: int = 0,
+        queue_depth: int = 0,
+        wait_ended_at: Optional[str] = None,
+        wait_seconds: Optional[float] = None,
+        metadata_json: str = "{}",
+        conn: Optional[Any] = None,
+    ) -> None:
+        """Persist one fair-admission contention episode for the publication barrier.
+
+        Records queue depth (waiting publishers / epoch openers), the wait
+        window, the current barrier owner (publisher vs epoch opener plus its
+        identifier), and the episode outcome. Keyed on ``episode_id`` so an
+        observability layer that refreshes the same episode as it closes calls
+        this with the same id and the row is updated in place rather than
+        appended. Side-effect-free beyond the write.
+        """
+        executor = self._executor(conn, self)
+        executor.execute(
+            """
+            INSERT INTO fleet_release_admission_episodes (
+                id, project, barrier_resource_digest, owner_kind, owner_id,
+                waiter_kind, waiter_id, waiting_publishers,
+                waiting_epoch_openers, queue_depth, wait_started_at,
+                wait_ended_at, wait_seconds, outcome, metadata,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                project                = excluded.project,
+                barrier_resource_digest = excluded.barrier_resource_digest,
+                owner_kind             = excluded.owner_kind,
+                owner_id               = excluded.owner_id,
+                waiter_kind            = excluded.waiter_kind,
+                waiter_id              = excluded.waiter_id,
+                waiting_publishers     = excluded.waiting_publishers,
+                waiting_epoch_openers  = excluded.waiting_epoch_openers,
+                queue_depth            = excluded.queue_depth,
+                wait_started_at        = excluded.wait_started_at,
+                wait_ended_at          = excluded.wait_ended_at,
+                wait_seconds           = excluded.wait_seconds,
+                outcome                = excluded.outcome,
+                metadata               = excluded.metadata,
+                updated_at             = excluded.updated_at
+            """,
+            (
+                episode_id, project, barrier_resource_digest, owner_kind,
+                owner_id, waiter_kind, waiter_id, waiting_publishers,
+                waiting_epoch_openers, queue_depth, wait_started_at,
+                wait_ended_at, wait_seconds, outcome, metadata_json,
+                created_at, updated_at,
+            ),
+        )
+
+    def get_fleet_release_admission_episode(
+        self, episode_id: str
+    ) -> Optional[Any]:
+        """Return a single admission episode by id, or None."""
+        return self.query_one(
+            "SELECT * FROM fleet_release_admission_episodes WHERE id = ?",
+            (episode_id,),
+        )
+
+    def list_fleet_release_admission_episodes(
+        self,
+        *,
+        project: Optional[str] = None,
+        barrier_resource_digest: Optional[str] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        limit: Optional[int] = None,
+    ) -> list:
+        """Return admission episodes, most recent first, optionally narrowed.
+
+        Filters are additive: ``project`` and/or ``barrier_resource_digest``
+        scope the barrier, and ``[since, until)`` bounds the creation time.
+        """
+        clauses: list = []
+        params: list = []
+        if project is not None:
+            clauses.append("project = ?")
+            params.append(project)
+        if barrier_resource_digest is not None:
+            clauses.append("barrier_resource_digest = ?")
+            params.append(barrier_resource_digest)
+        if since is not None:
+            clauses.append("created_at >= ?")
+            params.append(since)
+        if until is not None:
+            clauses.append("created_at < ?")
+            params.append(until)
+        sql = "SELECT * FROM fleet_release_admission_episodes"
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY created_at DESC, id DESC"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(int(limit))
+        return self.query_all(sql, tuple(params))

--- a/src/mac/store_postgres.py
+++ b/src/mac/store_postgres.py
@@ -234,6 +234,9 @@ class _Transaction:
             raise StoreError(str(exc)) from exc
 
 
+from mac.store_helpers import StoreHelpersMixin
+
+
 def _load_packaged_schema() -> str:
     """Read the bundled Postgres schema DDL from `src/mac/data/postgres/`.
 
@@ -249,7 +252,7 @@ def _load_packaged_schema() -> str:
     return SCHEMA_PATH.read_text()
 
 
-class PostgresStore:
+class PostgresStore(StoreHelpersMixin):
     """Postgres backend implementing the `Store` protocol.
 
     Construction opens the connection pool eagerly. The pool size is

--- a/src/mac/test_support.py
+++ b/src/mac/test_support.py
@@ -1,0 +1,120 @@
+"""Ephemeral Postgres control planes for the test suite.
+
+The fleet runs on Postgres. For most of this project's life the test suite ran
+on in-memory SQLite, which meant the engine under test was not the engine in
+production -- and the gap was not theoretical: the NEEDS_INPUT rollout shipped
+a task state that every SQLite test accepted and the live Postgres trigger
+rejected, surfacing as a 500 on a production endpoint. Tests that agree with
+each other but not with production are worse than no tests, because they
+license the deploy.
+
+This module gives each test its own PostgreSQL *schema* inside one shared
+database. A schema is cheap (measured ~0.24s to create and apply the full DDL,
+against ~0.15s for a fresh in-memory SQLite), it isolates completely, and it
+keeps the connection pool warm across tests, which a database-per-test would
+not.
+
+Point the suite at a database with ``MAC_TEST_PG_URL``; ``scripts/start-test-
+postgres.sh`` will start a container or use a local server and print the DSN.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import List, Optional
+
+DEFAULT_TEST_DSN_ENV = "MAC_TEST_PG_URL"
+
+# Schemas created since the last sweep. The pytest fixture in tests/conftest.py
+# drops these after each test; without that they accumulate for the life of the
+# database and a long run leaves thousands behind.
+_CREATED_SCHEMAS: List[str] = []
+
+# Open stores created for those schemas. Each holds a connection pool; dropping
+# the schema without closing the pool leaks connections, and a parallel run
+# exhausts Postgres' max_connections long before the suite finishes.
+_OPEN_STORES: List[object] = []
+
+
+class TestPostgresUnavailable(RuntimeError):
+    """Raised when no test database is configured.
+
+    Deliberately fatal rather than a skip: a silent skip is how a suite ends up
+    green while covering nothing.
+    """
+
+
+def test_dsn() -> str:
+    """Return the DSN for the shared test database, or explain how to get one."""
+    dsn = os.environ.get(DEFAULT_TEST_DSN_ENV, "").strip()
+    if dsn:
+        return dsn
+    raise TestPostgresUnavailable(
+        "%s is unset, so there is no database to run against.\n"
+        "Start one and export the DSN:\n"
+        "    eval \"$(scripts/start-test-postgres.sh)\"\n"
+        "or point at any existing server:\n"
+        "    export %s=postgresql://user@127.0.0.1:5432/mac_test"
+        % (DEFAULT_TEST_DSN_ENV, DEFAULT_TEST_DSN_ENV)
+    )
+
+
+def _scoped_dsn(dsn: str, schema: str) -> str:
+    separator = "&" if "?" in dsn else "?"
+    return "%s%soptions=-csearch_path%%3D%s" % (dsn, separator, schema)
+
+
+def create_schema(dsn: Optional[str] = None) -> tuple[str, str]:
+    """Create a fresh schema and return ``(schema_name, scoped_dsn)``."""
+    import psycopg
+
+    resolved = dsn or test_dsn()
+    schema = "mac_test_" + uuid.uuid4().hex[:12]
+    with psycopg.connect(resolved, autocommit=True) as conn:
+        conn.execute('CREATE SCHEMA "%s"' % schema)
+    _CREATED_SCHEMAS.append(schema)
+    return schema, _scoped_dsn(resolved, schema)
+
+
+def drop_created_schemas(dsn: Optional[str] = None) -> int:
+    """Close pooled connections and drop every schema created since the last
+    sweep. Returns how many schemas were dropped."""
+    stores, _OPEN_STORES[:] = list(_OPEN_STORES), []
+    for store in stores:
+        try:
+            store.close()
+        except Exception:  # noqa: BLE001 - a wedged pool must not block the sweep
+            pass
+    if not _CREATED_SCHEMAS:
+        return 0
+    import psycopg
+
+    resolved = dsn or os.environ.get(DEFAULT_TEST_DSN_ENV, "").strip()
+    pending, _CREATED_SCHEMAS[:] = list(_CREATED_SCHEMAS), []
+    if not resolved:
+        return 0
+    with psycopg.connect(resolved, autocommit=True) as conn:
+        for schema in pending:
+            conn.execute('DROP SCHEMA IF EXISTS "%s" CASCADE' % schema)
+    return len(pending)
+
+
+def ephemeral_store(dsn: Optional[str] = None, *, pool_size: int = 2):
+    """A `PostgresStore` on its own schema, with the full DDL applied."""
+    from mac.store_postgres import PostgresStore
+
+    _, scoped = create_schema(dsn)
+    store = PostgresStore(scoped, pool_size=pool_size, min_size=1)
+    store.initialize()
+    _OPEN_STORES.append(store)
+    return store
+
+
+def ephemeral_control_plane(dsn: Optional[str] = None, **kwargs):
+    """A `ControlPlane` on its own schema -- the test-suite replacement for
+    the old in-memory SQLite control plane."""
+    from mac.services import ControlPlane
+
+    kwargs.setdefault("secret_key", "test-key-with-enough-entropy-32+chars")
+    return ControlPlane(ephemeral_store(dsn), **kwargs)

--- a/tests/api/test_diagnostics_api.py
+++ b/tests/api/test_diagnostics_api.py
@@ -31,7 +31,9 @@ def test_diagnostics_route_serves_report_from_hub_authority():
     assert "lifecycle-stage-dwell" in report["checks"]
     assert "data-source-identity" in report["checks"]
     # The report self-identifies the authoritative backend it ran against.
-    assert report["data_source"]["backend"] == "sqlite"
+    # Which engine that is depends on how the suite is configured; what must
+    # hold is that the report names the one it actually used.
+    assert report["data_source"]["backend"] in {"sqlite", "postgres"}
     assert report["data_source"]["authoritative"] is True
 
 
@@ -42,7 +44,7 @@ def test_diagnostics_route_supports_check_subset():
     report = resp.json()
     assert {f["check"] for f in report["findings"]} == {"failed-tasks"}
     # Even a subset request keeps the machine-readable data_source identity.
-    assert report["data_source"]["backend"] == "sqlite"
+    assert report["data_source"]["backend"] in {"sqlite", "postgres"}
 
 
 def test_remote_dispatch_diagnostics_hits_hub_and_never_touches_local_store():
@@ -64,7 +66,7 @@ def test_remote_dispatch_diagnostics_hits_hub_and_never_touches_local_store():
 
     report = dispatch.diagnostics_report()
     assert report["schema"] == "mac.diagnostics.report.v1"
-    assert report["data_source"]["backend"] == "sqlite"
+    assert report["data_source"]["backend"] in {"sqlite", "postgres"}
     # The client augments the identity with the hub URL it actually talked to.
     assert report["data_source"]["hub_url"] == "http://hub.example:8789"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,25 @@ def _no_ticket_mirror(monkeypatch):
 # ----------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _drop_ephemeral_schemas() -> Iterator[None]:
+    """Drop the per-test Postgres schemas created during this test.
+
+    ControlPlane.in_memory() creates a schema per call. Without this sweep they
+    survive for the life of the database and a full run leaves thousands of
+    them behind, which makes the next run slower and the database unreadable.
+    """
+    from mac import test_support
+
+    try:
+        yield
+    finally:
+        try:
+            test_support.drop_created_schemas()
+        except Exception:  # noqa: BLE001 - teardown must not mask a test failure
+            pass
+
+
 @pytest.fixture(scope="session")
 def pg_dsn() -> str:
     dsn = os.environ.get("MAC_TEST_PG_URL", "").strip()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,24 @@ def _no_ticket_mirror(monkeypatch):
 # ----------------------------------------------------------------------
 
 
+def pytest_configure(config) -> None:
+    """Refuse to run without Postgres.
+
+    ControlPlane.in_memory() falls back to SQLite so build-time tooling works
+    without a database. The suite must never take that path: SQLite accepted a
+    task state the live Postgres trigger rejected, and agreed with a
+    register_artifact that returned the row it had just replaced. A suite that
+    silently covers the wrong engine is worse than one that will not start.
+    """
+    from mac.test_support import DEFAULT_TEST_DSN_ENV, test_dsn
+
+    if not os.environ.get(DEFAULT_TEST_DSN_ENV, "").strip():
+        try:
+            test_dsn()
+        except Exception as exc:  # noqa: BLE001 - message is the whole point
+            raise pytest.UsageError(str(exc)) from exc
+
+
 @pytest.fixture(autouse=True)
 def _drop_ephemeral_schemas() -> Iterator[None]:
     """Drop the per-test Postgres schemas created during this test.

--- a/tests/test_agents_list_index.py
+++ b/tests/test_agents_list_index.py
@@ -11,12 +11,23 @@ from __future__ import annotations
 from mac.services import ControlPlane
 
 
+def _backend(cp) -> str:
+    return str(cp.store.backend_identity().get("backend") or "").lower()
+
+
 def test_list_agents_query_uses_partial_live_index():
     cp = ControlPlane.in_memory()
-    plan = cp.store.query_all(
-        "EXPLAIN QUERY PLAN "
-        "SELECT * FROM agents WHERE deleted_at IS NULL ORDER BY name, id"
-    )
+    query = "SELECT * FROM agents WHERE deleted_at IS NULL ORDER BY name, id"
+    if _backend(cp) == "postgres":
+        plan = " ".join(
+            str(dict(row).get("QUERY PLAN", ""))
+            for row in cp.store.query_all("EXPLAIN " + query)
+        )
+        assert "idx_agents_live_name" in plan, plan
+        # A Sort node means the index is not supplying the ordering.
+        assert "Sort" not in plan, plan
+        return
+    plan = cp.store.query_all("EXPLAIN QUERY PLAN " + query)
     details = " ".join(str(dict(r).get("detail", "")) for r in plan)
     # index-only scan, and crucially NO 'USE TEMP B-TREE' (i.e. no filesort)
     assert "idx_agents_live_name" in details, details
@@ -26,6 +37,13 @@ def test_list_agents_query_uses_partial_live_index():
 
 def test_partial_index_exists_and_is_predicate_scoped():
     cp = ControlPlane.in_memory()
+    if _backend(cp) == "postgres":
+        row = cp.store.query_one(
+            "SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_agents_live_name'"
+        )
+        assert row is not None, "partial index missing on postgres"
+        assert "deleted_at IS NULL" in row["indexdef"]
+        return
     row = cp.store.query_one(
         "SELECT sql FROM sqlite_master WHERE type='index' AND name='idx_agents_live_name'"
     )

--- a/tests/test_agents_list_index.py
+++ b/tests/test_agents_list_index.py
@@ -38,8 +38,13 @@ def test_list_agents_query_uses_partial_live_index():
 def test_partial_index_exists_and_is_predicate_scoped():
     cp = ControlPlane.in_memory()
     if _backend(cp) == "postgres":
+        # Scoped to this test's own schema: pg_indexes spans every schema in
+        # the database, and a parallel worker dropping its schema mid-query
+        # makes an unscoped lookup flaky.
         row = cp.store.query_one(
-            "SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_agents_live_name'"
+            "SELECT indexdef FROM pg_indexes "
+            "WHERE indexname = 'idx_agents_live_name' "
+            "AND schemaname = current_schema()"
         )
         assert row is not None, "partial index missing on postgres"
         assert "deleted_at IS NULL" in row["indexdef"]

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -49,6 +49,7 @@ from mac.models import (
 )
 from mac.migration import migrate_acc_sqlite
 from mac.services import ControlPlane
+from mac.store import StoreError
 from mac.models import ensure_json_object
 from mac.store import SQLiteStore
 from mac.work_package_service import RepositoryBaseAttestation
@@ -9700,7 +9701,7 @@ def test_tasks_state_trigger_rejects_unknown_state(cp):
 
     register_agent(cp, "w", ["python"])
     task = cp.create_task("t", required_capabilities=["python"])
-    with pytest.raises(sqlite3.IntegrityError):
+    with pytest.raises(StoreError):
         cp.store.execute(
             "UPDATE tasks SET state = ? WHERE id = ?",
             ("not-a-real-state", task.id),
@@ -10433,8 +10434,10 @@ def test_workflow_tick_uses_indexed_deadline_not_definition_scan(cp, monkeypatch
     assert "next_action_at <= ?" in queries[0]
     assert "definition_snapshot LIKE" not in queries[0]
     indexes = {
-        row["name"]
-        for row in cp.store.query_all("PRAGMA index_list(workflow_runs)")
+        row["indexname"]
+        for row in cp.store.query_all(
+            "SELECT indexname FROM pg_indexes WHERE tablename = 'workflow_runs'"
+        )
     }
     assert "idx_workflow_runs_next_action" in indexes
 
@@ -12046,7 +12049,7 @@ def test_unique_active_lease_per_task_enforced_at_db_layer(cp):
     task = cp.create_task("t", required_capabilities=["python"])
     cp.claim_task(task.id, worker_a.id)
 
-    with pytest.raises(sqlite3.IntegrityError):
+    with pytest.raises(StoreError):
         cp.store.execute(
             "INSERT INTO leases (id, task_id, agent_id, expires_at, status, created_at, updated_at) "
             "VALUES (?, ?, ?, ?, 'active', ?, ?)",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -294,17 +294,33 @@ def test_stranded_replacements_check_ok_when_chain_ends_completed():
     assert findings[0].detail["count"] == 0
 
 
-def test_data_source_identity_reports_sqlite_backend():
+def test_data_source_identity_reports_the_backend_it_ran_against():
+    """The point of the check is self-identification, not a fixed engine name."""
     cp = ControlPlane.in_memory()
     findings = diagnostics.run_diagnostics(cp, names=["data-source-identity"])
     assert findings and len(findings) == 1
     finding = findings[0]
     assert finding.check == "data-source-identity"
-    # An in-memory authority is ephemeral, so the check warns rather than ok.
-    assert finding.severity == "warn"
-    assert finding.detail["backend"] == "sqlite"
-    assert finding.detail["in_memory"] is True
+    assert finding.detail["backend"] == cp.store.backend_identity()["backend"]
     assert finding.detail["authoritative"] is True
+
+
+def test_data_source_identity_warns_for_an_ephemeral_authority():
+    """An in-memory authority is ephemeral, so the check warns rather than ok."""
+    from mac.store import SQLiteStore
+
+    store = SQLiteStore(":memory:")
+    try:
+        cp = ControlPlane(
+            store=store, secret_key="diagnostics-test-secret-key-32-characters"
+        )
+        findings = diagnostics.run_diagnostics(cp, names=["data-source-identity"])
+        assert findings and len(findings) == 1
+        assert findings[0].severity == "warn"
+        assert findings[0].detail["in_memory"] is True
+        assert findings[0].detail["authoritative"] is True
+    finally:
+        store.close()
 
 
 def test_data_source_identity_ok_for_durable_sqlite_file(tmp_path):
@@ -340,12 +356,12 @@ def test_diagnostics_report_always_includes_data_source():
 
     full = cp.diagnostics_report()
     assert full["schema"] == "mac.diagnostics.report.v1"
-    assert full["data_source"]["backend"] == "sqlite"
+    assert full["data_source"]["backend"] == cp.store.backend_identity()["backend"]
 
     # Even a narrowed selection that omits the identity check still carries the
     # top-level machine-readable data_source block.
     subset = cp.diagnostics_report(names=["failed-tasks"])
-    assert subset["data_source"]["backend"] == "sqlite"
+    assert subset["data_source"]["backend"] == cp.store.backend_identity()["backend"]
     assert {f["check"] for f in subset["findings"]} == {"failed-tasks"}
 
 

--- a/tests/test_dispatch_service_v2.py
+++ b/tests/test_dispatch_service_v2.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 from mac.models import TaskState
 from mac.services import ControlPlane
 from mac.work_package_assignment import WorkPackageTaskRank
@@ -73,18 +75,44 @@ def test_idle_pull_is_write_free_and_does_not_claim_reconciliation_leases():
     cp = ControlPlane.in_memory()
     active_project(cp)
     idle_worker = worker(cp, "idle")
-    statements = []
-    cp.store._conn.set_trace_callback(statements.append)
+    # Recorded at the store API rather than through sqlite3's trace callback,
+    # which only exists on one backend. Both `store.execute` and the connection
+    # handed out by `store.transaction` are wrapped, since a write can go
+    # through either.
+    statements: list[str] = []
+    real_execute = cp.store.execute
+    real_transaction = cp.store.transaction
+
+    def recording_execute(sql, params=(), *args, **kwargs):
+        statements.append(str(sql))
+        return real_execute(sql, params, *args, **kwargs)
+
+    @contextmanager
+    def recording_transaction(*args, **kwargs):
+        with real_transaction(*args, **kwargs) as conn:
+            real_conn_execute = conn.execute
+
+            def conn_execute(sql, params=(), *inner, **inner_kwargs):
+                statements.append(str(sql))
+                return real_conn_execute(sql, params, *inner, **inner_kwargs)
+
+            conn.execute = conn_execute  # type: ignore[method-assign]
+            statements.append("BEGIN")
+            yield conn
+
+    cp.store.execute = recording_execute  # type: ignore[method-assign]
+    cp.store.transaction = recording_transaction  # type: ignore[method-assign]
     try:
         assert cp.claim_next_for_agent(idle_worker.id) is None
     finally:
-        cp.store._conn.set_trace_callback(None)
+        cp.store.execute = real_execute  # type: ignore[method-assign]
+        cp.store.transaction = real_transaction  # type: ignore[method-assign]
 
     writes = [
         statement
         for statement in statements
         if statement.lstrip().upper().startswith(
-            ("BEGIN IMMEDIATE", "INSERT", "UPDATE", "DELETE", "REPLACE")
+            ("BEGIN", "INSERT", "UPDATE", "DELETE", "REPLACE")
         )
     ]
     assert writes == []

--- a/tests/test_landing_service.py
+++ b/tests/test_landing_service.py
@@ -22,7 +22,7 @@ from mac.landing_service import (
     SubprocessGitRunner,
     compute_landing_input_digest,
 )
-from mac.store import SQLiteStore
+from mac.store import SQLiteStore, StoreError
 from mac.models import ValidationError, json_dumps, json_loads
 
 
@@ -1116,23 +1116,23 @@ def test_append_only_landing_records_reject_mutation_and_deletion(tmp_path: Path
             "work_package_landing_attempts",
             "work_package_landing_receipts",
         ):
-            with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+            with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
                 store.execute("UPDATE %s SET id = id" % table)
-            with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            with pytest.raises((StoreError, sqlite3.IntegrityError), match="append-only"):
                 store.execute("DELETE FROM %s" % table)
 
         stream = store.query_one("SELECT * FROM work_package_landing_streams")
-        with pytest.raises(sqlite3.IntegrityError, match="monotonic fence"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="monotonic fence"):
             store.execute(
                 "UPDATE work_package_landing_streams SET lease_fence = ? "
                 "WHERE repository_id = ? AND target_ref = ?",
                 (int(stream["lease_fence"]) - 1, "repo_1", TARGET_REF),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="append-only"):
             store.execute("DELETE FROM work_package_landing_streams")
 
         intent = store.query_one("SELECT * FROM work_package_landing_intents")
-        with pytest.raises(sqlite3.IntegrityError, match="current stream fence"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="current stream fence"):
             store.execute(
                 "INSERT INTO work_package_landing_attempts ("
                 "id, intent_id, attempt_number, repository_id, target_ref, "

--- a/tests/test_persona_instance_migration.py
+++ b/tests/test_persona_instance_migration.py
@@ -236,13 +236,13 @@ def test_migration_records_immutable_receipt(tmp_path):
         assert "hermes_instances->persona_instances" in receipt["detail"]
         assert receipt["applied_at"]
 
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             conn.execute(
                 "UPDATE schema_migration_receipts SET component = 'x' "
                 "WHERE version = ?",
                 (PERSONA_MIGRATION_VERSION,),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             conn.execute(
                 "DELETE FROM schema_migration_receipts WHERE version = ?",
                 (PERSONA_MIGRATION_VERSION,),

--- a/tests/test_pg_backup_live.py
+++ b/tests/test_pg_backup_live.py
@@ -32,8 +32,41 @@ def _pg_url():
     return url
 
 
-def test_dump_and_restore_drill_round_trips(tmp_path):
+@pytest.fixture()
+def drill_database():
+    """A database this drill owns outright.
+
+    pg_dump dumps a whole database, and the shared test database now has
+    per-test schemas being created and dropped by parallel workers. Dumping it
+    races them: pg_dump resolves the schema list up front, then fails when one
+    disappears underneath it ("schema ... does not exist"). Owning a database
+    removes the race instead of papering over it with a retry.
+    """
+    import subprocess
+    import uuid
+
     url = _pg_url()
+    name = "mac_backup_drill_" + uuid.uuid4().hex[:12]
+    admin = urlsplit(url)._replace(path="/postgres").geturl()
+
+    def run(dsn, sql):
+        return subprocess.run(
+            ["psql", "--no-psqlrc", "--tuples-only", "--no-align",
+             "--command", sql, dsn],
+            capture_output=True, text=True,
+        )
+
+    created = run(admin, 'CREATE DATABASE "%s"' % name)
+    if created.returncode != 0:
+        pytest.skip("could not create drill database: %s" % created.stderr.strip()[:200])
+    try:
+        yield urlsplit(url)._replace(path="/" + name).geturl()
+    finally:
+        run(admin, 'DROP DATABASE IF EXISTS "%s"' % name)
+
+
+def test_dump_and_restore_drill_round_trips(tmp_path, drill_database):
+    url = drill_database
     # Seed a representative table on the live authority.
     import subprocess
 

--- a/tests/test_postgres_live.py
+++ b/tests/test_postgres_live.py
@@ -746,7 +746,7 @@ def test_postgres_execution_cohort_backfill_marker_and_route_contract(
             "2026-07-17T00:00:00Z",
         ),
     )
-    with pytest.raises(StoreError, match="append-only"):
+    with pytest.raises(StoreError, match="immutable"):
         postgres_store.execute(
             "UPDATE execution_cohort_assignments SET reason = ? WHERE id = ?",
             ("changed", "cohort-unknown-managed-mode"),
@@ -822,7 +822,7 @@ def test_postgres_repairs_preliminary_package_after_v2_marker(
         "SELECT 1 FROM telemetry_data_migrations WHERE version = ?",
         ("execution_cohort_preliminary_package_repair_v3",),
     )
-    with pytest.raises(StoreError, match="append-only"):
+    with pytest.raises(StoreError, match="immutable"):
         postgres_store.execute(
             "UPDATE execution_cohort_assignments SET reason = ? WHERE package_id = ?",
             ("changed", package_id),

--- a/tests/test_provenance_seams.py
+++ b/tests/test_provenance_seams.py
@@ -179,5 +179,8 @@ def test_vector_ref_unique_on_point_per_collection(cp):
     # constraint. The contract: vector indexers must update their own point,
     # not re-register it under mac.
     import sqlite3
-    with pytest.raises(sqlite3.IntegrityError):
+
+    from mac.store import StoreError
+
+    with pytest.raises((StoreError, sqlite3.IntegrityError)):
         cp.record_vector_ref(memory.id, "qdrant", "c", "p1")

--- a/tests/test_source_convergence_service.py
+++ b/tests/test_source_convergence_service.py
@@ -171,12 +171,17 @@ def test_control_plane_tick_places_source_hold_before_dispatch(monkeypatch):
 
 def test_controller_schema_exists_in_sqlite_and_postgres():
     cp = ControlPlane.in_memory()
-    tables = {
-        row["name"]
-        for row in cp.store.query_all(
+    backend = str(cp.store.backend_identity().get("backend") or "").lower()
+    if backend == "postgres":
+        rows = cp.store.query_all(
+            "SELECT table_name AS name FROM information_schema.tables "
+            "WHERE table_schema = current_schema()"
+        )
+    else:
+        rows = cp.store.query_all(
             "SELECT name FROM sqlite_master WHERE type = 'table'"
         )
-    }
+    tables = {row["name"] for row in rows}
     assert "source_convergence_nodes" in tables
     assert "source_convergence_controller_leases" in tables
     schema = Path("src/mac/data/postgres/schema.sql").read_text(encoding="utf-8")

--- a/tests/test_source_release_store.py
+++ b/tests/test_source_release_store.py
@@ -29,7 +29,7 @@ from mac.models import (
     new_id,
     utcnow,
 )
-from mac.store import SQLiteStore
+from mac.store import SQLiteStore, StoreError
 
 
 # ---------------------------------------------------------------------------
@@ -437,7 +437,7 @@ class TestSQLiteConstraints:
 
     def test_duplicate_repo_sha_rejected(self, db: SQLiteStore) -> None:
         self._insert_release(db, GOOD_SHA)
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             # Same repository_id + commit_sha
             rel2 = _good_release()  # same defaults including repository_id
             _store_release(db, rel2)
@@ -445,14 +445,14 @@ class TestSQLiteConstraints:
     def test_sha_immutability_trigger(self, db: SQLiteStore) -> None:
         rel_id = self._insert_release(db)
         new_sha = "b" * 40
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             db.execute(
                 "UPDATE source_releases SET commit_sha = ? WHERE id = ?",
                 (new_sha, rel_id),
             )
 
     def test_branch_ref_check_constraint(self, db: SQLiteStore) -> None:
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             db.execute(
                 """
                 INSERT INTO source_releases
@@ -474,7 +474,7 @@ class TestSQLiteConstraints:
         rel_id = self._insert_release(db)
         dss = _good_desired_state(release_id=rel_id)
         _store_desired(db, dss)
-        with pytest.raises(sqlite3.IntegrityError, match="monotonically"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="monotonically"):
             db.execute(
                 "UPDATE fleet_desired_source_states SET generation = 1 WHERE id = ?",
                 (dss.id,),
@@ -503,7 +503,7 @@ class TestSQLiteConstraints:
             fleet_id="fleet_x",
             id=new_id("dss"),
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             _store_desired(db, dss2)
 
     def test_idempotency_unique_constraint(self, db: SQLiteStore) -> None:
@@ -518,7 +518,7 @@ class TestSQLiteConstraints:
             """,
             (new_id("idem"), "fleet:fleet_abc", "req_001", dss.id, 1, utcnow()),
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             db.execute(
                 """
                 INSERT INTO fleet_desired_source_idempotency

--- a/tests/test_store_protocol.py
+++ b/tests/test_store_protocol.py
@@ -279,3 +279,80 @@ def test_pipeline_cursor_rejects_oversized_value() -> None:
             store.set_pipeline_cursor("scope", "name", oversized)
     finally:
         store.close()
+
+
+def test_shared_store_helpers_use_sql_both_backends_accept():
+    """Shared helpers must not reacquire SQLite-only SQL.
+
+    store_helpers.py is compiled against both backends, so a SQLite-ism there
+    is not a dialect nit -- it is a runtime error on the engine the fleet runs.
+    `INSERT OR IGNORE` shipped this way and made every human-with-groups write
+    fail on Postgres.
+    """
+    import ast
+    import re
+    from pathlib import Path
+
+    source = (
+        Path(__file__).resolve().parents[1] / "src" / "mac" / "store_helpers.py"
+    ).read_text()
+    # Only SQL string literals. Prose about a SQLite-ism is not a SQLite-ism,
+    # and docstrings legitimately say things like "insert or replace a row".
+    tree = ast.parse(source)
+    docstrings = {
+        id(node.body[0].value)
+        for node in ast.walk(tree)
+        if isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        )
+        and node.body
+        and isinstance(node.body[0], ast.Expr)
+        and isinstance(node.body[0].value, ast.Constant)
+        and isinstance(node.body[0].value.value, str)
+    }
+    statements = [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstrings
+        and re.search(r"\b(SELECT|INSERT|UPDATE|DELETE)\b", node.value, re.I)
+    ]
+    assert statements, "found no SQL to check -- the scan is broken, not clean"
+    sqlite_only = {
+        "INSERT OR IGNORE/REPLACE": r"INSERT\s+OR\s+(IGNORE|REPLACE)",
+        "PRAGMA": r"\bPRAGMA\b",
+        "sqlite_master": r"\bsqlite_master\b",
+        "INDEXED BY": r"\bINDEXED\s+BY\b",
+        "AUTOINCREMENT": r"\bAUTOINCREMENT\b",
+    }
+    found = sorted(
+        {
+            label
+            for label, pattern in sqlite_only.items()
+            for statement in statements
+            if re.search(pattern, statement, re.I)
+        }
+    )
+    assert not found, "SQLite-only SQL in shared store helpers: %s" % found
+
+
+def test_both_backends_expose_the_same_store_surface():
+    """The two backends must not drift apart again.
+
+    Sixteen helpers lived on SQLiteStore alone while the protocol declared
+    only the seven primitives, so isinstance(store, Store) passed and
+    `GET /humans` returned 500 in production.
+    """
+    from mac.store import SQLiteStore
+    from mac.store_postgres import PostgresStore
+
+    def surface(cls):
+        return {
+            name
+            for name in dir(cls)
+            if not name.startswith("_") and callable(getattr(cls, name, None))
+        }
+
+    missing = surface(SQLiteStore) - surface(PostgresStore)
+    assert not missing, "PostgresStore is missing: %s" % sorted(missing)

--- a/tests/test_work_package_certification_service.py
+++ b/tests/test_work_package_certification_service.py
@@ -16,7 +16,7 @@ from mac.openshell_certifier import (
     CertificationCheckResult,
     OpenShellCertificationResult,
 )
-from mac.store import SQLiteStore
+from mac.store import SQLiteStore, StoreError
 from mac.work_package_certification_service import (
     CERTIFICATION_CONTRACT_SCHEMA,
     CertificationJobBusyError,
@@ -1082,26 +1082,26 @@ def test_sqlite_job_schema_rejects_incoherent_lifecycle_and_mutation(
     try:
         service = _service(store)
         public, _job = _prepared_job(service, bundle)
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "UPDATE work_package_certification_jobs SET state = 'running' "
                 "WHERE id = ?",
                 (public["id"],),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "UPDATE work_package_certification_jobs SET candidate_sha = ? "
                 "WHERE id = ?",
                 ("e" * 40, public["id"]),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "UPDATE work_package_certification_jobs SET state = 'running', "
                 "lease_owner = 'owner', lease_expires_at = ?, lease_fence = 2 "
                 "WHERE id = ?",
                 ((NOW + timedelta(hours=1)).isoformat(), public["id"]),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "DELETE FROM work_package_certification_jobs WHERE id = ?",
                 (public["id"],),

--- a/tests/test_work_package_publication_finalizer.py
+++ b/tests/test_work_package_publication_finalizer.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from mac.models import TransitionError, json_dumps
-from mac.store import SQLiteStore
+from mac.store import SQLiteStore, StoreError
 from mac.work_package_publication_finalizer import (
     PublicationReceiptError,
     StalePublicationError,
@@ -898,18 +898,18 @@ def test_append_only_receipts_and_projection_tamper_are_detected() -> None:
         result = _service(store).finalize_landed_batch(
             "batch_final", actor="pipeline"
         )
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "UPDATE work_package_publication_finalizations SET finalized_by = 'x' "
                 "WHERE id = ?",
                 (result.finalization_id,),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="append-only"):
             store.execute(
                 "DELETE FROM work_package_publication_finalizations WHERE id = ?",
                 (result.finalization_id,),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "UPDATE work_package_landing_receipts SET recorded_by = 'x' "
                 "WHERE id = 'landing_final'"

--- a/tests/test_work_package_schema.py
+++ b/tests/test_work_package_schema.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from mac.models import ValidationError, WorkPackageEpoch
-from mac.store import SQLiteStore
+from mac.store import SQLiteStore, StoreError
 from mac.work_package_store import (
     get_work_package_task_link,
     guard_generic_task_mutation,
@@ -416,7 +416,7 @@ def test_ref_retirement_intent_is_append_only_and_failed_attempt_is_retryable() 
         assert store.query_one(
             "SELECT COUNT(*) AS n FROM work_package_ref_retirement_receipts"
         )["n"] == 0
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "UPDATE work_package_ref_retirement_intents SET expected_sha = ? "
                 "WHERE id = ?",
@@ -427,7 +427,7 @@ def test_ref_retirement_intent_is_append_only_and_failed_attempt_is_retryable() 
             "id, intent_id, outcome, completed_at) VALUES (?, ?, ?, ?)",
             ("receipt_1", "intent_1", "missing", "later"),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="append-only"):
             store.execute(
                 "DELETE FROM work_package_ref_retirement_receipts WHERE id = ?",
                 ("receipt_1",),
@@ -440,14 +440,14 @@ def test_ref_retirement_intent_is_append_only_and_failed_attempt_is_retryable() 
 def test_package_state_and_single_active_epoch_are_database_invariants() -> None:
     store = SQLiteStore(":memory:")
     try:
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_packages ("
                 "id, goal, state, metadata, created_by, created_at, updated_at"
                 ") VALUES (?, ?, ?, ?, ?, ?, ?)",
                 ("wp_bad", "bad", "running-ish", "{}", "human", "now", "now"),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_packages ("
                 "id, goal, state, metadata, created_by, created_at, updated_at"
@@ -465,7 +465,7 @@ def test_package_state_and_single_active_epoch_are_database_invariants() -> None
             )
         )
         assert epoch_model.planning_base_sha == "a" * 40
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_package_epochs ("
                 "package_id, epoch, plan_version, planning_base_ref, planning_base_sha, status, reason, "
@@ -483,20 +483,20 @@ def test_package_state_and_single_active_epoch_are_database_invariants() -> None
                     "now",
                 ),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="deactivate"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="deactivate"):
             store.execute(
                 "UPDATE work_package_epochs SET status = ? "
                 "WHERE package_id = ? AND epoch = ?",
                 ("superseded", "wp_1", 1),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="state transition"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="state transition"):
             store.execute(
                 "UPDATE work_packages SET state = ? WHERE id = ?", ("draft", "wp_1")
             )
         store.execute(
             "UPDATE work_packages SET state = ? WHERE id = ?", ("completed", "wp_1")
         )
-        with pytest.raises(sqlite3.IntegrityError, match="state transition"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="state transition"):
             store.execute(
                 "UPDATE work_packages SET state = ? WHERE id = ?", ("active", "wp_1")
             )
@@ -515,7 +515,7 @@ def test_plan_versions_form_an_immutable_parent_chain() -> None:
             ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             ("wp_1", 2, 1, "{}", "sha256:two", "replan", "human", "now"),
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_package_plan_versions ("
                 "package_id, version, parent_version, definition, plan_digest, reason, "
@@ -523,7 +523,7 @@ def test_plan_versions_form_an_immutable_parent_chain() -> None:
                 ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                 ("wp_1", 3, 2, "{}", "sha256:one", "duplicate", "human", "now"),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "UPDATE work_package_plan_versions SET parent_version = 2 "
                 "WHERE package_id = ? AND version = 1",
@@ -575,7 +575,7 @@ def test_epoch_swap_is_atomic_and_failed_swap_rolls_back() -> None:
             )
         } == {1: "superseded", 2: "active"}
 
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             swap_work_package_epoch(
                 store,
                 package_id="wp_1",
@@ -637,14 +637,14 @@ def test_history_epoch_and_plan_version_must_identify_the_same_snapshot() -> Non
                 "now",
             ),
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_package_history ("
                 "id, package_id, seq, event_type, actor, plan_version, epoch, detail, "
                 "created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 ("history_bad", "wp_1", 1, "bad", "human", 2, 1, "{}", "now"),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_package_history ("
                 "id, package_id, seq, event_type, actor, plan_version, epoch, detail, "
@@ -733,20 +733,20 @@ def test_certification_is_bound_to_exact_batch_candidate() -> None:
             "agent_test",
             "now",
         )
-        with pytest.raises(sqlite3.IntegrityError, match="verifying batch"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="verifying batch"):
             store.execute(cert_sql, cert_params)
         store.execute(
             "UPDATE work_package_integration_batches SET state = ? WHERE id = ?",
             ("verifying", "batch_1"),
         )
         store.execute(cert_sql, cert_params)
-        with pytest.raises(sqlite3.IntegrityError, match="identity"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="identity"):
             store.execute(
                 "UPDATE work_package_certifications SET verification_digest = ? "
                 "WHERE id = ?",
                 ("sha256:forged", "cert_1"),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_package_certifications ("
                 "id, batch_id, package_id, plan_version, epoch, candidate_sha, "
@@ -791,18 +791,18 @@ def test_generic_mutation_guard_and_task_link_identity_are_fail_closed() -> None
         with pytest.raises(ValidationError, match="package-aware transaction"):
             guard_generic_task_mutation(store, "task_node", "update_task")
         guard_generic_task_mutation(store, "ordinary_task", "update_task")
-        with pytest.raises(sqlite3.IntegrityError, match="identity is immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="identity is immutable"):
             store.execute(
                 "UPDATE work_package_task_links SET input_digest = ? WHERE task_id = ?",
                 ("sha256:changed", "task_node"),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "UPDATE work_package_assignment_audit SET attempt_ref = ? "
                 "WHERE lease_id = ?",
                 ("refs/mac/forged", "lease_1"),
             )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             _insert_link_and_assignment(
                 store,
                 task_id="task_bad_digest",
@@ -855,7 +855,7 @@ def test_wip_token_survives_execution_lease_expiry() -> None:
             )["state"]
             == "held"
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_package_wip_tokens ("
                 "id, package_id, plan_version, epoch, node_key, task_id, resource_key, "
@@ -884,12 +884,12 @@ def test_wip_token_survives_execution_lease_expiry() -> None:
             "release_reason = ? WHERE id = ?",
             ("released", "now", "candidate buffered", "wip_1"),
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "UPDATE work_package_wip_tokens SET state = ? WHERE id = ?",
                 ("held", "wip_1"),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="metadata"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="metadata"):
             store.execute(
                 "UPDATE work_package_wip_tokens SET release_reason = ? WHERE id = ?",
                 ("rewritten", "wip_1"),
@@ -998,12 +998,12 @@ def test_expired_package_task_requeue_requires_receipt_and_retains_exact_wip() -
     store = SQLiteStore(":memory:")
     try:
         decision = _prepare_expired_package_execution(store, target_state="open")
-        with pytest.raises(sqlite3.IntegrityError, match="repair receipt"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="repair receipt"):
             store.execute(
                 "UPDATE tasks SET state = 'open', owner_agent_id = NULL, "
                 "lease_id = NULL, leased_until = NULL WHERE id = 'task_node'"
             )
-        with pytest.raises(sqlite3.IntegrityError, match="exact lease-expiry repair"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="exact lease-expiry repair"):
             store.execute(
                 "UPDATE work_package_task_links SET node_state = 'ready' "
                 "WHERE task_id = 'task_node'"
@@ -1014,7 +1014,7 @@ def test_expired_package_task_requeue_requires_receipt_and_retains_exact_wip() -
             decision=decision,
             target_task_state="open",
         )
-        with pytest.raises(sqlite3.IntegrityError, match="exact lease-expiry repair"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="exact lease-expiry repair"):
             store.execute(
                 "UPDATE work_package_task_links SET node_state = 'ready' "
                 "WHERE task_id = 'task_node'"
@@ -1030,7 +1030,7 @@ def test_expired_package_task_requeue_requires_receipt_and_retains_exact_wip() -
         assert store.query_one(
             "SELECT state FROM work_package_wip_tokens WHERE id = 'wip_1'"
         )["state"] == "held"
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "UPDATE work_package_lease_expiry_repairs SET reason = 'forged' "
                 "WHERE id = 'repair_lease_1'"
@@ -1052,7 +1052,7 @@ def test_terminal_expiry_repair_cancels_wip_before_node() -> None:
             "UPDATE tasks SET state = 'failed', owner_agent_id = NULL, lease_id = NULL, "
             "leased_until = NULL WHERE id = 'task_node'"
         )
-        with pytest.raises(sqlite3.IntegrityError, match="cancel exact held WIP"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="cancel exact held WIP"):
             store.execute(
                 "UPDATE work_package_task_links SET node_state = 'cancelled' "
                 "WHERE task_id = 'task_node'"
@@ -1086,7 +1086,7 @@ def test_batch_input_is_bound_to_exact_assignment_and_evidence_attempt() -> None
         _insert_package(store)
         _insert_link_and_assignment(store)
         _insert_evidence(store, "ev_attempt", "task_node")
-        with pytest.raises(sqlite3.IntegrityError, match="does not match"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="does not match"):
             _insert_attempt_link(
                 store,
                 evidence_id="ev_attempt",
@@ -1100,18 +1100,18 @@ def test_batch_input_is_bound_to_exact_assignment_and_evidence_attempt() -> None
             task_id="task_node",
             lease_id="lease_1",
         )
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "UPDATE evidence_attempt_links SET attempt_ref = ? WHERE evidence_id = ?",
                 ("refs/mac/other", "ev_attempt"),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "UPDATE evidence_attempt_verifications SET verifier = ? "
                 "WHERE evidence_id = ?",
                 ("forged", "ev_attempt"),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="append-only"):
             store.execute(
                 "DELETE FROM evidence_attempt_verifications WHERE evidence_id = ?",
                 ("ev_attempt",),
@@ -1189,7 +1189,7 @@ def test_batch_input_is_bound_to_exact_assignment_and_evidence_attempt() -> None
             "ev_attempt",
             "now",
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(batch_input_sql, batch_input_params)
         store.execute(
             "UPDATE work_package_node_candidates SET status = ?, accepted_at = ?, "
@@ -1236,17 +1236,17 @@ def test_batch_input_is_bound_to_exact_assignment_and_evidence_attempt() -> None
             "UPDATE work_package_integration_batches SET state = ? WHERE id = ?",
             ("assembling", "batch_inputs"),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="state transition"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="state transition"):
             store.execute(
                 "UPDATE work_package_integration_batches SET state = ? WHERE id = ?",
                 ("queued", "batch_inputs"),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "UPDATE work_package_batch_inputs SET ordinal = 2 WHERE id = ?",
                 ("input_1",),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             store.execute(
                 "DELETE FROM work_package_batch_inputs WHERE id = ?", ("input_1",)
             )
@@ -1287,12 +1287,12 @@ def test_integration_batch_fence_is_monotonic() -> None:
             "UPDATE work_package_integration_batches SET state = ? WHERE id = ?",
             ("assembling", "batch_fence"),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="identity"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="identity"):
             store.execute(
                 "UPDATE work_package_integration_batches SET target_ref = ? WHERE id = ?",
                 ("refs/heads/other", "batch_fence"),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="fence cannot decrease"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="fence cannot decrease"):
             store.execute(
                 "UPDATE work_package_integration_batches SET lease_fence = 3 WHERE id = ?",
                 ("batch_fence",),
@@ -1309,7 +1309,7 @@ def test_integration_batch_fence_is_monotonic() -> None:
             )["lease_fence"]
             == 4
         )
-        with pytest.raises(sqlite3.IntegrityError, match="new fence"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="new fence"):
             store.execute(
                 "UPDATE work_package_integration_batches "
                 "SET lease_owner = ?, lease_expires_at = ? WHERE id = ?",
@@ -1320,7 +1320,7 @@ def test_integration_batch_fence_is_monotonic() -> None:
             "SET lease_owner = ?, lease_expires_at = ?, lease_fence = ? WHERE id = ?",
             ("integrator_2", "later", 5, "batch_fence"),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="current fence"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="current fence"):
             store.execute(
                 "UPDATE work_package_integration_batches SET candidate_sha = ?, "
                 "candidate_tree_digest = ?, candidate_ref = ?, candidate_fence = ? "
@@ -1345,7 +1345,7 @@ def test_integration_batch_fence_is_monotonic() -> None:
                 "batch_fence",
             ),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="current fence"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="current fence"):
             store.execute(
                 "UPDATE work_package_integration_batches SET candidate_sha = ? "
                 "WHERE id = ?",
@@ -1386,7 +1386,7 @@ def test_node_candidate_requires_same_task_lease_and_evidence_attempt() -> None:
             task_id="task_other",
             lease_id="lease_other",
         )
-        with pytest.raises(sqlite3.IntegrityError):
+        with pytest.raises((StoreError, sqlite3.IntegrityError)):
             store.execute(
                 "INSERT INTO work_package_node_candidates ("
                 "id, task_id, package_id, plan_version, epoch, node_key, node_generation, "
@@ -1436,7 +1436,7 @@ def test_node_candidate_requires_same_task_lease_and_evidence_attempt() -> None:
             "UPDATE work_package_task_links SET node_state = ? WHERE task_id = ?",
             ("candidate_submitted", "task_node"),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="metadata"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="metadata"):
             store.execute(
                 "UPDATE work_package_node_candidates SET status = ?, accepted_at = ? "
                 "WHERE id = ?",
@@ -1454,7 +1454,7 @@ def test_node_candidate_requires_same_task_lease_and_evidence_attempt() -> None:
         assert get_work_package_task_link(store, "task_node").node_state == (
             "candidate_accepted"
         )
-        with pytest.raises(sqlite3.IntegrityError, match="metadata"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="metadata"):
             store.execute(
                 "UPDATE work_package_node_candidates SET accepted_by = ? WHERE id = ?",
                 ("forged", "candidate_1"),
@@ -1505,7 +1505,7 @@ def test_candidate_acceptance_ignores_legacy_mutable_verification_claims() -> No
             "UPDATE work_package_task_links SET node_state = ? WHERE task_id = ?",
             ("candidate_submitted", "task_node"),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="controller-verified"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="controller-verified"):
             store.execute(
                 "UPDATE work_package_node_candidates SET status = ?, accepted_at = ?, "
                 "accepted_by = ? WHERE id = ?",
@@ -1561,12 +1561,12 @@ def test_rejected_candidate_is_immutable_and_new_attempt_gets_new_candidate() ->
             "UPDATE work_package_task_links SET node_state = ? WHERE task_id = ?",
             ("rejected", "task_node"),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="newer bounded assignment"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="newer bounded assignment"):
             store.execute(
                 "UPDATE work_package_task_links SET node_state = ? WHERE task_id = ?",
                 ("executing", "task_node"),
             )
-        with pytest.raises(sqlite3.IntegrityError, match="metadata"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="metadata"):
             store.execute(
                 "UPDATE work_package_node_candidates SET rejection_reason = ? WHERE id = ?",
                 ("forged", "candidate_attempt_1"),

--- a/tests/test_work_package_telemetry.py
+++ b/tests/test_work_package_telemetry.py
@@ -7,7 +7,7 @@ import pytest
 
 from mac.models import ValidationError, json_dumps, utcnow
 from mac.services import ControlPlane
-from mac.store import SQLiteStore
+from mac.store import SQLiteStore, StoreError
 from mac.work_package_models import WORK_PACKAGE_PLAN_SCHEMA
 from mac.work_package_service import RepositoryBaseAttestation
 from mac.work_package_pipeline import control_plane_pipeline_observer
@@ -173,7 +173,7 @@ def test_new_legacy_tasks_receive_prospective_immutable_control_assignment() -> 
         assert assignment["reason"] == "atomic_fast_lane_shape_ineligible"
         assert assignment["detail"]["shape_blockers"]
 
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             cp.store.execute(
                 "UPDATE execution_cohort_assignments SET eligibility = 'eligible' "
                 "WHERE id = ?",
@@ -271,7 +271,7 @@ def test_managed_assignment_and_pipeline_attempts_are_exported_append_only() -> 
         assert all(row["execution_duration_ms"] >= 0 for row in by_station.values())
         assert exported["limitations"]
 
-        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="append-only"):
             cp.store.execute(
                 "DELETE FROM work_package_station_attempts WHERE id = ?",
                 (first[0]["id"],),
@@ -559,7 +559,7 @@ def test_preliminary_package_cohort_is_repaired_when_v2_marker_already_exists(
             "SELECT 1 FROM telemetry_data_migrations WHERE version = ?",
             ("execution_cohort_preliminary_package_repair_v3",),
         )
-        with pytest.raises(sqlite3.IntegrityError, match="immutable"):
+        with pytest.raises((StoreError, sqlite3.IntegrityError), match="immutable"):
             repaired.execute(
                 "UPDATE execution_cohort_assignments SET reason = ? WHERE package_id = ?",
                 ("changed", package_id),
@@ -1156,34 +1156,38 @@ def test_route_filtered_export_does_not_leak_other_cohort_finalization_outcomes(
             reason="test",
             actor="test",
         )
-        cp.store.execute("PRAGMA foreign_keys = OFF")
         now = "2026-07-17T12:00:00.000000Z"
-        cp.store.execute(
-            "INSERT INTO work_package_finalization_outcomes ("
-            "id, finalization_id, package_id, outcome_type, external_id, "
-            "observed_at, actor, detail, created_at"
-            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                "outcome_filter_managed",
-                "finalization_filter_managed",
-                "wp_filter_managed",
-                "incident",
-                "incident-managed",
-                now,
-                "test",
-                "{}",
-                now,
-                "outcome_filter_legacy",
-                "finalization_filter_legacy",
-                "wp_filter_legacy",
-                "incident",
-                "incident-legacy",
-                now,
-                "test",
-                "{}",
-                now,
-            ),
-        )
+        # The parent finalization/package rows are irrelevant to what this
+        # asserts (export filtering); building the real chain -- batches,
+        # landing receipts, repositories, certifications -- would test the
+        # fixture instead of the filter.
+        with cp.store.foreign_keys_suspended() as unchecked:
+            unchecked.execute(
+                "INSERT INTO work_package_finalization_outcomes ("
+                "id, finalization_id, package_id, outcome_type, external_id, "
+                "observed_at, actor, detail, created_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "outcome_filter_managed",
+                    "finalization_filter_managed",
+                    "wp_filter_managed",
+                    "incident",
+                    "incident-managed",
+                    now,
+                    "test",
+                    "{}",
+                    now,
+                    "outcome_filter_legacy",
+                    "finalization_filter_legacy",
+                    "wp_filter_legacy",
+                    "incident",
+                    "incident-legacy",
+                    now,
+                    "test",
+                    "{}",
+                    now,
+                ),
+            )
 
         managed = cp.work_package_telemetry_export(
             treatment_route="managed_synchronized", eligibility="eligible"


### PR DESCRIPTION
## Why

The fleet runs on Postgres. The suite ran on in-memory SQLite. That gap was not theoretical — it had already produced a 500 on a production endpoint (`needs_input`, fixed in #254) and a stale-read bug in `POST /artifacts` (#255).

Pointing the suite at the real engine surfaced **54 failures**. Most were not test noise.

## Three product bugs

**1. `PostgresStore` was missing sixteen store helpers.** Humans, pipeline cursors, task-flow analytics, admission episodes — all lived on `SQLiteStore` alone. The `Store` protocol declared only the seven primitives, so `isinstance(store, Store)` passed while the methods simply weren't there:

```
$ curl -H "..." http://<hub>/humans
HTTP 500
```

That was live in production. They're now defined once in `store_helpers.StoreHelpersMixin`, inherited by both backends, and declared on the protocol so a gap is a type error rather than an `AttributeError` at the first request that needs it.

**2. `idx_agents_live_name` didn't exist on Postgres.** The partial index that stops `/agents` scanning every tombstone was only created in the SQLite migration path — so the ~1s `/agents` latency it was added to fix was still being paid in production. Ported; the plan is now `Index Scan using idx_agents_live_name` with no sort.

**3. The optimizer compared a JSON boolean to an integer.** `json_extract` yields `1`/`0` on SQLite but `'true'`/`'false'` on Postgres, so `COALESCE(json_extract(...), 0) != 1` failed with `COALESCE types text and integer cannot be matched` and the optimizer could sample nothing. Compared as text now, accepting both spellings; I verified SQLite semantics are unchanged.

## Dialect and parity fixes

- `col IS ?` (SQLite null-safe) split into `IS NULL` / `= ?`, as `provisioning_service` and `workflow_service` already did.
- `INSERT OR IGNORE` → `ON CONFLICT DO NOTHING` in shared helpers.
- Append-only triggers reported different text per engine: SQLite says "immutable" for UPDATE and "append-only" for DELETE; the port collapsed both into "append-only" for ten tables. Aligned on `TG_OP`.

## Test-side, where the intent was engine-neutral all along

`sqlite3.IntegrityError` assertions now also accept `StoreError` (per `store.py`'s own guidance); index/table introspection branches on the backend instead of assuming `PRAGMA` and `sqlite_master`; the write-free dispatch assertion records statements at the store API rather than via sqlite3's trace callback.

`foreign_keys_suspended()` replaces a raw `PRAGMA`. It **yields the connection** rather than suspending globally — the Postgres setting is per-session and every `store.execute()` borrows a different pooled connection, the same hazard behind the artifact bug.

## Isolation and CI

Each test gets its own PostgreSQL schema (~0.24s vs ~0.15s for fresh in-memory SQLite); an autouse fixture closes pools and drops schemas after each test. Debris is not cosmetic — `pg_dump` locks every table in the database, so leftover schemas make the backup drill fail.

CI provisions Postgres for every job that runs tests, via the same script developers use. A service container can't work: `max_locks_per_transaction` is a postmaster setting, and the default of 64 is exhausted by parallel per-schema DDL — that one setting was the difference between 222 failures and 54.

## Testing

**10110 passed, 0 failed, in 590s** (vs 249s on SQLite — 2.4x).

Note this makes Postgres **required** to run the suite; without `MAC_TEST_PG_URL` it fails fast with instructions rather than skipping. `CLAUDE.md` documents the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)