### PR TITLE
Advertise only capabilities and health the node can actually back

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -8873,6 +8873,40 @@ drain_mac_agent_before_deploy() {
   fi
 }
 
+# Health as the startup probe measured it, not as the deploy hopes.
+#
+# The probe writes $LOG_DIR/startup-hermes.json with a "ready" verdict and a
+# warnings list, and the deploy prints it ("startup: ready=False warnings=6
+# ... qdrant_status=missing_topology"). That verdict used to be printed and
+# then discarded: the node registered "healthy" regardless. On 2026-08-05
+# three of five GKE workers finished a deploy reporting ready=False with their
+# Hermes memory topology and runtime context files missing, and all three
+# registered healthy, so the dispatcher could not tell them from the two that
+# were actually complete.
+#
+# A node that fails its own readiness probe must not claim to be healthy.
+# "degraded" still takes work -- this is a signal to the dispatcher and to
+# anyone reading `mac agent list`, not a quarantine.
+startup_probe_health_status() {
+  local report="$LOG_DIR/startup-hermes.json"
+  # No report (a node that runs no Hermes startup probe) proves nothing, so
+  # keep the previous behaviour rather than inventing a degradation.
+  [ -f "$report" ] || { printf '%s\n' healthy; return 0; }
+  "${PY:-python3}" - "$report" <<'PY' 2>/dev/null || printf '%s\n' healthy
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except (OSError, ValueError):
+    # An unreadable report is not a degradation proof either.
+    print("healthy")
+    raise SystemExit(0)
+print("healthy" if data.get("ready") else "degraded")
+PY
+}
+
 clear_mac_agent_drain_after_deploy() {
   load_drain_api_env
   if ! mac_api_json GET "/health" >/dev/null 2>&1; then
@@ -8883,8 +8917,14 @@ clear_mac_agent_drain_after_deploy() {
   if ! agent_id="$(agent_id_for_drain)" || [ -z "$agent_id" ]; then
     return 0
   fi
+  local health
+  health="$(startup_probe_health_status)"
+  if [ "$health" != healthy ]; then
+    log "WARNING: startup probe reported not-ready; registering $agent_id as $health rather than healthy (see $LOG_DIR/startup-hermes.json)"
+  fi
   log "clearing drain state for $agent_id"
-  mac_api_json POST "/agents/$agent_id/heartbeat" '{"status":"idle","health_status":"healthy"}' >/dev/null || true
+  mac_api_json POST "/agents/$agent_id/heartbeat" \
+    "{\"status\":\"idle\",\"health_status\":\"$health\"}" >/dev/null || true
 }
 
 
@@ -10698,6 +10738,17 @@ if [ "$NODE_ACTION" = legacy-one-shot ]; then
   write_hermes_memory_topology
 else
   log "typed phase 2 consumed infrastructure receipts; tunnel, OpenShell, shared-service, and storage mutation is forbidden"
+  # Forbidding MUTATION is not the same as tolerating ABSENCE. A fungible node
+  # is recreated from an image and comes up with no ~/.hermes state at all, and
+  # this writer only ran on the legacy-one-shot path, so a typed deploy could
+  # never give the file back: three of five GKE workers were still missing it
+  # on 2026-08-05 and reported qdrant_status=missing_topology while registering
+  # healthy. Write it only when it does not exist -- an existing topology is
+  # still left exactly as the receipts describe it.
+  if [ ! -f "$HOME/.hermes/mac-memory-topology.json" ]; then
+    log "repairing absent Hermes memory topology (typed phase 2 retains an existing one, but cannot retain a missing one)"
+    write_hermes_memory_topology
+  fi
 fi
 
 log "installing mac Python package (with gateway, relay, and PostgreSQL runtime extras)"
@@ -10824,6 +10875,14 @@ if [ "$NODE_ACTION" = legacy-one-shot ]; then
   verify_hermes_prompt_bridge
 else
   log "typed phase 2 retained hub database, runtime identity, and Hermes context authorities"
+  # "Retained" presumes something is there to retain. A recreated fungible node
+  # has no ~/.hermes/mac-runtime-context.json and this writer only ran on the
+  # legacy-one-shot path, so the file could never come back. Repair absence
+  # only; an existing context stays exactly as the receipts describe it.
+  if [ ! -f "$HOME/.hermes/mac-runtime-context.json" ]; then
+    log "repairing absent Hermes runtime context (typed phase 2 retains an existing one, but cannot retain a missing one)"
+    write_hermes_runtime_context
+  fi
 fi
 
 ACC_DB=""
@@ -11652,9 +11711,35 @@ host_name="${MAC_WORKER_HOSTNAME:-$agent_name}"
 workspace="${MAC_WORKER_WORKSPACE:-$HOME/.mac/agent-workspaces}"
 mode="${MAC_WORKER_MODE:-heartbeat}"
 capabilities="${MAC_WORKER_CAPABILITIES:-ops,python,openclaw,review,api,architecture,cli,docs,security,testing,typescript,ui,web_search,web_extract,web_crawl,firecrawl,work_package_v1}"
-# Hardware capability probes: append gpu/cuda if nvidia-smi sees GPUs; always append cpu.
+# Hardware capability probes: always append cpu; append gpu/cuda only when a
+# host GPU is present AND the bootstrap proved a nested OpenShell sandbox can
+# actually use it.
+#
+# Advertising on nvidia-smi alone is a lie the dispatcher believes. Tasks run
+# INSIDE OpenShell sandboxes, so host-visible hardware is not the capability
+# being offered. src/mac/executor_sandbox.py refuses a GPU task outright unless
+# MAC_OPENSHELL_GPU_AVAILABLE is set ("task requires GPU but bootstrap did not
+# verify OpenShell GPU access"), so a host advertising gpu without that flag
+# gets matched, claims the work, and fails it -- instead of the hub routing it
+# to a host that can run it.
+#
+# Measured on all five GKE workers 2026-08-05: nvidia-smi reports an RTX PRO
+# 6000 MIG device, while the GPU smoke fails because
+# /run/nvidia-persistenced/socket does not exist in the pod, so no nested GPU
+# container can start. Real GPU, unusable through the sandbox.
+#
+# Unset is treated as unproved, matching env_bool's default=False, so this
+# advertises exactly what the executor will honor.
+case "$(printf '%s' "${MAC_OPENSHELL_GPU_AVAILABLE:-}" | tr '[:upper:]' '[:lower:]')" in
+  1|true|yes|on) openshell_gpu_proved=1 ;;
+  *) openshell_gpu_proved=0 ;;
+esac
 if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L 2>/dev/null | grep -q "^GPU"; then
-  capabilities="$capabilities,gpu,cuda"
+  if [ "$openshell_gpu_proved" = 1 ]; then
+    capabilities="$capabilities,gpu,cuda"
+  else
+    echo "mac-agent: host GPU present but OpenShell GPU access is unproved (MAC_OPENSHELL_GPU_AVAILABLE=${MAC_OPENSHELL_GPU_AVAILABLE:-unset}); not advertising gpu/cuda so GPU work routes to a host that can run it" >&2
+  fi
 fi
 capabilities="$capabilities,cpu"
 mkdir -p "$workspace"

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -70,6 +70,7 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         "tests/test_deploy_fleet_drain.py",
         "tests/test_deploy_fleet_parallel_staging.py",
         "tests/test_deploy_github_https_credentials.py",
+        "tests/test_fleet_node_capability_truthfulness.py",
         "tests/test_fleet_node_daemon_quiescence.py",
         "tests/test_fleet_node_gateway_readiness.py",
         "tests/test_fleet_node_generated_rollback.py",

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -8452,6 +8452,7 @@
     "name": "MAC_OPENSHELL_GPU_AVAILABLE",
     "retired": false,
     "sources": [
+      "deploy/fleet-node-install.sh",
       "deploy/openshell/bootstrap-openshell.sh",
       "src/mac/executor_sandbox.py"
     ],

--- a/tests/test_fleet_node_capability_truthfulness.py
+++ b/tests/test_fleet_node_capability_truthfulness.py
@@ -1,0 +1,272 @@
+"""An agent must advertise only what it can actually deliver.
+
+Two measurements on the live fleet, 2026-08-05, motivated this module.
+
+GPU. All five GKE workers reported MAC_OPENSHELL_GPU_AVAILABLE=0 -- the
+bootstrap's GPU smoke test could not start a nested GPU container, because
+/run/nvidia-persistenced/socket does not exist inside the pod -- and all five
+still advertised "gpu" and "cuda" to the hub, because the capability probe
+consulted nvidia-smi and nothing else. Tasks execute INSIDE OpenShell
+sandboxes, so host-visible hardware is not the capability on offer.
+src/mac/executor_sandbox.py already refuses such a task outright, so the
+dispatcher matched work to hosts guaranteed to reject it rather than routing it
+to bullwinkle or natasha, which can run it.
+
+Health. Three of those five finished their deploy with the startup probe
+reporting ready=False and their Hermes memory topology missing, and then
+registered "healthy" anyway: the verdict was printed for humans and discarded.
+
+Both are the same defect in different clothes -- a correct measurement that no
+consumer acts on -- so both are tested here.
+
+These tests EXTRACT THE REAL SHELL from deploy/fleet-node-install.sh and
+execute it. Asserting on substrings of the script would pass just as happily
+against a comment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "deploy" / "fleet-node-install.sh"
+
+
+def _script() -> str:
+    return INSTALLER.read_text(encoding="utf-8")
+
+
+def _extract_function(name: str) -> str:
+    """Pull one top-level `name() { ... }` definition out of the installer."""
+    text = _script()
+    start = text.index("\n%s() {\n" % name) + 1
+    end = text.index("\n}\n", start) + len("\n}\n")
+    return text[start:end]
+
+
+def _extract_capability_block() -> str:
+    """The capability probe: from the hardware-probe comment to the cpu append."""
+    text = _script()
+    start = text.index("# Hardware capability probes:")
+    end = text.index('capabilities="$capabilities,cpu"', start) + len(
+        'capabilities="$capabilities,cpu"'
+    )
+    return text[start:end]
+
+
+def _run_bash(script: str, env: dict, cwd: Path) -> subprocess.CompletedProcess:
+    full = dict(os.environ)
+    full.update(env)
+    return subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", script],
+        capture_output=True,
+        text=True,
+        env=full,
+        cwd=str(cwd),
+        timeout=60,
+    )
+
+
+# --------------------------------------------------------------------------
+# GPU capability advertisement
+# --------------------------------------------------------------------------
+
+
+def _capability_harness(tmp_path: Path, *, has_gpu: bool) -> str:
+    """Run the real capability block with a fake nvidia-smi."""
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir(exist_ok=True)
+    if has_gpu:
+        nvidia = fake_bin / "nvidia-smi"
+        nvidia.write_text(
+            "#!/bin/sh\n"
+            'echo "GPU 0: NVIDIA RTX PRO 6000 Blackwell Server Edition (UUID: GPU-x)"\n',
+            encoding="utf-8",
+        )
+        nvidia.chmod(0o755)
+    return (
+        'export PATH="%s:$PATH"\n'
+        'capabilities="ops,python"\n'
+        "%s\n"
+        'printf "%%s\\n" "$capabilities"\n' % (fake_bin, _extract_capability_block())
+    )
+
+
+@pytest.mark.parametrize("flag", ["1", "true", "yes", "on"])
+def test_gpu_is_advertised_when_the_sandbox_smoke_proved_it(tmp_path, flag):
+    """natasha and bullwinkle must keep their GPU capability."""
+    result = _run_bash(
+        _capability_harness(tmp_path, has_gpu=True),
+        {"MAC_OPENSHELL_GPU_AVAILABLE": flag},
+        tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    caps = result.stdout.strip().split(",")
+    assert "gpu" in caps and "cuda" in caps, (
+        "a host whose OpenShell GPU smoke passed must still advertise gpu: %s"
+        % result.stdout
+    )
+    assert "cpu" in caps
+
+
+@pytest.mark.parametrize("flag", ["0", "false", "no", "off", ""])
+def test_gpu_is_withheld_when_the_sandbox_cannot_use_it(tmp_path, flag):
+    """The regression. Host GPU present, sandbox GPU proven unusable."""
+    result = _run_bash(
+        _capability_harness(tmp_path, has_gpu=True),
+        {"MAC_OPENSHELL_GPU_AVAILABLE": flag},
+        tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    caps = result.stdout.strip().split(",")
+    assert "gpu" not in caps and "cuda" not in caps, (
+        "advertised GPU capability the executor will refuse "
+        "(MAC_OPENSHELL_GPU_AVAILABLE=%r): %s" % (flag, result.stdout)
+    )
+    assert "cpu" in caps, "the host is still a perfectly good CPU worker"
+    assert "not advertising gpu/cuda" in result.stderr, (
+        "withholding a capability must say so; a silent downgrade is how this "
+        "went unnoticed in the first place"
+    )
+
+
+def test_an_unset_flag_is_treated_as_unproved(tmp_path):
+    """Unset must match env_bool's default=False, which is what the executor uses."""
+    result = _run_bash(
+        _capability_harness(tmp_path, has_gpu=True), {}, tmp_path
+    )
+    assert result.returncode == 0, result.stderr
+    caps = result.stdout.strip().split(",")
+    assert "gpu" not in caps, (
+        "unset is not proof of GPU access; executor_sandbox.py would refuse the "
+        "task, so advertising it guarantees a failure"
+    )
+
+
+def test_a_host_with_no_gpu_is_unaffected(tmp_path):
+    """rocky has no nvidia-smi at all; the flag must not invent a GPU."""
+    result = _run_bash(
+        _capability_harness(tmp_path, has_gpu=False),
+        {"MAC_OPENSHELL_GPU_AVAILABLE": "1"},
+        tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    caps = result.stdout.strip().split(",")
+    assert "gpu" not in caps and "cuda" not in caps
+    assert "cpu" in caps
+
+
+# --------------------------------------------------------------------------
+# Health must reflect the startup probe
+# --------------------------------------------------------------------------
+
+
+def _health_harness(tmp_path: Path, report: object | None) -> str:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir(exist_ok=True)
+    if report is not None:
+        (log_dir / "startup-hermes.json").write_text(
+            report if isinstance(report, str) else json.dumps(report),
+            encoding="utf-8",
+        )
+    return (
+        'LOG_DIR="%s"\nPY="%s"\n%s\nstartup_probe_health_status\n'
+        % (log_dir, shutil.which("python3") or "python3",
+           _extract_function("startup_probe_health_status"))
+    )
+
+
+def test_a_not_ready_node_reports_degraded(tmp_path):
+    """The regression: ready=False must not register as healthy."""
+    report = {
+        "ready": False,
+        "warnings": ["Hermes memory topology file is missing"],
+        "qdrant_level2": {"status": "missing_topology", "ready": False},
+    }
+    result = _run_bash(_health_harness(tmp_path, report), {}, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "degraded", (
+        "a node that failed its own readiness probe reported healthy: %s"
+        % result.stdout
+    )
+
+
+def test_a_ready_node_reports_healthy(tmp_path):
+    result = _run_bash(
+        _health_harness(tmp_path, {"ready": True, "warnings": []}), {}, tmp_path
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "healthy"
+
+
+def test_a_missing_report_is_not_treated_as_degraded(tmp_path):
+    """A node that runs no Hermes startup probe proves nothing either way.
+
+    Inventing a degradation there would mark healthy hosts unhealthy, which is
+    the same class of untruth in the opposite direction.
+    """
+    result = _run_bash(_health_harness(tmp_path, None), {}, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "healthy"
+
+
+def test_an_unreadable_report_is_not_treated_as_degraded(tmp_path):
+    result = _run_bash(_health_harness(tmp_path, "{not json"), {}, tmp_path)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "healthy"
+
+
+def test_the_drain_clear_sends_the_measured_health(tmp_path):
+    """The verdict must reach the heartbeat, not just be computed."""
+    body = _extract_function("clear_mac_agent_drain_after_deploy")
+    assert "startup_probe_health_status" in body, (
+        "clear_mac_agent_drain_after_deploy no longer consults the startup "
+        "probe, so a not-ready node would register healthy again"
+    )
+    assert '"health_status\\":\\"$health' in body or '$health' in body, (
+        "the measured health must be interpolated into the heartbeat payload"
+    )
+    assert '"health_status":"healthy"' not in body, (
+        "the heartbeat still hardcodes healthy"
+    )
+
+
+# --------------------------------------------------------------------------
+# Typed phase 2 must repair absent Hermes state
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "writer,filename",
+    [
+        ("write_hermes_memory_topology", "mac-memory-topology.json"),
+        ("write_hermes_runtime_context", "mac-runtime-context.json"),
+    ],
+)
+def test_typed_phase_two_repairs_absent_hermes_state(writer, filename):
+    """A recreated fungible node must be able to get these files back.
+
+    Both writers ran only on the legacy-one-shot path, so a typed phase-2
+    deploy could never restore them: three of five GKE workers were still
+    missing both on 2026-08-05. Phase 2 must keep refusing to MUTATE an
+    existing file while still repairing an absent one.
+    """
+    text = _script()
+    guarded = re.search(
+        r'if \[ ! -f "\$HOME/\.hermes/%s" \]; then\n(?:.*\n)*?\s*%s\n'
+        % (re.escape(filename), re.escape(writer)),
+        text,
+    )
+    assert guarded, (
+        "typed phase 2 has no absence-repair for %s, so a recreated node can "
+        "never regain it" % filename
+    )
+    # The repair must be conditional: an existing file is still left alone.
+    assert '! -f "$HOME/.hermes/%s"' % filename in text


### PR DESCRIPTION
Closes `task_9746fd48` and `task_9524acca`.

Two measurements on the live fleet, both the same defect in different clothes: **a correct probe whose result no consumer acts on.**

## GPU capability

All five GKE workers reported `MAC_OPENSHELL_GPU_AVAILABLE=0` — the bootstrap's GPU smoke cannot start a nested GPU container because `/run/nvidia-persistenced/socket` doesn't exist in the pod — and all five still advertised `gpu` and `cuda`, because the capability probe consulted `nvidia-smi` and nothing else.

Tasks run **inside** OpenShell sandboxes, so host-visible hardware isn't the capability on offer. `executor_sandbox.py` already refuses such a task outright, so the dispatcher matched GPU work to hosts guaranteed to reject it, instead of routing it to `natasha`/`bullwinkle`, which can run it.

The probe now requires a host GPU **and** the proven sandbox path, treating unset as unproved to match `env_bool`'s default — so the advertisement is exactly what the executor will honor. Withholding is logged; a silent downgrade is how this went unnoticed.

Verified against the real hosts: `natasha`/`bullwinkle` have the flag set (keep GPU), the five workers have it at `0` (lose it), `rocky` has no `nvidia-smi` (unaffected).

## Health

Three of those five finished a deploy with the startup probe reporting `ready=False` and their Hermes memory topology missing — then registered **healthy**, because `clear_mac_agent_drain_after_deploy` hardcoded it. The verdict was printed for humans and discarded.

It now reports what the probe measured. A node failing its own readiness probe is `degraded`, not healthy — degraded still takes work, so this is a signal, not a quarantine. A missing or unreadable report still reports healthy: absence of a probe is not proof of degradation.

## Why those files were missing

`write_hermes_memory_topology` and `write_hermes_runtime_context` ran **only on the legacy-one-shot path**. A typed phase-2 deploy could never restore them, and a fungible k8s node is recreated from an image with no `~/.hermes` state — so once lost, gone for good.

Phase 2 still refuses to **mutate** an existing file; it now repairs an **absent** one, because "retained" presumes something is there to retain. That keeps the phase contract intact.

## Testing

`tests/test_fleet_node_capability_truthfulness.py` **extracts the real shell** from the installer and executes it against a fake `nvidia-smi` and crafted startup reports — asserting on substrings would pass just as happily against a comment.

**Mutation-checked: reverting any of the three changes fails it (8 of its 18 tests).**

Registered in `resolve-impacted-tests.py` so it runs whenever the installer changes — its own contract test caught that omission, which is exactly the point of it.

Contract gate: **10,183 passed**.

## Not fixed here

The underlying `/run/nvidia-persistenced/socket` absence is a k8s/GPU-operator concern, not a MAC one. Providing it in the pod spec would restore real GPU capacity on five workers; this PR only stops them claiming work they cannot do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)