### PR TITLE
Support both human interfaces, activate one per agent

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -180,10 +180,11 @@ HERMES_GATEWAY_PROVIDER="${MAC_DEPLOY_HERMES_GATEWAY_PROVIDER:-custom}"
 HERMES_GATEWAY_BASE_URL="${MAC_DEPLOY_HERMES_GATEWAY_BASE_URL:-}"
 HERMES_SURFACE_B64="${MAC_DEPLOY_HERMES_SURFACE_B64:-}"
 # gateway_impl: which chat-gateway service to install.
-#   openclaw — stock OpenClaw inside a MAC-authored OpenShell policy (sole gateway)
+#   hermes   — the vendored Hermes gateway (mac-hermes-gateway console script)
+#   openclaw — stock OpenClaw inside a MAC-authored OpenShell policy
 #   none     — pure worker with no chat gateway
 # Decoded from the hermes_surface_b64 payload; also injectable via env. Any
-# legacy or unrecognized value is normalized to the sole supported gateway.
+# unrecognized value is normalized to openclaw.
 MAC_CHAT_GATEWAY_IMPL="${MAC_DEPLOY_CHAT_GATEWAY_IMPL:-$(
   if [ -n "${MAC_DEPLOY_HERMES_SURFACE_B64:-}" ]; then
     python3 -c "
@@ -198,8 +199,14 @@ except Exception:
     echo "openclaw"
   fi
 )}"
+# hermes was normalized away here on 2026-07-26 when OpenClaw was to be the
+# sole gateway. That migration was HALTED 2026-08-04 after all three of its
+# premises measured false (docs/hermes-retirement-premises.md), so hermes is a
+# selectable gateway again. The Hermes branches further down this script were
+# never removed -- they were only made unreachable by this normalization.
+# Anything still unrecognized normalizes to openclaw, as before.
 case "$MAC_CHAT_GATEWAY_IMPL" in
-  none) : ;;
+  none|hermes) : ;;
   *) MAC_CHAT_GATEWAY_IMPL="openclaw" ;;
 esac
 openclaw_runtime_value() {

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -11367,6 +11367,8 @@ EOF
   case "${MAC_CHAT_GATEWAY_IMPL:-openclaw}" in
     openclaw|"")
       install_linux_openclaw_service ;;
+    hermes)
+      install_linux_hermes_service ;;
     none)
       install_linux_no_gateway_service ;;
     *)
@@ -11381,6 +11383,114 @@ install_linux_no_gateway_service() {
     disable_systemd_service_if_present "$unit"
   done
   rm -f "$MAC_HOME/bin/openclaw-gateway" "$MAC_HOME/bin/hermes-gateway"
+  install_linux_agent_service
+}
+
+# Restored 2026-08-04 from dbb25ad0^ after the OpenClaw migration was halted
+# (docs/hermes-retirement-premises.md). Removed 2026-07-25 as "inactive
+# Hermes gateway code"; the premises that justified removing it were later
+# measured false. Unchanged from the original apart from the selector rename
+# HERMES_GATEWAY_IMPL -> MAC_CHAT_GATEWAY_IMPL.
+install_hermes_gateway_wrapper() {
+  # Worker/gateway decoupling: a pure worker (gateway_impl=none) runs no chat
+  # gateway at all — only the mac-agent worker. Skip installing the Hermes
+  # gateway wrapper so the node is a clean executor, not a conversational agent.
+  if [ "${MAC_CHAT_GATEWAY_IMPL:-hermes}" = "none" ]; then
+    log "gateway_impl=none: pure worker; skipping Hermes gateway wrapper install"
+    return 0
+  fi
+  local wrapper="${1:-$MAC_HOME/bin/hermes-gateway}"
+  mkdir -p "$(dirname "$wrapper")"
+  cat > "$wrapper" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+ulimit -n "${MAC_SERVICE_NOFILE_LIMIT:-4096}" 2>/dev/null || true
+set -a
+set +u
+[ -f "$HOME/.hermes/.env" ] && . "$HOME/.hermes/.env"
+[ -f "$HOME/.mac/mac.env" ] && . "$HOME/.mac/mac.env"
+set -u
+set +a
+export PATH="$HOME/.mac/bin:$HOME/.mac/venv/bin:$PATH"
+export HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+export HERMES_DISABLE_LAZY_INSTALLS=1
+export HERMES_REDACT_SECRETS=true
+if [ -z "${OPENAI_BASE_URL:-}" ] && [ -n "${CUSTOM_BASE_URL:-}" ]; then
+  export OPENAI_BASE_URL="$CUSTOM_BASE_URL"
+fi
+if [ -z "${ACC_HERMES_GATEWAY_API_KEY:-}" ] && [ -n "${MAC_HERMES_GATEWAY_API_KEY:-}" ]; then
+  export ACC_HERMES_GATEWAY_API_KEY="$MAC_HERMES_GATEWAY_API_KEY"
+fi
+# ADR 0001 hu-04: run the vendored Hermes gateway in-process from the mac venv
+# (mac-hermes-gateway -> hermes_cli.main "gateway run --replace"), instead of a
+# separate hermes-agent venv. Validated in fleet rollout 2026-05-31.
+exec "$HOME/.mac/venv/bin/python" -m mac.hermes_gateway
+EOF
+  chmod 700 "$wrapper"
+}
+
+install_linux_hermes_service() {
+  local unit="/etc/systemd/system/${HERMES_SERVICE_NAME}" restart_since control_after=""
+  local unit_staging="$LOG_DIR/${HERMES_SERVICE_NAME}.${DEPLOY_TS}.$$.stage"
+  disable_systemd_service_if_present "$OPENCLAW_SERVICE_NAME"
+  disable_systemd_service_if_present "$NEMOCLAW_SERVICE_NAME"
+  if control_plane_enabled; then
+    control_after="$MAC_SERVICE_NAME"
+  fi
+  log "installing systemd service $unit"
+  if sudo test -f "$unit"; then
+    HERMES_UNIT_BACKUP="$MAC_HOME/backups/${HERMES_SERVICE_NAME}.${AGENT}.${DEPLOY_TS}"
+    snapshot_rollback_file "$unit" "$HERMES_UNIT_BACKUP" system
+    write_rollback_script
+  fi
+  if [ "$DEPLOY_ROLLBACK_ARMED" = 1 ] && [ -z "$HERMES_UNIT_BACKUP" ]; then
+    die "cannot mutate the Hermes unit without a prior-generation backup"
+  fi
+  HERMES_UNIT_MUTATED=1
+  write_rollback_script
+  cat > "$unit_staging" <<EOF
+[Unit]
+Description=mac-managed Hermes gateway
+After=network-online.target $control_after
+Wants=network-online.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=$USER
+WorkingDirectory=$MAC_HOME
+EnvironmentFile=$ENV_FILE
+ExecStart=$MAC_HOME/bin/hermes-gateway
+Restart=always
+RestartSec=5
+RestartForceExitStatus=75
+SuccessExitStatus=75
+KillMode=mixed
+KillSignal=SIGTERM
+ExecReload=/bin/kill -USR1 \$MAINPID
+# Must exceed the gateway's restart_drain_timeout so systemd doesn't SIGKILL it
+# mid-drain. Mirrors hermes_cli/gateway.py: max(60, restart_drain_timeout) + 30
+# (=210 for the default drain of 180). A too-low value triggers the gateway's
+# "Stale systemd unit detected" startup warning. Bump if restart_drain_timeout
+# is raised above 180.
+TimeoutStopSec=210
+LimitNOFILE=65536
+LimitCORE=infinity
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  mac_launchd_atomic_replace "$unit_staging" "$unit" system 0644 0 0
+  run_systemctl daemon-reload
+  run_systemctl enable "$HERMES_SERVICE_NAME"
+  restart_since="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  run_systemctl restart "$HERMES_SERVICE_NAME"
+  run_systemctl --no-pager -l status "$HERMES_SERVICE_NAME" \
+    > "$LOG_DIR/hermes-gateway-status.txt" || true
+  run_journalctl -u "$HERMES_SERVICE_NAME" --since "$restart_since" --no-pager \
+    > "$LOG_DIR/hermes-gateway-journal.txt" || true
   install_linux_agent_service
 }
 
@@ -12798,6 +12908,9 @@ EOF
   openclaw|"")
     install_darwin_openclaw_service "$uid"
     ;;
+  hermes)
+    install_darwin_hermes_service "$uid"
+    ;;
   none)
     install_darwin_no_gateway_service "$uid"
     ;;
@@ -12857,6 +12970,87 @@ install_darwin_no_gateway_service() {
   mac_launchd_remove_file_and_fsync "$MAC_HOME/bin/hermes-gateway" user
   verify_selected_gateway_supervisor_health
   mac_launchd_transaction_commit
+}
+
+# Restored 2026-08-04 from dbb25ad0^ after the OpenClaw migration was halted
+# (docs/hermes-retirement-premises.md). Removed 2026-07-25 as "inactive
+# Hermes gateway code"; the premises that justified removing it were later
+# measured false. Unchanged from the original apart from the selector rename
+# HERMES_GATEWAY_IMPL -> MAC_CHAT_GATEWAY_IMPL.
+install_darwin_hermes_service() {
+  local uid="$1" plist="$HOME/Library/LaunchAgents/${HERMES_LAUNCHD_LABEL}.plist"
+  local plist_staging="$HOME/Library/LaunchAgents/.${HERMES_LAUNCHD_LABEL}.${DEPLOY_TS}.$$.stage"
+  local wrapper="$MAC_HOME/bin/hermes-gateway"
+  local wrapper_staging="$MAC_HOME/bin/.hermes-gateway.${DEPLOY_TS}.$$.stage"
+  local openclaw_plist="$HOME/Library/LaunchAgents/${OPENCLAW_LAUNCHD_LABEL}.plist"
+  local nemoclaw_plist="$HOME/Library/LaunchAgents/${NEMOCLAW_LAUNCHD_LABEL}.plist"
+  if [ -f "$plist" ]; then
+    HERMES_PLIST_BACKUP="$MAC_HOME/backups/${HERMES_LAUNCHD_LABEL}.${AGENT}.${DEPLOY_TS}.plist"
+    snapshot_rollback_file "$plist" "$HERMES_PLIST_BACKUP" user
+    write_rollback_script
+  fi
+  if [ "$DEPLOY_ROLLBACK_ARMED" = 1 ] && [ -z "$HERMES_PLIST_BACKUP" ]; then
+    die "cannot mutate the Hermes launchd job without a prior plist backup"
+  fi
+  HERMES_PLIST_MUTATED=1
+  write_rollback_script
+  darwin_clear_auxiliary_restore
+  mac_launchd_transaction_begin \
+    "gui/$uid" "$plist" "gui/$uid/$HERMES_LAUNCHD_LABEL" \
+    "$HERMES_LAUNCHD_LABEL" user
+  mac_launchd_transaction_set_expected_prior_state \
+    "$(darwin_expected_prior_state "$DARWIN_HERMES_LAUNCHD_ACTIVE")"
+  mac_launchd_transaction_track_file "$wrapper"
+  mac_launchd_transaction_track_file "$openclaw_plist"
+  mac_launchd_transaction_track_file "$nemoclaw_plist"
+  mac_launchd_transaction_track_temporary "$wrapper_staging"
+  mac_launchd_transaction_track_temporary "$plist_staging"
+  if [ "$DARWIN_OPENCLAW_LAUNCHD_ACTIVE" = 1 ]; then
+    darwin_set_auxiliary_restore \
+      "gui/$uid" "$openclaw_plist" "gui/$uid/$OPENCLAW_LAUNCHD_LABEL" \
+      "$OPENCLAW_LAUNCHD_LABEL" user
+  elif [ "$DARWIN_NEMOCLAW_LAUNCHD_ACTIVE" = 1 ]; then
+    darwin_set_auxiliary_restore \
+      "gui/$uid" "$nemoclaw_plist" "gui/$uid/$NEMOCLAW_LAUNCHD_LABEL" \
+      "$NEMOCLAW_LAUNCHD_LABEL" user
+  fi
+  install_hermes_gateway_wrapper "$wrapper_staging"
+  cat > "$plist_staging" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$HERMES_LAUNCHD_LABEL</string>
+  <key>ProgramArguments</key>
+  <array><string>$MAC_HOME/bin/hermes-gateway</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>WorkingDirectory</key><string>$MAC_HOME</string>
+  <key>StandardOutPath</key><string>$LOG_DIR/hermes-gateway.log</string>
+  <key>StandardErrorPath</key><string>$LOG_DIR/hermes-gateway.log</string>
+</dict>
+</plist>
+EOF
+  /bin/bash -n "$wrapper_staging"
+  if command -v plutil >/dev/null 2>&1; then
+    plutil -lint "$plist_staging"
+  fi
+  mac_launchd_transaction_mark_mutating
+  stop_gui_launchd_job_if_present "$uid" "$OPENCLAW_LAUNCHD_LABEL"
+  darwin_disable_job "gui/$uid/$OPENCLAW_LAUNCHD_LABEL" "$OPENCLAW_LAUNCHD_LABEL" user
+  stop_gui_launchd_job_if_present "$uid" "$NEMOCLAW_LAUNCHD_LABEL"
+  darwin_disable_job "gui/$uid/$NEMOCLAW_LAUNCHD_LABEL" "$NEMOCLAW_LAUNCHD_LABEL" user
+  stop_gui_launchd_job_if_present "$uid" "$HERMES_LAUNCHD_LABEL"
+  mac_launchd_transaction_replace "$wrapper_staging" "$wrapper" 0700
+  mac_launchd_transaction_replace "$plist_staging" "$plist" 0644
+  : > "$LOG_DIR/hermes-gateway.log"
+  mac_launchd_bootstrap_job \
+    "gui/$uid" "$plist" "gui/$uid/$HERMES_LAUNCHD_LABEL" \
+    "$HERMES_LAUNCHD_LABEL" user
+  verify_selected_gateway_supervisor_health
+  mac_launchd_transaction_commit
+  darwin_clear_auxiliary_restore
 }
 
 install_darwin_openclaw_service() {

--- a/docs/human-interface-selector.md
+++ b/docs/human-interface-selector.md
@@ -1,0 +1,136 @@
+# The human interface: support both, activate one
+
+Status: design note, 2026-08-04. Describes a model the deploy already mostly
+implements, and what remains to make it explicit.
+
+## The term
+
+Hermes and OpenClaw do the same job: they interface with human users and with
+the plugin ecosystems built during the era of human-to-service maps. Call that
+role the **human interface**. MAC is the control plane; the human interface is
+how people talk to it and how it reaches services people already use.
+
+Naming the role matters because it reframes the question. "Hermes or OpenClaw"
+sounds like a migration. "Which human interface is active on this agent"
+sounds like configuration — which is what it always was.
+
+## The model
+
+Both human interfaces are **supported and deployable**. Exactly **one is
+active per agent**. Agents may differ from one another.
+
+```yaml
+gateway_impl: hermes | openclaw | none
+```
+
+`none` is a pure worker with no human interface at all.
+
+## This is not a new architecture
+
+Three facts, verified 2026-08-04:
+
+**The selector already has this shape.** `gateway_impl` was always a
+three-valued choice. The 2026-07-26 change (`ab7a5020`) did not simplify an
+architecture; it deleted one arm of a switch that still exists.
+
+**Mutual exclusion is already enforced.** `install_linux_no_gateway_service`
+and its Darwin counterpart iterate `OPENCLAW_SERVICE_NAME`,
+`HERMES_SERVICE_NAME` **and** `NEMOCLAW_SERVICE_NAME`, proving each inactive
+and disabled. The restored `install_*_hermes_service` functions go further:
+they call `darwin_set_auxiliary_restore` on the OpenClaw and NemoClaw plists so
+that switching interfaces is a bounded launchd transaction with rollback, not a
+stop-and-hope. The "never two at once" property the model depends on was built
+in from the start.
+
+**Home consolidation is already half-done, in the right direction.** Per
+`docs/home-consolidation.md`, OpenClaw's real home is `~/.mac/openclaw/`;
+`~/.openclaw` is only a container symlink, and `.nemoclaw` is an env-var prefix
+rather than a directory. The single holdout is the legacy `~/.hermes` sibling.
+Once that moves under `~/.mac/hermes/`, "port the profile between interfaces"
+becomes a local operation under one root rather than a cross-home migration.
+
+## Why keep both rather than pick one
+
+**The premises that justified picking one were false.** All three — that MAC
+had superseded Hermes' learning capability, that OpenClaw needed no patches,
+that OpenClaw would run as `nemoclaw` in a constrained OpenShell sandbox — were
+measured false on 2026-08-04. See `docs/hermes-retirement-premises.md`. A
+system that can hold both options does not have to be right the first time.
+
+**Neither is currently tracking upstream ToT.** Both are roughly two months
+behind:
+
+| interface | pin | dated |
+|---|---|---|
+| Hermes | `NousResearch/hermes-agent` @ `b1a25404` | vendored 2026-05-31 |
+| OpenClaw | `ghcr.io/openclaw/openclaw:2026.6.11@sha256:3814fb…` | released 2026-06-11 |
+
+So "we migrated to OpenClaw, therefore we are current" is not true today. Both
+codebases move quickly, and staleness is a property of our update cadence, not
+of which one we chose.
+
+**The maintenance models are asymmetric, and that is the real cost.**
+
+*OpenClaw* is an image pin: an immutable multi-arch digest of an official
+release plus one local patch (`patch-stuck-session-recovery.py`, filed upstream
+as openclaw#105586). Updating is a digest bump and a rebuild.
+
+*Hermes* is a source vendor: 12 patches and 7 overlay files re-applied over a
+pristine upstream clone. Updating means re-vendoring at a newer commit and
+resolving patch conflicts. That is more expensive — but far better tooled than
+a typical fork. `scripts/vendor-hermes-snapshot.sh` reproduces the tree
+**byte-for-byte**, `SNAPSHOT_PIN` records the exact upstream base,
+`LOCAL_PATCHES.md` documents every patch's purpose, and
+`tests/test_hermes_vendor_integrity.py` pins a content digest so drift — a hand
+edit or a re-vendor — fails loudly instead of silently.
+
+## What carrying both actually costs
+
+Honestly, not nothing:
+
+* two deploy paths in `fleet-node-install.sh`, both needing to keep working;
+* two sets of gateway readiness tests;
+* a re-vendor cadence for Hermes that does not currently exist;
+* the 594-file vendored tree in the repository.
+
+The cheapest reduction available is to **shrink the Hermes patch set before
+the next re-vendor**. Of the twelve: `zz-public-api-docstrings.patch` is
+documentation-only, and `fts5-orphan-schema-recovery.patch` and
+`remove-duplicate-top-level-skills.patch` fix upstream bugs and belong
+upstream. Every patch removed is conflict surface removed from every future
+re-vendor.
+
+## What this model buys
+
+**Per-agent comparison instead of assertion.** The learning question that
+started this — does the human interface's self-training beat MAC's — is
+answerable by running Hermes on one host and OpenClaw on another and measuring
+the output. That is exactly the experiment that could not be run once one side
+was deleted.
+
+**Plugin ecosystems stay reachable.** The vendored tree carries 25 skill
+families. Whether they are worth keeping is a usage question that has not been
+measured; deleting them answers it by fiat.
+
+**Reversibility.** The migration was halted only because nothing had been
+deleted yet. Keeping both preserves that property for the next decision.
+
+## What remains
+
+1. Restore the Hermes service installers — done 2026-08-04 from `dbb25ad0^`.
+2. Move `~/.hermes` under `~/.mac/hermes/` per `docs/home-consolidation.md`, so
+   profile porting is intra-root.
+3. Define a profile-port operation between interfaces (identity/soul, memory,
+   home-channel bindings) — the piece that does not exist yet in either
+   direction.
+4. Establish a re-vendor cadence for Hermes and a digest-bump cadence for
+   OpenClaw, so "both supported" does not decay into "both stale".
+5. Gateway readiness coverage for both arms, so a broken interface fails in CI
+   rather than on a host.
+
+## References
+
+* `docs/hermes-retirement-premises.md` — why the migration was halted
+* `docs/home-consolidation.md` — the four-homes analysis and target
+* `deploy/hermes/LOCAL_PATCHES.md` — the Hermes patch set
+* `deploy/openclaw/patches/UPSTREAM-ISSUE-stuck-session-recovery.md`

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -140,6 +140,7 @@ for provenance and is not a current operating contract.
 | runbook | `hub-availability.md` | Hub Availability |
 | supplemental reference | `hub-ha-audit.md` | Ground-Truth Audit: Hub High-Availability Primitives |
 | supplemental reference | `hub-host-saturation-remediation.md` | Hub-Host Saturation Remediation |
+| supplemental reference | `human-interface-selector.md` | The human interface: support both, activate one |
 | supplemental reference | `image-publication-and-qualification.md` | Image Publication and Pre-Publication Qualification |
 | landing page | `index.md` | MAC: trustworthy work across an agent fleet |
 | supplemental reference | `integration-authority-contract.md` | Integration Authority Contract |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -5388,6 +5388,7 @@
     "name": "MAC_HERMES_GATEWAY_API_KEY",
     "retired": false,
     "sources": [
+      "deploy/fleet-node-install.sh",
       "deploy/hermes/overlay/plugins/image_gen/mac-hub/__init__.py",
       "deploy/hermes/overlay/plugins/image_gen/mac-hub/plugin.yaml",
       "deploy/hermes/overlay/plugins/image_gen/nvidia/__init__.py",

--- a/src/mac/fleet_setup.py
+++ b/src/mac/fleet_setup.py
@@ -196,17 +196,24 @@ def build_setup_plan(
     )
     worker_defaults = _mapping(defaults_block.get("worker"))
 
-    # Persona/Slack runtime selector: only OpenClaw (a chat-gateway host) or
-    # ``none`` (a pure worker) are supported. Mirror the network.provider
-    # allow-list pattern so an unknown runtime fails validation loudly instead
-    # of silently deploying an unsupported gateway.
+    # Persona/Slack runtime selector. ``hermes`` was removed from this
+    # allow-list on 2026-07-26 (ab7a5020) when OpenClaw was to be the sole
+    # gateway. That migration was HALTED on 2026-08-04 after all three of its
+    # premises were measured false -- most importantly, the learning capability
+    # that was supposed to make Hermes redundant produces null output while the
+    # Hermes curator ran 8 of 8 weekly cycles until it was switched off. See
+    # docs/hermes-retirement-premises.md.
+    #
+    # ``hermes`` is therefore a supported selector again. The vendored runtime,
+    # the mac-hermes-gateway console script and the launcher were never
+    # removed, so this restores a selection, not an implementation.
     gateway_impl = _str(
         spec.get("gateway_impl")
         or defaults_block.get("gateway_impl")
         or fleet_block.get("gateway_impl")
     ).lower()
-    if gateway_impl and gateway_impl not in {"openclaw", "none"}:
-        errors.append("gateway_impl must be openclaw or none")
+    if gateway_impl and gateway_impl not in {"hermes", "openclaw", "none"}:
+        errors.append("gateway_impl must be hermes, openclaw, or none")
 
     agents = _agent_configs(
         spec,

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -875,14 +875,35 @@ def test_agent_services_allow_full_openshell_task_withdrawal():
 
 
 def test_agent_service_wrapper_raises_file_descriptor_limit_without_hermes_wrapper():
+    """The agent wrapper raises its own FD limit, independently of any gateway.
+
+    The name means "without NEEDING the Hermes wrapper", not "while the Hermes
+    wrapper does not exist". The second assertion here used to be
+    `"install_hermes_gateway_wrapper() {" not in script` -- a removal assertion
+    added by dbb25ad0 pinning the Hermes gateway code as deleted. That deletion
+    was reversed on 2026-08-04 when the OpenClaw migration was halted
+    (docs/hermes-retirement-premises.md), so the assertion now protects the
+    property the test is named for: a pure worker gets its FD limit from its own
+    wrapper and never depends on a chat gateway being installed.
+    """
+    import re
+
     script = deploy_script_text()
-    agent_wrapper = script.split("install_mac_agent_wrapper() {", 1)[1].split(
-        "install_mac_hermes_task_executor() {", 1
-    )[0]
+    # Extract ONLY the function body. The previous split ran from
+    # install_mac_agent_wrapper to install_mac_hermes_task_executor, spanning
+    # ~97k characters of unrelated shell, so any function defined in between
+    # would trip a containment assertion by mere proximity.
+    match = re.search(
+        r"^install_mac_agent_wrapper\(\) \{.*?^\}$", script, re.M | re.S
+    )
+    assert match, "install_mac_agent_wrapper not found"
+    agent_wrapper = match.group(0)
 
     expected = 'ulimit -n "${MAC_SERVICE_NOFILE_LIMIT:-4096}" 2>/dev/null || true'
     assert expected in agent_wrapper
-    assert "install_hermes_gateway_wrapper() {" not in script
+    # Independence: the agent wrapper must not reach for any gateway wrapper.
+    assert "install_hermes_gateway_wrapper" not in agent_wrapper
+    assert "install_openclaw_gateway_wrapper" not in agent_wrapper
 
 
 def test_fleet_deploy_applies_hermes_patch_set():

--- a/tests/test_fleet_setup.py
+++ b/tests/test_fleet_setup.py
@@ -380,17 +380,30 @@ def test_bad_spec_collects_validation_errors_and_router_warning(tmp_path: Path) 
 
 
 def test_gateway_impl_runtime_selector_allowlist(tmp_path: Path) -> None:
-    """The persona/Slack runtime selector accepts only openclaw or none;
-    anything else is a validation error (mirrors network.provider)."""
-    ok = _base_spec()
-    ok['gateway_impl'] = 'openclaw'
-    assert not any('gateway_impl' in e for e in _build(tmp_path, ok)['errors'])
-    none_ok = _base_spec()
-    none_ok['gateway_impl'] = 'none'
-    assert not any('gateway_impl' in e for e in _build(tmp_path, none_ok)['errors'])
+    """The persona/Slack runtime selector accepts hermes, openclaw, or none.
+
+    `hermes` was removed from this allow-list on 2026-07-26 (ab7a5020) when
+    OpenClaw was to be the sole gateway. That migration was HALTED on
+    2026-08-04 after all three of its premises measured false -- see
+    docs/hermes-retirement-premises.md. The vendored runtime, the
+    mac-hermes-gateway console script and the launcher were never removed, so
+    restoring the selector restores a choice, not an implementation.
+
+    An unknown value must still fail loudly (mirrors network.provider), which
+    is the property this test exists to protect.
+    """
+    for accepted in ('hermes', 'openclaw', 'none'):
+        spec = _base_spec()
+        spec['gateway_impl'] = accepted
+        assert not any(
+            'gateway_impl' in e for e in _build(tmp_path, spec)['errors']
+        ), accepted
     bad = _base_spec()
-    bad['gateway_impl'] = 'hermes'
-    assert any('gateway_impl must be openclaw or none' in e for e in _build(tmp_path, bad)['errors'])
+    bad['gateway_impl'] = 'nemoclaw'
+    assert any(
+        'gateway_impl must be hermes, openclaw, or none' in e
+        for e in _build(tmp_path, bad)['errors']
+    )
 
 
 def test_openclaw_defaults_block_read_with_hermes_fallback(tmp_path: Path) -> None:


### PR DESCRIPTION
Restores `hermes` as a deployable `gateway_impl` after the OpenClaw migration was halted. **Changes no fleet config** — `gateway_impl` remains `openclaw` everywhere; this restores the *option*.

## Why the migration was halted

All three of its premises were measured false against the live fleet on 2026-08-04 (`docs/hermes-retirement-premises.md`):

| premise | finding |
|---|---|
| "MAC superseded the Hermes learning capability" | Hermes curator: **8 of 8** weekly cycles, 4 agent-created skills. MAC naps: **10 of 10** with `summary_evidence_id: null`, no loop-written memory in 9 days. OpenClaw's dream scripts: **not loaded at all**. |
| "OpenClaw runs with no patches" | It carries `patch-stuck-session-recovery.py` (upstream openclaw#105586). |
| "OpenClaw runs as nemoclaw in a constrained sandbox" | **No nemoclaw service exists** on the hub; `deploy/nemoclaw` is scaffolding. |

The curator stopped 2026-07-06; the OpenClaw gateway landed 2026-07-07. It was switched off mid-stride **while working**, not found wanting.

## What this restores

Verbatim from `dbb25ad0^`, single rename `HERMES_GATEWAY_IMPL` → `MAC_CHAT_GATEWAY_IMPL`:

- `install_hermes_gateway_wrapper` (37 lines)
- `install_linux_hermes_service` (64)
- `install_darwin_hermes_service` (75)
- the `hermes)` arm in both dispatches
- `fleet_setup.py` accepts `hermes`; the installer stops normalizing it to `openclaw`

Helpers survived the removal (`DARWIN_HERMES_LAUNCHD_ACTIVE` still tracked in 8 places, `mac_launchd_transaction_begin` and `darwin_set_auxiliary_restore` intact), so this is **recovery, not reimplementation**.

**Notable:** `install_darwin_hermes_service` already calls `darwin_set_auxiliary_restore` on the OpenClaw *and* NemoClaw plists — switching the active interface is a **bounded launchd transaction with rollback**. Mutual exclusion was designed in; the migration deleted one arm of that switch rather than simplifying it.

## Two tests encoded the migration and change with it

`test_gateway_impl_runtime_selector_allowlist` asserted `hermes` is rejected. Now accepts hermes/openclaw/none and asserts an unknown value still fails loudly — the property it actually protects.

`test_agent_service_wrapper_raises_file_descriptor_limit_without_hermes_wrapper` asserted `"install_hermes_gateway_wrapper() {" not in script`. The name means "without *needing* it", not "while it doesn't exist"; it now asserts the agent wrapper reaches for **no** gateway wrapper.

**That test also had a latent bug**: it extracted ~97,000 characters spanning unrelated shell, so *any* function added in that region would trip a containment assertion by proximity. Now extracts the function body. This would have bitten the next person to touch that area, unrelated to Hermes.

## The model

`docs/human-interface-selector.md` — both human interfaces supported and deployable, exactly one active per agent, `none` for a pure worker.

It records honestly what is **not** built (a profile-port operation between interfaces) and that **neither interface tracks upstream ToT** — Hermes vendored 2026-05-31, OpenClaw pinned to the 2026-06-11 release, both ~2 months behind. So "we're on OpenClaw therefore we're current" isn't true, and "both supported" needs an update cadence or it decays into "both stale".

## Verification

Full contract gate: **10,098 passed**, exit 0. All five `hermes_*` modules verified importing cleanly on the live hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)