### PR TITLE
Stop a stale CDI mount costing every GKE worker its GPU

### DIFF
--- a/deploy/openshell/bootstrap-openshell.sh
+++ b/deploy/openshell/bootstrap-openshell.sh
@@ -1548,6 +1548,93 @@ mirror_image_for_openshell_runtime() {
   fi
 }
 
+# A GKE worker pod inherits a CDI spec that mounts the nvidia-persistenced
+# socket into every GPU container. On these nodes nvidia-persistenced is not
+# running: /run/nvidia-persistenced/socket is a stale entry that stat(2) can
+# see but that cannot be bind-mounted, so EVERY GPU container fails to start:
+#
+#   error during container init: error mounting "/run/nvidia-persistenced/socket"
+#   to rootfs at "/run/nvidia-persistenced/socket": ... no such file or directory
+#
+# Measured on all five GKE workers 2026-08-05. It is not OpenShell-specific --
+# plain `docker run --gpus all` fails identically -- and it cost the fleet the
+# GPU capacity of five nodes, silently, because the smoke test's failure was
+# only a warning.
+#
+# The mount is not needed: persistence mode is a daemon feature and nothing in
+# a task container talks to that socket. Removing the entry made GPU containers
+# start immediately on worker5.
+#
+# The repair is deliberately narrow. It fires only when the socket is present
+# AND no daemon answers it, so a node where persistenced really is running is
+# left alone, and it never touches the /usr/bin/nvidia-persistenced binary
+# mount, which is a real file. Pod filesystems are recreated from an image, so
+# this must run on every bring-up rather than once by hand.
+repair_stale_cdi_persistenced_mount() {
+  local spec=/etc/cdi/nvidia.yaml
+  local socket=/run/nvidia-persistenced/socket
+  [ -f "$spec" ] || return 0
+  grep -q "hostPath: $socket" "$spec" 2>/dev/null || return 0
+  [ -e "$socket" ] || return 0
+  if python3 - "$socket" <<'PY'
+import socket
+import sys
+
+probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+probe.settimeout(2)
+try:
+    probe.connect(sys.argv[1])
+except OSError:
+    raise SystemExit(1)  # nothing listening: the mount is stale
+finally:
+    probe.close()
+raise SystemExit(0)  # a real daemon is there; leave the spec alone
+PY
+  then
+    log "nvidia-persistenced is live; leaving its CDI socket mount in place"
+    return 0
+  fi
+  log "removing stale nvidia-persistenced socket mount from $spec (no daemon is listening; it blocks every GPU container)"
+  local sudo_cmd=""
+  if [ ! -w "$spec" ]; then
+    if sudo -n true 2>/dev/null; then
+      sudo_cmd="sudo"
+    else
+      log "WARNING: cannot rewrite $spec (not writable and no sudo); GPU containers will keep failing"
+      return 0
+    fi
+  fi
+  $sudo_cmd cp -n "$spec" "$spec.mac-bak" 2>/dev/null || true
+  $sudo_cmd python3 - "$spec" "$socket" <<'PY'
+import pathlib
+import sys
+
+spec = pathlib.Path(sys.argv[1])
+needle = "hostPath: %s" % sys.argv[2]
+lines = spec.read_text().splitlines(keepends=True)
+out, index, removed = [], 0, 0
+while index < len(lines):
+    if needle in lines[index]:
+        # Drop this list item: the hostPath line plus its continuation lines,
+        # stopping at the next sibling item or any dedent.
+        indent = len(lines[index]) - len(lines[index].lstrip())
+        index += 1
+        while index < len(lines):
+            stripped = lines[index].lstrip()
+            current = len(lines[index]) - len(stripped)
+            if current < indent or (stripped.startswith("- ") and current <= indent):
+                break
+            index += 1
+        removed += 1
+        continue
+    out.append(lines[index])
+    index += 1
+if removed:
+    spec.write_text("".join(out))
+print("removed %d stale CDI mount entr(ies)" % removed)
+PY
+}
+
 gpu_runtime_available=0
 validate_openshell_runtime_image() {
   [ "$DO_ENABLE" = 1 ] || return 0
@@ -1576,6 +1663,7 @@ validate_openshell_runtime_image() {
     exit "$rc"
   fi
   if [ "$OSH_GPU" = yes ]; then
+    repair_stale_cdi_persistenced_mount
     gpu_smoke_name="mac-gpu-smoke-$$"
     gpu_smoke_log="$OSH_DIR/runtime-gpu-smoke.log"
     rm -f "$gpu_smoke_log"

--- a/tests/test_openshell_gpu_cdi_repair.py
+++ b/tests/test_openshell_gpu_cdi_repair.py
@@ -1,0 +1,213 @@
+"""A stale CDI mount must not cost a GPU node its accelerator.
+
+Measured on all five GKE workers 2026-08-05. Their CDI spec mounts the
+nvidia-persistenced socket into every GPU container, but nvidia-persistenced is
+not running on those nodes: /run/nvidia-persistenced/socket is a stale entry
+that stat(2) can see and bind(2) cannot mount. Every GPU container therefore
+failed to start --
+
+  error during container init: error mounting "/run/nvidia-persistenced/socket"
+  to rootfs ... no such file or directory
+
+-- and not just under OpenShell: plain `docker run --gpus all` failed
+identically. Five GPU nodes ran as CPU-only nodes and nothing said so, because
+the bootstrap's GPU smoke failure was a warning.
+
+The mount is unnecessary: persistence mode is a daemon feature and nothing in a
+task container speaks to that socket. Removing the entry made GPU containers
+start immediately.
+
+The repair has to be narrow, because the same spec is correct on a node where
+persistenced really is running, and it must survive pod recreation -- a GKE
+worker comes up from an image with a fresh filesystem, so a one-off manual edit
+is lost on the next bring-up.
+
+These tests extract the real shell function from the bootstrap and run it
+against fixture specs with a real listening socket, a real stale socket, and no
+socket at all.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = ROOT / "deploy" / "openshell" / "bootstrap-openshell.sh"
+
+SPEC_WITH_SOCKET = """\
+cdiVersion: 0.5.0
+kind: nvidia.com/gpu
+devices:
+  - name: all
+    containerEdits:
+      mounts:
+        - hostPath: /usr/lib/libcuda.so.1
+          containerPath: /usr/lib/libcuda.so.1
+          options:
+            - ro
+            - nosuid
+        - hostPath: {socket}
+          containerPath: {socket}
+          options:
+            - nosuid
+            - nodev
+            - rbind
+        - hostPath: /usr/bin/nvidia-persistenced
+          containerPath: /usr/bin/nvidia-persistenced
+          options:
+            - ro
+            - nosuid
+"""
+
+
+def _extract_function(name: str) -> str:
+    text = BOOTSTRAP.read_text(encoding="utf-8")
+    start = text.index("\n%s() {\n" % name) + 1
+    end = text.index("\n}\n", start) + len("\n}\n")
+    return text[start:end]
+
+
+def _harness(spec: Path, sock: Path) -> str:
+    """Run the real function with $spec/$socket redirected at fixtures."""
+    body = _extract_function("repair_stale_cdi_persistenced_mount")
+    body = body.replace("local spec=/etc/cdi/nvidia.yaml", 'local spec="%s"' % spec)
+    body = body.replace(
+        "local socket=/run/nvidia-persistenced/socket", 'local socket="%s"' % sock
+    )
+    return "log() { printf '%s\\n' \"$*\" >&2; }\n" + body + "\nrepair_stale_cdi_persistenced_mount\n"
+
+
+def _run(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-uo", "pipefail", "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=dict(os.environ),
+    )
+
+
+def _write_spec(tmp_path: Path, sock: Path) -> Path:
+    spec = tmp_path / "nvidia.yaml"
+    spec.write_text(SPEC_WITH_SOCKET.format(socket=sock), encoding="utf-8")
+    return spec
+
+
+def test_a_stale_socket_mount_is_removed(tmp_path):
+    """The regression: socket file exists, nothing listening."""
+    sock = tmp_path / "socket"
+    sock.write_text("", encoding="utf-8")  # present, but no listener
+    spec = _write_spec(tmp_path, sock)
+
+    result = _run(_harness(spec, sock))
+
+    text = spec.read_text(encoding="utf-8")
+    assert "hostPath: %s" % sock not in text, (
+        "the stale socket mount survived, so every GPU container still fails:\n%s"
+        % result.stderr
+    )
+    assert "removing stale nvidia-persistenced socket mount" in result.stderr
+
+
+def test_the_binary_mount_and_other_devices_survive(tmp_path):
+    """Only the socket entry goes. /usr/bin/nvidia-persistenced is a real file."""
+    sock = tmp_path / "socket"
+    sock.write_text("", encoding="utf-8")
+    spec = _write_spec(tmp_path, sock)
+
+    _run(_harness(spec, sock))
+
+    text = spec.read_text(encoding="utf-8")
+    assert "hostPath: /usr/bin/nvidia-persistenced" in text, (
+        "the persistenced BINARY mount was removed; only the socket is stale"
+    )
+    assert "hostPath: /usr/lib/libcuda.so.1" in text, "an unrelated mount was removed"
+    assert "containerPath: /usr/lib/libcuda.so.1" in text
+    assert "cdiVersion: 0.5.0" in text, "the spec header was damaged"
+    # The removed item must not leave its option list orphaned behind.
+    assert "- rbind" not in text, "the removed entry left dangling options"
+
+
+def test_a_live_persistenced_is_left_alone(tmp_path):
+    """On a node where the daemon really runs, the mount is correct."""
+    # AF_UNIX paths are capped near 104 bytes, well under pytest's tmp_path.
+    short_dir = Path(tempfile.mkdtemp(prefix="cdi", dir="/tmp"))
+    sock = short_dir / "s"
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(sock))
+    server.listen(1)
+    stop = threading.Event()
+
+    def _accept() -> None:
+        server.settimeout(0.2)
+        while not stop.is_set():
+            try:
+                conn, _ = server.accept()
+                conn.close()
+            except OSError:
+                continue
+
+    thread = threading.Thread(target=_accept, daemon=True)
+    thread.start()
+    try:
+        spec = _write_spec(tmp_path, sock)
+        result = _run(_harness(spec, sock))
+        text = spec.read_text(encoding="utf-8")
+        assert "hostPath: %s" % sock in text, (
+            "removed a mount for a LIVE nvidia-persistenced; that would break "
+            "persistence mode on a healthy node:\n%s" % result.stderr
+        )
+        assert "leaving its CDI socket mount in place" in result.stderr
+    finally:
+        stop.set()
+        thread.join(timeout=2)
+        server.close()
+
+
+def test_no_socket_at_all_is_left_alone(tmp_path):
+    """Nothing to repair when the host never had the socket."""
+    sock = tmp_path / "socket"  # never created
+    spec = _write_spec(tmp_path, sock)
+    before = spec.read_text(encoding="utf-8")
+
+    _run(_harness(spec, sock))
+
+    assert spec.read_text(encoding="utf-8") == before
+
+
+def test_a_spec_without_the_mount_is_untouched(tmp_path):
+    sock = tmp_path / "socket"
+    sock.write_text("", encoding="utf-8")
+    spec = tmp_path / "nvidia.yaml"
+    spec.write_text("cdiVersion: 0.5.0\nkind: nvidia.com/gpu\n", encoding="utf-8")
+    before = spec.read_text(encoding="utf-8")
+
+    _run(_harness(spec, sock))
+
+    assert spec.read_text(encoding="utf-8") == before
+
+
+def test_a_missing_spec_is_not_an_error(tmp_path):
+    """Non-GPU nodes have no CDI spec; the repair must be a quiet no-op."""
+    sock = tmp_path / "socket"
+    sock.write_text("", encoding="utf-8")
+    result = _run(_harness(tmp_path / "absent.yaml", sock))
+    assert result.returncode == 0, result.stderr
+
+
+def test_the_repair_runs_before_the_gpu_smoke():
+    """A repair that runs after the probe it fixes would prove nothing."""
+    text = BOOTSTRAP.read_text(encoding="utf-8")
+    repair = text.index("repair_stale_cdi_persistenced_mount\n    gpu_smoke_name")
+    smoke = text.index("gpu_smoke_name=")
+    assert repair < smoke, (
+        "the CDI repair must precede the GPU smoke, or the smoke still fails "
+        "and the node still advertises no GPU"
+    )


### PR DESCRIPTION
Makes the GPU fix persistent across worker bring-ups. Pairs with #278.

## What was wrong

All five GKE workers have a real RTX PRO 6000 MIG device and **could not start a single GPU container**. Their CDI spec mounts `/run/nvidia-persistenced/socket` into every GPU container, but `nvidia-persistenced` isn't running on those nodes — the socket is a stale entry that `stat(2)` can see and `bind(2)` cannot mount:

```
error mounting "/run/nvidia-persistenced/socket" to rootfs ... no such file or directory
```

Two things confirmed this isn't OpenShell-specific:

- plain `docker run --gpus all <image> true` fails identically
- connecting to the socket returns `ECONNREFUSED` — nothing is listening

So five GPU nodes have been running as CPU-only nodes, silently, because the bootstrap's GPU smoke failure was only a warning.

## The fix

The mount is unnecessary — persistence mode is a daemon feature and nothing in a task container talks to that socket. **Removing the entry made GPU containers start immediately on worker5, verified before writing any code.**

`repair_stale_cdi_persistenced_mount()` now runs immediately before the GPU smoke, and is deliberately narrow:

- fires **only** when the socket is present *and* no daemon answers it, so a node where `persistenced` really is running keeps its mount
- never touches the `/usr/bin/nvidia-persistenced` **binary** mount, which is a real file
- needs `sudo` to rewrite `/etc/cdi/nvidia.yaml`; warns rather than failing when it can't

## Why it lives in the bootstrap

This is the persistence requirement. A GKE worker pod is **recreated from an image with a fresh filesystem**, so fixing the five nodes by hand would be undone at the next bring-up. Putting it in the bootstrap means every future worker repairs itself before the probe that would otherwise condemn it.

## Combined effect with #278

With GPU access actually proved, `MAC_OPENSHELL_GPU_AVAILABLE` flips to `1`, and #278's capability gate then advertises `gpu`/`cuda` again — honestly this time, rather than on `nvidia-smi` alone.

## Testing

`tests/test_openshell_gpu_cdi_repair.py` extracts the real shell function and runs it against a stale socket, a **genuinely listening** socket, a missing socket, a spec without the mount, and a missing spec — asserting the binary mount and unrelated devices survive, and that the repair precedes the smoke. Removing the call fails it.

Contract gate: **10,190 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)