### PR TITLE
Let an agent's capabilities be edited without a fleet redeploy

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -3568,12 +3568,47 @@ def cmd_agent_register(args: argparse.Namespace) -> None:
 
 
 def cmd_agent_update(args: argparse.Namespace) -> None:
-    _print(
-        _plane(args).update_agent(
-            args.agent_id,
-            instance_kind=args.instance_kind,
+    """Change an agent's instance kind or its advertised capabilities.
+
+    ControlPlane.update_agent and PUT /agents/{id} have always accepted
+    `capabilities`; only this command ignored it, so the sole way to change what
+    an agent advertises was to re-register it through a fleet deploy. That
+    matters more than it sounds: capabilities are DECLARED, not probed, and the
+    default worker list omits `c`, `make` and `python3` entirely. On 2026-08-08
+    every fleet host had the full toolchain installed and exactly one agent
+    advertised `c`, which is why a single transient failure could make C work
+    permanently undispatchable.
+
+    --add/--remove edit the set in place, which is what you want when the
+    machine gained a toolchain and the record has not caught up. --capabilities
+    replaces it wholesale.
+    """
+    cp = _plane(args)
+    capabilities: Optional[List[str]] = None
+    if args.capabilities is not None:
+        capabilities = [c.strip() for c in args.capabilities.split(",") if c.strip()]
+    if args.add_capability or args.remove_capability:
+        if capabilities is None:
+            record = cp.get_agent(args.agent_id)
+            current = record.to_dict() if hasattr(record, "to_dict") else dict(record)
+            capabilities = list(current.get("capabilities") or [])
+        for value in args.add_capability or []:
+            if value not in capabilities:
+                capabilities.append(value)
+        for value in args.remove_capability or []:
+            if value in capabilities:
+                capabilities.remove(value)
+    updates: Dict[str, Any] = {}
+    if args.instance_kind is not None:
+        updates["instance_kind"] = args.instance_kind
+    if capabilities is not None:
+        updates["capabilities"] = sorted(set(capabilities))
+    if not updates:
+        raise SystemExit(
+            "nothing to update: supply --instance-kind, --capabilities, "
+            "--add-capability or --remove-capability"
         )
-    )
+    _print(cp.update_agent(args.agent_id, **updates))
 
 
 def _egress_contract_block(task: Any) -> Dict[str, Any]:
@@ -8498,7 +8533,19 @@ def build_parser() -> argparse.ArgumentParser:
     )
     agent_update.add_argument("agent_id")
     agent_update.add_argument(
-        "--instance-kind", choices=("static", "fungible"), required=True
+        "--instance-kind", choices=("static", "fungible"), required=False
+    )
+    agent_update.add_argument(
+        "--capabilities",
+        help="comma-separated capability list, replacing the current set",
+    )
+    agent_update.add_argument(
+        "--add-capability", action="append",
+        help="add one capability, keeping the rest (repeatable)",
+    )
+    agent_update.add_argument(
+        "--remove-capability", action="append",
+        help="remove one capability, keeping the rest (repeatable)",
     )
     _set(cmd_agent_update, agent_update)
 

--- a/tests/cli/test_agent_capability_update.py
+++ b/tests/cli/test_agent_capability_update.py
@@ -1,0 +1,127 @@
+"""An agent's advertised capabilities must be editable without a redeploy.
+
+Capabilities are DECLARED, not probed: the worker install writes a hardcoded
+default list that never mentioned `c`, `make` or `python3`. Measured on the
+live fleet 2026-08-08, every host had cc/gcc/clang/make/python3 installed and
+exactly ONE agent advertised `c` -- because somebody had set
+MAC_WORKER_CAPABILITIES on it by hand. Every C task could therefore match one
+worker, and a single transient failure that excluded it made the work
+permanently undispatchable.
+
+``ControlPlane.update_agent`` and ``PUT /agents/{id}`` have always accepted
+``capabilities``. Only this command ignored it, so the sole way to change what
+an agent advertises was to re-register it through a fleet deploy -- which is a
+long way round for "this machine gained a toolchain and the record has not
+caught up".
+
+--add/--remove edit the set in place; --capabilities replaces it wholesale.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--json", "--db", dsn_for(tmp_path), *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, json.loads(raw) if raw else None
+
+
+@pytest.fixture()
+def agent(tmp_path):
+    rc, machine = _run(tmp_path, "machine", "register", "host-a")
+    assert rc == 0
+    rc, created = _run(
+        tmp_path, "agent", "register", machine["id"], "worker-a",
+        "--capabilities", "python,testing",
+    )
+    assert rc == 0
+    return created
+
+
+def _caps(tmp_path, agent_id):
+    _rc, shown = _run(tmp_path, "agent", "show", agent_id)
+    return sorted(shown.get("capabilities") or [])
+
+
+def test_a_capability_can_be_added_in_place(tmp_path, agent):
+    """The live case: the machine has a C toolchain, the record does not."""
+    rc, _ = _run(tmp_path, "agent", "update", agent["id"], "--add-capability", "c")
+
+    assert rc == 0
+    assert _caps(tmp_path, agent["id"]) == ["c", "python", "testing"]
+
+
+def test_adding_keeps_the_existing_set(tmp_path, agent):
+    """An add must not be a silent replace; that is how an agent loses work."""
+    _run(tmp_path, "agent", "update", agent["id"], "--add-capability", "make")
+
+    caps = _caps(tmp_path, agent["id"])
+    assert "python" in caps and "testing" in caps and "make" in caps
+
+
+def test_several_capabilities_can_be_added_at_once(tmp_path, agent):
+    _run(
+        tmp_path, "agent", "update", agent["id"],
+        "--add-capability", "c", "--add-capability", "make",
+    )
+
+    assert _caps(tmp_path, agent["id"]) == ["c", "make", "python", "testing"]
+
+
+def test_a_capability_can_be_removed(tmp_path, agent):
+    """Withdrawing a claim matters as much: an agent advertising something it
+    cannot do gets matched, claims the work, and fails it."""
+    _run(tmp_path, "agent", "update", agent["id"], "--remove-capability", "testing")
+
+    assert _caps(tmp_path, agent["id"]) == ["python"]
+
+
+def test_capabilities_can_be_replaced_wholesale(tmp_path, agent):
+    _run(tmp_path, "agent", "update", agent["id"], "--capabilities", "c,make")
+
+    assert _caps(tmp_path, agent["id"]) == ["c", "make"]
+
+
+def test_adding_a_capability_twice_is_idempotent(tmp_path, agent):
+    _run(tmp_path, "agent", "update", agent["id"], "--add-capability", "c")
+    _run(tmp_path, "agent", "update", agent["id"], "--add-capability", "c")
+
+    assert _caps(tmp_path, agent["id"]).count("c") == 1
+
+
+def test_removing_something_absent_is_not_an_error(tmp_path, agent):
+    rc, _ = _run(tmp_path, "agent", "update", agent["id"], "--remove-capability", "fortran")
+
+    assert rc == 0
+    assert _caps(tmp_path, agent["id"]) == ["python", "testing"]
+
+
+def test_instance_kind_still_works_on_its_own(tmp_path, agent):
+    """It used to be required; making it optional must not break it."""
+    rc, _ = _run(tmp_path, "agent", "update", agent["id"], "--instance-kind", "static")
+
+    assert rc == 0
+    assert _caps(tmp_path, agent["id"]) == ["python", "testing"]
+
+
+def test_an_update_with_no_fields_is_refused(tmp_path, agent):
+    """Silently succeeding would hide a typo'd flag."""
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, "agent", "update", agent["id"])
+
+    assert "nothing to update" in str(excinfo.value)


### PR DESCRIPTION
Follow-up to #307. That fixed capability advertisement **going forward** (probe the sandbox at registration). This makes it fixable **now**, for agents already registered.

```bash
mac agent update <id> --add-capability c --add-capability make
mac agent update <id> --remove-capability gpu
mac agent update <id> --capabilities c,make,python
```

## Why this was missing

`ControlPlane.update_agent` and `PUT /agents/{id}` have **always** accepted `capabilities`. Only this command ignored it — so the sole way to change what an agent advertises was to re-register it through a fleet deploy. A long way round for *"this machine gained a toolchain and the record hasn't caught up"*.

Measured on the live fleet 2026-08-08: every host had `cc`, `gcc`, `clang`, `make` and `python3` installed, and exactly **one** agent advertised `c` — because somebody had set `MAC_WORKER_CAPABILITIES` on it by hand. Every C task could match that one worker, and when a transient failure excluded it the work became permanently undispatchable.

| capability | agents advertising | agents that could |
|---|---|---|
| `testing`, `python` | 8 | 8 |
| `c` | **1** | 8 |

## Decisions

- **`--add`/`--remove` edit in place.** An add that quietly replaced would strip an agent of work it can do — a test pins that.
- **Removal matters equally.** An agent advertising something it cannot do gets matched, claims the work, and fails it.
- **`--instance-kind` becomes optional.** It was required, so capabilities couldn't be changed without also restating the instance kind.
- **Refuses an empty update**, so a typo'd flag doesn't silently succeed.

## Verified live, and deliberately limited

`agent_rocky` gained `c` and `make` in place, no redeploy, confirmed against the hub.

I did **not** apply it to the six agents whose toolchain I could not reach to verify. Advertising unverified capability is the same *"lie the dispatcher believes"* the GPU probe comment describes — the dispatcher routes the work and the task fails on a box that was never able to run it. #307's sandbox probe is the durable answer for those.

9 tests; full CLI suite 542 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)