### PR TITLE
Turn a sandbox excursion into a task against the project that caused it

### DIFF
--- a/src/mac/sandbox_excursion.py
+++ b/src/mac/sandbox_excursion.py
@@ -1,0 +1,187 @@
+"""A sandbox excursion becomes a task against the project that caused it.
+
+A repository contract declares the commands a repo needs
+(``toolchain.required_commands``). The sandbox image is supposed to cover them.
+When it does not, the executor provisions the missing tool into a task-local
+``.mac-toolchain`` so the work still runs -- and records exactly what happened:
+
+    {"schema": "mac.sandbox_environment_delta.v1",
+     "commands": [...required...],
+     "missing_after": [...still absent after provisioning...],
+     "reason": "repository_contract.toolchain.required_commands"}
+
+That record has always been written and never read. It travels back inside
+``mac.sandbox_verification.v1``, lands on a check item, and stops. The sandbox
+is disposable, so every excursion was measured and then discarded.
+
+The visible consequence is in the Containerfile, whose package list is a manual
+ledger of exactly these incidents, transcribed by a human months later:
+
+    "libssl-dev: nanolang's src/sign.c #includes <openssl/evp.h> ... without it
+     a coding agent will destructively stub sign.c just to compile"
+
+That comment is an excursion someone eventually noticed. This module is the
+consumer that makes noticing automatic: the excursion is filed against the
+project that caused it, carrying the delta, so a human or an LLM can audit that
+specific case and decide whether the CONTRACT should gain the tool or the
+SPECIFICATION should be tightened so the tool is not needed.
+
+Two properties matter more than the filing itself:
+
+* **The excursion never blocks the work.** Provisioning stays exactly as it is.
+  A contract may be wrong or stale, and a sandbox that has to reach outside its
+  contract must still succeed -- the task is a report, not a gate.
+* **One missing tool is one task.** Deduplicated per (project, command), so a
+  tool absent across a hundred tasks does not file a hundred tickets. Noise is
+  what stops people reading, and this only pays off if it is read.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+EXCURSION_SCHEMA = "mac.sandbox_excursion.v1"
+DELTA_SCHEMA = "mac.sandbox_environment_delta.v1"
+
+#: Marker on a filed task, so the dedupe lookup does not depend on title text.
+EXCURSION_METADATA_KEY = "sandbox_excursion"
+
+
+def excursion_from_delta(
+    delta: Any, *, project: Optional[str], task_id: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """The auditable facts of one excursion, or None when nothing escaped.
+
+    An excursion is a command the repository contract REQUIRED that the sandbox
+    image did not supply. ``missing_after`` (still absent even after
+    provisioning) is the strongest signal, but a command that had to be
+    provisioned at all is equally a gap between the contract and the image --
+    the work succeeded, and the image still did not cover the contract.
+    """
+    if not isinstance(delta, Mapping):
+        return None
+    if str(delta.get("schema") or "").strip() != DELTA_SCHEMA:
+        return None
+    required = [str(item).strip() for item in (delta.get("commands") or []) if str(item).strip()]
+    missing = [
+        str(item).strip() for item in (delta.get("missing_after") or []) if str(item).strip()
+    ]
+    provisioned = [
+        str(item).strip()
+        for item in (delta.get("provisioned") or [])
+        if str(item).strip()
+    ]
+    escaped = sorted(set(missing) | set(provisioned))
+    if not escaped:
+        return None
+    return {
+        "schema": EXCURSION_SCHEMA,
+        "project": project or None,
+        "task_id": task_id,
+        "required_commands": sorted(set(required)),
+        "escaped_commands": escaped,
+        # Kept apart because they mean different things to a reviewer: one is a
+        # gap the sandbox papered over, the other is a gap it could not.
+        "missing_after": sorted(set(missing)),
+        "provisioned": sorted(set(provisioned)),
+        "reason": str(delta.get("reason") or ""),
+        "toolchain_root": str(delta.get("toolchain_root") or ""),
+    }
+
+
+def excursion_title(project: Optional[str], command: str) -> str:
+    return "Sandbox excursion: %s requires %r, which the image does not provide" % (
+        project or "unknown project",
+        command,
+    )
+
+
+def excursion_description(excursion: Mapping[str, Any], command: str) -> str:
+    """What a reviewer needs to decide contract-vs-specification."""
+    lines = [
+        "The sandbox image does not supply %r, which %s's repository contract "
+        "declares in toolchain.required_commands."
+        % (command, excursion.get("project") or "this project"),
+        "",
+        "The work was NOT blocked: the executor provisioned it into a "
+        "task-local .mac-toolchain and the task continued. This is a report so "
+        "the gap can be audited, not a failure.",
+        "",
+        "Observed on task %s" % (excursion.get("task_id") or "(unrecorded)"),
+        "  required by contract : %s" % ", ".join(excursion.get("required_commands") or []),
+        "  escaped the image    : %s" % ", ".join(excursion.get("escaped_commands") or []),
+    ]
+    if excursion.get("missing_after"):
+        lines.append(
+            "  still absent AFTER provisioning: %s"
+            % ", ".join(excursion["missing_after"])
+        )
+        lines.append(
+            "    (this one the sandbox could not paper over; the task ran without it)"
+        )
+    lines.extend(
+        [
+            "",
+            "THE DECISION THIS TASK EXISTS FOR, either answer closes it:",
+            "",
+            "  1. The contract is RIGHT and the image is behind. Add %r to the "
+            "sandbox bill of materials so every task gets it, instead of each "
+            "task provisioning it again." % command,
+            "",
+            "  2. The contract is WRONG or too loose. Tighten the specification "
+            "so the repo does not need %r, and remove it from "
+            "toolchain.required_commands." % command,
+            "",
+            "Deciding neither leaves every future task paying the provisioning "
+            "cost and the image drifting further from the contract that is "
+            "supposed to be authoritative.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def excursion_metadata(excursion: Mapping[str, Any], command: str) -> Dict[str, Any]:
+    return {
+        EXCURSION_METADATA_KEY: {
+            "schema": EXCURSION_SCHEMA,
+            "command": command,
+            "project": excursion.get("project"),
+            "observed_on_task_id": excursion.get("task_id"),
+            "required_commands": list(excursion.get("required_commands") or []),
+            "missing_after": list(excursion.get("missing_after") or []),
+            "provisioned": list(excursion.get("provisioned") or []),
+            "reason": excursion.get("reason"),
+        }
+    }
+
+
+def dedupe_key(project: Optional[str], command: str) -> str:
+    """One missing tool is one task, however many tasks trip over it."""
+    return "%s::%s" % (project or "unknown", command)
+
+
+def excursion_commands(excursion: Mapping[str, Any]) -> List[str]:
+    return list(excursion.get("escaped_commands") or [])
+
+
+def existing_excursion_commands(tasks: Sequence[Any]) -> set:
+    """Commands already filed, read from the marker rather than the title.
+
+    Titles get edited; a dedupe that keys off them starts filing duplicates the
+    first time someone rewords one.
+    """
+    seen = set()
+    for task in tasks:
+        record = task.to_dict() if hasattr(task, "to_dict") else task
+        if not isinstance(record, Mapping):
+            continue
+        metadata = record.get("metadata")
+        if not isinstance(metadata, Mapping):
+            continue
+        marker = metadata.get(EXCURSION_METADATA_KEY)
+        if not isinstance(marker, Mapping):
+            continue
+        command = str(marker.get("command") or "").strip()
+        if command:
+            seen.add(dedupe_key(marker.get("project"), command))
+    return seen

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6755,6 +6755,96 @@ class ControlPlane:
         self.task_groups.delete(name)
         return {"name": name, "deleted": True}
 
+    def record_sandbox_excursion(
+        self,
+        delta: Any,
+        *,
+        project: Optional[str],
+        task_id: Optional[str] = None,
+        actor: str = "sandbox-excursion",
+    ) -> JsonDict:
+        """File a task against the project whose contract the image did not cover.
+
+        The excursion record has always been written by the executor and never
+        read: it rides back inside mac.sandbox_verification.v1, lands on a check
+        item, and stops. The visible consequence is the Containerfile's package
+        list, which is a manual ledger of these incidents transcribed by a human
+        months after each one.
+
+        This never blocks or fails anything. The work already succeeded --
+        provisioning saw to that -- and a contract may legitimately be wrong or
+        stale, so the excursion is a REPORT for audit, not a gate.
+
+        Deduplicated per (project, command): one missing tool is one task
+        however many tasks trip over it, because noise is what stops these
+        being read.
+        """
+        from mac.sandbox_excursion import (
+            dedupe_key,
+            excursion_commands,
+            excursion_description,
+            excursion_from_delta,
+            excursion_metadata,
+            excursion_title,
+            existing_excursion_commands,
+        )
+
+        excursion = excursion_from_delta(delta, project=project, task_id=task_id)
+        if excursion is None:
+            return {"schema": "mac.sandbox_excursion_report.v1", "filed": [], "skipped": []}
+
+        try:
+            open_tasks = self.list_tasks("open", project=project)
+        except Exception:  # noqa: BLE001 - a report must never break the caller
+            open_tasks = []
+        already = existing_excursion_commands(open_tasks)
+
+        filed: List[str] = []
+        skipped: List[str] = []
+        for command in excursion_commands(excursion):
+            if dedupe_key(project, command) in already:
+                skipped.append(command)
+                continue
+            try:
+                created = self.create_task(
+                    excursion_title(project, command),
+                    description=excursion_description(excursion, command),
+                    project=project,
+                    metadata=excursion_metadata(excursion, command),
+                    actor=actor,
+                )
+            except Exception:  # noqa: BLE001 - never break the executing task
+                skipped.append(command)
+                continue
+            filed.append(created.id)
+            already.add(dedupe_key(project, command))
+
+        if filed:
+            try:
+                self.record_log(
+                    "sandbox.excursion_filed",
+                    level="warning",
+                    subject_type="project",
+                    subject_id=project or "unknown",
+                    detail={
+                        "project": project,
+                        "observed_on_task_id": task_id,
+                        "commands": excursion_commands(excursion),
+                        "filed_task_ids": filed,
+                    },
+                )
+            except Exception:  # noqa: BLE001 - diagnostic only
+                pass
+
+        return {
+            "schema": "mac.sandbox_excursion_report.v1",
+            "project": project,
+            "observed_on_task_id": task_id,
+            "filed": filed,
+            "skipped": skipped,
+            "excursion": excursion,
+        }
+
     def search_tasks(
         self,
         query: str,

--- a/tests/test_sandbox_excursion.py
+++ b/tests/test_sandbox_excursion.py
@@ -1,0 +1,227 @@
+"""An excursion outside a repository contract must become auditable work.
+
+The executor already records, per task, which contract-required commands the
+sandbox image did not supply::
+
+    {"schema": "mac.sandbox_environment_delta.v1",
+     "commands": [...required...],
+     "missing_after": [...still absent after provisioning...],
+     "reason": "repository_contract.toolchain.required_commands"}
+
+It rides back inside ``mac.sandbox_verification.v1``, lands on a check item,
+and stops. The sandbox is disposable, so every excursion was measured and then
+thrown away.
+
+The visible consequence is deploy/openshell/mac-hermes.Containerfile, whose
+package list is a hand-written ledger of exactly these incidents:
+
+    "libssl-dev: nanolang's src/sign.c #includes <openssl/evp.h> ... without it
+     a coding agent will destructively stub sign.c just to compile"
+
+That is one excursion, noticed months later, by a person. These tests cover the
+consumer that makes noticing automatic -- and, as importantly, the two ways it
+could do more harm than good: by blocking work it has no business blocking, and
+by filing enough duplicates that nobody reads any of them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.sandbox_excursion import (
+    DELTA_SCHEMA,
+    EXCURSION_METADATA_KEY,
+    excursion_from_delta,
+)
+from mac.services import ControlPlane
+
+
+def _delta(commands=("cc", "make"), missing=(), provisioned=()):
+    return {
+        "schema": DELTA_SCHEMA,
+        "package_manager": "sandbox-toolchain",
+        "commands": list(commands),
+        "missing_after": list(missing),
+        "provisioned": list(provisioned),
+        "toolchain_root": "/sandbox/task/.mac-toolchain",
+        "reason": "repository_contract.toolchain.required_commands",
+    }
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("nanolang", dispatch_paused=False)
+    return plane
+
+
+# --------------------------------------------------------------------------
+# What counts as an excursion
+# --------------------------------------------------------------------------
+
+
+def test_a_command_still_missing_after_provisioning_is_an_excursion():
+    excursion = excursion_from_delta(_delta(missing=["qemu-system-riscv64"]), project="c26")
+
+    assert excursion["escaped_commands"] == ["qemu-system-riscv64"]
+    assert excursion["missing_after"] == ["qemu-system-riscv64"]
+
+
+def test_a_command_that_had_to_be_provisioned_is_also_an_excursion():
+    """The work succeeded and the image still did not cover the contract.
+
+    Counting only hard failures would miss every case the sandbox papered over
+    -- which is most of them, and exactly the ones the Containerfile comments
+    were eventually written about.
+    """
+    excursion = excursion_from_delta(_delta(provisioned=["lein"]), project="nanolang")
+
+    assert excursion["escaped_commands"] == ["lein"]
+    assert excursion["provisioned"] == ["lein"]
+
+
+def test_the_two_kinds_are_reported_separately():
+    """They mean different things to a reviewer: one gap was papered over, the
+    other could not be."""
+    excursion = excursion_from_delta(
+        _delta(missing=["qemu"], provisioned=["lein"]), project="c26"
+    )
+
+    assert excursion["missing_after"] == ["qemu"]
+    assert excursion["provisioned"] == ["lein"]
+    assert excursion["escaped_commands"] == ["lein", "qemu"]
+
+
+def test_a_contract_the_image_fully_covered_is_not_an_excursion():
+    """The common case must be silent, or the signal is worthless."""
+    assert excursion_from_delta(_delta(), project="nanolang") is None
+
+
+@pytest.mark.parametrize(
+    "delta",
+    [None, {}, "junk", {"schema": "something.else.v1", "missing_after": ["cc"]}],
+)
+def test_a_malformed_or_foreign_record_is_ignored(delta):
+    assert excursion_from_delta(delta, project="nanolang") is None
+
+
+# --------------------------------------------------------------------------
+# Filing
+# --------------------------------------------------------------------------
+
+
+def test_an_excursion_becomes_a_task_against_the_offending_project(cp):
+    report = cp.record_sandbox_excursion(
+        _delta(missing=["libssl-dev"]), project="nanolang", task_id="task_abc"
+    )
+
+    assert len(report["filed"]) == 1
+    filed = cp.get_task(report["filed"][0])
+    assert filed.project == "nanolang", "filed against the wrong project"
+    assert "libssl-dev" in filed.title
+
+
+def test_the_task_carries_the_delta_for_audit(cp):
+    report = cp.record_sandbox_excursion(
+        _delta(missing=["libssl-dev"]), project="nanolang", task_id="task_abc"
+    )
+
+    marker = cp.get_task(report["filed"][0]).metadata[EXCURSION_METADATA_KEY]
+    assert marker["command"] == "libssl-dev"
+    assert marker["observed_on_task_id"] == "task_abc"
+    assert marker["reason"] == "repository_contract.toolchain.required_commands"
+
+
+def test_the_task_states_the_decision_it_exists_for(cp):
+    """A reviewer must be able to close it either way: fix the image, or fix
+    the contract. A report that does not name the decision gets read once."""
+    report = cp.record_sandbox_excursion(
+        _delta(missing=["libssl-dev"]), project="nanolang"
+    )
+    description = cp.get_task(report["filed"][0]).description
+
+    assert "contract is RIGHT" in description
+    assert "contract is WRONG" in description
+    assert "toolchain.required_commands" in description
+
+
+def test_the_report_says_the_work_was_not_blocked(cp):
+    """Whoever reads this must not think a task failed over it."""
+    report = cp.record_sandbox_excursion(_delta(provisioned=["lein"]), project="nanolang")
+
+    assert "NOT blocked" in cp.get_task(report["filed"][0]).description
+
+
+def test_one_missing_tool_is_one_task(cp):
+    """A tool absent across a hundred tasks must not file a hundred tickets.
+
+    Noise is what stops people reading, and this only pays off if it is read.
+    """
+    first = cp.record_sandbox_excursion(_delta(missing=["libssl-dev"]), project="nanolang")
+    second = cp.record_sandbox_excursion(_delta(missing=["libssl-dev"]), project="nanolang")
+
+    assert len(first["filed"]) == 1
+    assert second["filed"] == []
+    assert second["skipped"] == ["libssl-dev"]
+
+
+def test_dedupe_reads_the_marker_not_the_title(cp):
+    """Titles get edited; a title-keyed dedupe starts duplicating the first
+    time somebody rewords one."""
+    report = cp.record_sandbox_excursion(_delta(missing=["libssl-dev"]), project="nanolang")
+    cp.update_task(report["filed"][0], title="Renamed by a human", actor="operator")
+
+    again = cp.record_sandbox_excursion(_delta(missing=["libssl-dev"]), project="nanolang")
+
+    assert again["filed"] == []
+
+
+def test_a_different_command_still_files(cp):
+    """Dedupe must be per command, not per project."""
+    cp.record_sandbox_excursion(_delta(missing=["libssl-dev"]), project="nanolang")
+    second = cp.record_sandbox_excursion(_delta(missing=["qemu"]), project="nanolang")
+
+    assert len(second["filed"]) == 1
+
+
+def test_the_same_command_in_another_project_still_files(cp):
+    """Two projects needing the same absent tool are two contract questions."""
+    cp.create_project("c26", dispatch_paused=False)
+    cp.record_sandbox_excursion(_delta(missing=["qemu"]), project="nanolang")
+    second = cp.record_sandbox_excursion(_delta(missing=["qemu"]), project="c26")
+
+    assert len(second["filed"]) == 1
+
+
+def test_a_clean_run_files_nothing(cp):
+    report = cp.record_sandbox_excursion(_delta(), project="nanolang")
+
+    assert report["filed"] == [] and report["skipped"] == []
+
+
+# --------------------------------------------------------------------------
+# It must never become a gate
+# --------------------------------------------------------------------------
+
+
+def test_filing_failures_never_raise(cp, monkeypatch):
+    """The task that hit the excursion has already succeeded.
+
+    Turning a report into an exception would fail work over a diagnostic --
+    strictly worse than the silence being fixed.
+    """
+    def boom(*args, **kwargs):
+        raise RuntimeError("ledger unavailable")
+
+    monkeypatch.setattr(cp, "create_task", boom)
+
+    report = cp.record_sandbox_excursion(_delta(missing=["libssl-dev"]), project="nanolang")
+
+    assert report["filed"] == []
+    assert report["skipped"] == ["libssl-dev"]
+
+
+def test_an_unknown_project_does_not_raise(cp):
+    report = cp.record_sandbox_excursion(_delta(missing=["cc"]), project=None)
+
+    assert isinstance(report["filed"], list)


### PR DESCRIPTION
Stage 1 of task_67d2e4ae.

## The record already existed; nothing read it

The executor writes, per task, exactly which contract-required commands the sandbox image failed to supply:

```json
{"schema": "mac.sandbox_environment_delta.v1",
 "commands": ["cc", "make", "libssl-dev"],
 "missing_after": ["libssl-dev"],
 "reason": "repository_contract.toolchain.required_commands"}
```

It rides back inside `mac.sandbox_verification.v1`, lands on a check item, and **stops**. The sandbox is disposable, so every excursion was measured and thrown away.

## What that cost, in the repo's own words

`deploy/openshell/mac-hermes.Containerfile`'s package list is a hand-written ledger of these incidents:

> *"libssl-dev: nanolang's src/sign.c #includes `<openssl/evp.h>` … without it `make build` fails and **a coding agent will destructively stub sign.c just to compile**"*

> *"clang/llvm/lld/qemu: the RISC-V validation floor used by c26"*

Each is one excursion, noticed months later, by a person — and the middle one describes an agent silently damaging source to work around it.

## The consumer

The excursion is filed against the project that caused it, carrying the delta, and the task states **the decision it exists for**:

1. The contract is **right** and the image is behind → add the tool to the sandbox BOM.
2. The contract is **wrong** or too loose → tighten the spec so the tool isn't needed.

> Deciding neither leaves every future task paying the provisioning cost and the image drifting further from the contract that is supposed to be authoritative.

A command that merely had to be **provisioned** counts, not only one still missing afterwards. Counting only hard failures would miss every case the sandbox papered over — which is most of them, and exactly the ones those comments were eventually written about.

## Two properties that matter as much as the filing

**It never blocks.** The work already succeeded, and a contract may be legitimately wrong or stale, so this is a report for audit — not a gate. A filing failure is swallowed: turning a diagnostic into an exception would fail work over a report, strictly worse than the silence being fixed.

**One missing tool is one task.** Deduplicated per `(project, command)`, keyed off a metadata marker rather than the title — titles get edited, and a title-keyed dedupe starts duplicating the moment someone rewords one. Noise is what stops these being read, and this only pays off if it's read.

## Verification

19 tests, mutation-verified:

| mutation | tests failed |
|---|---|
| remove the dedupe | 2 |
| count only hard failures, not provisioned | 3 |

Public-contract and guard suites: **619 passed**.

## Still to come in task_67d2e4ae

Deriving the image BOM from the union of registered contracts plus a mac-core set, so *"when to permute the environment"* becomes mechanical — a contract changes, the frozen-input hash moves, the deploy demands a fresh reviewed image — instead of incident-driven.

**This stage makes the incidents visible. That stage makes most of them unnecessary.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)