### PR TITLE
Give the approved-but-undeliverable state a consumer

### DIFF
--- a/src/mac/diagnostics.py
+++ b/src/mac/diagnostics.py
@@ -479,6 +479,71 @@ def _data_source_identity(control_plane: Any) -> List[Finding]:
 LIFECYCLE_STAGE_DWELL_THRESHOLD_SECONDS = 10 * 60
 
 
+#: How long an approved-but-undeliverable task may sit before
+#: "reviewing-publication-parked" warns. Review -> publish is immediate when a
+#: target resolves, so anything still parked after an hour is not mid-flight;
+#: the margin only exists so a deferred publication barrier clearing normally
+#: is not reported as a stall.
+REVIEWING_PARKED_THRESHOLD_SECONDS = 60 * 60
+
+
+@register(
+    "reviewing-publication-parked",
+    "approved tasks with no publication destination, which can never complete",
+)
+def _reviewing_publication_parked(
+    control_plane: Any,
+    threshold_seconds: int = REVIEWING_PARKED_THRESHOLD_SECONDS,
+) -> List[Finding]:
+    """Report approved work that nothing will ever move to COMPLETED.
+
+    ``REVIEWING -> COMPLETED`` happens only in ``publish_task``, which needs a
+    resolved publication target. A task with none parks, and until this check
+    existed nothing downstream of that decision said so: four tasks sat approved
+    and undeliverable from 2026-08-01 to 2026-08-05 and surfaced only because an
+    operator happened to ask what was executing (task_ce6c8ea3).
+
+    ``lifecycle-stage-dwell`` does not cover this, despite overlapping on the
+    surface. Measured against the live hub on 2026-08-06 it emitted a single
+    warning reading "492 task(s) dwelling in one stage past 600 seconds", of
+    which it lists ten. A parked task is somewhere in that number. The
+    difference this check draws is not slow versus fast but *temporary versus
+    permanent*: everything reported here has been established to have no
+    destination at all, so the count is small by construction and every entry
+    needs an operator decision rather than patience.
+
+    A parked task is recoverable — set ``metadata.publication_target``, a
+    project target, or a fleet default — so this warns and never mutates.
+    """
+    parked = control_plane.parked_reviewing_tasks(min_age_seconds=float(threshold_seconds))
+    if not parked:
+        return [
+            Finding(
+                "reviewing-publication-parked",
+                "ok",
+                "no approved task is parked without a publication destination",
+                {"threshold_seconds": threshold_seconds},
+            )
+        ]
+    return [
+        Finding(
+            "reviewing-publication-parked",
+            "warn",
+            "%d approved task(s) have no publication destination and cannot complete"
+            % len(parked),
+            {
+                "threshold_seconds": threshold_seconds,
+                "count": len(parked),
+                "tasks": parked[:10],
+                "remedy": (
+                    "set metadata.publication_target on the task, a "
+                    "publication_target on its project, or cancel it"
+                ),
+            },
+        )
+    ]
+
+
 @register(
     "lifecycle-stage-dwell",
     "non-terminal tasks that have dwelled in one lifecycle stage past the threshold",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -925,6 +925,10 @@ REPOSITORY_CONTRACT_FILES = (
     Path(".mac") / "project.yml",
 )
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
+#: Marker recorded on a task that was approved but has no publication
+#: destination, so the task itself says why it is sitting in REVIEWING instead
+#: of leaving the reason in a code comment (task_ce6c8ea3).
+PUBLICATION_BLOCK_SCHEMA = "mac.publication_block.v1"
 _GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
 _FULL_GIT_OBJECT_ID_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
 
@@ -6672,7 +6676,17 @@ class ControlPlane:
         project: Optional[str] = None,
         tenant_id: Optional[str] = None,
     ) -> Dict[str, int]:
-        """Task counts by state (parity with bd stats)."""
+        """Task counts by state (parity with bd stats).
+
+        ``reviewing_parked`` is reported alongside the states whenever it is
+        non-zero: the count of REVIEWING tasks that are approved but have no
+        publication destination, so nothing will ever move them to COMPLETED.
+        Without it a permanently parked task is counted under ``reviewing`` and
+        is indistinguishable from work in flight — which is how four of them sat
+        unnoticed for four days (task_ce6c8ea3). It is an addition, not a
+        reclassification: ``reviewing`` still counts every reviewing task, so
+        the state counts continue to sum to the task total.
+        """
         if tenant_id is not None:
             tasks = self.list_tasks(tenant_id=tenant_id)
             if project is not None:
@@ -6680,7 +6694,7 @@ class ControlPlane:
             counts: Dict[str, int] = {}
             for t in tasks:
                 counts[t.state] = counts.get(t.state, 0) + 1
-            return dict(sorted(counts.items()))
+            return self._with_parked_reviewing_count(dict(sorted(counts.items())), project)
         where = ""
         params: list = []
         if project is not None:
@@ -6690,7 +6704,33 @@ class ControlPlane:
             "SELECT state, COUNT(*) AS n FROM tasks%s GROUP BY state ORDER BY state" % where,
             tuple(params),
         )
-        return {row["state"]: int(row["n"]) for row in rows}
+        counts = {row["state"]: int(row["n"]) for row in rows}
+        return self._with_parked_reviewing_count(counts, project)
+
+    def _with_parked_reviewing_count(
+        self,
+        counts: Dict[str, int],
+        project: Optional[str],
+    ) -> Dict[str, int]:
+        """Add ``reviewing_parked`` to ``counts`` when there is anything to add.
+
+        Resolving a publication target per task costs a project lookup, so this
+        short-circuits when nothing is in REVIEWING at all — which is the usual
+        case, and keeps `mac task stats` as cheap as it was.  A failure here
+        must not take the stats call down with it: the counts are the primary
+        answer and the parked count is an annotation on them.
+        """
+        if not counts.get(TaskState.REVIEWING.value):
+            return counts
+        try:
+            parked = self.parked_reviewing_tasks(limit=1_000_000)
+        except Exception:  # noqa: BLE001 - an annotation must not break the counts
+            return counts
+        if project is not None:
+            parked = [item for item in parked if item.get("project") == project]
+        if parked:
+            counts["reviewing_parked"] = len(parked)
+        return counts
 
     def diagnostics_report(
         self,
@@ -22666,6 +22706,20 @@ class ControlPlane:
                 # invent one. The review is approved, but the task stays in
                 # REVIEWING until an operator sets metadata.publication_target
                 # (mac-w29).
+                #
+                # Stamp the reason onto the task as well as into the event
+                # stream. The event is the record that it happened; the marker
+                # is what makes the CURRENT state self-describing, so the
+                # "reviewing-publication-parked" diagnostic and `mac task stats`
+                # can tell a parked task from work in flight without anyone
+                # thinking to go looking (task_ce6c8ea3).
+                self._record_publication_block(
+                    task_id,
+                    reason="no_publication_target",
+                    review_id=review.id,
+                    evidence_id=evidence.id,
+                    actor=str(actor or "control-plane"),
+                )
                 self._record_default_review_observation(
                     task_id,
                     "workflow.default_review.no_publication_target",
@@ -28546,6 +28600,112 @@ class ControlPlane:
             if isinstance(target, str) and target.strip():
                 return target.strip()
         return None
+
+    def _record_publication_block(
+        self,
+        task_id: str,
+        *,
+        reason: str,
+        review_id: Optional[str] = None,
+        evidence_id: Optional[str] = None,
+        actor: str = "control-plane",
+    ) -> None:
+        """Stamp a REVIEWING task with WHY it cannot leave that state.
+
+        Approval does not complete a task: ``REVIEWING -> COMPLETED`` happens
+        only inside :meth:`publish_task`, which needs a resolved publication
+        target.  When none resolves the task parks, and until this marker
+        existed the reason lived only in a code comment and a transient
+        observability event — the task itself carried nothing, so a parked task
+        was indistinguishable from work in flight (task_ce6c8ea3: four tasks sat
+        approved-and-undeliverable from 2026-08-01 to 2026-08-05, and only
+        surfaced because someone happened to ask what was executing).
+
+        ``since`` is set once and never refreshed.  Re-reviewing a task that is
+        already parked must not restart its clock, or a task re-examined every
+        few hours would never look old enough to report.
+        """
+        try:
+            task = self.get_task(task_id)
+        except NotFoundError:
+            return
+        metadata = ensure_json_object(task.metadata)
+        existing = ensure_json_object(metadata.get("publication_block"))
+        if existing.get("reason") == reason:
+            return
+        block: JsonDict = {
+            "schema": PUBLICATION_BLOCK_SCHEMA,
+            "reason": reason,
+            "since": str(existing.get("since") or utcnow()),
+        }
+        if review_id:
+            block["review_id"] = str(review_id)
+        if evidence_id:
+            block["evidence_id"] = str(evidence_id)
+        metadata["publication_block"] = block
+        self._persist_task_metadata_narrow(
+            task_id,
+            metadata,
+            actor=actor,
+            detail={"publication_block": reason},
+        )
+
+    def parked_reviewing_tasks(
+        self,
+        *,
+        min_age_seconds: float = 0.0,
+        limit: int = 50,
+    ) -> List[JsonDict]:
+        """REVIEWING tasks that cannot reach COMPLETED as things stand.
+
+        A task is parked when it is in REVIEWING, nobody holds it, and no
+        publication target resolves for it — so nothing downstream will ever
+        move it on.  Resolution is re-evaluated live rather than trusted from
+        the stored marker, because the marker is written when a task parks and
+        an operator may have set ``metadata.publication_target`` (or a project
+        target, or the fleet default) since; such a task is recoverable and must
+        not be reported as stuck.  Evaluating live also means tasks that parked
+        BEFORE the marker existed are still found, which matters — the four
+        tasks that motivated this have no marker.
+
+        Age is measured from the marker's ``since`` when present and from
+        ``updated_at`` otherwise, so a task keeps its original park time.
+        """
+        rows = self.store.query_all(
+            "SELECT id FROM tasks WHERE state = ? AND owner_agent_id IS NULL "
+            "ORDER BY updated_at",
+            (TaskState.REVIEWING.value,),
+        )
+        now = parse_time(utcnow())
+        parked: List[JsonDict] = []
+        for row in rows:
+            try:
+                task = self.get_task(str(row["id"]))
+            except NotFoundError:
+                continue
+            if self._default_publication_target(task) is not None:
+                continue
+            metadata = ensure_json_object(task.metadata)
+            block = ensure_json_object(metadata.get("publication_block"))
+            since = str(block.get("since") or task.updated_at or utcnow())
+            try:
+                age_seconds = (now - parse_time(since)).total_seconds()
+            except (TypeError, ValueError):
+                age_seconds = 0.0
+            if age_seconds < min_age_seconds:
+                continue
+            parked.append(
+                {
+                    "id": task.id,
+                    "title": task.title,
+                    "project": task.project,
+                    "reason": str(block.get("reason") or "no_publication_target"),
+                    "since": since,
+                    "age_seconds": round(age_seconds, 3),
+                }
+            )
+        parked.sort(key=lambda item: item["since"])
+        return parked[:limit]
 
     def _record_default_review_observation(
         self,

--- a/tests/test_reviewing_publication_parked.py
+++ b/tests/test_reviewing_publication_parked.py
@@ -1,0 +1,361 @@
+"""An approved task with nowhere to publish must not look like work in flight.
+
+Four tasks (task_a308126c, task_a12723af, task_b2ef42ea, task_b4906951) sat in
+REVIEWING from 2026-08-01 to 2026-08-05: reviewed, approved, memory recorded, no
+agent holding them, no events for four days. They surfaced only because someone
+asked "is anything executing right now".
+
+The mechanism is deliberate up to the last step. ``REVIEWING -> COMPLETED``
+happens in exactly one place, ``publish_task``, which runs only once a
+publication target resolves. ``_default_publication_target`` tries per-task
+metadata, then the project, then ``MAC_DEFAULT_PUBLICATION_TARGET``, and returns
+None when none apply -- correctly, because inventing a destination is worse. The
+four tasks were operator tasks (repository_required false) with project=None, so
+a ``git://`` fleet default was skipped by ``_task_git_publishable`` on purpose
+and every source missed them.
+
+So the guard is right and what was missing is everything downstream of it. These
+tests cover the three consumers added for that:
+
+  * the task records WHY it parked, instead of the reason living in a comment,
+  * ``task_stats`` reports ``reviewing_parked`` so it cannot masquerade as work,
+  * a diagnostic reports it within a bounded time with nobody looking.
+
+The recoverability half matters as much as the detection half. A parked task is
+fixable by setting a target, and a check that kept reporting it afterwards -- or
+that fired on tasks which can publish perfectly well -- would be noise, and noise
+is what stopped ``lifecycle-stage-dwell`` (one warning, 492 tasks, measured on
+the live hub 2026-08-06) from being the thing that caught these.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from mac.diagnostics import (
+    REVIEWING_PARKED_THRESHOLD_SECONDS,
+    _reviewing_publication_parked,
+)
+from mac.models import TaskState, parse_time, utcnow
+from mac.services import PUBLICATION_BLOCK_SCHEMA, ControlPlane
+
+
+@pytest.fixture()
+def cp(monkeypatch):
+    # An unset fleet default is the condition under test; a leaked
+    # MAC_DEFAULT_PUBLICATION_TARGET from the ambient environment would give
+    # every task a destination and make all of this pass vacuously.
+    monkeypatch.delenv("MAC_DEFAULT_PUBLICATION_TARGET", raising=False)
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+def _reviewing_task(cp, *, metadata=None, project="mac", title="approved work"):
+    """A task sitting unowned in REVIEWING, as an approved task does.
+
+    Driving the real review workflow needs a signed executor manifest, which is
+    deliberately unforgeable; the state these tests care about is "REVIEWING,
+    nobody holding it", so they establish that directly.
+    """
+    task = cp.create_task(title, project=project, metadata=dict(metadata or {}))
+    cp.store.execute(
+        "UPDATE tasks SET state = ?, owner_agent_id = NULL, updated_at = ? WHERE id = ?",
+        (TaskState.REVIEWING.value, utcnow(), task.id),
+    )
+    return cp.get_task(task.id)
+
+
+def _age(cp, task_id, seconds):
+    """Backdate the task so it reads as parked for ``seconds``."""
+    when = (parse_time(utcnow()) - timedelta(seconds=seconds)).isoformat(
+        timespec="microseconds"
+    )
+    cp.store.execute(
+        "UPDATE tasks SET updated_at = ? WHERE id = ?", (when, task_id)
+    )
+
+
+# --------------------------------------------------------------------------
+# Detection: what is parked, and what only looks like it
+# --------------------------------------------------------------------------
+
+
+def test_an_approved_task_with_no_destination_is_parked(cp):
+    task = _reviewing_task(cp)
+
+    parked = cp.parked_reviewing_tasks()
+
+    assert [item["id"] for item in parked] == [task.id]
+    assert parked[0]["reason"] == "no_publication_target"
+
+
+def test_a_task_with_a_per_task_target_is_not_parked(cp):
+    _reviewing_task(cp, metadata={"publication_target": "ledger://done"})
+
+    assert cp.parked_reviewing_tasks() == []
+
+
+def test_a_task_whose_project_supplies_a_target_is_not_parked(cp):
+    cp.create_project(
+        "delivered",
+        dispatch_paused=False,
+        metadata={"publication_target": "ledger://delivered"},
+    )
+    _reviewing_task(cp, project="delivered")
+
+    assert cp.parked_reviewing_tasks() == []
+
+
+def test_a_non_git_fleet_default_unparks_everything(cp, monkeypatch):
+    """Option 2 from the filing: a non-git default gives operator tasks a home.
+
+    It is not switched on here, but if an operator does switch it on the check
+    must go quiet, or it reports a problem the operator has already solved.
+    """
+    _reviewing_task(cp)
+    monkeypatch.setenv("MAC_DEFAULT_PUBLICATION_TARGET", "ledger://fleet")
+
+    assert cp.parked_reviewing_tasks() == []
+
+
+def test_a_git_fleet_default_does_not_unpark_a_non_repo_task(cp, monkeypatch):
+    """The exact shape of the four tasks that went missing.
+
+    ``git://`` is gated on ``_task_git_publishable``, which is False for an
+    operator task with no repository -- deliberately, since forcing a git
+    publish there would raise and block it. So the fleet default is set, looks
+    like it covers everything, and does not cover these.
+    """
+    _reviewing_task(cp, metadata={"execution_contract": {"repository_required": False}})
+    monkeypatch.setenv("MAC_DEFAULT_PUBLICATION_TARGET", "git://main")
+
+    assert len(cp.parked_reviewing_tasks()) == 1
+
+
+def test_a_task_someone_is_holding_is_not_parked(cp):
+    """An owned task is mid-review, not abandoned."""
+    task = _reviewing_task(cp)
+    machine = cp.register_machine("reviewer-host")
+    agent = cp.register_agent(machine.id, "reviewer", capabilities=["python"])
+    cp.store.execute(
+        "UPDATE tasks SET owner_agent_id = ? WHERE id = ?", (agent.id, task.id)
+    )
+
+    assert cp.parked_reviewing_tasks() == []
+
+
+@pytest.mark.parametrize("state", ["open", "running", "completed", "failed"])
+def test_only_reviewing_tasks_are_considered(cp, state):
+    task = cp.create_task("elsewhere", project="mac")
+    cp.store.execute("UPDATE tasks SET state = ? WHERE id = ?", (state, task.id))
+
+    assert cp.parked_reviewing_tasks() == []
+
+
+def test_resolution_is_re_evaluated_rather_than_trusted_from_the_marker(cp):
+    """An operator who sets a target has fixed it; stop reporting it.
+
+    The marker is written when the task parks and is never rewritten, so a check
+    that keyed off the marker alone would keep reporting a task that has been
+    repaired -- and a stale warning is how a real one gets ignored.
+    """
+    task = _reviewing_task(cp)
+    cp._record_publication_block(task.id, reason="no_publication_target")
+    assert len(cp.parked_reviewing_tasks()) == 1
+
+    metadata = dict(cp.get_task(task.id).metadata)
+    metadata["publication_target"] = "ledger://done"
+    cp._persist_task_metadata_narrow(task.id, metadata)
+
+    assert cp.parked_reviewing_tasks() == []
+
+
+def test_a_task_that_parked_before_the_marker_existed_is_still_found(cp):
+    """The four tasks this was filed for carry no marker.
+
+    A check that only found marked tasks would have been blind to every task
+    already parked when it shipped -- i.e. to all of the evidence.
+    """
+    task = _reviewing_task(cp)
+
+    assert "publication_block" not in cp.get_task(task.id).metadata
+    assert [item["id"] for item in cp.parked_reviewing_tasks()] == [task.id]
+
+
+# --------------------------------------------------------------------------
+# The marker: the task says why, instead of a code comment saying why
+# --------------------------------------------------------------------------
+
+
+def test_the_marker_records_the_reason_and_the_audit_trail(cp):
+    task = _reviewing_task(cp)
+
+    cp._record_publication_block(
+        task.id,
+        reason="no_publication_target",
+        review_id="rev_1",
+        evidence_id="ev_1",
+    )
+
+    block = cp.get_task(task.id).metadata["publication_block"]
+    assert block["schema"] == PUBLICATION_BLOCK_SCHEMA
+    assert block["reason"] == "no_publication_target"
+    assert block["review_id"] == "rev_1"
+    assert block["evidence_id"] == "ev_1"
+    assert block["since"]
+
+
+def test_re_parking_for_the_same_reason_is_a_no_op(cp):
+    """Re-review is routine; it must not rewrite the task or its clock.
+
+    This covers the early return only. It does NOT exercise the ``since``
+    carry-over below -- an early version of this file asserted the clock here
+    and passed happily against a build that reset ``since`` on every write,
+    because it never got that far.
+    """
+    task = _reviewing_task(cp)
+    cp._record_publication_block(task.id, reason="no_publication_target")
+    before = cp.get_task(task.id)
+
+    cp._record_publication_block(task.id, reason="no_publication_target")
+
+    assert cp.get_task(task.id).metadata == before.metadata
+
+
+def test_a_changed_reason_keeps_the_original_park_time(cp):
+    """The task has been blocked continuously; only the explanation moved.
+
+    Restarting the clock here would let a task whose block is re-characterized
+    stay permanently below the reporting threshold -- which is the failure this
+    whole check exists to prevent, reintroduced one level down.
+    """
+    task = _reviewing_task(cp)
+    cp._record_publication_block(task.id, reason="no_publication_target")
+    first_since = cp.get_task(task.id).metadata["publication_block"]["since"]
+
+    cp._record_publication_block(task.id, reason="publication_target_unresolvable")
+
+    block = cp.get_task(task.id).metadata["publication_block"]
+    assert block["reason"] == "publication_target_unresolvable"
+    assert block["since"] == first_since, "the park clock restarted"
+
+
+def test_age_is_measured_from_the_marker_not_from_the_last_touch(cp):
+    """Any unrelated metadata write moves updated_at; the park time must not."""
+    task = _reviewing_task(cp)
+    cp._record_publication_block(task.id, reason="no_publication_target")
+    old = (parse_time(utcnow()) - timedelta(days=4)).isoformat(timespec="microseconds")
+    metadata = dict(cp.get_task(task.id).metadata)
+    metadata["publication_block"]["since"] = old
+    cp._persist_task_metadata_narrow(task.id, metadata)
+
+    parked = cp.parked_reviewing_tasks()
+
+    assert parked[0]["since"] == old
+    assert parked[0]["age_seconds"] > 3 * 24 * 3600
+
+
+# --------------------------------------------------------------------------
+# task_stats: a parked task must not be counted as work in progress
+# --------------------------------------------------------------------------
+
+
+def test_stats_reports_parked_tasks_separately(cp):
+    _reviewing_task(cp)
+
+    stats = cp.task_stats()
+
+    assert stats["reviewing"] == 1
+    assert stats["reviewing_parked"] == 1
+
+
+def test_stats_does_not_report_the_key_when_nothing_is_parked(cp):
+    _reviewing_task(cp, metadata={"publication_target": "ledger://done"})
+
+    stats = cp.task_stats()
+
+    assert stats["reviewing"] == 1
+    assert "reviewing_parked" not in stats
+
+
+def test_the_state_counts_still_sum_to_the_task_total(cp):
+    """``reviewing_parked`` annotates the states; it must not reclassify one.
+
+    Anything summing the state counts to get a total would start double- or
+    under-counting if a parked task were moved out of ``reviewing``.
+    """
+    _reviewing_task(cp)
+    _reviewing_task(cp, metadata={"publication_target": "ledger://done"})
+    cp.create_task("open work", project="mac")
+
+    stats = cp.task_stats()
+    states = {k: v for k, v in stats.items() if k != "reviewing_parked"}
+
+    assert sum(states.values()) == 3
+    assert stats["reviewing_parked"] == 1
+
+
+def test_stats_is_filtered_by_project(cp):
+    cp.create_project("other", dispatch_paused=False)
+    _reviewing_task(cp, project="other")
+
+    assert "reviewing_parked" not in cp.task_stats(project="mac")
+    assert cp.task_stats(project="other")["reviewing_parked"] == 1
+
+
+# --------------------------------------------------------------------------
+# The diagnostic: bounded-time visibility with nobody looking
+# --------------------------------------------------------------------------
+
+
+def test_the_check_is_quiet_when_nothing_is_parked(cp):
+    findings = _reviewing_publication_parked(cp)
+
+    assert [f.severity for f in findings] == ["ok"]
+
+
+def test_the_check_warns_once_a_task_is_past_the_threshold(cp):
+    task = _reviewing_task(cp)
+    _age(cp, task.id, REVIEWING_PARKED_THRESHOLD_SECONDS + 60)
+
+    findings = _reviewing_publication_parked(cp)
+
+    assert findings[0].severity == "warn"
+    assert findings[0].detail["count"] == 1
+    assert findings[0].detail["tasks"][0]["id"] == task.id
+    assert "publication_target" in findings[0].detail["remedy"]
+
+
+def test_a_freshly_parked_task_is_not_reported_yet(cp):
+    """A publication barrier that clears normally must not read as a stall."""
+    _reviewing_task(cp)
+
+    assert _reviewing_publication_parked(cp)[0].severity == "ok"
+
+
+def test_the_check_never_mutates_the_task(cp):
+    """It reports; the disposition is an operator decision.
+
+    Auto-transitioning would change completion semantics fleet-wide off the back
+    of a health check, which is option 2 in the filing and wants a deliberate
+    decision rather than being switched on to clear a backlog.
+    """
+    task = _reviewing_task(cp)
+    _age(cp, task.id, REVIEWING_PARKED_THRESHOLD_SECONDS + 60)
+    before = cp.get_task(task.id)
+
+    _reviewing_publication_parked(cp)
+
+    after = cp.get_task(task.id)
+    assert after.state == before.state == TaskState.REVIEWING.value
+    assert after.metadata == before.metadata
+
+
+def test_the_check_is_registered_so_mac_diagnostics_runs_it(cp):
+    """An unregistered check is one nobody runs, which is the original defect."""
+    from mac.diagnostics import CHECKS
+
+    assert "reviewing-publication-parked" in {diag.name for diag in CHECKS}


### PR DESCRIPTION
Closes task_ce6c8ea3.

Four tasks (task_a308126c, task_a12723af, task_b2ef42ea, task_b4906951) sat in REVIEWING from 2026-08-01 to 2026-08-05 — reviewed, approved, nobody holding them, no events for four days. They surfaced only because someone asked what was executing.

## The mechanism is deliberate up to the last step

`REVIEWING -> COMPLETED` happens in exactly one place, `publish_task()`, which runs only once a publication target resolves. `_default_publication_target()` tries the task, then its project, then `MAC_DEFAULT_PUBLICATION_TARGET`, and returns `None` when none apply — **correctly**, since inventing a destination is worse than parking.

The hub sets `MAC_DEFAULT_PUBLICATION_TARGET=git://main`, which looks like it covers everything and does not: a `git://` default is gated on `_task_git_publishable()`, which is false for non-repo operator tasks precisely so a git default can never block them. All four were operator tasks with `project=None`, so every one of the three sources missed them.

**The guard is right. What was missing is everything downstream of it.**

## The three consumers

| | |
|---|---|
| `metadata.publication_block` | The task records *why* it parked, instead of the reason living only in a code comment. `since` is set once, so re-reviewing a parked task does not restart its clock. |
| `task_stats` → `reviewing_parked` | A permanently parked task can no longer be counted as work in flight. It **annotates** rather than reclassifies — `reviewing` still counts every reviewing task, so the state counts still sum to the total. |
| `reviewing-publication-parked` diagnostic | Reports them after an hour, with nobody looking. |

## On `lifecycle-stage-dwell`, which looks like it already covers this

It does not, and I measured rather than assumed. Run against the live hub today:

```
warn | 492 task(s) dwelling in one stage past 600 seconds
```

One warning, 492 tasks, ten of them listed. A parked task is somewhere in that number. The distinction the new check draws is not *slow vs. fast* but **temporary vs. permanent** — everything it reports has been established to have no destination at all, so the count is small by construction and every entry needs an operator decision rather than patience.

## Two design points worth stating

**Detection is re-evaluated live, not read from the marker.** That matters in both directions: an operator who sets a target has fixed the task and must stop being warned about it, and the four tasks that motivated this carry no marker at all — a marker-driven check would have been blind to every piece of the evidence.

**It reports and never mutates.** Auto-completing parked tasks is option 2 in the filing; it changes when tasks complete fleet-wide and deserves a deliberate decision rather than being switched on to clear a backlog.

## Verification

25 tests, checked by mutation — each of these fails a distinct test:

- dropping the live re-resolution → 6 failures
- letting the park clock reset on a changed reason → 1 failure
- dropping the `reviewing_parked` stats key → 3 failures
- stubbing the check to find nothing → 1 failure

The clock assertion did **not** catch its mutation on the first pass: it was passing through an early return without ever reaching the code it named. It was rewritten to exercise that path, and the file now says so, since that is the failure mode this repo has hit before.

Existing suites re-run clean: `test_diagnostics.py` (22), `test_dispatch.py` (66), `test_task_waiting_dispatch_explain.py` + `test_domains_cli.py` (51), `test_cli_task_extended.py -k stats` (4).

The check is currently quiet: no task is in REVIEWING fleet-wide, the original four having been cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)