### PR TITLE
Make a red main reach a person

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1026,3 +1026,58 @@ jobs:
           path: certifier-image-ref.txt
           if-no-files-found: error
           retention-days: 30
+
+  # A red main was invisible for four days (2026-08-02 to 2026-08-06, 28 of 30
+  # runs) because the jobs that failed -- docker and the two publish steps --
+  # are SKIPPED on pull requests. Every PR in that window showed green and
+  # merged honestly while the post-merge run failed, and nothing said so. The
+  # failing check was the black-box "deployed hub authentication and task round
+  # trip", so it was dark through a week in which the whole fleet was deployed
+  # from that main.
+  #
+  # Fixing the failure (#285) does not fix the silence. This does: a red main
+  # opens a GitHub issue and keeps commenting on it, so the condition has a
+  # consumer instead of only a red square nobody visits. The hub would be a
+  # better destination, but it lives on a private network CI cannot reach.
+  report-main-red:
+    name: Surface a red main
+    needs:
+      - dead-code
+      - hermes-revendor
+      - mainline
+      - compatibility
+      - postgres-contract
+      - publication-scope
+      - docker
+    if: always() && failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Open or update the red-main issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          FAILED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          title="main CI is red"
+          # One issue, reused. A new issue per failing commit would be its own
+          # kind of noise, and noise is what stops people reading.
+          number="$(gh issue list --state open --search "$title in:title" \
+            --json number,title \
+            --jq "[.[] | select(.title == \"$title\")] | .[0].number // empty")"
+          body="$(printf '%s\n' \
+            "main is failing at \`$FAILED_SHA\`." \
+            "" \
+            "Run: $RUN_URL" \
+            "" \
+            "This is opened automatically because the jobs that fail here are skipped on pull requests, so a red main is otherwise invisible. Close this issue once main is green; it will reopen if main breaks again.")"
+          if [ -n "$number" ]; then
+            gh issue comment "$number" --body "$body"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi
+

--- a/tests/test_red_main_is_surfaced.py
+++ b/tests/test_red_main_is_surfaced.py
@@ -1,0 +1,104 @@
+"""A red main must reach a person, not just a red square.
+
+main CI failed on 28 of 30 runs between 2026-08-02 and 2026-08-06 and nobody
+noticed for four days. The jobs that failed -- ``docker`` and the two publish
+steps -- are SKIPPED on pull requests, so every PR in that window showed green
+and merged honestly while the post-merge run went red.
+
+The failing check was the black-box "deployed hub authentication and task round
+trip", which is precisely the one that would catch a bad deploy, and it was
+dark through a week in which all eight fleet hosts were deployed from that
+main.
+
+#285 fixed the failure. It did not fix the silence, which is the part that let
+one broken commit become four broken days. ``report-main-red`` is the consumer
+that was missing.
+
+These tests guard the two ways it would quietly stop working: someone deletes
+it, or a job is added to CI whose failure it does not watch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+#: Jobs whose failure must reach a person. These are the ones that do NOT run
+#: on pull requests, so a failure here is invisible until something says so.
+#: If a job like this is added to CI, add it here too.
+MAIN_ONLY_CRITICAL = {"docker", "mainline", "publication-scope"}
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    return yaml.safe_load(CI.read_text(encoding="utf-8"))
+
+
+def test_a_job_exists_to_surface_a_red_main(workflow):
+    assert "report-main-red" in workflow["jobs"], (
+        "nothing surfaces a red main. Between 2026-08-02 and 2026-08-06 that "
+        "cost four days of a broken deploy check that nobody saw."
+    )
+
+
+def test_it_fires_only_on_a_failed_push_to_main(workflow):
+    """It must not fire on pull requests, or it becomes noise and gets muted."""
+    condition = workflow["jobs"]["report-main-red"]["if"]
+
+    assert "failure()" in condition
+    assert "github.event_name == 'push'" in condition
+    assert "refs/heads/main" in condition
+    # always() is required or the job is skipped when a dependency fails --
+    # which is exactly and only when it needs to run.
+    assert "always()" in condition, (
+        "without always() the job is skipped when a needed job fails, so it "
+        "would never run in the one case it exists for"
+    )
+
+
+def test_it_watches_every_job_that_pull_requests_never_run(workflow):
+    """A failure it does not depend on is a failure it cannot report."""
+    watched = set(workflow["jobs"]["report-main-red"]["needs"])
+    missing = MAIN_ONLY_CRITICAL - watched
+
+    assert not missing, (
+        "report-main-red does not depend on %s, so a failure there is invisible "
+        "again -- the exact condition this job exists for" % sorted(missing)
+    )
+
+
+def test_every_watched_job_actually_exists(workflow):
+    """A typo in `needs` makes the job silently never run."""
+    jobs = set(workflow["jobs"])
+    watched = set(workflow["jobs"]["report-main-red"]["needs"])
+    unknown = watched - jobs
+
+    assert not unknown, "report-main-red depends on non-existent job(s): %s" % sorted(unknown)
+
+
+def test_it_can_actually_write_an_issue(workflow):
+    """Without issues:write the job runs and fails to report, which is worse
+    than not running: it looks like coverage and is not."""
+    permissions = workflow["jobs"]["report-main-red"].get("permissions") or {}
+
+    assert permissions.get("issues") == "write", (
+        "the job cannot open an issue, so it would fail silently and the red "
+        "main would stay invisible"
+    )
+
+
+def test_it_reuses_one_issue_rather_than_opening_many(workflow):
+    """A new issue per failing commit is its own kind of noise, and noise is
+    what stops people reading."""
+    steps = workflow["jobs"]["report-main-red"]["steps"]
+    script = " ".join(str(s.get("run") or "") for s in steps)
+
+    assert "gh issue list" in script, "does not look for an existing issue"
+    assert "gh issue comment" in script, "cannot update an existing issue"
+    assert "gh issue create" in script, "cannot open the first issue"


### PR DESCRIPTION
Second half of `task_47357a02`. #285 fixed *why* main was failing; this fixes *why nobody knew for four days* — and the silence is what turned one broken commit into 28 broken runs.

## The gap

The jobs that failed — `docker` and the two publish steps — are **skipped on pull requests**. Every PR in that window showed 9/9 green and merged honestly while the post-merge run went red. A contributor doing everything right never saw it.

And the failing check was the black-box *"deployed hub authentication and task round trip"* — so it stayed dark through a week in which **all eight fleet hosts were deployed from that main**.

## The fix

`report-main-red` opens a GitHub issue when main fails, and comments on that same issue thereafter. One reused issue rather than one per commit: a new issue every failing push is its own kind of noise, and noise is what stops people reading.

The hub would be the better destination — it already holds the task ledger — but it's on a private network CI can't reach. A GitHub issue is what's actually reachable from a runner, so that's what this uses.

## Guarded, because a watchdog that quietly stops watching is worse than none

The tests fail if:

- the job is deleted
- `always()` is dropped — without it the job is **skipped exactly when a dependency fails**, which is the only time it matters
- it stops depending on a job that PRs never run
- a `needs` entry is a typo, which would make it silently never run
- it loses `issues: write` and would fail silently while looking like coverage

Both mutations verified: removing `docker` from `needs` and removing `always()` each fail the suite.

## Verified alongside

Main CI went **green on `d7b145d7`** — first time since 2026-08-02 — with `docker`, `Publish trusted certifier image` and `Publish OpenShell worker runtime image` all passing, confirming the single root cause.

Contract gate: **10,263 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)