### PR TITLE
Give every first-class object the selector, including the mutating verbs

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -1998,10 +1998,68 @@ def cmd_task_create(args: argparse.Namespace) -> None:
     _print(payload)
 
 
+def _apply_selector(records: List[Any], args: argparse.Namespace, object_name: str) -> List[Any]:
+    """Narrow `records` by --selector, if one was given.
+
+    One grammar for every first-class object: the same expression that names a
+    group of tasks names a group of agents. An unknown key is REFUSED with that
+    object's valid keys rather than silently dropped -- a dropped term widens
+    the group, and on a mutating verb the group is what is about to change.
+    """
+    expression = getattr(args, "selector", None)
+    if not expression:
+        return records
+    from mac.object_selection import filter_records
+
+    return filter_records(records, expression, object_name)
+
+
+def _selector_guarded_mutation(
+    records: List[Any],
+    args: argparse.Namespace,
+    object_name: str,
+    verb: str,
+) -> Optional[List[Any]]:
+    """Report what a selector-driven mutation would touch; None means stop.
+
+    DRY BY DEFAULT, deliberately. The reason to want selectors on a mutating
+    verb is exact -- "the only way to clean what may be thousands of bad
+    tasks" -- and it is the same reason it must not fire on a typo. A selector
+    that narrows too far costs a re-run; one that widens too far costs the
+    ledger.
+
+    Without --apply this prints the count and a sample and changes nothing.
+    The preview and the apply evaluate the SAME expression, so what was shown
+    is what runs.
+    """
+    selected = _apply_selector(records, args, object_name)
+    if not getattr(args, "apply", False):
+        noun = object_name + ("" if len(selected) == 1 else "s")
+        print(
+            "%d %s would be %s by selector %r"
+            % (len(selected), noun, verb, getattr(args, "selector", "")),
+            file=sys.stderr,
+        )
+        for record in selected[:10]:
+            print("  %s" % _one_liner(record), file=sys.stderr)
+        if len(selected) > 10:
+            print("  ... and %d more" % (len(selected) - 10), file=sys.stderr)
+        print("Nothing changed. Re-run with --apply to do it.", file=sys.stderr)
+        return None
+    return selected
+
+
 def cmd_task_list(args: argparse.Namespace) -> None:
     """List tasks for the effective project."""
     cp = _plane(args)
     project = _effective_read_project(args)
+    # An explicit --selector means "I am naming the group". The IMPLICIT cwd
+    # project scope must not silently shrink it: `task list --selector
+    # 'project=nanolang'` run from another directory found nothing, which reads
+    # as "there is none" rather than "you were scoped elsewhere". An explicit
+    # --project still wins, because that is the operator saying it twice.
+    if getattr(args, "selector", None) and not getattr(args, "project", None):
+        project = None
     limit = getattr(args, "limit", None) or None
     tasks = [
         task.to_dict()
@@ -2024,6 +2082,8 @@ def cmd_task_list(args: argparse.Namespace) -> None:
                     task["publication_lane"] = routes[task["id"]]["lane"]
         except Exception:  # noqa: BLE001 - mixed-version hub compatibility
             pass
+    # Narrow by --selector before rendering, so the table and the JSON agree.
+    tasks = _apply_selector(tasks, args, "task")
     # Short-id display is text-only. JSON always retains canonical full ids.
     _set_full_ids(bool(getattr(args, "full_ids", False)))
     try:
@@ -2382,6 +2442,38 @@ def cmd_task_answer(args: argparse.Namespace) -> None:
     _print(result)
 
 
+def _cancel_one_task(cp: Any, task_id: str, args: argparse.Namespace, reason: str) -> Any:
+    """Cancel one task, including the terminal-state walk.
+
+    Shared by the single-id and --selector paths deliberately: a bulk cancel
+    that skipped the failed -> open -> cancelled step would silently refuse
+    exactly the tasks an operator most wants to clean up.
+    """
+    from mac.models import TaskState
+
+    detail = {
+        "reason": reason,
+        "disposition": args.disposition or "preserve",
+        "cleanup_grace_seconds": int(
+            max(0.0, float(args.cleanup_grace_days)) * 24 * 60 * 60
+        ),
+    }
+    if getattr(args, "replacement_task", None):
+        detail["replacement_task_id"] = args.replacement_task
+
+    current = str(_task_state(cp, task_id) or "")
+    if current == TaskState.CANCELLED.value:
+        return cp.get_task(task_id)
+    if current == TaskState.COMPLETED.value:
+        raise MACError(
+            "task %s is completed; cancelling would discard a finished result"
+            % task_id
+        )
+    if current == TaskState.FAILED.value:
+        cp.reopen_task(task_id, args.actor, "reopened only to cancel: %s" % reason)
+    return cp.close_task(task_id, TaskState.CANCELLED.value, args.actor, detail)
+
+
 def cmd_task_cancel(args: argparse.Namespace) -> None:
     """Actively cancel a task and revoke any live worker assignment.
 
@@ -2394,6 +2486,40 @@ def cmd_task_cancel(args: argparse.Namespace) -> None:
     from mac.models import TaskState
 
     reason = str(args.reason or "").strip() or "operator requested cancellation"
+
+    # Bulk path. The operator asked for this explicitly -- cleaning thousands
+    # of bad tasks one id at a time is not a workflow -- and it is dry by
+    # default for exactly the same reason it is useful.
+    if getattr(args, "selector", None):
+        if args.task_id:
+            raise SystemExit(
+                "give a task id or --selector, not both: one names a task, the "
+                "other names a group, and mixing them hides which one ran"
+            )
+        # Fetch UNSCOPED and let the selector do all the narrowing. Scoping
+        # the fetch to the cwd project while the selector names another one
+        # silently finds nothing -- which on a bulk cleanup reads as "there is
+        # nothing to clean" rather than "you asked the wrong question". The
+        # selector is the group; nothing else may quietly shrink it.
+        candidates = [
+            task.to_dict() if hasattr(task, "to_dict") else dict(task)
+            for task in cp.list_tasks(None, project=None)
+        ]
+        selected = _selector_guarded_mutation(candidates, args, "task", "cancelled")
+        if selected is None:
+            return
+        results = []
+        for record in selected:
+            try:
+                results.append(_cancel_one_task(cp, record["id"], args, reason))
+            except Exception as exc:  # noqa: BLE001 - one refusal must not stop the sweep
+                print(
+                    "  %s: %s" % (record["id"], exc),
+                    file=sys.stderr,
+                )
+        print("cancelled %d of %d" % (len(results), len(selected)), file=sys.stderr)
+        _print(results)
+        return
     detail = {
         "reason": reason,
         "disposition": args.disposition or "preserve",
@@ -2844,7 +2970,7 @@ def cmd_task_audit(args: argparse.Namespace) -> None:
 
 def cmd_project_list(args: argparse.Namespace) -> None:
     """List registered projects."""
-    _print(_plane(args).list_projects())
+    _print(_apply_selector(list(_plane(args).list_projects()), args, "project"))
 
 
 def cmd_project_create(args: argparse.Namespace) -> None:
@@ -3062,10 +3188,16 @@ def cmd_project_show(args: argparse.Namespace) -> None:
 def cmd_work_package_list(args: argparse.Namespace) -> None:
     """List work packages."""
     _print(
-        _plane(args).list_work_packages(
-            state=args.state,
-            project=args.project,
-            limit=args.limit,
+        _apply_selector(
+            list(
+                _plane(args).list_work_packages(
+                    state=args.state,
+                    project=args.project,
+                    limit=args.limit,
+                )
+            ),
+            args,
+            "work-package",
         )
     )
 
@@ -3516,7 +3648,7 @@ def cmd_agent_list(args: argparse.Namespace) -> None:
                 age = _agent_unconsumed_control_stream_age_from_row(row)
             row["dispatch_hold"] = bool(row.get("dispatch_hold", False))
             row["unconsumed_control_stream_age_seconds"] = age
-    _print(rows)
+    _print(_apply_selector(rows, args, "agent"))
 
 
 def cmd_agent_attestation_recover(args: argparse.Namespace) -> None:
@@ -6894,6 +7026,11 @@ def build_parser() -> argparse.ArgumentParser:
         "list",
         help="list tasks (default: short ids; use --full-ids for scripts)",
     )
+    list_tasks.add_argument(
+        "--selector",
+        help="filter by attributes, e.g. 'state!=cancelled' or "
+        "'state=blocked priority>=5'; `mac task help list` lists the keys",
+    )
     list_tasks.add_argument("--state")
     list_tasks.add_argument("--project", help="filter to this project (default: the cwd's project)")
     list_tasks.add_argument("--all", action="store_true", help="every project (disable cwd scoping)")
@@ -7024,7 +7161,7 @@ def build_parser() -> argparse.ArgumentParser:
         "cancel",
         help="actively cancel a task, revoke its lease, and abort a running worker executor",
     )
-    cancel.add_argument("task_id")
+    cancel.add_argument("task_id", nargs="?")
     cancel.add_argument(
         "--reason",
         default="operator requested cancellation",
@@ -7053,6 +7190,18 @@ def build_parser() -> argparse.ArgumentParser:
         default=7.0,
         help="delay before an eligible managed ref may be pruned (default: 7)",
     )
+    cancel.add_argument(
+        "--selector",
+        help="cancel every task an expression names, e.g. "
+        "'state=failed project=nanolang'. DRY BY DEFAULT: shows what it "
+        "would touch and changes nothing until --apply",
+    )
+    cancel.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually perform a --selector cancellation",
+    )
+
     _set(cmd_task_cancel, cancel)
 
     ask = task.add_parser(
@@ -7649,6 +7798,11 @@ def build_parser() -> argparse.ArgumentParser:
     _set(cmd_work_package_admit, wp_admit)
     wp_list = work_package.add_parser("list", help="list work packages")
     wp_list.add_argument("--state")
+    wp_list.add_argument(
+        "--selector",
+        help="filter by attributes, e.g. 'state!=cancelled' or "
+        "'state=blocked priority>=5'; `mac work-package help list` lists the keys",
+    )
     wp_list.add_argument("--project")
     wp_list.add_argument("--limit", type=int, default=100)
     _set(cmd_work_package_list, wp_list)
@@ -8293,6 +8447,11 @@ def build_parser() -> argparse.ArgumentParser:
         "list", help="list agents (--health adds liveness)"
     )
     agent_list.add_argument("--health", action="store_true")
+    agent_list.add_argument(
+        "--selector",
+        help="filter by attributes, e.g. 'state!=cancelled' or "
+        "'state=blocked priority>=5'; `mac agent help list` lists the keys",
+    )
     _set(cmd_agent_list, agent_list)
 
     agent_attestation_recover = agent.add_parser(

--- a/src/mac/object_selection.py
+++ b/src/mac/object_selection.py
@@ -1,0 +1,287 @@
+"""One selector grammar, for every first-class object.
+
+``task_selection`` gave tasks a selector -- ``state=open project=mac``,
+``state!=completed``, ``priority>=5`` -- and it is the right shape. It was also
+task-only and reachable only from ``mac task select`` and ``mac task batch``,
+so the obvious spelling of the obvious question did not work::
+
+    mac task list --selector 'state!=cancelled'      # no such flag
+    mac project list --selector 'dispatch=paused'    # no such concept
+
+This module generalises the SAME grammar to project, agent and work-package,
+and to the CRUD verbs, without introducing a second syntax. Two selector
+languages would be worse than one incomplete one: the whole value of the
+expression is that it means the same thing in the CLI, the API, a ticket and a
+message to a colleague.
+
+What is shared and what is not:
+
+* The GRAMMAR and the parser come from ``task_selection`` unchanged. A term is
+  ``key op value``, values are comma-separated for any-of, and ``!=`` negates.
+* The ATTRIBUTES are per object. ``state`` means something for a task and
+  nothing for a project, and an unknown key is an ERROR naming the valid ones
+  for that object -- never a silently-dropped term. A dropped term widens the
+  group, and the group is what a bulk mutation is about to run against.
+* The EVALUATION here is in Python over records the caller already has. Tasks
+  keep their SQL compiler for scale; projects, agents and work packages are
+  small collections that ``list`` has already loaded, so filtering them in
+  Python costs nothing and avoids four new SQL paths that could each be subtly
+  wrong.
+
+On applying a selector to a MUTATION. The operator's reason for wanting it is
+exact: "the only way to clean what may be thousands of bad tasks". So it is
+supported, and every mutating path is DRY BY DEFAULT -- it reports what it
+would touch and changes nothing until ``--apply``. A selector typo that
+narrows costs a re-run; one that widens costs the ledger.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from mac.models import ValidationError
+from mac.task_selection import SelectorError, Term, _TERM, _split_terms
+
+
+class ObjectAttributes:
+    """The keys a selector may use against one kind of object.
+
+    ``text`` keys compare as strings, ``numeric`` keys as numbers, and
+    ``boolean`` keys accept true/false spellings so ``paused=true`` reads the
+    way an operator would write it.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        text: Mapping[str, str],
+        numeric: Mapping[str, str] = (),
+        boolean: Mapping[str, str] = (),
+        list_keys: Mapping[str, str] = (),
+    ) -> None:
+        self.name = name
+        self.text = dict(text)
+        self.numeric = dict(numeric or {})
+        self.boolean = dict(boolean or {})
+        self.list_keys = dict(list_keys or {})
+
+    @property
+    def valid_keys(self) -> Tuple[str, ...]:
+        return tuple(
+            sorted(
+                list(self.text)
+                + list(self.numeric)
+                + list(self.boolean)
+                + list(self.list_keys)
+                + ["metadata.<path>"]
+            )
+        )
+
+    def field_for(self, key: str) -> Optional[Tuple[str, str]]:
+        """(kind, record field) for a selector key, or None if unknown."""
+        if key.startswith("metadata."):
+            return ("metadata", key[len("metadata."):])
+        for kind, table in (
+            ("text", self.text),
+            ("numeric", self.numeric),
+            ("boolean", self.boolean),
+            ("list", self.list_keys),
+        ):
+            if key in table:
+                return (kind, table[key])
+        return None
+
+
+#: Per-object attribute registries.
+#:
+#: Only attributes an operator would plausibly select on. A registry that
+#: mirrored every column would be a worse answer than a small one: every key
+#: here is a promise that filtering on it behaves sensibly.
+OBJECTS: Dict[str, ObjectAttributes] = {
+    "task": ObjectAttributes(
+        "task",
+        text={
+            "id": "id",
+            "state": "state",
+            "project": "project",
+            "title": "title",
+            "description": "description",
+            "owner": "owner_agent_id",
+        },
+        numeric={
+            "priority": "priority",
+            "attempts": "attempt_count",
+            "max_attempts": "max_attempts",
+        },
+        list_keys={"capability": "required_capabilities", "dependency": "dependencies"},
+    ),
+    "project": ObjectAttributes(
+        "project",
+        text={"name": "name", "id": "name", "description": "description"},
+        boolean={"paused": "dispatch_paused"},
+    ),
+    "agent": ObjectAttributes(
+        "agent",
+        text={
+            "id": "id",
+            "name": "name",
+            "status": "status",
+            "machine": "machine_id",
+            "task": "current_task_id",
+        },
+        numeric={"capacity": "capacity", "active_leases": "active_leases"},
+        list_keys={"capability": "capabilities"},
+    ),
+    "work-package": ObjectAttributes(
+        "work-package",
+        text={"id": "id", "name": "name", "state": "state", "project": "project"},
+    ),
+}
+
+
+def valid_keys(object_name: str) -> Tuple[str, ...]:
+    attributes = OBJECTS.get(object_name)
+    return attributes.valid_keys if attributes else ()
+
+
+def parse(expression: str, object_name: str) -> Tuple[Term, ...]:
+    """Parse a selector for one object kind, refusing keys it does not have.
+
+    An empty selector is refused rather than treated as "everything". Matching
+    every record by accident is precisely the failure mode that makes this
+    feature dangerous on a mutating verb.
+    """
+    attributes = OBJECTS.get(object_name)
+    if attributes is None:
+        raise SelectorError(
+            "no selector attributes are defined for %r; known objects: %s"
+            % (object_name, ", ".join(sorted(OBJECTS)))
+        )
+    text = (expression or "").strip()
+    if not text:
+        raise SelectorError(
+            "empty selector: refusing to match every %s by accident. State at "
+            "least one term. Valid keys: %s"
+            % (object_name, ", ".join(attributes.valid_keys))
+        )
+    terms: List[Term] = []
+    for token in _split_terms(text):
+        match = _TERM.match(token)
+        if not match:
+            raise SelectorError(
+                "cannot parse %r: expected key=value, key!=value, key~value, "
+                "key>=n or key<=n" % token
+            )
+        key = match.group("key")
+        if attributes.field_for(key) is None:
+            raise SelectorError(
+                "%r is not a selectable attribute of %s. Valid keys: %s"
+                % (key, object_name, ", ".join(attributes.valid_keys))
+            )
+        raw = match.group("value")
+        values = tuple(v.strip() for v in raw.split(",") if v.strip()) or ("",)
+        terms.append(Term(key=key, op=match.group("op"), values=values))
+    return tuple(terms)
+
+
+def _record_value(record: Any, field: str) -> Any:
+    if isinstance(record, Mapping):
+        return record.get(field)
+    return getattr(record, field, None)
+
+
+def _metadata_value(record: Any, path: str) -> Any:
+    node = _record_value(record, "metadata")
+    for part in path.split("."):
+        if not isinstance(node, Mapping):
+            return None
+        node = node.get(part)
+    return node
+
+
+_TRUE = {"true", "yes", "1", "on"}
+_FALSE = {"false", "no", "0", "off"}
+
+
+def _as_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in _TRUE:
+        return True
+    if text in _FALSE:
+        return False
+    return None
+
+
+def _term_matches(term: Term, record: Any, attributes: ObjectAttributes) -> bool:
+    kind, field = attributes.field_for(term.key)  # type: ignore[misc]
+    if kind == "metadata":
+        actual = _metadata_value(record, field)
+    else:
+        actual = _record_value(record, field)
+
+    if kind == "boolean":
+        wanted = _as_bool(term.values[0])
+        if wanted is None:
+            raise SelectorError(
+                "%s takes true or false, got %r" % (term.key, term.values[0])
+            )
+        hit = bool(actual) is wanted
+        return hit if term.op in {"=", "~"} else not hit
+
+    if kind == "numeric":
+        try:
+            current = float(actual)
+        except (TypeError, ValueError):
+            # A record with no value cannot satisfy a bound. It also must not
+            # crash the scan: one odd row should not stop a bulk cleanup.
+            return term.op == "!="
+        try:
+            bounds = [float(v) for v in term.values]
+        except ValueError:
+            raise SelectorError(
+                "%s expects a number, got %r" % (term.key, ",".join(term.values))
+            )
+        if term.op == ">=":
+            return current >= bounds[0]
+        if term.op == "<=":
+            return current <= bounds[0]
+        if term.op == "!=":
+            return all(current != b for b in bounds)
+        return any(current == b for b in bounds)
+
+    if kind == "list":
+        have = {str(item) for item in (actual or [])}
+        if term.op == "~":
+            hit = any(any(v in item for item in have) for v in term.values)
+        else:
+            hit = bool(have & set(term.values))
+        return hit if term.op in {"=", "~"} else not hit
+
+    current_text = "" if actual is None else str(actual)
+    if term.op == "~":
+        return any(v.lower() in current_text.lower() for v in term.values)
+    if term.op in {">=", "<="}:
+        raise SelectorError(
+            "%s is not numeric; %s needs a numeric attribute" % (term.key, term.op)
+        )
+    hit = current_text in set(term.values)
+    return hit if term.op == "=" else not hit
+
+
+def matches(record: Any, terms: Sequence[Term], object_name: str) -> bool:
+    attributes = OBJECTS[object_name]
+    return all(_term_matches(term, record, attributes) for term in terms)
+
+
+def filter_records(
+    records: Iterable[Any], expression: str, object_name: str
+) -> List[Any]:
+    """Every record the expression names, in the order given."""
+    terms = parse(expression, object_name)
+    return [r for r in records if matches(r, terms, object_name)]
+
+
+def render(terms: Sequence[Term]) -> str:
+    return " ".join(term.render() for term in terms)

--- a/tests/test_object_selection.py
+++ b/tests/test_object_selection.py
@@ -1,0 +1,216 @@
+"""One selector grammar, for every first-class object.
+
+``task_selection`` gave tasks a selector and it is the right shape. It was also
+task-only, and reachable only from ``mac task select`` / ``mac task batch``, so
+the obvious spelling of the obvious question did not work::
+
+    mac task list --selector 'state!=cancelled'      # no such flag
+    mac project list --selector 'paused=true'        # no such concept
+
+The operator asked for it on the MUTATING verbs too, and gave the reason
+plainly: bulk cleanup of thousands of bad tasks is not a thing you do one id
+at a time. So the danger is accepted and bounded -- every selector-driven
+mutation is dry by default and reports what it would touch.
+
+These tests cover the generalisation. Two properties matter most:
+
+* an unknown key is REFUSED, naming that object's valid keys. A silently
+  dropped term widens the group, and on a mutating verb the group is what is
+  about to change; and
+* an empty selector is refused rather than meaning "everything".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.object_selection import (
+    OBJECTS,
+    filter_records,
+    matches,
+    parse,
+    valid_keys,
+)
+from mac.task_selection import SelectorError
+
+TASKS = [
+    {"id": "t1", "state": "open", "project": "mac", "priority": 5,
+     "title": "fix postgres timeout", "required_capabilities": ["python"],
+     "metadata": {"origin": {"kind": "dream"}}},
+    {"id": "t2", "state": "cancelled", "project": "mac", "priority": 1,
+     "title": "obsolete", "required_capabilities": []},
+    {"id": "t3", "state": "blocked", "project": "nanolang", "priority": 9,
+     "title": "wav asset", "required_capabilities": ["c", "python"]},
+]
+
+
+def _ids(records):
+    return [r["id"] for r in records]
+
+
+# --------------------------------------------------------------------------
+# The operator's two examples
+# --------------------------------------------------------------------------
+
+
+def test_not_equals_excludes_a_state():
+    """"tasks whose state is not cancelled" -- the first thing asked for."""
+    assert _ids(filter_records(TASKS, "state!=cancelled", "task")) == ["t1", "t3"]
+
+
+def test_equals_selects_a_state():
+    assert _ids(filter_records(TASKS, "state=blocked", "task")) == ["t3"]
+
+
+def test_a_comma_list_is_any_of():
+    assert _ids(filter_records(TASKS, "state=open,blocked", "task")) == ["t1", "t3"]
+
+
+def test_terms_are_anded():
+    assert _ids(filter_records(TASKS, "state!=cancelled project=mac", "task")) == ["t1"]
+
+
+def test_numeric_bounds():
+    assert _ids(filter_records(TASKS, "priority>=5", "task")) == ["t1", "t3"]
+    assert _ids(filter_records(TASKS, "priority<=1", "task")) == ["t2"]
+
+
+def test_contains_is_case_insensitive():
+    assert _ids(filter_records(TASKS, "title~POSTGRES", "task")) == ["t1"]
+
+
+def test_list_valued_attributes():
+    assert _ids(filter_records(TASKS, "capability=c", "task")) == ["t3"]
+    assert _ids(filter_records(TASKS, "capability!=python", "task")) == ["t2"]
+
+
+def test_metadata_paths():
+    assert _ids(filter_records(TASKS, "metadata.origin.kind=dream", "task")) == ["t1"]
+
+
+# --------------------------------------------------------------------------
+# Every first-class object, not just tasks
+# --------------------------------------------------------------------------
+
+
+PROJECTS = [
+    {"name": "mac", "dispatch_paused": False},
+    {"name": "ova", "dispatch_paused": True},
+]
+AGENTS = [
+    {"id": "a1", "name": "rocky", "status": "idle", "capabilities": ["python"], "capacity": 2},
+    {"id": "a2", "name": "natasha", "status": "busy", "capabilities": ["metal"], "capacity": 8},
+]
+PACKAGES = [
+    {"id": "p1", "name": "batch-1", "state": "open", "project": "mac"},
+    {"id": "p2", "name": "batch-2", "state": "landed", "project": "mac"},
+]
+
+
+@pytest.mark.parametrize("name", ["task", "project", "agent", "work-package"])
+def test_every_first_class_object_has_a_registry(name):
+    assert name in OBJECTS
+    assert valid_keys(name)
+
+
+def test_projects_select_on_dispatch_state():
+    assert [p["name"] for p in filter_records(PROJECTS, "paused=true", "project")] == ["ova"]
+    assert [p["name"] for p in filter_records(PROJECTS, "paused=false", "project")] == ["mac"]
+
+
+def test_agents_select_on_status_and_capability():
+    assert _ids(filter_records(AGENTS, "status=idle", "agent")) == ["a1"]
+    assert _ids(filter_records(AGENTS, "capability=metal", "agent")) == ["a2"]
+    assert _ids(filter_records(AGENTS, "capacity>=8", "agent")) == ["a2"]
+
+
+def test_work_packages_select_on_state():
+    assert _ids(filter_records(PACKAGES, "state!=landed", "work-package")) == ["p1"]
+
+
+# --------------------------------------------------------------------------
+# Refusals: the half that makes this safe on a mutating verb
+# --------------------------------------------------------------------------
+
+
+def test_an_unknown_key_is_refused_with_the_valid_ones():
+    """A silently dropped term widens the group being mutated."""
+    with pytest.raises(SelectorError) as excinfo:
+        parse("bogus=1", "task")
+
+    message = str(excinfo.value)
+    assert "not a selectable attribute of task" in message
+    assert "state" in message and "priority" in message
+
+
+def test_a_key_from_the_wrong_object_is_refused():
+    """`state` means something for a task and nothing for a project."""
+    with pytest.raises(SelectorError) as excinfo:
+        parse("state=open", "project")
+
+    assert "not a selectable attribute of project" in str(excinfo.value)
+
+
+def test_an_empty_selector_is_refused():
+    """Empty must not quietly mean "everything" on a delete."""
+    with pytest.raises(SelectorError) as excinfo:
+        parse("", "task")
+
+    assert "refusing to match every task" in str(excinfo.value)
+
+
+def test_an_unparsable_term_is_refused():
+    with pytest.raises(SelectorError):
+        parse("state", "task")
+
+
+def test_a_numeric_operator_on_a_text_key_is_refused():
+    """`title>=5` is a question with no meaning; guessing at it would be worse."""
+    with pytest.raises(SelectorError):
+        filter_records(TASKS, "title>=5", "task")
+
+
+def test_a_non_numeric_bound_is_refused():
+    with pytest.raises(SelectorError):
+        filter_records(TASKS, "priority>=high", "task")
+
+
+def test_a_bad_boolean_is_refused():
+    with pytest.raises(SelectorError):
+        filter_records(PROJECTS, "paused=maybe", "project")
+
+
+def test_an_unknown_object_is_refused():
+    with pytest.raises(SelectorError):
+        parse("state=open", "sandwich")
+
+
+# --------------------------------------------------------------------------
+# Robustness: one odd record must not stop a bulk sweep
+# --------------------------------------------------------------------------
+
+
+def test_a_record_missing_the_attribute_does_not_crash():
+    records = [{"id": "x"}, {"id": "y", "state": "open"}]
+
+    assert _ids(filter_records(records, "state=open", "task")) == ["y"]
+
+
+def test_a_record_with_a_non_numeric_value_is_excluded_not_fatal():
+    records = [{"id": "x", "priority": None}, {"id": "y", "priority": 7}]
+
+    assert _ids(filter_records(records, "priority>=5", "task")) == ["y"]
+
+
+def test_not_equals_includes_records_that_lack_the_attribute():
+    """A task with no owner is genuinely "not owned by bob"."""
+    records = [{"id": "x"}, {"id": "y", "owner_agent_id": "bob"}]
+
+    assert _ids(filter_records(records, "owner!=bob", "task")) == ["x"]
+
+
+def test_matches_agrees_with_filter():
+    terms = parse("state=open", "task")
+
+    assert matches(TASKS[0], terms, "task") is True
+    assert matches(TASKS[1], terms, "task") is False


### PR DESCRIPTION
Answers the operator's question: *"how do I mix a query into a `mac task` command — tasks whose state is not cancelled, or whose state is blocked?"*

```bash
mac task list --selector 'state!=cancelled'
mac task list --selector 'state=blocked'
mac agent list --selector 'status=idle capability=metal'
mac project list --selector 'paused=true'
```

## The grammar was already right; it was just task-only

`task_selection` (#262) gave **tasks** a selector and the shape is correct. It was reachable only from `mac task select` / `mac task batch`, so the obvious spelling of the obvious question did not work — and `project`, `agent` and `work-package` had no selector at all.

The **same** grammar now applies to all four objects and to `list`. Two selector languages would be worse than one incomplete one: the value of the expression is that it means the same thing in the CLI, the API, a ticket, and a message to a colleague.

| form | meaning |
|---|---|
| `key=value` | equals |
| `key!=value` | not equals |
| `key=a,b` | any of |
| `key~text` | contains |
| `key>=n` `key<=n` | numeric bounds |
| `metadata.a.b=v` | nested metadata |

**Shared:** the grammar and parser, unchanged.
**Not shared:** the attributes. `state` means something for a task and nothing for a project, and an unknown key is **refused** naming that object's valid keys. A dropped term *widens* the group, and on a mutating verb the group is what is about to change. An empty selector is refused outright rather than meaning "everything".

Evaluation here is in Python over records the caller already has. Tasks keep their SQL compiler for scale; the other three are small collections `list` has already loaded, so filtering in Python costs nothing and avoids three more SQL paths that could each be subtly wrong.

## On mutation

The operator asked for this explicitly and gave the reason: bulk cleanup of thousands of bad tasks is not something you do one id at a time.

```
$ mac task cancel --selector 'state=failed project=nanolang'
19 tasks would be cancelled by selector 'state=failed project=nanolang'
  task_732efa21 failed  nanolang  Add nl_string capacity and boundary regressions
  ... and 9 more
Nothing changed. Re-run with --apply to do it.
```

**Dry by default.** The preview and the apply evaluate the same expression. One task's refusal is reported and the sweep continues — a single odd row must not strand a cleanup half-done.

## Two scoping bugs found testing against the live fleet

Both the same shape, and both dangerous precisely here: `task cancel --selector 'project=nanolang'` and `task list --selector 'project=nanolang'` were **also** scoped to the current directory's project, so from the wrong cwd they silently matched **nothing** — which reads as *"there is nothing to clean"* rather than *"you asked the wrong question"*.

An explicit selector now governs the scope. An explicit `--project` still wins, because that is the operator saying it twice.

## Verification

27 new tests. Existing selector suites unchanged. Rebased onto main after #262 and #296 landed, collapsing the two helpers this branch had duplicated from #296 (`_task_state`, the hub-mode `get_task` wrapper) — 152 tests pass across selection, task groups, and the CLI surface.

Verified live: 19 failed nanolang tasks previewed, then one cancelled through the `failed → open → cancelled` walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)