### PR TITLE
Stop scope signals that cannot be false from classifying every task large

### DIFF
--- a/src/mac/executor_scope.py
+++ b/src/mac/executor_scope.py
@@ -30,6 +30,11 @@ from mac.executor_memory import (
 
 _SCOPE_LARGE_DESC_WORDS = 200
 _SCOPE_LARGE_DESC_CHARS = 800
+#: Retired as a scope signal and kept only for the documented compatibility
+#: re-export surface in executor_sandbox. It counted a PROJECT property (the
+#: repository contract's required_commands) toward per-TASK scope, so it was
+#: constant across a project and voted "large" on every task in it. See
+#: _compute_scope_signals.
 _SCOPE_LARGE_REPO_CMDS = 3
 
 MAC_TASK_SUMMARY_BEGIN = "=== MAC TASK SUMMARY ==="
@@ -82,31 +87,45 @@ def _compute_scope_signals(
     metadata: Dict[str, Any],
     prior_lessons: List[Dict[str, Any]],
 ) -> List[str]:
-    """Compute deterministic and memory-backed large-scope signals."""
-    signals: List[str] = []
-    word_count = len(description.split())
-    if word_count >= _SCOPE_LARGE_DESC_WORDS:
-        signals.append("desc_words:%d" % word_count)
-    if len(description) >= _SCOPE_LARGE_DESC_CHARS:
-        signals.append("desc_chars:%d" % len(description))
+    """Compute deterministic and memory-backed large-scope signals.
 
-    repository_contract = (
-        _nested_dict(metadata, "execution_contract", "repository_contract")
-        or _nested_dict(metadata, "origin", "repository_contract")
-        or {}
-    )
-    toolchain = (
-        repository_contract.get("toolchain")
-        if isinstance(repository_contract, dict)
-        else {}
-    )
-    if isinstance(toolchain, dict):
-        required_commands = toolchain.get("required_commands") or []
-        if (
-            isinstance(required_commands, list)
-            and len(required_commands) >= _SCOPE_LARGE_REPO_CMDS
-        ):
-            signals.append("repo_required_cmds:%d" % len(required_commands))
+    Every signal here must DISCRIMINATE: it has to be capable of being true of
+    one task and false of another in the same project. A signal that is
+    constant across a project cannot say anything about a particular task, but
+    it still counts toward the ``>= 2`` threshold, and two such signals
+    classify everything as large.
+
+    Measured on the live ledger 2026-08-07, that is what had happened. Of ten
+    open tasks, ten scored ``repo_required_cmds`` and nine scored BOTH
+    ``desc_words`` and ``desc_chars`` -- so every task with a description over
+    800 characters was "large" on two signals that were really one project
+    constant plus one description read twice.
+
+    The consequence is the yield table this was filed against (2026-08-02,
+    7,678 tasks): 0 deps 29.3% completed, 1 dep 5.5%, 2 deps 2.0%. Twelve
+    self-contained dependency-free tasks were filed that day and the planner
+    decomposed every one; none completed. Writing a thorough description was
+    the trigger.
+    """
+    signals: List[str] = []
+    # Length counted ONCE. 200 words of English prose is ~1,100-1,400
+    # characters, so the 800-character test is implied by the 200-word test and
+    # never fired independently -- it was one property contributing two votes.
+    # Both bounds are kept because either can be the one exceeded: a
+    # description can be long in characters (tables, paths, log excerpts) while
+    # short in words.
+    word_count = len(description.split())
+    char_count = len(description)
+    if word_count >= _SCOPE_LARGE_DESC_WORDS or char_count >= _SCOPE_LARGE_DESC_CHARS:
+        signals.append("desc_length:%dw/%dc" % (word_count, char_count))
+
+    # repo_required_cmds is deliberately NOT a scope signal.
+    # metadata.execution_contract.repository_contract.toolchain.required_commands
+    # comes from the PROJECT's contract, so every task in a project carries the
+    # same value: measured 2026-08-07, ['python3','git','gh'] for every mac
+    # task and ['python3','git','gh','make','cc'] for every nanolang task --
+    # one distinct set per project, both over the threshold. It described the
+    # repository, never the task, and it voted "large" on all of them.
 
     is_plan, plan_signals = detect_plan_signals(title, description)
     if is_plan:

--- a/tests/test_executor_scope.py
+++ b/tests/test_executor_scope.py
@@ -22,7 +22,21 @@ def test_task_executor_reexports_scope_surface() -> None:
         assert getattr(te, name) is getattr(scope, name)
 
 
-def test_compute_scope_estimate_classifies_repository_breadth() -> None:
+def test_repository_breadth_no_longer_classifies_task_scope() -> None:
+    """INVERTED by task_0ee0b7ce, because it was asserting the defect.
+
+    This paired a long title with the repository contract's required_commands
+    to reach the two-signal threshold. required_commands comes from the
+    PROJECT's contract, so it is identical for every task in a project
+    (measured 2026-08-07: ['python3','git','gh'] for every mac task,
+    ['python3','git','gh','make','cc'] for every nanolang task). A signal that
+    cannot be false for one task and true for another says nothing about
+    either, and this one voted "large" on all of them -- which is how twelve
+    self-contained, dependency-free tasks were decomposed on 2026-08-02, none
+    of which completed.
+
+    A long title on its own is weak evidence, and now correctly sizes small.
+    """
     task = {
         "title": "A" * 101,
         "description": "small",
@@ -35,8 +49,9 @@ def test_compute_scope_estimate_classifies_repository_breadth() -> None:
         },
     }
     estimate = scope.compute_scope_estimate(task)
-    assert estimate["size"] == "large"
-    assert estimate["estimated_units"] == 2
+    assert estimate["size"] == "small"
+    assert estimate["estimated_units"] == 1
+    assert not any("repo_required_cmds" in s for s in estimate["signals"])
 
 
 def test_is_planning_phase_excludes_child_tasks() -> None:

--- a/tests/test_scope_estimate.py
+++ b/tests/test_scope_estimate.py
@@ -86,31 +86,61 @@ def test_compute_scope_large_desc_words():
     long_desc = " ".join(["word"] * 250)
     task = _task(description=long_desc)
     result = te.compute_scope_estimate(task)
-    assert any("desc_words" in s for s in result["signals"])
+    assert any("desc_length" in s for s in result["signals"])
 
 
 def test_compute_scope_large_desc_chars():
-    # 900-char description → desc_chars signal
+    # 900-char description → the single desc_length signal.
+    # Was two signals (desc_words + desc_chars) until task_0ee0b7ce: 200 words
+    # of prose is ~1,100-1,400 chars, so the char test was implied by the word
+    # test and one description cast two "independent" votes for large.
     long_desc = "x" * 900
     task = _task(description=long_desc)
     result = te.compute_scope_estimate(task)
-    assert any("desc_chars" in s for s in result["signals"])
+    assert any("desc_length" in s for s in result["signals"])
+    assert sum(1 for s in result["signals"] if s.startswith("desc_")) == 1
 
 
 def test_compute_scope_repo_required_cmds():
-    # 3 required commands → repo_required_cmds signal
+    # INVERTED by task_0ee0b7ce. This used to assert that a repository
+    # contract listing 3+ required commands produced a repo_required_cmds
+    # scope signal. It does not any more, and asserting that it did was
+    # asserting the defect: required_commands comes from the PROJECT's
+    # contract, so it is identical for every task in a project (measured
+    # 2026-08-07: ['python3','git','gh'] for every mac task,
+    # ['python3','git','gh','make','cc'] for every nanolang task) and voted
+    # "large" on all of them. It described the repository, never the task.
     task = _repo_task()
     result = te.compute_scope_estimate(task)
-    assert any("repo_required_cmds" in s for s in result["signals"])
+    assert not any("repo_required_cmds" in s for s in result["signals"])
 
 
 def test_compute_scope_large_two_signals():
-    # Two signals → "large"
-    long_desc = " ".join(["word"] * 250)  # desc_words signal
-    task = _repo_task(description=long_desc)  # also repo_required_cmds signal
+    # Two signals → "large", but they must be two INDEPENDENT signals.
+    # This previously paired a long description with repo_required_cmds, i.e.
+    # with a project constant, which is how every substantial task in a
+    # project became large (task_0ee0b7ce). A long description plus a
+    # plan-shaped title/body is a real pair.
+    long_desc = " ".join(["word"] * 250)
+    task = _repo_task(
+        title="Implement authentication and add user management",
+        description="1. Add login\n2. Add register\n3. Add profile\n"
+        "4. Add sessions\n5. Add tokens\n" + long_desc,
+    )
     result = te.compute_scope_estimate(task)
     assert result["size"] == "large"
     assert result["estimated_units"] == 2
+
+
+def test_a_long_description_alone_is_not_large():
+    """The regression this file previously encoded.
+
+    A thorough description of ONE piece of work must not be decomposed.
+    Measured 2026-08-02 across 7,678 tasks: 0 deps completed 29.3% of the
+    time, 1 dep 5.5%, 2 deps 2.0%.
+    """
+    task = _repo_task(description=" ".join(["word"] * 250))
+    assert te.compute_scope_estimate(task)["size"] == "small"
 
 
 def test_compute_scope_plan_detected():
@@ -159,7 +189,10 @@ def test_compute_scope_origin_contract():
         }
     )
     result = te.compute_scope_estimate(task)
-    assert any("repo_required_cmds" in s for s in result["signals"])
+    # INVERTED with test_compute_scope_repo_required_cmds above: the
+    # origin.repository_contract path is still read, but a project-constant
+    # toolchain no longer votes on per-task scope.
+    assert not any("repo_required_cmds" in s for s in result["signals"])
 
 
 # ---------------------------------------------------------------------------
@@ -508,7 +541,7 @@ def test_compute_scope_signals_preserves_d1_to_d5():
     """D1-D5 signals still appear when prior_lessons is empty."""
     long_desc = " ".join(["word"] * 250)  # D1 trigger
     signals = te._compute_scope_signals("x", long_desc, {}, [])
-    assert any("desc_words" in s for s in signals)
+    assert any("desc_length" in s for s in signals)
 
 
 # ---------------------------------------------------------------------------
@@ -587,7 +620,7 @@ def test_compute_scope_estimate_no_regression_hub_unreachable(monkeypatch):
     task = _task(description=" ".join(["word"] * 250))
     result = te.compute_scope_estimate(task)
     assert result["schema"] == "mac.scope_estimate.v1"
-    assert "desc_words" in " ".join(result["signals"])
+    assert "desc_length" in " ".join(result["signals"])
     assert not any("memory" in s for s in result["signals"])
 
 
@@ -616,8 +649,10 @@ def test_compute_scope_estimate_memory_signal_flips_size(monkeypatch):
     """One textual large-signal + one memory hit → size='large'."""
     record = _make_plan_learning_record("task_flip")
     monkeypatch.setattr(scope, "recall_scope_lessons", lambda task, **kw: [record])
-    # _repo_task gives one textual large-signal (repo_required_cmds)
-    task = _repo_task()
+    # One real textual signal: a long description. This used to lean on
+    # repo_required_cmds, a project constant, which made the assertion true
+    # for every task in the project rather than for this one (task_0ee0b7ce).
+    task = _repo_task(description=" ".join(["word"] * 250))
     result = te.compute_scope_estimate(task)
     assert result["size"] == "large", (
         "One textual signal + one memory hit must produce size='large'; got: %r" % result

--- a/tests/test_scope_signals_discriminate.py
+++ b/tests/test_scope_signals_discriminate.py
@@ -1,0 +1,250 @@
+"""A scope signal must be able to be false.
+
+Completion yield by dependency count, measured across all 7,678 ledger tasks on
+2026-08-02:
+
+    0 deps   2,945 tasks   29.3% completed
+    1 dep    2,888 tasks    5.5% completed
+    2 deps   1,012 tasks    2.0% completed
+    3+ deps    833 tasks    2.0% completed
+
+One dependency costs 5.3x completion; two is effectively terminal. And the
+system attached them by default -- 62% of tasks carried dependencies, 82% of
+the waiting pool were decomposition children. Twelve self-contained,
+dependency-free tasks were filed that day against verified main; the planner
+decomposed every one, one child failed and stranded its parent permanently, and
+none of the twelve completed (task_0ee0b7ce).
+
+THE MECHANISM. ``compute_scope_estimate_from_lessons`` calls a task large on
+``>= 2`` signals, which reads like "two independent indicators". Measured on ten
+open ledger tasks 2026-08-07, it was not:
+
+  * ``repo_required_cmds`` fired on 10 of 10. It reads required_commands from
+    the PROJECT's repository contract, so it is constant within a project:
+    ['python3','git','gh'] for every mac task, ['python3','git','gh','make','cc']
+    for every nanolang task -- one distinct set each, both over the threshold.
+    It described the repository and voted "large" on every task in it.
+
+  * ``desc_words`` (>=200) and ``desc_chars`` (>=800) both fired on 9 of 10.
+    200 words of English prose is ~1,100-1,400 characters, so the character
+    test is implied by the word test and never fired independently. One
+    property, two votes.
+
+So the gate was really "project constant + description length >= 2", and every
+task with a substantial description was large. Writing a thorough description
+was the trigger for being decomposed.
+
+After the fix, the same ten tasks: 4 large instead of 10, and the four all carry
+a second signal that genuinely varies.
+
+These tests assert the property that was missing rather than the arithmetic:
+a signal that cannot be false is not evidence.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.executor_scope import (
+    _SCOPE_LARGE_DESC_CHARS,
+    _SCOPE_LARGE_DESC_WORDS,
+    _compute_scope_signals,
+    compute_scope_estimate_from_lessons,
+)
+
+#: A description that is thorough but describes ONE piece of work. This is the
+#: shape of the twelve tasks that were decomposed: measured, self-contained,
+#: dependency-free, and long because it is well specified.
+THOROUGH_BUT_ATOMIC = " ".join(
+    [
+        "The window lookup matches on created_by, which holds the actor rather",
+        "than the subject, so a summary written by the nap cycle is invisible",
+        "to it and the window never advances.",
+    ]
+    * 30
+)
+
+#: The repository contract every task in a project inherits.
+PROJECT_CONTRACT = {
+    "execution_contract": {
+        "repository_contract": {
+            "toolchain": {"required_commands": ["python3", "git", "gh"]}
+        }
+    }
+}
+
+
+def _hard_signals(title, description, metadata=None):
+    """Signals that count toward "large" (plan_signal: entries do not)."""
+    return [
+        s
+        for s in _compute_scope_signals(title, description, metadata or {}, [])
+        if not s.startswith("plan_signal:")
+    ]
+
+
+def _size(title, description, metadata=None):
+    task = {"title": title, "description": description, "metadata": metadata or {}}
+    return compute_scope_estimate_from_lessons(task, [])["size"]
+
+
+# --------------------------------------------------------------------------
+# The project constant
+# --------------------------------------------------------------------------
+
+
+def test_the_repository_contract_is_not_a_task_scope_signal():
+    """It is identical for every task in a project, so it discriminates nothing."""
+    signals = _hard_signals("short title", "short body", PROJECT_CONTRACT)
+
+    assert not any("repo_required_cmds" in s for s in signals), (
+        "a project-constant property is voting on per-task scope; measured "
+        "2026-08-07 it fired on 10 of 10 open tasks"
+    )
+
+
+def test_two_tasks_in_one_project_can_differ_in_size():
+    """The property the constant destroyed.
+
+    With a project constant contributing one guaranteed vote, a single further
+    signal was enough, so every substantial task in the project tipped large
+    together.
+    """
+    small = _size("small task", "a short description", PROJECT_CONTRACT)
+    large = _size(
+        "a plan with numbered phases",
+        "1. first step\n2. second step\n3. third step\n" + THOROUGH_BUT_ATOMIC,
+        PROJECT_CONTRACT,
+    )
+
+    assert small == "small"
+    assert large == "large", "nothing in this project can be large any more"
+
+
+def test_a_richer_toolchain_does_not_make_a_task_larger():
+    """nanolang's contract lists five commands, mac's three. Same task, same size."""
+    mac_like = _size("fix a typo", "one line", PROJECT_CONTRACT)
+    nanolang_like = _size(
+        "fix a typo",
+        "one line",
+        {
+            "execution_contract": {
+                "repository_contract": {
+                    "toolchain": {
+                        "required_commands": ["python3", "git", "gh", "make", "cc"]
+                    }
+                }
+            }
+        },
+    )
+
+    assert mac_like == nanolang_like == "small"
+
+
+# --------------------------------------------------------------------------
+# The double-counted description
+# --------------------------------------------------------------------------
+
+
+def test_description_length_votes_once():
+    """The regression: 9 of 10 tasks scored both desc_words and desc_chars."""
+    signals = _hard_signals("t", THOROUGH_BUT_ATOMIC)
+    length_signals = [s for s in signals if s.startswith("desc_")]
+
+    assert len(length_signals) == 1, (
+        "description length contributed %d votes: %s" % (len(length_signals), length_signals)
+    )
+
+
+def test_the_word_threshold_implies_the_character_threshold():
+    """Why they were never independent, asserted rather than assumed.
+
+    Anything reaching 200 words of prose has long since passed 800 characters,
+    so the second test could only ever agree with the first.
+    """
+    prose = " ".join(["consolidation"] * _SCOPE_LARGE_DESC_WORDS)
+
+    assert len(prose) > _SCOPE_LARGE_DESC_CHARS
+
+
+def test_a_long_but_wordless_description_still_registers():
+    """Both bounds are kept: either can be the one exceeded.
+
+    A description can be long in characters and short in words -- a table, a
+    stack trace, a list of paths -- and that is still a long description.
+    """
+    dense = "/very/long/path/to/some/module/file.py\n" * 40
+
+    assert len(dense.split()) < _SCOPE_LARGE_DESC_WORDS
+    assert len(dense) >= _SCOPE_LARGE_DESC_CHARS
+    assert any(s.startswith("desc_length") for s in _hard_signals("t", dense))
+
+
+def test_a_short_description_registers_nothing():
+    assert _hard_signals("t", "fix the typo on line 12") == []
+
+
+# --------------------------------------------------------------------------
+# The behaviour that was actually costing completions
+# --------------------------------------------------------------------------
+
+
+def test_a_thorough_but_atomic_task_is_not_large():
+    """The twelve tasks. Being well specified must not be the trigger.
+
+    Before the fix this scored desc_words + desc_chars + repo_required_cmds =
+    3 and was decomposed. It is one piece of work described carefully.
+    """
+    assert _size("Unfreeze the nap window", THOROUGH_BUT_ATOMIC, PROJECT_CONTRACT) == "small"
+
+
+def test_a_genuinely_multi_part_task_is_still_large():
+    """The other half. Decomposition is kept where it is warranted.
+
+    A fix that made nothing large would satisfy the yield table and lose the
+    capability, which is not what was asked for.
+    """
+    size = _size(
+        "Migrate task ids from TEXT to BIGINT across the schema and application",
+        "1. Convert the schema.\n2. Update the 4 generation sites.\n"
+        "3. Migrate ids embedded in JSON metadata.\n4. Fix ~180 shape-coupled "
+        "call sites.\n" + THOROUGH_BUT_ATOMIC,
+        PROJECT_CONTRACT,
+    )
+
+    assert size == "large"
+
+
+def test_an_empty_task_is_small():
+    assert _size("", "", {}) == "small"
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {},
+        {"execution_contract": None},
+        {"execution_contract": {"repository_contract": "not-an-object"}},
+        {"execution_contract": {"repository_contract": {"toolchain": []}}},
+        {"origin": {"repository_contract": {"toolchain": {"required_commands": "git"}}}},
+    ],
+)
+def test_malformed_contract_metadata_does_not_raise(metadata):
+    """Sizing runs at control-plane admission; it must not reject a task."""
+    assert _size("t", "short", metadata) == "small"
+
+
+def test_the_estimate_reports_its_own_signals():
+    """An operator has to be able to see WHY a task was called large.
+
+    This is the whole reason the defect was findable: the signal list named
+    repo_required_cmds on every task, which is what exposed it as a constant.
+    """
+    estimate = compute_scope_estimate_from_lessons(
+        {"title": "t", "description": THOROUGH_BUT_ATOMIC, "metadata": PROJECT_CONTRACT},
+        [],
+    )
+
+    assert estimate["schema"] == "mac.scope_estimate.v1"
+    assert estimate["signals"]
+    assert "desc_length" in estimate["rationale"]


### PR DESCRIPTION
Closes task_0ee0b7ce.

## The cost

Completion yield by dependency count, measured 2026-08-02 across all 7,678 ledger tasks:

| deps | tasks | completed |
|---|---|---|
| 0 | 2,945 | **29.3%** |
| 1 | 2,888 | 5.5% |
| 2 | 1,012 | 2.0% |
| 3+ | 833 | 2.0% |

One dependency costs **5.3x** completion; two is effectively terminal. Yet 62% of tasks carried dependencies and 82% of the waiting pool were decomposition children. Twelve self-contained, dependency-free tasks were filed that day against verified main — the planner decomposed every one, one child failed and stranded its parent permanently, and **none of the twelve completed**.

## The mechanism

`compute_scope_estimate_from_lessons` calls a task large on `>= 2` signals, which reads as *"two independent indicators"*. Measured across ten open ledger tasks on 2026-08-07, it was not:

**`repo_required_cmds` fired on 10 of 10.** It reads `required_commands` from the **project's** repository contract, so it is constant within a project:

```
mac       -> ['python3','git','gh']                    (every task)
nanolang  -> ['python3','git','gh','make','cc']        (every task)
```

One distinct set each, both over the threshold of 3. It described the repository, never the task, and voted "large" on all of them.

**`desc_words` (≥200) and `desc_chars` (≥800) both fired on 9 of 10.** 200 words of English prose is ~1,100–1,400 characters, so the character test is *implied* by the word test and never fired independently. One property, two votes.

So the gate was really **"project constant + description length ≥ 2"** — every task with a substantial description was large. **Writing a thorough description was the trigger for being decomposed.**

## The change

- `repo_required_cmds` retired as a scope signal (kept as a constant only for the documented `executor_sandbox` compatibility re-export).
- Description length counted once. Both bounds are kept because either can be the one exceeded — a description can be long in characters and short in words (a table, a stack trace, a list of paths).

**On the same ten tasks: 4 large instead of 10.** Decomposition is kept where warranted; a change that made nothing large would satisfy the yield table by losing the capability.

## Six existing assertions encoded the defect

Three asserted the project constant *was* a signal; three named `desc_words`/`desc_chars`. Each is inverted or repointed **with a note saying what it used to assert and why that was wrong**, rather than deleted — including `test_compute_scope_estimate_classifies_repository_breadth`, whose entire subject was the retired signal.

## Verification

16 new tests asserting the property that was missing: **a signal must be capable of being false**. Mutation-verified — restoring the constant fails 2, restoring the double count fails 4.

All adjacent suites pass: `test_executor_scope.py`, `test_planning_phase.py`, `test_planning.py`, `test_decompose_caps.py`, `test_plan_learning_loop.py`, `test_scope_estimate.py` — **209 passed**.

## Not fixed here — filed as task_20d7cfa2

All four survivors are large on `desc_length + plan_detected`, and `plan_detected` is **not independent of description length either**: `detect_plan_signals` is its own 2-of-6 vote whose signal 5 is *"word-count exceeds 300 words"*, and all four exceed it. Same double-count, laundered through a second function. That function has callers beyond scope estimation, so changing it in this commit would have made this measurement unattributable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)