### PR TITLE
Make the OpenShell guardrail text privileged on the read side

### DIFF
--- a/docs/openshell-sandbox.md
+++ b/docs/openshell-sandbox.md
@@ -164,6 +164,29 @@ Deliberate properties:
   malformed response leaves the existing policy in place. Confinement is never
   dropped because delivery failed.
 
+### Who can read a policy
+
+The guardrail text names the fleet's hub and gateway hosts, their ports, and the
+binaries permitted to reach them — a map of the control plane. Every *write* on a
+policy already required the global fleet principal, so `policy_text` is privileged
+on the read side to match:
+
+| Surface | Scope | Carries `policy_text`? |
+| --- | --- | --- |
+| `GET /openshell/policies/{id}`, `.../versions`, `POST .../render` | `admin` | yes |
+| `GET /agents/{id}/openshell/policy` | `agent`, self-only | yes (its own) |
+| `GET /openshell/policies`, `.../assignments`, `/agents/{id}/openshell/status`, `/dashboard/state` | `read` | **no** — identity, version and checksum only |
+
+`OpenShellPolicy.to_dict()` and `OpenShellPolicyVersion.to_dict()` omit the text
+**by default**; callers needing it pass `include_text=True`. The default is the
+control, not per-route filtering: every route that serialized a policy leaked the
+body by accident — `/dashboard/state`, which embeds the whole corpus, included —
+and a new route would have inherited the same leak. `render` is admin-gated too,
+because a rendered policy is the template with the placeholders filled *in*.
+
+`checksum` is retained everywhere, so drift detection and the worker's
+skip-if-converged check never need the body.
+
 ## Per-repo egress (ADR 0009 §2a)
 
 Deny-by-default egress is right for an unknown repo, but a real repository has to

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -2204,6 +2204,21 @@ def _required_scope(method: str, path: str) -> Optional[str]:
         # gateway hosts and the binary paths permitted to reach them, which is
         # a map of the control plane for anyone holding only a read token.
         return "agent"
+    if method in {"GET", "POST"} and re.match(
+        r"^/openshell/policies/[^/]+(/versions|/render)?$", path
+    ):
+        # Every route that returns the guardrail SOURCE — the fleet's hub and
+        # gateway hosts, their ports, and the binaries permitted to reach them —
+        # requires admin. `render` is included because a rendered policy is the
+        # same text with the placeholders filled IN, which makes it strictly
+        # more disclosive than the template, not less; it was reachable with a
+        # task-writing token.
+        #
+        # The list, assignment, status and dashboard views deliberately stay
+        # "read": after this change they carry identity, version and checksum,
+        # which is everything drift detection needs and nothing an attacker can
+        # navigate by.
+        return "admin"
     if method == "GET":
         return "read"
     if path.startswith("/agents/") and (
@@ -7741,8 +7756,22 @@ def create_app(
         ]
 
     @app.get("/openshell/policies/{policy_id}")
-    def get_openshell_policy(policy_id: str) -> Dict[str, Any]:
-        return cp.get_openshell_policy(policy_id, include_deleted=True).to_dict()
+    def get_openshell_policy(
+        policy_id: str,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        """One policy INCLUDING its guardrail text (`mac openshell policy show`).
+
+        Admin-gated: creating, updating, deleting and assigning a policy all
+        require the global fleet principal, so serving the same policy's source
+        to any read token was an asymmetry, not a decision. The list, status and
+        dashboard views stay readable — they return identity and checksum, which
+        is what drift detection needs.
+        """
+        principal.require_global_fleet()
+        return cp.get_openshell_policy(policy_id, include_deleted=True).to_dict(
+            include_text=True
+        )
 
     @app.put("/openshell/policies/{policy_id}")
     def update_openshell_policy(
@@ -7763,9 +7792,18 @@ def create_app(
         return cp.delete_openshell_policy(policy_id, actor=actor).to_dict()
 
     @app.get("/openshell/policies/{policy_id}/versions")
-    def list_openshell_policy_versions(policy_id: str) -> List[Dict[str, Any]]:
+    def list_openshell_policy_versions(
+        policy_id: str,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> List[Dict[str, Any]]:
+        """Version history WITH text, so an operator can diff guardrail changes.
+
+        A history of guardrail sources is exactly as sensitive as the current
+        one, so it carries the same admin gate.
+        """
+        principal.require_global_fleet()
         return [
-            version.to_dict()
+            version.to_dict(include_text=True)
             for version in cp.list_openshell_policy_versions(policy_id)
         ]
 

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -3909,7 +3909,17 @@ def cmd_openshell_policy_list(args: argparse.Namespace) -> None:
 
 
 def cmd_openshell_policy_show(args: argparse.Namespace) -> None:
-    _print(_plane(args).get_openshell_policy(args.policy, include_deleted=True))
+    # `policy_text` is omitted from OpenShellPolicy.to_dict() by default, and
+    # showing the policy body is the whole point of this command -- so ask for
+    # it explicitly. In hub mode the value is already a dict from the
+    # admin-gated endpoint and passes through unchanged; this branch is the
+    # direct-authority (--db) path, where _print would otherwise serialize the
+    # dataclass with its text stripped.
+    _print(
+        _policy_payload_with_text(
+            _plane(args).get_openshell_policy(args.policy, include_deleted=True)
+        )
+    )
 
 
 def cmd_openshell_policy_update(args: argparse.Namespace) -> None:
@@ -3964,10 +3974,25 @@ def cmd_openshell_policy_assign(args: argparse.Namespace) -> None:
     )
 
 
+def _policy_payload_with_text(value: Any) -> Any:
+    """Serialize a policy/version for an operator command that needs its body.
+
+    ``to_dict()`` omits ``policy_text`` by default (it is the guardrail source);
+    the direct-authority path therefore has to ask for it. Hub-mode ``_Dictish``
+    wrappers take no keyword and already carry whatever the admin-gated endpoint
+    permitted, so they fall through unchanged.
+    """
+    try:
+        return value.to_dict(include_text=True)
+    except (AttributeError, TypeError):
+        return value
+
+
 def cmd_openshell_policy_versions(args: argparse.Namespace) -> None:
+    # Diffing guardrail changes across versions requires the bodies.
     _print(
         [
-            version.to_dict() if hasattr(version, "to_dict") else version
+            _policy_payload_with_text(version)
             for version in _plane(args).list_openshell_policy_versions(args.policy)
         ]
     )

--- a/src/mac/models.py
+++ b/src/mac/models.py
@@ -2446,9 +2446,24 @@ class OpenShellPolicy:
     updated_at: str
     deleted_at: Optional[str]
 
-    def to_dict(self) -> JsonDict:
-        """Return a JSON-serializable dict representation of this OpenShellPolicy."""
-        return asdict(self)
+    def to_dict(self, *, include_text: bool = False) -> JsonDict:
+        """Return a JSON-serializable dict of this OpenShellPolicy.
+
+        ``policy_text`` is OMITTED by default and must be asked for. It is the
+        guardrail source: it names the fleet's hub and gateway hosts, their
+        ports, and the exact binary paths permitted to reach them — a map of the
+        control plane, and a map of what an attacker would have to avoid.
+
+        Defaulting it OUT rather than filtering per route is deliberate. Every
+        route that serialized a policy leaked the text by accident, including
+        ``/dashboard/state``, which embeds the whole policy corpus; a new route
+        would have inherited the same leak. ``checksum`` remains present, so
+        callers that only need to detect drift never need the body.
+        """
+        payload = asdict(self)
+        if not include_text:
+            payload.pop("policy_text", None)
+        return payload
 
 
 @dataclass
@@ -2462,9 +2477,17 @@ class OpenShellPolicyVersion:
     created_by: str
     created_at: str
 
-    def to_dict(self) -> JsonDict:
-        """Return a JSON-serializable dict representation of this OpenShellPolicyVersion."""
-        return asdict(self)
+    def to_dict(self, *, include_text: bool = False) -> JsonDict:
+        """Return a JSON-serializable dict of this OpenShellPolicyVersion.
+
+        ``policy_text`` is omitted by default for the same reason as
+        :meth:`OpenShellPolicy.to_dict` — a version history is a history of
+        guardrail sources, so it is exactly as sensitive as the current one.
+        """
+        payload = asdict(self)
+        if not include_text:
+            payload.pop("policy_text", None)
+        return payload
 
 
 @dataclass

--- a/tests/api/test_openshell_policy_text_scope.py
+++ b/tests/api/test_openshell_policy_text_scope.py
@@ -1,0 +1,280 @@
+"""`policy_text` is privileged; policy identity is not.
+
+A guardrail policy names the fleet's hub and gateway hosts, their ports, and the
+exact binary paths permitted to reach them — a map of the control plane, and a
+map of what an attacker would have to avoid. Creating, updating, deleting and
+assigning a policy already required the global fleet principal, but every READ
+of the same policy returned its full source to any dashboard-tier token,
+including `/dashboard/state`, which embeds the whole policy corpus.
+
+These tests pin the boundary in both directions: no text below admin, and the
+non-text views stay readable so drift detection keeps working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from mac.api import create_app, _required_scope
+from mac.models import OpenShellPolicy, OpenShellPolicyVersion
+from mac.services import ControlPlane
+
+SECRET_HOST = "hub-internal.example.invalid"
+POLICY_TEXT = """version: 1
+
+network_policies:
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: %s
+        port: 8789
+""" % SECRET_HOST
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": "Bearer %s" % token}
+
+
+@pytest.fixture
+def fleet():
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host")
+    mine = cp.register_agent(machine.id, "worker-self")
+    other = cp.register_agent(machine.id, "worker-other")
+    policy = cp.openshell.create_policy("fleet", POLICY_TEXT)
+    cp.openshell.assign_policy(policy.id, target_type="agent", target_id=mine.id)
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "reader": {"scopes": ["read"], "client_id": "dashboard"},
+                "writer": {"scopes": ["write"], "client_id": "ci"},
+                "admin": {"scopes": ["admin"], "client_id": "operator"},
+                "mine": {"scopes": ["agent"], "agent_id": mine.id},
+            },
+        )
+    )
+    return client, cp, policy, mine, other
+
+
+# --- default-safe serialisation -------------------------------------------
+#
+# Filtering per route is what failed: each route that serialised a policy leaked
+# the text by accident. The default is the fix; the routes are downstream of it.
+
+
+def test_policy_to_dict_omits_text_by_default():
+    policy = OpenShellPolicy(
+        id="p", name="n", description="", policy_text=POLICY_TEXT,
+        parsed_metadata={}, version=1, checksum="sha256:x", created_by="h",
+        updated_by="h", active=True, created_at="t", updated_at="t",
+        deleted_at=None,
+    )
+    assert "policy_text" not in policy.to_dict()
+    # Identity and drift detection survive.
+    assert policy.to_dict()["checksum"] == "sha256:x"
+    assert policy.to_dict()["version"] == 1
+    assert policy.to_dict(include_text=True)["policy_text"] == POLICY_TEXT
+
+
+def test_policy_version_to_dict_omits_text_by_default():
+    """A version history is a history of guardrail sources — equally sensitive."""
+    version = OpenShellPolicyVersion(
+        id="v", policy_id="p", version=2, policy_text=POLICY_TEXT,
+        parsed_metadata={}, checksum="sha256:x", created_by="h", created_at="t",
+    )
+    assert "policy_text" not in version.to_dict()
+    assert version.to_dict(include_text=True)["policy_text"] == POLICY_TEXT
+
+
+def test_parsed_metadata_is_a_safe_summary():
+    """parsed_metadata is retained in the default payload, so it must not carry
+    the hosts/ports/binaries the text does."""
+    from mac.openshell_service import parse_policy_metadata
+
+    assert SECRET_HOST not in repr(parse_policy_metadata(POLICY_TEXT))
+
+
+# --- scope boundary --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path_template",
+    [
+        ("GET", "/openshell/policies/%(policy)s"),
+        ("GET", "/openshell/policies/%(policy)s/versions"),
+        ("POST", "/openshell/policies/%(policy)s/render"),
+    ],
+)
+def test_text_bearing_routes_require_admin(method, path_template):
+    assert _required_scope(method, path_template % {"policy": "ospol_1"}) == "admin"
+
+
+@pytest.mark.parametrize(
+    "path_template",
+    [
+        "/openshell/policies",
+        "/openshell/policies/%(policy)s/assignments",
+        "/agents/%(agent)s/openshell/status",
+        "/dashboard/state",
+    ],
+)
+def test_identity_views_stay_readable(path_template):
+    """Narrowing must not break drift detection or the dashboard."""
+    assert (
+        _required_scope("GET", path_template % {"policy": "ospol_1", "agent": "agent_1"})
+        == "read"
+    )
+
+
+# --- no text reaches a read token, anywhere -------------------------------
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/openshell/policies",
+        "/openshell/policies/%(policy)s/assignments",
+        "/agents/%(agent)s/openshell/status",
+        "/dashboard/state",
+    ],
+)
+def test_read_token_sees_no_policy_text_on_any_reachable_route(fleet, route):
+    client, _cp, policy, mine, _other = fleet
+    path = route % {"policy": policy.id, "agent": mine.id}
+    response = client.get(path, headers=_headers("reader"))
+    assert response.status_code == 200, path
+    assert SECRET_HOST not in response.text, path
+
+
+def test_status_still_reports_convergence_without_the_text(fleet):
+    """The dashboard needs to know WHICH policy is assigned and whether the host
+    converged — not the guardrail body."""
+    client, _cp, policy, mine, _other = fleet
+    body = client.get(
+        "/agents/%s/openshell/status" % mine.id, headers=_headers("reader")
+    ).json()
+    assert body["policy"]["policy_id" if "policy_id" in body["policy"] else "id"] == policy.id
+    assert body["policy"]["checksum"] == policy.checksum
+    assert "policy_text" not in body["policy"]
+    assert body["assignment"]["policy_id"] == policy.id
+
+
+def test_dashboard_still_lists_policies_without_their_text(fleet):
+    client, _cp, policy, _mine, _other = fleet
+    body = client.get("/dashboard/state", headers=_headers("reader")).json()
+    listed = [p for p in body["openshell_policies"] if p["id"] == policy.id]
+    assert listed, "dashboard must still enumerate policies"
+    assert "policy_text" not in listed[0]
+    assert listed[0]["checksum"] == policy.checksum
+
+
+def test_read_and_write_tokens_are_denied_the_text_routes(fleet):
+    client, _cp, policy, _mine, _other = fleet
+    for token in ("reader", "writer"):
+        assert client.get(
+            "/openshell/policies/%s" % policy.id, headers=_headers(token)
+        ).status_code == 403
+        assert client.get(
+            "/openshell/policies/%s/versions" % policy.id, headers=_headers(token)
+        ).status_code == 403
+        assert client.post(
+            "/openshell/policies/%s/render" % policy.id,
+            headers=_headers(token),
+            json={"agent_user": "u", "hub_host": "h.example", "hub_port": 8789},
+        ).status_code == 403
+
+
+def test_render_was_reachable_with_a_write_token_before_this_change(fleet):
+    """Regression marker: a rendered policy is the template with the
+    placeholders filled IN, so it is strictly more disclosive, not less."""
+    client, _cp, policy, _mine, _other = fleet
+    response = client.post(
+        "/openshell/policies/%s/render" % policy.id,
+        headers=_headers("writer"),
+        json={"agent_user": "u", "hub_host": "h.example", "hub_port": 8789},
+    )
+    assert response.status_code == 403
+    assert SECRET_HOST not in response.text
+
+
+def test_admin_still_gets_the_text_it_needs(fleet):
+    """`mac openshell policy show` must keep working for operators."""
+    client, _cp, policy, _mine, _other = fleet
+    body = client.get(
+        "/openshell/policies/%s" % policy.id, headers=_headers("admin")
+    ).json()
+    assert body["policy_text"] == POLICY_TEXT.strip()
+
+    versions = client.get(
+        "/openshell/policies/%s/versions" % policy.id, headers=_headers("admin")
+    ).json()
+    assert versions and "policy_text" in versions[0]
+
+
+def test_agent_self_service_route_is_unaffected(fleet):
+    """The worker still converges: it needs the text for its OWN policy."""
+    client, _cp, policy, mine, _other = fleet
+    body = client.get(
+        "/agents/%s/openshell/policy" % mine.id, headers=_headers("mine")
+    ).json()
+    assert body["policy_text"] == POLICY_TEXT.strip()
+    assert body["checksum"] == policy.checksum
+
+
+# --- operator CLI must not lose the body it exists to print ----------------
+
+
+def _cli_json(fn, namespace, control_plane):
+    """Run a CLI handler against a direct ControlPlane and parse its JSON."""
+    import contextlib
+    import io
+    import json
+
+    from mac import cli
+
+    prior_plane, prior_json = cli._plane, cli._OUTPUT_JSON
+    cli._plane, cli._OUTPUT_JSON = (lambda _args: control_plane), True
+    try:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            fn(namespace)
+        return json.loads(buf.getvalue())
+    finally:
+        cli._plane, cli._OUTPUT_JSON = prior_plane, prior_json
+
+
+def test_cli_policy_show_and_versions_keep_the_text_on_the_db_path(fleet):
+    """`_print` calls `to_dict()` with no arguments, so defaulting the text out
+    silently emptied `mac openshell policy show` on the --db path -- the one
+    thing that command exists to display."""
+    from argparse import Namespace
+
+    from mac import cli
+
+    _client, cp, policy, _mine, _other = fleet
+
+    shown = _cli_json(
+        cli.cmd_openshell_policy_show, Namespace(policy=policy.id), cp
+    )
+    assert shown["policy_text"] == policy.policy_text
+
+    versions = _cli_json(
+        cli.cmd_openshell_policy_versions, Namespace(policy=policy.id), cp
+    )
+    assert versions and all("policy_text" in v for v in versions)
+
+
+def test_cli_policy_list_stays_text_free(fleet):
+    """Listing is an inventory view; it never needed the bodies."""
+    from argparse import Namespace
+
+    from mac import cli
+
+    _client, cp, _policy, _mine, _other = fleet
+    listed = _cli_json(
+        cli.cmd_openshell_policy_list, Namespace(include_deleted=False), cp
+    )
+    assert listed and all("policy_text" not in item for item in listed)


### PR DESCRIPTION
> **Stacked on #297 — merge that first.** Base is `claude/close-sandbox-expansion-loop` so the diff shows only this change. This PR removes `policy_text` from the read surface, and the replacement callers migrate to — the self-only `GET /agents/{id}/openshell/policy` — only exists in #297. Merging this alone would remove the field with nothing to migrate to. Because the repo squash-merges, this will need a rebase onto `main` after #297 lands.

## What

An OpenShell policy names the fleet's hub and gateway hosts, their ports, and the exact binary paths permitted to reach them — a map of the control plane, and a map of what an attacker would have to avoid.

Creating, updating, deleting and assigning one all require the global fleet principal. **Reading the same policy's source did not:**

| Route | Scope | Returned |
| --- | --- | --- |
| `GET /openshell/policies` | `read` | text of **every** policy |
| `GET /openshell/policies/{id}` | `read` | text |
| `GET /openshell/policies/{id}/versions` | `read` | text of every version |
| `GET /agents/{id}/openshell/status` | `read` | text |
| `GET /dashboard/state` | `read` | the **entire policy corpus** |
| `POST /openshell/policies/{id}/render` | `write` | rendered text |

That asymmetry is the defect. Narrowing one route would have been theatre — a read token simply calls the next one.

## How

**Fixed at the serialisation boundary, not per route.** `OpenShellPolicy.to_dict()` and `OpenShellPolicyVersion.to_dict()` now omit `policy_text` unless the caller passes `include_text=True`.

Per-route filtering is exactly what failed here: every route that serialised a policy leaked the body by accident — including `/dashboard/state`, which embeds the whole corpus via a list comprehension nobody thought of as a disclosure. A default-safe serialiser means the next route cannot inherit the same leak.

Routes returning the text now require `admin`, **`render` included**: a rendered policy is the template with the placeholders filled *in*, so it is strictly more disclosive than the template — and it was reachable with a task-writing token.

The list, assignment, status and dashboard views stay `read` and carry identity, version and checksum — everything drift detection and the worker's skip-if-converged check need, and nothing an attacker can navigate by.

Resulting matrix (verified):

| | reader | writer | admin | agent (self) | agent (other) |
| --- | --- | --- | --- | --- | --- |
| text routes | 403 | 403 | 200 + text | — | — |
| `/agents/{id}/openshell/policy` | 403 | 403 | 200 + text | 200 + text | 403 |
| list / status / dashboard | 200, no text | 403 | 200, no text | 403 | 403 |

## Two things worth recording

**`require_global_fleet()` was never the gate here.** It refuses only *tenant-bound* non-admin tokens, so an untenanted `read` token passes it untouched. The scope layer is the enforcement point, which is why `_required_scope` changed rather than the handler guards. Its other call sites may deserve the same audit.

**Defaulting the text out silently broke `mac openshell policy show` on the `--db` path.** `_print()` calls `to_dict()` with no arguments, so the one command whose entire purpose is displaying the policy body would have printed everything except the body. `show` and `versions` now opt in explicitly; `list` stays text-free. Covered on both the `--db` and hub paths.

## Verification

- **Contract gate: 10,397 passed, 2 skipped, exit 0.**
- 22 new tests; 652 passing across the API/CLI/openshell suites; lint clean; docs execution check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
