### PR TITLE
Give the deployed hub a database, and make its failure visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,18 +477,55 @@ jobs:
         env:
           MAC_BLACKBOX_TOKEN: ci-blackbox-token-with-at-least-32-characters
         run: |
-          docker run --rm -d --name mac-ci \
-            -e MAC_SECRET_KEY=ci-test-key-with-at-least-32-characters-of-entropy \
-            -e MAC_API_TOKEN="$MAC_BLACKBOX_TOKEN" \
-            -p 8000:8000 mac:ci-${{ github.sha }}
-          cleanup() { docker rm -f mac-ci >/dev/null 2>&1 || true; }
+          # The image needs a real control-plane database. SQLite support was
+          # removed in #261 and the image's MAC_DB default still pointed at
+          # /var/lib/mac/mac.db, so every container exited at startup with
+          # "unsupported control-plane DSN ... SQLite is no longer supported"
+          # and main stayed red from 2026-08-02 to 2026-08-06. Nobody saw it
+          # because this job is skipped on pull requests.
+          docker network create mac-ci-net >/dev/null
+          # trust auth, not a password: this database lives for one step on a
+          # private docker network and is never reachable off the runner. A
+          # literal password here would be a hardcoded credential for secret
+          # scanners to flag, and rightly so -- there is no secret worth having.
+          docker run -d --name mac-ci-pg --network mac-ci-net \
+            -e POSTGRES_HOST_AUTH_METHOD=trust \
+            -e POSTGRES_DB=mac \
+            postgres:16 >/dev/null
+          cleanup() {
+            # Always surface WHY the hub exited. Without this the step reported
+            # only "connection refused" and the real error stayed inside a
+            # container that had already been removed.
+            docker logs mac-ci 2>&1 | tail -40 || true
+            docker rm -f mac-ci mac-ci-pg >/dev/null 2>&1 || true
+            docker network rm mac-ci-net >/dev/null 2>&1 || true
+          }
           trap cleanup EXIT
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if curl -fsS http://127.0.0.1:8000/health >/dev/null; then
+          for i in $(seq 1 30); do
+            if docker exec mac-ci-pg pg_isready -U postgres >/dev/null 2>&1; then
               break
             fi
             sleep 2
           done
+          docker exec mac-ci-pg pg_isready -U postgres
+          docker run -d --name mac-ci --network mac-ci-net \
+            -e MAC_SECRET_KEY=ci-test-key-with-at-least-32-characters-of-entropy \
+            -e MAC_API_TOKEN="$MAC_BLACKBOX_TOKEN" \
+            -e MAC_DB="postgresql://postgres@mac-ci-pg:5432/mac" \
+            -p 8000:8000 mac:ci-${{ github.sha }} >/dev/null
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8000/health >/dev/null; then
+              break
+            fi
+            # Fail fast and loudly if the hub is already gone, instead of
+            # burning the whole retry budget on a container that has exited.
+            if [ -z "$(docker ps -q --filter name=mac-ci)" ]; then
+              echo "mac-ci exited before serving /health" >&2
+              exit 1
+            fi
+            sleep 2
+          done
+          curl -fsS http://127.0.0.1:8000/health >/dev/null
           python3 scripts/blackbox-hub-smoke.py \
             --url http://127.0.0.1:8000 \
             --token "$MAC_BLACKBOX_TOKEN"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 # mac control plane — production container.
 #
 # Multi-stage build: install deps into a slim image, run as non-root with a
-# pinned working directory. SQLite database is bind-mounted at /var/lib/mac/db.
-# MAC_SECRET_KEY MUST be provided at runtime; the container refuses to start
-# without it.
+# pinned working directory.
+#
+# MAC_SECRET_KEY and MAC_DB MUST both be provided at runtime. MAC_DB must be a
+# postgres:// or postgresql:// DSN -- SQLite support was removed in #261, and
+# this image used to default MAC_DB to /var/lib/mac/mac.db, so every container
+# exited at startup with "unsupported control-plane DSN". Shipping no default
+# is deliberate: a missing DSN now fails with a clear message about what to
+# supply, rather than with a confident-looking path that cannot work.
 
 FROM ghcr.io/astral-sh/uv@sha256:9874eb7afe5ca16c363fe80b294fe700e460df29a55532bbfea234a0f12eddb1 AS uv
 
@@ -31,8 +36,7 @@ FROM docker.io/library/python@sha256:60d9996b6a8a3689d36db740b49f4327be3be09a211
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONFAULTHANDLER=1 \
-    PATH=/opt/mac-venv/bin:/usr/local/bin:/usr/bin:/bin \
-    MAC_DB=/var/lib/mac/mac.db
+    PATH=/opt/mac-venv/bin:/usr/local/bin:/usr/bin:/bin
 
 RUN printf '%s\n' 'mac:x:10001:' >> /etc/group && \
     printf '%s\n' 'mac:x:10001:10001:MAC service:/var/lib/mac:/usr/sbin/nologin' >> /etc/passwd && \


### PR DESCRIPTION
Fixes `task_47357a02`. **`main` CI has been red since 2026-08-02** — 28 of the last 30 runs, across a dozen commits and several authors.

## Root cause, reproduced locally

#261 finished removing SQLite. The deployment image still shipped `MAC_DB=/var/lib/mac/mac.db`, so every container exited at startup:

```
mac.store.StoreError: unsupported control-plane DSN '/var/lib/mac/mac.db';
expected postgres:// or postgresql://. SQLite is no longer supported.
```

The black-box step then curled a hub that was already gone, reporting only `connection refused`.

Correcting my own earlier read: the two `Publish` jobs didn't fail independently — they were **cancelled** because they depend on `docker`. **One cause, three red squares.**

## Why it survived four days

This job is **skipped on pull requests**. Every PR in the window showed 9/9 green and merged honestly while the post-merge run went red, and nothing surfaced it. A contributor doing everything right never saw it.

That's the same defect as the others found this week — a check that runs, is correct, and reaches no consumer. It's worse here because the failing check is the black-box *"deployed hub authentication and task round trip"*: precisely the one that would catch a bad deploy. **It was dark through a week in which all eight fleet hosts were deployed from this main.**

## The fix

The step stands up `postgres:16` on a private docker network and passes a real DSN. **Verified locally** by building the image and running the exact CI sequence:

```
/health              → HTTP 200
blackbox-hub-smoke   → {"status": "pass", "authentication": "enforced",
                        "task_round_trip": "task_3fb68a23..."}
```

The image no longer defaults `MAC_DB` at all. A default that cannot work is worse than none — it fails confidently instead of saying what to supply. The header comment claimed a bind-mounted SQLite database, untrue since #261, and now states the postgres requirement.

## Two diagnosis fixes

Because the four days were mostly spent *not knowing*:

- the step dumps `docker logs mac-ci` on exit, so the container's own error reaches the log instead of dying with the container
- the readiness loop aborts as soon as the container is gone, rather than burning its retry budget curling nothing

## Still open

`task_47357a02` also asks that a red `main` be *visible* — notify, block, or appear somewhere a person looks. This PR fixes the failure; it does not fix the four-day silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)