### PR TITLE
Stop a generator that produces nothing from filing

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -438,6 +438,10 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_FLEET_PHASE_FAILURE_EVIDENCE_DIR` | str | consumer-defined | core | Core setting: fleet phase failure evidence dir. |
 | `MAC_FLEET_TENANT_ID` | str | consumer-defined | core | Core setting: fleet tenant id. |
 | `MAC_FORCE_ACC_MIGRATION` | str | consumer-defined | core | Core setting: force acc migration. |
+| `MAC_GENERATOR_YIELD_CACHE_TTL_SECONDS` | int | consumer-defined | core | Core setting: generator yield cache ttl seconds. |
+| `MAC_GENERATOR_YIELD_FLOOR` | int | consumer-defined | core | Core setting: generator yield floor. |
+| `MAC_GENERATOR_YIELD_GATE` | str | consumer-defined | core | Core setting: generator yield gate. |
+| `MAC_GENERATOR_YIELD_MIN_SAMPLE` | str | consumer-defined | core | Core setting: generator yield min sample. |
 | `MAC_GEN_AUDIO_SERVICE_NAME` | str | consumer-defined | core | Core setting: gen audio service name. |
 | `MAC_GEN_SERVICE_NAME` | str | consumer-defined | core | Core setting: gen service name. |
 | `MAC_GEN_VIDEO_SERVICE_NAME` | str | consumer-defined | core | Core setting: gen video service name. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -332,11 +332,11 @@ options:
 ```console
 $ mac task --help
 usage: mac task [-h]
-                {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
+                {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,generator-yield,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
                 ...
 
 positional arguments:
-  {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
+  {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,generator-yield,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
     list                list tasks (default: short ids; use --full-ids for
                         scripts)
     show                show task state, activity, diagnoses, and compact
@@ -379,6 +379,8 @@ positional arguments:
                         adversarial reviewer + contract gate auto-land is.
     search              keyword search across task title and description
     stats               count tasks by state
+    generator-yield     show each task origin's completion yield and whether
+                        the yield gate is letting it file
     throughput          task-to-main KPIs, stage dwell, stranded work, and
                         resource collisions
     audit               read-only reconciliation of every task's history,

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -331,6 +331,7 @@ request and response definitions.
 | `GET` | `/tasks` | List Tasks |
 | `POST` | `/tasks` | Create Task |
 | `GET` | `/tasks/audit` | Audit Tasks |
+| `GET` | `/tasks/generator-yield` | Task Generator Yield |
 | `GET` | `/tasks/ready` | Ready Tasks |
 | `GET` | `/tasks/ready/explain` | Ready Task Explanations |
 | `GET` | `/tasks/search` | Search Tasks |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -5443,6 +5443,12 @@ def create_app(
     ) -> Dict[str, int]:
         return cp.task_stats(project=project, tenant_id=tenant_id)
 
+    # Registered alongside the other static /tasks/* reads so it is not
+    # captured by the /tasks/{task_id} path parameter.
+    @app.get("/tasks/generator-yield")
+    def task_generator_yield() -> Dict[str, Any]:
+        return cp.generator_yield_report()
+
     @app.get("/tasks/throughput")
     def task_throughput(
         project: Optional[str] = Query(default=None),

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -2398,6 +2398,11 @@ def cmd_task_stats(args: argparse.Namespace) -> None:
     _print(cp.task_stats(project=project))
 
 
+def cmd_task_generator_yield(args: argparse.Namespace) -> None:
+    """Print each task origin's filed/completed record and gate standing."""
+    _print(_plane(args).generator_yield_report())
+
+
 def cmd_task_throughput(args: argparse.Namespace) -> None:
     """Print task-flow KPIs, stranded work, and shared-resource collisions."""
 
@@ -6651,6 +6656,15 @@ def build_parser() -> argparse.ArgumentParser:
     stats.add_argument("--project", help="filter to this project (default: the cwd's project)")
     stats.add_argument("--all", action="store_true", help="every project (disable cwd scoping)")
     _set(cmd_task_stats, stats)
+
+    _set(
+        cmd_task_generator_yield,
+        task.add_parser(
+            "generator-yield",
+            help="show each task origin's completion yield and whether the "
+            "yield gate is letting it file",
+        ),
+    )
 
     throughput = task.add_parser(
         "throughput",

--- a/src/mac/crash_service.py
+++ b/src/mac/crash_service.py
@@ -26,6 +26,7 @@ from mac.models import (
     parse_time,
     utcnow,
 )
+from mac.generator_yield import GeneratorSuppressed
 
 CRASH_REPORT_SCHEMA = "mac.agent_crash_report.v1"
 CRASH_OCCURRENCE_SCHEMA = "mac.agent_crash_occurrence.v1"
@@ -467,27 +468,46 @@ class CrashService:
                 prior_clause,
             )
         )
-        task = self.cp.create_task(
-            "P0: repair MAC crash %s at %s" % (
-                str(report["process_name"])[:50], str(report["revision"])[:12]
-            ),
-            description=description,
-            project="mac",
-            priority=0,
-            required_capabilities=["python", "ops"],
-            metadata={
-                "origin": {"type": "crash_observer", "schema": CRASH_REPORT_SCHEMA},
-                "crash_report_id": report_id,
-                "crash_fingerprint": report["fingerprint"],
-                "crash_revision": report["revision"],
-                "crash_affected_agent_ids": affected_ids,
-                "excluded_agent_ids": affected_ids,
-                "self_heal": True,
-                "evidence_type": "crash_repair",
-                "prior_repair_task_id": prior_task.id if prior_task is not None else None,
-            },
-            actor="crash-observer",
-        )
+        try:
+            task = self.cp.create_task(
+                "P0: repair MAC crash %s at %s" % (
+                    str(report["process_name"])[:50], str(report["revision"])[:12]
+                ),
+                description=description,
+                project="mac",
+                priority=0,
+                required_capabilities=["python", "ops"],
+                metadata={
+                    "origin": {"type": "crash_observer", "schema": CRASH_REPORT_SCHEMA},
+                    "crash_report_id": report_id,
+                    "crash_fingerprint": report["fingerprint"],
+                    "crash_revision": report["revision"],
+                    "crash_affected_agent_ids": affected_ids,
+                    "excluded_agent_ids": affected_ids,
+                    "self_heal": True,
+                    "evidence_type": "crash_repair",
+                    "prior_repair_task_id": prior_task.id if prior_task is not None else None,
+                },
+                actor="crash-observer",
+            )
+        except GeneratorSuppressed as exc:
+            # Autonomous crash repair has been measured and is not producing
+            # completed work. Stop manufacturing repair tasks, but do NOT drop
+            # the crash: the report escalates to a human, which is the outcome
+            # a suppressed repair channel should produce.
+            self.store.execute(
+                "UPDATE agent_crash_reports SET status = 'needs_human', updated_at = ? WHERE id = ?",
+                (utcnow(), report_id),
+            )
+            self.cp.record_notification(
+                "agent.crash.repair_suppressed",
+                "Crash repair suppressed: %s" % report_id,
+                "Autonomous repair for fingerprint %s was not filed: %s"
+                % (report["fingerprint"], exc),
+                channels=None,
+                metadata={"severity": "warning", "crash_report_id": report_id},
+            )
+            return None
         self.store.execute(
             """
             UPDATE agent_crash_reports

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -5175,6 +5175,50 @@
   },
   {
     "default": null,
+    "description": "Core setting: generator yield cache ttl seconds.",
+    "family": "core",
+    "name": "MAC_GENERATOR_YIELD_CACHE_TTL_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/generator_yield.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Core setting: generator yield floor.",
+    "family": "core",
+    "name": "MAC_GENERATOR_YIELD_FLOOR",
+    "retired": false,
+    "sources": [
+      "src/mac/generator_yield.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Core setting: generator yield gate.",
+    "family": "core",
+    "name": "MAC_GENERATOR_YIELD_GATE",
+    "retired": false,
+    "sources": [
+      "src/mac/generator_yield.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: generator yield min sample.",
+    "family": "core",
+    "name": "MAC_GENERATOR_YIELD_MIN_SAMPLE",
+    "retired": false,
+    "sources": [
+      "src/mac/generator_yield.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: gen audio service name.",
     "family": "core",
     "name": "MAC_GEN_AUDIO_SERVICE_NAME",

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -406,6 +406,9 @@ class RemoteDispatch:
     ) -> Dict[str, Any]:
         return self._get("/tasks/stats", project=project, tenant_id=tenant_id)
 
+    def generator_yield_report(self) -> Dict[str, Any]:
+        return self._get("/tasks/generator-yield")
+
     def task_flow_report(
         self,
         *,

--- a/src/mac/generator_yield.py
+++ b/src/mac/generator_yield.py
@@ -1,0 +1,312 @@
+"""Measured yield gate for automated task generators.
+
+A generator is any code path that files tasks without a human asking for
+them. Measured across 7,781 ledger tasks on 2026-08-02, several of them
+produced almost nothing that ever completed:
+
+    self_heal                      54 tasks    0.0%
+    dream_low_confidence_repair 1,396 tasks    0.3%   (generator deleted)
+    crash_observer                 50 tasks    2.0%
+    task_system_reset             137 tasks    2.9%
+    curiosity_adjudication         11 tasks    0.0%
+    backlog_grooming                5 tasks    0.0%
+
+against 20.0% for operator-filed work. The precedent for deleting one is
+already set: mac.dreaming records in its own source that the scanner it
+replaced "filed 1,259 investigation tasks of which 4 completed".
+
+Deleting named generators one at a time does not hold. Three of the
+zero-yield origins above were not in the ticket that asked for this, and a
+generator added next month would be ungated again. So the rule is stated
+once, here, and applied to every origin that is not a human asking:
+
+    a generator that cannot show its own yield does not get to file, and
+    one whose measured yield stays below the floor stops filing.
+
+A generator is never judged before it has filed ``min_sample`` tasks --
+there is nothing to measure yet, and a new generator must be allowed to
+earn its record. That is a deliberate hole: a generator can always file its
+first ``min_sample`` tasks. It is bounded, and it is the price of not
+blocking work on a statistic that does not exist.
+
+The gate is advisory-off by default in tests (``ControlPlane.in_memory``
+has no history to measure), and enforcing wherever a real ledger exists.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional
+
+from mac.env_config import env_bool, env_float, env_int
+
+GENERATOR_YIELD_SCHEMA = "mac.generator_yield.v1"
+
+#: Origins that record a human (or an external system acting for one) asking
+#: for work. These are never gated: a person filing a task is not a generator,
+#: and a low completion rate on operator-filed work is a statement about the
+#: work, not about a machine that should stop.
+HUMAN_ORIGIN_TYPES = frozenset(
+    {
+        "direct_task",
+        "operator_directive",
+        "operator_observation",
+        "hermes_interaction",
+        "beads",
+        "github_ingest",
+    }
+)
+
+DEFAULT_MIN_SAMPLE = 40
+DEFAULT_YIELD_FLOOR = 0.05
+DEFAULT_CACHE_TTL_SECONDS = 300
+
+
+class GeneratorSuppressed(Exception):
+    """Raised when a generator is not permitted to file.
+
+    Subclasses of this are caught by generator call sites, which log and skip
+    rather than crash: a suppressed generator is the gate working, not an
+    error in the caller.
+    """
+
+
+@dataclass(frozen=True)
+class YieldPolicy:
+    """Thresholds that decide whether a generator may keep filing."""
+
+    enabled: bool = True
+    min_sample: int = DEFAULT_MIN_SAMPLE
+    floor: float = DEFAULT_YIELD_FLOOR
+    cache_ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS
+
+    @classmethod
+    def from_env(cls, environ: Optional[Mapping[str, str]] = None) -> "YieldPolicy":
+        return cls(
+            enabled=env_bool("MAC_GENERATOR_YIELD_GATE", True, environ=environ),
+            min_sample=env_int(
+                "MAC_GENERATOR_YIELD_MIN_SAMPLE",
+                DEFAULT_MIN_SAMPLE,
+                minimum=1,
+                environ=environ,
+            ),
+            floor=env_float(
+                "MAC_GENERATOR_YIELD_FLOOR",
+                DEFAULT_YIELD_FLOOR,
+                minimum=0.0,
+                maximum=1.0,
+                environ=environ,
+            ),
+            cache_ttl_seconds=env_int(
+                "MAC_GENERATOR_YIELD_CACHE_TTL_SECONDS",
+                DEFAULT_CACHE_TTL_SECONDS,
+                minimum=0,
+                environ=environ,
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class OriginYield:
+    """One generator's measured record."""
+
+    origin_type: str
+    filed: int
+    completed: int
+
+    @property
+    def rate(self) -> float:
+        return (self.completed / self.filed) if self.filed else 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "origin_type": self.origin_type,
+            "filed": self.filed,
+            "completed": self.completed,
+            "yield": round(self.rate, 4),
+        }
+
+
+def is_generator_origin(origin_type: str) -> bool:
+    """Whether ``origin_type`` is an automated generator rather than a human."""
+
+    normalized = str(origin_type or "").strip()
+    return bool(normalized) and normalized not in HUMAN_ORIGIN_TYPES
+
+
+def origin_type_of(metadata: Any) -> str:
+    """Extract ``metadata.origin.type``, tolerating any malformed shape."""
+
+    if not isinstance(metadata, Mapping):
+        return ""
+    origin = metadata.get("origin")
+    if not isinstance(origin, Mapping):
+        return ""
+    return str(origin.get("type") or "").strip()
+
+
+_YIELD_SQL = """
+SELECT json_extract(metadata, '$.origin.type') AS origin_type,
+       COUNT(*) AS filed,
+       SUM(CASE WHEN state = 'completed' THEN 1 ELSE 0 END) AS completed
+FROM tasks
+WHERE json_extract(metadata, '$.origin.type') IS NOT NULL
+  AND json_extract(metadata, '$.origin.type') != ''
+GROUP BY json_extract(metadata, '$.origin.type')
+"""
+
+
+class GeneratorYieldGate:
+    """Measures generator yield from the ledger and decides who may file.
+
+    The measurement is a single grouped aggregate over ``tasks`` and is cached
+    for ``policy.cache_ttl_seconds``; a task-creation path must not pay a table
+    scan per call. The cache is intentionally coarse -- yield moves over days,
+    and a generator that just crossed the floor may file for one more TTL.
+    """
+
+    def __init__(self, store: Any, policy: Optional[YieldPolicy] = None) -> None:
+        self.store = store
+        self.policy = policy or YieldPolicy.from_env()
+        self._lock = threading.Lock()
+        self._cache: Optional[Dict[str, OriginYield]] = None
+        self._cached_at = 0.0
+
+    # -- measurement ------------------------------------------------------
+
+    def measure(self, *, refresh: bool = False) -> Dict[str, OriginYield]:
+        """Return every origin's record, from cache unless it has expired."""
+
+        with self._lock:
+            fresh_enough = (
+                self._cache is not None
+                and not refresh
+                and (time.monotonic() - self._cached_at)
+                < self.policy.cache_ttl_seconds
+            )
+            if fresh_enough:
+                return dict(self._cache or {})
+        measured = self._query()
+        with self._lock:
+            self._cache = measured
+            self._cached_at = time.monotonic()
+        return dict(measured)
+
+    def _query(self) -> Dict[str, OriginYield]:
+        try:
+            rows = self.store.query_all(_YIELD_SQL)
+        except Exception:  # noqa: BLE001 - measurement must never block filing
+            return {}
+        measured: Dict[str, OriginYield] = {}
+        for row in rows or []:
+            origin_type = str(row["origin_type"] or "").strip()
+            if not origin_type:
+                continue
+            measured[origin_type] = OriginYield(
+                origin_type=origin_type,
+                filed=int(row["filed"] or 0),
+                completed=int(row["completed"] or 0),
+            )
+        return measured
+
+    # -- decision ---------------------------------------------------------
+
+    def evaluate(self, origin_type: str) -> Dict[str, Any]:
+        """Decide whether ``origin_type`` may file, and say why.
+
+        Always returns a verdict rather than raising, so callers can report a
+        generator's standing without attempting to file.
+        """
+
+        verdict: Dict[str, Any] = {
+            "schema": GENERATOR_YIELD_SCHEMA,
+            "origin_type": origin_type,
+            "allowed": True,
+            "reason": "not_a_generator",
+            "floor": self.policy.floor,
+            "min_sample": self.policy.min_sample,
+            "filed": 0,
+            "completed": 0,
+            "yield": None,
+        }
+        if not is_generator_origin(origin_type):
+            return verdict
+        if not self.policy.enabled:
+            verdict["reason"] = "gate_disabled"
+            return verdict
+
+        record = self.measure().get(origin_type)
+        if record is None or record.filed < self.policy.min_sample:
+            verdict.update(
+                {
+                    "reason": "insufficient_sample",
+                    "filed": record.filed if record else 0,
+                    "completed": record.completed if record else 0,
+                    "yield": round(record.rate, 4) if record else None,
+                }
+            )
+            return verdict
+
+        verdict.update(
+            {
+                "filed": record.filed,
+                "completed": record.completed,
+                "yield": round(record.rate, 4),
+            }
+        )
+        if record.rate < self.policy.floor:
+            verdict["allowed"] = False
+            verdict["reason"] = "below_yield_floor"
+        else:
+            verdict["reason"] = "above_yield_floor"
+        return verdict
+
+    def enforce(self, metadata: Any) -> Optional[Dict[str, Any]]:
+        """Raise ``GeneratorSuppressed`` when this origin may not file.
+
+        Returns the verdict when filing is permitted (or is not a generator at
+        all), so the caller can record it.
+        """
+
+        origin_type = origin_type_of(metadata)
+        if not is_generator_origin(origin_type):
+            return None
+        verdict = self.evaluate(origin_type)
+        if verdict["allowed"]:
+            return verdict
+        raise GeneratorSuppressed(
+            "generator %r is suppressed: %d of %d filed tasks completed "
+            "(%.1f%%), below the %.1f%% floor. Fix what it files or retire it; "
+            "raise MAC_GENERATOR_YIELD_FLOOR only with a reason."
+            % (
+                origin_type,
+                verdict["completed"],
+                verdict["filed"],
+                100.0 * (verdict["yield"] or 0.0),
+                100.0 * self.policy.floor,
+            )
+        )
+
+    def report(self) -> List[Dict[str, Any]]:
+        """Every origin's record and standing, worst yield first.
+
+        This is the "show its own yield" half of the rule: a generator that
+        cannot appear here is not measurable and should not be filing.
+        """
+
+        measured = self.measure(refresh=True)
+        rows = []
+        for origin_type, record in measured.items():
+            verdict = self.evaluate(origin_type)
+            entry = record.to_dict()
+            entry.update(
+                {
+                    "generator": is_generator_origin(origin_type),
+                    "allowed": verdict["allowed"],
+                    "reason": verdict["reason"],
+                }
+            )
+            rows.append(entry)
+        rows.sort(key=lambda entry: (not entry["generator"], entry["yield"]))
+        return rows

--- a/src/mac/self_healing.py
+++ b/src/mac/self_healing.py
@@ -42,6 +42,7 @@ from mac.config_coercion import (
     bounded_env_number,
     parse_timestamp as _parse_ts,
 )
+from mac.generator_yield import GeneratorSuppressed
 
 SELF_HEAL_SCHEMA = "mac.self_healing.v1"
 SELF_HEAL_ORIGIN_TYPE = "self_heal"
@@ -682,6 +683,12 @@ class SelfHealingSentinel:
                 finding, attempt=attempt, actor=actor,
                 prior_task=newest_completed,
             )
+        except GeneratorSuppressed as exc:
+            # The yield gate refused this origin. That is the gate working, not
+            # a failure of this cycle -- report it as its own outcome so a
+            # suppressed generator is visibly suppressed rather than looking
+            # like one that simply had nothing to file.
+            return {"action": "suppressed", "reason": str(exc)[:500]}
         except Exception as exc:  # noqa: BLE001 - isolate one finding's failure.
             return {"action": "error", "error": str(exc)[:500]}
         return {"action": "task_filed", "task_id": getattr(task, "id", None),

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -187,6 +187,12 @@ from mac.repository_hygiene import (
     repository_ref_lifecycle_for_transition,
 )
 from mac.env_config import resolve_hub_agent
+from mac.generator_yield import (
+    GENERATOR_YIELD_SCHEMA,
+    GeneratorSuppressed,
+    GeneratorYieldGate,
+    origin_type_of as generator_origin_type_of,
+)
 from mac.executor_scope import compute_scope_estimate_from_lessons
 from mac.reconciliation import ReconciliationCoordinator
 from mac.ticketing_service import TicketingCoordinator
@@ -5214,6 +5220,55 @@ class ControlPlane:
                     pass
         return self.get_task(task_id)
 
+    @property
+    def generator_yield_gate(self) -> "GeneratorYieldGate":
+        """The measured yield gate, constructed once per control plane."""
+
+        gate = getattr(self, "_generator_yield_gate", None)
+        if gate is None:
+            gate = GeneratorYieldGate(self.store)
+            self._generator_yield_gate = gate
+        return gate
+
+    def _enforce_generator_yield(self, metadata: Any) -> None:
+        """Refuse a filing from a generator whose measured yield is too low.
+
+        Records the suppression before raising: a generator that silently
+        stopped filing would be indistinguishable from one that had nothing
+        to file, which is how the low-yield generators went unnoticed for six
+        weeks in the first place.
+        """
+
+        try:
+            self.generator_yield_gate.enforce(metadata)
+        except GeneratorSuppressed as exc:
+            origin_type = generator_origin_type_of(metadata)
+            try:
+                self.record_log(
+                    "task.generator_suppressed",
+                    level="warning",
+                    detail={
+                        "origin_type": origin_type,
+                        "verdict": self.generator_yield_gate.evaluate(origin_type),
+                        "message": str(exc),
+                    },
+                )
+            except Exception:  # noqa: BLE001 - reporting must not mask the refusal
+                pass
+            raise
+
+    def generator_yield_report(self) -> JsonDict:
+        """Every task origin's filed/completed record and gate standing."""
+
+        gate = self.generator_yield_gate
+        return {
+            "schema": GENERATOR_YIELD_SCHEMA,
+            "floor": gate.policy.floor,
+            "min_sample": gate.policy.min_sample,
+            "enabled": gate.policy.enabled,
+            "origins": gate.report(),
+        }
+
     def create_task(
         self,
         title: str,
@@ -5253,6 +5308,12 @@ class ControlPlane:
                 "workflow-linked task creation requires both run id and node key"
             )
         self._reject_reserved_break_glass_metadata(requested_metadata)
+        # An automated generator whose filed work does not complete stops
+        # filing. This is the single choke point every generator passes
+        # through, so a generator added later is gated by default rather than
+        # having to remember to opt in. Human-filed origins are exempt --
+        # see mac.generator_yield.HUMAN_ORIGIN_TYPES.
+        self._enforce_generator_yield(requested_metadata)
         requested_publication_policy = self._single_task_publication_policy(
             requested_metadata
         )

--- a/tests/cli/test_cli_generator_yield.py
+++ b/tests/cli/test_cli_generator_yield.py
@@ -1,0 +1,77 @@
+"""`mac task generator-yield` shows each origin's record and gate standing.
+
+This is the reporting half of the yield rule: a generator that cannot show
+its own yield should not be allowed to file, so the yield has to be visible
+from the CLI rather than only inside the gate.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from mac.cli import main
+from mac.models import TaskState
+from mac.test_support import dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, json.loads(raw) if raw else None
+
+
+def test_generator_yield_reports_an_empty_ledger(tmp_path):
+    rc, report = _run(tmp_path, "task", "generator-yield")
+    assert rc == 0
+    assert report["schema"] == "mac.generator_yield.v1"
+    assert report["origins"] == []
+    # The policy in force is part of the report: a reader must be able to see
+    # what threshold a verdict was made against.
+    assert report["floor"] > 0
+    assert report["min_sample"] >= 1
+
+
+def test_generator_yield_separates_generators_from_humans(tmp_path):
+    dsn = dsn_for(tmp_path)
+
+    from mac.services import ControlPlane
+    from mac.store import open_postgres_store
+
+    cp = ControlPlane(open_postgres_store(dsn, initialize_schema=True))
+    made = []
+    for index in range(6):
+        made.append(
+            cp.create_task(
+                "generated %d" % index,
+                project="mac",
+                metadata={"origin": {"type": "self_heal"}},
+            )
+        )
+    cp.create_task(
+        "a human asked for this",
+        project="mac",
+        metadata={"origin": {"type": "direct_task"}},
+    )
+    cp.store.execute(
+        "UPDATE tasks SET state = ? WHERE id = ?",
+        (TaskState.COMPLETED.value, made[0].id),
+    )
+
+    rc, report = _run(tmp_path, "task", "generator-yield")
+    assert rc == 0
+    by_origin = {row["origin_type"]: row for row in report["origins"]}
+
+    assert by_origin["self_heal"]["generator"] is True
+    assert by_origin["self_heal"]["filed"] == 6
+    assert by_origin["self_heal"]["completed"] == 1
+
+    assert by_origin["direct_task"]["generator"] is False
+    assert by_origin["direct_task"]["allowed"] is True
+    assert by_origin["direct_task"]["reason"] == "not_a_generator"

--- a/tests/test_generator_yield_gate.py
+++ b/tests/test_generator_yield_gate.py
@@ -1,0 +1,195 @@
+"""A generator that does not produce completed work stops filing.
+
+Measured on the live ledger 2026-08-02 (7,781 tasks), by task origin:
+
+    direct_task                 4,505 tasks   20.0%   (human, never gated)
+    dream_low_confidence_repair 1,396 tasks    0.3%
+    contract_prerequisite         599 tasks    7.7%
+    environment_prerequisite      594 tasks    9.6%
+    task_system_reset             137 tasks    2.9%
+    self_heal                      54 tasks    0.0%
+    crash_observer                 50 tasks    2.0%
+
+The gate's job is to stop the bottom of that table without touching the top,
+and to keep working for generators nobody has thought of yet.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mac.generator_yield import (
+    GeneratorSuppressed,
+    GeneratorYieldGate,
+    YieldPolicy,
+    is_generator_origin,
+)
+from mac.models import TaskState
+from mac.services import ControlPlane
+
+
+def _file(cp, origin_type, *, count, completed, title="generated"):
+    """File ``count`` tasks from ``origin_type``, completing ``completed``."""
+    made = []
+    for index in range(count):
+        task = cp.create_task(
+            "%s %d" % (title, index),
+            project="mac",
+            metadata={"origin": {"type": origin_type}},
+        )
+        made.append(task)
+    for task in made[:completed]:
+        cp.store.execute(
+            "UPDATE tasks SET state = ? WHERE id = ?",
+            (TaskState.COMPLETED.value, task.id),
+        )
+    return made
+
+
+def _gate(cp, **kwargs):
+    policy = YieldPolicy(
+        enabled=True, min_sample=10, floor=0.05, cache_ttl_seconds=0, **kwargs
+    )
+    return GeneratorYieldGate(cp.store, policy)
+
+
+def test_human_origins_are_never_gated():
+    assert not is_generator_origin("direct_task")
+    assert not is_generator_origin("operator_directive")
+    assert not is_generator_origin("hermes_interaction")
+    assert not is_generator_origin("")
+    assert is_generator_origin("self_heal")
+    assert is_generator_origin("crash_observer")
+    # A generator nobody has written yet is gated by default. This is the
+    # property that makes the rule survive the next generator.
+    assert is_generator_origin("some_generator_invented_next_month")
+
+
+def test_a_generator_below_the_floor_is_suppressed():
+    cp = ControlPlane.in_memory()
+    _file(cp, "self_heal", count=20, completed=0)
+    gate = _gate(cp)
+
+    verdict = gate.evaluate("self_heal")
+    assert verdict["allowed"] is False
+    assert verdict["reason"] == "below_yield_floor"
+    assert verdict["filed"] == 20
+    assert verdict["completed"] == 0
+
+    with pytest.raises(GeneratorSuppressed) as excinfo:
+        gate.enforce({"origin": {"type": "self_heal"}})
+    assert "self_heal" in str(excinfo.value)
+
+
+def test_a_generator_above_the_floor_keeps_filing():
+    cp = ControlPlane.in_memory()
+    # environment_prerequisite measured 9.6%, comfortably above a 5% floor.
+    _file(cp, "environment_prerequisite", count=20, completed=2)
+    gate = _gate(cp)
+
+    verdict = gate.evaluate("environment_prerequisite")
+    assert verdict["allowed"] is True
+    assert verdict["reason"] == "above_yield_floor"
+    assert gate.enforce({"origin": {"type": "environment_prerequisite"}}) is not None
+
+
+def test_a_new_generator_may_earn_a_record_before_being_judged():
+    cp = ControlPlane.in_memory()
+    _file(cp, "brand_new_generator", count=3, completed=0)
+    gate = _gate(cp)
+
+    verdict = gate.evaluate("brand_new_generator")
+    assert verdict["allowed"] is True
+    assert verdict["reason"] == "insufficient_sample"
+
+
+def test_human_filed_work_is_never_suppressed_however_bad_its_yield():
+    cp = ControlPlane.in_memory()
+    _file(cp, "direct_task", count=30, completed=0)
+    gate = _gate(cp)
+
+    verdict = gate.evaluate("direct_task")
+    assert verdict["allowed"] is True
+    assert verdict["reason"] == "not_a_generator"
+    assert gate.enforce({"origin": {"type": "direct_task"}}) is None
+
+
+def test_the_gate_blocks_creation_through_the_control_plane():
+    """End to end: the choke point is create_task, not each generator."""
+    cp = ControlPlane.in_memory()
+    # File the record first under the default policy (min_sample 40), then
+    # tighten the policy, so the fixture is not gated while building itself.
+    _file(cp, "crash_observer", count=15, completed=0)
+    cp.generator_yield_gate.policy = YieldPolicy(
+        enabled=True, min_sample=10, floor=0.05, cache_ttl_seconds=0
+    )
+
+    with pytest.raises(GeneratorSuppressed):
+        cp.create_task(
+            "one more crash repair",
+            project="mac",
+            metadata={"origin": {"type": "crash_observer"}},
+        )
+
+    # The same ledger still accepts operator-filed work.
+    assert cp.create_task("a human asked for this", project="mac") is not None
+
+
+def test_the_gate_can_be_disabled():
+    cp = ControlPlane.in_memory()
+    _file(cp, "self_heal", count=20, completed=0)
+    gate = GeneratorYieldGate(
+        cp.store,
+        YieldPolicy(enabled=False, min_sample=10, floor=0.05, cache_ttl_seconds=0),
+    )
+
+    verdict = gate.evaluate("self_heal")
+    assert verdict["allowed"] is True
+    assert verdict["reason"] == "gate_disabled"
+
+
+def test_every_origin_can_show_its_own_yield():
+    """'A generator that cannot be measured should not be allowed to file.'"""
+    cp = ControlPlane.in_memory()
+    _file(cp, "self_heal", count=20, completed=0)
+    _file(cp, "environment_prerequisite", count=20, completed=2)
+    _file(cp, "direct_task", count=10, completed=5)
+    # Tighten only after the fixture exists, so filing it is not itself gated.
+    cp.generator_yield_gate.policy = YieldPolicy(
+        enabled=True, min_sample=10, floor=0.05, cache_ttl_seconds=0
+    )
+
+    report = cp.generator_yield_report()
+    by_origin = {row["origin_type"]: row for row in report["origins"]}
+
+    assert by_origin["self_heal"]["yield"] == 0.0
+    assert by_origin["self_heal"]["allowed"] is False
+    assert by_origin["self_heal"]["generator"] is True
+
+    assert by_origin["environment_prerequisite"]["allowed"] is True
+    assert by_origin["direct_task"]["generator"] is False
+
+    # Worst-yielding generator first, so the thing to act on leads.
+    assert report["origins"][0]["origin_type"] == "self_heal"
+
+
+def test_suppression_is_recorded_rather_than_silent():
+    cp = ControlPlane.in_memory()
+    _file(cp, "self_heal", count=20, completed=0)
+    cp.generator_yield_gate.policy = YieldPolicy(
+        enabled=True, min_sample=10, floor=0.05, cache_ttl_seconds=0
+    )
+
+    with pytest.raises(GeneratorSuppressed):
+        cp.create_task(
+            "another self-heal finding",
+            project="mac",
+            metadata={"origin": {"type": "self_heal"}},
+        )
+
+    logged = [
+        event
+        for event in cp.list_observability(limit=200)
+        if getattr(event, "name", "") == "task.generator_suppressed"
+    ]
+    assert logged, "a suppressed generator must leave a record"
+    assert logged[0].detail["origin_type"] == "self_heal"


### PR DESCRIPTION
Implements `task_8c87e7d6`, which asked to retire or gate the task generators whose output never completes.

## Measuring first changed the answer

Completion yield by task origin, across **7,781 live ledger tasks** on 2026-08-02:

| origin | tasks | yield | |
|---|---|---|---|
| `direct_task` | 4,505 | 20.0% | human — never gated |
| `dream_low_confidence_repair` | 1,396 | 0.3% | generator already deleted |
| `contract_prerequisite` | 599 | 7.7% | |
| `environment_prerequisite` | 594 | 9.6% | |
| `task_system_reset` | 137 | 2.9% | **named in the task** |
| `self_heal` | 54 | 0.0% | **named in the task** |
| `crash_observer` | 50 | 2.0% | **named in the task** |
| `curiosity_adjudication` | 11 | 0.0% | *not named — still filing Aug 1* |
| `backlog_grooming` | 5 | 0.0% | *not named* |
| `shared_environment_incident` | 3 | 0.0% | *not named* |

The task named three generators. Measuring found **three more at 0%** that it didn't, two of them still filing this week. Deleting three by name would have left three behind and done nothing about the next one.

## So the rule is stated once, and inverted

The gate sits at `ControlPlane.create_task` — the single choke point every generator passes through — and gates **everything except an explicit human-origin allowlist**. A generator written next month is measured by default rather than having to remember to opt in.

With the defaults (`min_sample >= 40`, `floor 5%`) it suppresses exactly `self_heal`, `crash_observer`, `task_system_reset` and `dream_low_confidence_repair`, while leaving `contract_prerequisite`, `environment_prerequisite` and every human origin untouched. I verified that by replaying the live numbers through the shipped predicate rather than asserting it.

## Two deliberate properties

**A new generator may always file its first `min_sample` tasks.** You cannot judge a generator with no record. The hole is real and bounded — and it's why `curiosity_adjudication` and `backlog_grooming` are not suppressed today. They will be, automatically, once they've filed enough to measure, *without anyone naming them*.

**Suppression is recorded, never silent.** A generator that quietly stopped filing is indistinguishable from one that had nothing to file — which is how these went unnoticed for six weeks. There's a test asserting the record exists.

## Showing its own yield

`mac task generator-yield` and `GET /tasks/generator-yield` are the other half of the acceptance criterion: *"a generator that cannot be measured should not be allowed to file."* An origin that can't appear in that report isn't measurable.

## Callers that would otherwise crash

- `self_healing` reports `suppressed` as its own cycle outcome rather than `error`, so a working gate doesn't look like a broken sentinel.
- `crash_service` escalates the crash report to `needs_human` instead of dropping the crash on the floor.

## Verification

9 gate tests + 2 CLI tests, including the CLI subcommand coverage gate. Full local contract suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)