### PR TITLE
Recover the tasks the unsupervision bug left stranded

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -333,11 +333,11 @@ options:
 ```console
 $ mac task --help
 usage: mac task [-h]
-                {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,generator-yield,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
+                {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-stranded,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,generator-yield,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
                 ...
 
 positional arguments:
-  {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,generator-yield,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
+  {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-stranded,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,generator-yield,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
     list                list tasks (default: short ids; use --full-ids for
                         scripts)
     show                show task state, activity, diagnoses, and compact
@@ -369,6 +369,8 @@ positional arguments:
     reopen              recovery: return a stuck/terminal task
                         (failed/cancelled/blocked) to OPEN for retry or
                         reconciliation
+    recover-stranded    re-supervise tasks left waiting on a terminal
+                        dependency (dry-run unless --apply)
     recover-finalizer   revalidate and publish preserved work refused for
                         uncommitted new files
     recover-stalled-finalizer

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -334,6 +334,7 @@ request and response definitions.
 | `GET` | `/tasks/generator-yield` | Task Generator Yield |
 | `GET` | `/tasks/ready` | Ready Tasks |
 | `GET` | `/tasks/ready/explain` | Ready Task Explanations |
+| `POST` | `/tasks/recover-stranded` | Task Recover Stranded |
 | `GET` | `/tasks/search` | Search Tasks |
 | `GET` | `/tasks/stats` | Task Stats |
 | `GET` | `/tasks/throughput` | Task Throughput |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -5441,6 +5441,22 @@ def create_app(
     def task_generator_yield() -> Dict[str, Any]:
         return cp.generator_yield_report()
 
+    # Admin-only: applying this re-supervises live tasks in bulk. Registered
+    # with the other static /tasks/* routes so /tasks/{task_id} cannot capture
+    # it.
+    @app.post("/tasks/recover-stranded")
+    def task_recover_stranded(
+        body: Optional[Dict[str, Any]] = None,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.require_admin()
+        data = body or {}
+        return cp.recover_stranded_dependents(
+            limit=data.get("limit", 500),
+            dry_run=bool(data.get("dry_run", True)),
+            max_rounds=data.get("max_rounds", 10),
+        )
+
     @app.get("/tasks/throughput")
     def task_throughput(
         project: Optional[str] = Query(default=None),

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -2209,6 +2209,20 @@ def cmd_task_reopen(args: argparse.Namespace) -> None:
     _print(_plane(args).reopen_task(args.task_id, args.actor, args.reason or None))
 
 
+def cmd_task_recover_stranded(args: argparse.Namespace) -> None:
+    """Re-supervise tasks left waiting on a dependency that will never finish.
+
+    Dry-run by default: this mutates live task state, so the default reports
+    what it would touch and --apply is required to actually do it.
+    """
+    _print(
+        _plane(args).recover_stranded_dependents(
+            limit=args.limit,
+            dry_run=not args.apply,
+        )
+    )
+
+
 def cmd_task_recover_finalizer(args: argparse.Namespace) -> None:
     """Explicitly recover preserved work refused only for uncommitted new files."""
 
@@ -6590,6 +6604,24 @@ def build_parser() -> argparse.ArgumentParser:
     reopen.add_argument("--reason", default="")
     reopen.add_argument("--actor", default="human")
     _set(cmd_task_reopen, reopen)
+
+    recover_stranded = task.add_parser(
+        "recover-stranded",
+        help="re-supervise tasks left waiting on a terminal dependency "
+        "(dry-run unless --apply)",
+    )
+    recover_stranded.add_argument(
+        "--limit",
+        type=int,
+        default=500,
+        help="maximum terminal dependencies to reconcile in one pass",
+    )
+    recover_stranded.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually re-supervise; without it the command only reports",
+    )
+    _set(cmd_task_recover_stranded, recover_stranded)
 
     recover_finalizer = task.add_parser(
         "recover-finalizer",

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -409,6 +409,18 @@ class RemoteDispatch:
     def generator_yield_report(self) -> Dict[str, Any]:
         return self._get("/tasks/generator-yield")
 
+    def recover_stranded_dependents(
+        self,
+        *,
+        limit: int = 500,
+        dry_run: bool = True,
+        max_rounds: int = 10,
+    ) -> Dict[str, Any]:
+        return self._post(
+            "/tasks/recover-stranded",
+            {"limit": limit, "dry_run": dry_run, "max_rounds": max_rounds},
+        )
+
     def task_flow_report(
         self,
         *,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -11106,6 +11106,144 @@ class ControlPlane:
     def _resolve_waiting_dependents_of(self, dep_id: str, dep_state: str, actor: str) -> None:
         return self.task_transitions._resolve_waiting_dependents_of(dep_id, dep_state, actor)
 
+    def recover_stranded_dependents(
+        self,
+        *,
+        limit: int = 500,
+        dry_run: bool = True,
+        max_rounds: int = 10,
+        actor: str = "strand-recovery",
+    ) -> JsonDict:
+        """Re-supervise WAITING tasks left behind by a terminal dependency.
+
+        Repairs damage from the unsupervision bug: a startup migration
+        reverted supervised BLOCKED tasks to WAITING, and the
+        ``dependency_resolution`` marker then stopped counting, because
+        ``_dependency_state_satisfies_join`` requires BLOCKED *and* the marker.
+        Those tasks waited forever on a dependency that will never complete,
+        and so did their integration parents. Fixing the migration stops NEW
+        stranding; nothing re-supervises what was already reverted.
+
+        This re-runs the ordinary reconciler for each terminal dependency that
+        still has WAITING dependents. It is deliberately NOT a second
+        implementation of that logic: reusing it keeps replacement
+        substitution, ``cancel_scope``, work-package deferral, and the
+        integration-parent rule identical to the live path. In particular a
+        cooperative-integration parent correctly STAYS waiting, so its
+        ``all_settled`` join can settle on the newly supervised child rather
+        than being blocked itself.
+
+        Idempotent: once a dependency's dependents are BLOCKED they no longer
+        select, so a second run is a no-op. Opening the now-settled parents is
+        left to the ordinary dispatcher sweep -- this stays a repair, not a
+        dispatcher.
+        """
+
+        def _unsatisfiable_dependencies() -> List[Any]:
+            """Dependencies that will never complete, with WAITING dependents.
+
+            Terminal (failed/cancelled) OR already supervised. The supervised
+            case is what unwinds a CHAIN: with implement(failed) <- test <-
+            verify, only `test` has a terminal dependency. `verify` waits on
+            `test`, which is BLOCKED and unsatisfiable, so `verify` will never
+            run either -- but the live reconciler only propagates on terminal
+            transitions, so nothing ever marks it and the integration parent
+            waits on it forever. Measured on the live ledger: without this,
+            168 tasks are re-supervised and ZERO parents become dispatchable.
+            """
+            return list(
+                self.store.query_all(
+                    """
+                    SELECT DISTINCT e.dependency_task_id AS dep_id, d.state AS dep_state
+                    FROM task_edges e
+                    JOIN tasks t ON t.id = e.task_id
+                    JOIN tasks d ON d.id = e.dependency_task_id
+                    WHERE t.state = ?
+                      AND (
+                        d.state IN (?, ?)
+                        OR (d.state = ? AND json_extract(
+                              d.metadata, '$.dependency_resolution.status') = ?)
+                      )
+                    ORDER BY e.dependency_task_id
+                    LIMIT ?
+                    """,
+                    (
+                        TaskState.WAITING.value,
+                        TaskState.FAILED.value,
+                        TaskState.CANCELLED.value,
+                        TaskState.BLOCKED.value,
+                        "unsatisfied",
+                        max(1, int(limit)),
+                    ),
+                )
+                or []
+            )
+
+        report: JsonDict = {
+            "schema": "mac.strand_recovery.v1",
+            "dry_run": bool(dry_run),
+            "terminal_dependencies": 0,
+            "dependents_examined": 0,
+            "supervised": 0,
+            "unchanged": 0,
+            "rounds": 0,
+            "errors": [],
+        }
+
+        # A chain unwinds one hop per round: supervising `test` is what makes
+        # `verify` visible as stranded. Bounded so a cycle or a persistent
+        # failure cannot spin; the loop stops as soon as a round changes
+        # nothing, and a dry run never needs more than one round because it
+        # mutates nothing to cascade from.
+        seen_dependencies: set = set()
+        for round_index in range(1, (1 if dry_run else max_rounds) + 1):
+            rows = _unsatisfiable_dependencies()
+            report["rounds"] = round_index
+            supervised_this_round = 0
+
+            for row in rows:
+                dep_id = str(row["dep_id"])
+                dep_state = str(row["dep_state"])
+                if dep_id in seen_dependencies:
+                    continue
+                waiting_before = [
+                    str(record["id"])
+                    for record in (
+                        self.store.query_all(
+                            "SELECT t.id FROM task_edges e JOIN tasks t ON t.id = e.task_id "
+                            "WHERE e.dependency_task_id = ? AND t.state = ?",
+                            (dep_id, TaskState.WAITING.value),
+                        )
+                        or []
+                    )
+                ]
+                if not waiting_before:
+                    continue
+                report["terminal_dependencies"] += 1
+                report["dependents_examined"] += len(waiting_before)
+                if dry_run:
+                    continue
+                seen_dependencies.add(dep_id)
+                try:
+                    self._resolve_waiting_dependents_of(dep_id, dep_state, actor)
+                except Exception as exc:  # noqa: BLE001 - one dependency must not stop the sweep
+                    report["errors"].append({"dependency": dep_id, "error": str(exc)[:300]})
+                    continue
+                for task_id in waiting_before:
+                    try:
+                        if self.get_task(task_id).state != TaskState.WAITING.value:
+                            report["supervised"] += 1
+                            supervised_this_round += 1
+                        else:
+                            report["unchanged"] += 1
+                    except NotFoundError:
+                        report["unchanged"] += 1
+
+            if dry_run or supervised_this_round == 0:
+                break
+
+        return report
+
     def reopen_task(
         self,
         task_id: str,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -11139,6 +11139,25 @@ class ControlPlane:
         dispatcher.
         """
 
+        def _bounded(name: str, value: Any, *, default: int, ceiling: int) -> int:
+            """Coerce a caller-supplied bound, rejecting garbage as a MACError.
+
+            This is a public facade method, so a bad argument must surface as a
+            ValidationError rather than a TypeError from deep inside the loop.
+            """
+            if value is None:
+                return default
+            try:
+                coerced = int(value)
+            except (TypeError, ValueError):
+                raise ValidationError(
+                    "%s must be an integer, got %r" % (name, value)
+                ) from None
+            return max(1, min(ceiling, coerced))
+
+        limit = _bounded("limit", limit, default=500, ceiling=10000)
+        max_rounds = _bounded("max_rounds", max_rounds, default=10, ceiling=100)
+
         def _unsatisfiable_dependencies() -> List[Any]:
             """Dependencies that will never complete, with WAITING dependents.
 
@@ -11173,7 +11192,7 @@ class ControlPlane:
                         TaskState.CANCELLED.value,
                         TaskState.BLOCKED.value,
                         "unsatisfied",
-                        max(1, int(limit)),
+                        limit,
                     ),
                 )
                 or []
@@ -11196,7 +11215,8 @@ class ControlPlane:
         # nothing, and a dry run never needs more than one round because it
         # mutates nothing to cascade from.
         seen_dependencies: set = set()
-        for round_index in range(1, (1 if dry_run else max_rounds) + 1):
+        rounds_allowed = 1 if dry_run else max_rounds
+        for round_index in range(1, rounds_allowed + 1):
             rows = _unsatisfiable_dependencies()
             report["rounds"] = round_index
             supervised_this_round = 0

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -1555,6 +1555,9 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
         return RequestCase(path, kwargs, expected)
 
     bodies: Dict[RouteKey, Dict[str, Any]] = {
+        # Dry run: exercise the route without re-supervising live tasks in the
+        # coverage fixture.
+        ("POST", "/tasks/recover-stranded"): {"dry_run": True, "limit": 1},
         ("POST", "/directives"): {
             "document": {
                 "schema": "mac.directive.v1",

--- a/tests/cli/test_cli_recover_stranded.py
+++ b/tests/cli/test_cli_recover_stranded.py
@@ -1,0 +1,39 @@
+"""`mac task recover-stranded` is dry-run unless --apply.
+
+The command mutates live task state in bulk, so the default must report
+rather than act.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from mac.cli import main
+from mac.test_support import dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, json.loads(raw) if raw else None
+
+
+def test_recover_stranded_defaults_to_dry_run(tmp_path):
+    rc, report = _run(tmp_path, "task", "recover-stranded")
+    assert rc == 0
+    assert report["schema"] == "mac.strand_recovery.v1"
+    assert report["dry_run"] is True
+    assert report["supervised"] == 0
+
+
+def test_recover_stranded_apply_is_explicit(tmp_path):
+    rc, report = _run(tmp_path, "task", "recover-stranded", "--apply")
+    assert rc == 0
+    assert report["dry_run"] is False

--- a/tests/test_strand_recovery.py
+++ b/tests/test_strand_recovery.py
@@ -1,0 +1,180 @@
+"""Recovering tasks the unsupervision bug left stranded.
+
+The bug (fixed separately) reverted supervised BLOCKED tasks to WAITING on
+every hub restart. ``_dependency_state_satisfies_join`` needs BLOCKED *and*
+the ``dependency_resolution`` marker, so a reverted task counted for nothing:
+it waited forever on a dependency that will never complete, and its
+integration parent waited forever on it.
+
+Fixing the migration stops new stranding. It does not re-supervise the 240
+tasks already reverted on the live hub, which is what this sweep is for.
+"""
+from __future__ import annotations
+
+from mac.models import TaskState
+from mac.services import ControlPlane
+
+
+def _decomposed(cp):
+    """Parent -> [implement, test(depends_on implement)], as the planner emits."""
+    parent = cp.create_task("integration parent", project="mac")
+    result = cp.add_child_tasks(
+        parent.id,
+        [
+            {"title": "implement", "node_id": "implement"},
+            {"title": "test", "depends_on": ["implement"]},
+        ],
+    )
+    implement, test = [child["id"] for child in result["children"]]
+    return parent.id, implement, test
+
+
+def _strand(cp, task_id):
+    """Reproduce the bug's end state: WAITING, marker intact, state reverted."""
+    task = cp.get_task(task_id)
+    metadata = dict(task.metadata or {})
+    metadata["dependency_resolution"] = {
+        "schema": "mac.dependency_resolution.v1",
+        "status": "unsatisfied",
+        "policy": "supervise",
+    }
+    cp.update_task(task_id, metadata=metadata, actor="test")
+    cp.store.execute(
+        "UPDATE tasks SET state = ? WHERE id = ?",
+        (TaskState.WAITING.value, task_id),
+    )
+
+
+def test_dry_run_reports_without_changing_anything():
+    cp = ControlPlane.in_memory()
+    _parent, implement, test = _decomposed(cp)
+    cp._transition_task_internal(
+        implement, TaskState.FAILED.value, "test", {"reason": "executor_failed"}
+    )
+    _strand(cp, test)
+
+    report = cp.recover_stranded_dependents(dry_run=True)
+
+    assert report["dry_run"] is True
+    assert report["terminal_dependencies"] >= 1
+    assert report["dependents_examined"] >= 1
+    assert report["supervised"] == 0
+    assert cp.get_task(test).state == TaskState.WAITING.value
+
+
+def test_recovery_re_supervises_a_stranded_dependent():
+    cp = ControlPlane.in_memory()
+    _parent, implement, test = _decomposed(cp)
+    cp._transition_task_internal(
+        implement, TaskState.FAILED.value, "test", {"reason": "executor_failed"}
+    )
+    _strand(cp, test)
+
+    report = cp.recover_stranded_dependents(dry_run=False)
+
+    assert report["supervised"] >= 1
+    recovered = cp.get_task(test)
+    assert recovered.state == TaskState.BLOCKED.value
+    assert recovered.metadata["dependency_resolution"]["status"] == "unsatisfied"
+
+
+def test_an_integration_parent_stays_waiting_and_then_settles():
+    """The property a naive sweep gets wrong.
+
+    A cooperative-integration parent must NOT be blocked alongside its
+    children -- it stays WAITING so its all_settled join can settle on them.
+    Blocking it instead would leave it just as stuck, in a different state.
+    """
+    cp = ControlPlane.in_memory()
+    parent_id, implement, test = _decomposed(cp)
+    cp._transition_task_internal(
+        implement, TaskState.FAILED.value, "test", {"reason": "executor_failed"}
+    )
+    _strand(cp, test)
+
+    cp.recover_stranded_dependents(dry_run=False)
+
+    parent = cp.get_task(parent_id)
+    assert parent.state == TaskState.WAITING.value, "the parent must not be blocked"
+    assert cp._dependency_join_policy(parent) == "all_settled"
+    assert cp._dependencies_satisfied(parent)
+
+    cp._unblock_ready_tasks()
+    assert cp.get_task(parent_id).state == TaskState.OPEN.value
+
+
+def test_recovery_is_idempotent():
+    cp = ControlPlane.in_memory()
+    _parent, implement, test = _decomposed(cp)
+    cp._transition_task_internal(
+        implement, TaskState.FAILED.value, "test", {"reason": "executor_failed"}
+    )
+    _strand(cp, test)
+
+    first = cp.recover_stranded_dependents(dry_run=False)
+    second = cp.recover_stranded_dependents(dry_run=False)
+
+    assert first["supervised"] >= 1
+    # Nothing is WAITING on a terminal dependency any more, so the second pass
+    # selects no work at all.
+    assert second["supervised"] == 0
+    assert cp.get_task(test).state == TaskState.BLOCKED.value
+
+
+def test_a_task_waiting_on_a_live_dependency_is_untouched():
+    """The sweep must only touch work whose dependency is actually terminal."""
+    cp = ControlPlane.in_memory()
+    prerequisite = cp.create_task("still running", project="mac")
+    dependent = cp.create_task(
+        "waiting legitimately", dependencies=[prerequisite.id], project="mac"
+    )
+    assert cp.get_task(dependent.id).state == TaskState.WAITING.value
+
+    report = cp.recover_stranded_dependents(dry_run=False)
+
+    assert report["supervised"] == 0
+    assert cp.get_task(dependent.id).state == TaskState.WAITING.value
+
+
+def test_a_chain_unwinds_and_frees_the_parent():
+    """implement(failed) <- test <- verify: the shape that made this necessary.
+
+    Only `test` has a TERMINAL dependency. `verify` waits on `test`, which is
+    supervised and will never run, but the live reconciler propagates only on
+    terminal transitions -- so nothing marks `verify` and the all_settled
+    parent waits on it forever. Measured on the live ledger, without chain
+    propagation 168 tasks are re-supervised and ZERO parents become
+    dispatchable.
+    """
+    cp = ControlPlane.in_memory()
+    parent = cp.create_task("integration parent", project="mac")
+    result = cp.add_child_tasks(
+        parent.id,
+        [
+            {"title": "implement", "node_id": "implement"},
+            {"title": "test", "node_id": "test", "depends_on": ["implement"]},
+            {"title": "verify", "depends_on": ["test"]},
+        ],
+    )
+    implement, test, verify = [child["id"] for child in result["children"]]
+
+    cp._transition_task_internal(
+        implement, TaskState.FAILED.value, "test", {"reason": "executor_failed"}
+    )
+    # First hop supervises automatically; the second is left stranded.
+    assert cp.get_task(test).state == TaskState.BLOCKED.value
+    assert cp.get_task(verify).state == TaskState.WAITING.value
+
+    report = cp.recover_stranded_dependents(dry_run=False)
+
+    assert report["rounds"] >= 1
+    assert cp.get_task(verify).state == TaskState.BLOCKED.value, (
+        "the second hop must be supervised, or the parent never settles"
+    )
+
+    parent_task = cp.get_task(parent.id)
+    assert parent_task.state == TaskState.WAITING.value
+    assert cp._dependencies_satisfied(parent_task)
+
+    cp._unblock_ready_tasks()
+    assert cp.get_task(parent.id).state == TaskState.OPEN.value

--- a/tests/test_strand_recovery.py
+++ b/tests/test_strand_recovery.py
@@ -178,3 +178,15 @@ def test_a_chain_unwinds_and_frees_the_parent():
 
     cp._unblock_ready_tasks()
     assert cp.get_task(parent.id).state == TaskState.OPEN.value
+
+
+def test_the_sweep_is_reachable_over_the_hub():
+    """The stranded tasks live on the hub, so hub mode is the only mode that
+    matters. A CLI command that only works with --db would be unusable where
+    it is needed."""
+    from mac.dispatch import RemoteDispatch
+
+    assert hasattr(RemoteDispatch, "recover_stranded_dependents"), (
+        "recover_stranded_dependents must be wrapped in RemoteDispatch or "
+        "`mac task recover-stranded` fails in hub mode"
+    )


### PR DESCRIPTION
Implements `task_a7df0655`. PR #264 stopped **new** stranding; nothing re-supervised what was already reverted.

On the live hub, **240 tasks sit in `WAITING` while still carrying `dependency_resolution.status = "unsatisfied"`** — the marker survived in metadata, the state did not. `_dependency_state_satisfies_join` requires `BLOCKED` *and* the marker, so those tasks count for nothing and their integration parents wait on them forever.

## Measuring changed the design twice

**First correction.** I expected the sweep to free ~82 parents. Replayed under *live* semantics it freed **zero** — it would have relabelled stranded work from one non-executing state to another.

**Why.** A second gap, distinct from the migration bug:

```
implement (failed)  ←  test  ←  verify
  test:   dependency FAILED         → supervised ✓
  verify: dependency BLOCKED+marked → never supervised ✗
  parent: waits on verify, forever
```

`_resolve_waiting_dependents_of` propagates only on `FAILED`/`CANCELLED`. A task waiting on a *supervised* task will never run either, but nothing marks it. Measured over 7,794 live tasks to fixpoint:

| propagation | supervised | became dispatchable |
|---|---|---|
| terminal deps only | 168 | **0** |
| + supervised deps | 389 | **82** |

**All** of the recoverable dispatchable work sits beyond the first hop. So the sweep treats an already-supervised dependency as unsatisfiable and iterates — one hop per round, bounded by `max_rounds`, stopping as soon as a round changes nothing.

## Reuse, not reimplementation

The sweep re-runs the ordinary reconciler per unsatisfiable dependency. That inherits replacement substitution, `cancel_scope`, work-package deferral, and the integration-parent rule unchanged. The failure mode I most wanted to avoid is a repair tool that disagrees subtly with the live path.

In particular a cooperative-integration parent **stays `WAITING`**, so its `all_settled` join can settle on the newly supervised child. Blocking it alongside its children would leave it just as stuck in a different state — there's a test for that, because it's what a naive sweep gets wrong (and what my own first simulation got wrong).

## Scope held deliberately

- **The live path is not changed.** New chains will strand again past the first hop. Filed as `task_5e4634e8` with the measurement and care notes, rather than widening this PR into a behavioural change to dispatch.
- **The sweep does not open anything.** It restores supervision; the ordinary dispatcher sweep opens the settled parents. A repair tool that also dispatches is harder to reason about.
- **Dry-run unless `--apply`**, since it mutates live task state in bulk.

## Verification

7 tests (6 sweep + 2 CLI, incl. the CLI subcommand coverage gate). Full local contract gate: **10,082 passed**, exit 0.

The public-contract gate also caught a real defect mid-review: `max_rounds` raised a raw `TypeError` on a non-integer instead of a `MACError`. Fixed in the method (coerce + `ValidationError` + clamp) rather than by adding the parameter to the test's heuristic list — my own tests only ever passed sensible values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)