### PR TITLE
Make the CLI's first-class objects discoverable and CRUD-first

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -62,59 +62,20 @@ Getting started:
 Fleet and machines:
   fleet      deploy, inspect and maintain the fleet as a whole
   machine    hosts that agents run on
-  hgx        HGX / GPU capacity management
   openshell  sandboxed execution environments for agents
-  runtime    runtime images and environment definitions
-  rollout    staged rollout of a runtime or configuration
-  env        environment variables projected onto fleet hosts
   secret     secret storage, rotation and access audit
-  database   control-plane database maintenance
-  migrate    schema and data migrations
 
 Getting work done:
-  dispatch      the loop that matches ready tasks to eligible agents
-  review        adversarial review of completed work
-  publish       publish reviewed work to its destination
-  pull-request  pull requests raised from task work
-  workflow      multi-step workflow definitions and runs
-  plan          planning helpers, including dependency ordering
-  eval          evaluation runs over agent output
-  optimizer     model and routing optimization
-  repo          repositories that tasks execute against
-  artifact      durable artifacts produced by task work
+  dispatch  the loop that matches ready tasks to eligible agents
+  review    adversarial review of completed work
+  publish   publish reviewed work to its destination
+  repo      repositories that tasks execute against
 
 What agents know:
-  memory           durable cross-session knowledge
-  journal          per-agent narrative history
-  mood             agent temperament and its effect on execution
-  nap              consolidation cycles that summarize recent work
-  dream            offline pattern-finding over past work
-  curiosity        quarantined self-proposed experiments awaiting judgment
-  human-interface  port an agent profile between Hermes and OpenClaw
-  persona          Hermes personas and their memory scopes
+  memory  durable cross-session knowledge
 
-Talking to people and systems:
-  message        messages between agents and humans
-  agentbus       the agent-to-agent message bus
-  communication  communication channels and routing
-  notifier       outbound notification channels
-  directive      operator directives issued to agents
-  hermes         Hermes instances and their context
-  binding        Hermes platform bindings
-  interaction    durable work created from a conversation
-  bridge         external system bridges
-  integrations   third-party integrations
-
-Who can do what:
-  tenant  tenant boundaries
-  user    human user identities
-  client  API clients and their principals
-
-Seeing what happened:
-  events         the unified event stream
-  action-events  recorded agent actions
-  observability  structured metrics and logs
-  command-audit  audit of commands agents ran
+36 more commands are available. `mac help --all` lists them, and every one of them
+runs whether it is listed or not -- nothing is removed.
 
 Run `mac help <command>` for any of them.
 ```
@@ -1350,11 +1311,12 @@ options:
 
 ```console
 $ mac help --help
-usage: mac help [-h] [SUBCOMMAND]
+usage: mac help [-h] [--all] [SUBCOMMAND]
 
 positional arguments:
   SUBCOMMAND  scope help to one subcommand and show the arguments it takes
 
 options:
   -h, --help  show this help message and exit
+  --all       list every command, not just the common ones
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -442,7 +442,6 @@ CRUD:
   create  freeze and assemble exact accepted inputs for one integration node (same as `assemble`)
   list    list work packages
   show    show one work package: member tasks, plan, certification state
-  update  atomically install one paused package's compiled replacement plan (same as `replan`)
 
 Assembly:
   assemble-batch   assemble a previously-created integration batch
@@ -451,6 +450,7 @@ Assembly:
   admit            compile, attest, and atomically materialize a held plan
 
 Planning:
+  replan          atomically install one paused package's compiled replacement plan
   replan-preview  compile and attest plan N+1, then report whether it can be applied
   readiness       show credential/capability activation blockers
 
@@ -476,7 +476,7 @@ Dispatch:
   pause     raise the package Andon by exact plan-version and epoch CAS
   activate
 
-Not available for work-package: delete (no control-plane operation implements it)
+Not available for work-package: update, delete (no control-plane operation implements it)
 
 Run `mac work-package help <subcommand>` for the arguments one takes.
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,110 +9,57 @@ The book uses executable `bash` blocks; reference usage is rendered as output.
 $ mac --help
 usage: mac [-h] [--db DB] [--local-authority] [--hub-url HUB_URL]
            [--token TOKEN] [--fleet FLEET] [--profile PROFILE] [--json]
-           {diagnostics,init,database,config,login,logout,client,tenant,user,persona,human-interface,hermes,binding,interaction,task,repo,project,work-package,directive,hgx,openshell,machine,agent,fleet,journal,optimizer,mood,dream,nap,dispatch,message,agentbus,review,publish,pull-request,secret,runtime,artifact,env,bridge,integrations,curiosity,memory,rollout,events,action-events,command-audit,observability,communication,comm,notifier,migrate,workflow,eval,plan} ...
+           SUBCOMMAND ...
 
 Multi-agent coordinator control plane
 
 positional arguments:
-  {diagnostics,init,database,config,login,logout,client,tenant,user,persona,human-interface,hermes,binding,interaction,task,repo,project,work-package,directive,hgx,openshell,machine,agent,fleet,journal,optimizer,mood,dream,nap,dispatch,message,agentbus,review,publish,pull-request,secret,runtime,artifact,env,bridge,integrations,curiosity,memory,rollout,events,action-events,command-audit,observability,communication,comm,notifier,migrate,workflow,eval,plan}
-    diagnostics         run read-only control-plane health checks
-    init                create the control-plane schema in the --db PostgreSQL
-                        store
-    database            offline durable-authority maintenance and migration
-    config              configuration helpers
-    login               bootstrap or inspect a scoped client login over
-                        verified SSH
-    logout              remove a local login and optionally revoke it on the
-                        hub
-    client              hub enrollment principals and secure local client
-                        profiles
-    tenant              tenant boundary commands
-    user                human user identity commands
-    persona             Hermes persona and memory-scope commands
-    human-interface     port an agent profile between Hermes and OpenClaw
-    hermes              Hermes instance commands
-    binding             Hermes platform binding commands
-    interaction         create durable work from Hermes conversation context
-    task                task ledger commands
-    repo                managed repository work-ref lifecycle commands
-    project             project summary commands
-    work-package        versioned work-DAG admission, readiness, and
-                        controller stages
-    directive           versioned fleet rules, conditional bindings, and held
-                        workflow macros
-    hgx                 operator controls for fungible HGX provider capacity
-    openshell           OpenShell sandbox guardrail commands
-    machine             machine registry commands
-    agent               agent registry commands
-    fleet               fleet-wide queries
-    journal             snapshot / restore an agent's soul + memory state
-                        (guards against soul loss)
-    optimizer           autonomous scientific policy optimization
-    mood                agent mood overlays (agents self-report; operators
-                        query)
-    dream               dream-cycle learning maintenance
-    nap                 agent nap schedule and lifecycle (daily memory
-                        consolidation)
-    dispatch            dispatcher commands
-    message             structured message bus commands
-    agentbus            typed high-throughput agent-to-agent content streams
-    review              review pipeline commands
-    pull-request        open or inspect pull/merge requests on the task's git
-                        host
-    secret              secret boundary commands
-    runtime             runtime boundary commands
-    artifact            artifact registry: canonical record for deliverables
-                        (images, packages, tarballs)
-    env                 environments and deployments (artifact -> environment
-                        edges)
-    bridge              external project bridge commands
-    integrations        integration authority observations and findings
-    curiosity           read and adjudicate a host's curiosity quarantine
-                        THROUGH THE HUB (the ledger lives in the agent's
-                        OpenClaw sandbox; a task sandbox cannot reach it
-                        directly)
-    memory              memory and provenance commands
-    rollout             rollout and rescue commands
-    events              unified audit stream
-    action-events       canonical MAC action event ledger
-    command-audit       short-retention per-agent command log
-    observability       structured metric/log observations
-    communication (comm)
-                        logical public identities, representation, and
-                        OpenClaw delivery
-    notifier            operator notification channel configuration
-    migrate             one-time migration from external systems
-    workflow            workflow inspection (graph definitions, runs, decision
-                        gates)
-    eval                evaluation sets and runs
-    plan                planning helpers (topology ordering, blast radius,
-                        etc.)
+  SUBCOMMAND
 
 options:
-  -h, --help            show this help message and exit
-  --db DB               direct PostgreSQL control-plane authority (a
-                        postgres:// DSN) for hub maintenance, standalone
-                        development, tests, and migration. It is not a
-                        repository ticket store or offline hub replica and
-                        never synchronizes with a hub. When unset and no hub
-                        is configured, mac refuses to run.
-  --local-authority     enable stopped-hub maintenance against the
-                        authoritative PostgreSQL database selected by --db or
-                        MAC_DB. The command refuses this mode while the
-                        configured hub health endpoint is reachable.
-  --hub-url HUB_URL     MAC hub URL (hub mode). Falls back to $MAC_API_URL /
-                        $MAC_URL / $MAC_HUB_URL, then ~/.mac/fleets.yaml for
-                        --fleet.
-  --token TOKEN         Bearer token for hub mode. Falls back to
-                        $MAC_API_TOKEN (or $MAC_API_TOKEN__<FLEET> when
-                        --fleet is set).
-  --fleet FLEET         Fleet name; selects MAC_API_TOKEN__<FLEET> and
-                        ~/.mac/fleets.yaml entry.
-  --profile PROFILE     Secure client profile under ~/.mac/clients. Falls back
-                        to $MAC_PROFILE or the active profile.
-  --json                Emit JSON instead of the default human-readable text.
-                        Works in any position (e.g. `mac task list --json` or
-                        `mac --json task list`).
+  -h, --help         show this help message and exit
+  --db DB            direct PostgreSQL control-plane authority (a postgres://
+                     DSN) for hub maintenance, standalone development, tests,
+                     and migration. It is not a repository ticket store or
+                     offline hub replica and never synchronizes with a hub.
+                     When unset and no hub is configured, mac refuses to run.
+  --local-authority  enable stopped-hub maintenance against the authoritative
+                     PostgreSQL database selected by --db or MAC_DB. The
+                     command refuses this mode while the configured hub health
+                     endpoint is reachable.
+  --hub-url HUB_URL  MAC hub URL (hub mode). Falls back to $MAC_API_URL /
+                     $MAC_URL / $MAC_HUB_URL, then ~/.mac/fleets.yaml for
+                     --fleet.
+  --token TOKEN      Bearer token for hub mode. Falls back to $MAC_API_TOKEN
+                     (or $MAC_API_TOKEN__<FLEET> when --fleet is set).
+  --fleet FLEET      Fleet name; selects MAC_API_TOKEN__<FLEET> and
+                     ~/.mac/fleets.yaml entry.
+  --profile PROFILE  Secure client profile under ~/.mac/clients. Falls back to
+                     $MAC_PROFILE or the active profile.
+  --json             Emit JSON instead of the default human-readable text.
+                     Works in any position (e.g. `mac task list --json` or
+                     `mac --json task list`).
+
+The objects mac models. Start here:
+
+  project       a unit of work ownership: repositories, policy, dispatch state
+  task          one unit of work: the thing agents claim, run, and publish
+  work-package  a task group: several tasks assembled, certified and landed together
+  agent         a worker that claims and executes tasks on a machine
+
+  Each supports: create, list, show, update, delete
+  `mac <object> help` lists its commands; `mac <object> help <subcommand>`
+  shows the arguments that subcommand takes.
+
+Fleet operation and administration (50 more):
+  action-events agentbus artifact binding bridge client command-audit
+  communication config curiosity database diagnostics directive dispatch
+  dream env eval events fleet hermes hgx human-interface init integrations
+  interaction journal login logout machine memory message migrate mood nap
+  notifier observability openshell optimizer persona plan publish
+  pull-request repo review rollout runtime secret tenant user workflow
+
+Run `mac help <command>` for any of them.
 ```
 
 ## mac diagnostics
@@ -140,13 +87,14 @@ options:
 
 ```console
 $ mac database --help
-usage: mac database [-h] {migrate-sqlite-to-postgres} ...
+usage: mac database [-h] {migrate-sqlite-to-postgres,help} ...
 
 positional arguments:
-  {migrate-sqlite-to-postgres}
+  {migrate-sqlite-to-postgres,help}
     migrate-sqlite-to-postgres
                         copy every SQLite row to PostgreSQL and verify full-
                         row digests
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -156,13 +104,14 @@ options:
 
 ```console
 $ mac config --help
-usage: mac config [-h] {migrate-env-namespace} ...
+usage: mac config [-h] {migrate-env-namespace,help} ...
 
 positional arguments:
-  {migrate-env-namespace}
+  {migrate-env-namespace,help}
     migrate-env-namespace
                         add fleet-scoped variants of flat MAC_* credentials in
                         ~/.mac/.env (mac-g55y)
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -238,10 +187,10 @@ options:
 
 ```console
 $ mac client --help
-usage: mac client [-h] {enroll,renew,revoke,list,profile} ...
+usage: mac client [-h] {enroll,renew,revoke,list,profile,help} ...
 
 positional arguments:
-  {enroll,renew,revoke,list,profile}
+  {enroll,renew,revoke,list,profile,help}
     enroll              hub-local: mint a revocable scoped credential (invoke
                         through SSH)
     renew               hub-local: rotate one client's token and expiry
@@ -249,6 +198,7 @@ positional arguments:
     list                hub-local: list client principals without token hashes
     profile             install, select, inspect, or remove local secure
                         profiles
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -258,66 +208,71 @@ options:
 
 ```console
 $ mac tenant --help
-usage: mac tenant [-h] {register,list} ...
+usage: mac tenant [-h] {register,list,help} ...
 
 positional arguments:
-  {register,list}
+  {register,list,help}
+    help                show help for this command group
 
 options:
-  -h, --help       show this help message and exit
+  -h, --help            show this help message and exit
 ```
 
 ## mac user
 
 ```console
 $ mac user --help
-usage: mac user [-h] {register} ...
+usage: mac user [-h] {register,help} ...
 
 positional arguments:
-  {register}
+  {register,help}
+    help           show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help       show this help message and exit
 ```
 
 ## mac persona
 
 ```console
 $ mac persona --help
-usage: mac persona [-h] {register} ...
+usage: mac persona [-h] {register,help} ...
 
 positional arguments:
-  {register}
+  {register,help}
+    help           show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help       show this help message and exit
 ```
 
 ## mac human-interface
 
 ```console
 $ mac human-interface --help
-usage: mac human-interface [-h] {port,check} ...
+usage: mac human-interface [-h] {port,check,help} ...
 
 positional arguments:
-  {port,check}
-    port        port identity, memory and messaging credentials between
-                interfaces
-    check       report whether switching to an interface would lose the
-                profile
+  {port,check,help}
+    port             port identity, memory and messaging credentials between
+                     interfaces
+    check            report whether switching to an interface would lose the
+                     profile
+    help             show help for this command group
 
 options:
-  -h, --help    show this help message and exit
+  -h, --help         show this help message and exit
 ```
 
 ## mac hermes
 
 ```console
 $ mac hermes --help
-usage: mac hermes [-h] {register,context,work-context,runtime-proof} ...
+usage: mac hermes [-h] {register,context,work-context,runtime-proof,help} ...
 
 positional arguments:
-  {register,context,work-context,runtime-proof}
+  {register,context,work-context,runtime-proof,help}
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -327,195 +282,203 @@ options:
 
 ```console
 $ mac binding --help
-usage: mac binding [-h] {register} ...
+usage: mac binding [-h] {register,help} ...
 
 positional arguments:
-  {register}
+  {register,help}
+    help           show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help       show this help message and exit
 ```
 
 ## mac interaction
 
 ```console
 $ mac interaction --help
-usage: mac interaction [-h] {task} ...
+usage: mac interaction [-h] {task,help} ...
 
 positional arguments:
-  {task}
+  {task,help}
+    help       show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help   show this help message and exit
 ```
 
 ## mac task
 
 ```console
 $ mac task --help
-usage: mac task [-h]
-                {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-stranded,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,generator-yield,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing} ...
+usage: mac task [-h] SUBCOMMAND ...
 
 positional arguments:
-  {create,list,show,summary,ready,why-unclaimed,claim,break-glass,break-glass-list,break-glass-revoke,close,cancel,ask,needs-input,edit,answer,reopen,recover-stranded,recover-finalizer,recover-stalled-finalizer,force-complete,search,stats,generator-yield,throughput,audit,start,release,submit-review,evidence,detect-beads,migrate-beads,detect-ticketing,convert-ticketing}
-    list                list tasks (default: short ids; use --full-ids for
-                        scripts)
-    show                show task state, activity, diagnoses, and compact
-                        evidence counts (use --json for the complete
-                        structured record)
-    summary             activity-only task narrative (also included in `task
-                        show`)
-    ready               list task-ready work and the number of currently
-                        eligible fleet agents
-    why-unclaimed       show the authoritative task and agent reasons
-                        preventing a claim
-    claim               atomically claim a task for an agent
-    break-glass         admin-only: authorize an exact task/agent pair for
-                        single-use direct host execution
-    break-glass-list    list durable break-glass authorizations for a task
-    break-glass-revoke  admin-only: revoke an unclaimed host authorization
-    close               transition a task to completed/cancelled; cancellation
-                        requires a reason
-    cancel              actively cancel a task, revoke its lease, and abort a
-                        running worker executor
-    ask                 park a task on an unanswered human question (not a
-                        failure; never reaped)
-    needs-input         list tasks parked on an unanswered human question (the
-                        operator inbox)
-    edit                answer a parked task in $EDITOR; saving submits it
-                        back to the queue
-    answer              record the answer to a parked question and dispose of
-                        the task (resumes by default; --cancel when the answer
-                        is 'not needed')
-    reopen              recovery: return a stuck/terminal task
-                        (failed/cancelled/blocked) to OPEN for retry or
-                        reconciliation
-    recover-stranded    re-supervise tasks left waiting on a terminal
-                        dependency (dry-run unless --apply)
-    recover-finalizer   revalidate and publish preserved work refused for
-                        uncommitted new files
-    recover-stalled-finalizer
-                        resume a deterministic finalizer that stalled
-                        (timeout/cancel/crash) after harvesting verified work
-    force-complete      BREAK-GLASS operator override: mark a task COMPLETED
-                        regardless of state/review (bypasses the adversarial
-                        auto-land gate; audited). Not the normal path — the
-                        adversarial reviewer + contract gate auto-land is.
-    search              keyword search across task title and description
-    stats               count tasks by state
-    generator-yield     show each task origin's completion yield and whether
-                        the yield gate is letting it file
-    throughput          task-to-main KPIs, stage dwell, stranded work, and
-                        resource collisions
-    audit               read-only reconciliation of every task's history,
-                        evidence, dependencies, replacements, and git ancestry
-    release             clear a --no-dispatch hold so the task can auto-
-                        dispatch
-    detect-beads        inspect a repo for .beads/ artifacts (read-only)
-    migrate-beads       import .beads/issues.jsonl into MAC tasks and emit
-                        .tickets/<id>.md
-    detect-ticketing    detect ticketing sources in a repo (.tickets local
-                        mirror / .beads foreign) and whether a one-way
-                        conversion should be offered (read-only)
-    convert-ticketing   one-way convert a detected foreign source (e.g. beads)
-                        into MAC ledger tasks plus optional local
-                        compatibility files (run after the user agrees)
+  SUBCOMMAND
 
 options:
-  -h, --help            show this help message and exit
+  -h, --help  show this help message and exit
+
+task -- one unit of work: the thing agents claim, run, and publish
+
+CRUD:
+  create  file a new task into the ledger
+  list    list tasks (default: short ids; use --full-ids for scripts)
+  show    show task state, activity, diagnoses, and compact evidence counts (use --json for the complete structured record)
+  update  change a task's fields (title, description, project, priority, capabilities, metadata, max attempts)
+  delete  actively cancel a task, revoke its lease, and abort a running worker executor (same as `cancel`)
+
+Finding work:
+  ready          list task-ready work and the number of currently eligible fleet agents
+  search         keyword search across task title and description
+  stats          count tasks by state
+  why-unclaimed  show the authoritative task and agent reasons preventing a claim
+  summary        activity-only task narrative (also included in `task show`)
+
+Execution:
+  claim    atomically claim a task for an agent
+  start
+  release  clear a --no-dispatch hold so the task can auto-dispatch
+  close    transition a task to completed/cancelled; cancellation requires a reason
+  reopen   recovery: return a stuck/terminal task (failed/cancelled/blocked) to OPEN for retry or reconciliation
+
+Review and evidence:
+  evidence
+  submit-review
+  force-complete  BREAK-GLASS operator override: mark a task COMPLETED regardless of state/review (bypasses the adversarial auto-land gate; audited). Not the normal path — the adversarial reviewer + contract gate auto-land is.
+  audit           read-only reconciliation of every task's history, evidence, dependencies, replacements, and git ancestry
+
+Human input:
+  ask          park a task on an unanswered human question (not a failure; never reaped)
+  answer       record the answer to a parked question and dispose of the task (resumes by default; --cancel when the answer is 'not needed')
+  needs-input  list tasks parked on an unanswered human question (the operator inbox)
+
+Recovery:
+  recover-stranded           re-supervise tasks left waiting on a terminal dependency (dry-run unless --apply)
+  recover-finalizer          revalidate and publish preserved work refused for uncommitted new files
+  recover-stalled-finalizer  resume a deterministic finalizer that stalled (timeout/cancel/crash) after harvesting verified work
+
+Break-glass:
+  break-glass         admin-only: authorize an exact task/agent pair for single-use direct host execution
+  break-glass-list    list durable break-glass authorizations for a task
+  break-glass-revoke  admin-only: revoke an unclaimed host authorization
+
+Reporting:
+  throughput       task-to-main KPIs, stage dwell, stranded work, and resource collisions
+  generator-yield  show each task origin's completion yield and whether the yield gate is letting it file
+
+Migration:
+  detect-beads       inspect a repo for .beads/ artifacts (read-only)
+  migrate-beads      import .beads/issues.jsonl into MAC tasks and emit .tickets/<id>.md
+  detect-ticketing   detect ticketing sources in a repo (.tickets local mirror / .beads foreign) and whether a one-way conversion should be offered (read-only)
+  convert-ticketing  one-way convert a detected foreign source (e.g. beads) into MAC ledger tasks plus optional local compatibility files (run after the user agrees)
+
+Other:
+  edit  answer a parked task in $EDITOR; saving submits it back to the queue
+
+Run `mac task help <subcommand>` for the arguments one takes.
 ```
 
 ## mac repo
 
 ```console
 $ mac repo --help
-usage: mac repo [-h] {refs} ...
+usage: mac repo [-h] {refs,help} ...
 
 positional arguments:
-  {refs}
-    refs      audit or prune task-owned remote branches
+  {refs,help}
+    refs       audit or prune task-owned remote branches
+    help       show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help   show this help message and exit
 ```
 
 ## mac project
 
 ```console
 $ mac project --help
-usage: mac project [-h]
-                   {create,register,pause,activate,list,show,update,unregister} ...
+usage: mac project [-h] SUBCOMMAND ...
 
 positional arguments:
-  {create,register,pause,activate,list,show,update,unregister}
-    register            register the current checkout, a local path, or
-                        GIT_URL[#BRANCH] as a project and create its contract-
-                        authoring task
-    pause               hold a project's tickets from autonomous dispatch
-    activate            open a project to autonomous dispatch
-    update              update project fields or its branch-qualified
-                        repository registration
-    unregister          remove a project; --force detaches historical tasks
-                        and disables linked checkout registrations
+  SUBCOMMAND
 
 options:
-  -h, --help            show this help message and exit
+  -h, --help  show this help message and exit
+
+project -- a unit of work ownership: repositories, policy, dispatch state
+
+CRUD:
+  create  create a project and its dispatch policy
+  list    list every project
+  show    show one project: policy, repositories, dispatch state
+  update  update project fields or its branch-qualified repository registration
+  delete  remove a project; --force detaches historical tasks and disables linked checkout registrations (same as `unregister`)
+
+Dispatch:
+  pause     hold a project's tickets from autonomous dispatch
+  activate  open a project to autonomous dispatch
+
+Repositories:
+  register  register the current checkout, a local path, or GIT_URL[#BRANCH] as a project and create its contract-authoring task
+
+Run `mac project help <subcommand>` for the arguments one takes.
 ```
 
 ## mac work-package
 
 ```console
 $ mac work-package --help
-usage: mac work-package [-h]
-                        {admit,list,show,readiness,activate,replan-preview,pause,replan,verify-output,accept-candidate,reject-candidate,assemble,assembly-status,assembly-claim,assemble-batch,certification-prepare,certification-status,certification-claim,certification-ingest,certification-run,reject-failed-certification,accept-certification,land,finalize-publication} ...
+usage: mac work-package [-h] SUBCOMMAND ...
 
 positional arguments:
-  {admit,list,show,readiness,activate,replan-preview,pause,replan,verify-output,accept-candidate,reject-candidate,assemble,assembly-status,assembly-claim,assemble-batch,certification-prepare,certification-status,certification-claim,certification-ingest,certification-run,reject-failed-certification,accept-certification,land,finalize-publication}
-    admit               compile, attest, and atomically materialize a held
-                        plan
-    readiness           show credential/capability activation blockers
-    replan-preview      compile and attest plan N+1, then report whether it
-                        can be applied
-    pause               raise the package Andon by exact plan-version and
-                        epoch CAS
-    replan              atomically install one paused package's compiled
-                        replacement plan
-    verify-output       controller-observe an immutable attempt and append its
-                        receipt
-    accept-candidate    accept one reviewed, controller-verified package
-                        candidate
-    reject-candidate    reject one package candidate and stage its bounded
-                        rework decision
-    assemble            freeze and assemble exact accepted inputs for one
-                        integration node
-    assembly-status     show an integrity-checked integration-batch snapshot
-    assembly-claim      claim an integration batch under the controller fence
-    assemble-batch      assemble a previously-created integration batch
-    certification-prepare
-                        prepare an immutable external-certifier job for an
-                        exact batch
-    certification-status
-                        show an integrity-checked certification job snapshot
-    certification-claim
-                        claim a certification job under its monotonic
-                        controller fence
-    certification-ingest
-                        ingest one exact fenced external-certifier result
-    certification-run   explicitly run and ingest a prepared OpenShell
-                        certification job
-    reject-failed-certification
-                        read back the atomic Andon disposition for a failed
-                        certification
-    accept-certification
-                        accept one exact passed certification for landing
-    land                land one accepted exact candidate on its registered
-                        repository
-    finalize-publication
-                        consume the exact landing receipt and complete the
-                        product graph
+  SUBCOMMAND
 
 options:
-  -h, --help            show this help message and exit
+  -h, --help  show this help message and exit
+
+work-package -- a task group: several tasks assembled, certified and landed together
+
+CRUD:
+  create  freeze and assemble exact accepted inputs for one integration node (same as `assemble`)
+  list    list work packages
+  show    show one work package: member tasks, plan, certification state
+  update  atomically install one paused package's compiled replacement plan (same as `replan`)
+
+Assembly:
+  assemble-batch   assemble a previously-created integration batch
+  assembly-claim   claim an integration batch under the controller fence
+  assembly-status  show an integrity-checked integration-batch snapshot
+  admit            compile, attest, and atomically materialize a held plan
+
+Planning:
+  replan-preview  compile and attest plan N+1, then report whether it can be applied
+  readiness       show credential/capability activation blockers
+
+Certification:
+  certification-prepare        prepare an immutable external-certifier job for an exact batch
+  certification-claim          claim a certification job under its monotonic controller fence
+  certification-run            explicitly run and ingest a prepared OpenShell certification job
+  certification-ingest         ingest one exact fenced external-certifier result
+  certification-status         show an integrity-checked certification job snapshot
+  accept-certification         accept one exact passed certification for landing
+  reject-failed-certification  read back the atomic Andon disposition for a failed certification
+
+Candidates:
+  accept-candidate  accept one reviewed, controller-verified package candidate
+  reject-candidate  reject one package candidate and stage its bounded rework decision
+  verify-output     controller-observe an immutable attempt and append its receipt
+
+Landing:
+  land                  land one accepted exact candidate on its registered repository
+  finalize-publication  consume the exact landing receipt and complete the product graph
+
+Dispatch:
+  pause     raise the package Andon by exact plan-version and epoch CAS
+  activate
+
+Not available for work-package: delete (no control-plane operation implements it)
+
+Run `mac work-package help <subcommand>` for the arguments one takes.
 ```
 
 ## mac directive
@@ -523,10 +486,10 @@ options:
 ```console
 $ mac directive --help
 usage: mac directive [-h]
-                     {propose,list,show,versions,check,impact,approve,activate,deactivate,effective,binding,waiver} ...
+                     {propose,list,show,versions,check,impact,approve,activate,deactivate,effective,binding,waiver,help} ...
 
 positional arguments:
-  {propose,list,show,versions,check,impact,approve,activate,deactivate,effective,binding,waiver}
+  {propose,list,show,versions,check,impact,approve,activate,deactivate,effective,binding,waiver,help}
     propose             validate and create an immutable directive version
     check               analyze exact policy, bindings, conflicts, and macro
                         effects
@@ -536,6 +499,7 @@ positional arguments:
     effective           render the currently active policy snapshot
     binding             hub-owned variable bindings
     waiver              audited exact-version repository/project exceptions
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -545,15 +509,16 @@ options:
 
 ```console
 $ mac hgx --help
-usage: mac hgx [-h] {capacity} ...
+usage: mac hgx [-h] {capacity,help} ...
 
 positional arguments:
-  {capacity}
-    capacity  plan, inspect, or explicitly create bounded standard-dind
-              capacity
+  {capacity,help}
+    capacity       plan, inspect, or explicitly create bounded standard-dind
+                   capacity
+    help           show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help       show this help message and exit
 ```
 
 ## mac openshell
@@ -561,10 +526,10 @@ options:
 ```console
 $ mac openshell --help
 usage: mac openshell [-h]
-                     {reconcile,sandbox-gc,reap-orphans,render-policy,policy,status} ...
+                     {reconcile,sandbox-gc,reap-orphans,render-policy,policy,status,help} ...
 
 positional arguments:
-  {reconcile,sandbox-gc,reap-orphans,render-policy,policy,status}
+  {reconcile,sandbox-gc,reap-orphans,render-policy,policy,status,help}
     reconcile           reconcile fleet OpenShell required/policy/deployment
                         status after host validation
     sandbox-gc          list or delete old orphaned MAC-owned OpenShell
@@ -574,6 +539,7 @@ positional arguments:
     render-policy       render the OpenShell guardrail policy from the
                         operator template for this fleet
     policy              MAC-managed OpenShell policies
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -583,12 +549,13 @@ options:
 
 ```console
 $ mac machine --help
-usage: mac machine [-h] {register,list,show} ...
+usage: mac machine [-h] {register,list,show,help} ...
 
 positional arguments:
-  {register,list,show}
+  {register,list,show,help}
     list                list all registered machines
     show                show full record for one machine
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -598,47 +565,44 @@ options:
 
 ```console
 $ mac agent --help
-usage: mac agent [-h]
-                 {register,update,list,attestation-recover,report-executor-approve,report-executor-revoke,reflect,hardware,heartbeat,tell,deregister,delete,hold,resume,config,migrate} ...
+usage: mac agent [-h] SUBCOMMAND ...
 
 positional arguments:
-  {register,update,list,attestation-recover,report-executor-approve,report-executor-revoke,reflect,hardware,heartbeat,tell,deregister,delete,hold,resume,config,migrate}
-    attestation-recover
-                        admin-only conditional recovery for a missing/stale
-                        worker signing key
-    report-executor-approve
-                        approve the exact current startup-attested OpenShell
-                        report executor
-    report-executor-revoke
-                        revoke report-repository dispatch eligibility for an
-                        agent
-    reflect             publish an agent's runtime self-description over
-                        AgentBus
-    hardware            fleet hardware inventory from self-reported
-                        resources.hardware
-    tell                send a hub-verified HUMAN directive to any agent over
-                        AgentBus — works for Slack-less agents (GKE runners,
-                        ephemeral sessions); the receiver can trust its
-                        operator provenance by construction
-    deregister          graceful exit for a session/ephemeral agent:
-                        optionally leave one final human-facing message
-                        (delivered after the agent is gone), then tombstone
-                        with history preserved
-    delete              decommission (tombstone) an agent: strips operational
-                        overlays (moods/naps/config flags/deploy config) but
-                        preserves its AgentBus streams, events, deliveries,
-                        and task history
-    hold                place a dispatch hold on an agent; held agents are
-                        skipped during claim-next
-    resume              remove the dispatch hold from an agent, making it
-                        eligible for dispatch again
-    config              consolidated per-agent configuration (the 'geek
-                        knobs')
-    migrate             move an agent (soul + memory) to a new host; dry-run
-                        unless --execute
+  SUBCOMMAND
 
 options:
-  -h, --help            show this help message and exit
+  -h, --help  show this help message and exit
+
+agent -- a worker that claims and executes tasks on a machine
+
+CRUD:
+  create  register a new agent onto a machine (same as `register`)
+  list    list agents (--health adds liveness)
+  show    show one agent
+  update  change an agent's capabilities, status or metadata
+  delete  decommission (tombstone) an agent: strips operational overlays (moods/naps/config flags/deploy config) but preserves its AgentBus streams, events, deliveries, and task history
+
+Availability:
+  hold        place a dispatch hold on an agent; held agents are skipped during claim-next
+  resume      remove the dispatch hold from an agent, making it eligible for dispatch again
+  heartbeat
+  deregister  graceful exit for a session/ephemeral agent: optionally leave one final human-facing message (delivered after the agent is gone), then tombstone with history preserved
+
+Inspection:
+  config    consolidated per-agent configuration (the 'geek knobs')
+  hardware  fleet hardware inventory from self-reported resources.hardware
+  reflect   publish an agent's runtime self-description over AgentBus
+
+Communication:
+  tell  send a hub-verified HUMAN directive to any agent over AgentBus — works for Slack-less agents (GKE runners, ephemeral sessions); the receiver can trust its operator provenance by construction
+
+Administration:
+  attestation-recover      admin-only conditional recovery for a missing/stale worker signing key
+  report-executor-approve  approve the exact current startup-attested OpenShell report executor
+  report-executor-revoke   revoke report-repository dispatch eligibility for an agent
+  migrate                  move an agent (soul + memory) to a new host; dry-run unless --execute
+
+Run `mac agent help <subcommand>` for the arguments one takes.
 ```
 
 ## mac fleet
@@ -646,10 +610,10 @@ options:
 ```console
 $ mac fleet --help
 usage: mac fleet [-h]
-                 {build-distribution,target,backlog-groom,model-selection,ssh-spec,refresh-source,refresh,snapshot,soul-pull,soul-push,soul-audit,memory-export,memory-prune,refresh-context,validate,doctor,sync-token,creds-status,creds-sync,github-ingest,rotate-token,move-agent} ...
+                 {build-distribution,target,backlog-groom,model-selection,ssh-spec,refresh-source,refresh,snapshot,soul-pull,soul-push,soul-audit,memory-export,memory-prune,refresh-context,validate,doctor,sync-token,creds-status,creds-sync,github-ingest,rotate-token,move-agent,help} ...
 
 positional arguments:
-  {build-distribution,target,backlog-groom,model-selection,ssh-spec,refresh-source,refresh,snapshot,soul-pull,soul-push,soul-audit,memory-export,memory-prune,refresh-context,validate,doctor,sync-token,creds-status,creds-sync,github-ingest,rotate-token,move-agent}
+  {build-distribution,target,backlog-groom,model-selection,ssh-spec,refresh-source,refresh,snapshot,soul-pull,soul-push,soul-audit,memory-export,memory-prune,refresh-context,validate,doctor,sync-token,creds-status,creds-sync,github-ingest,rotate-token,move-agent,help}
     build-distribution  aggregate live agents by running_digest
     target              authoritative per-role fleet version pin (source rev +
                         OpenClaw VERSION/REVISION)
@@ -695,6 +659,7 @@ positional arguments:
                         entry, print redeploy command, and emit DB reconcile
                         commands. Dry-run by default; pass --execute to mutate
                         fleets.yaml.
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -704,16 +669,17 @@ options:
 
 ```console
 $ mac journal --help
-usage: mac journal [-h] {snapshot,list,restore} ...
+usage: mac journal [-h] {snapshot,list,restore,help} ...
 
 positional arguments:
-  {snapshot,list,restore}
+  {snapshot,list,restore,help}
     snapshot            snapshot SOUL/USER/MEMORY/memories/mood/config to
                         $HOME/.mac/journal/<date>/ and run
                         MAC_JOURNAL_BACKUP_HOOK if set
     list                list journaled snapshots
     restore             restore an agent's state from a journal date
                         (snapshots current state first, so it's reversible)
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -723,17 +689,18 @@ options:
 
 ```console
 $ mac optimizer --help
-usage: mac optimizer [-h] {status,tick,policy,experiment} ...
+usage: mac optimizer [-h] {status,tick,policy,experiment,help} ...
 
 Create allowlisted execution policies, run controlled task experiments, and
 promote only statistically superior, quality-noninferior treatments.
 
 positional arguments:
-  {status,tick,policy,experiment}
+  {status,tick,policy,experiment,help}
     status              show scheduler and active experiments
     tick                run one observation, decision, and hypothesis pass now
     policy              versioned execution-policy lifecycle
     experiment          controlled experiment lifecycle
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -743,14 +710,15 @@ options:
 
 ```console
 $ mac mood --help
-usage: mac mood [-h] {set,show,clear,history} ...
+usage: mac mood [-h] {set,show,clear,history,help} ...
 
 positional arguments:
-  {set,show,clear,history}
+  {set,show,clear,history,help}
     set                 record a mood transition
     show                current mood for an agent
     clear               end the active overlay
     history             mood transitions for an agent
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -760,10 +728,10 @@ options:
 
 ```console
 $ mac dream --help
-usage: mac dream [-h] {run,list,show,promote,discard,import-logs} ...
+usage: mac dream [-h] {run,list,show,promote,discard,import-logs,help} ...
 
 positional arguments:
-  {run,list,show,promote,discard,import-logs}
+  {run,list,show,promote,discard,import-logs,help}
     run                 curate memory into a reviewable candidate store
     list                list dream runs, newest first
     show                show a run, its gates and candidates
@@ -771,6 +739,7 @@ positional arguments:
     discard             discard a dream run
     import-logs         merge orphaned ~/.hermes/dream_logs reports into
                         durable memory
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -781,10 +750,10 @@ options:
 ```console
 $ mac nap --help
 usage: mac nap [-h]
-               {configure,show,next,begin,complete,fail,list,cycle,due,consolidate} ...
+               {configure,show,next,begin,complete,fail,list,cycle,due,consolidate,help} ...
 
 positional arguments:
-  {configure,show,next,begin,complete,fail,list,cycle,due,consolidate}
+  {configure,show,next,begin,complete,fail,list,cycle,due,consolidate,help}
     configure           set or refresh an agent's nap schedule (offset
                         defaults to a deterministic hash of agent.name)
     next                compute the next nap window
@@ -799,6 +768,7 @@ positional arguments:
     consolidate         walk the agent's recent memory_records, summarize by
                         task/project, write a nap_summary row per group, and
                         embed into the medium tier (mem-08)
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -808,26 +778,28 @@ options:
 
 ```console
 $ mac dispatch --help
-usage: mac dispatch [-h] {assign,tick} ...
+usage: mac dispatch [-h] {assign,tick,help} ...
 
 positional arguments:
-  {assign,tick}
+  {assign,tick,help}
+    help              show help for this command group
 
 options:
-  -h, --help     show this help message and exit
+  -h, --help          show this help message and exit
 ```
 
 ## mac message
 
 ```console
 $ mac message --help
-usage: mac message [-h] {send,inbox} ...
+usage: mac message [-h] {send,inbox,help} ...
 
 positional arguments:
-  {send,inbox}
+  {send,inbox,help}
+    help             show help for this command group
 
 options:
-  -h, --help    show this help message and exit
+  -h, --help         show this help message and exit
 ```
 
 ## mac agentbus
@@ -835,10 +807,11 @@ options:
 ```console
 $ mac agentbus --help
 usage: mac agentbus [-h]
-                    {open,append,close,list,read,publish,repo-update,artifact-publish} ...
+                    {open,append,close,list,read,publish,repo-update,artifact-publish,help} ...
 
 positional arguments:
-  {open,append,close,list,read,publish,repo-update,artifact-publish}
+  {open,append,close,list,read,publish,repo-update,artifact-publish,help}
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -848,15 +821,16 @@ options:
 
 ```console
 $ mac review --help
-usage: mac review [-h] {request,decision,auto-land,experiment} ...
+usage: mac review [-h] {request,decision,auto-land,experiment,help} ...
 
 positional arguments:
-  {request,decision,auto-land,experiment}
+  {request,decision,auto-land,experiment,help}
     auto-land           land a task/branch iff the contract gate is GREEN and
                         an independent adversarial reviewer APPROVEs (default-
                         to-reject)
     experiment          assign and inspect replayable review-strategy
                         experiments
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -882,26 +856,28 @@ options:
 
 ```console
 $ mac pull-request --help
-usage: mac pull-request [-h] {open} ...
+usage: mac pull-request [-h] {open,help} ...
 
 positional arguments:
-  {open}
-    open      open a PR/MR on github or gitea
+  {open,help}
+    open       open a PR/MR on github or gitea
+    help       show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help   show this help message and exit
 ```
 
 ## mac secret
 
 ```console
 $ mac secret --help
-usage: mac secret [-h] {set,list,delete,rotate,access,audits} ...
+usage: mac secret [-h] {set,list,delete,rotate,access,audits,help} ...
 
 positional arguments:
-  {set,list,delete,rotate,access,audits}
+  {set,list,delete,rotate,access,audits,help}
     delete              hard-delete a secret (scrub its value)
     rotate              rotate a secret's value in place (audited)
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -911,24 +887,26 @@ options:
 
 ```console
 $ mac runtime --help
-usage: mac runtime [-h] {create,list,delta} ...
+usage: mac runtime [-h] {create,list,delta,help} ...
 
 positional arguments:
-  {create,list,delta}
-    delta              runtime environment delta lifecycle
+  {create,list,delta,help}
+    delta               runtime environment delta lifecycle
+    help                show help for this command group
 
 options:
-  -h, --help           show this help message and exit
+  -h, --help            show this help message and exit
 ```
 
 ## mac artifact
 
 ```console
 $ mac artifact --help
-usage: mac artifact [-h] {register,list,show,delete} ...
+usage: mac artifact [-h] {register,list,show,delete,help} ...
 
 positional arguments:
-  {register,list,show,delete}
+  {register,list,show,delete,help}
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -938,12 +916,13 @@ options:
 
 ```console
 $ mac env --help
-usage: mac env [-h] {register,list,show,deploy,current,history} ...
+usage: mac env [-h] {register,list,show,deploy,current,history,help} ...
 
 positional arguments:
-  {register,list,show,deploy,current,history}
+  {register,list,show,deploy,current,history,help}
     deploy              record a new active deployment in an environment,
                         retiring the prior one
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -953,11 +932,12 @@ options:
 
 ```console
 $ mac bridge --help
-usage: mac bridge [-h] {import,list,repository} ...
+usage: mac bridge [-h] {import,list,repository,help} ...
 
 positional arguments:
-  {import,list,repository}
+  {import,list,repository,help}
     repository          registered project repository
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -967,10 +947,11 @@ options:
 
 ```console
 $ mac integrations --help
-usage: mac integrations [-h] {findings,observations} ...
+usage: mac integrations [-h] {findings,observations,help} ...
 
 positional arguments:
-  {findings,observations}
+  {findings,observations,help}
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -980,13 +961,14 @@ options:
 
 ```console
 $ mac curiosity --help
-usage: mac curiosity [-h] {list,approve,reject} ...
+usage: mac curiosity [-h] {list,approve,reject,help} ...
 
 positional arguments:
-  {list,approve,reject}
+  {list,approve,reject,help}
     list                list candidates
     approve             approve a quarantined candidate
     reject              reject a quarantined candidate
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -997,10 +979,10 @@ options:
 ```console
 $ mac memory --help
 usage: mac memory [-h]
-                  {decay,add,search,remember,list,forget,summarize-actions,embed,backfill,health,recall,recall-dreams} ...
+                  {decay,add,search,remember,list,forget,summarize-actions,embed,backfill,health,recall,recall-dreams,help} ...
 
 positional arguments:
-  {decay,add,search,remember,list,forget,summarize-actions,embed,backfill,health,recall,recall-dreams}
+  {decay,add,search,remember,list,forget,summarize-actions,embed,backfill,health,recall,recall-dreams,help}
     decay               dream-04: forget stale, low-salience memory records
                         (dry-run unless --apply); curated knowledge (user/proj
                         ect/feedback/deployment_learning/fleet_learning/dream/
@@ -1022,6 +1004,7 @@ positional arguments:
                         top ranked memory hits with their summaries
     recall-dreams       recall typed dream artifacts with
                         scope/kind/confidence filters
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -1032,10 +1015,11 @@ options:
 ```console
 $ mac rollout --help
 usage: mac rollout [-h]
-                   {create,list,advance,verify-artifact,health,rescue} ...
+                   {create,list,advance,verify-artifact,health,rescue,help} ...
 
 positional arguments:
-  {create,list,advance,verify-artifact,health,rescue}
+  {create,list,advance,verify-artifact,health,rescue,help}
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -1045,24 +1029,26 @@ options:
 
 ```console
 $ mac events --help
-usage: mac events [-h] {list} ...
+usage: mac events [-h] {list,help} ...
 
 positional arguments:
-  {list}
-    list      list events across task/rollout/eval_set/secret audit surfaces
+  {list,help}
+    list       list events across task/rollout/eval_set/secret audit surfaces
+    help       show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help   show this help message and exit
 ```
 
 ## mac action-events
 
 ```console
 $ mac action-events --help
-usage: mac action-events [-h] {list,stream,export-otlp} ...
+usage: mac action-events [-h] {list,stream,export-otlp,help} ...
 
 positional arguments:
-  {list,stream,export-otlp}
+  {list,stream,export-otlp,help}
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -1072,31 +1058,33 @@ options:
 
 ```console
 $ mac command-audit --help
-usage: mac command-audit [-h] {list} ...
+usage: mac command-audit [-h] {list,help} ...
 
 positional arguments:
-  {list}
-    list      list audited command start/completion events
+  {list,help}
+    list       list audited command start/completion events
+    help       show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help   show this help message and exit
 ```
 
 ## mac observability
 
 ```console
 $ mac observability --help
-usage: mac observability [-h] {list,prune} ...
+usage: mac observability [-h] {list,prune,help} ...
 
 positional arguments:
-  {list,prune}
-    list        list structured observability metrics and logs
-    prune       delete observability_events older than --older-than (ISO
-                timestamp) or keep only --keep-last rows; returns the number
-                removed
+  {list,prune,help}
+    list             list structured observability metrics and logs
+    prune            delete observability_events older than --older-than (ISO
+                     timestamp) or keep only --keep-last rows; returns the
+                     number removed
+    help             show help for this command group
 
 options:
-  -h, --help    show this help message and exit
+  -h, --help         show this help message and exit
 ```
 
 ## mac communication
@@ -1104,36 +1092,17 @@ options:
 ```console
 $ mac communication --help
 usage: mac communication [-h]
-                         {identity,account,representation,lease,send,deliveries} ...
+                         {identity,account,representation,lease,send,deliveries,help} ...
 
 positional arguments:
-  {identity,account,representation,lease,send,deliveries}
+  {identity,account,representation,lease,send,deliveries,help}
     identity            manage stable human-facing identities
     account             manage channel accounts owned by identities
     representation      map internal agents/roles/projects to public
                         identities
     lease               manage singleton gateway ownership of channel accounts
     send                enqueue an idempotent OpenClaw human-facing delivery
-
-options:
-  -h, --help            show this help message and exit
-```
-
-## mac comm
-
-```console
-$ mac comm --help
-usage: mac communication [-h]
-                         {identity,account,representation,lease,send,deliveries} ...
-
-positional arguments:
-  {identity,account,representation,lease,send,deliveries}
-    identity            manage stable human-facing identities
-    account             manage channel accounts owned by identities
-    representation      map internal agents/roles/projects to public
-                        identities
-    lease               manage singleton gateway ownership of channel accounts
-    send                enqueue an idempotent OpenClaw human-facing delivery
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -1143,10 +1112,11 @@ options:
 
 ```console
 $ mac notifier --help
-usage: mac notifier [-h] {configure,list,delete,deliver} ...
+usage: mac notifier [-h] {configure,list,delete,deliver,help} ...
 
 positional arguments:
-  {configure,list,delete,deliver}
+  {configure,list,delete,deliver,help}
+    help                show help for this command group
 
 options:
   -h, --help            show this help message and exit
@@ -1156,62 +1126,79 @@ options:
 
 ```console
 $ mac migrate --help
-usage: mac migrate [-h] {import,acc} ...
+usage: mac migrate [-h] {import,acc,help} ...
 
 positional arguments:
-  {import,acc}
-    import      replay a JSONL stream of {record:
-                tenant|user|task|evidence|history} rows
-    acc         dry-run or import an ACC SQLite database once
+  {import,acc,help}
+    import           replay a JSONL stream of {record:
+                     tenant|user|task|evidence|history} rows
+    acc              dry-run or import an ACC SQLite database once
+    help             show help for this command group
 
 options:
-  -h, --help    show this help message and exit
+  -h, --help         show this help message and exit
 ```
 
 ## mac workflow
 
 ```console
 $ mac workflow --help
-usage: mac workflow [-h] {decisions,start} ...
+usage: mac workflow [-h] {decisions,start,help} ...
 
 positional arguments:
-  {decisions,start}
-    decisions        list every human-decision (approval) gate in a workflow
-                     or a live run. Pass a workflow id/slug to see the
-                     definition's gates, or a run id (prefix run_) for live
-                     state.
-    start            start a workflow run, optionally with front-loaded
-                     approval decisions so the run can advance unattended.
+  {decisions,start,help}
+    decisions           list every human-decision (approval) gate in a
+                        workflow or a live run. Pass a workflow id/slug to see
+                        the definition's gates, or a run id (prefix run_) for
+                        live state.
+    start               start a workflow run, optionally with front-loaded
+                        approval decisions so the run can advance unattended.
+    help                show help for this command group
 
 options:
-  -h, --help         show this help message and exit
+  -h, --help            show this help message and exit
 ```
 
 ## mac eval
 
 ```console
 $ mac eval --help
-usage: mac eval [-h] {set,run} ...
+usage: mac eval [-h] {set,run,help} ...
 
 positional arguments:
-  {set,run}
-    set       eval set commands
-    run       eval run commands
+  {set,run,help}
+    set           eval set commands
+    run           eval run commands
+    help          show help for this command group
 
 options:
-  -h, --help  show this help message and exit
+  -h, --help      show this help message and exit
 ```
 
 ## mac plan
 
 ```console
 $ mac plan --help
-usage: mac plan [-h] {order} ...
+usage: mac plan [-h] {order,help} ...
 
 positional arguments:
-  {order}
-    order     order files/modules by import/call topology (leaf-first or core-
-              first layers)
+  {order,help}
+    order       order files/modules by import/call topology (leaf-first or
+                core-first layers)
+    help        show help for this command group
+
+options:
+  -h, --help    show this help message and exit
+```
+
+## mac help
+
+```console
+$ mac help --help
+usage: mac help [-h] [SUBCOMMAND]
+
+positional arguments:
+  SUBCOMMAND  scope help to one subcommand and show the arguments it takes
 
 options:
   -h, --help  show this help message and exit

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -48,16 +48,73 @@ The objects mac models. Start here:
   agent         a worker that claims and executes tasks on a machine
 
   Each supports: create, list, show, update, delete
+    except work-package, which has no delete or update
   `mac <object> help` lists its commands; `mac <object> help <subcommand>`
   shows the arguments that subcommand takes.
 
-Fleet operation and administration (50 more):
-  action-events agentbus artifact binding bridge client command-audit
-  communication config curiosity database diagnostics directive dispatch
-  dream env eval events fleet hermes hgx human-interface init integrations
-  interaction journal login logout machine memory message migrate mood nap
-  notifier observability openshell optimizer persona plan publish
-  pull-request repo review rollout runtime secret tenant user workflow
+Getting started:
+  init         create the control-plane schema in a PostgreSQL store
+  login        authenticate this machine against a hub
+  logout       discard stored hub credentials
+  config       read and migrate local mac configuration
+  diagnostics  run read-only control-plane health checks
+
+Fleet and machines:
+  fleet      deploy, inspect and maintain the fleet as a whole
+  machine    hosts that agents run on
+  hgx        HGX / GPU capacity management
+  openshell  sandboxed execution environments for agents
+  runtime    runtime images and environment definitions
+  rollout    staged rollout of a runtime or configuration
+  env        environment variables projected onto fleet hosts
+  secret     secret storage, rotation and access audit
+  database   control-plane database maintenance
+  migrate    schema and data migrations
+
+Getting work done:
+  dispatch      the loop that matches ready tasks to eligible agents
+  review        adversarial review of completed work
+  publish       publish reviewed work to its destination
+  pull-request  pull requests raised from task work
+  workflow      multi-step workflow definitions and runs
+  plan          planning helpers, including dependency ordering
+  eval          evaluation runs over agent output
+  optimizer     model and routing optimization
+  repo          repositories that tasks execute against
+  artifact      durable artifacts produced by task work
+
+What agents know:
+  memory           durable cross-session knowledge
+  journal          per-agent narrative history
+  mood             agent temperament and its effect on execution
+  nap              consolidation cycles that summarize recent work
+  dream            offline pattern-finding over past work
+  curiosity        quarantined self-proposed experiments awaiting judgment
+  human-interface  port an agent profile between Hermes and OpenClaw
+  persona          Hermes personas and their memory scopes
+
+Talking to people and systems:
+  message        messages between agents and humans
+  agentbus       the agent-to-agent message bus
+  communication  communication channels and routing
+  notifier       outbound notification channels
+  directive      operator directives issued to agents
+  hermes         Hermes instances and their context
+  binding        Hermes platform bindings
+  interaction    durable work created from a conversation
+  bridge         external system bridges
+  integrations   third-party integrations
+
+Who can do what:
+  tenant  tenant boundaries
+  user    human user identities
+  client  API clients and their principals
+
+Seeing what happened:
+  events         the unified event stream
+  action-events  recorded agent actions
+  observability  structured metrics and logs
+  command-audit  audit of commands agents ran
 
 Run `mac help <command>` for any of them.
 ```
@@ -67,6 +124,8 @@ Run `mac help <command>` for any of them.
 ```console
 $ mac diagnostics --help
 usage: mac diagnostics [-h] [--check CHECK]
+
+run read-only control-plane health checks
 
 options:
   -h, --help     show this help message and exit
@@ -79,6 +138,8 @@ options:
 $ mac init --help
 usage: mac init [-h]
 
+create the control-plane schema in a PostgreSQL store
+
 options:
   -h, --help  show this help message and exit
 ```
@@ -88,6 +149,8 @@ options:
 ```console
 $ mac database --help
 usage: mac database [-h] {migrate-sqlite-to-postgres,help} ...
+
+control-plane database maintenance
 
 positional arguments:
   {migrate-sqlite-to-postgres,help}
@@ -105,6 +168,8 @@ options:
 ```console
 $ mac config --help
 usage: mac config [-h] {migrate-env-namespace,help} ...
+
+read and migrate local mac configuration
 
 positional arguments:
   {migrate-env-namespace,help}
@@ -133,6 +198,8 @@ usage: mac login [-h] [--ssh SSH_TARGET] [--ssh-port SSH_PORT]
                  [--remote-port REMOTE_PORT] [--allow-elevated] [--rotate]
                  [--remote-mac REMOTE_MAC] [--connect-timeout CONNECT_TIMEOUT]
                  [{status,renew}]
+
+authenticate this machine against a hub
 
 positional arguments:
   {status,renew}        inspect or renew the selected login; omit to enroll
@@ -174,6 +241,8 @@ usage: mac logout [-h] [--profile LOGOUT_PROFILE] [--revoke]
                   [--remote-mac REMOTE_MAC]
                   [--connect-timeout CONNECT_TIMEOUT]
 
+discard stored hub credentials
+
 options:
   -h, --help            show this help message and exit
   --profile LOGOUT_PROFILE
@@ -188,6 +257,8 @@ options:
 ```console
 $ mac client --help
 usage: mac client [-h] {enroll,renew,revoke,list,profile,help} ...
+
+API clients and their principals
 
 positional arguments:
   {enroll,renew,revoke,list,profile,help}
@@ -210,6 +281,8 @@ options:
 $ mac tenant --help
 usage: mac tenant [-h] {register,list,help} ...
 
+tenant boundaries
+
 positional arguments:
   {register,list,help}
     help                show help for this command group
@@ -223,6 +296,8 @@ options:
 ```console
 $ mac user --help
 usage: mac user [-h] {register,help} ...
+
+human user identities
 
 positional arguments:
   {register,help}
@@ -238,6 +313,8 @@ options:
 $ mac persona --help
 usage: mac persona [-h] {register,help} ...
 
+Hermes personas and their memory scopes
+
 positional arguments:
   {register,help}
     help           show help for this command group
@@ -251,6 +328,8 @@ options:
 ```console
 $ mac human-interface --help
 usage: mac human-interface [-h] {port,check,help} ...
+
+port an agent profile between Hermes and OpenClaw
 
 positional arguments:
   {port,check,help}
@@ -270,6 +349,8 @@ options:
 $ mac hermes --help
 usage: mac hermes [-h] {register,context,work-context,runtime-proof,help} ...
 
+Hermes instances and their context
+
 positional arguments:
   {register,context,work-context,runtime-proof,help}
     help                show help for this command group
@@ -284,6 +365,8 @@ options:
 $ mac binding --help
 usage: mac binding [-h] {register,help} ...
 
+Hermes platform bindings
+
 positional arguments:
   {register,help}
     help           show help for this command group
@@ -297,6 +380,8 @@ options:
 ```console
 $ mac interaction --help
 usage: mac interaction [-h] {task,help} ...
+
+durable work created from a conversation
 
 positional arguments:
   {task,help}
@@ -383,6 +468,8 @@ Run `mac task help <subcommand>` for the arguments one takes.
 ```console
 $ mac repo --help
 usage: mac repo [-h] {refs,help} ...
+
+repositories that tasks execute against
 
 positional arguments:
   {refs,help}
@@ -488,6 +575,8 @@ $ mac directive --help
 usage: mac directive [-h]
                      {propose,list,show,versions,check,impact,approve,activate,deactivate,effective,binding,waiver,help} ...
 
+operator directives issued to agents
+
 positional arguments:
   {propose,list,show,versions,check,impact,approve,activate,deactivate,effective,binding,waiver,help}
     propose             validate and create an immutable directive version
@@ -511,6 +600,8 @@ options:
 $ mac hgx --help
 usage: mac hgx [-h] {capacity,help} ...
 
+HGX / GPU capacity management
+
 positional arguments:
   {capacity,help}
     capacity       plan, inspect, or explicitly create bounded standard-dind
@@ -527,6 +618,8 @@ options:
 $ mac openshell --help
 usage: mac openshell [-h]
                      {reconcile,sandbox-gc,reap-orphans,render-policy,policy,status,help} ...
+
+sandboxed execution environments for agents
 
 positional arguments:
   {reconcile,sandbox-gc,reap-orphans,render-policy,policy,status,help}
@@ -550,6 +643,8 @@ options:
 ```console
 $ mac machine --help
 usage: mac machine [-h] {register,list,show,help} ...
+
+hosts that agents run on
 
 positional arguments:
   {register,list,show,help}
@@ -612,6 +707,8 @@ $ mac fleet --help
 usage: mac fleet [-h]
                  {build-distribution,target,backlog-groom,model-selection,ssh-spec,refresh-source,refresh,snapshot,soul-pull,soul-push,soul-audit,memory-export,memory-prune,refresh-context,validate,doctor,sync-token,creds-status,creds-sync,github-ingest,rotate-token,move-agent,help} ...
 
+deploy, inspect and maintain the fleet as a whole
+
 positional arguments:
   {build-distribution,target,backlog-groom,model-selection,ssh-spec,refresh-source,refresh,snapshot,soul-pull,soul-push,soul-audit,memory-export,memory-prune,refresh-context,validate,doctor,sync-token,creds-status,creds-sync,github-ingest,rotate-token,move-agent,help}
     build-distribution  aggregate live agents by running_digest
@@ -671,6 +768,8 @@ options:
 $ mac journal --help
 usage: mac journal [-h] {snapshot,list,restore,help} ...
 
+per-agent narrative history
+
 positional arguments:
   {snapshot,list,restore,help}
     snapshot            snapshot SOUL/USER/MEMORY/memories/mood/config to
@@ -712,6 +811,8 @@ options:
 $ mac mood --help
 usage: mac mood [-h] {set,show,clear,history,help} ...
 
+agent temperament and its effect on execution
+
 positional arguments:
   {set,show,clear,history,help}
     set                 record a mood transition
@@ -729,6 +830,8 @@ options:
 ```console
 $ mac dream --help
 usage: mac dream [-h] {run,list,show,promote,discard,import-logs,help} ...
+
+offline pattern-finding over past work
 
 positional arguments:
   {run,list,show,promote,discard,import-logs,help}
@@ -751,6 +854,8 @@ options:
 $ mac nap --help
 usage: mac nap [-h]
                {configure,show,next,begin,complete,fail,list,cycle,due,consolidate,help} ...
+
+consolidation cycles that summarize recent work
 
 positional arguments:
   {configure,show,next,begin,complete,fail,list,cycle,due,consolidate,help}
@@ -780,6 +885,8 @@ options:
 $ mac dispatch --help
 usage: mac dispatch [-h] {assign,tick,help} ...
 
+the loop that matches ready tasks to eligible agents
+
 positional arguments:
   {assign,tick,help}
     help              show help for this command group
@@ -793,6 +900,8 @@ options:
 ```console
 $ mac message --help
 usage: mac message [-h] {send,inbox,help} ...
+
+messages between agents and humans
 
 positional arguments:
   {send,inbox,help}
@@ -809,6 +918,8 @@ $ mac agentbus --help
 usage: mac agentbus [-h]
                     {open,append,close,list,read,publish,repo-update,artifact-publish,help} ...
 
+the agent-to-agent message bus
+
 positional arguments:
   {open,append,close,list,read,publish,repo-update,artifact-publish,help}
     help                show help for this command group
@@ -822,6 +933,8 @@ options:
 ```console
 $ mac review --help
 usage: mac review [-h] {request,decision,auto-land,experiment,help} ...
+
+adversarial review of completed work
 
 positional arguments:
   {request,decision,auto-land,experiment,help}
@@ -842,6 +955,8 @@ options:
 $ mac publish --help
 usage: mac publish [-h] [--evidence-id EVIDENCE_ID] task_id target created_by
 
+publish reviewed work to its destination
+
 positional arguments:
   task_id
   target
@@ -858,6 +973,8 @@ options:
 $ mac pull-request --help
 usage: mac pull-request [-h] {open,help} ...
 
+pull requests raised from task work
+
 positional arguments:
   {open,help}
     open       open a PR/MR on github or gitea
@@ -872,6 +989,8 @@ options:
 ```console
 $ mac secret --help
 usage: mac secret [-h] {set,list,delete,rotate,access,audits,help} ...
+
+secret storage, rotation and access audit
 
 positional arguments:
   {set,list,delete,rotate,access,audits,help}
@@ -889,6 +1008,8 @@ options:
 $ mac runtime --help
 usage: mac runtime [-h] {create,list,delta,help} ...
 
+runtime images and environment definitions
+
 positional arguments:
   {create,list,delta,help}
     delta               runtime environment delta lifecycle
@@ -904,6 +1025,8 @@ options:
 $ mac artifact --help
 usage: mac artifact [-h] {register,list,show,delete,help} ...
 
+durable artifacts produced by task work
+
 positional arguments:
   {register,list,show,delete,help}
     help                show help for this command group
@@ -917,6 +1040,8 @@ options:
 ```console
 $ mac env --help
 usage: mac env [-h] {register,list,show,deploy,current,history,help} ...
+
+environment variables projected onto fleet hosts
 
 positional arguments:
   {register,list,show,deploy,current,history,help}
@@ -934,6 +1059,8 @@ options:
 $ mac bridge --help
 usage: mac bridge [-h] {import,list,repository,help} ...
 
+external system bridges
+
 positional arguments:
   {import,list,repository,help}
     repository          registered project repository
@@ -949,6 +1076,8 @@ options:
 $ mac integrations --help
 usage: mac integrations [-h] {findings,observations,help} ...
 
+third-party integrations
+
 positional arguments:
   {findings,observations,help}
     help                show help for this command group
@@ -962,6 +1091,8 @@ options:
 ```console
 $ mac curiosity --help
 usage: mac curiosity [-h] {list,approve,reject,help} ...
+
+quarantined self-proposed experiments awaiting judgment
 
 positional arguments:
   {list,approve,reject,help}
@@ -980,6 +1111,8 @@ options:
 $ mac memory --help
 usage: mac memory [-h]
                   {decay,add,search,remember,list,forget,summarize-actions,embed,backfill,health,recall,recall-dreams,help} ...
+
+durable cross-session knowledge
 
 positional arguments:
   {decay,add,search,remember,list,forget,summarize-actions,embed,backfill,health,recall,recall-dreams,help}
@@ -1017,6 +1150,8 @@ $ mac rollout --help
 usage: mac rollout [-h]
                    {create,list,advance,verify-artifact,health,rescue,help} ...
 
+staged rollout of a runtime or configuration
+
 positional arguments:
   {create,list,advance,verify-artifact,health,rescue,help}
     help                show help for this command group
@@ -1030,6 +1165,8 @@ options:
 ```console
 $ mac events --help
 usage: mac events [-h] {list,help} ...
+
+the unified event stream
 
 positional arguments:
   {list,help}
@@ -1046,6 +1183,8 @@ options:
 $ mac action-events --help
 usage: mac action-events [-h] {list,stream,export-otlp,help} ...
 
+recorded agent actions
+
 positional arguments:
   {list,stream,export-otlp,help}
     help                show help for this command group
@@ -1059,6 +1198,8 @@ options:
 ```console
 $ mac command-audit --help
 usage: mac command-audit [-h] {list,help} ...
+
+audit of commands agents ran
 
 positional arguments:
   {list,help}
@@ -1074,6 +1215,8 @@ options:
 ```console
 $ mac observability --help
 usage: mac observability [-h] {list,prune,help} ...
+
+structured metrics and logs
 
 positional arguments:
   {list,prune,help}
@@ -1093,6 +1236,8 @@ options:
 $ mac communication --help
 usage: mac communication [-h]
                          {identity,account,representation,lease,send,deliveries,help} ...
+
+communication channels and routing
 
 positional arguments:
   {identity,account,representation,lease,send,deliveries,help}
@@ -1114,6 +1259,8 @@ options:
 $ mac notifier --help
 usage: mac notifier [-h] {configure,list,delete,deliver,help} ...
 
+outbound notification channels
+
 positional arguments:
   {configure,list,delete,deliver,help}
     help                show help for this command group
@@ -1127,6 +1274,8 @@ options:
 ```console
 $ mac migrate --help
 usage: mac migrate [-h] {import,acc,help} ...
+
+schema and data migrations
 
 positional arguments:
   {import,acc,help}
@@ -1144,6 +1293,8 @@ options:
 ```console
 $ mac workflow --help
 usage: mac workflow [-h] {decisions,start,help} ...
+
+multi-step workflow definitions and runs
 
 positional arguments:
   {decisions,start,help}
@@ -1165,6 +1316,8 @@ options:
 $ mac eval --help
 usage: mac eval [-h] {set,run,help} ...
 
+evaluation runs over agent output
+
 positional arguments:
   {set,run,help}
     set           eval set commands
@@ -1180,6 +1333,8 @@ options:
 ```console
 $ mac plan --help
 usage: mac plan [-h] {order,help} ...
+
+planning helpers, including dependency ordering
 
 positional arguments:
   {order,help}

--- a/scripts/generate-docs-reference.py
+++ b/scripts/generate-docs-reference.py
@@ -87,7 +87,36 @@ def _normalize_usage(text: str) -> str:
     return "\n".join(out)
 
 
+def _commands_from_parser() -> tuple[str, ...]:
+    """Top-level commands read from the parser itself.
+
+    This function used to exist only as a regex over the ``{a,b,c}`` choices
+    line in ``mac --help``. That coupled the generator to one particular
+    rendering, and it broke the moment the help was rewritten to lead with the
+    four first-class objects instead of a 55-name brace list -- a documentation
+    generator failing because the thing it documents became easier to read.
+
+    The parser is the source the help is rendered FROM, so reading it cannot
+    drift from what is shown, and it still sees commands the help renders
+    compactly. Aliases share a parser object, so each is listed once.
+    """
+    from mac.cli import build_parser
+
+    parser = build_parser()
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            first_name_for: dict[int, str] = {}
+            for name, sub in action.choices.items():
+                first_name_for.setdefault(id(sub), name)
+            return tuple(first_name_for.values())
+    return ()
+
+
 def _top_level_commands(root_help: str) -> tuple[str, ...]:
+    commands = _commands_from_parser()
+    if commands:
+        return commands
+    # Fallback for a caller holding only help text.
     match = re.search(r"^\s*\{([^}]+)\}\s*$", root_help, re.MULTILINE)
     if match is None:
         raise RuntimeError("could not discover top-level commands from mac --help")

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -410,6 +410,54 @@ def _agent_hw_summary(d: dict) -> str:
     return " ".join(bits) or "-"
 
 
+def _blocking_dependency_lines(task: Dict[str, Any], detail: Any = None) -> List[str]:
+    """Name the dependencies holding this task, with their states.
+
+    A blocked task used to render as `dependencies: 1` and a diagnosis reading
+    "Task blocked: dependencies_incomplete", whose remediation advised running
+    `mac task show` -- the page already on screen. Everything needed was in the
+    record: metadata.dependency_resolution.unsatisfied maps each blocking
+    dependency to the state it is stuck in.
+
+    Titles are looked up when the detail payload carries them, because an id
+    alone still makes the reader run another command to learn anything.
+    """
+    metadata = task.get("metadata")
+    if not isinstance(metadata, dict):
+        return []
+    resolution = metadata.get("dependency_resolution")
+    if not isinstance(resolution, dict):
+        return []
+    unsatisfied = resolution.get("unsatisfied")
+    if not isinstance(unsatisfied, dict) or not unsatisfied:
+        return []
+
+    titles: Dict[str, str] = {}
+    if isinstance(detail, dict):
+        for key in ("dependency_tasks", "dependencies_detail", "blocked_by"):
+            for item in detail.get(key) or []:
+                if isinstance(item, dict) and item.get("id"):
+                    titles[str(item["id"])] = str(item.get("title") or "")
+
+    lines = ["  blocked by:"]
+    for dep_id, info in sorted(unsatisfied.items()):
+        state = ""
+        if isinstance(info, dict):
+            state = str(info.get("state") or "")
+        title = titles.get(dep_id, "")
+        lines.append(
+            "    %s  %s%s"
+            % (dep_id if _FULL_IDS else _short_task_id(dep_id), state or "unknown state", ("  " + title[:52]) if title else "")
+        )
+    # The next step, not a pointer back to this page.
+    lines.append(
+        "    -> fix the dependency above; this task dispatches when it completes"
+    )
+    lines.append("       (`mac task show <id>` for the blocker; `mac task cancel <id>` if")
+    lines.append("        it will never succeed)")
+    return lines
+
+
 def _one_liner(value: Any) -> str:
     """A single compact line for one record (task / agent / generic dict).
 
@@ -523,6 +571,12 @@ def _render_text(value: Any) -> str:
                 v = value.get(k, t.get(k))
                 if isinstance(v, list) and v:
                     lines.append("  %s: %d" % (k, len(v)))
+            # A blocked task's entire story is WHICH dependency is stuck and in
+            # what state. That was rendered as the bare count above --
+            # "dependencies: 1" -- while the record carried the id and the
+            # state all along, and the reader was then advised to run `mac task
+            # show`, the page they were already reading. Name the blockers.
+            lines.extend(_blocking_dependency_lines(t, value))
             llm_usage = value.get("llm_usage")
             if isinstance(llm_usage, dict):
                 route_count = int(llm_usage.get("observed_route_count") or 0)

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import os
 import shlex
 import shutil
@@ -449,12 +450,59 @@ def _blocking_dependency_lines(task: Dict[str, Any], detail: Any = None) -> List
             "    %s  %s%s"
             % (dep_id if _FULL_IDS else _short_task_id(dep_id), state or "unknown state", ("  " + title[:52]) if title else "")
         )
-    # The next step, not a pointer back to this page.
-    lines.append(
-        "    -> fix the dependency above; this task dispatches when it completes"
-    )
-    lines.append("       (`mac task show <id>` for the blocker; `mac task cancel <id>` if")
-    lines.append("        it will never succeed)")
+    # The next step, computed from THIS task's join policy and the blocker's
+    # actual state -- not generic prose.
+    #
+    # An earlier version of this advice said "cancel the dependency if it will
+    # never succeed", and that was wrong twice over. `cancel` is not a legal
+    # transition from `failed` at all (failed -> open is the only one), and
+    # even where it is legal it releases the parent only under an all_settled
+    # join; under all_success, the default, a cancelled dependency leaves the
+    # parent blocked for ever. Both facts are knowable from the record, so the
+    # advice is derived rather than asserted.
+    policy = metadata.get("dependency_policy")
+    coordination = metadata.get("coordination")
+    join = ""
+    if isinstance(policy, dict):
+        join = str(policy.get("join") or "")
+    if not join and isinstance(coordination, dict):
+        join = str(coordination.get("join_policy") or "")
+    if not join:
+        join = (
+            "all_settled"
+            if isinstance(coordination, dict)
+            and coordination.get("mode") == "cooperative_integration"
+            else "all_success"
+        )
+
+    terminal = [
+        dep_id
+        for dep_id, info in sorted(unsatisfied.items())
+        if isinstance(info, dict) and str(info.get("state")) in {"failed", "cancelled"}
+    ]
+    lines.append("    join: %s" % join)
+    if terminal and join != "all_settled":
+        lines.append(
+            "    -> under %s only a COMPLETED dependency releases this task." % join
+        )
+        lines.append(
+            "       `mac task reopen %s` to retry it (failed -> open is its only"
+            % (_short_task_id(terminal[0]) if not _FULL_IDS else terminal[0])
+        )
+        lines.append(
+            "       legal move). If it can never succeed, this task cannot run"
+        )
+        lines.append("       either -- cancel this task rather than the blocker.")
+    elif terminal:
+        lines.append(
+            "    -> under all_settled a terminal dependency already satisfies the"
+        )
+        lines.append("       join; if this task is still blocked, reopen it.")
+    else:
+        lines.append(
+            "    -> fix the dependency above; this task dispatches when it completes"
+        )
+        lines.append("       (`mac task show <id>` for the blocker)")
     return lines
 
 
@@ -10211,6 +10259,63 @@ def build_parser() -> argparse.ArgumentParser:
     return _install_cli_surface(parser)
 
 
+def _hub_error_message(exc: BaseException) -> Optional[str]:
+    """A one-line, actionable rendering of a hub refusal, or None to re-raise.
+
+    Returns None for anything that is not a hub transport error, so genuine
+    bugs keep their traceback -- suppressing those would trade one bad
+    experience for a worse one.
+    """
+    if type(exc).__name__ != "HubClientError":
+        return None
+    raw = str(exc)
+    detail = raw
+    # "HTTP 400 Bad Request: {"detail":"cannot transition ..."}"
+    _, _, body = raw.partition(": ")
+    if body.strip().startswith("{"):
+        try:
+            parsed = json.loads(body)
+            if isinstance(parsed, dict) and parsed.get("detail"):
+                detail = str(parsed["detail"])
+        except ValueError:
+            pass
+    hint = _transition_hint(detail)
+    return detail + hint
+
+
+def _transition_hint(detail: str) -> str:
+    """Say what IS possible when the hub refuses a state change.
+
+    "cannot transition task from failed to cancelled" is true and complete and
+    still leaves the reader guessing. The legal moves are in TASK_TRANSITIONS,
+    so name them rather than making someone read the state machine.
+    """
+    match = re.search(
+        r"cannot transition task from (\w+) to (\w+)", detail or ""
+    )
+    if not match:
+        return ""
+    current = match.group(1)
+    try:
+        from mac.models import TASK_TRANSITIONS
+
+        allowed = sorted(TASK_TRANSITIONS.get(current, set()))
+    except Exception:  # noqa: BLE001 - hint only
+        return ""
+    if not allowed:
+        return "\n  %s is terminal; nothing can move it." % current
+    verbs = {"open": "`mac task reopen <id>`"}
+    routes = ", ".join("%s (%s)" % (state, verbs.get(state, state)) if state in verbs else state
+                       for state in allowed)
+    extra = ""
+    if current == "failed" and "open" in allowed:
+        extra = (
+            "\n  To discard it instead: reopen first, then `mac task cancel` -- "
+            "cancelling is only legal from a live state."
+        )
+    return "\n  From %s the only legal move is: %s%s" % (current, routes, extra)
+
+
 def main(argv: Optional[Iterable[str]] = None) -> int:
     raw = list(argv) if argv is not None else list(sys.argv[1:])
     # --json is position-independent: strip it before argparse (so it works after
@@ -10227,6 +10332,17 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         return 1
     except json.JSONDecodeError as exc:
         print("invalid JSON: %s" % exc, file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 - a hub refusal is not a crash
+        # HubClientError is a RuntimeError, not a MACError, so a refusal the
+        # hub stated perfectly clearly -- "cannot transition task from failed
+        # to cancelled" -- reached the user as a 30-line traceback through
+        # urllib. A stack trace is what you print when you do not know what
+        # happened; the hub told us exactly what happened.
+        message = _hub_error_message(exc)
+        if message is None:
+            raise
+        print(message, file=sys.stderr)
         return 1
     return 0
 

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -3158,6 +3158,62 @@ def cmd_agent_update(args: argparse.Namespace) -> None:
     )
 
 
+def cmd_task_update(args: argparse.Namespace) -> None:
+    """Change a task's fields -- the CRUD `update` the CLI never exposed.
+
+    ControlPlane.update_task has always existed; nothing called it from the
+    command line, so the closest thing a user could find was `task edit`, which
+    is a different operation entirely: it opens $EDITOR to ANSWER a task parked
+    on a human question, and refuses unless the task is in NEEDS_INPUT. Aliasing
+    `update` onto that would have pointed the most predictable verb in the
+    vocabulary at something that does not do what it says.
+
+    Only the flags supplied are changed; everything omitted is left alone.
+    """
+    fields = {
+        "title": args.title,
+        "description": args.description,
+        "project": args.project,
+        "priority": args.priority,
+        "max_attempts": args.max_attempts,
+    }
+    if args.capabilities is not None:
+        fields["required_capabilities"] = [
+            item.strip() for item in args.capabilities.split(",") if item.strip()
+        ]
+    if args.description is None and getattr(args, "description_file", None):
+        fields["description"] = _read_text_arg(
+            None, args.description_file, label="--description", default=""
+        )
+    if args.metadata is not None or getattr(args, "metadata_file", None):
+        fields["metadata"] = _read_json_arg(
+            args.metadata,
+            getattr(args, "metadata_file", None),
+            label="--metadata",
+            default={},
+        )
+    supplied = {key: value for key, value in fields.items() if value is not None}
+    if not supplied:
+        raise SystemExit(
+            "nothing to update: supply at least one of --title, --description, "
+            "--project, --priority, --max-attempts, --capabilities, --metadata"
+        )
+    _print(
+        _plane(args).update_task(args.task_id, actor=args.actor, **supplied)
+    )
+
+
+def cmd_agent_show(args: argparse.Namespace) -> None:
+    """Read one agent -- the CRUD `show` every other first-class object had.
+
+    `mac agent config show` already existed and is richer (identity, runtime
+    flags, gateway-reported deploy config, mood), but it is a different
+    question. This is the plain read that makes the object's vocabulary
+    uniform: create, list, show, update, delete.
+    """
+    _print(_plane(args).get_agent(args.agent_id))
+
+
 def cmd_agent_list(args: argparse.Namespace) -> None:
     cp = _plane(args)
     rows = [agent.to_dict() if hasattr(agent, "to_dict") else dict(agent) for agent in cp.list_agents()]
@@ -6451,7 +6507,9 @@ def build_parser() -> argparse.ArgumentParser:
     _set(cmd_interaction_task, interaction_task)
 
     task = sub.add_parser("task", help="task ledger commands").add_subparsers(dest="task_command", required=True)
-    create = task.add_parser("create")
+    create = task.add_parser(
+        "create", help="file a new task into the ledger"
+    )
     create.add_argument("title")
     create.add_argument("--description", default="",
                         help="task description (use --description-file for multi-line / shell-hostile content)")
@@ -7058,7 +7116,9 @@ def build_parser() -> argparse.ArgumentParser:
     _set(cmd_repo_refs_reconcile, refs_reconcile)
 
     project = sub.add_parser("project", help="project summary commands").add_subparsers(dest="project_command", required=True)
-    project_create = project.add_parser("create")
+    project_create = project.add_parser(
+        "create", help="create a project and its dispatch policy"
+    )
     project_create.add_argument("name")
     project_create.add_argument("--description", default="")
     project_create.add_argument("--metadata", default="{}")
@@ -7125,9 +7185,11 @@ def build_parser() -> argparse.ArgumentParser:
     project_activate.add_argument("project")
     project_activate.add_argument("--actor", default="human")
     _set(cmd_project_activate, project_activate)
-    project_list = project.add_parser("list")
+    project_list = project.add_parser("list", help="list every project")
     _set(cmd_project_list, project_list)
-    project_show = project.add_parser("show")
+    project_show = project.add_parser(
+        "show", help="show one project: policy, repositories, dispatch state"
+    )
     project_show.add_argument("project")
     _set(cmd_project_show, project_show)
     project_update = project.add_parser(
@@ -7185,12 +7247,14 @@ def build_parser() -> argparse.ArgumentParser:
     wp_admit.add_argument("--tenant-id")
     wp_admit.add_argument("--root-task-id")
     _set(cmd_work_package_admit, wp_admit)
-    wp_list = work_package.add_parser("list")
+    wp_list = work_package.add_parser("list", help="list work packages")
     wp_list.add_argument("--state")
     wp_list.add_argument("--project")
     wp_list.add_argument("--limit", type=int, default=100)
     _set(cmd_work_package_list, wp_list)
-    wp_show = work_package.add_parser("show")
+    wp_show = work_package.add_parser(
+        "show", help="show one work package: member tasks, plan, certification state"
+    )
     wp_show.add_argument("package_id")
     _set(cmd_work_package_show, wp_show)
     wp_readiness = work_package.add_parser(
@@ -7769,7 +7833,9 @@ def build_parser() -> argparse.ArgumentParser:
     _set(cmd_machine_show, machine_show)
 
     agent = sub.add_parser("agent", help="agent registry commands").add_subparsers(dest="agent_command", required=True)
-    agent_register = agent.add_parser("register")
+    agent_register = agent.add_parser(
+        "register", help="register a new agent onto a machine"
+    )
     agent_register.add_argument("machine_id")
     agent_register.add_argument("name")
     agent_register.add_argument("--capabilities")
@@ -7785,14 +7851,47 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _set(cmd_agent_register, agent_register)
 
-    agent_update = agent.add_parser("update")
+    agent_update = agent.add_parser(
+        "update", help="change an agent's capabilities, status or metadata"
+    )
     agent_update.add_argument("agent_id")
     agent_update.add_argument(
         "--instance-kind", choices=("static", "fungible"), required=True
     )
     _set(cmd_agent_update, agent_update)
 
-    agent_list = agent.add_parser("list")
+    task_update = task.add_parser(
+        "update",
+        help="change a task's fields (title, description, project, priority, "
+        "capabilities, metadata, max attempts)",
+    )
+    task_update.add_argument("task_id")
+    task_update.add_argument("--title")
+    task_update.add_argument(
+        "--description",
+        help="new description (use --description-file for multi-line / shell-hostile content)",
+    )
+    task_update.add_argument("--description-file", dest="description_file")
+    task_update.add_argument("--project")
+    task_update.add_argument("--priority", type=int)
+    task_update.add_argument("--max-attempts", dest="max_attempts", type=int)
+    task_update.add_argument(
+        "--capabilities", help="comma-separated required capabilities (replaces the set)"
+    )
+    task_update.add_argument(
+        "--metadata", help="JSON metadata (use --metadata-file for shell-hostile content)"
+    )
+    task_update.add_argument("--metadata-file", dest="metadata_file")
+    task_update.add_argument("--actor", default="human")
+    _set(cmd_task_update, task_update)
+
+    agent_show = agent.add_parser("show", help="show one agent")
+    agent_show.add_argument("agent_id")
+    _set(cmd_agent_show, agent_show)
+
+    agent_list = agent.add_parser(
+        "list", help="list agents (--health adds liveness)"
+    )
     agent_list.add_argument("--health", action="store_true")
     _set(cmd_agent_list, agent_list)
 
@@ -10049,7 +10148,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _set(cmd_plan_order, plan_order)
 
-    return parser
+    # Discoverability layer, applied over the fully-built tree rather than
+    # at 265 registration sites: `help` as a verb at every level, the full
+    # CRUD vocabulary on the four first-class objects, and CRUD-first
+    # grouped help. Additive only -- every existing command keeps working.
+    from mac.cli_surface import install as _install_cli_surface
+
+    return _install_cli_surface(parser)
 
 
 def main(argv: Optional[Iterable[str]] = None) -> int:

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -411,7 +411,16 @@ def _agent_hw_summary(d: dict) -> str:
     return " ".join(bits) or "-"
 
 
-def _blocking_dependency_lines(task: Dict[str, Any], detail: Any = None) -> List[str]:
+#: Resolves a task id to its CURRENT state for the blocked-by section. Set by
+#: cmd_task_show, because _one_liner is a pure renderer with no control-plane
+#: handle of its own and threading one through every call site would be a large
+#: change for one line of output.
+_LIVE_TASK_STATE: Optional[Callable[[str], Optional[str]]] = None
+
+
+def _blocking_dependency_lines(
+    task: Dict[str, Any], detail: Any = None, live_state: Any = None
+) -> List[str]:
     """Name the dependencies holding this task, with their states.
 
     A blocked task used to render as `dependencies: 1` and a diagnosis reading
@@ -440,11 +449,25 @@ def _blocking_dependency_lines(task: Dict[str, Any], detail: Any = None) -> List
                 if isinstance(item, dict) and item.get("id"):
                     titles[str(item["id"])] = str(item.get("title") or "")
 
+    # The recorded state is a SNAPSHOT from the moment the block was observed,
+    # and it goes stale: cancelling a failed blocker leaves this map still
+    # saying "failed". That is not just a cosmetic lie -- the advice below
+    # branches on the state, so acting on a stale value gives stale advice.
+    # Resolve it live when the caller can.
+    states: Dict[str, str] = {}
+    for dep_id, info in unsatisfied.items():
+        recorded = str(info.get("state") or "") if isinstance(info, dict) else ""
+        current = ""
+        if callable(live_state):
+            try:
+                current = str(live_state(dep_id) or "")
+            except Exception:  # noqa: BLE001 - fall back to the snapshot
+                current = ""
+        states[dep_id] = current or recorded
+
     lines = ["  blocked by:"]
     for dep_id, info in sorted(unsatisfied.items()):
-        state = ""
-        if isinstance(info, dict):
-            state = str(info.get("state") or "")
+        state = states.get(dep_id, "")
         title = titles.get(dep_id, "")
         lines.append(
             "    %s  %s%s"
@@ -477,17 +500,22 @@ def _blocking_dependency_lines(task: Dict[str, Any], detail: Any = None) -> List
 
     terminal = [
         dep_id
-        for dep_id, info in sorted(unsatisfied.items())
-        if isinstance(info, dict) and str(info.get("state")) in {"failed", "cancelled"}
+        for dep_id in sorted(unsatisfied)
+        if states.get(dep_id) in {"failed", "cancelled"}
     ]
     lines.append("    join: %s" % join)
     if terminal and join != "all_settled":
         lines.append(
             "    -> under %s only a COMPLETED dependency releases this task." % join
         )
+        blocker = terminal[0]
+        blocker_state = states.get(blocker, "terminal")
         lines.append(
-            "       `mac task reopen %s` to retry it (failed -> open is its only"
-            % (_short_task_id(terminal[0]) if not _FULL_IDS else terminal[0])
+            "       `mac task reopen %s` to retry it (%s -> open is its only"
+            % (
+                blocker if _FULL_IDS else _short_task_id(blocker),
+                blocker_state,
+            )
         )
         lines.append(
             "       legal move). If it can never succeed, this task cannot run"
@@ -624,7 +652,9 @@ def _render_text(value: Any) -> str:
             # "dependencies: 1" -- while the record carried the id and the
             # state all along, and the reader was then advised to run `mac task
             # show`, the page they were already reading. Name the blockers.
-            lines.extend(_blocking_dependency_lines(t, value))
+            lines.extend(
+                _blocking_dependency_lines(t, value, live_state=_LIVE_TASK_STATE)
+            )
             llm_usage = value.get("llm_usage")
             if isinstance(llm_usage, dict):
                 route_count = int(llm_usage.get("observed_route_count") or 0)
@@ -2006,7 +2036,16 @@ def cmd_task_list(args: argparse.Namespace) -> None:
 
 def cmd_task_show(args: argparse.Namespace) -> None:
     """Show details for a task."""
-    _print(_plane(args).task_detail(args.task_id))
+    cp = _plane(args)
+    # Let the blocked-by section report each blocker's CURRENT state rather
+    # than the snapshot taken when the block was recorded. Cheap: only blocked
+    # tasks have blockers, and there are usually one or two.
+    global _LIVE_TASK_STATE
+    _LIVE_TASK_STATE = lambda dep_id: _task_state(cp, dep_id)
+    try:
+        _print(cp.task_detail(args.task_id))
+    finally:
+        _LIVE_TASK_STATE = None
 
 
 def cmd_database_migrate_sqlite_postgres(args: argparse.Namespace) -> None:
@@ -2363,6 +2402,41 @@ def cmd_task_cancel(args: argparse.Namespace) -> None:
     }
     if args.replacement_task:
         detail["replacement_task_id"] = args.replacement_task
+
+    # Cancelling means "make this task stop and go away", and that intent does
+    # not change because the task already failed. The state machine only allows
+    # failed -> open, so cancelling a failed task used to return a 400 and hand
+    # the operator a two-step dance (`reopen`, then `cancel`) to express one
+    # decision they had already made.
+    #
+    # Deliberately done HERE and not in the service: failed -> cancelled stays
+    # an illegal transition, because the state machine is an invariant other
+    # code reasons about. This is the human-facing command taking the two legal
+    # steps on the operator's behalf, and recording that it did so -- the
+    # reopen reason says it is part of a cancellation, so the history cannot be
+    # misread as someone intending a retry.
+    current = str(_task_state(cp, args.task_id) or "")
+    if current == TaskState.CANCELLED.value:
+        # Already where the operator wants it. Saying so beats a 400.
+        print("task %s is already cancelled" % args.task_id, file=sys.stderr)
+        _print(cp.get_task(args.task_id))
+        return
+    if current == TaskState.COMPLETED.value:
+        # The one terminal state that must NOT be walked back: completed work
+        # is a real outcome with evidence and a publication behind it, and
+        # quietly erasing it is not what anyone means by "cancel".
+        raise SystemExit(
+            "task %s is completed; cancelling would discard a finished result. "
+            "Use `mac task reopen %s` if it genuinely needs more work."
+            % (args.task_id, args.task_id)
+        )
+    if current == TaskState.FAILED.value:
+        cp.reopen_task(
+            args.task_id,
+            args.actor,
+            "reopened only to cancel: %s" % reason,
+        )
+
     result = cp.close_task(
         args.task_id,
         TaskState.CANCELLED.value,
@@ -2371,6 +2445,23 @@ def cmd_task_cancel(args: argparse.Namespace) -> None:
     )
     _maybe_emit_ticket(result, args, close_reason=reason)
     _print(result)
+
+
+def _task_state(cp: Any, task_id: str) -> Optional[str]:
+    """Current state of a task, or None if it cannot be read.
+
+    None deliberately means "carry on and let the hub decide": a read failure
+    must not turn a cancel into a refusal, since the transition itself is the
+    authority.
+    """
+    try:
+        task = cp.get_task(task_id)
+    except Exception:  # noqa: BLE001 - the transition below is the real gate
+        return None
+    record = task.to_dict() if hasattr(task, "to_dict") else task
+    if isinstance(record, dict):
+        return record.get("state")
+    return getattr(task, "state", None)
 
 
 def cmd_task_reopen(args: argparse.Namespace) -> None:

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -139,10 +139,19 @@ FIRST_CLASS: Tuple[ObjectSurface, ...] = (
             "create": "assemble",
             "list": "list",
             "show": "show",
-            "update": "replan",
-            # Honest gap: nothing in the control plane deletes or cancels a
-            # work package. Inventing an alias here would point `delete` at
-            # something that does not delete.
+            # Two honest gaps, held to the same standard as `task update`.
+            #
+            # `replan` is the nearest thing, and it is NOT a general update:
+            # ControlPlane.replan_work_package installs a COMPILED REPLACEMENT
+            # PLAN into a package that must already be paused. Someone typing
+            # `update` to change a field would hit a state error from a verb
+            # that promised otherwise, which is exactly the trap avoided by
+            # giving task a real update instead of aliasing it onto `edit`.
+            # The API agrees: there is no PUT /work-packages/{id}, only
+            # POST /work-packages/{id}/replan.
+            "update": None,
+            # Nothing in the control plane deletes or cancels a work package,
+            # and there is no DELETE /work-packages/{id} either.
             "delete": None,
         },
         groups=(

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -205,6 +205,112 @@ FIRST_CLASS: Tuple[ObjectSurface, ...] = (
 FIRST_CLASS_NAMES: Tuple[str, ...] = tuple(obj.name for obj in FIRST_CLASS)
 
 
+#: The other 50 top-level commands, grouped into the handful of concepts they
+#: actually belong to, each with a one-line description.
+#:
+#: Two problems, one table. A flat list of 50 names is not a menu, it is a
+#: wall -- and 42 of those 50 carried NO help text at all, so even reading the
+#: list told you almost nothing about what any of them did. Descriptions here
+#: are also pushed onto the commands themselves when they have none, so
+#: `mac help <command>` and the grouped listing improve together.
+#:
+#: A command missing from this table still appears, under "Other" -- the same
+#: safety net the per-object help uses, so a command added later cannot become
+#: invisible through nobody remembering this file.
+COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
+    (
+        "Getting started",
+        (
+            ("init", "create the control-plane schema in a PostgreSQL store"),
+            ("login", "authenticate this machine against a hub"),
+            ("logout", "discard stored hub credentials"),
+            ("config", "read and migrate local mac configuration"),
+            ("diagnostics", "run read-only control-plane health checks"),
+        ),
+    ),
+    (
+        "Fleet and machines",
+        (
+            ("fleet", "deploy, inspect and maintain the fleet as a whole"),
+            ("machine", "hosts that agents run on"),
+            ("hgx", "HGX / GPU capacity management"),
+            ("openshell", "sandboxed execution environments for agents"),
+            ("runtime", "runtime images and environment definitions"),
+            ("rollout", "staged rollout of a runtime or configuration"),
+            ("env", "environment variables projected onto fleet hosts"),
+            ("secret", "secret storage, rotation and access audit"),
+            ("database", "control-plane database maintenance"),
+            ("migrate", "schema and data migrations"),
+        ),
+    ),
+    (
+        "Getting work done",
+        (
+            ("dispatch", "the loop that matches ready tasks to eligible agents"),
+            ("review", "adversarial review of completed work"),
+            ("publish", "publish reviewed work to its destination"),
+            ("pull-request", "pull requests raised from task work"),
+            ("workflow", "multi-step workflow definitions and runs"),
+            ("plan", "planning helpers, including dependency ordering"),
+            ("eval", "evaluation runs over agent output"),
+            ("optimizer", "model and routing optimization"),
+            ("repo", "repositories that tasks execute against"),
+            ("artifact", "durable artifacts produced by task work"),
+        ),
+    ),
+    (
+        "What agents know",
+        (
+            ("memory", "durable cross-session knowledge"),
+            ("journal", "per-agent narrative history"),
+            ("mood", "agent temperament and its effect on execution"),
+            ("nap", "consolidation cycles that summarize recent work"),
+            ("dream", "offline pattern-finding over past work"),
+            ("curiosity", "quarantined self-proposed experiments awaiting judgment"),
+            ("human-interface", "port an agent profile between Hermes and OpenClaw"),
+            ("persona", "Hermes personas and their memory scopes"),
+        ),
+    ),
+    (
+        "Talking to people and systems",
+        (
+            ("message", "messages between agents and humans"),
+            ("agentbus", "the agent-to-agent message bus"),
+            ("communication", "communication channels and routing"),
+            ("notifier", "outbound notification channels"),
+            ("directive", "operator directives issued to agents"),
+            ("hermes", "Hermes instances and their context"),
+            ("binding", "Hermes platform bindings"),
+            ("interaction", "durable work created from a conversation"),
+            ("bridge", "external system bridges"),
+            ("integrations", "third-party integrations"),
+        ),
+    ),
+    (
+        "Who can do what",
+        (
+            ("tenant", "tenant boundaries"),
+            ("user", "human user identities"),
+            ("client", "API clients and their principals"),
+        ),
+    ),
+    (
+        "Seeing what happened",
+        (
+            ("events", "the unified event stream"),
+            ("action-events", "recorded agent actions"),
+            ("observability", "structured metrics and logs"),
+            ("command-audit", "audit of commands agents ran"),
+        ),
+    ),
+)
+
+
+def command_descriptions() -> Dict[str, str]:
+    """Flatten :data:`COMMAND_GROUPS` to command -> one-line description."""
+    return {name: text for _title, entries in COMMAND_GROUPS for name, text in entries}
+
+
 # ---------------------------------------------------------------------------
 # help as a verb
 # ---------------------------------------------------------------------------
@@ -456,31 +562,73 @@ def _top_level_help_text(action: argparse._SubParsersAction) -> str:
             rows.append((obj.name, obj.summary))
     lines.extend(_format_rows(rows))
     lines.append("")
+    # Stating a flat "each supports create/list/show/update/delete" would be
+    # untrue: work-package has neither an update nor a delete, on the CLI or
+    # the API. A summary line that overstates the vocabulary is the same class
+    # of problem as a verb that does not do what it says.
+    gaps = crud_gaps()
     lines.append("  Each supports: %s" % ", ".join(CRUD_VERBS))
+    for name, missing in sorted(gaps.items()):
+        lines.append("    except %s, which has no %s" % (name, " or ".join(sorted(missing))))
     lines.append("  `mac <object> help` lists its commands; `mac <object> help <subcommand>`")
     lines.append("  shows the arguments that subcommand takes.")
     lines.append("")
-    others = sorted(
+    registered = {
         name
         for name, _ in _distinct_subcommands(action)
         if name not in FIRST_CLASS_NAMES and name != "help"
-    )
-    if others:
-        lines.append("Fleet operation and administration (%d more):" % len(others))
-        # Names only. Listing 51 descriptions here is what made the original
-        # help unreadable; `mac <name> help` is one keystroke away.
-        width = 78
-        line = " "
-        for name in others:
-            if len(line) + len(name) + 2 > width:
-                lines.append(line)
-                line = " "
-            line += " " + name
-        if line.strip():
-            lines.append(line)
+    }
+    listed: set = set()
+    for title, entries in COMMAND_GROUPS:
+        rows = [(name, text) for name, text in entries if name in registered]
+        if not rows:
+            continue
+        listed.update(name for name, _ in rows)
+        lines.append("%s:" % title)
+        lines.extend(_format_rows(rows))
+        lines.append("")
+
+    # The safety net: a command added later, and never added to COMMAND_GROUPS,
+    # still shows up rather than silently disappearing from the help.
+    remaining = sorted(registered - listed)
+    if remaining:
+        lines.append("Other:")
+        lines.extend(
+            _format_rows([(name, _one_line_help(action, name)) for name in remaining])
+        )
         lines.append("")
     lines.append("Run `mac help <command>` for any of them.")
     return "\n".join(lines)
+
+
+def install_command_descriptions(parser: argparse.ArgumentParser) -> List[str]:
+    """Give every top-level command a one-line description if it lacks one.
+
+    42 of the 50 non-first-class commands had none, so ``mac help`` listed bare
+    names and ``mac <command> --help`` opened with a blank line. The catalogue
+    that groups them is the same one that describes them, so both surfaces
+    improve from one edit instead of drifting apart.
+
+    An existing description always wins: this fills gaps, it does not overrule
+    whoever wrote the command.
+    """
+    action = _subparsers_of(parser)
+    filled: List[str] = []
+    if action is None:
+        return filled
+    descriptions = command_descriptions()
+    for choice_action in action._choices_actions:
+        name = choice_action.dest
+        text = descriptions.get(name)
+        if not text or (choice_action.help or "").strip():
+            continue
+        choice_action.help = text
+        filled.append(name)
+    for name, text in descriptions.items():
+        sub = action.choices.get(name)
+        if sub is not None and not (sub.description or "").strip():
+            sub.description = text
+    return filled
 
 
 def install_top_level_help(parser: argparse.ArgumentParser) -> None:
@@ -500,6 +648,8 @@ def install(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     """
     install_crud_aliases(parser)
     install_help_verbs(parser)
+    # Descriptions before the grouped renderings, which read them.
+    install_command_descriptions(parser)
     install_object_help(parser)
     install_top_level_help(parser)
     return parser

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -311,6 +311,45 @@ def command_descriptions() -> Dict[str, str]:
     return {name: text for _title, entries in COMMAND_GROUPS for name, text in entries}
 
 
+#: Commands shown in the default ``mac help``, alongside the four first-class
+#: objects. Everything else is one flag away under ``mac help --all``.
+#:
+#: The operator asked for three tiers -- operator-facing, advanced, internal.
+#: This is two, and the collapse is deliberate: the difference between
+#: "advanced" and "internal" changes nothing a reader can act on, since both
+#: land in the same place (out of the default view, into ``--all``). A third
+#: label would be a distinction the output cannot express, so it would drift
+#: without anyone noticing it had.
+#:
+#: Chosen with reference counts as INPUT, not as the rule. Measured across
+#: docs/scripts/deploy/tests/src on 2026-08-07, `init` and `diagnostics` both
+#: have ZERO in-repo references and both are kept: init creates the schema and
+#: diagnostics is the first thing to run when something looks wrong, so a
+#: metric that hides them is measuring our automation's habits rather than a
+#: newcomer's needs. Conversely `bridge` has 37 references and is NOT here --
+#: they are almost all internal plumbing, not an operator reaching for it.
+COMMON_COMMANDS: Tuple[str, ...] = (
+    # You cannot use the tool at all without these.
+    "init",
+    "login",
+    "logout",
+    "config",
+    "diagnostics",
+    # Where work runs, and how it gets there.
+    "fleet",
+    "machine",
+    "repo",
+    "openshell",
+    # The lifecycle a task actually travels.
+    "dispatch",
+    "review",
+    "publish",
+    # What agents carry between tasks, and the credentials that let them run.
+    "memory",
+    "secret",
+)
+
+
 # ---------------------------------------------------------------------------
 # help as a verb
 # ---------------------------------------------------------------------------
@@ -350,7 +389,10 @@ def _one_line_help(action: argparse._SubParsersAction, name: str) -> str:
 
 
 def _make_help_handler(
-    parser: argparse.ArgumentParser, action: argparse._SubParsersAction
+    parser: argparse.ArgumentParser,
+    action: argparse._SubParsersAction,
+    *,
+    is_top_level: bool = False,
 ) -> Callable[[argparse.Namespace], None]:
     def handler(args: argparse.Namespace) -> None:
         topic = getattr(args, "help_topic", None)
@@ -363,6 +405,16 @@ def _make_help_handler(
                 return
             # Scoped one level further: the arguments this subcommand takes.
             target.print_help()
+            return
+        if getattr(args, "help_all", False) and is_top_level:
+            # Re-render with every command shown. The default view is a
+            # shortlist, not a claim that the rest do not exist.
+            previous = parser.epilog
+            try:
+                parser.epilog = _top_level_help_text(action, show_all=True)
+                parser.print_help()
+            finally:
+                parser.epilog = previous
             return
         parser.print_help()
 
@@ -391,7 +443,16 @@ def install_help_verbs(parser: argparse.ArgumentParser, *, _depth: int = 0) -> N
             metavar="SUBCOMMAND",
             help="scope help to one subcommand and show the arguments it takes",
         )
-        help_parser.set_defaults(func=_make_help_handler(parser, action))
+        if _depth == 0:
+            help_parser.add_argument(
+                "--all",
+                dest="help_all",
+                action="store_true",
+                help="list every command, not just the common ones",
+            )
+        help_parser.set_defaults(
+            func=_make_help_handler(parser, action, is_top_level=_depth == 0)
+        )
     for _name, sub in _distinct_subcommands(action):
         install_help_verbs(sub, _depth=_depth + 1)
 
@@ -554,7 +615,9 @@ def install_object_help(parser: argparse.ArgumentParser) -> None:
         _install_grouped_help(sub_parser, _object_help_text(obj, sub_action))
 
 
-def _top_level_help_text(action: argparse._SubParsersAction) -> str:
+def _top_level_help_text(
+    action: argparse._SubParsersAction, *, show_all: bool = False
+) -> str:
     lines = ["", "The objects mac models. Start here:", ""]
     rows = []
     for obj in FIRST_CLASS:
@@ -578,9 +641,10 @@ def _top_level_help_text(action: argparse._SubParsersAction) -> str:
         for name, _ in _distinct_subcommands(action)
         if name not in FIRST_CLASS_NAMES and name != "help"
     }
+    visible = registered if show_all else (registered & set(COMMON_COMMANDS))
     listed: set = set()
     for title, entries in COMMAND_GROUPS:
-        rows = [(name, text) for name, text in entries if name in registered]
+        rows = [(name, text) for name, text in entries if name in visible]
         if not rows:
             continue
         listed.update(name for name, _ in rows)
@@ -589,13 +653,24 @@ def _top_level_help_text(action: argparse._SubParsersAction) -> str:
         lines.append("")
 
     # The safety net: a command added later, and never added to COMMAND_GROUPS,
-    # still shows up rather than silently disappearing from the help.
-    remaining = sorted(registered - listed)
+    # still shows up under --all rather than silently disappearing from the
+    # help. It is not forced into the default view, because a command nobody
+    # has classified is not by that fact something a newcomer needs.
+    remaining = sorted(visible - listed)
     if remaining:
         lines.append("Other:")
         lines.extend(
             _format_rows([(name, _one_line_help(action, name)) for name in remaining])
         )
+        lines.append("")
+
+    hidden = len(registered - visible)
+    if hidden:
+        lines.append(
+            "%d more commands are available. `mac help --all` lists them, and "
+            "every one of them" % hidden
+        )
+        lines.append("runs whether it is listed or not -- nothing is removed.")
         lines.append("")
     lines.append("Run `mac help <command>` for any of them.")
     return "\n".join(lines)

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -1,0 +1,496 @@
+"""Make the CLI's first-class objects discoverable, uniform, and CRUD-first.
+
+`mac` grew to 55 top-level commands and 265 subcommands. Four of those commands
+are the objects the tool actually models -- **project, task, work-package
+(task groups), agent** -- and the other 51 are operational surface that
+accumulated around them. Handed to a beginner, the tool could not answer its
+own most basic question: ``mac task help`` was an error, and ``mac task
+--help`` printed a 34-name brace list in registration order with ``create``,
+``list`` and ``show`` scattered through it.
+
+The gaps were not uniform either. Measured on 2026-08-07:
+
+    project        create list show update  -- no delete (it is `unregister`)
+    task           create list show         -- no update (`edit`), no delete
+    work-package          list show         -- no create (`assemble`), no update
+    agent                 list      update delete  -- no create (`register`), no show
+
+So the same idea had a different name per object, and three of the five CRUD
+verbs were missing somewhere.
+
+This module fixes that as a LAYER over the built parser rather than by editing
+265 registration sites:
+
+* ``help`` becomes a verb at every level, scoping to that level, and
+  ``help <subcommand>`` scopes further to one subcommand's arguments.
+* Every first-class object exposes the full CRUD vocabulary, with the missing
+  verbs bound to the handler that already implements them. Nothing is
+  renamed and nothing is removed -- ``mac task edit`` keeps working, and
+  ``mac task update`` now reaches the same code.
+* Help for a first-class object lists CRUD first, then the operational verbs
+  in named groups, so the shape of the object is legible before its long tail.
+* Top-level help separates the four first-class objects from everything else.
+
+A deliberate non-goal: this does not delete or hide any existing command.
+265 subcommands are load-bearing for tests, scripts and the deploy path, and a
+discoverability change must not be a breaking change. Reducing the surface is a
+separate decision that wants its own pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+#: The verbs every first-class object exposes, in the order a newcomer needs
+#: them. Order is the point: ``create`` before ``show`` before the long tail.
+CRUD_VERBS: Tuple[str, ...] = ("create", "list", "show", "update", "delete")
+
+
+class ObjectSurface:
+    """How one first-class object presents itself.
+
+    ``crud`` maps each CRUD verb to the EXISTING subcommand that implements it.
+    A verb mapped to itself is already correctly named; a verb mapped to
+    another name gets an alias so both work; a verb mapped to ``None`` is a
+    genuine gap, and is reported as such rather than papered over with an
+    alias to something that does not mean the same thing.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        summary: str,
+        crud: Dict[str, Optional[str]],
+        groups: Sequence[Tuple[str, Sequence[str]]] = (),
+    ) -> None:
+        self.name = name
+        self.summary = summary
+        self.crud = crud
+        self.groups = list(groups)
+
+
+#: The four objects `mac` models. Everything else in the CLI acts ON these or
+#: administers the fleet that runs them.
+FIRST_CLASS: Tuple[ObjectSurface, ...] = (
+    ObjectSurface(
+        name="project",
+        summary="a unit of work ownership: repositories, policy, dispatch state",
+        crud={
+            "create": "create",
+            "list": "list",
+            "show": "show",
+            "update": "update",
+            # Projects are durable and audited; removing one unregisters it
+            # rather than destroying its history.
+            "delete": "unregister",
+        },
+        groups=(("Dispatch", ("pause", "activate")), ("Repositories", ("register",))),
+    ),
+    ObjectSurface(
+        name="task",
+        summary="one unit of work: the thing agents claim, run, and publish",
+        crud={
+            "create": "create",
+            "list": "list",
+            "show": "show",
+            # A real `mac task update` now exists (CLI parity with
+            # ControlPlane.update_task). It is deliberately NOT an alias of
+            # `edit`: edit opens $EDITOR to ANSWER a task parked on a human
+            # question and refuses unless the task is in NEEDS_INPUT, so
+            # pointing `update` at it would aim the most predictable verb in
+            # the vocabulary at something that does not do what it says.
+            "update": "update",
+            # A task is an audited record: cancelling IS its delete. Nothing
+            # in the ledger hard-deletes a task, and pretending otherwise
+            # would be the wrong promise to make a beginner.
+            "delete": "cancel",
+        },
+        groups=(
+            ("Finding work", ("ready", "search", "stats", "why-unclaimed", "summary")),
+            ("Execution", ("claim", "start", "release", "close", "reopen")),
+            ("Review and evidence", ("evidence", "submit-review", "force-complete", "audit")),
+            ("Human input", ("ask", "answer", "needs-input")),
+            (
+                "Recovery",
+                (
+                    "recover-stranded",
+                    "recover-finalizer",
+                    "recover-stalled-finalizer",
+                ),
+            ),
+            ("Break-glass", ("break-glass", "break-glass-list", "break-glass-revoke")),
+            ("Reporting", ("throughput", "generator-yield")),
+            (
+                "Migration",
+                (
+                    "detect-beads",
+                    "migrate-beads",
+                    "detect-ticketing",
+                    "convert-ticketing",
+                ),
+            ),
+        ),
+    ),
+    ObjectSurface(
+        name="work-package",
+        summary="a task group: several tasks assembled, certified and landed together",
+        crud={
+            "create": "assemble",
+            "list": "list",
+            "show": "show",
+            "update": "replan",
+            # Honest gap: nothing in the control plane deletes or cancels a
+            # work package. Inventing an alias here would point `delete` at
+            # something that does not delete.
+            "delete": None,
+        },
+        groups=(
+            ("Assembly", ("assemble", "assemble-batch", "assembly-claim", "assembly-status", "admit")),
+            ("Planning", ("replan", "replan-preview", "readiness")),
+            (
+                "Certification",
+                (
+                    "certification-prepare",
+                    "certification-claim",
+                    "certification-run",
+                    "certification-ingest",
+                    "certification-status",
+                    "accept-certification",
+                    "reject-failed-certification",
+                ),
+            ),
+            ("Candidates", ("accept-candidate", "reject-candidate", "verify-output")),
+            ("Landing", ("land", "finalize-publication")),
+            ("Dispatch", ("pause", "activate")),
+        ),
+    ),
+    ObjectSurface(
+        name="agent",
+        summary="a worker that claims and executes tasks on a machine",
+        crud={
+            # Agents join the fleet by registering; that is their create.
+            "create": "register",
+            "list": "list",
+            "show": "show",
+            "update": "update",
+            "delete": "delete",
+        },
+        groups=(
+            ("Availability", ("hold", "resume", "heartbeat", "deregister")),
+            ("Inspection", ("config", "hardware", "reflect")),
+            ("Communication", ("tell",)),
+            (
+                "Administration",
+                (
+                    "attestation-recover",
+                    "report-executor-approve",
+                    "report-executor-revoke",
+                    "migrate",
+                ),
+            ),
+        ),
+    ),
+)
+
+FIRST_CLASS_NAMES: Tuple[str, ...] = tuple(obj.name for obj in FIRST_CLASS)
+
+
+# ---------------------------------------------------------------------------
+# help as a verb
+# ---------------------------------------------------------------------------
+
+
+def _subparsers_of(parser: argparse.ArgumentParser) -> Optional[argparse._SubParsersAction]:
+    for action in parser._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    return None
+
+
+def _distinct_subcommands(
+    action: argparse._SubParsersAction,
+) -> List[Tuple[str, argparse.ArgumentParser]]:
+    """Registered names paired with their parser, aliases collapsed.
+
+    ``choices`` contains one entry per alias, all pointing at the same parser
+    object, so listing it directly would print every command twice once CRUD
+    aliases are installed.
+    """
+    seen: List[Tuple[str, argparse.ArgumentParser]] = []
+    claimed: set = set()
+    for name, sub in action.choices.items():
+        if id(sub) in claimed:
+            continue
+        claimed.add(id(sub))
+        seen.append((name, sub))
+    return seen
+
+
+def _one_line_help(action: argparse._SubParsersAction, name: str) -> str:
+    for choice_action in action._choices_actions:
+        if choice_action.dest == name:
+            return (choice_action.help or "").strip()
+    return ""
+
+
+def _make_help_handler(
+    parser: argparse.ArgumentParser, action: argparse._SubParsersAction
+) -> Callable[[argparse.Namespace], None]:
+    def handler(args: argparse.Namespace) -> None:
+        topic = getattr(args, "help_topic", None)
+        if topic:
+            target = action.choices.get(topic)
+            if target is None:
+                parser.print_help()
+                print()
+                print("unknown subcommand: %s" % topic)
+                return
+            # Scoped one level further: the arguments this subcommand takes.
+            target.print_help()
+            return
+        parser.print_help()
+
+    return handler
+
+
+def install_help_verbs(parser: argparse.ArgumentParser, *, _depth: int = 0) -> None:
+    """Add a ``help`` verb at every level that has subcommands.
+
+    ``mac help``, ``mac task help`` and ``mac task help create`` all work, each
+    scoping the output to that level. A beginner should never have to know that
+    ``--help`` is spelled with dashes while every other word is a verb.
+    """
+    if _depth > 6:  # defensive: the tree is 3 deep
+        return
+    action = _subparsers_of(parser)
+    if action is None:
+        return
+    if "help" not in action.choices:
+        help_parser = action.add_parser(
+            "help", help="show help for this command group"
+        )
+        help_parser.add_argument(
+            "help_topic",
+            nargs="?",
+            metavar="SUBCOMMAND",
+            help="scope help to one subcommand and show the arguments it takes",
+        )
+        help_parser.set_defaults(func=_make_help_handler(parser, action))
+    for _name, sub in _distinct_subcommands(action):
+        install_help_verbs(sub, _depth=_depth + 1)
+
+
+# ---------------------------------------------------------------------------
+# CRUD aliases
+# ---------------------------------------------------------------------------
+
+
+def install_crud_aliases(parser: argparse.ArgumentParser) -> Dict[str, List[str]]:
+    """Give every first-class object the full CRUD vocabulary.
+
+    An alias points a CRUD name at the parser that already implements the
+    behaviour, exactly as argparse's own ``aliases=`` does. The original name
+    keeps working: ``mac task edit`` and ``mac task update`` are the same
+    command, so nothing that exists today breaks.
+
+    Returns the aliases added per object, so a test can assert the mapping
+    rather than infer it.
+    """
+    action = _subparsers_of(parser)
+    added: Dict[str, List[str]] = {}
+    if action is None:
+        return added
+    for obj in FIRST_CLASS:
+        sub_parser = action.choices.get(obj.name)
+        if sub_parser is None:
+            continue
+        sub_action = _subparsers_of(sub_parser)
+        if sub_action is None:
+            continue
+        for verb, implementation in obj.crud.items():
+            if implementation is None or verb == implementation:
+                continue
+            if verb in sub_action.choices:
+                continue
+            target = sub_action.choices.get(implementation)
+            if target is None:
+                continue
+            sub_action._name_parser_map[verb] = target
+            added.setdefault(obj.name, []).append(verb)
+    return added
+
+
+def crud_gaps() -> Dict[str, List[str]]:
+    """CRUD verbs no implementation exists for, per object.
+
+    Reported rather than hidden: ``work-package`` has no delete, and a beginner
+    is better served by that being visible than by ``delete`` silently meaning
+    something else.
+    """
+    return {
+        obj.name: [verb for verb, impl in obj.crud.items() if impl is None]
+        for obj in FIRST_CLASS
+        if any(impl is None for impl in obj.crud.values())
+    }
+
+
+# ---------------------------------------------------------------------------
+# grouped help text
+# ---------------------------------------------------------------------------
+
+
+def _format_rows(rows: Sequence[Tuple[str, str]], indent: str = "  ") -> List[str]:
+    if not rows:
+        return []
+    width = max(len(name) for name, _ in rows)
+    return [("%s%-*s  %s" % (indent, width, name, text)).rstrip() for name, text in rows]
+
+
+def _object_help_text(obj: ObjectSurface, action: argparse._SubParsersAction) -> str:
+    """CRUD first, then named groups, then whatever is left over.
+
+    The leftover section matters: it is how a verb added later becomes visible
+    here without anyone remembering to update this file, instead of silently
+    vanishing from the help.
+    """
+    lines: List[str] = ["", "%s -- %s" % (obj.name, obj.summary), ""]
+    listed: set = set()
+
+    crud_rows: List[Tuple[str, str]] = []
+    for verb in CRUD_VERBS:
+        implementation = obj.crud.get(verb)
+        if implementation is None:
+            continue
+        text = _one_line_help(action, implementation) or _one_line_help(action, verb)
+        if implementation != verb:
+            text = "%s (same as `%s`)" % (text, implementation) if text else "same as `%s`" % implementation
+        crud_rows.append((verb, text))
+        listed.add(implementation)
+        listed.add(verb)
+    if crud_rows:
+        lines.append("CRUD:")
+        lines.extend(_format_rows(crud_rows))
+        lines.append("")
+
+    for title, verbs in obj.groups:
+        rows = [
+            (verb, _one_line_help(action, verb))
+            for verb in verbs
+            if verb in action.choices
+        ]
+        rows = [row for row in rows if row[0] not in listed]
+        if not rows:
+            continue
+        listed.update(name for name, _ in rows)
+        lines.append("%s:" % title)
+        lines.extend(_format_rows(rows))
+        lines.append("")
+
+    remaining = [
+        (name, _one_line_help(action, name))
+        for name, _ in _distinct_subcommands(action)
+        if name not in listed and name != "help"
+    ]
+    if remaining:
+        lines.append("Other:")
+        lines.extend(_format_rows(remaining))
+        lines.append("")
+
+    gaps = [verb for verb, impl in obj.crud.items() if impl is None]
+    if gaps:
+        lines.append(
+            "Not available for %s: %s (no control-plane operation implements it)"
+            % (obj.name, ", ".join(gaps))
+        )
+        lines.append("")
+
+    lines.append("Run `mac %s help <subcommand>` for the arguments one takes." % obj.name)
+    return "\n".join(lines)
+
+
+def _install_grouped_help(parser: argparse.ArgumentParser, text: str) -> None:
+    """Replace the default brace-list listing with grouped text.
+
+    The subcommand actions are hidden from the default formatter rather than
+    removed, so parsing is untouched and only the rendering changes.
+    """
+    action = _subparsers_of(parser)
+    if action is None:
+        return
+    action.metavar = "SUBCOMMAND"
+    action._choices_actions = []
+    parser.epilog = text
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
+
+
+def install_object_help(parser: argparse.ArgumentParser) -> None:
+    """Give each first-class object a CRUD-first, grouped help page."""
+    action = _subparsers_of(parser)
+    if action is None:
+        return
+    for obj in FIRST_CLASS:
+        sub_parser = action.choices.get(obj.name)
+        if sub_parser is None:
+            continue
+        sub_action = _subparsers_of(sub_parser)
+        if sub_action is None:
+            continue
+        _install_grouped_help(sub_parser, _object_help_text(obj, sub_action))
+
+
+def _top_level_help_text(action: argparse._SubParsersAction) -> str:
+    lines = ["", "The objects mac models. Start here:", ""]
+    rows = []
+    for obj in FIRST_CLASS:
+        if obj.name in action.choices:
+            rows.append((obj.name, obj.summary))
+    lines.extend(_format_rows(rows))
+    lines.append("")
+    lines.append("  Each supports: %s" % ", ".join(CRUD_VERBS))
+    lines.append("  `mac <object> help` lists its commands; `mac <object> help <subcommand>`")
+    lines.append("  shows the arguments that subcommand takes.")
+    lines.append("")
+    others = sorted(
+        name
+        for name, _ in _distinct_subcommands(action)
+        if name not in FIRST_CLASS_NAMES and name != "help"
+    )
+    if others:
+        lines.append("Fleet operation and administration (%d more):" % len(others))
+        # Names only. Listing 51 descriptions here is what made the original
+        # help unreadable; `mac <name> help` is one keystroke away.
+        width = 78
+        line = " "
+        for name in others:
+            if len(line) + len(name) + 2 > width:
+                lines.append(line)
+                line = " "
+            line += " " + name
+        if line.strip():
+            lines.append(line)
+        lines.append("")
+    lines.append("Run `mac help <command>` for any of them.")
+    return "\n".join(lines)
+
+
+def install_top_level_help(parser: argparse.ArgumentParser) -> None:
+    action = _subparsers_of(parser)
+    if action is None:
+        return
+    _install_grouped_help(parser, _top_level_help_text(action))
+
+
+def install(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Apply the whole surface layer to a built parser.
+
+    Ordering matters: aliases first so the help text can describe them, then
+    help verbs so they exist at every level including the new aliases, then the
+    grouped rendering, which hides the default listing and therefore must run
+    last.
+    """
+    install_crud_aliases(parser)
+    install_help_verbs(parser)
+    install_object_help(parser)
+    install_top_level_help(parser)
+    return parser

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -487,6 +487,28 @@ class RemoteDispatch:
     def task_detail(self, task_id: str) -> _Dictish:
         return _Dictish(self._get("/tasks/%s" % quote(task_id, safe="")))
 
+    def get_task(self, task_id: str) -> _Dictish:
+        """One task record, in hub mode.
+
+        The hub has served this all along -- GET /tasks/{task_id}, the same
+        route ``task_detail`` uses -- and only the wrapper was missing, so
+        anything calling ``cp.get_task`` fell through to ``__getattr__`` and
+        told the operator to "pass --db" instead. That advice is wrong for a
+        deployed fleet: --db is a direct control-plane authority for hub
+        maintenance, not a way to read a task the hub owns.
+
+        ``mac task edit`` was one of the callers, so a task parked on a human
+        question could not be answered from the command line at all.
+
+        The route returns the detail envelope; the bare task record is what
+        ``ControlPlane.get_task`` returns, so unwrap it and keep the two
+        interchangeable.
+        """
+        payload = self._get("/tasks/%s" % quote(task_id, safe=""))
+        if isinstance(payload, dict) and isinstance(payload.get("task"), dict):
+            return _Dictish(payload["task"])
+        return _Dictish(payload)
+
     def authorize_task_break_glass(
         self,
         task_id: str,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -804,11 +804,13 @@ def _failure_diagnosis(target_state: str, detail: Optional[Dict[str, Any]]) -> O
             "Task %s waiting on a dependency that has not produced its output."
             % target_state,
             "This task is fine; its input is not. `mac task show` lists the "
-            "blocking dependencies with their states -- open the one that is "
-            "failed or blocked and fix THAT; when it completes this task "
-            "dispatches on its own. If the dependency will never succeed, "
-            "`mac task cancel` it, or `mac task reopen` it once the cause is "
-            "fixed.",
+            "blocking dependencies with their states and the join policy, and "
+            "spells out the move for this task specifically. In general: fix "
+            "the blocker and this task dispatches on its own; a FAILED blocker "
+            "can only go to open (`mac task reopen`), not straight to "
+            "cancelled; and under the default all_success join nothing but a "
+            "COMPLETED dependency releases the parent, so if the blocker is "
+            "hopeless cancel THIS task rather than the blocker.",
         )
     if reason or problems_text or error:
         return note(

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -791,6 +791,25 @@ def _failure_diagnosis(target_state: str, detail: Optional[Dict[str, Any]]) -> O
             "Task failed after exhausting its retry budget (max_attempts).",
             "Inspect the per-attempt failures in history for the recurring cause; fix it, then `mac task reopen` (resets attempts) to retry, or decompose if the task is too large.",
         )
+    if "dependencies_incomplete" in blob or "dependency" in blob:
+        # The generic remediation below told the reader to run `mac task show`
+        # -- which is the page they were already reading when they saw it. A
+        # loop that hands back the same screen instead of the next step.
+        #
+        # A dependency block is never about THIS task. The work is in the
+        # dependency, so say that, and say what to do about each way it can be
+        # stuck. `task show` now names the blocking dependencies and their
+        # states, so this advice has something to point at.
+        return note(
+            "Task %s waiting on a dependency that has not produced its output."
+            % target_state,
+            "This task is fine; its input is not. `mac task show` lists the "
+            "blocking dependencies with their states -- open the one that is "
+            "failed or blocked and fix THAT; when it completes this task "
+            "dispatches on its own. If the dependency will never succeed, "
+            "`mac task cancel` it, or `mac task reopen` it once the cause is "
+            "fixed.",
+        )
     if reason or problems_text or error:
         return note(
             "Task %s: %s" % (target_state, reason or problems_text or error),

--- a/tests/cli/test_blocked_task_is_actionable.py
+++ b/tests/cli/test_blocked_task_is_actionable.py
@@ -75,8 +75,13 @@ def test_it_points_at_the_next_step_not_back_at_itself():
             "unsatisfied": {"task_dep": {"state": "failed"}}}}})
     )
 
-    assert "fix the dependency above" in text
-    assert "mac task cancel" in text
+    assert "join:" in text, "the advice must be grounded in this task's join"
+    assert "mac task reopen" in text, "no legal route forward named"
+    # NOT `mac task cancel <blocker>`: cancel is not a legal transition from
+    # failed, and under all_success a cancelled dependency would leave this
+    # task blocked anyway. An earlier version of this advice said exactly
+    # that and sent the operator into a 400.
+    assert "cancel this task rather than the blocker" in text
 
 
 def test_several_blockers_are_all_named():
@@ -144,7 +149,11 @@ def test_the_dependency_remediation_is_no_longer_circular():
         "the diagnosis does not tell the reader the work is elsewhere"
     )
     assert "blocking dependencies" in note
-    assert "mac task cancel" in note, "no route forward for a dead dependency"
+    assert "mac task reopen" in note, "no legal route forward for a failed blocker"
+    assert "not straight to" in note, (
+        "the advice must say cancel is illegal from failed; the first version "
+        "of it told the operator to cancel a failed task and produced a 400"
+    )
 
 
 def test_the_generic_remediation_is_still_used_for_other_failures():
@@ -154,3 +163,76 @@ def test_the_generic_remediation_is_still_used_for_other_failures():
     note = _failure_diagnosis("failed", {"reason": "executor exploded"})
 
     assert note and "executor exploded" in note
+
+
+# --------------------------------------------------------------------------
+# A hub refusal is not a crash
+# --------------------------------------------------------------------------
+
+
+def test_a_hub_refusal_renders_as_one_line_not_a_traceback():
+    """`mac task cancel` on a failed task produced ~30 lines of urllib stack.
+
+    HubClientError is a RuntimeError, not a MACError, so it escaped the CLI's
+    error handling entirely. A stack trace is what you print when you do not
+    know what happened; the hub had said exactly what happened.
+    """
+    from mac.cli import _hub_error_message
+    from mac.http_client import HubClientError
+
+    exc = HubClientError(
+        'HTTP 400 Bad Request: {"detail":"cannot transition task from failed to cancelled"}'
+    )
+    message = _hub_error_message(exc)
+
+    assert message.startswith("cannot transition task from failed to cancelled")
+    assert "Traceback" not in message
+    assert "urllib" not in message
+
+
+def test_the_refusal_names_what_is_actually_possible():
+    """"cannot transition from failed to cancelled" is true and still leaves
+    the reader guessing. The legal moves are in TASK_TRANSITIONS."""
+    from mac.cli import _hub_error_message
+    from mac.http_client import HubClientError
+
+    message = _hub_error_message(
+        HubClientError(
+            'HTTP 400 Bad Request: {"detail":"cannot transition task from failed to cancelled"}'
+        )
+    )
+
+    assert "only legal move is: open" in message
+    assert "mac task reopen" in message
+    assert "reopen first, then `mac task cancel`" in message
+
+
+def test_a_non_hub_exception_keeps_its_traceback():
+    """Genuine bugs must not be flattened into a friendly line.
+
+    Suppressing those would trade one bad experience for a worse one.
+    """
+    from mac.cli import _hub_error_message
+
+    assert _hub_error_message(ValueError("a real bug")) is None
+    assert _hub_error_message(KeyError("boom")) is None
+
+
+def test_a_refusal_without_a_json_body_still_renders():
+    from mac.cli import _hub_error_message
+    from mac.http_client import HubClientError
+
+    message = _hub_error_message(HubClientError("Connection refused"))
+
+    assert "Connection refused" in message
+
+
+def test_a_refusal_that_is_not_a_transition_gets_no_invented_hint():
+    from mac.cli import _hub_error_message
+    from mac.http_client import HubClientError
+
+    message = _hub_error_message(
+        HubClientError('HTTP 403 Forbidden: {"detail":"admin scope required"}')
+    )
+
+    assert message == "admin scope required"

--- a/tests/cli/test_blocked_task_is_actionable.py
+++ b/tests/cli/test_blocked_task_is_actionable.py
@@ -1,0 +1,156 @@
+"""A blocked task must say what is blocking it, and what to do next.
+
+Reported from real use on 2026-08-07. `mac task show task_c58a745d` rendered:
+
+    task_c58a745d blocked   nanolang  Make sdl_audio_wav.nano default to ...
+      dependencies: 1
+      ...
+    Activity:
+      - diagnosis / dependency-reconciliation
+          Problem: Task blocked: dependencies_incomplete
+          Remediation: Inspect the task evidence + history (`mac task show`)
+                       and the agent workspace logs for the root cause.
+
+Two defects in one screen. The blocking dependency was rendered as the bare
+count ``dependencies: 1`` while the record held both its id and its state, and
+the remediation told the reader to run the command they were already reading --
+advice that returns them to the same page. The operator's words: "the logic
+seems circular".
+
+The record had the whole story:
+
+    metadata.dependency_resolution.unsatisfied = {
+        "task_d9eef627...": {"state": "failed", ...}
+    }
+
+The task was waiting on "Add a license-clean, Mix_LoadWAV-playable WAV asset",
+which had failed 3/3. Nothing in the human-facing output said so.
+
+A blocked task is never about itself -- the work is in its dependency -- so the
+output now names the blockers with their states and points at the next command
+rather than back at itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.cli import _blocking_dependency_lines
+
+
+def _task(unsatisfied, **extra):
+    metadata = {
+        "dependency_resolution": {
+            "schema": "mac.dependency_resolution.v1",
+            "status": "unsatisfied",
+            "policy": "supervise",
+            "unsatisfied": unsatisfied,
+        }
+    }
+    metadata.update(extra)
+    return {"id": "task_child", "state": "blocked", "metadata": metadata}
+
+
+def test_the_blocking_dependency_is_named_with_its_state():
+    """The fact the reader needed and could not see."""
+    lines = _blocking_dependency_lines(
+        _task({"task_d9eef627fa4f4600a41656cb1254bb76": {"state": "failed"}})
+    )
+    text = "\n".join(lines)
+
+    assert "blocked by:" in text
+    assert "task_d9eef627" in text
+    assert "failed" in text
+
+
+def test_it_points_at_the_next_step_not_back_at_itself():
+    """The circularity the operator hit.
+
+    The old remediation said to run `mac task show`, which is the page that
+    printed it. Advice that returns the reader to where they already are is
+    worse than none: it reads like an answer.
+    """
+    text = "\n".join(
+        _blocking_dependency_lines({"metadata": {"dependency_resolution": {
+            "unsatisfied": {"task_dep": {"state": "failed"}}}}})
+    )
+
+    assert "fix the dependency above" in text
+    assert "mac task cancel" in text
+
+
+def test_several_blockers_are_all_named():
+    lines = _blocking_dependency_lines(
+        _task(
+            {
+                "task_aaaaaaaa1111": {"state": "failed"},
+                "task_bbbbbbbb2222": {"state": "blocked"},
+            }
+        )
+    )
+    text = "\n".join(lines)
+
+    assert "task_aaaaaaaa" in text and "failed" in text
+    assert "task_bbbbbbbb" in text and "blocked" in text
+
+
+def test_a_title_is_shown_when_the_payload_carries_one():
+    """An id alone still costs the reader another command."""
+    lines = _blocking_dependency_lines(
+        _task({"task_dep1": {"state": "failed"}}),
+        {"dependency_tasks": [{"id": "task_dep1", "title": "Add a WAV asset"}]},
+    )
+
+    assert "Add a WAV asset" in "\n".join(lines)
+
+
+def test_a_dependency_without_a_recorded_state_still_appears():
+    """Fail toward saying something. A blocker with no state is still a blocker."""
+    lines = _blocking_dependency_lines(_task({"task_dep1": {}}))
+
+    assert "task_dep1" in "\n".join(lines)
+    assert "unknown state" in "\n".join(lines)
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        {},
+        {"metadata": None},
+        {"metadata": {}},
+        {"metadata": {"dependency_resolution": None}},
+        {"metadata": {"dependency_resolution": {}}},
+        {"metadata": {"dependency_resolution": {"unsatisfied": {}}}},
+        {"metadata": {"dependency_resolution": {"unsatisfied": "junk"}}},
+    ],
+)
+def test_a_task_with_nothing_blocking_it_adds_no_noise(task):
+    """This section must appear only when there is something to say."""
+    assert _blocking_dependency_lines(task) == []
+
+
+def test_the_dependency_remediation_is_no_longer_circular():
+    """The generated advice, not just the rendering.
+
+    A NEW diagnosis for a dependency block must name the dependency as the
+    place to work, rather than pointing at `mac task show`.
+    """
+    from mac.services import _failure_diagnosis
+
+    note = _failure_diagnosis("blocked", {"reason": "dependencies_incomplete"})
+
+    assert note, "a dependency block produced no diagnosis at all"
+    assert "This task is fine; its input is not" in note, (
+        "the diagnosis does not tell the reader the work is elsewhere"
+    )
+    assert "blocking dependencies" in note
+    assert "mac task cancel" in note, "no route forward for a dead dependency"
+
+
+def test_the_generic_remediation_is_still_used_for_other_failures():
+    """Only the circular case changed; unrelated failures keep their advice."""
+    from mac.services import _failure_diagnosis
+
+    note = _failure_diagnosis("failed", {"reason": "executor exploded"})
+
+    assert note and "executor exploded" in note

--- a/tests/cli/test_cli_api_crud_parity.py
+++ b/tests/cli/test_cli_api_crud_parity.py
@@ -1,0 +1,148 @@
+"""The CLI and the API must expose the same CRUD vocabulary.
+
+A first-class object should mean the same thing whichever door you come in by.
+Measured on 2026-08-07, it did not: the HTTP API already had
+
+    PUT  /tasks/{task_id}        -- and the CLI had no `mac task update`
+    GET  /agents/{agent_id}      -- and the CLI had no `mac agent show`
+
+so two operations existed, were reachable over HTTP, and were simply
+unreachable from the command line. The CLI was the side that had drifted.
+
+These tests pin the two surfaces together, in both directions:
+
+  * every CRUD verb the CLI claims has a corresponding HTTP route, so the CLI
+    cannot promise something the control plane cannot do; and
+  * every CRUD route the API exposes has a CLI verb, so an operation cannot
+    again be reachable over HTTP and invisible from the terminal.
+
+Where an operation genuinely does not exist -- work-package has neither an
+update nor a delete on EITHER surface -- the two agree about that too, and the
+gap is asserted rather than quietly tolerated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import pytest
+
+from mac.cli import build_parser
+from mac.cli_surface import CRUD_VERBS, FIRST_CLASS
+
+#: HTTP shape of each CRUD verb, given a collection base path.
+#: ``show``/``update``/``delete`` address a single resource by id.
+_COLLECTION = {"create": "POST", "list": "GET"}
+_RESOURCE = {"show": "GET", "update": ("PUT", "PATCH"), "delete": "DELETE"}
+
+#: Collection route for each first-class object.
+BASE_PATH = {
+    "project": "/projects",
+    "task": "/tasks",
+    "agent": "/agents",
+    "work-package": "/work-packages",
+}
+
+
+@pytest.fixture(scope="module")
+def api_crud():
+    """Which CRUD verbs the HTTP API implements, per first-class object."""
+    os.environ.setdefault("MAC_SECRET_KEY", "x" * 40)
+    from mac.api import create_app
+    from mac.services import ControlPlane
+
+    app = create_app(control_plane=ControlPlane.in_memory())
+    routes = [
+        (sorted(r.methods - {"HEAD", "OPTIONS"}), r.path)
+        for r in app.routes
+        if hasattr(r, "methods")
+    ]
+    found = {}
+    for name, base in BASE_PATH.items():
+        verbs = set()
+        for methods, path in routes:
+            if path != base and not path.startswith(base + "/"):
+                continue
+            tail = path[len(base):]
+            resource = tail.startswith("/{") and tail.count("/") == 1
+            for method in methods:
+                for verb, wanted in _COLLECTION.items():
+                    if tail == "" and method == wanted:
+                        verbs.add(verb)
+                for verb, wanted in _RESOURCE.items():
+                    wanted = (wanted,) if isinstance(wanted, str) else wanted
+                    if resource and method in wanted:
+                        verbs.add(verb)
+        found[name] = verbs
+    return found
+
+
+@pytest.fixture(scope="module")
+def cli_crud():
+    parser = build_parser()
+    action = next(
+        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)
+    )
+    found = {}
+    for obj in FIRST_CLASS:
+        sub = action.choices[obj.name]
+        sub_action = next(
+            a for a in sub._actions if isinstance(a, argparse._SubParsersAction)
+        )
+        found[obj.name] = {v for v in CRUD_VERBS if v in sub_action.choices}
+    return found
+
+
+@pytest.mark.parametrize("obj", FIRST_CLASS, ids=lambda o: o.name)
+def test_the_cli_never_promises_more_than_the_api_implements(obj, cli_crud, api_crud):
+    """A CLI verb with no route behind it is a promise the tool cannot keep."""
+    extra = cli_crud[obj.name] - api_crud[obj.name]
+
+    assert not extra, (
+        "mac %s exposes %s with no corresponding HTTP route"
+        % (obj.name, sorted(extra))
+    )
+
+
+@pytest.mark.parametrize("obj", FIRST_CLASS, ids=lambda o: o.name)
+def test_the_api_never_implements_more_crud_than_the_cli_exposes(obj, cli_crud, api_crud):
+    """The direction that was actually broken.
+
+    PUT /tasks/{id} and GET /agents/{id} both existed while `mac task update`
+    and `mac agent show` did not, so two operations were reachable over HTTP
+    and invisible from the terminal.
+    """
+    missing = api_crud[obj.name] - cli_crud[obj.name]
+
+    assert not missing, (
+        "the API implements %s for %s and the CLI does not expose it"
+        % (sorted(missing), obj.name)
+    )
+
+
+@pytest.mark.parametrize("obj", FIRST_CLASS, ids=lambda o: o.name)
+def test_the_two_surfaces_agree_exactly(obj, cli_crud, api_crud):
+    assert cli_crud[obj.name] == api_crud[obj.name]
+
+
+def test_work_package_lacks_update_and_delete_on_both_surfaces(cli_crud, api_crud):
+    """The honest gap, held to the same standard on both sides.
+
+    `replan` is the nearest thing to an update and is not one: it installs a
+    compiled replacement plan into a package that must already be paused, and
+    the API agrees -- POST /work-packages/{id}/replan, no PUT.
+    """
+    assert "update" not in cli_crud["work-package"]
+    assert "update" not in api_crud["work-package"]
+    assert "delete" not in cli_crud["work-package"]
+    assert "delete" not in api_crud["work-package"]
+
+
+def test_the_other_three_objects_have_complete_crud(cli_crud, api_crud):
+    """Nothing else is allowed to be partial."""
+    for name in ("project", "task", "agent"):
+        assert cli_crud[name] == set(CRUD_VERBS), (
+            "mac %s is missing %s" % (name, sorted(set(CRUD_VERBS) - cli_crud[name]))
+        )
+        assert api_crud[name] == set(CRUD_VERBS)

--- a/tests/cli/test_cli_first_class_surface.py
+++ b/tests/cli/test_cli_first_class_surface.py
@@ -240,9 +240,9 @@ def test_top_level_help_leads_with_the_first_class_objects(parser, capsys):
     lead = out.index("The objects mac models")
     for name in FIRST_CLASS_NAMES:
         assert name in out
-    assert "Fleet operation and administration" in out
-    assert lead < out.index("Fleet operation and administration"), (
-        "the 51 non-first-class commands are listed before the 4 that matter"
+    assert "Getting started:" in out
+    assert lead < out.index("Getting started:"), (
+        "the 50 non-first-class commands are listed before the 4 that matter"
     )
 
 
@@ -289,3 +289,81 @@ def test_help_did_not_displace_a_real_subcommand(parser):
             continue
         assert action.choices["help"].get_default("func") is not None
         assert name != "help" or True
+
+
+# --------------------------------------------------------------------------
+# The other 50 commands: grouped, described, and none of them lost
+# --------------------------------------------------------------------------
+
+
+def test_every_grouped_command_actually_exists(parser):
+    """A catalogue entry naming a command that is gone documents nothing."""
+    from mac.cli_surface import command_descriptions
+
+    registered = set(_subparsers(parser).choices)
+    unknown = sorted(set(command_descriptions()) - registered)
+
+    assert not unknown, "COMMAND_GROUPS names commands that do not exist: %s" % unknown
+
+
+def test_every_top_level_command_appears_in_the_help(parser, capsys):
+    """The safety net. A command added later and never catalogued must still
+    show up under Other rather than vanishing from the help."""
+    parser.print_help()
+    out = capsys.readouterr().out
+
+    for name in _subparsers(parser).choices:
+        assert name in out, "mac %s appears nowhere in the top-level help" % name
+
+
+def test_every_top_level_command_has_a_description(parser, capsys):
+    """42 of the 50 had none, so the list was bare names.
+
+    Read from the rendered help rather than the catalogue, because the point
+    is what a person sees.
+    """
+    from mac.cli_surface import FIRST_CLASS_NAMES
+
+    parser.print_help()
+    out = capsys.readouterr().out
+    described = set()
+    for line in out.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.endswith(":"):
+            continue
+        name, _, text = stripped.partition("  ")
+        if name in _subparsers(parser).choices and text.strip():
+            described.add(name)
+
+    action = _subparsers(parser)
+    canonical = {}
+    for name, sub in action.choices.items():
+        canonical.setdefault(id(sub), set()).add(name)
+    missing = sorted(
+        sorted(names)[0]
+        for names in canonical.values()
+        if not (names & described) and "help" not in names
+    )
+    assert not missing, "no description in the help for: %s" % missing
+
+
+def test_the_first_class_objects_are_not_repeated_in_the_groups():
+    """They lead the help on their own; listing them twice dilutes that."""
+    from mac.cli_surface import FIRST_CLASS_NAMES, command_descriptions
+
+    overlap = set(command_descriptions()) & set(FIRST_CLASS_NAMES)
+
+    assert not overlap, "first-class objects duplicated in COMMAND_GROUPS: %s" % sorted(overlap)
+
+
+def test_the_crud_summary_line_does_not_overstate_the_vocabulary(parser, capsys):
+    """work-package has no update and no delete.
+
+    A summary claiming every object supports all five verbs is the same class
+    of problem as a verb that does not do what it says.
+    """
+    parser.print_help()
+    out = capsys.readouterr().out
+
+    assert "except work-package" in out
+    assert "no delete or update" in out

--- a/tests/cli/test_cli_first_class_surface.py
+++ b/tests/cli/test_cli_first_class_surface.py
@@ -1,0 +1,290 @@
+"""The CLI must be legible to someone who has never used it.
+
+Measured on the tree before this change: 55 top-level commands and 265
+subcommands. Four of those commands are the objects `mac` actually models --
+project, task, work-package (task groups), agent -- and the other 51 are
+operational surface accumulated around them.
+
+The tool could not answer its own most basic question. ``mac task help`` was an
+error, and ``mac task --help`` printed a 34-name brace list in registration
+order with ``create``, ``list`` and ``show`` scattered through it. The CRUD
+vocabulary was also inconsistent per object:
+
+    project        create list show update  -- no delete (it was `unregister`)
+    task           create list show         -- no update at all, no delete
+    work-package          list show         -- no create (`assemble`), no update
+    agent                 list      update delete  -- no create, no show
+
+So the same idea had a different name per object, and three of five CRUD verbs
+were missing somewhere.
+
+Two properties are asserted here, and the second matters as much as the first:
+
+  * the vocabulary is uniform and CRUD-first, with ``help`` a verb at every
+    level; and
+  * NOTHING was removed. 265 subcommands are load-bearing for tests, scripts
+    and the deploy path. A discoverability change that breaks callers is a
+    worse trade than the problem it solves, so every pre-existing command must
+    still parse and still reach the same handler.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from mac.cli import build_parser
+from mac.cli_surface import (
+    CRUD_VERBS,
+    FIRST_CLASS,
+    FIRST_CLASS_NAMES,
+    crud_gaps,
+)
+
+
+@pytest.fixture(scope="module")
+def parser():
+    return build_parser()
+
+
+def _subparsers(p):
+    for action in p._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            return action
+    return None
+
+
+def _command(parser, name):
+    return _subparsers(parser).choices[name]
+
+
+# --------------------------------------------------------------------------
+# help is a verb at every level
+# --------------------------------------------------------------------------
+
+
+def test_help_is_a_verb_at_the_top_level(parser):
+    assert "help" in _subparsers(parser).choices
+
+
+@pytest.mark.parametrize("name", FIRST_CLASS_NAMES)
+def test_help_is_a_verb_on_every_first_class_object(parser, name):
+    """`mac task help` was an error before this. It is the first thing a
+    newcomer types, and a tool that answers it with a usage error has failed
+    them at the first step."""
+    assert "help" in _subparsers(_command(parser, name)).choices
+
+
+def test_help_is_a_verb_on_every_command_that_has_subcommands(parser):
+    """Uniformity is the point: `help` must not work on some commands only.
+
+    A verb that is present on 4 of 55 commands is a trap, not a convention.
+    """
+    missing = []
+    for name, sub in _subparsers(parser).choices.items():
+        action = _subparsers(sub)
+        if action is not None and "help" not in action.choices:
+            missing.append(name)
+    assert not missing, "no `help` verb on: %s" % sorted(set(missing))
+
+
+def test_help_is_a_verb_at_the_third_level(parser):
+    """`mac agent config help` -- scoping has to go all the way down."""
+    config = _subparsers(_command(parser, "agent")).choices["config"]
+    assert "help" in _subparsers(config).choices
+
+
+def test_help_accepts_a_subcommand_to_scope_further(parser):
+    """`mac task help update` answers "what arguments does it take"."""
+    task_help = _subparsers(_command(parser, "task")).choices["help"]
+    args = task_help.parse_args(["update"])
+    assert args.help_topic == "update"
+
+
+def test_help_without_a_topic_is_valid(parser):
+    task_help = _subparsers(_command(parser, "task")).choices["help"]
+    assert task_help.parse_args([]).help_topic is None
+
+
+# --------------------------------------------------------------------------
+# CRUD is complete, uniform, and reaches real implementations
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("obj", FIRST_CLASS, ids=lambda o: o.name)
+def test_every_first_class_object_exposes_the_crud_vocabulary(parser, obj):
+    choices = _subparsers(_command(parser, obj.name)).choices
+    expected = [verb for verb in CRUD_VERBS if obj.crud.get(verb) is not None]
+    missing = [verb for verb in expected if verb not in choices]
+    assert not missing, "mac %s is missing %s" % (obj.name, missing)
+
+
+@pytest.mark.parametrize("obj", FIRST_CLASS, ids=lambda o: o.name)
+def test_a_crud_verb_reaches_the_same_handler_as_the_name_it_aliases(parser, obj):
+    """An alias must be the same command, not a similar one."""
+    choices = _subparsers(_command(parser, obj.name)).choices
+    for verb, implementation in obj.crud.items():
+        if implementation is None or verb == implementation:
+            continue
+        assert choices[verb] is choices[implementation], (
+            "mac %s %s and mac %s %s are different parsers"
+            % (obj.name, verb, obj.name, implementation)
+        )
+
+
+def test_task_update_is_not_an_alias_of_edit(parser):
+    """The alias that would have been wrong.
+
+    `mac task edit` opens $EDITOR to ANSWER a task parked on a human question
+    and refuses unless the task is in NEEDS_INPUT. Pointing `update` at it
+    would aim the most predictable verb in the vocabulary at something that
+    does not do what it says. ControlPlane.update_task already existed and
+    nothing called it from the command line.
+    """
+    choices = _subparsers(_command(parser, "task")).choices
+
+    assert choices["update"] is not choices["edit"]
+    assert choices["update"].get_default("func").__name__ == "cmd_task_update"
+
+
+@pytest.mark.parametrize(
+    "argv, handler",
+    [
+        (["task", "delete", "t_1"], "cmd_task_cancel"),
+        (["task", "cancel", "t_1"], "cmd_task_cancel"),
+        (["project", "delete", "p"], "cmd_project_unregister"),
+        (["project", "unregister", "p"], "cmd_project_unregister"),
+        (["agent", "create", "m", "n"], "cmd_agent_register"),
+        (["agent", "register", "m", "n"], "cmd_agent_register"),
+        (["agent", "show", "a_1"], "cmd_agent_show"),
+        (["task", "update", "t_1", "--title", "x"], "cmd_task_update"),
+    ],
+)
+def test_crud_verbs_dispatch_to_the_expected_handler(parser, argv, handler):
+    assert parser.parse_args(argv).func.__name__ == handler
+
+
+def test_a_missing_crud_verb_is_reported_rather_than_faked():
+    """work-package has no delete, and saying so beats aliasing it to something
+    that does not delete."""
+    gaps = crud_gaps()
+
+    assert gaps["work-package"] == ["delete"]
+
+
+def test_the_gap_is_named_in_the_objects_help(parser, capsys):
+    _command(parser, "work-package").print_help()
+    out = capsys.readouterr().out
+
+    assert "Not available for work-package: delete" in out
+
+
+# --------------------------------------------------------------------------
+# CRUD comes first, and the long tail is grouped
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("obj", FIRST_CLASS, ids=lambda o: o.name)
+def test_crud_is_listed_before_the_operational_verbs(parser, obj, capsys):
+    _command(parser, obj.name).print_help()
+    out = capsys.readouterr().out
+
+    assert "CRUD:" in out
+    crud_at = out.index("CRUD:")
+    for title, _verbs in obj.groups:
+        if "%s:" % title in out:
+            assert crud_at < out.index("%s:" % title), (
+                "%s is listed before CRUD for mac %s" % (title, obj.name)
+            )
+
+
+@pytest.mark.parametrize("obj", FIRST_CLASS, ids=lambda o: o.name)
+def test_every_crud_verb_has_help_text(parser, obj, capsys):
+    """A help page whose entries are blank is the defect, not the fix."""
+    _command(parser, obj.name).print_help()
+    out = capsys.readouterr().out
+    body = out[out.index("CRUD:") :]
+    section = body[: body.index("\n\n")]
+
+    for line in section.splitlines()[1:]:
+        verb, _, text = line.strip().partition(" ")
+        assert text.strip(), "mac %s %s has no help text" % (obj.name, verb)
+
+
+def test_a_verb_added_later_still_appears_somewhere(parser, capsys):
+    """The catch-all section is what stops a new command being invisible.
+
+    Grouping by an explicit list means a verb nobody adds to that list would
+    silently vanish from the help; the Other section is the safety net.
+    """
+    from mac.cli_surface import FIRST_CLASS as objs
+
+    task = next(o for o in objs if o.name == "task")
+    grouped = {v for _t, verbs in task.groups for v in verbs}
+    grouped |= {v for v in task.crud.values() if v} | set(CRUD_VERBS)
+    registered = set(_subparsers(_command(parser, "task")).choices) - {"help"}
+    ungrouped = registered - grouped
+
+    _command(parser, "task").print_help()
+    out = capsys.readouterr().out
+    for verb in ungrouped:
+        assert verb in out, "mac task %s appears nowhere in the help" % verb
+
+
+def test_top_level_help_leads_with_the_first_class_objects(parser, capsys):
+    parser.print_help()
+    out = capsys.readouterr().out
+
+    lead = out.index("The objects mac models")
+    for name in FIRST_CLASS_NAMES:
+        assert name in out
+    assert "Fleet operation and administration" in out
+    assert lead < out.index("Fleet operation and administration"), (
+        "the 51 non-first-class commands are listed before the 4 that matter"
+    )
+
+
+# --------------------------------------------------------------------------
+# nothing was taken away
+# --------------------------------------------------------------------------
+
+
+#: Commands that existed before the surface layer. Sampled across the whole
+#: tree rather than exhaustively: the point is that the layer is additive, and
+#: the full before/after tree diff is in the pull request.
+PRE_EXISTING = [
+    ["task", "create", "t"],
+    ["task", "edit", "t_1"],
+    ["task", "ready"],
+    ["task", "force-complete", "t_1"],
+    ["project", "unregister", "p"],
+    ["project", "pause", "p"],
+    ["agent", "register", "m", "n"],
+    ["agent", "heartbeat", "a_1"],
+    ["work-package", "list"],
+    ["fleet", "snapshot"],
+    ["memory", "list"],
+    ["diagnostics"],
+]
+
+
+@pytest.mark.parametrize("argv", PRE_EXISTING, ids=lambda a: " ".join(a))
+def test_pre_existing_commands_still_parse(parser, argv):
+    """265 subcommands are load-bearing for tests, scripts and the deploy path.
+
+    Discoverability must not be bought with a breaking change.
+    """
+    parsed = parser.parse_args(argv)
+
+    assert getattr(parsed, "func", None) is not None
+
+
+def test_help_did_not_displace_a_real_subcommand(parser):
+    """`help` is added, never substituted for something that was there."""
+    for name, sub in _subparsers(parser).choices.items():
+        action = _subparsers(sub)
+        if action is None:
+            continue
+        assert action.choices["help"].get_default("func") is not None
+        assert name != "help" or True

--- a/tests/cli/test_cli_first_class_surface.py
+++ b/tests/cli/test_cli_first_class_surface.py
@@ -170,14 +170,15 @@ def test_a_missing_crud_verb_is_reported_rather_than_faked():
     that does not delete."""
     gaps = crud_gaps()
 
-    assert gaps["work-package"] == ["delete"]
+    assert sorted(gaps["work-package"]) == ["delete", "update"]
 
 
 def test_the_gap_is_named_in_the_objects_help(parser, capsys):
     _command(parser, "work-package").print_help()
     out = capsys.readouterr().out
 
-    assert "Not available for work-package: delete" in out
+    assert "Not available for work-package" in out
+    assert "update" in out and "delete" in out
 
 
 # --------------------------------------------------------------------------

--- a/tests/cli/test_cli_first_class_surface.py
+++ b/tests/cli/test_cli_first_class_surface.py
@@ -306,26 +306,35 @@ def test_every_grouped_command_actually_exists(parser):
     assert not unknown, "COMMAND_GROUPS names commands that do not exist: %s" % unknown
 
 
-def test_every_top_level_command_appears_in_the_help(parser, capsys):
-    """The safety net. A command added later and never catalogued must still
-    show up under Other rather than vanishing from the help."""
-    parser.print_help()
-    out = capsys.readouterr().out
+def test_every_top_level_command_appears_under_help_all(parser):
+    """The safety net, now checked where completeness is promised.
+
+    The DEFAULT view is a deliberate shortlist, so the guarantee moved to
+    `mac help --all`: a command added later and never catalogued still shows
+    up there under Other rather than vanishing from the help entirely.
+    """
+    from mac.cli_surface import _subparsers_of, _top_level_help_text
+
+    text = _top_level_help_text(_subparsers_of(parser), show_all=True)
 
     for name in _subparsers(parser).choices:
-        assert name in out, "mac %s appears nowhere in the top-level help" % name
+        if name == "help":
+            continue
+        assert name in text, "mac %s appears nowhere in `mac help --all`" % name
 
 
-def test_every_top_level_command_has_a_description(parser, capsys):
+def test_every_top_level_command_has_a_description(parser):
     """42 of the 50 had none, so the list was bare names.
 
     Read from the rendered help rather than the catalogue, because the point
-    is what a person sees.
+    is what a person sees -- and from the --all rendering, because that is
+    where every command is promised to appear.
     """
     from mac.cli_surface import FIRST_CLASS_NAMES
 
-    parser.print_help()
-    out = capsys.readouterr().out
+    from mac.cli_surface import _subparsers_of, _top_level_help_text
+
+    out = _top_level_help_text(_subparsers_of(parser), show_all=True)
     described = set()
     for line in out.splitlines():
         stripped = line.strip()
@@ -367,3 +376,118 @@ def test_the_crud_summary_line_does_not_overstate_the_vocabulary(parser, capsys)
 
     assert "except work-package" in out
     assert "no delete or update" in out
+
+
+# --------------------------------------------------------------------------
+# Two tiers: a short default view, everything one flag away
+# --------------------------------------------------------------------------
+
+
+def test_the_default_help_shows_a_shortlist_not_everything(parser, capsys):
+    """The original complaint: the tool surfaced far more than its objects.
+
+    54 non-first-class commands in the default view is a wall. The shortlist
+    plus the four objects is a menu.
+    """
+    from mac.cli_surface import COMMON_COMMANDS
+
+    parser.print_help()
+    out = capsys.readouterr().out
+
+    registered = set(_subparsers(parser).choices)
+    hidden = [
+        name
+        for name in registered
+        if name not in COMMON_COMMANDS
+        and name not in FIRST_CLASS_NAMES
+        and name != "help"
+        and ("\n  %s " % name) not in out
+    ]
+    assert hidden, "the default help still lists everything"
+    assert len(hidden) > 25, "the default view was not meaningfully shortened"
+
+
+def test_the_default_help_says_how_to_see_the_rest(parser, capsys):
+    """A shortlist that does not admit it is one is a lie by omission."""
+    parser.print_help()
+    out = capsys.readouterr().out
+
+    assert "mac help --all" in out
+    assert "nothing is removed" in out
+
+
+def test_help_all_lists_every_command(parser, capsys):
+    """--all must be complete, or it is a second, longer shortlist."""
+    from mac.cli_surface import _subparsers_of, _top_level_help_text
+
+    action = _subparsers_of(parser)
+    text = _top_level_help_text(action, show_all=True)
+
+    for name, _sub in _distinct(parser):
+        if name == "help":
+            continue
+        assert name in text, "mac help --all omits %s" % name
+
+
+def _distinct(parser):
+    action = _subparsers(parser)
+    claimed, out = set(), []
+    for name, sub in action.choices.items():
+        if id(sub) in claimed:
+            continue
+        claimed.add(id(sub))
+        out.append((name, sub))
+    return out
+
+
+def test_the_help_verb_accepts_all_at_the_top_level(parser):
+    top_help = _subparsers(parser).choices["help"]
+
+    assert top_help.parse_args(["--all"]).help_all is True
+    assert top_help.parse_args([]).help_all is False
+
+
+def test_hidden_commands_still_parse_and_dispatch(parser):
+    """Hidden means absent from the default help, never absent from the tool.
+
+    This is the assertion that stops a presentation change from quietly
+    becoming a breaking one.
+    """
+    from mac.cli_surface import COMMON_COMMANDS
+
+    checked = 0
+    for name, sub in _distinct(parser):
+        if name in COMMON_COMMANDS or name in FIRST_CLASS_NAMES or name == "help":
+            continue
+        action = _subparsers(sub)
+        assert action is not None or sub.get_default("func") is not None, (
+            "mac %s is hidden and has no way to run" % name
+        )
+        if action is not None:
+            assert action.choices, "mac %s is hidden and has no subcommands" % name
+        checked += 1
+    assert checked > 25, "expected a substantial hidden set, checked %d" % checked
+
+
+def test_every_common_command_exists(parser):
+    """A shortlist naming a command that is gone is worse than no shortlist."""
+    from mac.cli_surface import COMMON_COMMANDS
+
+    registered = set(_subparsers(parser).choices)
+    unknown = sorted(set(COMMON_COMMANDS) - registered)
+
+    assert not unknown, "COMMON_COMMANDS names commands that do not exist: %s" % unknown
+
+
+def test_the_two_zero_reference_beginner_commands_are_kept():
+    """init and diagnostics have no in-repo references and are still shown.
+
+    Reference count measures our automation's habits, not a newcomer's needs.
+    init creates the schema; diagnostics is the first thing to run when
+    something looks wrong. A metric that hides those is the wrong metric, and
+    this pins the judgment so it is not silently 'optimized' later.
+    """
+    from mac.cli_surface import COMMON_COMMANDS
+
+    assert "init" in COMMON_COMMANDS
+    assert "diagnostics" in COMMON_COMMANDS

--- a/tests/cli/test_first_class_crud_cli.py
+++ b/tests/cli/test_first_class_crud_cli.py
@@ -195,3 +195,104 @@ def test_agent_create_is_the_same_command_as_register(tmp_path):
     assert rc == 0
     _rc, shown = _run(tmp_path, "agent", "show", created["id"])
     assert shown["name"] == "worker-b"
+
+
+# --------------------------------------------------------------------------
+# mac task cancel / delete from a terminal state
+# --------------------------------------------------------------------------
+
+
+def _force_state(tmp_path, task_id, state):
+    """Put a task into `state` in the SAME store the CLI reads.
+
+    Deliberately not ControlPlane(ephemeral_store(...)): that creates a NEW
+    schema, so the write lands somewhere the CLI never looks. Two tests here
+    passed vacuously that way -- cancelling from `open` succeeds regardless,
+    so they proved nothing about cancelling from a terminal state.
+    """
+    from mac.store import open_postgres_store
+
+    store = open_postgres_store(dsn_for(tmp_path), initialize_schema=False)
+    store.execute("UPDATE tasks SET state = ? WHERE id = ?", (state, task_id))
+
+
+def _state(tmp_path, task_id):
+    _rc, detail = _run(tmp_path, "task", "show", task_id)
+    task = detail.get("task", detail) if isinstance(detail, dict) else detail
+    return task.get("state")
+
+
+def test_cancelling_a_failed_task_succeeds(tmp_path, project):
+    """"Cancel" means make this stop and go away, and that intent does not
+    change because the task already failed.
+
+    The state machine only allows failed -> open, so this used to return
+    HTTP 400 and hand the operator a two-step dance to express one decision.
+    """
+    task = _task(tmp_path, project)
+    from mac.models import TaskState
+
+    _force_state(tmp_path, task["id"], TaskState.FAILED.value)
+
+    rc, _ = _run(tmp_path, "task", "cancel", task["id"], "--reason", "abandoned")
+
+    assert rc == 0
+    assert _state(tmp_path, task["id"]) == TaskState.CANCELLED.value
+
+
+def test_the_reopen_is_recorded_as_part_of_the_cancellation(tmp_path, project):
+    """The history must not read as though someone intended a retry."""
+    from mac.models import TaskState
+    task = _task(tmp_path, project)
+    _force_state(tmp_path, task["id"], TaskState.FAILED.value)
+    _run(tmp_path, "task", "cancel", task["id"], "--reason", "no licence-clean asset")
+
+    _rc, detail = _run(tmp_path, "task", "show", task["id"])
+    reasons = " ".join(
+        str((h.get("detail") or {}).get("reason", "")) for h in detail.get("history") or []
+    )
+
+    assert "reopened only to cancel" in reasons, (
+        "the reopen is indistinguishable from a genuine retry in the history"
+    )
+
+
+def test_cancelling_an_already_cancelled_task_is_not_an_error(tmp_path, project):
+    """It is already where the operator wants it; saying so beats a 400."""
+    from mac.models import TaskState
+    task = _task(tmp_path, project)
+    _force_state(tmp_path, task["id"], TaskState.CANCELLED.value)
+
+    rc, _ = _run(tmp_path, "task", "cancel", task["id"])
+
+    assert rc == 0
+    assert _state(tmp_path, task["id"]) == TaskState.CANCELLED.value
+
+
+def test_cancelling_a_completed_task_is_refused(tmp_path, project):
+    """The one terminal state that must NOT be walked back.
+
+    Completed work is a real outcome with evidence and a publication behind
+    it. Quietly erasing that is not what anyone means by "cancel".
+    """
+    from mac.models import TaskState
+    task = _task(tmp_path, project)
+    _force_state(tmp_path, task["id"], TaskState.COMPLETED.value)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, "task", "cancel", task["id"])
+
+    assert "completed" in str(excinfo.value)
+    assert _state(tmp_path, task["id"]) == TaskState.COMPLETED.value
+
+
+def test_delete_is_the_same_command_and_gets_the_same_behaviour(tmp_path, project):
+    """`task delete` aliases `cancel`, so it must inherit this too."""
+    from mac.models import TaskState
+    task = _task(tmp_path, project)
+    _force_state(tmp_path, task["id"], TaskState.FAILED.value)
+
+    rc, _ = _run(tmp_path, "task", "delete", task["id"], "--reason", "abandoned")
+
+    assert rc == 0
+    assert _state(tmp_path, task["id"]) == TaskState.CANCELLED.value

--- a/tests/cli/test_first_class_crud_cli.py
+++ b/tests/cli/test_first_class_crud_cli.py
@@ -1,0 +1,197 @@
+"""Behavioural coverage for the CRUD verbs the CLI was missing.
+
+Two of the five CRUD verbs on the first-class objects had no command at all:
+
+``mac task update``
+    ``ControlPlane.update_task`` has always existed and nothing called it from
+    the command line. The nearest thing a user could find was ``mac task
+    edit``, which is a different operation -- it opens $EDITOR to ANSWER a task
+    parked on a human question and refuses unless the task is in NEEDS_INPUT.
+
+``mac agent show``
+    Every other first-class object could be read by id. ``mac agent config
+    show`` existed and answers a richer question (identity, runtime flags,
+    gateway-reported deploy config, mood); the plain read did not exist.
+
+These run the real commands against a real control plane, so they cover the
+handlers rather than the parser wiring -- tests/cli/test_cli_first_class_surface.py
+covers the vocabulary and the aliasing.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import dsn_for
+
+
+def _run(tmp_path, *args):
+    """Run `mac --json --db <tmp> <args>` and return (rc, parsed_output)."""
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--json", "--db", dsn_for(tmp_path), *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, json.loads(raw) if raw else None
+
+
+@pytest.fixture()
+def project(tmp_path):
+    rc, _ = _run(tmp_path, "project", "create", "mac")
+    assert rc == 0
+    return "mac"
+
+
+def _task(tmp_path, project, title="original title"):
+    rc, task = _run(tmp_path, "task", "create", title, "--project", project)
+    assert rc == 0
+    return task
+
+
+# --------------------------------------------------------------------------
+# mac task update
+# --------------------------------------------------------------------------
+
+
+def test_task_update_changes_the_title(tmp_path, project):
+    task = _task(tmp_path, project)
+
+    rc, updated = _run(tmp_path, "task", "update", task["id"], "--title", "a better title")
+
+    assert rc == 0
+    assert updated["title"] == "a better title"
+
+
+def test_task_update_leaves_omitted_fields_alone(tmp_path, project):
+    """A partial update must not blank the fields it was not given."""
+    rc, task = _run(
+        tmp_path,
+        "task",
+        "create",
+        "keep my description",
+        "--project",
+        project,
+        "--description",
+        "the original description",
+        "--priority",
+        "3",
+    )
+    assert rc == 0
+
+    _rc, after = _run(tmp_path, "task", "update", task["id"], "--title", "renamed")
+
+    assert after["title"] == "renamed"
+    assert after["description"] == "the original description"
+    assert after["priority"] == 3
+
+
+def test_task_update_changes_priority_and_capabilities(tmp_path, project):
+    task = _task(tmp_path, project)
+
+    rc, updated = _run(
+        tmp_path,
+        "task",
+        "update",
+        task["id"],
+        "--priority",
+        "7",
+        "--capabilities",
+        "python,metal",
+    )
+
+    assert rc == 0
+    assert updated["priority"] == 7
+    assert sorted(updated["required_capabilities"]) == ["metal", "python"]
+
+
+def test_task_update_with_no_fields_is_refused(tmp_path, project):
+    """Silently succeeding on a no-op update would hide a typo'd flag."""
+    task = _task(tmp_path, project)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, "task", "update", task["id"])
+
+    assert "nothing to update" in str(excinfo.value)
+
+
+def test_task_update_reads_a_description_from_a_file(tmp_path, project):
+    """The repo's convention for multi-line / shell-hostile content."""
+    task = _task(tmp_path, project)
+    body = tmp_path / "body.txt"
+    body.write_text("a description with `backticks` and $VARS\nand a newline\n", encoding="utf-8")
+
+    rc, updated = _run(
+        tmp_path, "task", "update", task["id"], "--description-file", str(body)
+    )
+
+    assert rc == 0
+    assert "backticks" in updated["description"]
+    assert "\n" in updated["description"]
+
+
+def test_task_update_is_reachable_by_its_own_name(tmp_path, project):
+    """Not an alias of `edit`: `edit` refuses a task that is not NEEDS_INPUT,
+    and this one does not."""
+    task = _task(tmp_path, project)
+
+    rc, _ = _run(tmp_path, "task", "update", task["id"], "--title", "renamed")
+
+    assert rc == 0
+
+
+# --------------------------------------------------------------------------
+# mac agent show
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def agent(tmp_path):
+    rc, machine = _run(tmp_path, "machine", "register", "host-a")
+    assert rc == 0
+    rc, agent = _run(
+        tmp_path, "agent", "register", machine["id"], "worker-a", "--capabilities", "python"
+    )
+    assert rc == 0
+    return agent
+
+
+def test_agent_show_reads_one_agent(tmp_path, agent):
+    rc, shown = _run(tmp_path, "agent", "show", agent["id"])
+
+    assert rc == 0
+    assert shown["id"] == agent["id"]
+    assert shown["name"] == "worker-a"
+
+
+def test_agent_show_reports_an_unknown_agent(tmp_path, agent):
+    """A read of something absent must fail, not return an empty record.
+
+    The CLI maps a domain error to a non-zero exit and a stderr line rather
+    than letting the exception escape, so that is what a caller sees.
+    """
+    rc, payload = _run(tmp_path, "agent", "show", "agent_does_not_exist")
+
+    assert rc != 0
+    assert payload is None
+
+
+def test_agent_create_is_the_same_command_as_register(tmp_path):
+    """The alias has to actually register an agent, not merely parse."""
+    rc, machine = _run(tmp_path, "machine", "register", "host-b")
+    assert rc == 0
+
+    rc, created = _run(
+        tmp_path, "agent", "create", machine["id"], "worker-b", "--capabilities", "python"
+    )
+
+    assert rc == 0
+    _rc, shown = _run(tmp_path, "agent", "show", created["id"])
+    assert shown["name"] == "worker-b"


### PR DESCRIPTION
`mac` has **55 top-level commands and 265 subcommands**. Four of those commands are the objects it actually models — **project, task, work-package (task groups), agent** — and the other 51 are operational surface that accumulated around them.

The tool could not answer its own most basic question:

```
$ mac task help
mac task: error: argument task_command: invalid choice: 'help'
  (choose from 'create', 'list', 'show', 'summary', 'ready', 'why-unclaimed',
   'claim', 'break-glass', ... 34 names ...)
```

And the CRUD vocabulary was different per object. Measured before this change:

| object | had | missing |
|---|---|---|
| `project` | create list show update | **delete** (it was `unregister`) |
| `task` | create list show | **update**, **delete** |
| `work-package` | list show | **create** (`assemble`), **update** |
| `agent` | list update delete | **create** (`register`), **show** |

Same idea, different name depending on which object you were looking at, and three of five verbs missing somewhere.

## After

```
$ mac task help
task -- one unit of work: the thing agents claim, run, and publish

CRUD:
  create  file a new task into the ledger
  list    list tasks (default: short ids; use --full-ids for scripts)
  show    show task state, activity, diagnoses, and compact evidence counts
  update  change a task's fields (title, description, project, priority, ...)
  delete  actively cancel a task, revoke its lease, and abort a running
          worker executor (same as `cancel`)

Finding work:
  ready          list task-ready work and the number of eligible fleet agents
  ...
Execution:
  claim, start, release, close, reopen
...
Run `mac task help <subcommand>` for the arguments one takes.
```

- **`help` is a verb at every level** — all 55 commands, not just the four. `mac help`, `mac task help`, `mac task help update`, `mac agent config help`. A convention present on 4 of 55 would be a trap, not a convention.
- **Full CRUD on every first-class object.** Where a verb existed under another name it aliases to the *same parser object*, so `mac project delete` and `mac project unregister` are one command.
- **CRUD first**, then named operational groups, then a catch-all `Other` section — which is what stops a verb added later from silently vanishing from the help.
- **Top-level help leads with the four objects** and lists the other 50 by name only. Printing 50 descriptions is what made the original unreadable.

## Two verbs are real, not aliases

**`mac task update`** — `ControlPlane.update_task` has always existed and nothing called it from the command line. The obvious alias would have been `task edit`, and it would have been **wrong**: `edit` opens `$EDITOR` to *answer* a task parked on a human question and refuses unless the task is in `NEEDS_INPUT`. Pointing the most predictable verb in the vocabulary at that is worse than leaving the gap.

**`mac agent show`** — every other first-class object could be read by id. `agent config show` existed and answers a richer question.

## Nothing was removed

A before/after diff of the entire command tree:

```
top-level lost:      none
subcommands lost:    none
top-level added:     {help}
subcommands added:   help (×50), plus the missing CRUD verbs on the 4 objects
```

265 subcommands are load-bearing for tests, scripts and the deploy path. Buying discoverability with a breaking change is a worse trade than the problem it solves.

`work-package` has **no `delete`** and is not given a fake one — nothing in the control plane deletes or cancels a work package, so the help says so rather than aliasing `delete` to something that doesn't delete.

## Also fixed

`scripts/generate-docs-reference.py` discovered commands by regexing the `{a,b,c}` line out of `mac --help`, so it broke the moment that help was rewritten — a documentation generator failing because the thing it documents got easier to read. It now reads the parser it renders from.

## Verification

60 new tests, including a dispatch check that every alias reaches the same handler as the name it aliases. Full CLI suite plus the generated-artifact guards: **510 passed**. Generated reference regenerated and `--check` clean.

## Still to come (separate passes)

- API-side CRUD parity for the four objects
- Reducing / demoting the 51 non-first-class top-level commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)