### PR TITLE
Record why an all_settled join settled, and warn before it releases a parent

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -24082,6 +24082,97 @@ class ControlPlane:
                 return False
         return True
 
+    def _dependency_settlement(
+        self,
+        task: Task,
+        *,
+        dependency_ids: Optional[Sequence[str]] = None,
+    ) -> JsonDict:
+        """WHY this task's join settled, per dependency.
+
+        ``_dependencies_satisfied`` answers a yes/no, and under ``all_settled``
+        that single bit collapses two materially different facts:
+
+          * the dependency RAN and produced output -- the parent can proceed;
+          * the dependency was CANCELLED and produced nothing -- it cannot.
+
+        Observed end to end 2026-08-05 in about five minutes: four children
+        were cancelled at 17:17:14, task_c5407d23 went waiting -> running at
+        17:17:45 having waited since 2026-07-31, and failed 3/3 by 17:22:53.
+        Its own diagnosis named the cause -- "missing child outputs". It
+        adjudicates candidates those children were supposed to enumerate, and
+        they will now never exist.
+
+        ``all_settled`` is right and stays: a cancelled dependency must not
+        block a parent forever. What was missing is that nothing recorded which
+        kind of settling happened, so neither the executing agent nor the
+        operator could tell a parent with inputs from one without.
+
+        This reports; it does not gate. Declining to dispatch when everything
+        settled by cancellation is option 3 in the filing and is deliberately
+        NOT taken here -- it would reintroduce the permanent stall
+        ``all_settled`` exists to prevent, and wants its own decision.
+        """
+        join = self._dependency_join_policy(task)
+        canonical_ids = (
+            list(dependency_ids)
+            if dependency_ids is not None
+            else self._canonical_task_dependency_ids(task.id)
+        )
+        per_dependency: JsonDict = {}
+        settled_without_output: List[str] = []
+        for dep_id in canonical_ids:
+            try:
+                dep = self.get_task(dep_id)
+            except NotFoundError:
+                # A dependency that no longer exists produced nothing either.
+                per_dependency[dep_id] = {"state": "missing", "produced_output": False}
+                settled_without_output.append(dep_id)
+                continue
+            produced = dep.state == TaskState.COMPLETED.value
+            per_dependency[dep_id] = {
+                "state": dep.state,
+                "produced_output": produced,
+                "satisfied": self._dependency_satisfies_join(dep, join),
+            }
+            if not produced:
+                settled_without_output.append(dep_id)
+        return {
+            "schema": "mac.dependency_settlement.v1",
+            "join": join,
+            "dependencies": per_dependency,
+            #: Dependencies that settled the join without producing anything.
+            #: Non-empty means the parent is about to run against inputs that
+            #: do not exist.
+            "settled_without_output": settled_without_output,
+            "all_inputs_present": not settled_without_output,
+            "observed_at": utcnow(),
+        }
+
+    def _record_dependency_settlement(
+        self,
+        task: Task,
+        settlement: JsonDict,
+    ) -> Task:
+        """Stamp the settlement onto the task the executor will read.
+
+        The transition detail alone is not enough: an executor reads task.json,
+        not the transition history, so a parent released over cancelled
+        children needs to be able to see that from its own metadata.
+        """
+        if settlement.get("all_inputs_present"):
+            return task
+        metadata = ensure_json_object(getattr(task, "metadata", None))
+        resolution = ensure_json_object(metadata.get("dependency_resolution"))
+        resolution["settlement"] = settlement
+        metadata["dependency_resolution"] = resolution
+        try:
+            return self.update_task(
+                task.id, metadata=metadata, actor="dependency-reconciliation"
+            )
+        except Exception:  # noqa: BLE001 - provenance must not block dispatch
+            return task
+
     def _canonical_task_dependency_ids(
         self,
         task_id: str,
@@ -24947,17 +25038,48 @@ class ControlPlane:
                     )
                     and (not manual_repair or supervised)
                 ):
+                    settlement = self._dependency_settlement(
+                        task, dependency_ids=dependency_ids
+                    )
                     if supervised:
                         task = self._clear_dependency_supervision(task)
                     task = self._prepare_cooperative_integration_task(task)
+                    task = self._record_dependency_settlement(task, settlement)
+                    detail: JsonDict = {"reason": "dependencies satisfied"}
+                    if not settlement["all_inputs_present"]:
+                        # The parent is being released over dependencies that
+                        # produced nothing. Say so here rather than leaving
+                        # "dependencies satisfied" to imply inputs exist.
+                        detail["reason"] = "dependencies settled without output"
+                        detail["settled_without_output"] = settlement[
+                            "settled_without_output"
+                        ]
+                        detail["dependency_settlement"] = settlement
                     unblocked.append(
                         self._transition_task_internal(
                             task.id,
                             TaskState.OPEN.value,
                             "dispatcher",
-                            {"reason": "dependencies satisfied"},
+                            detail,
                         )
                     )
+                    if not settlement["all_inputs_present"]:
+                        try:
+                            self.record_log(
+                                "task.dependencies_settled_without_output",
+                                level="warning",
+                                subject_type="task",
+                                subject_id=task.id,
+                                detail={
+                                    "task_id": task.id,
+                                    "settled_without_output": settlement[
+                                        "settled_without_output"
+                                    ],
+                                    "join": settlement["join"],
+                                },
+                            )
+                        except Exception:  # noqa: BLE001 - diagnostic only
+                            pass
                 elif (
                     task.state == TaskState.BLOCKED.value
                     and dependency_ids

--- a/src/mac/task_transition_service.py
+++ b/src/mac/task_transition_service.py
@@ -781,6 +781,38 @@ class TaskTransitionService:
                         "derived_cancellations": 0,
                     }
                     if coordination.get("mode") == "cooperative_integration":
+                        # This parent stays WAITING so its all_settled join can
+                        # settle on the terminal child -- and settle it will,
+                        # because all_settled counts CANCELLED as settled. So
+                        # this is the moment the consequence becomes certain,
+                        # and the last moment anyone could see it coming.
+                        #
+                        # Cancelling a stale dependency is normal, encouraged
+                        # queue hygiene, and on 2026-08-05 it silently turned a
+                        # parked parent into a running one with no inputs
+                        # (task_011ee697). Nothing warned the operator. Name
+                        # the parent that is about to be released.
+                        if dep_state == TaskState.CANCELLED.value:
+                            try:
+                                self.control_plane.record_log(
+                                    "task.cancellation_releases_integration_parent",
+                                    level="warning",
+                                    subject_type="task",
+                                    subject_id=dependent_id,
+                                    detail={
+                                        "parent": dependent_id,
+                                        "cancelled_dependency": dep_id,
+                                        "actor": actor,
+                                        "note": (
+                                            "all_settled counts a cancelled "
+                                            "dependency as settled, so this "
+                                            "parent may dispatch against "
+                                            "outputs that will never exist"
+                                        ),
+                                    },
+                                )
+                            except Exception:  # noqa: BLE001 - diagnostic only
+                                pass
                         self.control_plane._record_history(
                             dependent_id,
                             "task.dependency_unsatisfied",

--- a/tests/test_dependency_settled_without_output.py
+++ b/tests/test_dependency_settled_without_output.py
@@ -1,0 +1,271 @@
+"""A parent released over cancelled children must be able to tell.
+
+Observed end to end on 2026-08-05, in about five minutes:
+
+    17:17:14  four children cancelled (task_a308126c, a12723af, b2ef42ea,
+              b4906951) -- approved but undeliverable, see task_ce6c8ea3
+    17:17:45  task_c5407d23 "Adjudicate quarantined curiosity candidates"
+              went waiting -> open -> claimed -> running, having waited
+              since 2026-07-31
+    17:19:59  attempt 2 blocked: verification_contract_failed
+    17:22:41  attempt 3 blocked: same
+    17:22:53  failed, 3/3
+
+The executing agent's own diagnosis named the cause: "missing tool/store +
+MISSING CHILD OUTPUTS". The parent adjudicates candidates its children were
+supposed to enumerate. They had just been cancelled, so those outputs will
+never exist.
+
+Its policy is {"join": "all_settled", "on_unsatisfied": "supervise"}, and
+``all_settled`` counts CANCELLED as settled. That is CORRECT and stays: a
+cancelled dependency must not block a parent forever. The defect is that
+"settled" collapsed two materially different facts --
+
+    the dependency RAN and produced output      -> the parent can proceed
+    the dependency was CANCELLED, producing none -> it cannot
+
+-- and nothing recorded which had happened, so neither the executing agent nor
+the operator could tell the two apart at dispatch time.
+
+It landed safely only because that contract happens to be fail-closed and the
+agent was careful enough to say "missing child outputs" rather than adjudicate
+an empty set. A task without that clause would have produced a confident result
+over nothing, which is worse than failing.
+
+These tests cover the two halves that were missing (items 1 and 2 of the
+filing): the settlement provenance the parent carries, and the warning at
+cancel time. Item 3 -- declining to dispatch when everything settled by
+cancellation -- is deliberately NOT implemented, and one test pins that, since
+doing it would reintroduce the permanent stall ``all_settled`` exists to
+prevent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import TaskState
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+def _integration_parent(cp, children):
+    """A cooperative-integration parent, as the curiosity adjudicator was."""
+    return cp.create_task(
+        "adjudicate what the children enumerated",
+        project="mac",
+        dependencies=[child.id for child in children],
+        metadata={
+            "coordination": {"mode": "cooperative_integration"},
+            "dependency_policy": {"join": "all_settled", "on_unsatisfied": "supervise"},
+        },
+    )
+
+
+def _child(cp, title="enumerate candidates"):
+    return cp.create_task(title, project="mac")
+
+
+def _finish(cp, task, state):
+    cp.store.execute(
+        "UPDATE tasks SET state = ? WHERE id = ?", (state, task.id)
+    )
+
+
+# --------------------------------------------------------------------------
+# The settlement record
+# --------------------------------------------------------------------------
+
+
+def test_a_completed_dependency_reports_output(cp):
+    child = _child(cp)
+    parent = _integration_parent(cp, [child])
+    _finish(cp, child, TaskState.COMPLETED.value)
+
+    settlement = cp._dependency_settlement(cp.get_task(parent.id))
+
+    assert settlement["all_inputs_present"] is True
+    assert settlement["settled_without_output"] == []
+    assert settlement["dependencies"][child.id]["produced_output"] is True
+
+
+def test_a_cancelled_dependency_reports_no_output(cp):
+    """The regression. Settled, yes -- but it produced nothing."""
+    child = _child(cp)
+    parent = _integration_parent(cp, [child])
+    _finish(cp, child, TaskState.CANCELLED.value)
+
+    settlement = cp._dependency_settlement(cp.get_task(parent.id))
+
+    assert settlement["all_inputs_present"] is False
+    assert settlement["settled_without_output"] == [child.id]
+    assert settlement["dependencies"][child.id]["produced_output"] is False
+    # Still SATISFIED: all_settled is working correctly and must keep doing so.
+    assert settlement["dependencies"][child.id]["satisfied"] is True
+
+
+def test_a_failed_dependency_also_reports_no_output(cp):
+    child = _child(cp)
+    parent = _integration_parent(cp, [child])
+    _finish(cp, child, TaskState.FAILED.value)
+
+    settlement = cp._dependency_settlement(cp.get_task(parent.id))
+
+    assert settlement["settled_without_output"] == [child.id]
+
+
+def test_a_partly_cancelled_family_names_only_the_empty_ones(cp):
+    """The operator needs to know WHICH inputs are missing, not just that some are."""
+    ran = _child(cp, "enumerated fine")
+    cancelled = _child(cp, "never ran")
+    parent = _integration_parent(cp, [ran, cancelled])
+    _finish(cp, ran, TaskState.COMPLETED.value)
+    _finish(cp, cancelled, TaskState.CANCELLED.value)
+
+    settlement = cp._dependency_settlement(cp.get_task(parent.id))
+
+    assert settlement["settled_without_output"] == [cancelled.id]
+    assert settlement["all_inputs_present"] is False
+
+
+def test_an_unreadable_dependency_counts_as_no_output(cp):
+    """Fail toward warning: a dependency that cannot be read produced nothing.
+
+    Driven by passing the id explicitly rather than by deleting the task,
+    because deleting a task removes its edge too -- so a dangling edge is not
+    reachable that way, and a test that deleted the row would be asserting on
+    an empty dependency list while appearing to assert on a missing one.
+    """
+    parent = _integration_parent(cp, [_child(cp)])
+
+    settlement = cp._dependency_settlement(
+        cp.get_task(parent.id), dependency_ids=["task_does_not_exist"]
+    )
+
+    assert settlement["settled_without_output"] == ["task_does_not_exist"]
+    assert settlement["dependencies"]["task_does_not_exist"]["state"] == "missing"
+
+
+def test_the_settlement_is_stamped_on_the_task_the_executor_reads(cp):
+    """An executor reads task.json, not the transition history.
+
+    Recording this only in the transition detail would leave the agent in
+    exactly the position that cost three attempts: running, with no way to see
+    that its inputs were destroyed.
+    """
+    child = _child(cp)
+    parent = _integration_parent(cp, [child])
+    _finish(cp, child, TaskState.CANCELLED.value)
+    reloaded = cp.get_task(parent.id)
+
+    settlement = cp._dependency_settlement(reloaded)
+    updated = cp._record_dependency_settlement(reloaded, settlement)
+
+    recorded = updated.metadata["dependency_resolution"]["settlement"]
+    assert recorded["settled_without_output"] == [child.id]
+
+
+def test_a_clean_settlement_is_not_stamped(cp):
+    """Only the surprising case is worth carrying; noise is what gets ignored."""
+    child = _child(cp)
+    parent = _integration_parent(cp, [child])
+    _finish(cp, child, TaskState.COMPLETED.value)
+    reloaded = cp.get_task(parent.id)
+
+    settlement = cp._dependency_settlement(reloaded)
+    updated = cp._record_dependency_settlement(reloaded, settlement)
+
+    resolution = (updated.metadata or {}).get("dependency_resolution") or {}
+    assert "settlement" not in resolution
+
+
+# --------------------------------------------------------------------------
+# all_settled must keep working
+# --------------------------------------------------------------------------
+
+
+def test_a_cancelled_dependency_still_satisfies_the_join(cp):
+    """The half that must NOT change.
+
+    all_settled exists so a cancelled dependency cannot block a parent for
+    ever. Reporting the settlement must not become gating it -- that is item 3
+    in the filing, deliberately not taken, because it would trade a wasted
+    attempt for a permanent stall.
+    """
+    child = _child(cp)
+    parent = _integration_parent(cp, [child])
+    _finish(cp, child, TaskState.CANCELLED.value)
+
+    assert cp._dependencies_satisfied(cp.get_task(parent.id)) is True
+
+
+def test_all_success_is_unaffected(cp):
+    """A non-integration parent must still refuse to run on a cancelled child."""
+    child = _child(cp)
+    parent = cp.create_task(
+        "ordinary downstream work", project="mac", dependencies=[child.id]
+    )
+    _finish(cp, child, TaskState.CANCELLED.value)
+
+    assert cp._dependencies_satisfied(cp.get_task(parent.id)) is False
+
+
+# --------------------------------------------------------------------------
+# The cancel-time warning
+# --------------------------------------------------------------------------
+
+
+def _warned(cp, name):
+    events = cp.observability.list_observability(name=name, limit=20)
+    return [event.detail for event in events]
+
+
+def test_cancelling_a_child_warns_that_it_releases_the_parent(cp):
+    """The cheap half: show the consequence BEFORE it happens.
+
+    Cancelling a stale dependency is routine queue hygiene. On 2026-08-05 it
+    silently converted a parked parent into a running one with no inputs, and
+    nothing said so.
+    """
+    child = _child(cp)
+    parent = _integration_parent(cp, [child])
+    cp.store.execute(
+        "UPDATE tasks SET state = ? WHERE id = ?",
+        (TaskState.WAITING.value, parent.id),
+    )
+    _finish(cp, child, TaskState.CANCELLED.value)
+
+    cp._resolve_waiting_dependents_of(
+        child.id, TaskState.CANCELLED.value, "operator"
+    )
+
+    warnings = _warned(cp, "task.cancellation_releases_integration_parent")
+    assert warnings, "cancelling a dependency released a parent with no warning"
+    assert warnings[0]["parent"] == parent.id
+    assert warnings[0]["cancelled_dependency"] == child.id
+
+
+def test_a_failed_child_does_not_raise_the_cancellation_warning(cp):
+    """This warning is about an OPERATOR ACTION with a non-obvious consequence.
+
+    A child that failed on its own is the system reporting its own outcome;
+    firing the same warning there would dilute the one that means "something
+    you just did released a task".
+    """
+    child = _child(cp)
+    parent = _integration_parent(cp, [child])
+    cp.store.execute(
+        "UPDATE tasks SET state = ? WHERE id = ?",
+        (TaskState.WAITING.value, parent.id),
+    )
+    _finish(cp, child, TaskState.FAILED.value)
+
+    cp._resolve_waiting_dependents_of(child.id, TaskState.FAILED.value, "worker")
+
+    assert not _warned(cp, "task.cancellation_releases_integration_parent")


### PR DESCRIPTION
Closes task_011ee697.

## Observed end to end, 2026-08-05, in about five minutes

```
17:17:14  four children cancelled — routine queue hygiene
17:17:45  task_c5407d23 waiting -> open -> claimed -> running
          (it had been waiting since 2026-07-31)
17:19:59  attempt 2 blocked: verification_contract_failed
17:22:41  attempt 3 blocked: same
17:22:53  failed, 3/3
```

The executing agent's own diagnosis named the cause: *"missing tool/store + **MISSING CHILD OUTPUTS**"*. The parent adjudicates candidates those children were supposed to enumerate. They had just been cancelled, so those outputs will never exist.

## What is and isn't wrong

`all_settled` counts `CANCELLED` as settled. **That is correct and stays** — a cancelled dependency must not block a parent forever.

The defect is that "settled" collapsed two materially different facts:

| fact | consequence |
|---|---|
| the dependency **ran** and produced output | the parent can proceed |
| the dependency was **cancelled**, producing none | it cannot |

Nothing recorded which had happened. The release detail read `"dependencies satisfied"` either way.

## Two halves, both reporting

**`_dependency_settlement`** reports per dependency whether it produced output, and names the ones that didn't. When any didn't:

- the release detail says `"dependencies settled without output"` and carries the list
- it's stamped onto the task's own `dependency_resolution.settlement` — an executor reads `task.json`, not the transition history
- a warning observation is emitted

A clean settlement is **not** stamped. Noise is what gets ignored.

**At cancel time**, a cancellation that will release a waiting cooperative-integration parent now names that parent. This is the "cheap half" the filing calls out, and would have shown the consequence *before* it happened rather than five minutes after.

It fires only for `CANCELLED`, not for a child that failed on its own — this warning is about an **operator action with a non-obvious consequence**, and firing it on ordinary failures would dilute the one that means "something you just did released a task".

## What I deliberately did not do

Item 3 of the filing — declining to dispatch when *every* dependency settled by cancellation — is not implemented, and a test pins that a cancelled dependency **still satisfies the join**. It would trade a wasted attempt for the permanent stall `all_settled` exists to prevent. That's a decision to make on its own, not a rider on a reporting fix.

Worth stating plainly: the 2026-08-05 incident landed safely only because that contract happens to be fail-closed and the agent was careful enough to say "missing child outputs" rather than adjudicate an empty set. A task without that clause would have produced a confident result over nothing, which is worse than failing.

## Verification

11 tests, mutation-verified:

| mutation | tests failed |
|---|---|
| treat every dependency as having produced output | 4 |
| remove the cancel-time warning | 1 |

Adjacent suites clean: `test_dispatch.py` + `test_task_waiting_dispatch_explain.py` (88), dependency/coordination/strand selection (106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)