### PR TITLE
Give the nightly jobs an interpreter and a database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,15 @@ jobs:
         run: scripts/run-contract-tests.sh
       - name: Prove historical fault detection
         if: matrix.python-version == '3.11'
-        run: scripts/fault-replay.py
+        # Through `uv run`, not bare. Invoked bare, the script's
+        # `#!/usr/bin/env python3` shebang selects the SYSTEM interpreter, which
+        # has no psycopg -- and fault-replay spawns every probe with its own
+        # `sys.executable`, so each one died on
+        # "ImportError: PostgresStore requires psycopg" before it could replay
+        # anything. The step still passed its own smoke checks, so the nightly
+        # reported a failure that looked like a product regression and was a
+        # missing interpreter.
+        run: uv run --extra dev --python ${{ matrix.python-version }} python scripts/fault-replay.py
 
   portfolio:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -360,6 +368,21 @@ jobs:
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39
       - name: Sync dependencies
         run: uv sync --extra dev --python 3.11
+      - name: Start test PostgreSQL
+        # This job ran pytest with no database at all -- the only pytest job in
+        # the workflow missing this step. The suite fails fast rather than
+        # skipping when MAC_TEST_PG_URL is unset (a suite that silently covers
+        # nothing is worse than a red one), so the job died on
+        # "MAC_TEST_PG_URL is unset" before collecting a single test.
+        run: |
+          eval "$(scripts/start-test-postgres.sh)"
+          # eval of a script that died leaves this empty and the step green,
+          # which then fails much later as "MAC_TEST_PG_URL is unset".
+          if [ -z "${MAC_TEST_PG_URL:-}" ]; then
+            echo "::error::start-test-postgres.sh produced no DSN" >&2
+            exit 1
+          fi
+          echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
       - name: Run in-container OpenShell and relay contracts
         env:
           TEST_CONTAINER_CONTRACT: "1"


### PR DESCRIPTION
The scheduled CI run has been failing on two jobs that **never run on push**, so every push-triggered run on `main` is green while the nightly is red. Neither failure is a product regression; both are setup gaps in the workflow itself.

## `nightly (3.11)` — fault-replay ran under the wrong interpreter

```yaml
- name: Prove historical fault detection
  run: scripts/fault-replay.py
```

Invoked bare, the script's `#!/usr/bin/env python3` shebang selects the **system** interpreter rather than the uv venv the job just synced. `fault-replay` then spawns every probe with its own `sys.executable`, so each probe inherited that interpreter and died before replaying anything:

```
ModuleNotFoundError: No module named 'psycopg'
ImportError: PostgresStore requires psycopg. Install via 'pip install "mac[postgres]"'.
```

Every other step in that job goes through `uv`; this one did not. Now it does.

**Reproduced locally.** Bare invocation dies on a missing project dependency (`cryptography` on my machine, `psycopg` on the runner — same root cause: a system interpreter without the project's deps). Through `uv run`, the replay returns `"status": "pass"`.

## `container-contract` — ran pytest with no database

The job went straight from `uv sync` to `pytest`. It is the **only pytest job in the workflow with no "Start test PostgreSQL" step**, and the suite fails fast rather than skipping when `MAC_TEST_PG_URL` is unset — deliberately, because a suite that silently covers nothing is worse than a red one. So it died before collecting a single test:

```
ERROR: MAC_TEST_PG_URL is unset, so there is no database to run against.
```

Added the same step the other jobs use, including the empty-DSN guard — an `eval` of a script that died leaves the variable empty and the step *green*, which then surfaces much later as this exact error.

**Reproduced locally.** Without a DSN the selection collects nothing; with one it is `1 passed, 3 skipped`.

## Verification

| Job | Before | After |
| --- | --- | --- |
| `nightly (3.11)` fault-replay | dies on missing module | `"status": "pass"` |
| `container-contract` | `MAC_TEST_PG_URL is unset`, 0 tests | `1 passed, 3 skipped` |

`ci.yml` parses as valid YAML.

## Caveat

Both jobs are `schedule` / `workflow_dispatch` only, so **this cannot be verified by merging** — merging triggers a push run, which skips both. It needs a scheduled run or a manual `workflow_dispatch`. Worth confirming on the next nightly rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
