### PR TITLE
Add a CLI verb for a task's declared egress contract

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -423,6 +423,7 @@ Other:
   select  preview the group of tasks a selector expression names
   batch   apply one operation to every task a selector names (dry by default)
   group   named, saved task groups
+  egress  declare which hosts a task's sandbox may reach
 
 Run `mac task help <subcommand>` for the arguments one takes.
 ```

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -3444,6 +3444,94 @@ def cmd_agent_update(args: argparse.Namespace) -> None:
     )
 
 
+def _egress_contract_block(task: Any) -> Dict[str, Any]:
+    """The task's TOP-LEVEL metadata.egress_contract, as a plain dict."""
+    record = task.to_dict() if hasattr(task, "to_dict") else task
+    metadata = (record or {}).get("metadata") if isinstance(record, dict) else None
+    block = (metadata or {}).get("egress_contract") if isinstance(metadata, dict) else None
+    return dict(block) if isinstance(block, dict) else {}
+
+
+def _write_egress_hosts(
+    cp: Any, task_id: str, hosts: List[str], args: argparse.Namespace, reason: str
+) -> Any:
+    """Persist the host list at metadata.egress_contract, TOP LEVEL.
+
+    The location is the security model, not a detail. `metadata.runtime` is
+    written by the worker from repo content, so anything placed there carries
+    only repo trust and is classified `derived` -- refused unless it happens to
+    match the reviewed registry allowlist. Top-level task metadata was set
+    through an authenticated hub credential, which is what earns the
+    `hub_declared` tier. A CLI that wrote to the wrong subtree would quietly
+    defeat the whole distinction, so it is asserted in the tests rather than
+    left to a reader's care.
+    """
+    task = cp.get_task(task_id)
+    record = task.to_dict() if hasattr(task, "to_dict") else dict(task)
+    metadata = dict(record.get("metadata") or {})
+    block = dict(metadata.get("egress_contract") or {})
+    block["hosts"] = hosts
+    if reason:
+        block["reason"] = reason
+    metadata["egress_contract"] = block
+    return cp.update_task(task_id, metadata=metadata, actor=args.actor)
+
+
+def cmd_task_egress_list(args: argparse.Namespace) -> None:
+    """Show the hosts a task declares for sandbox egress."""
+    cp = _plane(args)
+    block = _egress_contract_block(cp.get_task(args.task_id))
+    _print(
+        {
+            "task_id": args.task_id,
+            "hosts": list(block.get("hosts") or []),
+            "reason": block.get("reason"),
+            # Named so the reader can see WHICH tier these will be granted at
+            # without going to read the policy module.
+            "trust_tier": "hub_declared",
+            "source": "metadata.egress_contract",
+        }
+    )
+
+
+def cmd_task_egress_grant(args: argparse.Namespace) -> None:
+    """Add a host to a task's declared egress contract."""
+    from mac.sandbox_egress import normalize_host
+
+    cp = _plane(args)
+    normalized = normalize_host(args.host)
+    if normalized is None:
+        # Rejected HERE rather than silently dropped at sandbox build time,
+        # where the operator would see a host they granted simply not work.
+        raise MACError(
+            "%r is not a plain DNS hostname. Schemes, ports, paths, globs and "
+            "IP literals are refused: egress policy is keyed on the DNS name."
+            % args.host
+        )
+    block = _egress_contract_block(cp.get_task(args.task_id))
+    hosts = list(block.get("hosts") or [])
+    if normalized in hosts:
+        _print({"task_id": args.task_id, "hosts": hosts, "unchanged": True})
+        return
+    hosts.append(normalized)
+    _print(_write_egress_hosts(cp, args.task_id, sorted(hosts), args, args.reason or ""))
+
+
+def cmd_task_egress_revoke(args: argparse.Namespace) -> None:
+    """Remove a host from a task's declared egress contract."""
+    from mac.sandbox_egress import normalize_host
+
+    cp = _plane(args)
+    normalized = normalize_host(args.host) or str(args.host).strip().lower()
+    block = _egress_contract_block(cp.get_task(args.task_id))
+    hosts = [h for h in (block.get("hosts") or []) if h != normalized]
+    if len(hosts) == len(block.get("hosts") or []):
+        raise MACError(
+            "%s is not in the task's declared egress contract" % normalized
+        )
+    _print(_write_egress_hosts(cp, args.task_id, hosts, args, block.get("reason") or ""))
+
+
 def cmd_task_update(args: argparse.Namespace) -> None:
     """Change a task's fields -- the CRUD `update` the CLI never exposed.
 
@@ -8260,6 +8348,34 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _set(cmd_agent_update, agent_update)
 
+
+    egress = task.add_parser(
+        "egress",
+        help="declare which hosts a task's sandbox may reach",
+        description=(
+            "Hosts declared here are granted at the hub_declared trust tier, "
+            "because top-level task metadata is set through an authenticated "
+            "hub credential. Hosts the worker derives from repo content are "
+            "untrusted and refused unless they match the reviewed registry."
+        ),
+    ).add_subparsers(dest="egress_command", required=True)
+
+    egress_list = egress.add_parser("list", help="show a task's declared hosts")
+    egress_list.add_argument("task_id")
+    _set(cmd_task_egress_list, egress_list)
+
+    egress_grant = egress.add_parser("grant", help="allow one host")
+    egress_grant.add_argument("task_id")
+    egress_grant.add_argument("host", help="a plain DNS hostname, e.g. api.example.com")
+    egress_grant.add_argument("--reason", help="why this task needs it")
+    egress_grant.add_argument("--actor", default="human")
+    _set(cmd_task_egress_grant, egress_grant)
+
+    egress_revoke = egress.add_parser("revoke", help="withdraw one host")
+    egress_revoke.add_argument("task_id")
+    egress_revoke.add_argument("host")
+    egress_revoke.add_argument("--actor", default="human")
+    _set(cmd_task_egress_revoke, egress_revoke)
     task_update = task.add_parser(
         "update",
         help="change a task's fields (title, description, project, priority, "

--- a/tests/cli/test_task_egress_cli.py
+++ b/tests/cli/test_task_egress_cli.py
@@ -1,0 +1,204 @@
+"""Declaring a task's sandbox egress, at the right trust tier.
+
+PR #297 grants sandbox egress to hosts listed in a task's TOP-LEVEL
+``metadata.egress_contract.hosts``, at the ``hub_declared`` tier. Until now the
+only way to set that was ``mac task create --metadata-file``, i.e. hand-
+authoring the whole metadata object -- and getting the location wrong does not
+fail loudly. It silently downgrades the hosts to the untrusted ``derived`` tier,
+where they are refused, and the operator sees a host they granted simply not
+work (task_97b97266).
+
+The location IS the security model:
+
+``metadata.egress_contract``      top level, set through an authenticated hub
+                                  credential -> hub_declared
+``metadata.runtime.…``            written by the worker from repo content, so
+                                  it carries only repo trust -> derived, and
+                                  refused unless it matches the reviewed
+                                  registry allowlist
+
+A CLI that wrote to the wrong subtree would quietly defeat that distinction
+while appearing to work, which is why it is asserted here rather than left to
+a reader's care.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--json", "--db", dsn_for(tmp_path), *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, json.loads(raw) if raw else None
+
+
+@pytest.fixture()
+def task(tmp_path):
+    rc, _ = _run(tmp_path, "project", "create", "mac")
+    assert rc == 0
+    rc, created = _run(tmp_path, "task", "create", "needs egress", "--project", "mac")
+    assert rc == 0
+    return created
+
+
+def _metadata(tmp_path, task_id):
+    _rc, detail = _run(tmp_path, "task", "show", task_id)
+    record = detail.get("task", detail) if isinstance(detail, dict) else detail
+    return record.get("metadata") or {}
+
+
+# --------------------------------------------------------------------------
+# The security property
+# --------------------------------------------------------------------------
+
+
+def test_a_granted_host_lands_at_top_level_not_under_runtime(tmp_path, task):
+    """The whole point. Under `runtime` these hosts would be classified
+    `derived` and refused, and nothing would say so."""
+    rc, _ = _run(tmp_path, "task", "egress", "grant", task["id"], "api.example.com")
+    assert rc == 0
+
+    metadata = _metadata(tmp_path, task["id"])
+
+    assert metadata["egress_contract"]["hosts"] == ["api.example.com"]
+    runtime = metadata.get("runtime") or {}
+    assert "egress_contract" not in runtime
+    assert "api.example.com" not in json.dumps(runtime)
+
+
+def test_the_listing_names_the_tier_it_grants(tmp_path, task):
+    """An operator should not have to read the policy module to learn which
+    tier they just used."""
+    _run(tmp_path, "task", "egress", "grant", task["id"], "api.example.com")
+
+    _rc, listed = _run(tmp_path, "task", "egress", "list", task["id"])
+
+    assert listed["trust_tier"] == "hub_declared"
+    assert listed["source"] == "metadata.egress_contract"
+
+
+# --------------------------------------------------------------------------
+# Validation at write time
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "https://api.example.com",   # scheme
+        "api.example.com:443",       # port
+        "api.example.com/v1",        # path
+        "*.example.com",             # glob
+        "10.0.0.1",                  # IP literal
+        "user:pw@example.com",       # credentials
+        "api example.com",           # whitespace
+        "",
+    ],
+)
+def test_a_malformed_host_is_refused_at_the_cli(tmp_path, task, bad):
+    """Rejected here, not silently dropped at sandbox build time.
+
+    Dropping it later shows the operator a host they granted that simply does
+    not work, with nothing pointing at why.
+    """
+    # The CLI maps a domain error to a non-zero exit and a stderr line rather
+    # than letting the exception escape, so that is the contract to assert.
+    rc, _ = _run(tmp_path, "task", "egress", "grant", task["id"], bad)
+
+    assert rc != 0
+    assert not (_metadata(tmp_path, task["id"]).get("egress_contract") or {}).get("hosts")
+
+
+def test_a_hostname_is_normalized(tmp_path, task):
+    """The DNS root dot and case are not two different hosts."""
+    _run(tmp_path, "task", "egress", "grant", task["id"], "API.Example.COM.")
+
+    listed = _metadata(tmp_path, task["id"])["egress_contract"]["hosts"]
+
+    assert listed == ["api.example.com"]
+
+
+# --------------------------------------------------------------------------
+# Ordinary behaviour
+# --------------------------------------------------------------------------
+
+
+def test_hosts_accumulate_and_stay_sorted(tmp_path, task):
+    _run(tmp_path, "task", "egress", "grant", task["id"], "b.example.com")
+    _run(tmp_path, "task", "egress", "grant", task["id"], "a.example.com")
+
+    _rc, listed = _run(tmp_path, "task", "egress", "list", task["id"])
+
+    assert listed["hosts"] == ["a.example.com", "b.example.com"]
+
+
+def test_granting_the_same_host_twice_is_a_no_op(tmp_path, task):
+    _run(tmp_path, "task", "egress", "grant", task["id"], "a.example.com")
+
+    _rc, again = _run(tmp_path, "task", "egress", "grant", task["id"], "a.example.com")
+
+    assert again["unchanged"] is True
+    assert _metadata(tmp_path, task["id"])["egress_contract"]["hosts"] == ["a.example.com"]
+
+
+def test_revoke_removes_only_that_host(tmp_path, task):
+    _run(tmp_path, "task", "egress", "grant", task["id"], "a.example.com")
+    _run(tmp_path, "task", "egress", "grant", task["id"], "b.example.com")
+
+    _run(tmp_path, "task", "egress", "revoke", task["id"], "a.example.com")
+
+    _rc, listed = _run(tmp_path, "task", "egress", "list", task["id"])
+    assert listed["hosts"] == ["b.example.com"]
+
+
+def test_revoking_a_host_that_was_not_granted_is_an_error(tmp_path, task):
+    """Silently succeeding would let an operator believe they closed something."""
+    rc, _ = _run(tmp_path, "task", "egress", "revoke", task["id"], "never.example.com")
+
+    assert rc != 0
+
+
+def test_listing_a_task_with_no_contract_is_empty_not_an_error(tmp_path, task):
+    _rc, listed = _run(tmp_path, "task", "egress", "list", task["id"])
+
+    assert listed["hosts"] == []
+
+
+def test_a_reason_is_recorded_with_the_grant(tmp_path, task):
+    """Why a host was opened is the thing a later reviewer needs."""
+    _run(
+        tmp_path, "task", "egress", "grant", task["id"], "a.example.com",
+        "--reason", "aviation_apis moved per-repo",
+    )
+
+    _rc, listed = _run(tmp_path, "task", "egress", "list", task["id"])
+    assert "aviation_apis" in (listed["reason"] or "")
+
+
+def test_granting_preserves_unrelated_metadata(tmp_path):
+    """A grant must not be a metadata overwrite."""
+    _run(tmp_path, "project", "create", "mac")
+    _rc, created = _run(
+        tmp_path, "task", "create", "keep my metadata", "--project", "mac",
+        "--metadata", json.dumps({"origin": {"kind": "operator"}}),
+    )
+
+    _run(tmp_path, "task", "egress", "grant", created["id"], "a.example.com")
+
+    metadata = _metadata(tmp_path, created["id"])
+    assert metadata["origin"]["kind"] == "operator"
+    assert metadata["egress_contract"]["hosts"] == ["a.example.com"]


### PR DESCRIPTION
Closes task_97b97266.

#297 grants sandbox egress to hosts listed in a task's **top-level** `metadata.egress_contract.hosts`, at the `hub_declared` trust tier. The only way to set that was `mac task create --metadata-file` — hand-authoring the whole metadata object.

**Getting the location wrong does not fail loudly.** It silently downgrades the hosts to the untrusted `derived` tier, where they're refused, so the operator sees a host they granted simply not work with nothing pointing at why. That's the worst shape a security control can have: it *appears* configured and isn't.

```bash
mac task egress grant  <task_id> <host> [--reason ...]
mac task egress list   <task_id>
mac task egress revoke <task_id> <host>
```

## The write location is the security model

| path | written by | tier |
|---|---|---|
| `metadata.egress_contract` | authenticated hub credential | **hub_declared** |
| `metadata.runtime.…` | the worker, from repo content | derived — refused unless it matches the reviewed registry |

So it's asserted rather than left to a reader's care: a test grants a host and then asserts it appears **nowhere** under `runtime`. Moving the write there fails **7** tests.

## Validation happens at write time

Hosts go through `sandbox_egress.normalize_host` before being stored, so a scheme, port, path, glob, IP literal, embedded credential or stray space is refused **at the CLI** rather than silently dropped when the sandbox is built. Skipping that check fails **8** tests.

```
$ mac task egress grant task_x 'https://api.example.com:443/v1'
'https://api.example.com:443/v1' is not a plain DNS hostname. Schemes, ports,
paths, globs and IP literals are refused: egress policy is keyed on the DNS name.
```

Hostnames are normalized, so `API.Example.COM.` and `api.example.com` aren't two different grants.

## Smaller decisions

- `list` reports the **tier** and the metadata path it read — an operator shouldn't have to open the policy module to learn which trust tier they just used.
- A grant **merges** into existing metadata rather than replacing it; re-granting the same host is a no-op.
- Revoking a host that was never granted is an **error**. Succeeding silently would let an operator believe they had closed something.
- `--reason` is stored with the contract, because why a host was opened is what a later reviewer needs.

## Verification

18 tests, mutation-verified on both security properties. `mac task egress help` works automatically, from the surface layer in #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)