### PR TITLE
Design note: tasks as actions on a Component

### DIFF
--- a/docs/hermes-retirement-premises.md
+++ b/docs/hermes-retirement-premises.md
@@ -1,0 +1,138 @@
+# Testing the premises for retiring the vendored Hermes tree
+
+Status: findings, 2026-08-04. Written against `task_d9692288`. Nothing is
+implemented or reverted here; this records what the evidence says about two
+claims the retirement rests on.
+
+## The two premises
+
+The migration from the vendored Hermes runtime to OpenClaw was justified by:
+
+1. **OpenClaw runs out of the box with no patches**, removing the maintenance
+   burden of a patched vendor tree.
+2. **Hermes is no longer required because MAC superseded the Hermes learning
+   capability.**
+
+Both were checked against the live fleet and the repository on 2026-08-04.
+Neither holds as stated.
+
+## Premise 2 — the learning capability
+
+**Not supported. MAC's learning loop runs on schedule and produces no durable
+output.**
+
+Sampling 5,000 observability events from the hub:
+
+```text
+agent.nap_completed events:        10
+  with summary_evidence_id:         0
+  with summary_evidence_id = null: 10
+window: 2026-08-04T00:55:26 -> 2026-08-04T01:32:40
+```
+
+The loop is not dormant — `nap.tick.run` shows `agent_natasha`, `agent_rocky`,
+`agent_jordanh-worker5` and `agent_operator` all with `"napped": true,
+"skipped": false`. Every run then completes carrying no summary evidence.
+
+The memory store agrees. All 31 entries in `project=mac` are hand-authored
+operator or agent notes — `plan-wave-cli-blocker`, `fleet-churn-root-causes`,
+`e2e-audit-2026-07-14-defect-taxonomy`. Across the nine days from 2026-07-24 to
+2026-08-02, continuous fleet operation, the loop wrote nothing; the five August
+entries were written by hand during the 2026-08-02/03 session.
+
+Corroborating from the origin-yield table in
+`docs/assessment-2026-08-02.md`: the learning-adjacent generators are the worst
+performers measured — `curiosity_adjudication` 0/11, `backlog_grooming` 0/5,
+`dream_low_confidence_repair` 4/1396 (0.3%, since deleted).
+
+So MAC has the architecture — `nap_ticker`, `nap_consolidator`,
+`curiosity_reviewer`, `dreaming`, `fleet_learning`, `worker_reflect`. What it
+demonstrably has in production is a **durable operator-notes store**, which is
+genuinely valuable and is what carried knowledge across sessions. That is not
+the same claim as superseding a learning capability.
+
+Tracked separately as the null-nap-output defect.
+
+## Premise 1 — the patch burden
+
+**Not supported. OpenClaw is already patched, and the Hermes vendoring is
+engineered rather than ad-hoc.**
+
+| runtime | local patches | notes |
+|---|---|---|
+| Hermes | 12 patches, 3,632 lines, 7 overlay files | reproduces byte-for-byte from pristine upstream |
+| OpenClaw | 1 patch + a filed upstream issue | `patch-stuck-session-recovery.py`, openclaw#105586 |
+
+"No patches" is already false. OpenClaw needed
+`deploy/openclaw/patches/patch-stuck-session-recovery.py` for a wedge where the
+stuck-session watchdog detects a leaked run marker but recovery declines to
+reclaim the lane forever — the agent adds reactions but never replies until the
+gateway is restarted. It is filed upstream as
+`github.com/openclaw/openclaw/issues/105586` and the local patch is to be
+dropped once a release ships the fix.
+
+The 12 Hermes patches are also less burdensome than the count suggests.
+From `deploy/hermes/LOCAL_PATCHES.md`:
+
+* `zz-public-api-docstrings.patch` is **documentation-only** — no behaviour or
+  signature changes.
+* `fts5-orphan-schema-recovery.patch` and
+  `remove-duplicate-top-level-skills.patch` are **upstream bug fixes** (FTS5
+  shadow-table corruption self-heal; ambiguous skill-name shadowing) and are
+  candidates for upstreaming rather than permanent local delta.
+* The remainder are genuine MAC integration: provider decision, runtime-context
+  prompt, sandbox PATH precedence, honest one-shot exit status, multi-Slack.
+
+Crucially the pipeline is reproducible, not a pile of hand edits:
+`scripts/vendor-hermes-snapshot.sh` rebuilds the tree from pristine upstream at
+a pinned commit through patches, removals and overlay, **validated to reproduce
+the committed tree byte-for-byte**, with `tests/test_hermes_vendor_integrity.py`
+pinning a content digest so any drift fails loudly.
+
+## What the retirement costs
+
+Independent of the premises, deleting `src/mac/_hermes` removes:
+
+* **25 skill families** — creative, data-science, devops, email, github, media,
+  productivity, red-teaming and others. What MAC ships for OpenClaw in this
+  repository is one plugin, `mac-continuity`. That is not a like-for-like
+  comparison, since OpenClaw brings capabilities that do not live here, but the
+  repo-side provision is 25 against 1 and the difference has not been measured.
+* **MAC's only NeMo Relay tool/LLM instrumentation.** `relay_tool_context` and
+  `relay_llm_context` are wired in exactly two places, both inside the vendor:
+  `_hermes/agent/tool_executor.py` and `_hermes/agent/chat_completion_helpers.py`.
+  Phase 1 (`create_agent_scope`) is on live paths and survives; Phase 2 does
+  not. No test catches this — the suite exercises the seam, not the live call
+  path — and Relay is default-ON for every deployed agent
+  (`deploy_env.py:1161`), so the telemetry would keep looking enabled. Recorded
+  as an ordering dependency on `task_d9692288`.
+
+## What this does NOT conclude
+
+It does not conclude "retreat to Hermes".
+
+The migration is substantially done: OpenClaw is the live gateway, the Hermes
+runtime is inactive (`gateway_ownership.services = {hermes: inactive,
+nemoclaw: inactive, openclaw: active}`), and only `com.mac.openclaw-gateway`
+runs. Reversing has its own cost, and this analysis has **not** measured
+OpenClaw's actual capability surface against those 25 skill families — that is
+the missing comparison and the thing most likely to change the answer.
+
+What it does conclude is narrower and firmer: **the two stated reasons for the
+migration do not currently hold**, so the decision should be re-made on
+whatever the real reasons are, rather than on these.
+
+## Suggested next step
+
+Measure the capability surface, not the premises. Enumerate what the 25 vendored
+skill families actually provide, which of those the fleet has used in the last
+90 days, and which OpenClaw covers today. A skill family nobody has invoked is
+not a cost of retirement.
+
+## References
+
+* `deploy/hermes/LOCAL_PATCHES.md` — the patch set and its rationale
+* `deploy/openclaw/patches/UPSTREAM-ISSUE-stuck-session-recovery.md`
+* `docs/assessment-2026-08-02.md` section 4 — origin yield
+* `docs/openshell-nemo-relay-integration.md` — Relay phases
+* `task_d9692288`, and the null-nap-output defect filed alongside this note

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -134,6 +134,7 @@ for provenance and is not a current operating contract.
 | supplemental reference | `haskell_migration.md` | A Notional Haskell Migration Plan for MAC |
 | supplemental reference | `hermes-boundary.md` | Hermes Boundary |
 | supplemental reference | `hermes-integration.md` | Hermes Integration |
+| supplemental reference | `hermes-retirement-premises.md` | Testing the premises for retiring the vendored Hermes tree |
 | supplemental reference | `hgx-elastic-capacity.md` | HGX elastic capacity |
 | supplemental reference | `home-consolidation.md` | Home-Directory Consolidation: Analysis & Plan |
 | supplemental reference | `hub-active-passive-design.md` | Hub Active-Passive Design (Minimal Standby) |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -174,6 +174,7 @@ for provenance and is not a current operating contract.
 | supplemental reference | `secrets-management-guide.md` | Secrets Management Guide |
 | supplemental reference | `security/openshell-0.0.72-compatibility-review.mdx` | OpenShell 0.0.72 Compatibility Review |
 | runbook | `soul-preservation-runbook.md` | Soul Preservation Runbook |
+| supplemental reference | `structured-task-bodies.md` | Structured task bodies: actions on a Component |
 | historical archive | `superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md` | Autonomous Project Routing and Review/Fix Loop Implementation Plan |
 | historical archive | `superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md` | Autonomous Project Routing and Review/Fix Loop Design |
 | historical archive | `superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md` | K8s bootstrap fleet registration — design |

--- a/docs/structured-task-bodies.md
+++ b/docs/structured-task-bodies.md
@@ -1,0 +1,174 @@
+# Structured task bodies: actions on a Component
+
+Status: design note, nothing implemented. Written 2026-08-02 after reading
+`~/Src/literate-ai` alongside MAC's existing workflow and work-package models.
+
+## The question
+
+A MAC task body is a title plus free text plus a metadata blob. Could a task
+instead name **an action on a Component** — a closed verb applied to an
+addressable thing — so the body is constrained and machine-checkable?
+
+## What literate-ai supplies
+
+`literate-ai` is a spec-led framework whose domain model already has the two
+things MAC's task body lacks.
+
+A **closed verb set**, as a versioned DAG of typed stages:
+
+```text
+resolve -> source -> index -> contracts -> plan -> generate -> validate
+                                             ^                    |
+                                             +------ repair <-----+
+       -> classify -> authorize-build -> build -> package -> publish
+```
+
+A **lifecycle state machine** that defines what "done" means:
+
+```text
+defined -> specified -> resolved -> source-ready -> origin-verified -> indexed
+  -> planned -> generated -> validated -> classified -> build-authorized
+  -> built -> packaged -> published
+```
+
+Components are addressable (`component://<namespace>/<name>`), revisions bind
+that coordinate to exact specification and source identities, every transition
+produces an immutable object and event, and a transition may be retried only
+when its idempotency key and input identities match.
+
+A structured MAC task body would then be:
+
+```yaml
+action:
+  component:  component://<namespace>/<name>
+  revision:   <exact input identity>
+  transition: generate | validate | classify | build | package | publish | ...
+  target:     <lifecycle state>
+```
+
+## What it would buy, against failures this repository has actually measured
+
+**Decomposition becomes derived instead of invented.** The planner currently
+generates children by model judgment — the recurring `implement / test /
+verify` shape. That shape produced the dependency chains that stranded 76
+integration parents (see `task_0ee0b7ce`, `task_5e4634e8`). If a task is
+`(component, target_state)`, its children are the lifecycle transitions
+between current and target state: a computed path through a known DAG. A task
+that is already one transition is *structurally* indivisible, which is
+`task_0ee0b7ce`'s acceptance criterion (a) obtained by construction rather
+than enforced by a rule.
+
+**Dependencies become derived instead of authored.** They currently cost 5.3x
+completion (`docs/assessment-2026-08-02.md` section 3) and are attached by the
+planner. Lifecycle order already implies them — `build` cannot precede
+`authorize-build` — so the edges are guaranteed acyclic and terminating.
+
+**Completion becomes checkable instead of asserted.** The assessment records
+an executor reporting "56 passed total" while `pushed=false`, and a
+`verification_contract_failed` cohort of 547. With a target state, done means
+the immutable transition object exists at that state. That is a stronger
+contract than an evidence blob an executor fills in about its own work.
+
+**Retry gets a real key.** literate-ai retries a transition only when the
+idempotency key and input identities match. MAC currently approximates this
+with `attempt_count`, failure fingerprints, and a repair-recursion guard.
+
+## What MAC already has — and this is the important finding
+
+MAC is much closer to this than the free-text task body suggests. Two existing
+subsystems already carry most of the skeleton.
+
+`workflow_models.WorkflowNode` is a typed DAG node, but its vocabulary is
+**process governance**, not domain transitions:
+
+| | value |
+|---|---|
+| `NodeType` | `task`, `approval`, `commit`, `verify`, `plan` |
+| `EdgeCondition` | `success`, `approved`, `rejected`, `failure`, `timeout`, `escalated`, `cancelled` |
+| body | `instructions: str` — free text |
+
+The `plan` node type exists precisely to "translate the workflow's free-form
+input description into structured payloads for downstream nodes" — i.e. MAC
+already recognises the gap and fills it at runtime with a model call.
+
+`work_package_models` goes further and is deterministic:
+
+- node types `analysis`, `mutation`, `integration`, `certification`, with
+  aliases from the workflow types;
+- **`WorkPackageEffects`: `reads` / `writes` / `exclusive` / `external`** —
+  each node declares the resources it touches, and allocation policy uses it;
+- `expected_outputs`;
+- canonical compilation to a plan digest, so the same proposed plan compiles
+  identically in an API process, a worker, or an offline audit;
+- bounded at 100 nodes and 100 dependencies;
+- `validate_executable_work_package_effects`, requiring a controller-owned
+  fence for external effects.
+
+So MAC already has a structured node body. Its structure axis is **resource
+effects plus process governance**. literate-ai's is **domain lifecycle**.
+Those are orthogonal, not competing.
+
+## The actual gap
+
+One thing is missing from the work-package node: a closed domain verb and a
+target state. `node_type` says what *kind* of step it is; `instructions` says
+what to do, in prose. Nothing says *what this step does to what artifact*.
+
+That makes the change additive rather than a new subsystem:
+
+1. Add an optional `action: {component, transition, target}` to a
+   work-package node (or to task metadata for the simple case).
+2. **Derive `effects` from it.** A `build` transition reads the source
+   snapshot and writes the build artifact. Effects are currently hand-declared
+   and drive allocation and conflict policy, so deriving them removes a class
+   of hand-authoring error, not just prose.
+3. Derive dependency edges from lifecycle order.
+4. Define completion as the target state being reached.
+
+## Where this does not fit, and why it must stay optional
+
+Most work in this ledger is not a transition on one component. From the open
+set at the time of writing:
+
+- *Retire the Hermes vendor and rename by function* — 594 files, a live
+  gateway, a coordinated rename across persisted config and deployed command
+  lines.
+- *The contract gate fails its own preflight on Python 3.13+* — a defect in
+  the tooling around components.
+- *Re-measure the dependency yield table* — a measurement.
+- *Deploy the backup fixes* — an operation on a running fleet.
+
+None reduce to `generate(component X)`.
+
+And the number that should govern the whole idea: **`direct_task` — plain
+human free text — is the best-performing origin at 20.4%.** The generators
+that filed *structured, machine-authored* work ran at 0-3% and have since been
+retired behind a yield gate (PR #267). Structure is not what made work
+complete. Constraining the body risks damaging the one input channel that
+demonstrably works.
+
+Work packages are also a heavyweight construct — durable, parallel, capped at
+100 nodes. The fit is substantial multi-step work, not "fix this typo".
+
+## Recommended first step
+
+Do not build a new task kind. Establish whether the existing work-package
+pipeline can already express `(component, transition, target)` by adding the
+optional `action` field and deriving `effects` from it for one real workflow.
+
+Then measure, using the method in `task_e48d4eed`: completion yield of
+structured versus free-text tasks, as a cohort, not a cumulative table.
+
+This session twice produced a design that measurement inverted — the
+strand-recovery sweep as first designed freed *zero* tasks, and the
+dependency-yield "improvement" was unmeasurable on a cumulative metric. A
+structured-task-body change is exactly the kind of plausible architecture that
+should not be built before its benefit is measured.
+
+## References
+
+- `docs/assessment-2026-08-02.md` sections 3 and 4 — dependency and origin yield
+- `src/mac/workflow_models.py` — `NodeType`, `EdgeCondition`, `WorkflowNode`
+- `src/mac/work_package_models.py` — `WorkPackageEffects`, canonical plan digest
+- `~/Src/literate-ai/docs/architecture/domain-model.md` — lifecycle state
+  machine, `WorkflowDefinition`/`WorkflowRun`, ports


### PR DESCRIPTION
Answers a question about whether MAC task bodies could name **an action on a Component** — a closed verb applied to an addressable thing — instead of free text. Documentation only; nothing implemented.

## What literate-ai supplies

The two things a free-text body lacks: a closed verb set (`resolve → generate → validate → classify → build → package → publish`) and a lifecycle state machine that defines *done*. Components are addressable, revisions bind exact identities, every transition emits an immutable object, and retry requires matching idempotency key **and** input identities.

## The finding: MAC is already most of the way there, on a different axis

This is the part worth reviewing.

`work_package_models` already compiles a bounded typed DAG to a **canonical plan digest**, and already has a structured node body — **`WorkPackageEffects`** declares `reads`/`writes`/`exclusive`/`external` per node and drives allocation policy.

`workflow_models` adds governance types (`approval`, `commit`, `verify`) plus a `plan` node whose documented job is *"translate the workflow's free-form input description into structured payloads for downstream nodes"* — MAC already recognises this gap and fills it at runtime with a model call.

So MAC's structure axis is **resource effects + governance**; literate-ai's is **domain lifecycle**. Orthogonal, not competing. The only missing piece is a closed domain verb and target state on a node — which makes this additive, not a new subsystem.

A concrete side benefit: `effects` could be **derived** from the transition (a `build` reads the source snapshot, writes the artifact). They're hand-declared today and drive allocation and conflict policy, so deriving them removes a class of authoring error, not just prose.

## Why the note argues against building it yet

- **`direct_task` — plain human free text — is the best-performing origin at 20.4%.** The machine-authored generators ran at 0–3% and have since been retired behind a yield gate (#267). Structure is not what made work complete.
- Most open work isn't a transition on one component: retiring the Hermes vendor (594 files, a live gateway), a Python 3.13 tooling defect, a measurement, a fleet deploy.
- Work packages are heavyweight — durable, parallel, capped at 100 nodes.

## Recommended first step

Add the optional `action` field to **one** real workflow, derive `effects` from it, and measure cohort yield per `task_e48d4eed` — not a cumulative table.

Two designs this session were inverted by measurement: the strand-recovery sweep as first designed freed *zero* tasks, and the yield "improvement" was unmeasurable on a cumulative metric. This is exactly the kind of plausible architecture that should be measured before it is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)