### PR TITLE
Port agent profiles between human interfaces, preserving every Slack workspace

### DIFF
--- a/docs/human-interface-selector.md
+++ b/docs/human-interface-selector.md
@@ -120,13 +120,53 @@ deleted yet. Keeping both preserves that property for the next decision.
 1. Restore the Hermes service installers — done 2026-08-04 from `dbb25ad0^`.
 2. Move `~/.hermes` under `~/.mac/hermes/` per `docs/home-consolidation.md`, so
    profile porting is intra-root.
-3. Define a profile-port operation between interfaces (identity/soul, memory,
-   home-channel bindings) — the piece that does not exist yet in either
-   direction.
+3. Define a profile-port operation between interfaces — done 2026-08-04 as
+   `src/mac/human_interface_profile.py`, both directions. See below.
 4. Establish a re-vendor cadence for Hermes and a digest-bump cadence for
    OpenClaw, so "both supported" does not decay into "both stale".
 5. Gateway readiness coverage for both arms, so a broken interface fails in CI
    rather than on a host.
+6. **Fix the multi-Slack patch for `slack_bolt` 1.27 — this blocks activating
+   Hermes anywhere.** The patch builds each account's app as
+   `AsyncApp(token=bot_token)`; 1.27.0 rejects that with `signing_secret must
+   not be empty` at construction, verified directly against the installed
+   library on the hub. Socket Mode has no inbound HTTP request to verify, so
+   the fix is `request_verification_enabled=False`, re-vendored through
+   `scripts/vendor-hermes-snapshot.sh`. This is the staleness risk in this
+   very document arriving in practice: a pinned source fork drifting against
+   an unpinned dependency.
+
+## Porting a profile between interfaces
+
+The rule: **whichever interface the agent used last holds the freshest
+configuration**, so it is the source, and it is ported before switching.
+
+Both interfaces are **multi-account**. They differ only in encoding:
+
+| | account list | encoding |
+|---|---|---|
+| Hermes | `~/.hermes/slack_accounts.json` | JSON array of `{name, bot_token, app_token}` — one `AsyncApp` and one websocket each, from `multi-slack-mvp.patch`. Flat `SLACK_BOT_TOKEN` is a single-account fallback used only when the file is absent. |
+| OpenClaw | namespaced env | `MAC_OPENCLAW_SLACK_<ACCOUNT>_{BOT,APP}_TOKEN`, with `MAC_OPENCLAW_SLACK_ACCOUNT_ID` naming the default |
+
+Two properties matter more than the translation itself:
+
+**Accounts are a union, never a collapse.** The source wins for accounts it
+has; an account known only to the *target* is carried through untouched. An
+earlier draft of this module modelled Hermes as single-account and would have
+written only the active workspace into the flat keys — silently dropping
+`offtera` while reporting success. Both hosts carry both workspaces today.
+
+**Identity documents are preserved, not overwritten.** Where both sides have a
+document and they differ, the destination is kept and the incoming version is
+written alongside as `<file>.incoming` for a human to reconcile. On the hub,
+`USER.md` and `MEMORY.md` are genuinely disjoint — neither is a superset — so
+any last-writer-wins copy would destroy knowledge.
+
+**No signing secret is required.** Socket Mode carries no inbound HTTP
+request, so there are no signatures to verify. `SLACK_SIGNING_SECRET` appears
+in no `~/.hermes/.env` backup going back to 2026-05-13, and Hermes served both
+workspaces for months without one. The port reports it as *not required*
+rather than *missing*, so a complete port is not misread as a failed one.
 
 ## References
 

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -8085,7 +8085,8 @@
       "deploy/openclaw/install-openclaw-gateway.sh",
       "deploy/openclaw/run-script-cron-job.py",
       "scripts/mac-fetch-openclaw-secrets.py",
-      "src/mac/deploy_env.py"
+      "src/mac/deploy_env.py",
+      "src/mac/human_interface_profile.py"
     ],
     "type": "str"
   },

--- a/src/mac/human_interface_profile.py
+++ b/src/mac/human_interface_profile.py
@@ -45,9 +45,11 @@ import hashlib
 import json
 import os
 import tempfile
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from typing import OrderedDict as OrderedDictType
 
 PROFILE_PORT_SCHEMA = "mac.human_interface_profile_port.v1"
 
@@ -55,31 +57,33 @@ PROFILE_PORT_SCHEMA = "mac.human_interface_profile_port.v1"
 #: USER.md the operator model, MEMORY.md the durable operational knowledge.
 IDENTITY_FILES: Tuple[str, ...] = ("SOUL.md", "USER.md", "MEMORY.md")
 
-#: Hermes' messaging credentials: single-account and flat.
-MESSAGING_KEYS: Tuple[str, ...] = (
-    "SLACK_BOT_TOKEN",
-    "SLACK_APP_TOKEN",
-    "SLACK_SIGNING_SECRET",
-)
-
-#: The two interfaces do not merely NAME credentials differently -- they use
-#: different credential MODELS, so porting is a translation, not a copy.
+#: BOTH interfaces are multi-account. They differ in ENCODING, not in model.
 #:
-#:   OpenClaw: multi-account and namespaced. MAC_OPENCLAW_SLACK_<ACCOUNT>_BOT_TOKEN
-#:             and _APP_TOKEN, with MAC_OPENCLAW_SLACK_ACCOUNT_ID naming the
-#:             active account. Verified on the hub: OMGJKH and OFFTERA both
-#:             present.
-#:   Hermes:   single-account and flat. SLACK_BOT_TOKEN / SLACK_APP_TOKEN /
-#:             SLACK_SIGNING_SECRET.
+#:   OpenClaw: namespaced env keys --
+#:             MAC_OPENCLAW_SLACK_<ACCOUNT>_BOT_TOKEN / _APP_TOKEN, with
+#:             MAC_OPENCLAW_SLACK_ACCOUNT_ID naming the default account.
+#:   Hermes:   a JSON array at ~/.hermes/slack_accounts.json --
+#:             [{"name": ..., "bot_token": ..., "app_token": ...}, ...].
+#:             Added by deploy/hermes/multi-slack-mvp.patch, which gives each
+#:             account its own AsyncApp and its own Socket Mode websocket.
+#:             Flat SLACK_BOT_TOKEN / SLACK_APP_TOKEN remain a single-account
+#:             FALLBACK, used only when the JSON file is absent.
 #:
-#: SLACK_SIGNING_SECRET HAS NO OPENCLAW SOURCE. OpenClaw connects over Socket
-#: Mode using app+bot tokens; Hermes' slack_bolt additionally verifies request
-#: signatures. Porting therefore CANNOT produce it -- it must come from the hub
-#: vault. Reporting it as merely "missing" would imply the port could supply it,
-#: so it is reported separately as unavailable-from-source.
+#: Getting this wrong loses a workspace silently. Verified on the hub
+#: 2026-08-04: BOTH sides already carry the same two accounts, `omgjkh` and
+#: `offtera`. A port that wrote only the active account into the flat keys
+#: would drop `offtera` while reporting success -- so the port is a UNION over
+#: accounts, and an account present only at the TARGET is always preserved.
+HERMES_ACCOUNTS_FILE = "slack_accounts.json"
 OPENCLAW_ACCOUNT_KEY = "MAC_OPENCLAW_SLACK_ACCOUNT_ID"
 OPENCLAW_TOKEN_TEMPLATE = "MAC_OPENCLAW_SLACK_%s_%s"
-UNAVAILABLE_FROM_OPENCLAW: Tuple[str, ...] = ("SLACK_SIGNING_SECRET",)
+
+#: Hermes-only extras that are NOT part of an account. Socket Mode carries no
+#: inbound HTTP request, so there are no signatures to verify and no signing
+#: secret is required; it is reported as not-required rather than missing, so
+#: an operator does not read a complete port as a failed one.
+FLAT_FALLBACK_KEYS: Tuple[str, ...] = ("SLACK_BOT_TOKEN", "SLACK_APP_TOKEN")
+SOCKET_MODE_NOT_REQUIRED: Tuple[str, ...] = ("SLACK_SIGNING_SECRET",)
 
 HERMES = "hermes"
 OPENCLAW = "openclaw"
@@ -134,6 +138,9 @@ class InterfaceLayout:
     identity_fallbacks: Tuple[Path, ...] = ()
     #: Files searched for messaging credentials, in order (later wins).
     credential_files: Tuple[Path, ...] = ()
+    #: Hermes only: the multi-account JSON array. When present it is the
+    #: authoritative account list and the flat env keys are ignored.
+    accounts_file: Optional[Path] = None
 
     def identity_path(self, name: str) -> Optional[Path]:
         for directory in (self.identity_dir, *self.identity_fallbacks):
@@ -151,6 +158,7 @@ def hermes_layout(home: Path) -> InterfaceLayout:
         env_file=hermes_home / ".env",
         identity_fallbacks=(hermes_home / "memories",),
         credential_files=(hermes_home / ".env",),
+        accounts_file=hermes_home / HERMES_ACCOUNTS_FILE,
     )
 
 
@@ -230,6 +238,15 @@ def upsert_env(path: Path, updates: Dict[str, str]) -> None:
     _atomic_write(path, "\n".join(output) + "\n")
 
 
+@dataclass(frozen=True)
+class SlackAccount:
+    """One Slack workspace, in the encoding-independent form both sides share."""
+
+    name: str
+    bot_token: str
+    app_token: str
+
+
 @dataclass
 class PortReport:
     """What a port did, or would do."""
@@ -240,10 +257,20 @@ class PortReport:
     ported: List[str] = field(default_factory=list)
     unchanged: List[str] = field(default_factory=list)
     conflicts: List[Dict[str, str]] = field(default_factory=list)
+    #: Slack workspaces written to the target from the source.
+    accounts_ported: List[str] = field(default_factory=list)
+    #: Already identical on both sides.
+    accounts_unchanged: List[str] = field(default_factory=list)
+    #: Known only to the TARGET and carried through untouched. A non-empty
+    #: list here is the port declining to lose a workspace.
+    accounts_preserved: List[str] = field(default_factory=list)
+    #: Missing a bot or app token, so the gateway would skip them.
+    accounts_incomplete: List[str] = field(default_factory=list)
     credentials_ported: List[str] = field(default_factory=list)
     credentials_missing: List[str] = field(default_factory=list)
-    #: Keys the target needs that the SOURCE model cannot supply at all.
-    credentials_unavailable: List[str] = field(default_factory=list)
+    #: Keys the TARGET does not need, distinguished from keys it needs and
+    #: lacks, so a complete port is not read as a failed one.
+    credentials_not_required: List[str] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -255,9 +282,13 @@ class PortReport:
             "ported": list(self.ported),
             "unchanged": list(self.unchanged),
             "conflicts": list(self.conflicts),
+            "accounts_ported": list(self.accounts_ported),
+            "accounts_unchanged": list(self.accounts_unchanged),
+            "accounts_preserved": list(self.accounts_preserved),
+            "accounts_incomplete": list(self.accounts_incomplete),
             "credentials_ported": list(self.credentials_ported),
             "credentials_missing": list(self.credentials_missing),
-            "credentials_unavailable": list(self.credentials_unavailable),
+            "credentials_not_required": list(self.credentials_not_required),
             "errors": list(self.errors),
             "clean": not self.conflicts and not self.errors,
         }
@@ -360,53 +391,155 @@ class ProfilePort:
 
     # -- credentials ------------------------------------------------------
 
-    def _openclaw_messaging(self, env: Dict[str, str]) -> Dict[str, str]:
-        """Translate OpenClaw's namespaced Slack keys into Hermes' flat ones.
+    def _merged_env(self, layout: InterfaceLayout) -> Dict[str, str]:
+        env: Dict[str, str] = {}
+        for candidate in layout.credential_files or (layout.env_file,):
+            env.update(parse_env(candidate))
+        return env
 
-        Uses MAC_OPENCLAW_SLACK_ACCOUNT_ID to pick the active account, so a
-        multi-account host ports the account it is actually serving rather than
-        an arbitrary one.
+    def _read_openclaw_accounts(
+        self, layout: InterfaceLayout, report: PortReport
+    ) -> "OrderedDictType[str, SlackAccount]":
+        """Collect EVERY namespaced account, not just the active one."""
+        env = self._merged_env(layout)
+        tokens: "OrderedDictType[str, Dict[str, str]]" = OrderedDict()
+        for key, value in env.items():
+            for suffix, field_name in (("_BOT_TOKEN", "bot_token"),
+                                       ("_APP_TOKEN", "app_token")):
+                prefix = "MAC_OPENCLAW_SLACK_"
+                if key.startswith(prefix) and key.endswith(suffix):
+                    name = key[len(prefix):-len(suffix)]
+                    if not name or key == OPENCLAW_ACCOUNT_KEY:
+                        continue
+                    value = str(value or "").strip()
+                    if value:
+                        tokens.setdefault(name.lower(), {})[field_name] = value
+        return self._finalise_accounts(tokens, report)
+
+    def _read_hermes_accounts(
+        self, layout: InterfaceLayout, report: PortReport
+    ) -> "OrderedDictType[str, SlackAccount]":
+        """slack_accounts.json is authoritative; flat env is the fallback."""
+        path = layout.accounts_file
+        if path is not None and path.is_file():
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError) as exc:
+                report.errors.append("%s: unreadable (%s)" % (path.name, exc))
+                return OrderedDict()
+            if not isinstance(data, list):
+                report.errors.append("%s: must contain a JSON array" % path.name)
+                return OrderedDict()
+            tokens: "OrderedDictType[str, Dict[str, str]]" = OrderedDict()
+            for index, entry in enumerate(data):
+                if not isinstance(entry, dict):
+                    continue
+                name = str(entry.get("name") or "account-%d" % index).strip().lower()
+                tokens[name] = {
+                    "bot_token": str(entry.get("bot_token") or "").strip(),
+                    "app_token": str(entry.get("app_token") or "").strip(),
+                }
+            return self._finalise_accounts(tokens, report)
+
+        env = self._merged_env(layout)
+        bot = str(env.get("SLACK_BOT_TOKEN") or "").strip()
+        app = str(env.get("SLACK_APP_TOKEN") or "").strip()
+        if not bot and not app:
+            return OrderedDict()
+        return self._finalise_accounts(
+            OrderedDict({"default": {"bot_token": bot, "app_token": app}}), report
+        )
+
+    def _finalise_accounts(
+        self, tokens: "OrderedDictType[str, Dict[str, str]]", report: PortReport
+    ) -> "OrderedDictType[str, SlackAccount]":
+        """Drop accounts the gateway would refuse, and SAY SO.
+
+        The patched adapter skips any account missing either token. Silently
+        dropping them here would make a partial port read as a complete one.
         """
-        account = str(env.get(OPENCLAW_ACCOUNT_KEY) or "").strip()
-        if not account:
-            return {}
-        translated: Dict[str, str] = {}
-        for flat, suffix in (("SLACK_BOT_TOKEN", "BOT_TOKEN"),
-                             ("SLACK_APP_TOKEN", "APP_TOKEN")):
-            namespaced = OPENCLAW_TOKEN_TEMPLATE % (account.upper(), suffix)
-            value = str(env.get(namespaced) or "").strip()
-            if value:
-                translated[flat] = value
-        return translated
+        accounts: "OrderedDictType[str, SlackAccount]" = OrderedDict()
+        for name, pair in tokens.items():
+            bot = str(pair.get("bot_token") or "").strip()
+            app = str(pair.get("app_token") or "").strip()
+            if bot and app:
+                accounts[name] = SlackAccount(name=name, bot_token=bot, app_token=app)
+            elif bot or app:
+                report.accounts_incomplete.append(name)
+        return accounts
 
-    def _source_messaging(self) -> Tuple[Dict[str, str], List[str]]:
-        """Read messaging credentials from the source in ITS OWN model."""
-        if self.source.name == OPENCLAW:
-            # OpenClaw keeps them in the managed runtime env and a sibling
-            # credentials file; read both, later wins.
-            env: Dict[str, str] = {}
-            for candidate in self.source.credential_files:
-                env.update(parse_env(candidate))
-            return self._openclaw_messaging(env), list(UNAVAILABLE_FROM_OPENCLAW)
-        env = parse_env(self.source.env_file)
-        present = {
-            key: env[key] for key in MESSAGING_KEYS if str(env.get(key) or "").strip()
-        }
-        return present, []
+    def _read_accounts(
+        self, layout: InterfaceLayout, report: PortReport
+    ) -> "OrderedDictType[str, SlackAccount]":
+        if layout.name == OPENCLAW:
+            return self._read_openclaw_accounts(layout, report)
+        return self._read_hermes_accounts(layout, report)
+
+    def _write_hermes_accounts(
+        self, accounts: "OrderedDictType[str, SlackAccount]"
+    ) -> None:
+        payload = [
+            {"name": a.name, "bot_token": a.bot_token, "app_token": a.app_token}
+            for a in accounts.values()
+        ]
+        _atomic_write(
+            self.target.accounts_file, json.dumps(payload, indent=2) + "\n"
+        )
+
+    def _write_openclaw_accounts(
+        self, accounts: "OrderedDictType[str, SlackAccount]", default: Optional[str]
+    ) -> None:
+        updates: Dict[str, str] = {}
+        for account in accounts.values():
+            upper = account.name.upper()
+            updates[OPENCLAW_TOKEN_TEMPLATE % (upper, "BOT_TOKEN")] = account.bot_token
+            updates[OPENCLAW_TOKEN_TEMPLATE % (upper, "APP_TOKEN")] = account.app_token
+        existing = self._merged_env(self.target)
+        if default and not str(existing.get(OPENCLAW_ACCOUNT_KEY) or "").strip():
+            updates[OPENCLAW_ACCOUNT_KEY] = default
+        upsert_env(self.target.env_file, updates)
 
     def _port_credentials(self, report: PortReport) -> None:
-        present, unavailable = self._source_messaging()
-        report.credentials_unavailable.extend(unavailable)
-        report.credentials_missing.extend(
-            key
-            for key in MESSAGING_KEYS
-            if key not in present and key not in unavailable
+        source_accounts = self._read_accounts(self.source, report)
+        target_accounts = self._read_accounts(self.target, report)
+
+        # Union, source-preferred: the interface the agent used LAST holds the
+        # freshest tokens, so it wins where both describe the same account. An
+        # account only the target knows about is carried through untouched --
+        # that is the invariant that stops a port losing a workspace.
+        merged: "OrderedDictType[str, SlackAccount]" = OrderedDict()
+        for name, account in target_accounts.items():
+            merged[name] = account
+        for name, account in source_accounts.items():
+            if name in target_accounts and target_accounts[name] == account:
+                report.accounts_unchanged.append(name)
+            else:
+                report.accounts_ported.append(name)
+            merged[name] = account
+        report.accounts_preserved.extend(
+            name for name in target_accounts if name not in source_accounts
         )
-        if not present:
+
+        if not source_accounts:
+            report.credentials_missing.extend(FLAT_FALLBACK_KEYS)
             return
-        if not report.dry_run:
-            upsert_env(self.target.env_file, present)
-        report.credentials_ported.extend(sorted(present))
+
+        if self.target.name == HERMES:
+            # Socket Mode verifies no inbound signatures, so a signing secret
+            # is not a gap in the port.
+            report.credentials_not_required.extend(SOCKET_MODE_NOT_REQUIRED)
+            if not report.dry_run:
+                self._write_hermes_accounts(merged)
+        else:
+            default = None
+            source_env = self._merged_env(self.source)
+            for candidate in (str(source_env.get(OPENCLAW_ACCOUNT_KEY) or "").strip(),
+                              next(iter(source_accounts), "")):
+                if candidate:
+                    default = candidate.lower()
+                    break
+            if not report.dry_run:
+                self._write_openclaw_accounts(merged, default)
 
     # -- entry point ------------------------------------------------------
 

--- a/src/mac/human_interface_profile.py
+++ b/src/mac/human_interface_profile.py
@@ -1,0 +1,437 @@
+"""Port an agent's profile between human interfaces (Hermes <-> OpenClaw).
+
+A *human interface* is the component that faces humans and the plugin
+ecosystem: Hermes or OpenClaw. MAC supports both and activates one per agent
+(``gateway_impl``). Switching the active interface without moving the agent's
+accumulated state silently reverts its identity, memory and messaging
+credentials to whatever the other interface last held.
+
+That is not hypothetical. Measured on the hub 2026-08-04, four weeks after the
+fleet moved to OpenClaw:
+
+* ``SOUL.md`` was identical on both sides -- no loss.
+* ``MEMORY.md`` had **diverged and become disjoint**. OpenClaw's copy carried
+  April-July operational knowledge (thread etiquette, a mandatory
+  context-search directive, the AgentFS canonical-storage rule, safety-filter
+  workarounds); Hermes' April copy carried the record of the *previous*
+  migration -- including its hard-won fix, that Slack tokens do not port
+  automatically. Neither was a superset. A file copy in either direction
+  destroys real operational knowledge.
+* The Slack signing secret was absent from ``~/.hermes/.env`` entirely, because
+  the projection that writes it is gated behind a non-OpenClaw gateway and had
+  not run in four weeks.
+
+So the rule this module implements is: **the interface the agent last used is
+authoritative, and its profile must be ported before the switch** -- in either
+direction.
+
+Design, inherited deliberately from
+``deploy/openclaw/migrate-hermes-continuity.py`` rather than reinvented:
+
+* **The source is never modified.** Porting is a read of one tree and a write
+  into the other.
+* **Merge by preservation, never by overwrite.** When a destination file
+  differs from both the proposed content and the hash recorded by the previous
+  port, the destination is kept and the candidate is written beside it for an
+  operator to reconcile. Divergent content is therefore never lost -- it is
+  made visible.
+* **Idempotent.** Re-porting unchanged state is a no-op.
+* **Dry-run by default.** Porting mutates an agent's identity; the caller must
+  ask for it explicitly.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+PROFILE_PORT_SCHEMA = "mac.human_interface_profile_port.v1"
+
+#: Identity documents carried between interfaces. SOUL.md is the personality,
+#: USER.md the operator model, MEMORY.md the durable operational knowledge.
+IDENTITY_FILES: Tuple[str, ...] = ("SOUL.md", "USER.md", "MEMORY.md")
+
+#: Hermes' messaging credentials: single-account and flat.
+MESSAGING_KEYS: Tuple[str, ...] = (
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "SLACK_SIGNING_SECRET",
+)
+
+#: The two interfaces do not merely NAME credentials differently -- they use
+#: different credential MODELS, so porting is a translation, not a copy.
+#:
+#:   OpenClaw: multi-account and namespaced. MAC_OPENCLAW_SLACK_<ACCOUNT>_BOT_TOKEN
+#:             and _APP_TOKEN, with MAC_OPENCLAW_SLACK_ACCOUNT_ID naming the
+#:             active account. Verified on the hub: OMGJKH and OFFTERA both
+#:             present.
+#:   Hermes:   single-account and flat. SLACK_BOT_TOKEN / SLACK_APP_TOKEN /
+#:             SLACK_SIGNING_SECRET.
+#:
+#: SLACK_SIGNING_SECRET HAS NO OPENCLAW SOURCE. OpenClaw connects over Socket
+#: Mode using app+bot tokens; Hermes' slack_bolt additionally verifies request
+#: signatures. Porting therefore CANNOT produce it -- it must come from the hub
+#: vault. Reporting it as merely "missing" would imply the port could supply it,
+#: so it is reported separately as unavailable-from-source.
+OPENCLAW_ACCOUNT_KEY = "MAC_OPENCLAW_SLACK_ACCOUNT_ID"
+OPENCLAW_TOKEN_TEMPLATE = "MAC_OPENCLAW_SLACK_%s_%s"
+UNAVAILABLE_FROM_OPENCLAW: Tuple[str, ...] = ("SLACK_SIGNING_SECRET",)
+
+HERMES = "hermes"
+OPENCLAW = "openclaw"
+INTERFACES: Tuple[str, ...] = (HERMES, OPENCLAW)
+
+
+class ProfilePortError(RuntimeError):
+    """A profile port cannot be performed safely."""
+
+
+def _digest_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _digest_file(path: Path) -> Optional[str]:
+    try:
+        return _digest_bytes(path.read_bytes())
+    except OSError:
+        return None
+
+
+def _atomic_write(path: Path, data: str, mode: int = 0o600) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, temporary = tempfile.mkstemp(dir=str(path.parent))
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            stream.write(data)
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+@dataclass(frozen=True)
+class InterfaceLayout:
+    """Where one human interface keeps the state a port must move.
+
+    The two interfaces do NOT share locations. Hermes keeps identity and its
+    messaging env under ``~/.hermes``; OpenClaw keeps identity in its workspace
+    under ``~/.mac/openclaw`` and messaging config in its managed tree.
+    """
+
+    name: str
+    identity_dir: Path
+    env_file: Path
+    #: Extra directories searched (in order) for an identity document, because
+    #: Hermes historically stored them under ``memories/`` as well.
+    identity_fallbacks: Tuple[Path, ...] = ()
+    #: Files searched for messaging credentials, in order (later wins).
+    credential_files: Tuple[Path, ...] = ()
+
+    def identity_path(self, name: str) -> Optional[Path]:
+        for directory in (self.identity_dir, *self.identity_fallbacks):
+            candidate = directory / name
+            if candidate.is_file():
+                return candidate
+        return None
+
+
+def hermes_layout(home: Path) -> InterfaceLayout:
+    hermes_home = home / ".hermes"
+    return InterfaceLayout(
+        name=HERMES,
+        identity_dir=hermes_home,
+        env_file=hermes_home / ".env",
+        identity_fallbacks=(hermes_home / "memories",),
+        credential_files=(hermes_home / ".env",),
+    )
+
+
+def openclaw_layout(home: Path) -> InterfaceLayout:
+    openclaw_home = home / ".mac" / "openclaw"
+    return InterfaceLayout(
+        name=OPENCLAW,
+        identity_dir=openclaw_home / "workspace",
+        env_file=openclaw_home / "managed" / "runtime.env",
+        identity_fallbacks=(openclaw_home / "state",),
+        credential_files=(
+            openclaw_home / "managed" / "runtime.env",
+            openclaw_home / "credentials.env",
+        ),
+    )
+
+
+def layout_for(interface: str, home: Path) -> InterfaceLayout:
+    interface = str(interface or "").strip().lower()
+    if interface == HERMES:
+        return hermes_layout(home)
+    if interface == OPENCLAW:
+        return openclaw_layout(home)
+    raise ProfilePortError(
+        "unknown human interface %r; expected one of %s"
+        % (interface, ", ".join(INTERFACES))
+    )
+
+
+def parse_env(path: Path) -> Dict[str, str]:
+    """Read a shell-style env file into a mapping, tolerating junk."""
+    values: Dict[str, str] = {}
+    try:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return values
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("export "):
+            stripped = stripped[len("export ") :]
+        key, separator, value = stripped.partition("=")
+        if not separator:
+            continue
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def upsert_env(path: Path, updates: Dict[str, str]) -> None:
+    """Write ``updates`` into an env file, PRESERVING every other line.
+
+    Deliberately line-preserving: the target env holds keys this port knows
+    nothing about, and rewriting the file from a parsed mapping would drop
+    comments and unrecognised entries.
+    """
+    existing_lines: List[str] = []
+    try:
+        existing_lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        existing_lines = []
+
+    remaining = dict(updates)
+    output: List[str] = []
+    for line in existing_lines:
+        stripped = line.strip()
+        body = stripped[len("export ") :] if stripped.startswith("export ") else stripped
+        key, separator, _ = body.partition("=")
+        key = key.strip()
+        if separator and key in remaining:
+            prefix = "export " if stripped.startswith("export ") else ""
+            output.append("%s%s=%s" % (prefix, key, remaining.pop(key)))
+            continue
+        output.append(line)
+    for key in sorted(remaining):
+        output.append("%s=%s" % (key, remaining[key]))
+    _atomic_write(path, "\n".join(output) + "\n")
+
+
+@dataclass
+class PortReport:
+    """What a port did, or would do."""
+
+    source: str
+    target: str
+    dry_run: bool
+    ported: List[str] = field(default_factory=list)
+    unchanged: List[str] = field(default_factory=list)
+    conflicts: List[Dict[str, str]] = field(default_factory=list)
+    credentials_ported: List[str] = field(default_factory=list)
+    credentials_missing: List[str] = field(default_factory=list)
+    #: Keys the target needs that the SOURCE model cannot supply at all.
+    credentials_unavailable: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema": PROFILE_PORT_SCHEMA,
+            "source": self.source,
+            "target": self.target,
+            "dry_run": self.dry_run,
+            "ported": list(self.ported),
+            "unchanged": list(self.unchanged),
+            "conflicts": list(self.conflicts),
+            "credentials_ported": list(self.credentials_ported),
+            "credentials_missing": list(self.credentials_missing),
+            "credentials_unavailable": list(self.credentials_unavailable),
+            "errors": list(self.errors),
+            "clean": not self.conflicts and not self.errors,
+        }
+
+
+class ProfilePort:
+    """Port an agent profile from one human interface to the other."""
+
+    def __init__(
+        self,
+        source: str,
+        target: str,
+        *,
+        home: Optional[Path] = None,
+        state_file: Optional[Path] = None,
+    ) -> None:
+        source = str(source or "").strip().lower()
+        target = str(target or "").strip().lower()
+        if source == target:
+            raise ProfilePortError(
+                "source and target are the same interface (%r); nothing to port"
+                % source
+            )
+        self.home = Path(home) if home is not None else Path.home()
+        self.source = layout_for(source, self.home)
+        self.target = layout_for(target, self.home)
+        self.state_file = (
+            Path(state_file)
+            if state_file is not None
+            else self.home / ".mac" / "human-interface-port-state.json"
+        )
+        self._previous: Dict[str, str] = self._load_state()
+
+    # -- previously-ported hashes ----------------------------------------
+
+    def _state_key(self, relative: str) -> str:
+        return "%s->%s:%s" % (self.source.name, self.target.name, relative)
+
+    def _load_state(self) -> Dict[str, str]:
+        try:
+            data = json.loads(self.state_file.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _save_state(self, updates: Dict[str, str]) -> None:
+        merged = dict(self._previous)
+        merged.update(updates)
+        _atomic_write(self.state_file, json.dumps(merged, indent=1, sort_keys=True) + "\n")
+
+    # -- identity ---------------------------------------------------------
+
+    def _port_identity_file(
+        self, name: str, report: PortReport, updates: Dict[str, str]
+    ) -> None:
+        source_path = self.source.identity_path(name)
+        if source_path is None:
+            return
+        try:
+            content = source_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            report.errors.append("%s: unreadable source (%s)" % (name, exc))
+            return
+        if not content.endswith("\n"):
+            content += "\n"
+        proposed = _digest_bytes(content.encode("utf-8"))
+
+        destination = self.target.identity_dir / name
+        current = _digest_file(destination) if destination.is_file() else None
+        previous = self._previous.get(self._state_key(name))
+
+        if current == proposed:
+            report.unchanged.append(name)
+            updates[self._state_key(name)] = proposed
+            return
+
+        if current is not None and (previous is None or current != previous):
+            # The target has content this port did not write. It may hold
+            # knowledge the source lacks -- on the hub, the two MEMORY.md files
+            # were disjoint -- so the destination is PRESERVED and the incoming
+            # version is written beside it for a human to reconcile.
+            candidate = destination.with_name(destination.name + ".incoming")
+            if not report.dry_run:
+                _atomic_write(candidate, content)
+            report.conflicts.append(
+                {
+                    "file": name,
+                    "reason": "target has unmanaged local content; not overwritten",
+                    "preserved": str(destination),
+                    "candidate": str(candidate),
+                    "source": str(source_path),
+                }
+            )
+            return
+
+        if not report.dry_run:
+            _atomic_write(destination, content)
+        report.ported.append(name)
+        updates[self._state_key(name)] = proposed
+
+    # -- credentials ------------------------------------------------------
+
+    def _openclaw_messaging(self, env: Dict[str, str]) -> Dict[str, str]:
+        """Translate OpenClaw's namespaced Slack keys into Hermes' flat ones.
+
+        Uses MAC_OPENCLAW_SLACK_ACCOUNT_ID to pick the active account, so a
+        multi-account host ports the account it is actually serving rather than
+        an arbitrary one.
+        """
+        account = str(env.get(OPENCLAW_ACCOUNT_KEY) or "").strip()
+        if not account:
+            return {}
+        translated: Dict[str, str] = {}
+        for flat, suffix in (("SLACK_BOT_TOKEN", "BOT_TOKEN"),
+                             ("SLACK_APP_TOKEN", "APP_TOKEN")):
+            namespaced = OPENCLAW_TOKEN_TEMPLATE % (account.upper(), suffix)
+            value = str(env.get(namespaced) or "").strip()
+            if value:
+                translated[flat] = value
+        return translated
+
+    def _source_messaging(self) -> Tuple[Dict[str, str], List[str]]:
+        """Read messaging credentials from the source in ITS OWN model."""
+        if self.source.name == OPENCLAW:
+            # OpenClaw keeps them in the managed runtime env and a sibling
+            # credentials file; read both, later wins.
+            env: Dict[str, str] = {}
+            for candidate in self.source.credential_files:
+                env.update(parse_env(candidate))
+            return self._openclaw_messaging(env), list(UNAVAILABLE_FROM_OPENCLAW)
+        env = parse_env(self.source.env_file)
+        present = {
+            key: env[key] for key in MESSAGING_KEYS if str(env.get(key) or "").strip()
+        }
+        return present, []
+
+    def _port_credentials(self, report: PortReport) -> None:
+        present, unavailable = self._source_messaging()
+        report.credentials_unavailable.extend(unavailable)
+        report.credentials_missing.extend(
+            key
+            for key in MESSAGING_KEYS
+            if key not in present and key not in unavailable
+        )
+        if not present:
+            return
+        if not report.dry_run:
+            upsert_env(self.target.env_file, present)
+        report.credentials_ported.extend(sorted(present))
+
+    # -- entry point ------------------------------------------------------
+
+    def run(self, *, dry_run: bool = True) -> Dict[str, Any]:
+        report = PortReport(
+            source=self.source.name, target=self.target.name, dry_run=bool(dry_run)
+        )
+        updates: Dict[str, str] = {}
+        for name in IDENTITY_FILES:
+            self._port_identity_file(name, report, updates)
+        self._port_credentials(report)
+        if not dry_run and updates:
+            self._save_state(updates)
+        return report.to_dict()
+
+
+def port_profile(
+    source: str,
+    target: str,
+    *,
+    home: Optional[Path] = None,
+    dry_run: bool = True,
+    state_file: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Port an agent profile between human interfaces. Dry-run by default."""
+    return ProfilePort(source, target, home=home, state_file=state_file).run(
+        dry_run=dry_run
+    )

--- a/src/mac/human_interface_profile.py
+++ b/src/mac/human_interface_profile.py
@@ -45,11 +45,9 @@ import hashlib
 import json
 import os
 import tempfile
-from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-from typing import OrderedDict as OrderedDictType
 
 PROFILE_PORT_SCHEMA = "mac.human_interface_profile_port.v1"
 
@@ -399,10 +397,10 @@ class ProfilePort:
 
     def _read_openclaw_accounts(
         self, layout: InterfaceLayout, report: PortReport
-    ) -> "OrderedDictType[str, SlackAccount]":
+    ) -> Dict[str, SlackAccount]:
         """Collect EVERY namespaced account, not just the active one."""
         env = self._merged_env(layout)
-        tokens: "OrderedDictType[str, Dict[str, str]]" = OrderedDict()
+        tokens: Dict[str, Dict[str, str]] = {}
         for key, value in env.items():
             for suffix, field_name in (("_BOT_TOKEN", "bot_token"),
                                        ("_APP_TOKEN", "app_token")):
@@ -418,7 +416,7 @@ class ProfilePort:
 
     def _read_hermes_accounts(
         self, layout: InterfaceLayout, report: PortReport
-    ) -> "OrderedDictType[str, SlackAccount]":
+    ) -> Dict[str, SlackAccount]:
         """slack_accounts.json is authoritative; flat env is the fallback."""
         path = layout.accounts_file
         if path is not None and path.is_file():
@@ -426,11 +424,11 @@ class ProfilePort:
                 data = json.loads(path.read_text(encoding="utf-8"))
             except (OSError, ValueError) as exc:
                 report.errors.append("%s: unreadable (%s)" % (path.name, exc))
-                return OrderedDict()
+                return {}
             if not isinstance(data, list):
                 report.errors.append("%s: must contain a JSON array" % path.name)
-                return OrderedDict()
-            tokens: "OrderedDictType[str, Dict[str, str]]" = OrderedDict()
+                return {}
+            tokens: Dict[str, Dict[str, str]] = {}
             for index, entry in enumerate(data):
                 if not isinstance(entry, dict):
                     continue
@@ -445,20 +443,20 @@ class ProfilePort:
         bot = str(env.get("SLACK_BOT_TOKEN") or "").strip()
         app = str(env.get("SLACK_APP_TOKEN") or "").strip()
         if not bot and not app:
-            return OrderedDict()
+            return {}
         return self._finalise_accounts(
-            OrderedDict({"default": {"bot_token": bot, "app_token": app}}), report
+            {"default": {"bot_token": bot, "app_token": app}}, report
         )
 
     def _finalise_accounts(
-        self, tokens: "OrderedDictType[str, Dict[str, str]]", report: PortReport
-    ) -> "OrderedDictType[str, SlackAccount]":
+        self, tokens: Dict[str, Dict[str, str]], report: PortReport
+    ) -> Dict[str, SlackAccount]:
         """Drop accounts the gateway would refuse, and SAY SO.
 
         The patched adapter skips any account missing either token. Silently
         dropping them here would make a partial port read as a complete one.
         """
-        accounts: "OrderedDictType[str, SlackAccount]" = OrderedDict()
+        accounts: Dict[str, SlackAccount] = {}
         for name, pair in tokens.items():
             bot = str(pair.get("bot_token") or "").strip()
             app = str(pair.get("app_token") or "").strip()
@@ -470,13 +468,13 @@ class ProfilePort:
 
     def _read_accounts(
         self, layout: InterfaceLayout, report: PortReport
-    ) -> "OrderedDictType[str, SlackAccount]":
+    ) -> Dict[str, SlackAccount]:
         if layout.name == OPENCLAW:
             return self._read_openclaw_accounts(layout, report)
         return self._read_hermes_accounts(layout, report)
 
     def _write_hermes_accounts(
-        self, accounts: "OrderedDictType[str, SlackAccount]"
+        self, accounts: Dict[str, SlackAccount]
     ) -> None:
         payload = [
             {"name": a.name, "bot_token": a.bot_token, "app_token": a.app_token}
@@ -487,7 +485,7 @@ class ProfilePort:
         )
 
     def _write_openclaw_accounts(
-        self, accounts: "OrderedDictType[str, SlackAccount]", default: Optional[str]
+        self, accounts: Dict[str, SlackAccount], default: Optional[str]
     ) -> None:
         updates: Dict[str, str] = {}
         for account in accounts.values():
@@ -507,7 +505,10 @@ class ProfilePort:
         # freshest tokens, so it wins where both describe the same account. An
         # account only the target knows about is carried through untouched --
         # that is the invariant that stops a port losing a workspace.
-        merged: "OrderedDictType[str, SlackAccount]" = OrderedDict()
+        # Plain dicts: insertion order is guaranteed, and it is what fixes the
+        # account order written back out, so the target's existing accounts are
+        # seeded first and keep their positions.
+        merged: Dict[str, SlackAccount] = {}
         for name, account in target_accounts.items():
             merged[name] = account
         for name, account in source_accounts.items():

--- a/tests/test_human_interface_profile.py
+++ b/tests/test_human_interface_profile.py
@@ -1,0 +1,270 @@
+"""Porting an agent profile between human interfaces must not lose knowledge.
+
+Grounded in what was measured on the hub 2026-08-04, four weeks after the fleet
+switched to OpenClaw:
+
+* SOUL.md was byte-identical on both sides.
+* MEMORY.md had DIVERGED AND BECOME DISJOINT -- OpenClaw's copy held April-July
+  operational knowledge, Hermes' April copy held the record of the previous
+  migration including its fix for Slack tokens not porting. Neither was a
+  superset of the other.
+* The Slack signing secret was absent from ~/.hermes/.env entirely, which is
+  why the Hermes gateway started but could not connect.
+
+The property under test is therefore not "the target matches the source" but
+"no content is lost in either direction".
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mac.human_interface_profile import (
+    HERMES,
+    OPENCLAW,
+    ProfilePortError,
+    hermes_layout,
+    openclaw_layout,
+    parse_env,
+    port_profile,
+    upsert_env,
+)
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _seed(home, *, hermes_memory=None, openclaw_memory=None, hermes_soul=None,
+          openclaw_soul=None, hermes_env=None, openclaw_env=None):
+    h, o = hermes_layout(home), openclaw_layout(home)
+    if hermes_soul is not None:
+        _write(h.identity_dir / "SOUL.md", hermes_soul)
+    if openclaw_soul is not None:
+        _write(o.identity_dir / "SOUL.md", openclaw_soul)
+    if hermes_memory is not None:
+        _write(h.identity_dir / "MEMORY.md", hermes_memory)
+    if openclaw_memory is not None:
+        _write(o.identity_dir / "MEMORY.md", openclaw_memory)
+    if hermes_env is not None:
+        _write(h.env_file, hermes_env)
+    if openclaw_env is not None:
+        _write(o.env_file, openclaw_env)
+    return h, o
+
+
+def test_disjoint_memory_is_never_overwritten(tmp_path):
+    """The case that motivated this module.
+
+    Each side holds knowledge the other lacks. Porting must preserve the
+    destination and surface the incoming version, not clobber it.
+    """
+    openclaw_only = "AgentFS is canonical for all jkh-requested projects.\n"
+    hermes_only = "Slack tokens do not port automatically; fix by hand.\n"
+    _seed(tmp_path, openclaw_memory=openclaw_only, hermes_memory=hermes_only)
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert report["conflicts"], "divergent MEMORY.md must be reported, not merged silently"
+    conflict = [c for c in report["conflicts"] if c["file"] == "MEMORY.md"][0]
+
+    # Destination preserved.
+    preserved = hermes_layout(tmp_path).identity_dir / "MEMORY.md"
+    assert preserved.read_text(encoding="utf-8") == hermes_only
+    # Incoming content is on disk for reconciliation -- nothing is lost.
+    assert (tmp_path / conflict["candidate"]).exists() or __import__("pathlib").Path(
+        conflict["candidate"]
+    ).exists()
+    incoming = __import__("pathlib").Path(conflict["candidate"]).read_text(encoding="utf-8")
+    assert incoming == openclaw_only
+    assert report["clean"] is False
+
+
+def test_identical_identity_is_a_no_op(tmp_path):
+    """SOUL.md was identical on both sides; that must not be reported as work."""
+    soul = "You are Rocky.\n"
+    _seed(tmp_path, hermes_soul=soul, openclaw_soul=soul)
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert "SOUL.md" in report["unchanged"]
+    assert "SOUL.md" not in report["ported"]
+    assert not [c for c in report["conflicts"] if c["file"] == "SOUL.md"]
+
+
+def test_a_missing_target_file_is_ported(tmp_path):
+    """The ordinary case: the target has never seen this document."""
+    _seed(tmp_path, openclaw_soul="You are Rocky.\n")
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert "SOUL.md" in report["ported"]
+    assert (hermes_layout(tmp_path).identity_dir / "SOUL.md").read_text(
+        encoding="utf-8"
+    ) == "You are Rocky.\n"
+
+
+def test_dry_run_writes_nothing(tmp_path):
+    _seed(tmp_path, openclaw_soul="You are Rocky.\n")
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=True)
+
+    assert report["dry_run"] is True
+    assert "SOUL.md" in report["ported"]
+    assert not (hermes_layout(tmp_path).identity_dir / "SOUL.md").exists()
+
+
+def test_the_source_is_never_modified(tmp_path):
+    original = "You are Rocky.\n"
+    _seed(tmp_path, openclaw_soul=original, hermes_soul="different\n")
+
+    port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert openclaw_layout(tmp_path).identity_dir.joinpath("SOUL.md").read_text(
+        encoding="utf-8"
+    ) == original
+
+
+def test_openclaw_namespaced_tokens_translate_to_hermes_flat_keys(tmp_path):
+    """The interfaces use different credential MODELS, not just different names.
+
+    OpenClaw is multi-account and namespaced
+    (MAC_OPENCLAW_SLACK_<ACCOUNT>_BOT_TOKEN); Hermes is single-account and flat
+    (SLACK_BOT_TOKEN). The active account is chosen by
+    MAC_OPENCLAW_SLACK_ACCOUNT_ID so a multi-account host ports the account it
+    actually serves.
+    """
+    _seed(
+        tmp_path,
+        openclaw_env=(
+            "MAC_OPENCLAW_SLACK_ACCOUNT_ID=omgjkh\n"
+            "MAC_OPENCLAW_SLACK_OMGJKH_BOT_TOKEN=xoxb-omgjkh\n"
+            "MAC_OPENCLAW_SLACK_OMGJKH_APP_TOKEN=xapp-omgjkh\n"
+            "MAC_OPENCLAW_SLACK_OFFTERA_BOT_TOKEN=xoxb-offtera\n"
+        ),
+        hermes_env="UNRELATED=keepme\n",
+    )
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    ported = parse_env(hermes_layout(tmp_path).env_file)
+    assert ported["SLACK_BOT_TOKEN"] == "xoxb-omgjkh"
+    assert ported["SLACK_APP_TOKEN"] == "xapp-omgjkh"
+    # The other account's token must NOT leak into a single-account gateway.
+    assert "xoxb-offtera" not in ported.values()
+    # Keys this port knows nothing about survive.
+    assert ported["UNRELATED"] == "keepme"
+    assert "SLACK_BOT_TOKEN" in report["credentials_ported"]
+
+
+def test_the_signing_secret_is_reported_unavailable_not_missing(tmp_path):
+    """OpenClaw has no signing secret to give, and saying "missing" would imply
+    the port could have supplied it.
+
+    OpenClaw connects over Socket Mode (app+bot tokens). Hermes' slack_bolt
+    additionally verifies request signatures, so SLACK_SIGNING_SECRET must come
+    from the hub vault, not from a port. This distinction is what stops an
+    operator concluding the port failed when it did all it can.
+    """
+    _seed(
+        tmp_path,
+        openclaw_env=(
+            "MAC_OPENCLAW_SLACK_ACCOUNT_ID=omgjkh\n"
+            "MAC_OPENCLAW_SLACK_OMGJKH_BOT_TOKEN=xoxb-omgjkh\n"
+        ),
+    )
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert "SLACK_SIGNING_SECRET" in report["credentials_unavailable"]
+    assert "SLACK_SIGNING_SECRET" not in report["credentials_missing"]
+    assert "SLACK_BOT_TOKEN" in report["credentials_ported"]
+
+
+def test_hermes_flat_credentials_port_as_is(tmp_path):
+    """The reverse direction needs no translation -- Hermes is already flat."""
+    _seed(
+        tmp_path,
+        hermes_env=(
+            "SLACK_BOT_TOKEN=xoxb-h\nSLACK_APP_TOKEN=xapp-h\n"
+            "SLACK_SIGNING_SECRET=s3cr3t\n"
+        ),
+    )
+
+    report = port_profile(HERMES, OPENCLAW, home=tmp_path, dry_run=False)
+
+    assert set(report["credentials_ported"]) == {
+        "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_SIGNING_SECRET",
+    }
+    assert not report["credentials_unavailable"]
+
+
+def test_an_openclaw_account_with_no_tokens_reports_missing(tmp_path):
+    _seed(tmp_path, openclaw_env="MAC_OPENCLAW_SLACK_ACCOUNT_ID=omgjkh\n")
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert "SLACK_BOT_TOKEN" in report["credentials_missing"]
+    assert not report["credentials_ported"]
+
+
+def test_porting_is_idempotent(tmp_path):
+    _seed(tmp_path, openclaw_soul="You are Rocky.\n")
+
+    first = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+    second = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert "SOUL.md" in first["ported"]
+    assert "SOUL.md" in second["unchanged"]
+    assert not second["conflicts"]
+
+
+def test_a_re_port_of_managed_content_is_not_a_conflict(tmp_path):
+    """Content this port previously wrote may be updated, not flagged."""
+    _seed(tmp_path, openclaw_memory="v1\n")
+    port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    _write(openclaw_layout(tmp_path).identity_dir / "MEMORY.md", "v2\n")
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert "MEMORY.md" in report["ported"]
+    assert not report["conflicts"]
+    assert hermes_layout(tmp_path).identity_dir.joinpath("MEMORY.md").read_text(
+        encoding="utf-8"
+    ) == "v2\n"
+
+
+def test_both_directions_are_supported(tmp_path):
+    """The reverse direction is the one that did not exist before."""
+    _seed(tmp_path, hermes_soul="from hermes\n")
+    report = port_profile(HERMES, OPENCLAW, home=tmp_path, dry_run=False)
+    assert "SOUL.md" in report["ported"]
+    assert openclaw_layout(tmp_path).identity_dir.joinpath("SOUL.md").read_text(
+        encoding="utf-8"
+    ) == "from hermes\n"
+
+
+def test_porting_to_the_same_interface_is_refused(tmp_path):
+    with pytest.raises(ProfilePortError):
+        port_profile(HERMES, HERMES, home=tmp_path)
+
+
+def test_an_unknown_interface_is_refused(tmp_path):
+    with pytest.raises(ProfilePortError):
+        port_profile("nemoclaw", HERMES, home=tmp_path)
+
+
+def test_upsert_env_preserves_comments_and_unknown_keys(tmp_path):
+    path = tmp_path / ".env"
+    _write(path, "# a comment\nKEEP=1\nSLACK_BOT_TOKEN=old\n")
+
+    upsert_env(path, {"SLACK_BOT_TOKEN": "new", "SLACK_SIGNING_SECRET": "s"})
+
+    text = path.read_text(encoding="utf-8")
+    assert "# a comment" in text
+    assert "KEEP=1" in text
+    values = parse_env(path)
+    assert values["SLACK_BOT_TOKEN"] == "new"
+    assert values["SLACK_SIGNING_SECRET"] == "s"

--- a/tests/test_human_interface_profile.py
+++ b/tests/test_human_interface_profile.py
@@ -8,11 +8,18 @@ switched to OpenClaw:
   operational knowledge, Hermes' April copy held the record of the previous
   migration including its fix for Slack tokens not porting. Neither was a
   superset of the other.
-* The Slack signing secret was absent from ~/.hermes/.env entirely, which is
-  why the Hermes gateway started but could not connect.
+* BOTH interfaces already carried BOTH Slack workspaces, `omgjkh` and
+  `offtera` -- Hermes through ~/.hermes/slack_accounts.json (the multi-Slack
+  patch), OpenClaw through namespaced env keys. An earlier reading of this
+  module treated Hermes as single-account; that was wrong, and a port written
+  to it would have dropped a workspace while reporting success.
 
 The property under test is therefore not "the target matches the source" but
-"no content is lost in either direction".
+"no content is lost in either direction" -- for identity documents AND for
+Slack workspaces.
+
+Note the signing secret is NOT a gap: Socket Mode verifies no inbound request
+signatures, and no ~/.hermes/.env backup has ever contained one.
 """
 from __future__ import annotations
 
@@ -127,14 +134,19 @@ def test_the_source_is_never_modified(tmp_path):
     ) == original
 
 
-def test_openclaw_namespaced_tokens_translate_to_hermes_flat_keys(tmp_path):
-    """The interfaces use different credential MODELS, not just different names.
+def _hermes_accounts(home):
+    path = hermes_layout(home).accounts_file
+    return {a["name"]: a for a in json.loads(path.read_text(encoding="utf-8"))}
 
-    OpenClaw is multi-account and namespaced
-    (MAC_OPENCLAW_SLACK_<ACCOUNT>_BOT_TOKEN); Hermes is single-account and flat
-    (SLACK_BOT_TOKEN). The active account is chosen by
-    MAC_OPENCLAW_SLACK_ACCOUNT_ID so a multi-account host ports the account it
-    actually serves.
+
+def test_every_openclaw_account_reaches_hermes(tmp_path):
+    """BOTH interfaces are multi-account; a port must not collapse them.
+
+    deploy/hermes/multi-slack-mvp.patch gives Hermes true multi-workspace
+    Socket Mode via ~/.hermes/slack_accounts.json -- one AsyncApp and one
+    websocket per account. Writing only the active account into the flat
+    SLACK_BOT_TOKEN would silently drop every other workspace. Verified on the
+    hub 2026-08-04: both sides carry `omgjkh` AND `offtera`.
     """
     _seed(
         tmp_path,
@@ -143,62 +155,122 @@ def test_openclaw_namespaced_tokens_translate_to_hermes_flat_keys(tmp_path):
             "MAC_OPENCLAW_SLACK_OMGJKH_BOT_TOKEN=xoxb-omgjkh\n"
             "MAC_OPENCLAW_SLACK_OMGJKH_APP_TOKEN=xapp-omgjkh\n"
             "MAC_OPENCLAW_SLACK_OFFTERA_BOT_TOKEN=xoxb-offtera\n"
+            "MAC_OPENCLAW_SLACK_OFFTERA_APP_TOKEN=xapp-offtera\n"
         ),
-        hermes_env="UNRELATED=keepme\n",
     )
 
     report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
 
-    ported = parse_env(hermes_layout(tmp_path).env_file)
-    assert ported["SLACK_BOT_TOKEN"] == "xoxb-omgjkh"
-    assert ported["SLACK_APP_TOKEN"] == "xapp-omgjkh"
-    # The other account's token must NOT leak into a single-account gateway.
-    assert "xoxb-offtera" not in ported.values()
-    # Keys this port knows nothing about survive.
-    assert ported["UNRELATED"] == "keepme"
-    assert "SLACK_BOT_TOKEN" in report["credentials_ported"]
+    accounts = _hermes_accounts(tmp_path)
+    assert set(accounts) == {"omgjkh", "offtera"}, "a workspace was lost"
+    assert accounts["offtera"]["bot_token"] == "xoxb-offtera"
+    assert accounts["offtera"]["app_token"] == "xapp-offtera"
+    assert set(report["accounts_ported"]) == {"omgjkh", "offtera"}
 
 
-def test_the_signing_secret_is_reported_unavailable_not_missing(tmp_path):
-    """OpenClaw has no signing secret to give, and saying "missing" would imply
-    the port could have supplied it.
+def test_an_account_only_the_target_knows_is_preserved(tmp_path):
+    """The union property, stated directly.
 
-    OpenClaw connects over Socket Mode (app+bot tokens). Hermes' slack_bolt
-    additionally verifies request signatures, so SLACK_SIGNING_SECRET must come
-    from the hub vault, not from a port. This distinction is what stops an
-    operator concluding the port failed when it did all it can.
+    The source is authoritative for accounts it HAS -- it is the interface the
+    agent used last. It is not authoritative for accounts it has never heard
+    of, and porting must not delete those.
     """
+    h = hermes_layout(tmp_path)
+    h.accounts_file.parent.mkdir(parents=True, exist_ok=True)
+    h.accounts_file.write_text(
+        json.dumps([
+            {"name": "omgjkh", "bot_token": "xoxb-old", "app_token": "xapp-old"},
+            {"name": "legacy", "bot_token": "xoxb-legacy", "app_token": "xapp-legacy"},
+        ]),
+        encoding="utf-8",
+    )
     _seed(
         tmp_path,
         openclaw_env=(
-            "MAC_OPENCLAW_SLACK_ACCOUNT_ID=omgjkh\n"
-            "MAC_OPENCLAW_SLACK_OMGJKH_BOT_TOKEN=xoxb-omgjkh\n"
+            "MAC_OPENCLAW_SLACK_OMGJKH_BOT_TOKEN=xoxb-new\n"
+            "MAC_OPENCLAW_SLACK_OMGJKH_APP_TOKEN=xapp-new\n"
         ),
     )
 
     report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
 
-    assert "SLACK_SIGNING_SECRET" in report["credentials_unavailable"]
-    assert "SLACK_SIGNING_SECRET" not in report["credentials_missing"]
-    assert "SLACK_BOT_TOKEN" in report["credentials_ported"]
+    accounts = _hermes_accounts(tmp_path)
+    assert accounts["omgjkh"]["bot_token"] == "xoxb-new", "source wins where both know it"
+    assert accounts["legacy"]["bot_token"] == "xoxb-legacy", "target-only survives"
+    assert report["accounts_preserved"] == ["legacy"]
 
 
-def test_hermes_flat_credentials_port_as_is(tmp_path):
-    """The reverse direction needs no translation -- Hermes is already flat."""
-    _seed(
-        tmp_path,
-        hermes_env=(
-            "SLACK_BOT_TOKEN=xoxb-h\nSLACK_APP_TOKEN=xapp-h\n"
-            "SLACK_SIGNING_SECRET=s3cr3t\n"
-        ),
+def test_hermes_accounts_port_back_to_openclaw_namespaced_keys(tmp_path):
+    """The reverse direction, account for account."""
+    h = hermes_layout(tmp_path)
+    h.accounts_file.parent.mkdir(parents=True, exist_ok=True)
+    h.accounts_file.write_text(
+        json.dumps([
+            {"name": "omgjkh", "bot_token": "xoxb-1", "app_token": "xapp-1"},
+            {"name": "offtera", "bot_token": "xoxb-2", "app_token": "xapp-2"},
+        ]),
+        encoding="utf-8",
     )
 
     report = port_profile(HERMES, OPENCLAW, home=tmp_path, dry_run=False)
 
-    assert set(report["credentials_ported"]) == {
-        "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_SIGNING_SECRET",
-    }
-    assert not report["credentials_unavailable"]
+    env = parse_env(openclaw_layout(tmp_path).env_file)
+    assert env["MAC_OPENCLAW_SLACK_OMGJKH_BOT_TOKEN"] == "xoxb-1"
+    assert env["MAC_OPENCLAW_SLACK_OFFTERA_APP_TOKEN"] == "xapp-2"
+    assert env["MAC_OPENCLAW_SLACK_ACCOUNT_ID"] == "omgjkh"
+    assert set(report["accounts_ported"]) == {"omgjkh", "offtera"}
+
+
+def test_flat_hermes_env_is_read_when_the_accounts_file_is_absent(tmp_path):
+    """The patch keeps the flat env as a single-account fallback."""
+    _seed(tmp_path, hermes_env="SLACK_BOT_TOKEN=xoxb-h\nSLACK_APP_TOKEN=xapp-h\n")
+
+    report = port_profile(HERMES, OPENCLAW, home=tmp_path, dry_run=False)
+
+    env = parse_env(openclaw_layout(tmp_path).env_file)
+    assert env["MAC_OPENCLAW_SLACK_DEFAULT_BOT_TOKEN"] == "xoxb-h"
+    assert report["accounts_ported"] == ["default"]
+
+
+def test_no_signing_secret_is_required_for_socket_mode(tmp_path):
+    """Socket Mode carries no inbound HTTP request, so there is nothing to
+    verify -- the absence of a signing secret is not a gap in the port.
+
+    Confirmed on the hub: SLACK_SIGNING_SECRET appears in no ~/.hermes/.env
+    backup going back to 2026-05-13, and Hermes served both workspaces anyway.
+    """
+    _seed(
+        tmp_path,
+        openclaw_env=(
+            "MAC_OPENCLAW_SLACK_OMGJKH_BOT_TOKEN=xoxb-omgjkh\n"
+            "MAC_OPENCLAW_SLACK_OMGJKH_APP_TOKEN=xapp-omgjkh\n"
+        ),
+    )
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert "SLACK_SIGNING_SECRET" in report["credentials_not_required"]
+    assert "SLACK_SIGNING_SECRET" not in report["credentials_missing"]
+    assert report["accounts_ported"] == ["omgjkh"]
+
+
+def test_an_account_missing_a_token_is_reported_not_silently_dropped(tmp_path):
+    """The gateway skips such accounts. If the port dropped them quietly, a
+    partial port would read as a complete one."""
+    _seed(
+        tmp_path,
+        openclaw_env=(
+            "MAC_OPENCLAW_SLACK_OMGJKH_BOT_TOKEN=xoxb-omgjkh\n"
+            "MAC_OPENCLAW_SLACK_OMGJKH_APP_TOKEN=xapp-omgjkh\n"
+            "MAC_OPENCLAW_SLACK_HALFWAY_BOT_TOKEN=xoxb-halfway\n"
+        ),
+    )
+
+    report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
+
+    assert "halfway" in report["accounts_incomplete"]
+    assert "halfway" not in report["accounts_ported"]
+    assert set(_hermes_accounts(tmp_path)) == {"omgjkh"}
 
 
 def test_an_openclaw_account_with_no_tokens_reports_missing(tmp_path):
@@ -207,7 +279,7 @@ def test_an_openclaw_account_with_no_tokens_reports_missing(tmp_path):
     report = port_profile(OPENCLAW, HERMES, home=tmp_path, dry_run=False)
 
     assert "SLACK_BOT_TOKEN" in report["credentials_missing"]
-    assert not report["credentials_ported"]
+    assert not report["accounts_ported"]
 
 
 def test_porting_is_idempotent(tmp_path):


### PR DESCRIPTION
Adds `src/mac/human_interface_profile.py`: a bidirectional profile port between
the two human interfaces, so that switching an agent's `gateway_impl` carries
its configuration across instead of stranding it.

The rule it implements: **whichever interface the agent used last holds the
freshest configuration**, so that side is the source, and the port runs before
the switch.

## What it moves

**Identity documents** (`SOUL.md`, `USER.md`, `MEMORY.md`) and **Slack
accounts**.

## Both interfaces are multi-account

This is the correction that shaped the design. An earlier draft modelled Hermes
as single-account and flat (`SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN`), picking one
OpenClaw account via `MAC_OPENCLAW_SLACK_ACCOUNT_ID`. That is wrong.

`deploy/hermes/multi-slack-mvp.patch` — one of our own maintained patches —
gives Hermes true multi-workspace Socket Mode through
`~/.hermes/slack_accounts.json`, a JSON array where each account gets its own
bot token, app token, `AsyncApp` and websocket. The flat env keys are only the
single-account *fallback*, used when that file is absent.

So the two interfaces differ in **encoding**, not in model. The earlier design
would have written one account into the flat keys and dropped every other
workspace **while reporting success**. Not hypothetical: the hub carries the
same two accounts, `omgjkh` and `offtera`, on *both* sides, and
`slack_accounts.json` has held both since 2026-07-07.

## The two invariants

**Accounts merge as a union.** The source wins for accounts it has — it is the
interface used last, so its tokens are freshest — but an account known only to
the *target* is carried through untouched. Accounts missing either token are
reported as `accounts_incomplete` rather than dropped quietly, matching the
adapter, which skips them.

**Identity documents are preserved, never overwritten.** Where both sides hold
a document and they differ, the destination is kept and the incoming version
lands beside it as `<file>.incoming` for a human to reconcile. On the hub
`USER.md` and `MEMORY.md` are genuinely disjoint — neither is a superset — so
any last-writer-wins copy would destroy knowledge.

## The signing secret is not a gap

Socket Mode carries no inbound HTTP request, so there are no signatures to
verify. `SLACK_SIGNING_SECRET` appears in no `~/.hermes/.env` backup going back
to 2026-05-13, and Hermes served both workspaces for months without one. It is
reported as `credentials_not_required`, not `credentials_missing`, so a
complete port is not misread as a failed one. An earlier claim that a missing
signing secret was why the gateway could not connect is withdrawn.

## Dry run against live hub state

```
accounts_unchanged       ['offtera', 'omgjkh']
accounts_preserved       []
accounts_incomplete      []
credentials_missing      []
credentials_not_required ['SLACK_SIGNING_SECRET']
identity conflicts       ['USER.md', 'MEMORY.md']
```

Both workspaces seen, nothing lost, real identity divergence surfaced rather
than clobbered.

## Still blocking Hermes activation — not fixed here

`task_fe7cdb1e`: the multi-Slack patch builds each account as
`AsyncApp(token=bot_token)`, which `slack_bolt` 1.27.0 rejects at construction
with `signing_secret must not be empty`, verified directly against the
installed library on the hub. The fix is `request_verification_enabled=False`
re-vendored through `scripts/vendor-hermes-snapshot.sh`, and it is deliberately
separate from this PR because it touches the vendored tree and its integrity
digest. **No host should switch to `gateway_impl: hermes` until that lands.**

This is the staleness risk named in `docs/human-interface-selector.md` showing
up in practice: a pinned source fork drifting against an unpinned dependency.

## Testing

18 unit tests covering both directions, the union property, incomplete
accounts, the flat fallback, dry-run, idempotency and source immutability.
Full contract gate green: **10,116 passed**, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)