### PR TITLE
Rename require_global_fleet to refuse_tenant_bound, so it cannot be misread again

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -149,12 +149,34 @@ class TokenPrincipal:
                 "token is bound to a tenant and cannot write to a different tenant"
             )
 
-    def require_global_fleet(self) -> None:
+    def refuse_tenant_bound(self) -> None:
         """Refuse the call for tenant-bound, non-admin tokens.
 
         Machines, agents, runtimes, environments, and rollouts are part of the
         shared fleet today. A tenant-bound token has no business reaching them
         until we extend the schema to be tenant-aware.
+
+        **This is NOT an authorization gate.** It answers exactly one question —
+        "is this principal confined to a tenant?" — and an UNTENANTED token of
+        any scope passes straight through::
+
+            if self.is_admin or self.tenant_id is None:
+                return
+
+        Authorization is decided by :func:`_required_scope`. Calling this method
+        does not make a route privileged; it only keeps a tenant's token out of
+        shared fleet state.
+
+        It was previously named ``require_global_fleet``, which read as "require
+        fleet-level authority" and was taken that way at 61 call sites. Two holes
+        came from that reading: an ordinary ``write`` token could open a debug
+        shell on any fleet host and drive it, and could author the OpenShell
+        guardrail policy every ``--yolo`` agent runs under. Both are fixed; the
+        name was renamed so the assumption cannot be made a 62nd time.
+
+        If a route needs real privilege, set its scope in ``_required_scope``
+        (and use :meth:`require_admin` or :meth:`assert_actor` for the in-handler
+        narrowing).
         """
         if self.is_admin or self.tenant_id is None:
             return
@@ -2167,6 +2189,16 @@ def _load_auth_tokens_from_env() -> Dict[str, TokenPrincipal]:
 
 
 def _required_scope(method: str, path: str) -> Optional[str]:
+    """The token scope a request must carry. THIS is the authorization gate.
+
+    In-handler guards narrow further but do not substitute for this: a route's
+    privilege is whatever scope it is given here. In particular
+    :meth:`TokenPrincipal.refuse_tenant_bound` (formerly ``require_global_fleet``)
+    only refuses tenant-bound tokens — an untenanted token of any scope passes
+    it — so a route that needs privilege must say so here, not rely on that call.
+
+    Returning ``None`` makes a route public.
+    """
     if path == "/health":
         return None
     if path == "/.well-known/acp":
@@ -2523,7 +2555,7 @@ def _require_terminal_principal(principal: "TokenPrincipal") -> None:
     """Gate the debug-terminal routes: admin, or an agent acting on itself.
 
     A debug terminal is an interactive shell on a fleet host, so the set of
-    principals allowed near one is small. ``require_global_fleet()`` was doing
+    principals allowed near one is small. ``refuse_tenant_bound()`` was doing
     this job and cannot: it refuses only TENANT-BOUND non-admin tokens
     (``if self.is_admin or self.tenant_id is None: return``). An untenanted
     client token — the ordinary ``write`` scope, the same one that creates a
@@ -2535,7 +2567,7 @@ def _require_terminal_principal(principal: "TokenPrincipal") -> None:
     handler still narrows that to the acting agent with ``assert_actor``. This
     only removes the principal class that was never meant to be here.
     """
-    principal.require_global_fleet()
+    principal.refuse_tenant_bound()
     if principal.is_admin or principal.agent_id:
         return
     raise AuthorizationError(
@@ -4872,7 +4904,7 @@ def create_app(
         body: DashboardHermesConfigUpdate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         data = _data(body)
         for key in ("runtime", "config", "env", "plugins", "skills"):
             _ensure_payload_bounded(data.get(key) or {}, "dashboard.hermes_config.%s" % key)
@@ -4889,7 +4921,7 @@ def create_app(
         body: DashboardHermesConfigApply,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         fleet = cp.get_fleet(fleet_id_or_name).to_dict()
         recipients = list(body.recipient_agent_ids or [])
         if not recipients:
@@ -5218,7 +5250,7 @@ def create_app(
     ) -> Dict[str, Any]:
         # Creating tenants is a cross-tenant operation; only admin/unbound
         # principals can perform it.
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.register_tenant(**_data(body)).to_dict()
 
     @app.get("/tenants")
@@ -5254,7 +5286,7 @@ def create_app(
         body: HumanRegister,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.register_human(**_data(body)).to_dict()
 
     @app.get("/humans")
@@ -5936,7 +5968,7 @@ def create_app(
         body: FleetCreate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         _ensure_payload_bounded(body.metadata, "fleet.metadata")
         return cp.create_fleet(**_data(body)).to_dict()
 
@@ -5957,7 +5989,7 @@ def create_app(
         body: FleetUpdate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         data = _data(body)
         if data.get("metadata") is not None:
             _ensure_payload_bounded(data["metadata"], "fleet.metadata")
@@ -5969,7 +6001,7 @@ def create_app(
         body: FleetAgentObserve,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         _ensure_payload_bounded(body.metadata, "fleet_observation.metadata")
         return cp.observe_fleet_agent(fleet_id_or_name, **_data(body)).to_dict()
 
@@ -5979,7 +6011,7 @@ def create_app(
         actor: str = Query(default="human"),
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         cp.delete_fleet(fleet_id_or_name, actor=actor)
         return {"deleted": fleet_id_or_name}
 
@@ -6642,7 +6674,7 @@ def create_app(
         body: MachineRegister,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         _ensure_payload_bounded(body.labels, "machine.labels")
         _ensure_payload_bounded(body.resources, "machine.resources")
         return cp.register_machine(**_data(body)).to_dict()
@@ -6660,7 +6692,7 @@ def create_app(
         body: AgentRegister,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         _ensure_payload_bounded(body.resources, "agent.resources")
         data = _data(body)
         requested_agent_id = str(data.get("agent_id") or "")
@@ -6734,7 +6766,7 @@ def create_app(
         body: AgentAttestationKeyVerify,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         if not principal.is_admin:
             # Verification is deliberately available to a worker as a
             # challenge-response health check, but only for its own key. It
@@ -6951,7 +6983,7 @@ def create_app(
         # _required_scope already enforces this, but we double-check the
         # principal isn't tenant-bound to avoid stamping global rows from a
         # tenant token if scopes are ever relaxed).
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return [role.to_dict() for role in cp.roles.seed_defaults(replace=body.replace)]
 
     @app.post("/agents/{agent_id}/role")
@@ -7003,7 +7035,7 @@ def create_app(
     ) -> Dict[str, Any]:
         """Return the durable hub identity used to bind a fleet transaction."""
 
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         principal.require_admin()
         return {
             "schema": "mac.fleet_release_hub_authority.v1",
@@ -7018,7 +7050,7 @@ def create_app(
     ) -> Dict[str, Any]:
         """Read one durable fleet-release epoch without replaying it."""
 
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         principal.require_admin()
         if identity_sha256.startswith("sha256:"):
             return cp.fleet_release_epochs.status(epoch_id, identity_sha256)
@@ -7032,7 +7064,7 @@ def create_app(
     ) -> Dict[str, Any]:
         """Fail closed unless the exact pending cohort is ready to prove."""
 
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         principal.require_admin()
         return cp.fleet_release_epochs.pre_prove_readiness(
             epoch_id, identity_sha256
@@ -7045,7 +7077,7 @@ def create_app(
     ) -> Dict[str, Any]:
         """Atomically reserve one exact cohort without promoting authority."""
 
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         principal.require_admin()
         participants: List[Dict[str, Any]] = []
         for item in body.participants:
@@ -7071,7 +7103,7 @@ def create_app(
     ) -> Dict[str, Any]:
         """Verify exact post-apply evidence without promoting authority."""
 
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         principal.require_admin()
         proofs: List[Dict[str, Any]] = []
         for item in body.proofs:
@@ -7097,7 +7129,7 @@ def create_app(
     ) -> Dict[str, Any]:
         """Promote identity, approval, policy, and holds in one transaction."""
 
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         principal.require_admin()
         return cp.fleet_release_epochs.commit(
             epoch_id,
@@ -7113,7 +7145,7 @@ def create_app(
     ) -> Dict[str, Any]:
         """Discard epoch staging and restore each exact pre-open authority."""
 
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         principal.require_admin()
         return cp.fleet_release_epochs.abort(
             epoch_id,
@@ -7417,7 +7449,7 @@ def create_app(
         body: WorkflowSeed,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> List[Dict[str, Any]]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return [wf.to_dict() for wf in cp.workflows.seed_defaults()]
 
     @app.post("/workflows/{workflow_id_or_slug}/start")
@@ -7749,7 +7781,7 @@ def create_app(
         body: DirectivePropose,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.directives.propose(body.document, actor=body.actor)
 
     @app.get("/directives")
@@ -7798,7 +7830,7 @@ def create_app(
         body: DirectiveBindingSet,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.directives.set_binding(**_data(body))
 
     @app.get("/directive-waivers")
@@ -7813,7 +7845,7 @@ def create_app(
         body: DirectiveWaiverRevoke,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.directives.revoke_waiver(waiver_id, **_data(body))
 
     @app.post("/agents/{agent_id}/directive-activations/{activation_id}/ack")
@@ -7848,7 +7880,7 @@ def create_app(
         body: DirectiveCheck,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.directives.check(directive_id, **_data(body))
 
     @app.post("/directives/{directive_id}/approve")
@@ -7857,7 +7889,7 @@ def create_app(
         body: DirectiveApprove,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.directives.approve(directive_id, **_data(body))
 
     @app.post("/directives/{directive_id}/activate")
@@ -7866,7 +7898,7 @@ def create_app(
         body: DirectiveActivate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.directives.activate(directive_id, **_data(body))
 
     @app.post("/directives/{directive_id}/deactivate")
@@ -7875,7 +7907,7 @@ def create_app(
         body: DirectiveDeactivate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.directives.deactivate(directive_id, **_data(body))
 
     @app.post("/directives/{directive_id}/waivers")
@@ -7884,7 +7916,7 @@ def create_app(
         body: DirectiveWaiverCreate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.directives.create_waiver(directive_id, **_data(body))
 
     @app.post("/openshell/policies")
@@ -7892,7 +7924,7 @@ def create_app(
         body: OpenShellPolicyCreate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.create_openshell_policy(**_data(body)).to_dict()
 
     @app.get("/openshell/policies")
@@ -7917,7 +7949,7 @@ def create_app(
         dashboard views stay readable — they return identity and checksum, which
         is what drift detection needs.
         """
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.get_openshell_policy(policy_id, include_deleted=True).to_dict(
             include_text=True
         )
@@ -7928,7 +7960,7 @@ def create_app(
         body: OpenShellPolicyUpdate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.update_openshell_policy(policy_id, **_data(body)).to_dict()
 
     @app.delete("/openshell/policies/{policy_id}")
@@ -7937,7 +7969,7 @@ def create_app(
         actor: str = Query(default="human"),
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.delete_openshell_policy(policy_id, actor=actor).to_dict()
 
     @app.get("/openshell/policies/{policy_id}/versions")
@@ -7950,7 +7982,7 @@ def create_app(
         A history of guardrail sources is exactly as sensitive as the current
         one, so it carries the same admin gate.
         """
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return [
             version.to_dict(include_text=True)
             for version in cp.list_openshell_policy_versions(policy_id)
@@ -7976,7 +8008,7 @@ def create_app(
         body: OpenShellPolicyAssign,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.assign_openshell_policy(policy_id, **_data(body)).to_dict()
 
     @app.get("/agents/{agent_id}/openshell/status")
@@ -8251,7 +8283,7 @@ def create_app(
         body: ObservabilityPruneRequest,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, int]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return {"removed": cp.prune_observability(**_data(body))}
 
     @app.get("/observability/metrics")
@@ -8359,7 +8391,7 @@ def create_app(
         body: IntegrationFindingCreate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         finding = cp.record_integration_finding(
             body.source_kind,
             body.source_id,
@@ -8426,7 +8458,7 @@ def create_app(
         body: NotifierChannelConfig,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.configure_notifier_channel(**_data(body)).to_dict()
 
     @app.get("/notifier/channels")
@@ -8451,7 +8483,7 @@ def create_app(
         channel_id_or_name: str,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         cp.delete_notifier_channel(channel_id_or_name)
         return {"deleted": channel_id_or_name}
 
@@ -8460,7 +8492,7 @@ def create_app(
         body: NotifierDeliveryRun,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.deliver_pending_notifications(
             limit=body.limit,
             notification_id=body.notification_id,
@@ -8473,7 +8505,7 @@ def create_app(
         body: CommunicationIdentityConfig,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.configure_communication_identity(**_data(body)).to_dict()
 
     @app.get("/communication/identities")
@@ -8491,7 +8523,7 @@ def create_app(
         identity_id_or_name: str,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         cp.delete_communication_identity(identity_id_or_name)
         return {"deleted": identity_id_or_name}
 
@@ -8500,7 +8532,7 @@ def create_app(
         body: CommunicationAccountConfig,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.configure_communication_account(**_data(body)).to_dict()
 
     @app.get("/communication/accounts")
@@ -8525,7 +8557,7 @@ def create_app(
         account_id: str,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         cp.delete_communication_account(account_id)
         return {"deleted": account_id}
 
@@ -8534,7 +8566,7 @@ def create_app(
         body: RepresentationBindingConfig,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.configure_representation_binding(**_data(body)).to_dict()
 
     @app.get("/communication/representations")
@@ -8555,7 +8587,7 @@ def create_app(
         binding_id: str,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         cp.delete_representation_binding(binding_id)
         return {"deleted": binding_id}
 
@@ -8850,7 +8882,7 @@ def create_app(
         limit: int = Query(default=250, ge=1, le=1000),
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.source_convergence_status(fleet_id=fleet_id, limit=limit)
 
     @app.post("/source-convergence/tick")
@@ -9230,7 +9262,7 @@ def create_app(
         body: RuntimeCreate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.create_runtime(**_data(body)).to_dict()
 
     @app.get("/runtimes")
@@ -9242,7 +9274,7 @@ def create_app(
         body: RuntimeDeltaPropose,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         principal.assert_actor(body.agent_id)
         return cp.propose_runtime_delta(**_data(body)).to_dict()
 
@@ -9273,7 +9305,7 @@ def create_app(
         body: RuntimeDeltaValidate,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.validate_runtime_delta(delta_id, body.actor).to_dict()
 
     @app.post("/runtime-deltas/{delta_id}/reject")
@@ -9282,7 +9314,7 @@ def create_app(
         body: RuntimeDeltaReject,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.reject_runtime_delta(delta_id, body.actor, body.reason).to_dict()
 
     @app.post("/runtime-deltas/{delta_id}/promote")
@@ -9291,7 +9323,7 @@ def create_app(
         body: RuntimeDeltaPromote,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
-        principal.require_global_fleet()
+        principal.refuse_tenant_bound()
         return cp.promote_runtime_delta(
             delta_id,
             body.actor,

--- a/src/mac/http_routes/system.py
+++ b/src/mac/http_routes/system.py
@@ -36,8 +36,8 @@ def build_system_router(
 
     router = APIRouter()
 
-    def require_global_fleet(principal: Any) -> None:
-        principal.require_global_fleet()
+    def refuse_tenant_bound(principal: Any) -> None:
+        principal.refuse_tenant_bound()
 
     @router.get("/health")
     def health() -> Dict[str, str]:
@@ -52,7 +52,7 @@ def build_system_router(
         body: RepositoryRefReconcileRequest,
         principal: Any = Depends(get_principal),
     ) -> Dict[str, Any]:
-        require_global_fleet(principal)
+        refuse_tenant_bound(principal)
         return services.repository_ref_reconciler.run_once(
             mode=body.mode,
             actor=body.actor,
@@ -66,7 +66,7 @@ def build_system_router(
 
         @router.post("/%s/run" % prefix, name="%s_run" % prefix.replace("-", "_"))
         def run(principal: Any = Depends(get_principal)) -> Dict[str, Any]:
-            require_global_fleet(principal)
+            refuse_tenant_bound(principal)
             return controller.run_once(trigger="operator")
 
     controller_routes("github-ingest", services.github_ingestor)
@@ -84,14 +84,14 @@ def build_system_router(
     def model_selection_refresh(
         principal: Any = Depends(get_principal),
     ) -> Dict[str, Any]:
-        require_global_fleet(principal)
+        refuse_tenant_bound(principal)
         return services.model_selection_service.run_once(trigger="operator")
 
     @router.post("/model-selection/promote")
     def model_selection_promote(
         principal: Any = Depends(get_principal),
     ) -> Dict[str, Any]:
-        require_global_fleet(principal)
+        refuse_tenant_bound(principal)
         return services.model_selection_service.promote(actor="operator")
 
     if services.work_package_pipeline is not None:
@@ -105,7 +105,7 @@ def build_system_router(
         ) -> Dict[str, Any]:
             # Trigger is intentionally wake-only: Git integration and external
             # certification must never occupy an HTTP request thread.
-            require_global_fleet(principal)
+            refuse_tenant_bound(principal)
             accepted = bool(services.work_package_pipeline.trigger())
             return {
                 "accepted": accepted,

--- a/tests/api/test_tenant_bound_guard_naming.py
+++ b/tests/api/test_tenant_bound_guard_naming.py
@@ -1,0 +1,53 @@
+"""`refuse_tenant_bound` is a multi-tenancy check, not an authorization gate.
+
+Named `require_global_fleet` it read as "require fleet-level authority" and was
+taken that way at 61 call sites. Two holes came from that reading: an ordinary
+`write` token could open a debug shell on any fleet host (PR #300), and could
+author the OpenShell guardrail policy every `--yolo` agent runs under (PR #303).
+
+The behaviour was always correct and is unchanged here. These tests pin the
+semantics the name now advertises, so the next reader cannot re-acquire the
+assumption.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.api import TokenPrincipal
+from mac.models import AuthorizationError
+
+
+def _principal(**kw) -> TokenPrincipal:
+    return TokenPrincipal(**kw)
+
+
+def test_the_misleading_name_is_gone_with_no_alias():
+    """An alias would preserve the exact name this change exists to remove."""
+    assert hasattr(TokenPrincipal, "refuse_tenant_bound")
+    assert not hasattr(TokenPrincipal, "require_global_fleet")
+
+
+def test_an_untenanted_non_admin_token_passes():
+    """The whole point: this does NOT confer privilege. An ordinary write token
+    sails through, which is why it can never be a route's only gate."""
+    _principal(scopes=("write",), client_id="ci").refuse_tenant_bound()
+    _principal(scopes=("read",), client_id="dash").refuse_tenant_bound()
+    _principal(scopes=("deploy",), client_id="cd").refuse_tenant_bound()
+
+
+def test_a_tenant_bound_non_admin_token_is_refused():
+    """The one thing it does do, and should keep doing."""
+    with pytest.raises(AuthorizationError, match="bound to a tenant"):
+        _principal(scopes=("write",), tenant_id="tenant-a").refuse_tenant_bound()
+
+
+def test_a_tenant_bound_admin_token_passes():
+    _principal(scopes=("admin",), tenant_id="tenant-a").refuse_tenant_bound()
+
+
+def test_docstring_states_it_is_not_an_authorization_gate():
+    """The prose is the deliverable here as much as the name."""
+    doc = TokenPrincipal.refuse_tenant_bound.__doc__ or ""
+    assert "NOT an authorization gate" in doc
+    assert "_required_scope" in doc


### PR DESCRIPTION
Mechanical rename plus two docstrings. **No behaviour change.**

## Why

The method does exactly one useful thing, and always did:

```python
if self.is_admin or self.tenant_id is None:
    return
raise AuthorizationError(...)
```

It refuses **tenant-bound** non-admin tokens from touching shared fleet state. That's a real multi-tenancy check and it stays.

The problem was the name. `require_global_fleet` reads as *"require fleet-level authority"* — and it was taken that way at **61 call sites**. An untenanted token of any scope (the ordinary `read`/`write` credential) passes straight through, so a route guarded only by this call is not protected at all.

Two holes came from that reading, both already fixed:

- **#300** — an ordinary `write` token could open a debug terminal on any fleet host and send it keystrokes. Confirmed by execution, not inspection.
- **#303** — the same token could create, update, delete and assign the OpenShell guardrail policy every `--yolo` agent runs under, then be refused when it tried to read back what it had just written.

The audit behind those (`task_40c4fe38`) probed all 34 routes where this was the only in-handler gate below admin: **34 reachable, 0 blocked**. 18 were real holes and were fixed. The remaining 22 have legitimate non-admin callers — bootstrap registers machines, CI records integration findings, the `deploy` scope promotes runtime deltas — so `write`/`deploy` *is* their correct level and they were never vulnerabilities.

That leaves the name as the only untreated cause.

## What changed

- `TokenPrincipal.require_global_fleet` → `refuse_tenant_bound`, 61 call sites (54 `api.py`, 7 `http_routes/system.py`).
- **No backward-compatibility alias**, deliberately: an alias would preserve the exact identifier this change exists to remove.

The docstrings are the substance:

- `refuse_tenant_bound` now states outright that it is **not** an authorization gate, shows the two-line body that lets any untenanted token through, names the two holes, and points at `_required_scope`.
- `_required_scope` now says from the other side that **it** is the gate — so a developer adding a route meets the correct statement from whichever end they start.

## Tests

Pin semantics rather than spelling:

- untenanted `write` / `read` / `deploy` all pass — the property that makes it unusable as a sole gate
- tenant-bound non-admin is refused; tenant-bound admin passes
- the old name is absent, with no alias
- the docstring must keep saying it is not an authorization gate

## Verification

Contract gate: **10,859 passed, 2 skipped**, exit 0. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
