### PR TITLE
Keep the retirement premises doc generic for any fleet owner

### DIFF
--- a/docs/hermes-retirement-premises.md
+++ b/docs/hermes-retirement-premises.md
@@ -30,9 +30,10 @@ agent.nap_completed events:        10
 window: 2026-08-04T00:55:26 -> 2026-08-04T01:32:40
 ```
 
-The loop is not dormant — `nap.tick.run` shows `agent_natasha`, `agent_rocky`,
-`agent_jordanh-worker5` and `agent_operator` all with `"napped": true,
-"skipped": false`. Every run then completes carrying no summary evidence.
+The loop is not dormant — `nap.tick.run` shows four agents (`agent_hub`,
+`agent_worker-1`, `agent_worker-2` and `agent_operator`) all with
+`"napped": true, "skipped": false`. Every run then completes carrying no
+summary evidence.
 
 The memory store agrees. All 31 entries in `project=mac` are hand-authored
 operator or agent notes — `plan-wave-cli-blocker`, `fleet-churn-root-causes`,


### PR DESCRIPTION
## `main` is red

`tests/test_docs_no_operator_identity.py` fails on `36f59783`:

```
FAILED tests/test_docs_no_operator_identity.py::test_docs_carry_no_operator_identity
  docs/hermes-retirement-premises.md:33: 'The loop is not dormant —
  `nap.tick.run` shows `agent_natasha`, `agent_rocky`,' (matched 'natasha')
```

Reproduced on a clean checkout of `origin/main` with nothing else applied. It is also failing the `sanity` check on every open PR, since PR checks test the merge of the head into `main` — #297 inherited it.

## Why the guard exists

The repo documents a **generic** fleet. Operational identity — real agent names, the operator user, concrete hosts — belongs in `~/.mac/specs` and `~/.mac/fleets.yaml`, outside git, not in docs that travel with the repo to any fork.

## The fix

The line named four real hosts. Only `natasha` shows up in the failure because the guard reports the **first match per line** — `rocky` on the same line is the same leak, and `jordanh-worker5` on the next line is too, it just isn't in the token list.

All four are replaced with the readable role names the guard's own docstring prescribes (`hub` / `worker-1` / `worker-2`), so a later addition to `_TOKENS` can't re-red this line.

```diff
-The loop is not dormant — `nap.tick.run` shows `agent_natasha`, `agent_rocky`,
-`agent_jordanh-worker5` and `agent_operator` all with `"napped": true,
-"skipped": false`. Every run then completes carrying no summary evidence.
+The loop is not dormant — `nap.tick.run` shows four agents (`agent_hub`,
+`agent_worker-1`, `agent_worker-2` and `agent_operator`) all with
+`"napped": true, "skipped": false`. Every run then completes carrying no
+summary evidence.
```

The claim is unchanged: four agents napped, none carried summary evidence. *Which* four hosts they were is not what the paragraph is evidence for.

## Verification

- `test_docs_no_operator_identity` passes.
- Executable book: 18 chapters, 20 shell blocks, pass.
- Docs accessibility: 179 pages, links and images validated.
- Repo-wide scan for the other tokens (`rocky`, `bullwinkle`, `madmax`, `puck`, `sparky`, `jkh`, `do-host`, `devuser`, `agentuser`) across `docs/`, `skills/`, `deploy/*.md`, root `*.md`: no remaining hits.

Single-file, docs-only change. Landing this should turn `main` green and unblock the `sanity` check on open PRs without touching them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
