### PR TITLE
Stop a retry exclusion making work permanently undispatchable

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -11895,6 +11895,45 @@ if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L 2>/dev/null | grep -q 
   fi
 fi
 capabilities="$capabilities,cpu"
+
+# Toolchain capability probes, on the same principle as the GPU block above:
+# advertise what the SANDBOX can do, because that is where tasks run.
+#
+# The default capability list is a hardcoded string that never mentioned `c`,
+# `make` or `python3`, so no standard worker advertised them however capable
+# the machine was. Measured 2026-08-08: every fleet host had cc, gcc, clang,
+# make and python3 installed, and exactly ONE agent advertised `c` -- because
+# someone had set MAC_WORKER_CAPABILITIES on it by hand. Every C task in the
+# ledger could therefore match only that one worker, and when a transient
+# failure excluded it (see the retry ratchet), the work became permanently
+# undispatchable while eight idle agents watched.
+#
+# Probed rather than declared, and probed INSIDE the sandbox rather than on the
+# host: a host toolchain the sandbox cannot reach is the same lie the GPU
+# comment describes -- the dispatcher believes it, routes the work, and the
+# task fails on a box that was never able to run it.
+#
+# Fails closed. If the sandbox cannot be probed, nothing is advertised, so work
+# routes to a host that has proven it can run it.
+probe_sandbox_tool() {
+  local tool="$1"
+  [ -n "${MAC_OPENSHELL_BIN:-}" ] || return 1
+  command -v "$MAC_OPENSHELL_BIN" >/dev/null 2>&1 || return 1
+  "$MAC_OPENSHELL_BIN" run --quiet -- command -v "$tool" >/dev/null 2>&1
+}
+
+for probe_pair in "cc:c" "make:make" "python3:python3"; do
+  probe_tool="${probe_pair%%:*}"
+  probe_cap="${probe_pair##*:}"
+  case ",$capabilities," in
+    *",$probe_cap,"*) continue ;;
+  esac
+  if probe_sandbox_tool "$probe_tool"; then
+    capabilities="$capabilities,$probe_cap"
+  else
+    echo "mac-agent: sandbox cannot run '$probe_tool'; not advertising '$probe_cap' so that work routes to a host that can" >&2
+  fi
+done
 mkdir -p "$workspace"
 
 stable_agent_id() {

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -77,6 +77,7 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         # human-interface switch gate: both assert on this installer, so
         # a change to it must select them.
         "tests/test_container_runtime_declaration.py",
+        "tests/test_retry_exclusion_ratchet.py",
         "tests/test_human_interface_switch_gate.py",
         "tests/test_generated_artifact_guards_always_run.py",
         "tests/test_fleet_node_gateway_readiness.py",

--- a/src/mac/allocator.py
+++ b/src/mac/allocator.py
@@ -667,13 +667,14 @@ def classify_requirement_eligibility(
     unmet: dict = {}
     for agent in agents:
         pair = evaluate_pair(ready, agent)
-        # A task pinned to one agent (target/break-glass) makes every other
-        # agent mismatch. That is the task's own routing, not evidence about
-        # what the fleet can do, so those agents are not considered at all.
-        if any(
-            code.split(":", 1)[0] == AGENT_TARGET_MISMATCH
-            for code in pair.agent_rejections
-        ):
+        # A task PINNED to one agent makes every other agent mismatch. That is
+        # the task's own routing, not evidence about what the fleet can do, so
+        # those agents are not considered at all.
+        #
+        # An EXCLUDED agent is the opposite: it is one the fleet has, that
+        # could otherwise run this task, and has been barred from it. Skipping
+        # it hid the real blocker behind a capability verdict.
+        if any(code == "%s:pinned" % AGENT_TARGET_MISMATCH for code in pair.agent_rejections):
             continue
         considered.append(agent.id)
         blocking = [
@@ -760,10 +761,24 @@ def evaluate_pair(
     if not break_glass_active:
         if agent.dispatch_held:
             reasons.append(AGENT_HELD)
+        # Two opposite meanings used to share one bare code, and the
+        # difference matters to everything downstream:
+        #
+        #   :excluded  this agent may NOT run this task -- an accumulated bar
+        #   :pinned    ONLY another agent may run it -- the task's own routing
+        #
+        # classify_requirement_eligibility skips mismatching agents as "the
+        # task's own routing, not evidence about the fleet". That is right for
+        # a pin and wrong for an exclusion: on 2026-08-08 the one agent able to
+        # run task_b23269b4 was excluded, every other agent lacked the
+        # capabilities, and the fleet was reported as unable to meet the
+        # requirements -- pointing the operator at agent capabilities when the
+        # actual bar was an exclusion. Codes are matched on their stem
+        # (rejection_kind), so suffixing is backwards compatible.
         if agent.id in task.excluded_agent_ids:
-            reasons.append(AGENT_TARGET_MISMATCH)
+            reasons.append("%s:excluded" % AGENT_TARGET_MISMATCH)
         if task.target_agent_id is not None and task.target_agent_id != agent.id:
-            reasons.append(AGENT_TARGET_MISMATCH)
+            reasons.append("%s:pinned" % AGENT_TARGET_MISMATCH)
         if not task.required_capabilities.issubset(agent.capabilities):
             reasons.append(AGENT_CAPABILITIES_MISSING)
         if not task.required_role_capabilities.issubset(agent.capabilities):
@@ -895,6 +910,42 @@ class AuthoritativeAllocator:
             if task_evaluations[task.id].allowed
             for agent in agent_list
         }
+        # LAST RESORT. A retry exclusion exists so a bounded cross-worker retry
+        # lands somewhere else after a transient failure, which is right
+        # whenever somewhere else exists. It is written as a HARD bar and never
+        # expires, so in a finite pool it ratchets: measured on the live fleet
+        # 2026-08-08, task_b23269b4 required ['c','testing'], exactly ONE agent
+        # advertised 'c', that agent failed once transiently and was excluded,
+        # and the task became permanently undispatchable while eight agents sat
+        # idle.
+        #
+        # The codebase already argues this in _coordination_excluded_agent_ids
+        # ("accumulated exclusions ratchet a task family into a permanent
+        # no-eligible-agent deadlock") and in avoid_agent_ids, which is soft for
+        # the same reason. A retry on the same worker is worse than a different
+        # worker and far better than a task that can never run again.
+        #
+        # The task OBJECT is substituted rather than just its cached pair: the
+        # proposal loop re-evaluates against the task it is given, so relaxing
+        # only the cache would plan an assignment that the claim then refuses --
+        # which is how the first attempt at this fix silently changed nothing.
+        relaxed_exclusions: Dict[str, tuple[str, ...]] = {}
+        for index, task in enumerate(task_list):
+            if not task_evaluations[task.id].allowed or not task.excluded_agent_ids:
+                continue
+            if any(base_pairs[(task.id, agent.id)].allowed for agent in agent_list):
+                continue
+            unbarred = replace(task, excluded_agent_ids=frozenset())
+            recovered = [
+                agent.id for agent in agent_list if evaluate_pair(unbarred, agent).allowed
+            ]
+            if not recovered:
+                continue
+            task_list[index] = unbarred
+            task_evaluations[unbarred.id] = evaluate_task(unbarred)
+            for agent in agent_list:
+                base_pairs[(unbarred.id, agent.id)] = evaluate_pair(unbarred, agent)
+            relaxed_exclusions[task.id] = tuple(sorted(recovered))
 
         # Plan a maximum-cardinality bipartite assignment before claiming.
         # Each capacity slot is explicit; augmenting paths can move a generic

--- a/src/mac/diagnostics.py
+++ b/src/mac/diagnostics.py
@@ -349,12 +349,31 @@ def _unsatisfiable_requirements(
 
     count = len(offenders)
     severity = "ok" if count <= threshold else "warn"
-    summary = (
-        "every open task's requirements can be met by some registered agent"
-        if severity == "ok"
-        else "%d open task(s) state requirements no agent can satisfy: %s"
-        % (count, ", ".join(sorted(unmet_counts)))
+    # An EXCLUSION is not an unmet requirement, and conflating them sends the
+    # operator to the wrong repair. "no agent can satisfy" reads as "teach an
+    # agent this capability"; the actual fix for an exclusion is to clear it.
+    # Measured on 2026-08-08: the one agent able to run task_b23269b4 had both
+    # required capabilities and was barred, while every other agent lacked
+    # them -- so the honest summary names both, and names the excluded case
+    # first because it is the one nobody would guess.
+    excluded = sum(
+        1 for item in offenders
+        if any(code.endswith(":excluded") for code in item["unmet"])
     )
+    if severity == "ok":
+        summary = "every open task's requirements can be met by some registered agent"
+    elif excluded:
+        summary = (
+            "%d open task(s) cannot be dispatched; %d of them have a capable "
+            "agent that is EXCLUDED from the task (clear the exclusion, do not "
+            "add capabilities). Blockers: %s"
+            % (count, excluded, ", ".join(sorted(unmet_counts)))
+        )
+    else:
+        summary = (
+            "%d open task(s) state requirements no agent can satisfy: %s"
+            % (count, ", ".join(sorted(unmet_counts)))
+        )
     return [
         Finding(
             check="unsatisfiable-requirements",

--- a/tests/test_authoritative_allocator.py
+++ b/tests/test_authoritative_allocator.py
@@ -250,10 +250,16 @@ def test_hard_constraints_are_structured_and_unmatched_task_is_stranded():
     rejections = {
         evaluation.agent_id: evaluation.agent_rejections for evaluation in decision.pair_evaluations
     }
-    assert "agent_target_mismatch" in rejections["a"]
+    # `:pinned` rather than the bare code: a task PINNED to one agent and an
+    # agent EXCLUDED from a task both used to emit `agent_target_mismatch`, and
+    # they mean opposite things. Everything that classifies codes matches on the
+    # stem, so the suffix is additive -- but it is what lets a reader (and
+    # classify_requirement_eligibility) tell "the task routes elsewhere" from
+    # "this agent is barred".
+    assert "agent_target_mismatch:pinned" in rejections["a"]
     assert rejections["b"] == (
         AGENT_CAPACITY_FULL,
-        "agent_target_mismatch",
+        "agent_target_mismatch:pinned",
         AGENT_CAPABILITIES_MISSING,
     )
 
@@ -281,7 +287,7 @@ def test_break_glass_bypasses_placement_constraints_for_exact_agent_only():
 
     assert evaluate_pair(constrained, recovery).allowed is True
     assert evaluate_pair(constrained, peer).agent_rejections == (
-        "agent_target_mismatch",
+        "agent_target_mismatch:pinned",
     )
 
 

--- a/tests/test_retry_exclusion_ratchet.py
+++ b/tests/test_retry_exclusion_ratchet.py
@@ -1,0 +1,210 @@
+"""A retry exclusion must never be the reason work can never run again.
+
+Measured on the live fleet 2026-08-08, after two weeks in which no agent
+executed anything while eight sat idle:
+
+    task_b23269b4 required ['c', 'testing']
+    exactly ONE agent advertised 'c'          (jordanh-worker5)
+    that agent failed once, transiently
+    metadata.retry_excluded_agent_ids = ['agent_jordanh-worker5']
+    -> zero eligible agents, permanently
+
+The exclusion is written by the "one bounded cross-worker retry after transient
+failure" path, and the idea is right: retrying the same transient failure on the
+same worker usually reproduces it. What was wrong is that the bar is HARD and
+never expires, so in a finite pool it ratchets -- which is the failure mode the
+codebase already names in ``_coordination_excluded_agent_ids`` ("accumulated
+exclusions ratchet a task family into a permanent no-eligible-agent deadlock")
+and already avoids for ``avoid_agent_ids``, which is soft for this reason.
+
+So the bar is honoured whenever ANY agent can take the task, and dropped only
+when the alternative is never running it at all. A retry on the same worker is
+worse than a different worker and far better than a task that can never run.
+
+Two rejection codes also stopped sharing one spelling. ``agent_target_mismatch``
+meant both "only another agent may run this" (a pin, the task's own routing) and
+"this agent is barred from it" (an exclusion, an accumulated bar). Everything
+classifies on the code stem, so ``:pinned`` / ``:excluded`` is additive -- but it
+is what lets the requirement diagnostic stop reporting an exclusion as an unmet
+requirement, which sent the operator to add capabilities that were already there.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.allocator import (
+    AllocationAgent,
+    AllocationTask,
+    AuthoritativeAllocator,
+    ClaimCommit,
+    classify_requirement_eligibility,
+    evaluate_pair,
+)
+
+CAPABLE = frozenset({"c", "testing"})
+
+
+def _task(excluded=(), target=None, capabilities=CAPABLE):
+    return AllocationTask(
+        id="task_b23269b4",
+        priority=1,
+        created_at="2026-08-02T03:00:25Z",
+        required_capabilities=frozenset(capabilities),
+        excluded_agent_ids=frozenset(excluded),
+        target_agent_id=target,
+    )
+
+
+def _fleet(*, extra_capable=False, capable_count=1):
+    agents = [
+        AllocationAgent(id="agent_worker5", capabilities=CAPABLE, capacity=4)
+    ]
+    if extra_capable:
+        agents.append(
+            AllocationAgent(id="agent_worker9", capabilities=CAPABLE, capacity=4)
+        )
+    # The rest of the fleet: identically configured, python/testing only.
+    agents += [
+        AllocationAgent(id="agent_%d" % i, capabilities=frozenset({"testing"}), capacity=4)
+        for i in range(8)
+    ]
+    return agents
+
+
+def _dispatch(task, agents):
+    placed = []
+
+    def claim_pair(proposal):
+        placed.append(proposal.agent_id)
+        return ClaimCommit.success(object())
+
+    AuthoritativeAllocator().allocate_round([task], agents, claim_pair)
+    return placed
+
+
+# --------------------------------------------------------------------------
+# The ratchet
+# --------------------------------------------------------------------------
+
+
+def test_the_only_capable_agent_is_used_even_when_excluded():
+    """The live deadlock. Nothing else in the fleet can run this task."""
+    placed = _dispatch(_task(excluded={"agent_worker5"}), _fleet())
+
+    assert placed == ["agent_worker5"], (
+        "the only agent able to run this task stayed excluded, so the task is "
+        "undispatchable for ever"
+    )
+
+
+def test_the_exclusion_is_honoured_when_an_alternative_exists():
+    """The half that must NOT change.
+
+    The exclusion exists so a bounded cross-worker retry lands somewhere else.
+    Relaxing it whenever it is inconvenient would discard that entirely.
+    """
+    placed = _dispatch(_task(excluded={"agent_worker5"}), _fleet(extra_capable=True))
+
+    assert placed == ["agent_worker9"]
+
+
+def test_an_unexcluded_task_is_unaffected():
+    assert _dispatch(_task(), _fleet()) == ["agent_worker5"]
+
+
+def test_a_pin_is_never_relaxed():
+    """A pin is the task's own routing, not an accumulated bar.
+
+    Relaxing it would send work to an agent the operator deliberately excluded
+    -- break-glass and targeted repair depend on that holding.
+    """
+    placed = _dispatch(_task(target="agent_does_not_exist"), _fleet())
+
+    assert placed == []
+
+
+def test_relaxing_does_not_bypass_capabilities():
+    """Only the exclusion is dropped; every other requirement still applies."""
+    task = _task(excluded={"agent_worker5"}, capabilities={"c", "testing", "fortran"})
+
+    assert _dispatch(task, _fleet()) == []
+
+
+# --------------------------------------------------------------------------
+# The two meanings that shared one code
+# --------------------------------------------------------------------------
+
+
+def test_an_exclusion_and_a_pin_are_distinguishable():
+    agent = AllocationAgent(id="agent_worker5", capabilities=CAPABLE, capacity=4)
+
+    excluded = evaluate_pair(_task(excluded={"agent_worker5"}), agent)
+    pinned = evaluate_pair(_task(target="agent_other"), agent)
+
+    assert excluded.agent_rejections == ("agent_target_mismatch:excluded",)
+    assert pinned.agent_rejections == ("agent_target_mismatch:pinned",)
+
+
+def test_both_codes_still_classify_on_their_stem():
+    """Suffixing must be additive: everything downstream matches the stem."""
+    from mac.allocator import rejection_kind
+
+    assert rejection_kind("agent_target_mismatch:excluded") == rejection_kind(
+        "agent_target_mismatch"
+    )
+    assert rejection_kind("agent_target_mismatch:pinned") == rejection_kind(
+        "agent_target_mismatch"
+    )
+
+
+# --------------------------------------------------------------------------
+# The diagnostic that reported the wrong cause
+# --------------------------------------------------------------------------
+
+
+def test_an_excluded_agent_is_counted_not_skipped():
+    """It used to be dropped as "the task's own routing".
+
+    That is true of a pin and false of an exclusion, and the consequence was a
+    verdict of "no agent can meet the requirements" for a task whose one
+    capable agent met them perfectly and was barred -- pointing the operator at
+    agent capabilities instead of at the bar.
+    """
+    verdict = classify_requirement_eligibility(
+        _task(excluded={"agent_worker5"}), _fleet()
+    )
+
+    assert "agent_target_mismatch:excluded" in verdict.unmet_requirements
+    assert "agent_worker5" in verdict.considered_agent_ids
+
+
+def test_a_pinned_task_still_reports_only_the_pinned_agent():
+    """A pin genuinely is routing, and must not be reported as a fleet defect."""
+    verdict = classify_requirement_eligibility(
+        _task(target="agent_worker5"), _fleet()
+    )
+
+    assert verdict.considered_agent_ids == ("agent_worker5",)
+    assert not any(
+        code.startswith("agent_target_mismatch") for code in verdict.unmet_requirements
+    )
+
+
+def test_a_pin_survives_even_when_the_task_also_has_an_exclusion():
+    """The case that actually exercises the relaxation against a pin.
+
+    test_a_pin_is_never_relaxed above does NOT: with no exclusion the task
+    never enters the relaxation path at all, so it passes against a build that
+    happily clears the pin. A task carrying both is what proves only the
+    exclusion is dropped -- and it is a real shape, since a pinned repair task
+    can also have excluded a worker that failed it.
+    """
+    task = _task(excluded={"agent_worker9"}, target="agent_absent")
+
+    placed = _dispatch(task, _fleet(extra_capable=True))
+
+    assert placed == [], (
+        "the relaxation cleared the pin as well as the exclusion; a pin is the "
+        "task's own routing and break-glass depends on it holding"
+    )


### PR DESCRIPTION
**The fleet executed nothing for two weeks while eight agents sat idle.** Running it down on the live hub:

```
0 running tasks · 0 dispatch events · agents heartbeating normally
1 of 20 open tasks was dispatch-ready — and it had ZERO eligible agents
```

That task required `['c', 'testing']`. Exactly one agent advertised `c`. That agent had failed **once**, transiently, and carried:

```json
"retry_excluded_agent_ids": ["agent_jordanh-worker5"]
```

Three defects, stacked. Each is survivable alone.

## 1. Capabilities were declared, not probed

The worker capability list is a hardcoded default string:

```bash
capabilities="${MAC_WORKER_CAPABILITIES:-ops,python,openclaw,review,api,architecture,
cli,docs,security,testing,typescript,ui,web_search,web_extract,web_crawl,firecrawl,work_package_v1}"
```

`c`, `make` and `python3` appear **nowhere in it**. Every fleet host has `cc`, `gcc`, `clang`, `make` and `python3` installed; exactly one agent advertised `c`, because someone set `MAC_WORKER_CAPABILITIES` on it by hand. So every C task in the ledger could match one worker only.

| capability | agents advertising |
|---|---|
| `testing`, `python`, `cli`, `docs` | 8 |
| `c` | **1** |
| `make` | **1** |

The installer already had the right pattern and had never applied it to toolchains: the GPU block probes the host **and** requires proof the sandbox can use it, because *"advertising on nvidia-smi alone is a lie the dispatcher believes"*. Toolchains are now probed the same way — inside the sandbox where tasks actually run — and fail closed.

## 2. The retry exclusion ratcheted

"One bounded cross-worker retry after transient failure" writes a **hard** bar that never expires. The idea is right — retrying a transient failure on the same worker usually reproduces it — but in a finite pool it accumulates. That is the exact failure `_coordination_excluded_agent_ids` documents:

> accumulated exclusions ratchet a task family into a permanent no-eligible-agent deadlock

…and which `avoid_agent_ids` is deliberately **soft** to avoid. With one capable agent, one failure was enough.

The bar is now honoured whenever **any** agent can take the task, and dropped only when the alternative is never running it again.

The task **object** is substituted, not just its cached pair evaluation — the proposal loop re-evaluates against the task it is handed, so relaxing only the cache planned an assignment the claim then refused. That is how my first attempt changed nothing while appearing to work.

## 3. The diagnostic blamed the wrong thing

`agent_target_mismatch` meant two opposite things:

| | meaning |
|---|---|
| **pin** | only another agent may run this — the task's own routing |
| **exclusion** | this agent is barred from it — an accumulated bar |

`classify_requirement_eligibility` skipped every mismatching agent as routing. Right for a pin; wrong for an exclusion — it dropped the one capable agent and reported *"no agent can satisfy the requirements"*, pointing the operator at capabilities that were already present.

Codes are now `:pinned` and `:excluded`, matched on their stem so the split is additive, and the finding names an exclusion as such:

```
N open task(s) cannot be dispatched; M of them have a capable agent that is
EXCLUDED from the task (clear the exclusion, do not add capabilities).
```

## Verification

10 new tests, mutation-verified. **Two exist only because mutation caught my own gaps**: removing the relaxation, and relaxing pins alongside exclusions — my first pin test never entered the relaxation path, so it passed against a build that cleared pins happily.

Affected suites (allocator, allocation, dispatch, requirement, diagnostics, fleet-node): **1427 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)