### PR TITLE
Let an operator read back the guardrail they can write, and stop write tokens authoring policy

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -2204,20 +2204,53 @@ def _required_scope(method: str, path: str) -> Optional[str]:
         # gateway hosts and the binary paths permitted to reach them, which is
         # a map of the control plane for anyone holding only a read token.
         return "agent"
-    if method in {"GET", "POST"} and re.match(
-        r"^/openshell/policies/[^/]+(/versions|/render)?$", path
-    ):
-        # Every route that returns the guardrail SOURCE — the fleet's hub and
-        # gateway hosts, their ports, and the binaries permitted to reach them —
-        # requires admin. `render` is included because a rendered policy is the
-        # same text with the placeholders filled IN, which makes it strictly
-        # more disclosive than the template, not less; it was reachable with a
-        # task-writing token.
+    if path == "/openshell/policies" or path.startswith("/openshell/policies/"):
+        # One rule for the whole guardrail-policy resource, because the previous
+        # split was indefensible: reading a policy's SOURCE required admin while
+        # CREATING, UPDATING, DELETING and ASSIGNING one needed only `write`.
+        # A token could author the guardrail it was not allowed to read back.
         #
-        # The list, assignment, status and dashboard views deliberately stay
-        # "read": after this change they carry identity, version and checksum,
-        # which is everything drift detection needs and nothing an attacker can
-        # navigate by.
+        # Reads and writes now meet at admin. The disclosive reads
+        # (`{id}`, `{id}/versions`, `{id}/render`) require it because the text is
+        # the fleet's hub and gateway hosts, their ports, and the binaries
+        # permitted to reach them — `render` most of all, being that template
+        # with the placeholders filled IN. The mutations require it because
+        # authoring the confinement every --yolo agent runs under is at least as
+        # privileged as reading it. Every caller is already an operator CLI path
+        # (`mac openshell policy ...`, `mac openshell reconcile`); no worker or
+        # agent creates or assigns policies.
+        #
+        # Two identity views stay `read` deliberately — they carry name, version
+        # and checksum but never the body, which is everything drift detection
+        # and the dashboard need, and nothing an attacker can navigate by.
+        if method == "GET" and (
+            path == "/openshell/policies" or path.endswith("/assignments")
+        ):
+            return "read"
+        return "admin"
+    if method != "GET" and (
+        path == "/directives"
+        or path.startswith("/directives/")
+        or path == "/directive-bindings"
+        or path.startswith("/directive-waivers/")
+    ):
+        # Authoring a directive is operator speech, and this codebase already
+        # says so: /agentbus/human-directive is admin precisely because human
+        # directives are "never mintable via the agent scope (authority =
+        # attested provenance)". A directive proposed, approved and activated
+        # with a task-writing token has exactly the provenance problem that rule
+        # exists to prevent -- it changes fleet-wide behaviour while claiming an
+        # authority nobody granted.
+        #
+        # Covers the whole authoring lifecycle: propose, check, approve,
+        # activate, deactivate, waivers, waiver revocation, and bindings.
+        #
+        # GETs stay `read` -- the directive documents, versions and impact views
+        # are a read model, not a secret, and operators and dashboards depend on
+        # them. The agent-side distribution paths
+        # (/agents/{id}/directives/effective and .../directive-activations/...)
+        # are matched earlier and keep the `agent` scope, so a worker still
+        # receives and acknowledges directives normally.
         return "admin"
     if method == "GET":
         return "read"

--- a/tests/api/test_directive_authoring_authz.py
+++ b/tests/api/test_directive_authoring_authz.py
@@ -1,0 +1,140 @@
+"""Authoring a directive is operator speech, so it requires an operator.
+
+This codebase already states the principle: `/agentbus/human-directive` is admin
+because human directives are "never mintable via the agent scope (authority =
+attested provenance)". The directive *authoring* lifecycle carried only `write`,
+which is the same provenance problem — a token that writes tasks could propose,
+approve and activate a directive that changes fleet-wide behaviour, claiming an
+authority nobody granted it.
+
+The two boundaries that must NOT move are pinned here too: the read models stay
+readable, and the agent-side distribution paths keep the `agent` scope so a
+worker still receives and acknowledges directives normally.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from mac.api import _required_scope, create_app
+from mac.services import ControlPlane
+
+AUTHORING = [
+    ("POST", "/directives"),
+    ("POST", "/directives/d1/check"),
+    ("POST", "/directives/d1/approve"),
+    ("POST", "/directives/d1/activate"),
+    ("POST", "/directives/d1/deactivate"),
+    ("POST", "/directives/d1/waivers"),
+    ("POST", "/directive-bindings"),
+    ("POST", "/directive-waivers/w1/revoke"),
+]
+
+READ_MODELS = [
+    "/directives",
+    "/directives/effective",
+    "/directives/d1",
+    "/directives/d1/versions",
+    "/directives/d1/impact",
+    "/directive-bindings",
+    "/directive-waivers",
+]
+
+AGENT_DISTRIBUTION = [
+    ("GET", "/agents/a1/directives/effective"),
+    ("POST", "/agents/a1/directive-activations/x1/ack"),
+]
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": "Bearer %s" % token}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("MAC_DIRECTIVES_ENABLED", "1")
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host")
+    agent = cp.register_agent(machine.id, "worker-1")
+    return TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "reader": {"scopes": ["read"], "client_id": "dashboard"},
+                "writer": {"scopes": ["write"], "client_id": "ci"},
+                "admin": {"scopes": ["admin"], "client_id": "operator"},
+                "worker": {"scopes": ["agent"], "agent_id": agent.id},
+            },
+        )
+    ), agent
+
+
+@pytest.mark.parametrize("method,path", AUTHORING)
+def test_authoring_requires_admin(method, path):
+    assert _required_scope(method, path) == "admin"
+
+
+@pytest.mark.parametrize("path", READ_MODELS)
+def test_read_models_stay_readable(path):
+    """Directive documents, versions and impact are a read model, not a secret;
+    operators and dashboards depend on them."""
+    assert _required_scope("GET", path) == "read"
+
+
+@pytest.mark.parametrize("method,path", AGENT_DISTRIBUTION)
+def test_agent_distribution_keeps_the_agent_scope(method, path):
+    """A worker must still receive and acknowledge directives. These are matched
+    earlier than the authoring rule; if that ordering ever breaks, directive
+    delivery silently stops fleet-wide."""
+    assert _required_scope(method, path) == "agent"
+
+
+@pytest.mark.parametrize("method,path", AUTHORING)
+def test_a_write_token_can_no_longer_author_a_directive(client, method, path):
+    api, _agent = client
+    response = api.request(
+        method,
+        path,
+        headers=_headers("writer"),
+        json={"document": {}, "actor": "ci"},
+    )
+    assert response.status_code == 403
+
+
+def test_a_write_token_previously_reached_the_service_layer(client):
+    """POST /directives/{id}/check used to get past the guard and raise a
+    TypeError from inside DirectiveService — proof it was executing business
+    logic, not merely failing validation."""
+    api, _agent = client
+    response = api.post(
+        "/directives/d1/check", headers=_headers("writer"), json={}
+    )
+    assert response.status_code == 403
+
+
+def test_an_operator_can_still_propose(client):
+    """Raising the scope must not break `mac directive propose`."""
+    api, _agent = client
+    response = api.post(
+        "/directives",
+        headers=_headers("admin"),
+        json={
+            "document": {
+                "schema": "mac.directive.v1",
+                "name": "build.example",
+                "description": "Example.",
+                "scope": "fleet",
+                "when": {"eq": [{"literal": 1}, {"literal": 1}]},
+                "set": {"example.enabled": True},
+            },
+            "actor": "operator",
+        },
+    )
+    assert response.status_code == 200
+
+
+def test_a_reader_can_still_list_directives(client):
+    api, _agent = client
+    assert api.get("/directives", headers=_headers("reader")).status_code == 200

--- a/tests/api/test_openshell_policy_symmetry.py
+++ b/tests/api/test_openshell_policy_symmetry.py
@@ -1,0 +1,165 @@
+"""Reads and writes of an OpenShell guardrail policy meet at the same scope.
+
+PR #298 made the policy BODY admin-only because it names the fleet's hub and
+gateway hosts, their ports, and the binaries permitted to reach them. It left
+the mutations at `write`, which produced an indefensible split: a token could
+CREATE, UPDATE, DELETE and ASSIGN the guardrail every ``--yolo`` agent runs
+under, and then be refused when it tried to read back what it had just written.
+
+Authoring a confinement is at least as privileged as reading one, so the two
+meet at admin rather than the body being lowered to `write`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fastapi.testclient import TestClient
+
+from mac.api import _required_scope, create_app
+from mac.services import ControlPlane
+
+SECRET_HOST = "hub-internal.example.invalid"
+POLICY_TEXT = """version: 1
+
+network_policies:
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: %s
+        port: 8789
+""" % SECRET_HOST
+
+#: Everything that mutates the guardrail resource.
+WRITES = [
+    ("POST", "/openshell/policies"),
+    ("PUT", "/openshell/policies/%(policy)s"),
+    ("DELETE", "/openshell/policies/%(policy)s"),
+    ("POST", "/openshell/policies/%(policy)s/assignments"),
+]
+#: Everything that discloses the guardrail SOURCE.
+BODY_READS = [
+    ("GET", "/openshell/policies/%(policy)s"),
+    ("GET", "/openshell/policies/%(policy)s/versions"),
+    ("POST", "/openshell/policies/%(policy)s/render"),
+]
+#: Identity-only views that stay readable so drift detection keeps working.
+IDENTITY_READS = [
+    ("GET", "/openshell/policies"),
+    ("GET", "/openshell/policies/%(policy)s/assignments"),
+]
+
+
+def _headers(token: str) -> dict:
+    return {"Authorization": "Bearer %s" % token}
+
+
+@pytest.fixture
+def fleet():
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host")
+    agent = cp.register_agent(machine.id, "worker-1")
+    policy = cp.openshell.create_policy("fleet", POLICY_TEXT)
+    cp.openshell.assign_policy(policy.id, target_type="agent", target_id=agent.id)
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "reader": {"scopes": ["read"], "client_id": "dashboard"},
+                "writer": {"scopes": ["write"], "client_id": "ci"},
+                "admin": {"scopes": ["admin"], "client_id": "operator"},
+            },
+        )
+    )
+    return client, cp, policy
+
+
+def test_every_write_requires_the_same_scope_as_reading_the_body():
+    """The property this change exists to establish."""
+    body_scope = _required_scope("GET", "/openshell/policies/p1")
+    assert body_scope == "admin"
+    for method, template in WRITES:
+        assert _required_scope(method, template % {"policy": "p1"}) == body_scope, (
+            method,
+            template,
+        )
+
+
+@pytest.mark.parametrize("method,template", WRITES + BODY_READS)
+def test_guardrail_source_and_mutations_require_admin(method, template):
+    assert _required_scope(method, template % {"policy": "p1"}) == "admin"
+
+
+@pytest.mark.parametrize("method,template", IDENTITY_READS)
+def test_identity_views_stay_readable(method, template):
+    assert _required_scope(method, template % {"policy": "p1"}) == "read"
+
+
+@pytest.mark.parametrize("method,template", WRITES)
+def test_a_write_token_can_no_longer_author_a_guardrail(fleet, method, template):
+    """`POST /openshell/policies` previously accepted a `write` token, so a
+    task-writing credential could author the confinement every agent runs under."""
+    client, _cp, policy = fleet
+    response = client.request(
+        method,
+        template % {"policy": policy.id},
+        headers=_headers("writer"),
+        json={"name": "pwn", "policy_text": POLICY_TEXT},
+    )
+    assert response.status_code == 403
+
+
+def test_an_operator_can_still_do_the_full_lifecycle(fleet):
+    """Raising the writes must not break `mac openshell policy ...`."""
+    client, _cp, _policy = fleet
+    created = client.post(
+        "/openshell/policies",
+        headers=_headers("admin"),
+        json={"name": "second", "policy_text": POLICY_TEXT},
+    )
+    assert created.status_code == 200
+    new_id = created.json()["id"]
+
+    assert client.put(
+        "/openshell/policies/%s" % new_id,
+        headers=_headers("admin"),
+        json={"policy_text": POLICY_TEXT.replace("8789", "9999")},
+    ).status_code == 200
+    # ...and read back exactly what was written.
+    fetched = client.get(
+        "/openshell/policies/%s" % new_id, headers=_headers("admin")
+    ).json()
+    assert "9999" in fetched["policy_text"]
+    assert client.delete(
+        "/openshell/policies/%s" % new_id, headers=_headers("admin")
+    ).status_code == 200
+
+
+def test_write_and_read_back_is_coherent_for_the_one_scope_that_has_it(fleet):
+    """The bug in one sentence: whatever principal can write must be able to
+    read back. Assert it as a round trip rather than as two scope constants."""
+    client, _cp, _policy = fleet
+    created = client.post(
+        "/openshell/policies",
+        headers=_headers("admin"),
+        json={"name": "roundtrip", "policy_text": POLICY_TEXT},
+    )
+    assert created.status_code == 200
+    readback = client.get(
+        "/openshell/policies/%s" % created.json()["id"], headers=_headers("admin")
+    )
+    assert readback.status_code == 200
+    assert readback.json()["policy_text"] == POLICY_TEXT.strip()
+
+
+def test_read_token_still_sees_no_guardrail_text_anywhere(fleet):
+    """The #298 guarantee must survive this change."""
+    client, _cp, policy = fleet
+    for path in (
+        "/openshell/policies",
+        "/openshell/policies/%s/assignments" % policy.id,
+        "/dashboard/state",
+    ):
+        response = client.get(path, headers=_headers("reader"))
+        assert response.status_code == 200, path
+        assert SECRET_HOST not in response.text, path


### PR DESCRIPTION
Audit first, then two groups from it.

## The audit

`require_global_fleet()` refuses only **tenant-bound** non-admin tokens:

```python
if self.is_admin or self.tenant_id is None:
    return
```

It reads like an authorization gate and is not one. An untenanted client token — the ordinary `read`/`write` scope — has no tenant, is not admin, and carries no `agent_id`, so it passes untouched.

416 routes parsed; **51** call `require_global_fleet()`; **34** had it as their *only* in-handler gate at a scope below admin.

Every one of those 34 was probed with the weakest token its scope permits. FastAPI validates the request body **before** the handler guard runs, so a `422` proves auth already passed — which makes the result unambiguous:

```
REACHABLE past the guard with a non-admin token:  34 / 34
BLOCKED:                                           0
```

| Response | Count | Meaning |
| --- | --- | --- |
| `422` | 20 | auth passed, body invalid |
| `404` | 8 | auth passed, entity missing |
| `200` | 4 | fully executed |
| `TypeError` | 1 | reached business logic inside `DirectiveService` |

Executed outright with a non-admin token: `GET /source-convergence`, `POST /roles/seed`, `POST /workflows/seed`, `POST /notifier/deliver`.

## Group 1 — the guardrail policy resource (4 routes)

#298 made the policy **body** admin-only because it names the fleet's hub and gateway hosts, their ports, and the binaries permitted to reach them. It left the mutations at `write`. The result was indefensible:

> A token could **create, update, delete and assign** the confinement every `--yolo` agent runs under — then be refused when it tried to read back what it had just written.

Reads and writes now meet at `admin`.

I raised the writes rather than lowering the body. Lowering would restore symmetry too, but by putting the control-plane map back in reach of any dashboard token. Verified every caller is already an operator CLI path (`mac openshell policy …`, `mac openshell reconcile`) — no worker or agent creates or assigns policies.

Two identity views stay `read`: `GET /openshell/policies` and `.../assignments` carry name, version and checksum but never the body — what drift detection and the dashboard actually need.

## Group 2 — directive authoring (8 routes)

This codebase already states the principle. `/agentbus/human-directive` is admin because human directives are *"never mintable via the agent scope (authority = attested provenance)"*.

Authoring a directive carried only `write` — the same provenance problem. A task-writing token could propose, approve and activate a directive that changes fleet-wide behaviour while claiming an authority nobody granted it.

Covers propose, check, approve, activate, deactivate, waivers, waiver revocation, bindings.

**Two boundaries deliberately not moved**, both pinned by tests:

- **GETs stay `read`.** Directive documents, versions and impact are a read model, not a secret. This is the opposite call from OpenShell policies, and the reason is the content: a guardrail policy names your infrastructure; a directive says "prefer Bazel."
- **`/agents/{id}/directives/effective` and `.../directive-activations/{id}/ack` keep `agent`.** They're the only directive routes a worker touches. If that match ordering ever breaks, directive delivery stops fleet-wide *silently*.

## Not in this change

22 of the 34 remain: fleets (4), runtime-deltas + runtimes (5), notifier (3), dashboard hermes config-surface (2), and 8 singletons.

`/machines`, `/integrations/findings` and the `deploy`-scoped runtime routes need caller analysis first — bootstrap and CI plausibly hold non-admin tokens there, and raising them blind would break real fleet operations. Tracked in `task_40c4fe38`.

## Verification

- Contract gate: **10,683 passed, 2 skipped**, exit 0.
- 45 new tests, including a round-trip that asserts write-then-read-back directly rather than comparing two scope constants.
- 758 passing across `tests/api`, `tests/cli`, directive-sync and openshell suites; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
