### PR TITLE
Fail the startup self-test when a worker cannot execute at all

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -11856,8 +11856,58 @@ if openshell_enabled and shutil.which(openshell_bin) is None:
     problems.append(
         f"OpenShell sandbox is enabled but MAC_OPENSHELL_BIN is not executable: {openshell_bin}"
     )
+# The checks above only fire when the sandbox is ENABLED, so a worker with
+# MAC_OPENSHELL_SANDBOX=0 passed this vacuously -- reporting
+# openshell_executor_config: true while being unable to execute anything at
+# all. That is what happened to jordanh-worker6/7: a sandbox A/B experiment
+# set MAC_OPENSHELL_SANDBOX=0 and MAC_OPENSHELL_REQUIRED=0 without granting
+# MAC_ALLOW_UNSANDBOXED_YOLO, so every task routed to them died in the
+# executor while the self-test said the host was healthy.
+#
+# Mirror the executor's own refusal (executor_sandbox._unsandboxed_agent_argv):
+# with no sandbox, launching is permitted only by MAC_ALLOW_UNSANDBOXED_YOLO,
+# whose default is "0" when OpenShell is required and "1" when it is not. If
+# neither path is open the worker cannot run a task at all, and that is a
+# BLOCKING problem -- it must surface at registration, not at first dispatch.
+#
+# This is deliberately a property of the worker rather than of how it was
+# provisioned: an SSH-installed host, a container, and a future AWS or Azure
+# node all answer the same question the same way.
+if not openshell_enabled:
+    # Empty string falls back to the default, matching the executor's
+    # `env_str(...) or default_unsandboxed`.
+    yolo_raw = str(os.environ.get("MAC_ALLOW_UNSANDBOXED_YOLO") or "").strip()
+    required_raw = os.environ.get("MAC_OPENSHELL_REQUIRED")
+    if yolo_raw:
+        can_run_unsandboxed = truthy(yolo_raw)
+        basis = f"MAC_ALLOW_UNSANDBOXED_YOLO={yolo_raw}"
+    elif required_raw is not None:
+        # Unset YOLO defaults to "0" exactly when OpenShell is required.
+        can_run_unsandboxed = not truthy(required_raw)
+        basis = (
+            "MAC_ALLOW_UNSANDBOXED_YOLO unset defaults to 0 because "
+            f"MAC_OPENSHELL_REQUIRED={required_raw}"
+        )
+    else:
+        # With neither set, the executor consults an identity allowlist this
+        # self-test cannot see. Do not guess -- a false blocking problem would
+        # stop a worker that can in fact run.
+        can_run_unsandboxed = True
+        basis = ""
+    if not can_run_unsandboxed:
+        problems.append(
+            "worker cannot execute: MAC_OPENSHELL_SANDBOX is disabled and "
+            f"unsandboxed execution is not permitted ({basis}). Enable the "
+            "sandbox, or explicitly set MAC_ALLOW_UNSANDBOXED_YOLO=1."
+        )
 checks["openshell_executor_config"] = not any(
-    problem.startswith(("MAC_OPENSHELL_CREATE_ARGS", "OpenShell sandbox is enabled"))
+    problem.startswith(
+        (
+            "MAC_OPENSHELL_CREATE_ARGS",
+            "OpenShell sandbox is enabled",
+            "worker cannot execute",
+        )
+    )
     for problem in problems
 )
 report_executor_attestation: dict[str, object] = {}

--- a/tests/test_selftest_execution_boundary.py
+++ b/tests/test_selftest_execution_boundary.py
@@ -1,0 +1,242 @@
+"""A worker that cannot execute anything must fail its startup self-test.
+
+The startup self-test's ``openshell_executor_config`` check only ever
+validated the sandbox configuration when the sandbox was *enabled*. A worker
+with ``MAC_OPENSHELL_SANDBOX=0`` therefore passed it vacuously -- no branch
+appended a problem, so the check reported ``true``.
+
+That is not hypothetical. A sandbox A/B experiment left jordanh-worker6 and
+jordanh-worker7 with ``MAC_OPENSHELL_SANDBOX=0`` and
+``MAC_OPENSHELL_REQUIRED=0`` but without ``MAC_ALLOW_UNSANDBOXED_YOLO``, so
+the executor refused to launch anything while the self-test reported the
+hosts healthy, the hub accepted their registration, and every task dispatched
+to them died at first execution.
+
+The fix asks the question the check never asked: with no sandbox, is
+unsandboxed execution actually permitted? It mirrors the executor's own
+refusal in ``executor_sandbox._unsandboxed_agent_argv`` so the two cannot
+drift, and it is a property of the worker rather than of how the worker was
+provisioned -- an SSH-installed host, a container, and a future AWS or Azure
+node all answer it the same way.
+
+Extract-and-run pattern follows tests/test_selftest_transient_timeout_crash.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _startup_self_test_source() -> str:
+    script = (ROOT / "deploy" / "fleet-node-install.sh").read_text(encoding="utf-8")
+    match = re.search(
+        r"exec \"\$selftest_python\" - <<'PY'\n(?P<source>.*?)\nPY\n",
+        script,
+        re.DOTALL,
+    )
+    assert match, "self-test PY heredoc not found in fleet-node-install.sh"
+    return match.group("source")
+
+
+def _run_self_test(tmp_path, monkeypatch, sandbox_env, *, openshell_on_path=False):
+    """Exec the startup self-test for a pure worker with ``sandbox_env`` applied.
+
+    Everything unrelated to the execution boundary is configured to pass: no
+    mandatory shared services, no hub heartbeat, and a non-OpenClaw gateway
+    impl, so the only thing that can fail is the boundary check under test.
+    """
+    home = tmp_path / "home"
+    mac_home = home / ".mac"
+    (mac_home / "openclaw" / "managed").mkdir(parents=True, exist_ok=True)
+    (mac_home / "bin").mkdir(parents=True, exist_ok=True)
+    (mac_home / "logs").mkdir(parents=True, exist_ok=True)
+    report_path = mac_home / "logs" / "mac-agent-startup-self-test.json"
+
+    env = {
+        "MAC_CHAT_GATEWAY_IMPL": "none",
+        "MAC_WORKER_AGENT_NAME": "worker6",
+        "MAC_AGENT_ID": "agent_worker6",
+        "MAC_HERMES_INSTANCE_ID": "instance-1",
+        "MAC_HERMES_PERSONA_ID": "persona-1",
+        "MAC_FLEET_TENANT_ID": "tenant-1",
+        # Mandatory shared services must be required AND reachable; the probes
+        # are stubbed to succeed below so the only thing that can fail is the
+        # execution boundary under test.
+        "MAC_REQUIRE_QDRANT_MEMORY": "1",
+        "QDRANT_URL": "http://qdrant.local:6333",
+        "MAC_REQUIRE_FIRECRAWL": "1",
+        "FIRECRAWL_API_URL": "http://firecrawl.local:3002",
+        "MAC_AGENT_STARTUP_SELF_TEST_REPORT": str(report_path),
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+    }
+    env.update(sandbox_env)
+
+    if openshell_on_path:
+        bindir = tmp_path / "bin"
+        bindir.mkdir(exist_ok=True)
+        fake = bindir / "openshell"
+        fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake.chmod(0o755)
+        env["PATH"] = "%s:%s" % (bindir, env["PATH"])
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+
+    import time as _time
+    import urllib.request
+
+    monkeypatch.setattr(_time, "sleep", lambda *a, **k: None)
+
+    class _OkResponse:
+        status = 200
+
+        def read(self, *args):
+            return b"{}"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: _OkResponse())
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("a pure worker must not invoke openclaw-agent")
+        ),
+    )
+
+    namespace = {"__name__": "__mac_selftest__", "os": os}
+    saved_environ = dict(os.environ)
+    os.environ.clear()
+    os.environ.update(env)
+    exit_code = 0
+    try:
+        exec(compile(_startup_self_test_source(), "<selftest>", "exec"), namespace)
+    except SystemExit as exc:
+        exit_code = exc.code or 0
+    finally:
+        os.environ.clear()
+        os.environ.update(saved_environ)
+
+    return exit_code, json.loads(report_path.read_text(encoding="utf-8"))
+
+
+def _boundary_problems(report):
+    return [
+        problem
+        for problem in report["problems"]
+        if problem.startswith("worker cannot execute")
+    ]
+
+
+def test_the_worker6_configuration_fails_the_self_test(tmp_path, monkeypatch):
+    """The exact configuration that ran for days while reporting healthy."""
+    exit_code, report = _run_self_test(
+        tmp_path,
+        monkeypatch,
+        {
+            "MAC_OPENSHELL_SANDBOX": "0",
+            "MAC_OPENSHELL_REQUIRED": "0",
+            "MAC_ALLOW_UNSANDBOXED_YOLO": "0",
+        },
+    )
+
+    assert report["checks"]["openshell_executor_config"] is False, report["checks"]
+    assert _boundary_problems(report), report["problems"]
+    # Blocking, not degraded: a worker that cannot run a task must not register.
+    assert _boundary_problems(report)[0] in report["blocking_problems"]
+    assert report["status"] == "failed"
+    assert exit_code == 1
+
+
+def test_requiring_openshell_without_the_sandbox_fails(tmp_path, monkeypatch):
+    """Unset YOLO defaults to 0 exactly when OpenShell is required."""
+    exit_code, report = _run_self_test(
+        tmp_path,
+        monkeypatch,
+        {"MAC_OPENSHELL_SANDBOX": "0", "MAC_OPENSHELL_REQUIRED": "1"},
+    )
+
+    assert report["checks"]["openshell_executor_config"] is False
+    assert exit_code == 1
+    assert any("MAC_OPENSHELL_REQUIRED=1" in p for p in _boundary_problems(report))
+
+
+def test_explicitly_allowing_unsandboxed_execution_passes(tmp_path, monkeypatch):
+    """An operator who accepts the risk is not blocked -- the worker can run."""
+    exit_code, report = _run_self_test(
+        tmp_path,
+        monkeypatch,
+        {
+            "MAC_OPENSHELL_SANDBOX": "0",
+            "MAC_OPENSHELL_REQUIRED": "0",
+            "MAC_ALLOW_UNSANDBOXED_YOLO": "1",
+        },
+    )
+
+    assert report["checks"]["openshell_executor_config"] is True
+    assert _boundary_problems(report) == []
+    assert exit_code == 0
+
+
+def test_an_enabled_sandbox_still_passes(tmp_path, monkeypatch):
+    """The normal fleet configuration: sandboxed execution, boundary present."""
+    exit_code, report = _run_self_test(
+        tmp_path,
+        monkeypatch,
+        {"MAC_OPENSHELL_SANDBOX": "1", "MAC_OPENSHELL_REQUIRED": "1"},
+        openshell_on_path=True,
+    )
+
+    assert report["checks"]["openshell_executor_config"] is True
+    assert _boundary_problems(report) == []
+    assert exit_code == 0
+
+
+def test_an_undeterminable_boundary_is_not_guessed(tmp_path, monkeypatch):
+    """With neither variable set, the executor consults an identity allowlist
+    the self-test cannot see. Guessing would block workers that can in fact
+    run, so the check stays silent rather than inventing a problem."""
+    exit_code, report = _run_self_test(
+        tmp_path, monkeypatch, {"MAC_OPENSHELL_SANDBOX": "0"}
+    )
+
+    assert report["checks"]["openshell_executor_config"] is True
+    assert _boundary_problems(report) == []
+    assert exit_code == 0
+
+
+def test_the_check_matches_the_executors_own_refusal(tmp_path, monkeypatch):
+    """Guard against drift between the self-test and the code it predicts.
+
+    The self-test reimplements the executor's gate (it runs standalone, with
+    no `mac` package importable), so the two can silently diverge. This pins
+    them together on every combination the self-test claims to decide.
+    """
+    from mac.openshell_runtime import truthy
+
+    for required in ("0", "1"):
+        for yolo in (None, "0", "1"):
+            sandbox_env = {"MAC_OPENSHELL_SANDBOX": "0", "MAC_OPENSHELL_REQUIRED": required}
+            if yolo is not None:
+                sandbox_env["MAC_ALLOW_UNSANDBOXED_YOLO"] = yolo
+
+            # What executor_sandbox._unsandboxed_agent_argv would decide.
+            default_unsandboxed = "0" if truthy(required) else "1"
+            executor_allows = truthy(yolo or default_unsandboxed)
+
+            _, report = _run_self_test(tmp_path / f"{required}-{yolo}", monkeypatch, sandbox_env)
+            self_test_allows = report["checks"]["openshell_executor_config"]
+
+            assert self_test_allows is executor_allows, (
+                f"MAC_OPENSHELL_REQUIRED={required} MAC_ALLOW_UNSANDBOXED_YOLO={yolo}: "
+                f"self-test says {self_test_allows}, executor says {executor_allows}"
+            )


### PR DESCRIPTION
## The gap

The startup self-test's `openshell_executor_config` check only validated the sandbox configuration when the sandbox was **enabled**. Every branch feeding it was guarded by `openshell_enabled`:

```python
openshell_enabled = truthy(os.environ.get("MAC_OPENSHELL_SANDBOX"))
if openshell_enabled and openshell_create_args: ...
if openshell_enabled and shutil.which(openshell_bin) is None: ...
checks["openshell_executor_config"] = not any(...)
```

With `MAC_OPENSHELL_SANDBOX=0`, no problem is ever appended and the check reports `true` — vacuously.

## What that cost

A sandbox A/B experiment left `jordanh-worker6` and `jordanh-worker7` with `MAC_OPENSHELL_SANDBOX=0` and `MAC_OPENSHELL_REQUIRED=0`, but without granting `MAC_ALLOW_UNSANDBOXED_YOLO`. The executor refuses to launch in exactly that combination, so neither worker could run a single task — while:

- the self-test reported `openshell_executor_config: true`,
- the hub's `_report_executor_release_ready` accepted the registration,
- and the allocator kept routing work to both.

Every task dispatched there died at first execution, and it read as a task problem rather than a host problem.

## The fix

Ask the question the check never asked: **with no sandbox, is unsandboxed execution actually permitted?** It mirrors the executor's own refusal in `executor_sandbox._unsandboxed_agent_argv`, including its `or` fallback so an empty string defaults rather than reading as false.

Where the executor consults an identity allowlist the self-test cannot see (neither variable set), the check stays silent rather than guessing — a false blocking problem would stop a worker that can in fact run.

The problem is **blocking**, so a worker that cannot execute fails at registration instead of at first dispatch.

## Drift guard

The self-test runs standalone and cannot import the predicate it predicts, so the two can silently diverge. `test_the_check_matches_the_executors_own_refusal` pins them together across every combination the self-test claims to decide.

## Blast radius

All 8 live nodes (rocky, natasha, bullwinkle, jordanh-worker1/2/5/6/7) currently run `MAC_OPENSHELL_SANDBOX=1`, so the new branch never executes on any of them and none are newly blocked. This guards against regressing into the state that produced the outage.

This is a property of the worker rather than of how it was provisioned, which matters because this repository creates workers on demand and can assume nothing beyond basic Linux on future AWS/Azure targets.

## Tests

- 6 new tests in `tests/test_selftest_execution_boundary.py`, including the exact worker6 configuration
- 595 passing across the selftest/openshell/deploy-attestation suites

Implements recommendation 3 of `docs/assessment-2026-08-02.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)