### PR TITLE
Make the curiosity quarantine reachable from where it is adjudicated

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -130,6 +130,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_CURIOSITY_REVIEW_ENABLED` | bool | consumer-defined | core | Core setting: curiosity review enabled. |
 | `MAC_CURIOSITY_REVIEW_INITIAL_DELAY_SECONDS` | int | consumer-defined | core | Core setting: curiosity review initial delay seconds. |
 | `MAC_CURIOSITY_REVIEW_INTERVAL_SECONDS` | int | consumer-defined | core | Core setting: curiosity review interval seconds. |
+| `MAC_CURIOSITY_TIMEOUT_SECONDS` | int | consumer-defined | core | Core setting: curiosity timeout seconds. |
+| `MAC_CURIOSITY_WRAPPER` | str | consumer-defined | core | Core setting: curiosity wrapper. |
 | `MAC_CURSOR_ENDPOINT` | str | consumer-defined | core | Core setting: cursor endpoint. |
 | `MAC_CURSOR_MODEL` | str | consumer-defined | core | Core setting: cursor model. |
 | `MAC_DATABASE_URL` | str | consumer-defined | core | Core setting: database url. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,12 +9,12 @@ The book uses executable `bash` blocks; reference usage is rendered as output.
 $ mac --help
 usage: mac [-h] [--db DB] [--local-authority] [--hub-url HUB_URL]
            [--token TOKEN] [--fleet FLEET] [--profile PROFILE] [--json]
-           {diagnostics,init,database,config,login,logout,client,tenant,user,persona,hermes,binding,interaction,task,repo,project,work-package,directive,hgx,openshell,machine,agent,fleet,journal,optimizer,mood,dream,nap,dispatch,message,agentbus,review,publish,pull-request,secret,runtime,artifact,env,bridge,integrations,memory,rollout,events,action-events,command-audit,observability,communication,comm,notifier,migrate,workflow,eval,plan} ...
+           {diagnostics,init,database,config,login,logout,client,tenant,user,persona,hermes,binding,interaction,task,repo,project,work-package,directive,hgx,openshell,machine,agent,fleet,journal,optimizer,mood,dream,nap,dispatch,message,agentbus,review,publish,pull-request,secret,runtime,artifact,env,bridge,integrations,curiosity,memory,rollout,events,action-events,command-audit,observability,communication,comm,notifier,migrate,workflow,eval,plan} ...
 
 Multi-agent coordinator control plane
 
 positional arguments:
-  {diagnostics,init,database,config,login,logout,client,tenant,user,persona,hermes,binding,interaction,task,repo,project,work-package,directive,hgx,openshell,machine,agent,fleet,journal,optimizer,mood,dream,nap,dispatch,message,agentbus,review,publish,pull-request,secret,runtime,artifact,env,bridge,integrations,memory,rollout,events,action-events,command-audit,observability,communication,comm,notifier,migrate,workflow,eval,plan}
+  {diagnostics,init,database,config,login,logout,client,tenant,user,persona,hermes,binding,interaction,task,repo,project,work-package,directive,hgx,openshell,machine,agent,fleet,journal,optimizer,mood,dream,nap,dispatch,message,agentbus,review,publish,pull-request,secret,runtime,artifact,env,bridge,integrations,curiosity,memory,rollout,events,action-events,command-audit,observability,communication,comm,notifier,migrate,workflow,eval,plan}
     diagnostics         run read-only control-plane health checks
     init                create the control-plane schema in the --db PostgreSQL
                         store
@@ -66,6 +66,10 @@ positional arguments:
                         edges)
     bridge              external project bridge commands
     integrations        integration authority observations and findings
+    curiosity           read and adjudicate a host's curiosity quarantine
+                        THROUGH THE HUB (the ledger lives in the agent's
+                        OpenClaw sandbox; a task sandbox cannot reach it
+                        directly)
     memory              memory and provenance commands
     rollout             rollout and rescue commands
     events              unified audit stream
@@ -949,6 +953,22 @@ usage: mac integrations [-h] {findings,observations} ...
 
 positional arguments:
   {findings,observations}
+
+options:
+  -h, --help            show this help message and exit
+```
+
+## mac curiosity
+
+```console
+$ mac curiosity --help
+usage: mac curiosity [-h] {list,approve,reject} ...
+
+positional arguments:
+  {list,approve,reject}
+    list                list candidates
+    approve             approve a quarantined candidate
+    reject              reject a quarantined candidate
 
 options:
   -h, --help            show this help message and exit

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -122,6 +122,8 @@ request and response definitions.
 | `POST` | `/crash-reports/{report_id}/resolve` | Resolve Crash Report |
 | `POST` | `/curiosity-review/run` | Curiosity Review Run |
 | `GET` | `/curiosity-review/status` | Curiosity Review Status |
+| `GET` | `/curiosity/candidates` | List Curiosity Candidates |
+| `POST` | `/curiosity/candidates/{candidate_id}/{decision}` | Decide Curiosity Candidate |
 | `GET` | `/dashboard/agents/{agent_id}` | Dashboard Agent |
 | `POST` | `/dashboard/agents/{agent_id}/terminal-sessions` | Dashboard Terminal Session Open |
 | `GET` | `/dashboard/dispatch/explain` | Dashboard Dispatch Explain |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -954,6 +954,20 @@ class AgentUpdate(BaseModel):
     actor: str = "human"
 
 
+class CuriosityDecision(BaseModel):
+    """Approve/reject one quarantined curiosity candidate.
+
+    actor, reason and approval_id are all mandatory: the sidecar withholds
+    approve/reject from the submitting agent precisely so that promotion
+    carries external judgment with an auditable trail, and dropping any of the
+    three would defeat that.
+    """
+
+    actor: str
+    reason: str
+    approval_id: str
+
+
 class AgentBulkUpdate(BaseModel):
     agent_ids: List[str] = Field(default_factory=list)
     status: Optional[str] = None
@@ -6613,6 +6627,39 @@ def create_app(
             body.reason,
             actor=body.actor,
         ).to_dict()
+
+    # Hub-mediated curiosity quarantine access (task_3a4503f0).
+    #
+    # The ledger lives inside the mac-openclaw-<agent> sandbox, and dispatched
+    # tasks run in a different mac-task-* sandbox that cannot reach it -- so
+    # every adjudication task ever filed against the quarantine was
+    # unsatisfiable, no matter which host it was pinned to. The hub runs ON the
+    # agent host and can invoke the wrapper, and every task sandbox can already
+    # reach the hub, so mediating here is what makes the loop closable.
+    @app.get("/curiosity/candidates")
+    def list_curiosity_candidates(
+        status: Optional[str] = None,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        # ControlPlane already raises domain errors (ValidationError for a bad
+        # request or a failing wrapper, NotFoundError for a host with no
+        # OpenClaw ledger at all), which the app's handlers map to status codes.
+        return cp.list_curiosity_candidates(status)
+
+    @app.post("/curiosity/candidates/{candidate_id}/{decision}")
+    def decide_curiosity_candidate(
+        candidate_id: str,
+        decision: str,
+        body: CuriosityDecision,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        return cp.decide_curiosity_candidate(
+            candidate_id,
+            decision,
+            actor=body.actor,
+            reason=body.reason,
+            approval_id=body.approval_id,
+        )
 
     @app.get("/agents")
     def list_agents() -> List[Dict[str, Any]]:

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -5272,6 +5272,30 @@ def cmd_memory_forget(args: argparse.Namespace) -> None:
     _print(_plane(args).forget_memory(args.key, project=args.project))
 
 
+def cmd_curiosity_list(args: argparse.Namespace) -> None:
+    """List curiosity candidates through the hub.
+
+    The ledger lives inside the owning agent's OpenClaw sandbox, which a task
+    sandbox cannot reach, so reading it locally only works on the host. Going
+    through the hub works from anywhere, including a dispatched task
+    (task_3a4503f0).
+    """
+    _print(_plane(args).list_curiosity_candidates(args.status))
+
+
+def cmd_curiosity_decide(args: argparse.Namespace) -> None:
+    """Approve or reject one candidate, with the audit trail the ledger wants."""
+    _print(
+        _plane(args).decide_curiosity_candidate(
+            args.candidate_id,
+            args.decision,
+            actor=args.actor,
+            reason=args.reason,
+            approval_id=args.approval_id,
+        )
+    )
+
+
 def cmd_memory_decay(args: argparse.Namespace) -> None:
     """dream-04: forget stale, low-salience memory (dry-run unless --apply)."""
     _print(
@@ -9209,6 +9233,32 @@ def build_parser() -> argparse.ArgumentParser:
     integrations_observations.add_argument("--limit", type=int, default=100)
     _set(cmd_integrations_observations, integrations_observations)
 
+    curiosity = sub.add_parser(
+        "curiosity",
+        help="read and adjudicate a host's curiosity quarantine THROUGH THE HUB "
+        "(the ledger lives in the agent's OpenClaw sandbox; a task sandbox "
+        "cannot reach it directly)",
+    ).add_subparsers(dest="curiosity_command", required=True)
+    curiosity_list = curiosity.add_parser("list", help="list candidates")
+    curiosity_list.add_argument(
+        "--status", choices=["quarantined", "approved", "rejected"], default=None
+    )
+    _set(cmd_curiosity_list, curiosity_list)
+    for _decision in ("approve", "reject"):
+        _parser = curiosity.add_parser(
+            _decision, help="%s a quarantined candidate" % _decision
+        )
+        _parser.add_argument("candidate_id")
+        _parser.add_argument("--actor", required=True)
+        _parser.add_argument("--reason", required=True)
+        _parser.add_argument(
+            "--approval-id",
+            required=True,
+            help="external approval id; use the adjudicating task id so the "
+            "promotion is traceable in both the curiosity ledger and task history",
+        )
+        _parser.set_defaults(decision=_decision)
+        _set(cmd_curiosity_decide, _parser)
     memory = sub.add_parser("memory", help="memory and provenance commands").add_subparsers(dest="memory_command", required=True)
     memory_decay = memory.add_parser(
         "decay",

--- a/src/mac/curiosity_service.py
+++ b/src/mac/curiosity_service.py
@@ -1,0 +1,245 @@
+"""Hub-mediated access to a host's curiosity quarantine ledger.
+
+The ledger is not reachable by the agents that need it. The real CLI lives at
+``/usr/local/bin/curiosity`` INSIDE the ``mac-openclaw-<agent>`` sandbox, and
+its store is ``<state_dir>/mac-curiosity`` inside that same sandbox. A
+dispatched task executes in a freshly created ``mac-task-*`` sandbox, which is
+a different namespace with neither the CLI nor the store, and cannot reach the
+host's ``openshell`` to get them -- that isolation is the point.
+
+So every adjudication task ever filed against the quarantine was unsatisfiable.
+``curiosity_reviewer`` pins its tasks to the owning agent via
+``metadata.target_agent_id``, which fixes the HOST and not the NAMESPACE; three
+attempts on 2026-08-05 failed for exactly this reason, including one that ran
+on the correct host. See task_3a4503f0.
+
+The hub is the one process that sits in the right place: it runs on the agent's
+host, so it can invoke the ``~/.mac/bin/curiosity`` wrapper (which execs into
+the OpenClaw sandbox), and every task sandbox can already reach the hub over
+HTTP. Mediating here makes adjudication runnable from any sandbox on any host
+and removes the need to pin at all.
+
+A read-only copy uploaded into the task sandbox would NOT have been enough:
+adjudication is a write against the real ledger, so enumeration would have
+started working while approve/reject stayed broken.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from mac import mac_paths
+
+CURIOSITY_SCHEMA = "mac.curiosity_candidates.v1"
+CURIOSITY_DECISION_SCHEMA = "mac.curiosity_decision.v1"
+
+#: Statuses the sidecar CLI accepts for ``list --status``.
+CURIOSITY_STATUSES = ("quarantined", "approved", "rejected")
+
+#: Decisions the sidecar exposes. Submission is deliberately NOT proxied: the
+#: sidecar withholds approve/reject from the submitting agent on purpose, and
+#: this service exists to supply the external judgment, not to widen the
+#: submission path.
+CURIOSITY_DECISIONS = ("approve", "reject")
+
+DEFAULT_TIMEOUT_SECONDS = 60.0
+
+
+class CuriosityUnavailable(RuntimeError):
+    """The host has no reachable curiosity wrapper.
+
+    Distinct from a failing command: an agent host that never ran an OpenClaw
+    gateway has no ledger at all, and that is not an error to retry.
+    """
+
+
+class CuriosityCommandError(RuntimeError):
+    """The wrapper ran and failed. Carries the CLI's own stderr."""
+
+
+@dataclass(frozen=True)
+class CuriosityConfig:
+    """Where the wrapper is and how long it may take."""
+
+    wrapper_path: Path
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+
+    @classmethod
+    def from_env(
+        cls, environ: Optional[Mapping[str, str]] = None
+    ) -> "CuriosityConfig":
+        env = os.environ if environ is None else environ
+        raw = str(env.get("MAC_CURIOSITY_WRAPPER") or "").strip()
+        if raw:
+            wrapper = Path(raw).expanduser()
+        else:
+            # Resolve through mac_paths rather than a home literal: the fleet
+            # has four different homes and tests/test_mac_paths_no_hardcode.py
+            # exists to stop new code assuming one of them.
+            override = str(env.get("MAC_HOME") or "").strip()
+            root = Path(override).expanduser() if override else mac_paths.mac_home()
+            wrapper = root / "bin" / "curiosity"
+        timeout = DEFAULT_TIMEOUT_SECONDS
+        raw_timeout = str(env.get("MAC_CURIOSITY_TIMEOUT_SECONDS") or "").strip()
+        if raw_timeout:
+            try:
+                parsed = float(raw_timeout)
+            except ValueError:
+                parsed = DEFAULT_TIMEOUT_SECONDS
+            # A hung sandbox exec must not pin a hub request open.
+            timeout = min(600.0, max(1.0, parsed))
+        return cls(wrapper_path=wrapper, timeout_seconds=timeout)
+
+
+class CuriosityService:
+    """Proxy the host curiosity wrapper for callers that cannot reach it."""
+
+    def __init__(
+        self,
+        config: Optional[CuriosityConfig] = None,
+        *,
+        runner: Optional[Any] = None,
+    ) -> None:
+        self.config = config or CuriosityConfig.from_env()
+        # Injectable so tests exercise this module rather than a fake CLI.
+        self._runner = runner or subprocess.run
+
+    # -- availability ------------------------------------------------------
+
+    def available(self) -> bool:
+        path = self.config.wrapper_path
+        return bool(path) and path.is_file() and os.access(str(path), os.X_OK)
+
+    def _require_wrapper(self) -> Path:
+        path = self.config.wrapper_path
+        if not self.available():
+            raise CuriosityUnavailable(
+                "no curiosity wrapper at %s; this host has no OpenClaw "
+                "quarantine ledger" % path
+            )
+        return path
+
+    # -- invocation --------------------------------------------------------
+
+    def _run(self, args: Sequence[str]) -> str:
+        wrapper = self._require_wrapper()
+        argv = [str(wrapper), *[str(arg) for arg in args]]
+        try:
+            completed = self._runner(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=self.config.timeout_seconds,
+                # The wrapper resolves its own sandbox and env; inheriting the
+                # hub's environment would leak hub credentials into a sandbox
+                # exec for no benefit.
+                env={
+                    "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                    "HOME": os.environ.get("HOME", ""),
+                },
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise CuriosityCommandError(
+                "curiosity %s timed out after %.0fs"
+                % (" ".join(str(a) for a in args), self.config.timeout_seconds)
+            ) from exc
+        except OSError as exc:
+            raise CuriosityUnavailable(
+                "could not execute %s: %s" % (wrapper, exc)
+            ) from exc
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout or "").strip()
+            raise CuriosityCommandError(
+                "curiosity %s failed (exit %s): %s"
+                % (
+                    " ".join(str(a) for a in args),
+                    completed.returncode,
+                    detail[:400],
+                )
+            )
+        return completed.stdout or ""
+
+    # -- read --------------------------------------------------------------
+
+    def list_candidates(self, status: Optional[str] = None) -> Dict[str, Any]:
+        """Candidates, optionally filtered by status."""
+        args: List[str] = ["list"]
+        if status is not None:
+            normalized = str(status).strip().lower()
+            if normalized not in CURIOSITY_STATUSES:
+                raise ValueError(
+                    "status must be one of %s" % ", ".join(CURIOSITY_STATUSES)
+                )
+            args += ["--status", normalized]
+        raw = self._run(args)
+        try:
+            payload = json.loads(raw) if raw.strip() else []
+        except ValueError as exc:
+            raise CuriosityCommandError(
+                "curiosity list returned output that is not JSON: %s"
+                % raw.strip()[:200]
+            ) from exc
+        candidates = payload if isinstance(payload, list) else [payload]
+        return {
+            "schema": CURIOSITY_SCHEMA,
+            "status": status,
+            "count": len(candidates),
+            "candidates": candidates,
+        }
+
+    # -- write -------------------------------------------------------------
+
+    def decide(
+        self,
+        decision: str,
+        candidate_id: str,
+        *,
+        actor: str,
+        reason: str,
+        approval_id: str,
+    ) -> Dict[str, Any]:
+        """Approve or reject one candidate.
+
+        actor/reason/approval_id are all required by the sidecar and are the
+        whole point of the external-judgment design: every promotion carries an
+        auditable trail in the curiosity ledger. They are validated here so a
+        bad request fails before it reaches a sandbox exec.
+        """
+        verb = str(decision).strip().lower()
+        if verb not in CURIOSITY_DECISIONS:
+            raise ValueError(
+                "decision must be one of %s" % ", ".join(CURIOSITY_DECISIONS)
+            )
+        identifier = str(candidate_id or "").strip()
+        if not identifier:
+            raise ValueError("candidate_id is required")
+        fields = {"actor": actor, "reason": reason, "approval_id": approval_id}
+        for name, value in fields.items():
+            if not str(value or "").strip():
+                raise ValueError("%s is required" % name)
+        self._run(
+            [
+                verb,
+                identifier,
+                "--actor",
+                str(actor).strip(),
+                "--reason",
+                str(reason).strip(),
+                "--approval-id",
+                str(approval_id).strip(),
+            ]
+        )
+        return {
+            "schema": CURIOSITY_DECISION_SCHEMA,
+            "candidate_id": identifier,
+            "decision": verb,
+            "actor": str(actor).strip(),
+            "reason": str(reason).strip(),
+            "approval_id": str(approval_id).strip(),
+        }

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -1528,6 +1528,28 @@
   },
   {
     "default": null,
+    "description": "Core setting: curiosity timeout seconds.",
+    "family": "core",
+    "name": "MAC_CURIOSITY_TIMEOUT_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/curiosity_service.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Core setting: curiosity wrapper.",
+    "family": "core",
+    "name": "MAC_CURIOSITY_WRAPPER",
+    "retired": false,
+    "sources": [
+      "src/mac/curiosity_service.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: cursor endpoint.",
     "family": "core",
     "name": "MAC_CURSOR_ENDPOINT",
@@ -5972,6 +5994,7 @@
       "deploy/openclaw/install-openclaw-gateway.sh",
       "deploy/openshell/bootstrap-openshell.sh",
       "src/mac/api.py",
+      "src/mac/curiosity_service.py",
       "src/mac/hermes_runtime.py",
       "src/mac/mac_paths.py",
       "src/mac/model_selection.py",

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -1636,6 +1636,33 @@ class RemoteDispatch:
             )
         )
 
+    def list_curiosity_candidates(self, status: Optional[str] = None) -> _Dictish:
+        """Quarantined curiosity candidates, read through the hub.
+
+        The ledger lives inside the agent's OpenClaw sandbox, which a task
+        sandbox cannot reach; the hub can, so this is the route that works from
+        anywhere (task_3a4503f0).
+        """
+        params = {} if status is None else {"status": status}
+        return _Dictish(self._get("/curiosity/candidates", **params))
+
+    def decide_curiosity_candidate(
+        self,
+        candidate_id: str,
+        decision: str,
+        *,
+        actor: str,
+        reason: str,
+        approval_id: str,
+    ) -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/curiosity/candidates/%s/%s"
+                % (quote(candidate_id, safe=""), quote(decision, safe="")),
+                {"actor": actor, "reason": reason, "approval_id": approval_id},
+            )
+        )
+
     def list_agents(self) -> List[_Dictish]:
         return _wrap_list(self._get("/agents"))
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -16345,6 +16345,74 @@ class ControlPlane:
             raise NotFoundError("agent not found: %s" % agent_id)
         return self._agent_from_row(row)
 
+    # -- curiosity quarantine (hub-mediated) -------------------------------
+    #
+    # The ledger lives inside the mac-openclaw-<agent> sandbox and a dispatched
+    # task runs in a different mac-task-* sandbox that cannot reach it, so
+    # adjudication was impossible from the one place it needed to happen
+    # (task_3a4503f0). One implementation here serves both transports: the
+    # local CLI on the host, and the hub API for every sandboxed caller.
+
+    def _curiosity(self) -> Any:
+        service = getattr(self, "_curiosity_service", None)
+        if service is None:
+            from mac.curiosity_service import CuriosityService
+
+            service = CuriosityService()
+            self._curiosity_service = service
+        return service
+
+    def _curiosity_call(self, operation: Any) -> Dict[str, Any]:
+        """Translate curiosity failures into the domain errors callers expect.
+
+        The service layer speaks ValueError / RuntimeError because it is also
+        usable outside the control plane, but every public ControlPlane method
+        must raise a domain error (tests/test_control_plane_public_contract.py).
+        """
+        from mac.curiosity_service import (
+            CuriosityCommandError,
+            CuriosityUnavailable,
+        )
+
+        try:
+            return operation()
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+        except CuriosityUnavailable as exc:
+            # A host with no OpenClaw gateway has no ledger. That is a fact
+            # about the host, not a transient fault to retry.
+            raise NotFoundError(str(exc)) from exc
+        except CuriosityCommandError as exc:
+            raise ValidationError(str(exc)) from exc
+
+    def list_curiosity_candidates(
+        self, status: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Quarantined/approved/rejected curiosity candidates for this host."""
+        return self._curiosity_call(
+            lambda: self._curiosity().list_candidates(status)
+        )
+
+    def decide_curiosity_candidate(
+        self,
+        candidate_id: str,
+        decision: str,
+        *,
+        actor: str,
+        reason: str,
+        approval_id: str,
+    ) -> Dict[str, Any]:
+        """Approve or reject one candidate, recording the external judgment."""
+        return self._curiosity_call(
+            lambda: self._curiosity().decide(
+                decision,
+                candidate_id,
+                actor=actor,
+                reason=reason,
+                approval_id=approval_id,
+            )
+        )
+
     def list_agents(self, *, include_deleted: bool = False) -> List[Agent]:
         sql = "SELECT * FROM agents"
         if not include_deleted:

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -432,6 +432,11 @@ def _seed_route_state(client: TestClient, cp: ControlPlane, tmp_path) -> Dict[st
     )
     ctx["disable_agent_id"] = agent("disable-route-agent", ["python"])["id"]
     ctx["bulk_agent_id"] = agent("bulk-route-agent", ["python"])["id"]
+    # No real quarantine ledger exists on a CI host, so these only have to be
+    # well-formed: the route answers 404 ("this host has no ledger"), which is
+    # the fail-closed behaviour this inventory is meant to exercise.
+    ctx["curiosity_candidate_id"] = "cur_route_coverage"
+    ctx["curiosity_decision"] = "approve"
     ctx["claim_agent_id"] = agent("claim-route-agent", ["python"])["id"]
     ctx["claim_next_agent_id"] = agent("claim-next-route-agent", ["python"])["id"]
     ctx["lease_agent_id"] = agent("lease-route-agent", ["python"])["id"]
@@ -1333,6 +1338,10 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("GET", "/agentbus/streams/{stream_id}/directive-verification"): {"stream_id": "stream_id"},
         ("PUT", "/v1/agents/{agent_id}/agentbus-cursor"): {"agent_id": "agent_id"},
         ("POST", "/agents/bulk"): {},
+        ("POST", "/curiosity/candidates/{candidate_id}/{decision}"): {
+            "candidate_id": "curiosity_candidate_id",
+            "decision": "curiosity_decision",
+        },
         ("POST", "/agents/dispatch-hold/release-batch"): {},
         ("GET", "/agents/dispatch-hold/epochs/{epoch_id}"): {
             "epoch_id": "absent_dispatch_hold_epoch_id"
@@ -1503,6 +1512,14 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
         # treats the fail-closed domain guard as successful route coverage.
         expected = (200, 400, 404, 409)
     if path_template.startswith("/agents/dispatch-hold/epochs/"):
+        expected = (200, 400, 404)
+    if path_template.startswith("/curiosity/"):
+        # The curiosity ledger lives inside the owning agent's OpenClaw
+        # sandbox, so a machine with no gateway installed has no wrapper to
+        # proxy and the route answers 404 by design ("this host has no
+        # quarantine ledger"). CI hosts are in exactly that state, so treat the
+        # fail-closed answer as coverage rather than pretending a ledger
+        # exists. 400 covers a wrapper that is present but rejects the call.
         expected = (200, 400, 404)
     if method == "GET":
         if path_template == "/dashboard/service-links/tokenhub/sso":
@@ -1907,6 +1924,11 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
             "actor": "route-coverage",
         },
         ("POST", "/agents/bulk"): {"agent_ids": [ctx["bulk_agent_id"]], "health_status": "healthy"},
+        ("POST", "/curiosity/candidates/{candidate_id}/{decision}"): {
+            "actor": "agent_rocky",
+            "reason": "route coverage",
+            "approval_id": "task_route_coverage",
+        },
         ("POST", "/agents/dispatch-hold/release-batch"): {
             "epoch_id": "route-coverage-release-epoch",
             "holds": [

--- a/tests/cli/test_cli_curiosity.py
+++ b/tests/cli/test_cli_curiosity.py
@@ -1,0 +1,159 @@
+"""`mac curiosity list|approve|reject` — the hub-mediated quarantine verbs.
+
+These exist because the curiosity ledger is unreachable from where it needs to
+be used. The real CLI and its store live inside the ``mac-openclaw-<agent>``
+sandbox; a dispatched task runs in a different ``mac-task-*`` sandbox and
+cannot reach either. Every adjudication task ever filed against the quarantine
+was therefore unsatisfiable, including ones correctly pinned to the owning host
+(task_3a4503f0).
+
+Routing through the hub is what makes adjudication possible from a task at all,
+so these verbs are the agent-facing half of that fix.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+from mac.curiosity_service import CuriosityService, CuriosityUnavailable
+
+
+def _run(tmp_path, *args, monkeypatch=None):
+    from mac.test_support import dsn_for
+
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, (json.loads(raw) if raw else None)
+
+
+def test_curiosity_list_reports_the_hosts_candidates(tmp_path, monkeypatch):
+    payload = {
+        "schema": "mac.curiosity_candidates.v1",
+        "status": "quarantined",
+        "count": 2,
+        "candidates": [{"id": "cur_1"}, {"id": "cur_2"}],
+    }
+    monkeypatch.setattr(
+        "mac.services.ControlPlane.list_curiosity_candidates",
+        lambda self, status=None: payload,
+    )
+
+    rc, out = _run(tmp_path, "curiosity", "list", "--status", "quarantined")
+
+    assert rc in (None, 0)
+    assert out["count"] == 2
+    assert [c["id"] for c in out["candidates"]] == ["cur_1", "cur_2"]
+
+
+def test_curiosity_list_without_a_status_asks_for_everything(tmp_path, monkeypatch):
+    seen = {}
+
+    def _list(self, status=None):
+        seen["status"] = status
+        return {"schema": "mac.curiosity_candidates.v1", "count": 0, "candidates": []}
+
+    monkeypatch.setattr(
+        "mac.services.ControlPlane.list_curiosity_candidates", _list
+    )
+
+    rc, _out = _run(tmp_path, "curiosity", "list")
+
+    assert rc in (None, 0)
+    assert seen["status"] is None
+
+
+@pytest.mark.parametrize("decision", ["approve", "reject"])
+def test_curiosity_decision_carries_the_audit_trail(tmp_path, monkeypatch, decision):
+    """actor/reason/approval-id are the external judgment the ledger requires."""
+    seen = {}
+
+    def _decide(self, candidate_id, verb, *, actor, reason, approval_id):
+        seen.update(
+            candidate_id=candidate_id,
+            decision=verb,
+            actor=actor,
+            reason=reason,
+            approval_id=approval_id,
+        )
+        return {"schema": "mac.curiosity_decision.v1", "decision": verb}
+
+    monkeypatch.setattr(
+        "mac.services.ControlPlane.decide_curiosity_candidate", _decide
+    )
+
+    rc, out = _run(
+        tmp_path,
+        "curiosity",
+        decision,
+        "cur_abc",
+        "--actor",
+        "agent_rocky",
+        "--reason",
+        "reproducible",
+        "--approval-id",
+        "task_123",
+    )
+
+    assert rc in (None, 0)
+    assert out["decision"] == decision
+    assert seen == {
+        "candidate_id": "cur_abc",
+        "decision": decision,
+        "actor": "agent_rocky",
+        "reason": "reproducible",
+        "approval_id": "task_123",
+    }
+
+
+@pytest.mark.parametrize("omit", ["--actor", "--reason", "--approval-id"])
+def test_a_decision_missing_an_audit_field_is_rejected_by_the_parser(tmp_path, omit):
+    """The three fields are required at the CLI boundary, not just server-side.
+
+    Dropping any one of them would let a promotion land without the external
+    trail the quarantine design depends on.
+    """
+    args = [
+        "curiosity",
+        "approve",
+        "cur_abc",
+        "--actor",
+        "a",
+        "--reason",
+        "r",
+        "--approval-id",
+        "t",
+    ]
+    index = args.index(omit)
+    del args[index : index + 2]
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, *args)
+    assert excinfo.value.code != 0
+
+
+def test_an_unknown_status_is_rejected_by_the_parser(tmp_path):
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, "curiosity", "list", "--status", "bogus")
+    assert excinfo.value.code != 0
+
+
+def test_a_host_without_a_ledger_is_reported_as_unavailable(tmp_path):
+    """Not every host runs an OpenClaw gateway; that is not a fault."""
+    service = CuriosityService.__new__(CuriosityService)
+    from mac.curiosity_service import CuriosityConfig
+
+    service.config = CuriosityConfig(wrapper_path=tmp_path / "nope")
+    service._runner = None
+    with pytest.raises(CuriosityUnavailable):
+        service.list_candidates()

--- a/tests/test_curiosity_service.py
+++ b/tests/test_curiosity_service.py
@@ -1,0 +1,283 @@
+"""Hub-mediated curiosity access, so adjudication is possible at all.
+
+The quarantine ledger lives at ``<state_dir>/mac-curiosity`` INSIDE the
+``mac-openclaw-<agent>`` sandbox, reachable only through
+``/usr/local/bin/curiosity`` in that same sandbox. A dispatched task runs in a
+freshly created ``mac-task-*`` sandbox: different namespace, neither the CLI
+nor the store, and no route to the host's ``openshell`` to get them.
+
+So every adjudication task ever filed against the quarantine was unsatisfiable.
+``curiosity_reviewer`` pins its tasks to the owning agent, which fixes the HOST
+and not the NAMESPACE -- on 2026-08-05 three attempts failed for exactly this,
+including one that ran on the correct host and still could not see the ledger
+(task_3a4503f0).
+
+The hub sits in the one place that works: on the agent's host, able to invoke
+``~/.mac/bin/curiosity``, and reachable over HTTP from every task sandbox.
+
+A read-only copy mounted into the task sandbox would have been a trap: it makes
+enumeration work while approve/reject stays broken, which looks like a fix and
+is half of one. These tests therefore cover the WRITE path as carefully as the
+read path.
+
+The subprocess runner is injected, so these exercise this module's argument
+construction, validation, parsing and error mapping rather than a stub CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mac.curiosity_service import (
+    CURIOSITY_DECISIONS,
+    CURIOSITY_STATUSES,
+    CuriosityCommandError,
+    CuriosityConfig,
+    CuriosityService,
+    CuriosityUnavailable,
+)
+
+
+class _Result:
+    def __init__(self, returncode=0, stdout="", stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _wrapper(tmp_path: Path) -> Path:
+    path = tmp_path / "curiosity"
+    path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _service(tmp_path: Path, result=None, calls=None, raises=None):
+    def runner(argv, **kwargs):
+        if calls is not None:
+            calls.append((argv, kwargs))
+        if raises is not None:
+            raise raises
+        return result if result is not None else _Result(stdout="[]")
+
+    return CuriosityService(
+        CuriosityConfig(wrapper_path=_wrapper(tmp_path)), runner=runner
+    )
+
+
+# -- availability ----------------------------------------------------------
+
+
+def test_a_host_without_the_wrapper_is_unavailable_not_broken(tmp_path):
+    """An agent host that never ran an OpenClaw gateway has no ledger.
+
+    That is a fact about the host, not a fault to retry, so it must be
+    distinguishable from a command that ran and failed.
+    """
+    service = CuriosityService(CuriosityConfig(wrapper_path=tmp_path / "absent"))
+    assert service.available() is False
+    with pytest.raises(CuriosityUnavailable):
+        service.list_candidates()
+
+
+def test_a_non_executable_wrapper_is_unavailable(tmp_path):
+    path = tmp_path / "curiosity"
+    path.write_text("#!/bin/sh\n", encoding="utf-8")
+    path.chmod(0o644)
+    service = CuriosityService(CuriosityConfig(wrapper_path=path))
+    assert service.available() is False
+
+
+# -- read ------------------------------------------------------------------
+
+
+def test_listing_returns_the_candidates_verbatim(tmp_path):
+    payload = [
+        {"id": "cur_1", "confidence": "high", "hypothesis": "h1"},
+        {"id": "cur_2", "confidence": "low", "hypothesis": "h2"},
+    ]
+    calls = []
+    service = _service(
+        tmp_path, result=_Result(stdout=json.dumps(payload)), calls=calls
+    )
+
+    out = service.list_candidates("quarantined")
+
+    assert out["count"] == 2
+    assert out["candidates"] == payload, "candidate records must not be reshaped"
+    assert out["status"] == "quarantined"
+    argv = calls[0][0]
+    assert argv[1:] == ["list", "--status", "quarantined"]
+
+
+def test_listing_without_a_status_does_not_pass_the_flag(tmp_path):
+    calls = []
+    service = _service(tmp_path, result=_Result(stdout="[]"), calls=calls)
+    service.list_candidates()
+    assert calls[0][0][1:] == ["list"]
+
+
+def test_an_unknown_status_is_refused_before_invoking_anything(tmp_path):
+    calls = []
+    service = _service(tmp_path, calls=calls)
+    with pytest.raises(ValueError):
+        service.list_candidates("bogus")
+    assert not calls, "a bad status must not reach a sandbox exec"
+
+
+def test_empty_output_is_an_empty_list_not_a_parse_error(tmp_path):
+    service = _service(tmp_path, result=_Result(stdout="   "))
+    assert service.list_candidates()["candidates"] == []
+
+
+def test_non_json_output_is_reported_as_such(tmp_path):
+    service = _service(tmp_path, result=_Result(stdout="Error: sandbox gone"))
+    with pytest.raises(CuriosityCommandError) as excinfo:
+        service.list_candidates()
+    assert "not JSON" in str(excinfo.value)
+
+
+# -- write -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize("decision", CURIOSITY_DECISIONS)
+def test_a_decision_passes_the_full_audit_trail(tmp_path, decision):
+    """actor/reason/approval_id are the point of external judgment."""
+    calls = []
+    service = _service(tmp_path, result=_Result(stdout=""), calls=calls)
+
+    out = service.decide(
+        decision,
+        "cur_abc",
+        actor="agent_rocky",
+        reason="reproducible and useful",
+        approval_id="task_123",
+    )
+
+    argv = calls[0][0]
+    assert argv[1] == decision
+    assert argv[2] == "cur_abc"
+    assert argv[3:] == [
+        "--actor",
+        "agent_rocky",
+        "--reason",
+        "reproducible and useful",
+        "--approval-id",
+        "task_123",
+    ]
+    assert out["decision"] == decision
+    assert out["approval_id"] == "task_123"
+
+
+@pytest.mark.parametrize("missing", ["actor", "reason", "approval_id"])
+def test_a_decision_missing_any_audit_field_is_refused(tmp_path, missing):
+    """Dropping any of the three would defeat the external-judgment design."""
+    calls = []
+    service = _service(tmp_path, calls=calls)
+    fields = {
+        "actor": "agent_rocky",
+        "reason": "because",
+        "approval_id": "task_123",
+    }
+    fields[missing] = "   "
+    with pytest.raises(ValueError) as excinfo:
+        service.decide("approve", "cur_abc", **fields)
+    assert missing in str(excinfo.value)
+    assert not calls, "an incomplete decision must not reach the ledger"
+
+
+def test_an_unknown_decision_is_refused(tmp_path):
+    calls = []
+    service = _service(tmp_path, calls=calls)
+    with pytest.raises(ValueError):
+        service.decide(
+            "delete", "cur_abc", actor="a", reason="r", approval_id="t"
+        )
+    assert not calls, "only approve/reject may be proxied"
+
+
+def test_submission_is_not_proxied():
+    """The sidecar withholds approve/reject from the submitter on purpose.
+
+    This service exists to supply the missing external judgment, not to widen
+    the submission path, so 'submit' must not be reachable through it.
+    """
+    assert "submit" not in CURIOSITY_DECISIONS
+    assert set(CURIOSITY_DECISIONS) == {"approve", "reject"}
+
+
+def test_an_empty_candidate_id_is_refused(tmp_path):
+    calls = []
+    service = _service(tmp_path, calls=calls)
+    with pytest.raises(ValueError):
+        service.decide("approve", "  ", actor="a", reason="r", approval_id="t")
+    assert not calls
+
+
+# -- failure mapping -------------------------------------------------------
+
+
+def test_a_failing_command_carries_the_cli_stderr(tmp_path):
+    service = _service(
+        tmp_path, result=_Result(returncode=2, stderr="candidate not found")
+    )
+    with pytest.raises(CuriosityCommandError) as excinfo:
+        service.decide(
+            "approve", "cur_missing", actor="a", reason="r", approval_id="t"
+        )
+    assert "candidate not found" in str(excinfo.value)
+
+
+def test_a_hung_sandbox_exec_times_out_rather_than_pinning_the_hub(tmp_path):
+    service = _service(
+        tmp_path, raises=subprocess.TimeoutExpired(cmd="curiosity", timeout=60)
+    )
+    with pytest.raises(CuriosityCommandError) as excinfo:
+        service.list_candidates()
+    assert "timed out" in str(excinfo.value)
+
+
+def test_the_hub_environment_is_not_handed_to_the_sandbox(tmp_path):
+    """The wrapper execs into a sandbox; hub credentials have no business there."""
+    calls = []
+    service = _service(tmp_path, result=_Result(stdout="[]"), calls=calls)
+    service.list_candidates()
+    env = calls[0][1]["env"]
+    assert set(env) <= {"PATH", "HOME"}, (
+        "only PATH/HOME may cross into the sandbox exec, got %s" % sorted(env)
+    )
+
+
+# -- config ----------------------------------------------------------------
+
+
+def test_the_wrapper_path_is_configurable(tmp_path):
+    config = CuriosityConfig.from_env({"MAC_CURIOSITY_WRAPPER": str(tmp_path / "c")})
+    assert config.wrapper_path == tmp_path / "c"
+
+
+def test_the_default_wrapper_follows_mac_home(tmp_path):
+    config = CuriosityConfig.from_env({"MAC_HOME": str(tmp_path)})
+    assert config.wrapper_path == tmp_path / "bin" / "curiosity"
+
+
+def test_the_timeout_is_clamped(tmp_path):
+    """A hung exec must not hold a hub request open indefinitely."""
+    assert CuriosityConfig.from_env(
+        {"MAC_CURIOSITY_TIMEOUT_SECONDS": "99999"}
+    ).timeout_seconds == 600.0
+    assert CuriosityConfig.from_env(
+        {"MAC_CURIOSITY_TIMEOUT_SECONDS": "0"}
+    ).timeout_seconds == 1.0
+    assert CuriosityConfig.from_env(
+        {"MAC_CURIOSITY_TIMEOUT_SECONDS": "not-a-number"}
+    ).timeout_seconds == 60.0
+
+
+def test_statuses_match_the_sidecar_cli():
+    """These are passed through to `curiosity list --status`; drift breaks it."""
+    assert set(CURIOSITY_STATUSES) == {"quarantined", "approved", "rejected"}


### PR DESCRIPTION
Closes the mechanism half of `task_3a4503f0`.

## The problem

The ledger has never been reachable by the thing that needs it:

| | location |
|---|---|
| real CLI | `/usr/local/bin/curiosity` **inside** `mac-openclaw-<agent>` |
| store | `<state_dir>/mac-curiosity` in that same sandbox |
| a dispatched task | runs in a fresh `mac-task-*` sandbox — different namespace, neither the CLI nor the store, no route to the host's `openshell` |

That isolation is the *point* of the sandbox, so this was never going to be fixed by trying harder from inside one.

**Every adjudication task ever filed against the quarantine was unsatisfiable.** `curiosity_reviewer` pins via `metadata.target_agent_id`, which fixes the **host** and not the **namespace** — three attempts on 2026-08-05 failed for exactly this, including one that ran on the correct host and still couldn't see the ledger. Meanwhile an install-time cron made submission mandatory, so the quarantine grew monotonically: **30 candidates, no way to judge any of them.**

## The fix

The hub is the one process in the right place — it runs on the agent's host so it can invoke the `~/.mac/bin/curiosity` wrapper, and every task sandbox can already reach the hub over HTTP.

One implementation on `ControlPlane` serves both transports:

- `mac curiosity list|approve|reject` — local on the host, hub-mediated everywhere else
- `GET /curiosity/candidates`, `POST /curiosity/candidates/{id}/{decision}`

**Adjudication no longer needs pinning at all.**

## The alternative that would have been a trap

Mounting a read-only copy into the task sandbox was the obvious move. Adjudication is a **write** against the real ledger, so that would have made enumeration start working while approve/reject stayed broken — half a fix that looks like a whole one.

## Deliberate restrictions

- **Submission is not proxied.** The sidecar withholds approve/reject from the submitting agent so promotion carries *external* judgment. This supplies the missing judgment; it doesn't widen the submission path.
- **`actor`/`reason`/`approval_id` are required** at the CLI boundary *and* in the service — a promotion without that trail defeats the design.
- **The wrapper gets only `PATH` and `HOME`.** It execs into a sandbox, and the hub's environment carries credentials that have no business crossing that line.
- **The timeout is clamped**, so a hung sandbox exec can't pin a hub request open.

## Testing

34 new tests with an injected runner, so they exercise this code rather than a stub CLI: argument construction, validation before any exec, JSON parsing, error mapping, env isolation, timeout clamping, and both parser and service refusing an incomplete audit trail.

Contract gate: **10,229 passed**. The single failure in that run (`test_crash_observer.py::test_observer_stop_reaches_wrapper_preflight_process_group`) passes in isolation — load-flakiness under xdist, as were the fleet-node readiness/rollback tests in an earlier run; both verified separately against clean `main`.

## Still open

`task_ce6c8ea3` (approved tasks parking in `REVIEWING` with no publication target) is untouched and still applies to the reviewer's tasks, which carry `project=None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)