### PR TITLE
Stop a general write token opening a shell on a fleet host

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -2438,6 +2438,31 @@ def _clamp_int(value: Any, minimum: int, maximum: int, default: int) -> int:
     return min(maximum, max(minimum, parsed))
 
 
+def _require_terminal_principal(principal: "TokenPrincipal") -> None:
+    """Gate the debug-terminal routes: admin, or an agent acting on itself.
+
+    A debug terminal is an interactive shell on a fleet host, so the set of
+    principals allowed near one is small. ``require_global_fleet()`` was doing
+    this job and cannot: it refuses only TENANT-BOUND non-admin tokens
+    (``if self.is_admin or self.tenant_id is None: return``). An untenanted
+    client token — the ordinary ``write`` scope, the same one that creates a
+    task — has no tenant, is not admin, and carries no ``agent_id``, so it fell
+    through every check and could open a session on any agent and type into it.
+
+    The agent path is deliberately preserved rather than collapsed into
+    admin-only: a worker legitimately opens its own debug terminal, and each
+    handler still narrows that to the acting agent with ``assert_actor``. This
+    only removes the principal class that was never meant to be here.
+    """
+    principal.require_global_fleet()
+    if principal.is_admin or principal.agent_id:
+        return
+    raise AuthorizationError(
+        "debug terminal sessions require an admin token, or the acting agent's "
+        "own token; a general read/write client token is not sufficient"
+    )
+
+
 def _new_terminal_session_id() -> str:
     return "term_" + secrets.token_hex(12)
 
@@ -4832,7 +4857,7 @@ def create_app(
         limit: int = Query(default=120),
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        _require_terminal_principal(principal)
         query_agent_id = agent_id
         if principal.agent_id and not principal.is_admin:
             if query_agent_id and query_agent_id != principal.agent_id:
@@ -4860,7 +4885,7 @@ def create_app(
         body: DashboardTerminalOpen,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        _require_terminal_principal(principal)
         agent = cp.get_agent(agent_id)
         sender_agent_id = str(body.sender_agent_id or agent.id)
         cp.get_agent(sender_agent_id)
@@ -4941,7 +4966,7 @@ def create_app(
         body: DashboardTerminalInput,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        _require_terminal_principal(principal)
         stream = _terminal_stream_for_session(
             cp,
             session_id=session_id,
@@ -4974,7 +4999,7 @@ def create_app(
         body: DashboardTerminalResize,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        _require_terminal_principal(principal)
         stream = _terminal_stream_for_session(
             cp,
             session_id=session_id,
@@ -5012,7 +5037,7 @@ def create_app(
         body: DashboardTerminalClose,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        _require_terminal_principal(principal)
         stream = _terminal_stream_for_session(
             cp,
             session_id=session_id,
@@ -5057,7 +5082,7 @@ def create_app(
         poll_interval_seconds: float = Query(default=0.25),
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> StreamingResponse:
-        principal.require_global_fleet()
+        _require_terminal_principal(principal)
         stream = _terminal_stream_for_session(
             cp,
             session_id=session_id,

--- a/tests/api/test_terminal_session_authz.py
+++ b/tests/api/test_terminal_session_authz.py
@@ -1,0 +1,141 @@
+"""A debug terminal is an interactive shell on a fleet host.
+
+`require_global_fleet()` was guarding these routes and cannot do this job: it
+refuses only TENANT-BOUND non-admin tokens
+(``if self.is_admin or self.tenant_id is None: return``). An untenanted client
+token — the ordinary ``write`` scope, the same one that creates a task — has no
+tenant, is not admin, and carries no ``agent_id``, so it fell through every
+check and could open a session on any agent and type into its shell.
+
+These tests pin the boundary in both directions: the general client token is
+out, and the two legitimate principals (an operator, and a worker acting on
+itself) are still in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": "Bearer %s" % token}
+
+
+@pytest.fixture
+def fleet():
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host")
+    mine = cp.register_agent(machine.id, "worker-1")
+    other = cp.register_agent(machine.id, "worker-2")
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "reader": {"scopes": ["read"], "client_id": "dashboard"},
+                # Untenanted general client token: the principal class that
+                # should never have reached a shell.
+                "writer": {"scopes": ["write"], "client_id": "ci"},
+                "tenant_w": {"scopes": ["write"], "tenant_id": "tenant-a"},
+                "admin": {"scopes": ["admin"], "client_id": "operator"},
+                # A worker: `agent` alone cannot satisfy the route's `write`
+                # scope, so the real-world worker token carries both.
+                "mine": {"scopes": ["agent", "write"], "agent_id": mine.id},
+                "other": {"scopes": ["agent", "write"], "agent_id": other.id},
+            },
+        )
+    )
+    return client, cp, mine, other
+
+
+def _open(client, agent_id, token):
+    return client.post(
+        "/dashboard/agents/%s/terminal-sessions" % agent_id,
+        headers=_headers(token),
+        json={"shell": "/bin/sh"},
+    )
+
+
+# --- the hole -------------------------------------------------------------
+
+
+def test_general_write_token_cannot_open_a_shell(fleet):
+    """The regression that motivated this: `write` opened a session and could
+    then type into it — arbitrary command execution on a fleet host with an
+    ordinary task-writing credential."""
+    client, _cp, mine, _other = fleet
+    response = _open(client, mine.id, "writer")
+    assert response.status_code == 403
+    assert "admin token" in response.json()["detail"]
+
+
+def test_general_write_token_cannot_drive_an_existing_session(fleet):
+    """Opening is not the only entry point: input/resize/close each took the
+    same insufficient guard, so a session opened by anyone was drivable."""
+    client, _cp, mine, _other = fleet
+    opened = _open(client, mine.id, "admin").json()
+    session, stream = opened["session_id"], opened["input_stream_id"]
+
+    for path, body in [
+        ("input", {"input_stream_id": stream, "data": "whoami\n"}),
+        ("resize", {"input_stream_id": stream, "rows": 40, "cols": 100}),
+        ("close", {"input_stream_id": stream}),
+    ]:
+        response = client.post(
+            "/dashboard/terminal-sessions/%s/%s" % (session, path),
+            headers=_headers("writer"),
+            json=body,
+        )
+        assert response.status_code == 403, path
+
+
+def test_read_token_cannot_enumerate_sessions(fleet):
+    """Session listing names agents with live shells — reconnaissance, and the
+    session id is the handle the other routes take."""
+    client, _cp, _mine, _other = fleet
+    assert client.get(
+        "/dashboard/terminal-sessions", headers=_headers("reader")
+    ).status_code == 403
+
+
+def test_tenant_bound_token_is_still_refused(fleet):
+    """The one case require_global_fleet() did cover must keep working."""
+    client, _cp, mine, _other = fleet
+    response = _open(client, mine.id, "tenant_w")
+    assert response.status_code == 403
+    assert "bound to a tenant" in response.json()["detail"]
+
+
+# --- the principals that must keep working --------------------------------
+
+
+def test_admin_can_open_and_drive_a_session(fleet):
+    client, _cp, mine, _other = fleet
+    opened = _open(client, mine.id, "admin")
+    assert opened.status_code == 200
+    body = opened.json()
+    assert client.post(
+        "/dashboard/terminal-sessions/%s/input" % body["session_id"],
+        headers=_headers("admin"),
+        json={"input_stream_id": body["input_stream_id"], "data": "whoami\n"},
+    ).status_code == 200
+    assert client.get(
+        "/dashboard/terminal-sessions", headers=_headers("admin")
+    ).status_code == 200
+
+
+def test_a_worker_can_still_open_its_own_terminal(fleet):
+    """Deliberately not collapsed to admin-only: a worker legitimately opens its
+    own debug terminal, and that path predates this change."""
+    client, _cp, mine, _other = fleet
+    assert _open(client, mine.id, "mine").status_code == 200
+
+
+def test_a_worker_cannot_open_another_agents_terminal(fleet):
+    """The handler's own assert_actor narrowing still applies on top."""
+    client, _cp, mine, _other = fleet
+    assert _open(client, mine.id, "other").status_code == 403


### PR DESCRIPTION
## The finding

Executed against `main` (`b2823a4b`) with an untenanted client token holding only the `write` scope — **the same scope that creates an ordinary task**:

```
POST /dashboard/agents/<agent>/terminal-sessions   -> 200
POST /dashboard/terminal-sessions/<id>/input       -> 200    "whoami; cat /etc/shadow\n"
```

Arbitrary command execution on any fleet host, reachable with a routine write credential.

## Why the existing guard didn't catch it

These routes were guarded by `principal.require_global_fleet()`:

```python
if self.is_admin or self.tenant_id is None:
    return
```

It refuses only **tenant-bound** non-admin tokens. An untenanted client token has no tenant, is not admin, and carries no `agent_id` — so it fell through every check.

The tenant-bound case it *does* cover still returns 403, which is exactly why this stayed invisible: the guard works precisely as its docstring says. It simply isn't the guard these routes need.

## The change

All six debug-terminal routes now take `_require_terminal_principal`: **admin, or an agent acting on itself.**

Opening was not the only entry point — `input`, `resize`, `close`, `list` and `events` each carried the same insufficient guard, so a session opened by anyone was drivable by anyone.

**Deliberately not collapsed to admin-only.** Each handler already narrows an agent principal to itself via `assert_actor`, and a worker legitimately opens its own debug terminal. This removes only the principal class that was never meant to be there.

## Behaviour, verified by execution

| Principal | Before | After |
| --- | --- | --- |
| untenanted `write` client | **200** — open + type | **403** |
| `read` client (list sessions) | 200 | 403 |
| tenant-bound `write` | 403 | 403 |
| admin | 200 | 200 |
| worker (`agent`+`write`) on **itself** | 200 | 200 |
| worker on **another agent** | 403 | 403 |

One check worth calling out: a first run showed "agent opens own → 403" and looked like a regression. It isn't — I tested unmodified `main` and a **pure `agent` token is already 403 here**, because the route's declared scope is `write`, which an agent token doesn't carry. The real-world worker token is `agent`+`write`, and that path is preserved.

The dashboard UI is unaffected: it takes an operator-pasted token from `sessionStorage` rather than holding a fixed scope, so an operator opening a shell carries an admin token — appropriate for the capability.

## Verification

- Contract gate: **10,403 passed, 2 skipped**, exit 0.
- 7 new tests covering both directions (the hole closed, both legitimate principals preserved).
- 235 passing across `tests/api` + `tests/ui`; lint clean.

## Scope

This is **one** finding from a wider audit. **40 routes** have `require_global_fleet()` as their only in-handler gate at a scope below admin — `POST /openshell/policies` at `write` is the most incongruous, since policy *reads* are admin-gated. Those need per-route judgement and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
