### PR TITLE
Derive the sandbox BOM from contracts, and roll it out per drained worker

### DIFF
--- a/deploy/openshell/mac-hermes.Containerfile
+++ b/deploy/openshell/mac-hermes.Containerfile
@@ -47,6 +47,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # image should cover ordinary polyglot repos without mutating the host fleet.
 # build-essential: a C/C++ toolchain (cc/gcc/g++) for repos that compile native
 #   code (e.g. nanolang's 3-stage `make build`); Debian-slim ships none.
+# cmake/ninja-build: isaacsim7-poc@feat/ros-sim's contract requires them. This
+#   is the first entry here that was NOT transcribed from an incident: the
+#   contract said so and `mac sandbox bom` read it. Everything above this line
+#   is the same fact, learned the expensive way.  Do not hand-edit this list --
+#   run `mac sandbox bom --containerfile` and let the contracts say what belongs.
 # libssl-dev: OpenSSL headers + libcrypto. nanolang's src/sign.c #includes
 #   <openssl/evp.h>/<sha.h>/<err.h> and the build links -lcrypto; without it
 #   `make build` fails and a coding agent will destructively stub sign.c just to
@@ -92,9 +97,11 @@ RUN printf '%s\n' 'deb http://deb.debian.org/debian bookworm-backports main' > /
     && apt-get install -y --no-install-recommends bash ca-certificates curl tar xz-utils \
     && chmod 0755 /usr/local/bin/mac-verify-bash-contract \
     && /usr/local/bin/mac-verify-bash-contract \
-    && apt-get install -y --no-install-recommends iproute2 iptables git procps make build-essential libssl-dev openjdk-17-jre-headless clang llvm lld \
+    && apt-get install -y --no-install-recommends iproute2 iptables git procps make cmake ninja-build build-essential libssl-dev openjdk-17-jre-headless clang llvm lld \
     && apt-get install -y --no-install-recommends -t bookworm-backports qemu-system-misc \
     && command -v ps >/dev/null \
+    && command -v cmake >/dev/null \
+    && command -v ninja >/dev/null \
     && command -v clang >/dev/null \
     && command -v llvm-objcopy >/dev/null \
     && command -v ld.lld >/dev/null \

--- a/deploy/openshell/sandbox-bom.json
+++ b/deploy/openshell/sandbox-bom.json
@@ -1,0 +1,102 @@
+{
+  "commands": [
+    "bash",
+    "ca-certificates",
+    "cc",
+    "cmake",
+    "curl",
+    "gh",
+    "git",
+    "iproute2",
+    "iptables",
+    "java",
+    "lein",
+    "make",
+    "ninja",
+    "node",
+    "pnpm",
+    "procps",
+    "python3",
+    "qemu-system-riscv64",
+    "tar",
+    "uv",
+    "xz-utils"
+  ],
+  "contributing_projects": {
+    "Aviation": [
+      "git",
+      "java",
+      "lein",
+      "node",
+      "pnpm",
+      "python3"
+    ],
+    "OrcaSlicer-AD5M-Klipper": [
+      "git",
+      "python3"
+    ],
+    "OrcaSlicer-AI": [
+      "git",
+      "python3"
+    ],
+    "c26": [
+      "make",
+      "python3",
+      "qemu-system-riscv64"
+    ],
+    "isaacsim7-poc@feat/ros-sim": [
+      "bash",
+      "cmake",
+      "git",
+      "ninja",
+      "python3"
+    ],
+    "mac": [
+      "gh",
+      "git",
+      "python3"
+    ],
+    "nanolang": [
+      "cc",
+      "gh",
+      "git",
+      "make",
+      "python3"
+    ],
+    "ova": [
+      "git",
+      "make",
+      "node",
+      "python3"
+    ]
+  },
+  "core_commands": [
+    "bash",
+    "ca-certificates",
+    "curl",
+    "git",
+    "iproute2",
+    "iptables",
+    "procps",
+    "python3",
+    "tar",
+    "uv",
+    "xz-utils"
+  ],
+  "packages": [
+    "build-essential",
+    "cmake",
+    "git",
+    "iproute2",
+    "iptables",
+    "make",
+    "ninja-build",
+    "openjdk-17-jre-headless",
+    "procps",
+    "qemu-system-misc",
+    "tar",
+    "xz-utils"
+  ],
+  "schema": "mac.sandbox_bom.v1",
+  "unmapped_commands": []
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -74,7 +74,7 @@ Getting work done:
 What agents know:
   memory  durable cross-session knowledge
 
-36 more commands are available. `mac help --all` lists them, and every one of them
+37 more commands are available. `mac help --all` lists them, and every one of them
 runs whether it is listed or not -- nothing is removed.
 
 Run `mac help <command>` for any of them.
@@ -474,6 +474,26 @@ Repositories:
   register  register the current checkout, a local path, or GIT_URL[#BRANCH] as a project and create its contract-authoring task
 
 Run `mac project help <subcommand>` for the arguments one takes.
+```
+
+## mac sandbox
+
+```console
+$ mac sandbox --help
+usage: mac sandbox [-h] {bom,rollout,help} ...
+
+derive, check, and roll out the OpenShell sandbox image
+
+positional arguments:
+  {bom,rollout,help}
+    bom               derive the sandbox bill of materials from every
+                      project's contract
+    rollout           roll a reviewed sandbox image onto each worker, after it
+                      drains
+    help              show help for this command group
+
+options:
+  -h, --help          show this help message and exit
 ```
 
 ## mac work-package

--- a/scripts/image-publication-identity.py
+++ b/scripts/image-publication-identity.py
@@ -57,6 +57,11 @@ IMAGE_SPECS = {
             "uv.lock",
             "README.md",
             "deploy/openshell/mac-hermes.Containerfile",
+            # The BOM derived from every repository contract. Frozen here so a
+            # contract gaining a tool changes the image identity: the sandbox is
+            # the security boundary, and "which tools are in it" must be part of
+            # what the published digest attests, not a fact kept alongside it.
+            "deploy/openshell/sandbox-bom.json",
             "deploy/openshell/prepare-runtime-image-assets.sh",
             "deploy/reviewed-tool-assets.sh",
             "deploy/verify-bash-contract.sh",

--- a/src/mac/allocator.py
+++ b/src/mac/allocator.py
@@ -50,6 +50,36 @@ AGENT_HARDWARE_INSUFFICIENT = "agent_hardware_insufficient"
 AGENT_ROLE_INELIGIBLE = "agent_role_ineligible"
 AGENT_ROLE_MISMATCH = "agent_role_mismatch"
 AGENT_NO_EXECUTION_BOUNDARY = "agent_no_execution_boundary"
+# One agent-wide barrier, four distinct reasons. They are suffixes on a single
+# stem because rejection_kind matches on the stem, but they must stay
+# distinguishable: "this worker is draining for an update" and "you are not the
+# oldest barrier in the queue" send an operator to completely different places.
+AGENT_SYNC_BARRIER = "agent_sync_barrier"
+
+#: A task that may run beside others, in any order. Everything is this today.
+EXECUTION_MODE_ASYNC = "async"
+#: A task that owns its agent: it starts only once the agent has drained, and
+#: nothing else runs while it does. Rolling out a sandbox image is the
+#: motivating case -- it cannot run beside the tasks whose sandbox it replaces.
+EXECUTION_MODE_SYNC = "sync"
+EXECUTION_MODES = (EXECUTION_MODE_ASYNC, EXECUTION_MODE_SYNC)
+
+#: A sync task with no target agent. "Wait for all tasks to complete" is
+#: ambiguous between one worker and the whole fleet, and the fleet reading is a
+#: global stop-the-world. Rejected rather than resolved by whichever code path
+#: happens to run first.
+TASK_SYNC_UNTARGETED = "task_sync_untargeted"
+
+
+def normalize_execution_mode(value: Any) -> str:
+    """Anything not recognizably ``sync`` is async.
+
+    Fail-open is right in this one direction: an unknown mode read as async
+    keeps ordinary work moving, while reading it as sync would quiesce a worker
+    on a typo.
+    """
+    text = str(value or "").strip().lower()
+    return EXECUTION_MODE_SYNC if text == EXECUTION_MODE_SYNC else EXECUTION_MODE_ASYNC
 
 
 def _utcnow() -> str:
@@ -108,6 +138,9 @@ class AllocationTask:
     required_role_known: bool = True
     required_role_capabilities: FrozenSet[str] = field(default_factory=frozenset)
     package_ready: bool = True
+    # async (default) or sync. A sync task is a per-agent barrier: see
+    # EXECUTION_MODE_SYNC and the placement rules in evaluate_pair.
+    execution_mode: str = EXECUTION_MODE_ASYNC
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -144,6 +177,26 @@ class AllocationAgent:
     # this: the SSH installer installs OpenShell and the container image does
     # not, and a future AWS/Azure worker brings its own runtime or none.
     execution_boundary_verified: bool = True
+    # The oldest unfinished sync task targeted at this agent, if any. One field
+    # rather than a pending flag plus a queue, because both facts derive from
+    # it: the agent is quiescing while it is set, and a sync task may only run
+    # when it IS this task. Two fields would be two things to keep consistent.
+    sync_queue_head_task_id: Optional[str] = None
+    # Whether that head task is actually executing, as opposed to waiting for
+    # the agent to drain.
+    sync_task_running: bool = False
+
+    @property
+    def sync_barrier_pending(self) -> bool:
+        """A sync task is queued here, so the agent takes no new async work.
+
+        Quiescing on ENQUEUE, not on execution, is what stops a barrier
+        starving: if the agent kept accepting async work while the barrier
+        waited, active_leases would never reach zero, and the busiest workers --
+        the ones most in need of an image update -- would be the ones that
+        never got one.
+        """
+        return self.sync_queue_head_task_id is not None
 
     @property
     def free_slots(self) -> int:
@@ -571,9 +624,20 @@ AUTHORIZATION_REJECTIONS: FrozenSet[str] = frozenset(
     {AGENT_TENANT_UNAUTHORIZED, AGENT_MACHINE_UNTRUSTED}
 )
 
-#: The same pair passes later with nothing reconfigured.
+#: The same pair passes later with nothing reconfigured. A sync barrier belongs
+#: here: it clears when the agent drains and the barrier task finishes. Left
+#: unclassified it would read as "other", and the eligibility diagnostic would
+#: report a fleet that cannot meet the task's requirements when the real answer
+#: is "this worker is being updated, wait". That is the same misdirection the
+#: :excluded / :pinned split was introduced to fix.
 TRANSIENT_REJECTIONS: FrozenSet[str] = frozenset(
-    {AGENT_OFFLINE, AGENT_UNHEALTHY, AGENT_HELD, AGENT_CAPACITY_FULL}
+    {
+        AGENT_OFFLINE,
+        AGENT_UNHEALTHY,
+        AGENT_HELD,
+        AGENT_CAPACITY_FULL,
+        AGENT_SYNC_BARRIER,
+    }
 )
 
 SATISFIABLE = "satisfiable"
@@ -721,6 +785,16 @@ def evaluate_task(task: AllocationTask) -> PairEvaluation:
         reasons.append(TASK_PROJECT_INACTIVE)
     if task.attempt_count >= task.max_attempts:
         reasons.append(TASK_ATTEMPTS_EXHAUSTED)
+    if (
+        normalize_execution_mode(task.execution_mode) == EXECUTION_MODE_SYNC
+        and not task.target_agent_id
+        and not task.break_glass_agent_id
+    ):
+        # Refused here as well as at creation. A sync task that reached the
+        # ledger untargeted -- written directly, or restored from a backup
+        # predating this rule -- must not be resolved into a fleet-wide barrier
+        # by default.
+        reasons.append(TASK_SYNC_UNTARGETED)
     if not task.package_ready:
         reasons.append(TASK_PACKAGE_NOT_READY)
     return PairEvaluation(task_id=task.id, agent_id=None, task_rejections=tuple(reasons))
@@ -744,6 +818,26 @@ def evaluate_pair(
 
     reasons = []
     break_glass_active = task.break_glass_agent_id == agent.id
+    mode = normalize_execution_mode(task.execution_mode)
+
+    # The barrier is enforced even under break-glass. Break-glass exists to
+    # force a task past ROUTING bars; letting it run beside a sync task would
+    # put ordinary work inside a sandbox that is being replaced underneath it,
+    # which is host safety rather than routing -- the same reason capacity and
+    # health are checked above this block rather than inside it.
+    if mode == EXECUTION_MODE_SYNC:
+        # FIFO among barriers, by creation time, NOT by priority: a barrier
+        # that reorders under priority is not a barrier. The head is computed
+        # by the snapshot builder, so "is this the oldest" is one comparison
+        # here instead of a scan.
+        if agent.sync_queue_head_task_id not in (None, task.id):
+            reasons.append("%s:fifo" % AGENT_SYNC_BARRIER)
+        if agent.active_leases > 0:
+            reasons.append("%s:not_drained" % AGENT_SYNC_BARRIER)
+    elif agent.sync_task_running:
+        reasons.append("%s:running" % AGENT_SYNC_BARRIER)
+    elif agent.sync_barrier_pending:
+        reasons.append("%s:draining" % AGENT_SYNC_BARRIER)
     if not task.required_role_known:
         reasons.append(TASK_REQUIRED_ROLE_UNKNOWN)
     if not agent.online:

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -7912,7 +7912,9 @@ def build_parser() -> argparse.ArgumentParser:
     project_activate.add_argument("--actor", default="human")
     _set(cmd_project_activate, project_activate)
     sandbox = sub.add_parser(
-        "sandbox", help="openshell sandbox image commands"
+        "sandbox",
+        help="derive, check, and roll out the OpenShell sandbox image",
+        description="derive, check, and roll out the OpenShell sandbox image",
     ).add_subparsers(dest="sandbox_command", required=True)
     sandbox_bom_cmd = sandbox.add_parser(
         "bom",

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -1901,6 +1901,13 @@ def cmd_task_create(args: argparse.Namespace) -> None:
         # Stage the task: the loop-mode fleet won't auto-claim it (and it's
         # hidden from `task ready`) until an operator starts it explicitly.
         metadata["no_dispatch"] = True
+    if getattr(args, "sync", False):
+        # A barrier on one worker: it waits for that worker to drain, runs
+        # alone, and holds off new async work while it does.
+        metadata["execution_mode"] = "sync"
+    target_agent = str(getattr(args, "target_agent", "") or "").strip()
+    if target_agent:
+        metadata["target_agent_id"] = target_agent
     if getattr(args, "no_decompose", False):
         # Handoff / plan-note guard: the executor will not auto-decompose this
         # task into child tasks (add_child_tasks refuses with no_decompose).
@@ -3236,6 +3243,19 @@ def cmd_sandbox_bom(args: argparse.Namespace) -> None:
         return
 
     _print(derived)
+
+
+def cmd_sandbox_rollout(args: argparse.Namespace) -> None:
+    """File one drained-worker barrier task per agent for a reviewed image."""
+    cp = _plane(args)
+    bom = {}
+    if args.manifest:
+        bom = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    _print(
+        cp.roll_out_sandbox_image(
+            args.image, bom=bom, actor=args.actor, project=args.project
+        )
+    )
 
 
 def cmd_work_package_list(args: argparse.Namespace) -> None:
@@ -7149,6 +7169,22 @@ def build_parser() -> argparse.ArgumentParser:
                         help="BREAK-GLASS human hold: stage the task so the loop-mode fleet won't "
                              "auto-claim it (hidden from `task ready`) until started "
                              "explicitly. Not the normal path; auto-dispatch is.")
+    create.add_argument(
+        "--sync",
+        dest="sync",
+        action="store_true",
+        help="run this task as a BARRIER on one worker: it starts only after "
+             "that worker drains, nothing else runs while it does, and the "
+             "worker accepts no new async work from the moment it is queued. "
+             "Requires --target-agent. For work that mutates the worker "
+             "itself, such as a sandbox image rollout.",
+    )
+    create.add_argument(
+        "--target-agent",
+        dest="target_agent",
+        metavar="AGENT_ID",
+        help="pin this task to one agent (required by --sync)",
+    )
     create.add_argument("--no-decompose", dest="no_decompose", action="store_true",
                         help="handoff/plan-note guard: the executor will not auto-decompose "
                              "this task into child tasks")
@@ -7898,6 +7934,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="also report what the derived BOM requires that this image never mentions",
     )
     _set(cmd_sandbox_bom, sandbox_bom_cmd)
+    sandbox_rollout_cmd = sandbox.add_parser(
+        "rollout",
+        help="roll a reviewed sandbox image onto each worker, after it drains",
+    )
+    sandbox_rollout_cmd.add_argument(
+        "--image",
+        required=True,
+        help="the immutable GHCR digest to install (not a tag)",
+    )
+    sandbox_rollout_cmd.add_argument(
+        "--manifest",
+        help="the reviewed BOM manifest to record on each rollout task",
+    )
+    sandbox_rollout_cmd.add_argument("--project", default=None)
+    sandbox_rollout_cmd.add_argument("--actor", default="human")
+    _set(cmd_sandbox_rollout, sandbox_rollout_cmd)
     project_list = project.add_parser("list", help="list every project")
     _set(cmd_project_list, project_list)
     project_show = project.add_parser(

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -31,6 +31,7 @@ from mac.models import (
     parse_time,
     utcnow,
 )
+from mac import sandbox_bom
 from mac.repository_hygiene import (
     CANCELLATION_DISPOSITIONS,
     REPOSITORY_REF_CLEANUP_SCHEMA,
@@ -3183,6 +3184,58 @@ def cmd_project_activate(args: argparse.Namespace) -> None:
 def cmd_project_show(args: argparse.Namespace) -> None:
     """Show details for a project."""
     _print(_plane(args).get_project(args.project))
+
+
+def _derive_sandbox_bom(args: argparse.Namespace) -> Dict[str, Any]:
+    """Derive the BOM from EVERY repository registration's contract.
+
+    Registrations, not projects, for three reasons that all bit a first
+    implementation of this:
+
+    * A contract belongs to a repository, so a project with several repos has
+      several contracts, and the registration is where they live.
+    * ``project list`` does not show every registration. Two OrcaSlicer repos
+      are registered and neither appears there; deriving per project silently
+      omitted both.
+    * A branch-qualified project name contains a slash
+      (``isaacsim7-poc@feat/ros-sim``), and ``GET /projects/{project}`` 404s on
+      it however the name is escaped. That project's contract requires cmake and
+      ninja, so the per-project derivation dropped a real toolchain on the floor.
+
+    One list call has none of those failure modes.
+    """
+    return sandbox_bom.derive_bom(_plane(args).list_project_repositories())
+
+
+def cmd_sandbox_bom(args: argparse.Namespace) -> None:
+    """Derive the sandbox bill of materials from every project's contract."""
+    derived = _derive_sandbox_bom(args)
+
+    if args.containerfile:
+        text = Path(args.containerfile).read_text(encoding="utf-8")
+        derived = dict(derived, gaps=sandbox_bom.bom_gaps(derived, text))
+
+    if args.compare:
+        committed = json.loads(Path(args.compare).read_text(encoding="utf-8"))
+        drift = sandbox_bom.manifest_drift(committed, derived)
+        _print({"drift": drift, "has_drift": sandbox_bom.manifest_has_drift(drift)})
+        if sandbox_bom.manifest_has_drift(drift):
+            raise SystemExit(1)
+        return
+
+    if args.write:
+        target = Path(args.write)
+        target.write_text(
+            json.dumps(sandbox_bom.manifest(derived), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        # Writing the manifest is NOT deploying it. The image is rebuilt and
+        # republished by the reviewed workflow, and the frozen-input hash
+        # changes when this file does -- which is the point.
+        _print({"written": str(target), "packages": derived.get("packages")})
+        return
+
+    _print(derived)
 
 
 def cmd_work_package_list(args: argparse.Namespace) -> None:
@@ -7822,6 +7875,29 @@ def build_parser() -> argparse.ArgumentParser:
     project_activate.add_argument("project")
     project_activate.add_argument("--actor", default="human")
     _set(cmd_project_activate, project_activate)
+    sandbox = sub.add_parser(
+        "sandbox", help="openshell sandbox image commands"
+    ).add_subparsers(dest="sandbox_command", required=True)
+    sandbox_bom_cmd = sandbox.add_parser(
+        "bom",
+        help="derive the sandbox bill of materials from every project's contract",
+    )
+    sandbox_bom_cmd.add_argument(
+        "--write",
+        metavar="PATH",
+        help="write the reviewed manifest (commit it; the image hash covers it)",
+    )
+    sandbox_bom_cmd.add_argument(
+        "--compare",
+        metavar="PATH",
+        help="compare live contracts against a committed manifest; exit 1 on drift",
+    )
+    sandbox_bom_cmd.add_argument(
+        "--containerfile",
+        metavar="PATH",
+        help="also report what the derived BOM requires that this image never mentions",
+    )
+    _set(cmd_sandbox_bom, sandbox_bom_cmd)
     project_list = project.add_parser("list", help="list every project")
     _set(cmd_project_list, project_list)
     project_show = project.add_parser(

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -235,6 +235,7 @@ COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
             ("machine", "hosts that agents run on"),
             ("hgx", "HGX / GPU capacity management"),
             ("openshell", "sandboxed execution environments for agents"),
+            ("sandbox", "the sandbox image: its bill of materials and its rollout"),
             ("runtime", "runtime images and environment definitions"),
             ("rollout", "staged rollout of a runtime or configuration"),
             ("env", "environment variables projected onto fleet hosts"),

--- a/src/mac/sandbox_bom.py
+++ b/src/mac/sandbox_bom.py
@@ -1,0 +1,324 @@
+"""Derive the sandbox bill of materials from repository contracts.
+
+The OpenShell sandbox image is shared by every agent, and an agent does not
+know which project will land on it. So the image must cover the union of EVERY
+registered project's contract -- not the projects with work in flight, which
+would make the BOM move as the backlog moves and destroy reproducibility.
+
+Today that union is maintained by hand. deploy/openshell/mac-hermes.Containerfile
+carries a package list whose comments are a ledger of incidents transcribed
+after the fact:
+
+    "build-essential: for repos that compile native code (e.g. nanolang's
+     3-stage `make build`)"
+    "libssl-dev: nanolang's src/sign.c #includes <openssl/evp.h> ... without it
+     a coding agent will destructively stub sign.c just to compile"
+    "clang/llvm/lld/qemu: the RISC-V validation floor used by c26"
+
+Each names a project whose contract already said what it needed. The contract
+was authoritative and nobody read it, so the answer to "when do we permute the
+environment" was "when someone notices a repo broke".
+
+This module makes the union mechanical. A contract gains a command, the derived
+BOM changes, and the difference is a fact a test can assert rather than a thing
+somebody has to remember.
+
+Two deliberate limits:
+
+* A required COMMAND is not a package name. The mapping is CURATED, and a
+  command with no mapping is REPORTED, never guessed. Guessing an apt package
+  from a binary name is how you install the wrong thing quietly -- and the
+  sandbox is the security boundary, so the wrong thing is expensive.
+* Deriving the BOM does not install anything. It produces a manifest to compare
+  against the image; publishing a new image stays a reviewed step, because the
+  frozen-input hash is what makes the deployed sandbox auditable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+BOM_SCHEMA = "mac.sandbox_bom.v1"
+
+#: What mac itself needs in every sandbox, independent of any project.
+#:
+#: These are the tools the executor and its policy layer use to do their own
+#: work: fetch and verify the repo, run the contract, enforce egress. A project
+#: contract never has to declare them, and removing one breaks every task
+#: regardless of project.
+MAC_CORE_COMMANDS: Tuple[str, ...] = (
+    "bash",
+    "ca-certificates",
+    "curl",
+    "git",
+    "iproute2",
+    "iptables",
+    "procps",
+    "python3",
+    "tar",
+    "uv",
+    "xz-utils",
+)
+
+#: Curated command -> Debian package. A command is what a contract declares; a
+#: package is what installs it, and the two are not the same word often enough
+#: to infer. Unmapped commands are reported by :func:`derive_bom` so the gap is
+#: visible instead of silently absent from the image.
+COMMAND_PACKAGES: Dict[str, Tuple[str, ...]] = {
+    # C/C++ toolchain. `cc`, `gcc` and `g++` all come from one package, which
+    # is exactly why command != package.
+    "cc": ("build-essential",),
+    "gcc": ("build-essential",),
+    "g++": ("build-essential",),
+    "ld": ("build-essential",),
+    "make": ("make",),
+    # cmake/ninja arrived from isaacsim7-poc's contract, which the first
+    # derivation could not read at all -- see _derive_sandbox_bom in cli.py.
+    "cmake": ("cmake",),
+    "ninja": ("ninja-build",),
+    "clang": ("clang",),
+    "llvm-objcopy": ("llvm",),
+    "ld.lld": ("lld",),
+    "qemu-system-riscv64": ("qemu-system-misc",),
+    # Runtimes. node/npm map to NO apt package on purpose: the image installs
+    # Node v22 LTS from NodeSource and explicitly rejects Debian's v18, because
+    # current pnpm refuses Node < v22.13 and silently breaks every `pnpm install`
+    # repo bootstrap. Claiming apt supplies node made the gap check demand a
+    # `nodejs` package the image had deliberately chosen not to install.
+    "node": (),
+    "npm": (),
+    "java": ("openjdk-17-jre-headless",),
+    # Libraries a build links against rather than a binary it invokes. A
+    # contract may legitimately name these; nanolang's sign.c needs libcrypto.
+    "libssl-dev": ("libssl-dev",),
+    "openssl": ("openssl",),
+    # Base-image commands: declared by contracts, already present, no package
+    # to add. Mapped to nothing so they are neither "unmapped" nor duplicated.
+    "bash": (),
+    "ca-certificates": (),
+    "curl": (),
+    "git": ("git",),
+    "iproute2": ("iproute2",),
+    "iptables": ("iptables",),
+    "procps": ("procps",),
+    "python3": (),
+    "tar": ("tar",),
+    "uv": (),
+    "xz-utils": ("xz-utils",),
+    # Supplied by the image build through a channel that is not apt. Mapping
+    # them to no package is not the same as leaving them unmapped: these ARE
+    # provided, so reporting them as gaps would cry wolf every run.
+    #
+    #   gh, codegraph, mac  installed by the build
+    #   pnpm                npm install -g, pinned to PNPM_VERSION
+    #   lein                installed from the reviewed build assets
+    "gh": (),
+    "codegraph": (),
+    "mac": (),
+    "pnpm": (),
+    "lein": (),
+}
+
+
+def contract_commands(project_record: Any) -> Set[str]:
+    """Required commands declared by one project's repository contracts.
+
+    A project may register several repositories, each with its own contract, so
+    this is a union within the project as well as across them.
+    """
+    commands: Set[str] = set()
+    record = project_record.to_dict() if hasattr(project_record, "to_dict") else project_record
+    if not isinstance(record, Mapping):
+        return commands
+    repositories = record.get("project_repositories") or record.get("repositories") or []
+    candidates: List[Any] = list(repositories)
+    # A contract may also sit directly on the project's own metadata.
+    if isinstance(record.get("metadata"), Mapping):
+        candidates.append(record)
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            continue
+        metadata = candidate.get("metadata")
+        if not isinstance(metadata, Mapping):
+            continue
+        for key in ("repository_contract", "contract"):
+            contract = metadata.get(key)
+            if not isinstance(contract, Mapping):
+                continue
+            toolchain = contract.get("toolchain")
+            if not isinstance(toolchain, Mapping):
+                continue
+            for item in toolchain.get("required_commands") or []:
+                text = str(item).strip()
+                if text:
+                    commands.add(text)
+    return commands
+
+
+def derive_bom(
+    project_records: Iterable[Any],
+    *,
+    core_commands: Sequence[str] = MAC_CORE_COMMANDS,
+    command_packages: Optional[Mapping[str, Sequence[str]]] = None,
+) -> Dict[str, Any]:
+    """The sandbox BOM implied by every registered project, plus mac's own core.
+
+    ``unmapped`` is the important output. A command no mapping covers cannot be
+    installed by this derivation, and saying so is the whole point: the
+    alternative is inferring a package name from a binary name and installing
+    something plausible into the security boundary.
+    """
+    packages_for = dict(command_packages or COMMAND_PACKAGES)
+    per_project: Dict[str, List[str]] = {}
+    commands: Set[str] = set(core_commands)
+    for record in project_records:
+        raw = record.to_dict() if hasattr(record, "to_dict") else record
+        name = ""
+        if isinstance(raw, Mapping):
+            name = str(raw.get("project") or raw.get("name") or "").strip()
+        declared = contract_commands(record)
+        if declared:
+            per_project[name or "(unnamed)"] = sorted(declared)
+        commands |= declared
+
+    packages: Set[str] = set()
+    unmapped: List[str] = []
+    for command in sorted(commands):
+        if command not in packages_for:
+            unmapped.append(command)
+            continue
+        packages.update(packages_for[command])
+
+    return {
+        "schema": BOM_SCHEMA,
+        "commands": sorted(commands),
+        "core_commands": sorted(core_commands),
+        "packages": sorted(packages),
+        "unmapped_commands": unmapped,
+        "contributing_projects": per_project,
+    }
+
+
+#: apt flags to skip when reading an install line, and the ones that consume the
+#: token after them (``-t bookworm-backports`` names a suite, not a package).
+_APT_VALUE_FLAGS = ("-t", "--target-release", "-o")
+
+
+def installed_packages(image_text: str) -> Set[str]:
+    """The packages the Containerfile actually installs.
+
+    Deliberately NOT a substring search over the file. The first version of this
+    was, and it silently passed a mutation that deleted cmake and ninja-build
+    from the apt line -- because the COMMENT above it still said "cmake/ninja".
+    A check that a package is mentioned somewhere is satisfied by the prose
+    explaining why it used to be there, which is the one thing it must not
+    accept.
+    """
+    packages: Set[str] = set()
+    for raw_line in image_text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("#"):
+            continue
+        marker = "apt-get install"
+        index = line.find(marker)
+        if index < 0:
+            continue
+        tokens = line[index + len(marker) :].rstrip("\\").split()
+        skip_next = False
+        for token in tokens:
+            if skip_next:
+                skip_next = False
+                continue
+            if token in _APT_VALUE_FLAGS:
+                skip_next = True
+                continue
+            if token.startswith("-"):
+                continue
+            if token in ("&&", "|", "||", ";"):
+                break
+            packages.add(token)
+    return packages
+
+
+def bom_gaps(bom: Mapping[str, Any], image_text: str) -> Dict[str, List[str]]:
+    """What the derived BOM requires that the image does not install.
+
+    ``missing_packages`` is the precise signal: it compares against the packages
+    the apt lines actually name. ``missing_commands`` stays a containment check
+    over non-comment text, because a command can arrive by npm, by COPY from
+    build assets, or from the base image, and there is no single line to parse.
+    It is a hint; the package list is the assertion.
+
+    Neither answers "does the BUILT image contain this" -- only a build can. The
+    drift worth catching in a test is a contract declaring something the
+    Containerfile never installs, which is exactly what the hand-maintained
+    ledger kept missing.
+    """
+    installed = installed_packages(image_text)
+    body = "\n".join(
+        line for line in image_text.splitlines() if not line.strip().startswith("#")
+    )
+    missing_packages = [
+        package for package in bom.get("packages") or [] if package not in installed
+    ]
+    missing_commands = [
+        command for command in bom.get("commands") or [] if command not in body
+    ]
+    return {
+        "missing_packages": missing_packages,
+        "missing_commands": missing_commands,
+        "unmapped_commands": list(bom.get("unmapped_commands") or []),
+    }
+
+
+#: The reviewed manifest, committed to the repo.
+#:
+#: The derivation reads the live hub, which is not reproducible from a checkout
+#: and must not be: an image build that reaches out to a mutable ledger for its
+#: own inputs cannot be audited afterwards. So the flow is deliberately in two
+#: steps -- derive from contracts, review the diff, commit the manifest -- and
+#: the manifest is what the frozen-input hash covers.
+MANIFEST_PATH = "deploy/openshell/sandbox-bom.json"
+
+#: Fields carried into the committed manifest, in a stable order.
+_MANIFEST_FIELDS = (
+    "schema",
+    "commands",
+    "core_commands",
+    "packages",
+    "unmapped_commands",
+    "contributing_projects",
+)
+
+
+def manifest(bom: Mapping[str, Any]) -> Dict[str, Any]:
+    """The committable form of a derived BOM.
+
+    ``contributing_projects`` is kept even though it churns more than the rest.
+    It is the provenance -- why qemu-system-misc is in the image at all -- and
+    reconstructing that by hand months later is precisely the work the
+    Containerfile's incident comments were doing badly.
+    """
+    return {field: bom.get(field) for field in _MANIFEST_FIELDS if field in bom}
+
+
+def manifest_drift(
+    committed: Mapping[str, Any], derived: Mapping[str, Any]
+) -> Dict[str, List[str]]:
+    """How the live contracts differ from the reviewed manifest.
+
+    Drift in EITHER direction is reported. A removed command matters as much as
+    an added one: it is a package in the security boundary that no contract asks
+    for any more, and nothing else in the system will ever notice it went stale.
+    """
+    drift: Dict[str, List[str]] = {}
+    for field in ("commands", "packages"):
+        before = set(committed.get(field) or [])
+        after = set(derived.get(field) or [])
+        drift["added_" + field] = sorted(after - before)
+        drift["removed_" + field] = sorted(before - after)
+    return drift
+
+
+def manifest_has_drift(drift: Mapping[str, Sequence[str]]) -> bool:
+    return any(drift.values())

--- a/src/mac/sandbox_bom.py
+++ b/src/mac/sandbox_bom.py
@@ -322,3 +322,17 @@ def manifest_drift(
 
 def manifest_has_drift(drift: Mapping[str, Sequence[str]]) -> bool:
     return any(drift.values())
+
+
+def committed_manifest_path() -> Optional["Path"]:
+    """The reviewed manifest inside the installed tree, if it is there.
+
+    Returns None rather than raising when it is absent. The hub can run from a
+    packaged install that ships no deploy/ directory, and a drift check is a
+    diagnostic -- it must never be the reason a project cannot be registered.
+    """
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    candidate = root / MANIFEST_PATH
+    return candidate if candidate.is_file() else None

--- a/src/mac/sandbox_rollout.py
+++ b/src/mac/sandbox_rollout.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Mapping, Optional, Sequence
 
+from mac.models import ValidationError
+
 ROLLOUT_SCHEMA = "mac.sandbox_rollout.v1"
 
 #: Marker on a filed rollout task, so "is this worker already scheduled for
@@ -45,8 +47,13 @@ IMAGE_DIGEST_PATTERN = re.compile(
 )
 
 
-class RolloutError(ValueError):
-    """The rollout was refused before anything was filed."""
+class RolloutError(ValidationError):
+    """The rollout was refused before anything was filed.
+
+    A domain error rather than a bare ValueError: callers across the CLI and
+    the API already handle MACError, and a rollout refused for a bad image ref
+    is a validation failure, not an internal one.
+    """
 
 
 def validate_image_ref(image_ref: str) -> str:

--- a/src/mac/sandbox_rollout.py
+++ b/src/mac/sandbox_rollout.py
@@ -1,0 +1,172 @@
+"""Roll a new sandbox image onto each worker, one drained worker at a time.
+
+Today the image goes out through deploy-mac-fleet.sh, which pushes to nodes
+from outside the control plane. That has no idea what any worker is doing. A
+worker mid-task gets its sandbox replaced underneath the task -- the tools the
+running work resolved at start are gone, and the failure surfaces as the task
+misbehaving rather than as a deployment that ran at the wrong moment.
+
+A rollout is work that mutates the worker, so it is exactly what the sync
+execution mode exists for. This files ONE sync task per agent:
+
+* it does not start until that agent has drained,
+* nothing else runs on that agent while it does,
+* the agent stops accepting new async work the moment it is queued,
+* and each agent is independent, so the fleet rolls rather than stops.
+
+Two limits, both deliberate:
+
+* This does not BUILD or publish an image. It takes a digest that has already
+  been through the reviewed publication path. Deriving a BOM is mechanical;
+  putting a new image into the security boundary is not, and an automated path
+  from "a contract changed" to "every worker is running a new image" is the
+  supply-chain hole the frozen-input hash exists to close.
+* It never mutates a running worker directly. It files work the worker itself
+  executes, so a rollout is visible, auditable, and refusable like anything
+  else in the ledger.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+ROLLOUT_SCHEMA = "mac.sandbox_rollout.v1"
+
+#: Marker on a filed rollout task, so "is this worker already scheduled for
+#: this digest" is answered from structure rather than by matching a title.
+ROLLOUT_METADATA_KEY = "sandbox_rollout"
+
+#: The digest form the deploy path already requires. Accepting a tag here would
+#: make the rollout non-reproducible: a tag can be repointed after review, so
+#: what shipped and what was reviewed could differ with nothing recording it.
+IMAGE_DIGEST_PATTERN = re.compile(
+    r"^ghcr\.io/jordanhubbard/mac-openshell-runtime@sha256:[0-9a-f]{64}$"
+)
+
+
+class RolloutError(ValueError):
+    """The rollout was refused before anything was filed."""
+
+
+def validate_image_ref(image_ref: str) -> str:
+    text = str(image_ref or "").strip()
+    if not IMAGE_DIGEST_PATTERN.match(text):
+        raise RolloutError(
+            "a sandbox rollout requires the immutable GHCR digest "
+            "(ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:<64 hex>), not "
+            "%r. A tag can be repointed after review, so what ships and what "
+            "was reviewed could differ with nothing recording it." % text
+        )
+    return text
+
+
+def rollout_title(agent_name: str, image_ref: str) -> str:
+    return "Sandbox rollout: %s -> %s" % (agent_name, image_ref.split("@", 1)[-1][:19])
+
+
+def rollout_description(agent_name: str, image_ref: str, bom: Mapping[str, Any]) -> str:
+    packages = ", ".join(bom.get("packages") or []) or "(none recorded)"
+    return "\n".join(
+        [
+            "Install the reviewed OpenShell sandbox image on %s." % agent_name,
+            "",
+            "  image: %s" % image_ref,
+            "",
+            "This is a SYNCHRONOUS task. It will not start until this worker "
+            "has drained, and no other work runs on it until this finishes. "
+            "That is not a precaution: replacing the sandbox under a running "
+            "task removes the tools that task resolved when it started, and it "
+            "fails in a way that looks like the task's fault.",
+            "",
+            "The image covers this bill of materials, derived from every "
+            "registered repository contract:",
+            "",
+            "  %s" % packages,
+            "",
+            "If this worker cannot pull or verify the digest, FAIL the task "
+            "rather than falling back to the previous image. A fleet that is "
+            "half-rolled and says nothing is worse than one that is not rolled "
+            "at all, because nothing downstream can tell which sandbox a task "
+            "actually ran in.",
+        ]
+    )
+
+
+def rollout_metadata(agent_id: str, image_ref: str, bom: Mapping[str, Any]) -> Dict[str, Any]:
+    return {
+        "execution_mode": "sync",
+        # The barrier is per agent, and a rollout with no agent is meaningless,
+        # so this is set here rather than left to the caller.
+        "target_agent_id": agent_id,
+        ROLLOUT_METADATA_KEY: {
+            "schema": ROLLOUT_SCHEMA,
+            "image": image_ref,
+            "agent_id": agent_id,
+            "bom_schema": bom.get("schema"),
+            "packages": list(bom.get("packages") or []),
+        },
+    }
+
+
+def scheduled_rollouts(tasks: Sequence[Any]) -> set:
+    """(agent, image) pairs already filed and not finished.
+
+    Read from the marker, not the title: a rollout re-filed on every hub tick
+    would queue a barrier per tick, and since barriers quiesce their agent, the
+    worker would stop taking work permanently.
+    """
+    seen = set()
+    for task in tasks:
+        record = task.to_dict() if hasattr(task, "to_dict") else task
+        if not isinstance(record, Mapping):
+            continue
+        metadata = record.get("metadata")
+        if not isinstance(metadata, Mapping):
+            continue
+        marker = metadata.get(ROLLOUT_METADATA_KEY)
+        if not isinstance(marker, Mapping):
+            continue
+        agent_id = str(marker.get("agent_id") or "").strip()
+        image = str(marker.get("image") or "").strip()
+        if agent_id and image:
+            seen.add((agent_id, image))
+    return seen
+
+
+def plan_rollout(
+    agents: Sequence[Any],
+    image_ref: str,
+    *,
+    bom: Optional[Mapping[str, Any]] = None,
+    already_scheduled: Optional[set] = None,
+) -> List[Dict[str, Any]]:
+    """One barrier task per agent that is not already scheduled for this image.
+
+    Every agent, including the ones that are busy: busy is the normal state,
+    and skipping them would roll the idle half of the fleet and quietly leave
+    the working half behind -- the workers doing the most work would be the
+    ones running the oldest sandbox.
+    """
+    image_ref = validate_image_ref(image_ref)
+    manifest = dict(bom or {})
+    scheduled = set(already_scheduled or ())
+    plan: List[Dict[str, Any]] = []
+    for agent in agents:
+        record = agent.to_dict() if hasattr(agent, "to_dict") else agent
+        if not isinstance(record, Mapping):
+            continue
+        agent_id = str(record.get("id") or "").strip()
+        if not agent_id or (agent_id, image_ref) in scheduled:
+            continue
+        name = str(record.get("name") or agent_id)
+        plan.append(
+            {
+                "agent_id": agent_id,
+                "agent_name": name,
+                "title": rollout_title(name, image_ref),
+                "description": rollout_description(name, image_ref, manifest),
+                "metadata": rollout_metadata(agent_id, image_ref, manifest),
+            }
+        )
+    return plan

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6852,7 +6852,16 @@ class ControlPlane:
                     ]
                 ),
                 project=project,
-                metadata={"sandbox_bom_drift": marker},
+                metadata={
+                    "sandbox_bom_drift": marker,
+                    # Staged, NOT dispatchable. An open task is fleet-claimed
+                    # within minutes, and what an agent would do with this one
+                    # is edit the Containerfile and publish an image -- the
+                    # unreviewed supply-chain path this whole design exists to
+                    # keep closed. It is a decision for a human or an LLM to
+                    # pick up deliberately, so it waits to be started.
+                    "no_dispatch": True,
+                },
                 actor=actor,
             )
             return {"checked": True, "drift": drift, "filed": filed.id}

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6810,7 +6810,24 @@ class ControlPlane:
                 [repository.to_dict() for repository in self.list_project_repositories()]
             )
             drift = manifest_drift(committed, derived)
-            if not manifest_has_drift(drift):
+            # Filed only when something is NEWLY REQUIRED. Both directions are
+            # still reported, but they are not the same kind of problem:
+            #
+            #   added    a contract needs a tool the image lacks. Work breaks,
+            #            or an agent quietly edits source until it compiles.
+            #   removed  a package nothing asks for any more. Hygiene.
+            #
+            # Filing on removal was actively harmful. Deleting a project can
+            # only ever remove requirements, and there is no project left to
+            # own the ticket -- so every deletion left an unowned task in the
+            # "unassigned" bucket that nothing would claim or close. It also
+            # fired constantly in any control plane whose registrations differ
+            # from the reviewed manifest, which is every dev and test hub.
+            #
+            # Removal drift is surfaced by `mac sandbox bom --compare`, which
+            # exits non-zero on drift in either direction, so CI still catches
+            # a stale manifest.
+            if not (drift.get("added_commands") or drift.get("added_packages")):
                 return {"checked": True, "drift": drift, "filed": None}
             marker = {
                 "schema": BOM_SCHEMA,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -252,6 +252,20 @@ from mac.task_batch import (
     TaskGroupService,
     UnsatisfiableTaskParker,
 )
+from mac.allocator import EXECUTION_MODE_SYNC, normalize_execution_mode
+from mac.sandbox_bom import (
+    BOM_SCHEMA,
+    committed_manifest_path,
+    derive_bom,
+    manifest_drift,
+    manifest_has_drift,
+)
+from mac.sandbox_rollout import (
+    ROLLOUT_SCHEMA,
+    plan_rollout,
+    scheduled_rollouts,
+    validate_image_ref,
+)
 from mac.task_lifecycle import DispatchService, TaskLedgerService
 from mac.task_transition_service import TaskTransitionService
 from mac.workflow_runtime import WorkflowRuntime
@@ -5340,6 +5354,23 @@ class ControlPlane:
         title = title.strip()
         if not title:
             raise ValidationError("task title is required")
+        supplied_metadata = metadata if isinstance(metadata, Mapping) else {}
+        if (
+            normalize_execution_mode(supplied_metadata.get("execution_mode"))
+            == EXECUTION_MODE_SYNC
+            and not str(supplied_metadata.get("target_agent_id") or "").strip()
+            and not str(supplied_metadata.get("target_agent_name") or "").strip()
+        ):
+            # Refused at the door as well as in the allocator. A sync task is a
+            # barrier on ONE agent, and untargeted there is no answer to "all
+            # tasks on what?" that is not either a guess or a fleet-wide
+            # stop-the-world.
+            raise ValidationError(
+                "a synchronous task must name its agent: set "
+                "metadata.target_agent_id (or target_agent_name). Without one, "
+                "'wait for all tasks to complete' is ambiguous between a single "
+                "worker and the whole fleet."
+            )
         dependency_refs = coerce_list(dependencies)
         supplied_task_id = str(_task_id or "").strip()
         if supplied_task_id and any(
@@ -6754,6 +6785,138 @@ class ControlPlane:
     def delete_task_group(self, name: str) -> JsonDict:
         self.task_groups.delete(name)
         return {"name": name, "deleted": True}
+
+    def check_sandbox_bom_drift(self, *, actor: str = "hub", project: Optional[str] = None) -> Dict[str, Any]:
+        """Has a contract change made the reviewed sandbox manifest stale?
+
+        Called when a repository registration appears or a project is deleted,
+        because those are the only two events that can change the union of
+        contracts. Without this the manifest goes stale silently and the fleet
+        keeps running an image that no longer matches what projects declare --
+        which is the exact failure the derivation was built to end, just moved
+        one step later.
+
+        It FILES a task; it does not publish an image. An automated path from
+        "someone registered a repo" to "every worker is running a new image"
+        would be a supply-chain hole, and the frozen-input hash exists to make
+        that step reviewed.
+        """
+        try:
+            manifest_path = committed_manifest_path()
+            if manifest_path is None:
+                return {"checked": False, "reason": "no committed manifest in this tree"}
+            committed = json.loads(manifest_path.read_text(encoding="utf-8"))
+            derived = derive_bom(
+                [repository.to_dict() for repository in self.list_project_repositories()]
+            )
+            drift = manifest_drift(committed, derived)
+            if not manifest_has_drift(drift):
+                return {"checked": True, "drift": drift, "filed": None}
+            marker = {
+                "schema": BOM_SCHEMA,
+                "added_commands": drift.get("added_commands") or [],
+                "removed_commands": drift.get("removed_commands") or [],
+            }
+            signature = json_dumps(marker)
+            for task in self.list_tasks():
+                if task.state in TERMINAL_TASK_STATES:
+                    continue
+                existing = ensure_json_object(task.metadata).get("sandbox_bom_drift")
+                if isinstance(existing, Mapping) and json_dumps(dict(existing)) == signature:
+                    # Same drift already reported. Re-filing per registration
+                    # would bury the one report that matters.
+                    return {"checked": True, "drift": drift, "filed": None}
+            filed = self.create_task(
+                "Sandbox BOM drift: the reviewed image no longer matches the contracts",
+                description="\n".join(
+                    [
+                        "A repository contract changed, so the union of required "
+                        "commands no longer matches deploy/openshell/sandbox-bom.json.",
+                        "",
+                        "  newly required : %s" % (", ".join(drift.get("added_commands") or []) or "(none)"),
+                        "  no longer required: %s" % (", ".join(drift.get("removed_commands") or []) or "(none)"),
+                        "",
+                        "A command that is newly required and absent from the image "
+                        "means a coding agent on that repo will provision it per task, "
+                        "or -- worse -- edit the source until it builds without it.",
+                        "",
+                        "To resolve:",
+                        "  1. mac sandbox bom --containerfile deploy/openshell/mac-hermes.Containerfile",
+                        "  2. add anything it reports to the Containerfile, and",
+                        "     mac sandbox bom --write deploy/openshell/sandbox-bom.json",
+                        "  3. publish the image through the reviewed workflow, then",
+                        "     mac sandbox rollout --image <digest> --manifest deploy/openshell/sandbox-bom.json",
+                        "",
+                        "Step 3 is a barrier task per worker: each one drains before it "
+                        "updates, so the fleet rolls rather than stopping.",
+                    ]
+                ),
+                project=project,
+                metadata={"sandbox_bom_drift": marker},
+                actor=actor,
+            )
+            return {"checked": True, "drift": drift, "filed": filed.id}
+        except Exception as exc:  # noqa: BLE001
+            # A diagnostic must never be why a registration fails -- but a
+            # blanket swallow hides its own bugs, and this one did: an
+            # unsupported json_dumps kwarg made every check report "no drift"
+            # while looking healthy. Name the error so the next one is visible.
+            return {
+                "checked": False,
+                "reason": "drift check failed: %s: %s" % (type(exc).__name__, exc),
+            }
+
+    def roll_out_sandbox_image(
+        self,
+        image_ref: str,
+        *,
+        bom: Optional[Mapping[str, Any]] = None,
+        actor: str = "human",
+        project: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """File one barrier task per agent to install a reviewed image.
+
+        Rolling, not fleet-wide: each agent drains and updates independently,
+        so the fleet keeps working through the rollout instead of stopping at
+        once. Deduplicated per (agent, image) because a rollout re-filed on
+        every tick would queue a barrier per tick, and barriers quiesce their
+        agent -- the worker would stop taking work permanently.
+        """
+        image_ref = validate_image_ref(image_ref)
+        agents = [agent.to_dict() for agent in self.list_agents()]
+        plan = plan_rollout(
+            agents,
+            image_ref,
+            bom=bom or {},
+            already_scheduled=scheduled_rollouts(
+                [task for task in self.list_tasks() if task.state not in TERMINAL_TASK_STATES]
+            ),
+        )
+        filed: List[str] = []
+        skipped: List[str] = []
+        for item in plan:
+            try:
+                task = self.create_task(
+                    item["title"],
+                    description=item["description"],
+                    project=project,
+                    metadata=item["metadata"],
+                    actor=actor,
+                )
+            except (ValidationError, TransitionError, NotFoundError):
+                # One unfilable worker must not abort the rollout for the rest:
+                # a partial roll is recoverable by re-running, an aborted one
+                # leaves whichever workers were reached in an unknown mix.
+                skipped.append(item["agent_id"])
+            else:
+                filed.append(task.id)
+        return {
+            "schema": ROLLOUT_SCHEMA,
+            "image": image_ref,
+            "filed": filed,
+            "skipped": skipped,
+            "agents_considered": len(agents),
+        }
 
     def record_sandbox_excursion(
         self,
@@ -8386,6 +8549,10 @@ class ControlPlane:
             channels=["dashboard"],
             metadata={"actor": actor, "force": force},
         )
+        # The other direction matters too: a deleted project may have been the
+        # only thing requiring a package, and a tool nothing asks for is still
+        # sitting in the security boundary with nothing that would ever notice.
+        self.check_sandbox_bom_drift(actor=actor)
 
     def task_detail(
         self,
@@ -23369,7 +23536,7 @@ class ControlPlane:
         metadata: Optional[Dict[str, Any]] = None,
         actor: str = "project-repo",
     ) -> ProjectRepository:
-        return self.project_repositories.register(
+        registered = self.project_repositories.register(
             name,
             path,
             source=source,
@@ -23380,6 +23547,13 @@ class ControlPlane:
             metadata=metadata,
             actor=actor,
         )
+        # A new registration can bring a contract requiring tools the image
+        # does not ship. Checked here because this is one of only two events
+        # that change the union of contracts, and because a worker does not
+        # know which project will land on it -- so a gap on one repo is a gap
+        # for the whole fleet.
+        self.check_sandbox_bom_drift(actor=actor, project=project)
+        return registered
 
     def get_project_repository(self, repo_id_or_name: str) -> ProjectRepository:
         return self.project_repositories.get(repo_id_or_name)

--- a/src/mac/task_lifecycle.py
+++ b/src/mac/task_lifecycle.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from mac.allocator import (
     AGENT_NO_EXECUTION_BOUNDARY,
+    EXECUTION_MODE_SYNC,
     AllocationAgent,
     AllocationRoundResult,
     AllocationTask,
@@ -23,10 +24,12 @@ from mac.allocator import (
     classify_requirement_eligibility,
     evaluate_pair,
     evaluate_task,
+    normalize_execution_mode,
 )
 from mac.executor_scope import compute_scope_estimate_from_lessons
 from mac.models import (
     AuthorizationError,
+    TERMINAL_TASK_STATES,
     JsonDict,
     NotFoundError,
     Task,
@@ -413,8 +416,37 @@ class DispatchService:
             required_role_known=required_role_known,
             required_role_capabilities=frozenset(required_role_capabilities),
             package_ready=package_ready,
+            execution_mode=normalize_execution_mode(metadata.get("execution_mode")),
             metadata=metadata,
         )
+
+    def _sync_barrier_state(self, agent_id: str) -> Tuple[Optional[str], bool]:
+        """The oldest unfinished sync task targeted at this agent, and whether
+        it is running.
+
+        Derived rather than stored. A stored "agent is quiescing" flag has to be
+        cleared by whatever finishes the barrier, and if that path is ever
+        missed the worker stays quiesced forever with nothing indicating why.
+        Recomputing from the tasks themselves cannot get stuck: no unfinished
+        sync task, no barrier.
+        """
+        head_id: Optional[str] = None
+        head_created_at: Optional[str] = None
+        running = False
+        for task in self.control_plane.list_tasks():
+            if task.state in TERMINAL_TASK_STATES:
+                continue
+            metadata = ensure_json_object(task.metadata)
+            if normalize_execution_mode(metadata.get("execution_mode")) != EXECUTION_MODE_SYNC:
+                continue
+            if str(metadata.get("target_agent_id") or "") != agent_id:
+                continue
+            created_at = str(task.created_at or "")
+            if head_created_at is None or created_at < head_created_at:
+                head_id = task.id
+                head_created_at = created_at
+                running = task.lease_id is not None
+        return head_id, running
 
     def _v2_snapshot_agent(self, agent: Any) -> AllocationAgent:
         try:
@@ -481,8 +513,11 @@ class DispatchService:
                     hardware_ok
                     and self.control_plane.roles.soul_accepts_role(agent, role)
                 )
+        sync_head_id, sync_running = self._sync_barrier_state(agent.id)
         return replace(
             snapshot,
+            sync_queue_head_task_id=sync_head_id,
+            sync_task_running=sync_running,
             hardware=ensure_json_object(machine.hardware),
             bound_role_slug=bound_role_slug,
             bound_role_eligible=bound_role_eligible,

--- a/tests/cli/test_cli_sandbox.py
+++ b/tests/cli/test_cli_sandbox.py
@@ -1,0 +1,107 @@
+"""Behavioral tests for `mac sandbox bom` and `mac sandbox rollout`.
+
+Both commands are the operator-facing end of the contract-derived image: one
+answers "what does the fleet's sandbox need", the other puts a reviewed image
+onto workers without interrupting their work. Neither is useful if it only
+works when called as a Python function, so these go through the CLI.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import control_plane_on, dsn_for
+
+DIGEST = "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, (json.loads(raw) if raw else None)
+
+
+def test_bom_derives_the_commands_mac_itself_needs(tmp_path):
+    """With no project registered the answer is not empty: the executor's own
+    tools are in every sandbox regardless of what any contract says."""
+    rc, out = _run(tmp_path, "sandbox", "bom")
+
+    assert rc in (None, 0)
+    assert {"git", "python3", "bash"} <= set(out["commands"])
+
+
+def test_bom_reports_gaps_against_a_containerfile(tmp_path):
+    image = tmp_path / "Containerfile"
+    image.write_text("FROM debian\nRUN apt-get install -y git\n", encoding="utf-8")
+
+    _rc, out = _run(tmp_path, "sandbox", "bom", "--containerfile", str(image))
+
+    assert "gaps" in out
+    assert "tar" in out["gaps"]["missing_packages"]
+
+
+def test_bom_writes_a_manifest_that_can_be_committed(tmp_path):
+    target = tmp_path / "sandbox-bom.json"
+
+    _rc, out = _run(tmp_path, "sandbox", "bom", "--write", str(target))
+
+    assert out["written"] == str(target)
+    assert json.loads(target.read_text(encoding="utf-8"))["schema"]
+
+
+def test_bom_compare_exits_nonzero_on_drift(tmp_path):
+    """So CI can fail when contracts move past the reviewed manifest, rather
+    than the manifest going stale in silence."""
+    stale = tmp_path / "stale.json"
+    stale.write_text(json.dumps({"commands": ["nothing-like-reality"]}), encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, "sandbox", "bom", "--compare", str(stale))
+
+    assert excinfo.value.code == 1
+
+
+def test_bom_compare_is_quiet_when_the_manifest_matches(tmp_path):
+    current = tmp_path / "current.json"
+    _run(tmp_path, "sandbox", "bom", "--write", str(current))
+
+    rc, out = _run(tmp_path, "sandbox", "bom", "--compare", str(current))
+
+    assert rc in (None, 0)
+    assert out["has_drift"] is False
+
+
+def test_rollout_files_a_barrier_task_for_each_worker(tmp_path):
+    cp = control_plane_on(dsn_for(tmp_path))
+    machine = cp.register_machine("cli-roll-host")
+    cp.register_agent(machine.id, "worker1")
+
+    rc, out = _run(tmp_path, "sandbox", "rollout", "--image", DIGEST)
+
+    assert rc in (None, 0)
+    assert len(out["filed"]) == 1
+
+
+def test_rollout_refuses_a_tag(tmp_path):
+    """A tag can be repointed after review, so what ships and what was
+    reviewed could differ with nothing recording it."""
+    rc, out = _run(
+        tmp_path,
+        "sandbox",
+        "rollout",
+        "--image",
+        "ghcr.io/jordanhubbard/mac-openshell-runtime:latest",
+    )
+
+    assert rc not in (None, 0)

--- a/tests/test_sandbox_bom.py
+++ b/tests/test_sandbox_bom.py
@@ -1,0 +1,222 @@
+"""The sandbox image must be derived from repository contracts, not memory.
+
+deploy/openshell/mac-hermes.Containerfile is a hand-maintained package list
+whose comments are a ledger of incidents transcribed after the fact::
+
+    "libssl-dev: nanolang's src/sign.c #includes <openssl/evp.h> ... without it
+     a coding agent will destructively stub sign.c just to compile"
+
+Every one of those names a project whose contract already declared the tool.
+The contract was authoritative and nobody read it, so the answer to "when do we
+permute the environment" was "when someone notices a repo broke".
+
+These tests cover the derivation that replaces that, and -- more usefully -- the
+ways it could be worse than the manual list it replaces: by under-deriving
+silently, by guessing package names, or by drifting from the image it claims to
+describe.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mac.sandbox_bom import (
+    MANIFEST_PATH,
+    bom_gaps,
+    contract_commands,
+    derive_bom,
+    installed_packages,
+    manifest,
+    manifest_drift,
+    manifest_has_drift,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTAINERFILE = REPO_ROOT / "deploy/openshell/mac-hermes.Containerfile"
+MANIFEST = REPO_ROOT / MANIFEST_PATH
+
+
+def _registration(project, commands, *, key="repository_contract"):
+    """A repository registration as the ledger returns it."""
+    return {
+        "project": project,
+        "metadata": {key: {"toolchain": {"required_commands": list(commands)}}},
+    }
+
+
+# --------------------------------------------------------------------------
+# Reading contracts
+# --------------------------------------------------------------------------
+
+
+def test_a_contract_supplies_its_required_commands():
+    assert contract_commands(_registration("c26", ["qemu-system-riscv64"])) == {
+        "qemu-system-riscv64"
+    }
+
+
+@pytest.mark.parametrize("record", [None, {}, "junk", {"metadata": "not-a-mapping"}])
+def test_a_record_with_no_contract_contributes_nothing(record):
+    assert contract_commands(record) == set()
+
+
+def test_every_project_contributes_not_only_the_busy_ones():
+    """An agent does not know which project will land on it.
+
+    A BOM that tracked projects with work in flight would change as the backlog
+    moved, which destroys the reproducibility the frozen hash exists to give.
+    """
+    bom = derive_bom(
+        [_registration("idle-project", ["cmake"]), _registration("busy", ["make"])]
+    )
+
+    assert "cmake" in bom["commands"]
+
+
+def test_several_repositories_in_one_project_are_all_read():
+    bom = derive_bom(
+        [_registration("ova", ["make"]), _registration("ova", ["node"])]
+    )
+
+    assert {"make", "node"} <= set(bom["commands"])
+
+
+def test_mac_core_commands_are_present_without_any_contract():
+    """git and python3 are how the executor does its own work. No contract has
+    to ask for them, and removing one breaks every project at once."""
+    bom = derive_bom([])
+
+    assert {"git", "python3", "bash", "curl"} <= set(bom["commands"])
+
+
+def test_the_bom_records_which_project_asked_for_what():
+    """Provenance is the thing the Containerfile comments were doing by hand.
+
+    Without it, nobody can answer "why is qemu in the sandbox" a year later,
+    which is how a package outlives the contract that justified it.
+    """
+    bom = derive_bom([_registration("c26", ["qemu-system-riscv64"])])
+
+    assert bom["contributing_projects"]["c26"] == ["qemu-system-riscv64"]
+
+
+# --------------------------------------------------------------------------
+# Commands are not package names
+# --------------------------------------------------------------------------
+
+
+def test_a_command_maps_to_the_package_that_installs_it():
+    """`cc` is not a package; build-essential is. This is exactly why the
+    mapping cannot be inferred from the binary name."""
+    bom = derive_bom([_registration("nanolang", ["cc"])])
+
+    assert "build-essential" in bom["packages"]
+
+
+def test_an_unmapped_command_is_reported_and_never_guessed():
+    """Guessing an apt package from a binary name installs something plausible
+    into the security boundary. Reporting is the whole design."""
+    bom = derive_bom([_registration("new", ["some-unheard-of-tool"])])
+
+    assert bom["unmapped_commands"] == ["some-unheard-of-tool"]
+    assert "some-unheard-of-tool" not in bom["packages"]
+
+
+def test_a_tool_installed_outside_apt_is_covered_not_unmapped():
+    """pnpm comes from `npm install -g` and lein from the reviewed build assets.
+
+    Reporting them as gaps because no apt package supplies them would cry wolf
+    on every run, and a gap report nobody trusts is a gap report nobody reads.
+    """
+    bom = derive_bom([_registration("Aviation", ["pnpm", "lein"])])
+
+    assert bom["unmapped_commands"] == []
+
+
+# --------------------------------------------------------------------------
+# Drift against the image
+# --------------------------------------------------------------------------
+
+
+def test_the_committed_manifest_is_covered_by_the_image():
+    """The check that makes the whole thing worth having.
+
+    If this fails, some project's contract requires a tool the sandbox does not
+    ship, and the failure mode is a coding agent quietly mutilating source to
+    get a build to pass -- which is what the libssl-dev comment records.
+    """
+    committed = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    gaps = bom_gaps(committed, CONTAINERFILE.read_text(encoding="utf-8"))
+
+    assert gaps["missing_packages"] == []
+    assert gaps["unmapped_commands"] == []
+
+
+def test_the_manifest_is_what_the_published_image_hash_covers():
+    """Otherwise the BOM is a document beside the image rather than part of its
+    identity, and the two can disagree without anything noticing."""
+    identity = (REPO_ROOT / "scripts/image-publication-identity.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert MANIFEST_PATH in identity
+
+
+def test_a_missing_package_is_reported():
+    gaps = bom_gaps({"packages": ["libfoo-dev"], "commands": []}, "FROM debian")
+
+    assert gaps["missing_packages"] == ["libfoo-dev"]
+
+
+def test_drift_reports_a_newly_required_tool():
+    drift = manifest_drift({"commands": ["make"]}, {"commands": ["make", "cmake"]})
+
+    assert drift["added_commands"] == ["cmake"]
+    assert manifest_has_drift(drift)
+
+
+def test_drift_reports_a_tool_no_contract_asks_for_any_more():
+    """A package nothing requires is still in the security boundary, and
+    nothing else in the system will ever notice it went stale."""
+    drift = manifest_drift({"commands": ["make", "lein"]}, {"commands": ["make"]})
+
+    assert drift["removed_commands"] == ["lein"]
+    assert manifest_has_drift(drift)
+
+
+def test_no_drift_when_the_manifest_matches_the_contracts():
+    drift = manifest_drift({"commands": ["make"]}, {"commands": ["make"]})
+
+    assert not manifest_has_drift(drift)
+
+
+def test_the_manifest_form_is_stable_and_committable():
+    written = manifest(derive_bom([_registration("c26", ["make"])]))
+
+    assert json.loads(json.dumps(written, sort_keys=True)) == written
+    assert "schema" in written
+
+
+def test_a_package_named_only_in_a_comment_is_not_installed():
+    """The mutation that caught this: deleting cmake from the apt line left the
+    comment above it saying "cmake/ninja", and a substring check over the file
+    passed. A gap test satisfied by the prose explaining a package is worthless.
+    """
+    image = "# cmake/ninja-build: needed by isaacsim7-poc\nRUN apt-get install -y make\n"
+
+    gaps = bom_gaps({"packages": ["cmake", "make"], "commands": []}, image)
+
+    assert gaps["missing_packages"] == ["cmake"]
+
+
+def test_an_apt_suite_is_not_read_as_a_package():
+    """`-t bookworm-backports` names a suite. Treating it as installed would
+    make a BOM entry called "bookworm-backports" look satisfied."""
+    installed = installed_packages(
+        "RUN apt-get install -y --no-install-recommends -t bookworm-backports qemu-system-misc\n"
+    )
+
+    assert installed == {"qemu-system-misc"}

--- a/tests/test_sandbox_bom_drift_trigger.py
+++ b/tests/test_sandbox_bom_drift_trigger.py
@@ -142,3 +142,17 @@ def test_deleting_a_project_also_checks(cp, tmp_path):
     cp.delete_project("doomed", force=True)
 
     assert isinstance(cp.check_sandbox_bom_drift(), dict)
+
+
+def test_the_drift_report_is_staged_not_dispatchable(cp, tmp_path):
+    """An open task is fleet-claimed within minutes, and what an agent would do
+    with this one is edit the Containerfile and publish an image -- the
+    unreviewed supply-chain path the whole design exists to keep closed.
+
+    The existing dispatch suite caught this: registering a repository started
+    handing the fleet work as a side effect.
+    """
+    repo = _repo(tmp_path, "needy", ["zig"])
+    cp.register_project_repository("needy", str(repo), project="mac")
+
+    assert _drift_tasks(cp)[0].metadata.get("no_dispatch") is True

--- a/tests/test_sandbox_bom_drift_trigger.py
+++ b/tests/test_sandbox_bom_drift_trigger.py
@@ -1,0 +1,144 @@
+"""Registering or deleting a project must not leave the image manifest stale.
+
+The derivation is only worth having if something runs it. Registering a repo
+whose contract needs a tool the image lacks is exactly the moment the fleet
+becomes wrong, and it is silent -- the gap shows up later as a coding agent
+provisioning a tool per task, or editing source until it builds without one.
+
+These cover the trigger and, more importantly, the two ways it could be worse
+than nothing: by failing a registration over a diagnostic, and by filing the
+same report often enough that nobody reads it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp(tmp_path):
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+def _repo(tmp_path, name, commands, project="mac"):
+    """A real checkout with a real contract.
+
+    Registration reads .mac/project.yaml from the repo rather than trusting
+    metadata handed to it, which is the right call and means a test that fakes
+    the metadata would be testing a path production never takes.
+    """
+    repo = tmp_path / name
+    (repo / ".mac").mkdir(parents=True)
+    (repo / ".mac" / "project.yaml").write_text(
+        "\n".join(
+            [
+                "schema: mac.repository_contract.v1",
+                "project: %s" % project,
+                "platforms: [linux]",
+                "toolchain:",
+                "  required_commands: [%s]" % ", ".join(commands),
+                "bootstrap:",
+                "  command: '/bin/true'",
+                "test:",
+                "  command: '/bin/true'",
+                "evidence:",
+                "  required: [log]",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    return repo
+
+
+def _drift_tasks(cp):
+    return [
+        task
+        for task in cp.list_tasks()
+        if "sandbox_bom_drift" in (task.metadata or {})
+    ]
+
+
+def test_registering_a_repo_with_a_new_tool_reports_drift(cp, tmp_path):
+    repo = _repo(tmp_path, "newrepo", ["zig"])
+    cp.register_project_repository("newrepo", str(repo), project="mac")
+
+    assert _drift_tasks(cp), "a contract requiring an unshipped tool went unreported"
+
+
+def test_the_report_names_the_tool_and_the_next_step(cp, tmp_path):
+    """A drift report that does not say what to do gets read once."""
+    repo = _repo(tmp_path, "newrepo", ["zig"])
+    cp.register_project_repository("newrepo", str(repo), project="mac")
+
+    description = _drift_tasks(cp)[0].description
+    assert "zig" in description
+    assert "mac sandbox rollout" in description
+
+
+def test_the_same_drift_is_not_filed_twice(cp, tmp_path):
+    """Re-filing per registration buries the one report that matters."""
+    for name in ("repo_a", "repo_b"):
+        cp.register_project_repository(
+            name, str(_repo(tmp_path, name, ["zig"])), project="mac"
+        )
+
+    assert len(_drift_tasks(cp)) == 1
+
+
+def test_registering_a_repo_the_image_already_covers_adds_no_requirement(cp, tmp_path):
+    """The common case must not claim the image needs anything new.
+
+    Asserted on added_commands rather than on "no task was filed": drift is
+    reported in BOTH directions, and this control plane holds only the repo the
+    test registered, so every OTHER command in the reviewed manifest correctly
+    reads as no-longer-required. That is the removed half doing its job, not a
+    false positive on the added half.
+    """
+    repo = _repo(tmp_path, "covered", ["make", "git"])
+    cp.register_project_repository("covered", str(repo), project="mac")
+
+    report = cp.check_sandbox_bom_drift()
+
+    assert report["checked"], report
+    assert report["drift"]["added_commands"] == []
+
+
+def test_a_newly_required_tool_shows_up_as_added(cp, tmp_path):
+    """The half that breaks work if it is missed."""
+    repo = _repo(tmp_path, "needy", ["zig"])
+    cp.register_project_repository("needy", str(repo), project="mac")
+
+    report = cp.check_sandbox_bom_drift()
+
+    assert report["drift"]["added_commands"] == ["zig"]
+
+
+def test_a_failing_drift_check_never_fails_the_registration(cp, tmp_path, monkeypatch):
+    """A diagnostic must not be why a project cannot be registered."""
+    monkeypatch.setattr(
+        cp, "list_project_repositories", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    repo = _repo(tmp_path, "newrepo", ["zig"])
+
+    registered = cp.register_project_repository("newrepo", str(repo), project="mac")
+
+    assert registered.id
+
+
+def test_deleting_a_project_also_checks(cp, tmp_path):
+    """A deleted project may have been the only thing requiring a package, and
+    a tool nothing asks for is still sitting in the security boundary."""
+    cp.create_project("doomed", dispatch_paused=False)
+    repo = _repo(tmp_path, "gone", ["make"], project="doomed")
+    cp.register_project_repository("gone", str(repo), project="doomed")
+
+    cp.delete_project("doomed", force=True)
+
+    assert isinstance(cp.check_sandbox_bom_drift(), dict)

--- a/tests/test_sandbox_bom_drift_trigger.py
+++ b/tests/test_sandbox_bom_drift_trigger.py
@@ -156,3 +156,32 @@ def test_the_drift_report_is_staged_not_dispatchable(cp, tmp_path):
     cp.register_project_repository("needy", str(repo), project="mac")
 
     assert _drift_tasks(cp)[0].metadata.get("no_dispatch") is True
+
+
+def test_deleting_a_project_does_not_leave_an_ownerless_task(cp, tmp_path):
+    """Deletion can only REMOVE requirements, and there is no project left to
+    own a ticket about it.
+
+    Filing anyway put an unowned task in the "unassigned" bucket on every
+    project deletion -- work nothing would claim or close. CI caught this;
+    review did not.
+    """
+    cp.create_project("doomed", dispatch_paused=False)
+    repo = _repo(tmp_path, "doomed-repo", ["make"], project="doomed")
+    cp.register_project_repository("doomed-repo", str(repo), project="doomed")
+    before = len(_drift_tasks(cp))
+
+    cp.delete_project("doomed", force=True)
+
+    assert len(_drift_tasks(cp)) == before
+
+
+def test_removal_only_drift_is_reported_even_though_it_is_not_filed(cp):
+    """Not filing is not the same as not noticing. `mac sandbox bom --compare`
+    exits non-zero on drift in either direction, so CI still catches a stale
+    manifest; this just does not manufacture a ticket for it."""
+    report = cp.check_sandbox_bom_drift()
+
+    assert report["checked"]
+    assert report["drift"]["removed_commands"], "removal drift went unreported"
+    assert report["filed"] is None

--- a/tests/test_sandbox_rollout.py
+++ b/tests/test_sandbox_rollout.py
@@ -1,0 +1,193 @@
+"""A new sandbox image reaches each worker only after that worker drains.
+
+The image goes out today through deploy-mac-fleet.sh, which pushes to nodes
+from outside the control plane and has no idea what any worker is doing. A
+worker mid-task gets its sandbox replaced underneath the task: the tools that
+task resolved at start are gone, and it surfaces as the task misbehaving rather
+than as a deployment that ran at the wrong moment.
+
+A rollout is work that mutates the worker, so it is filed as a sync task --
+which makes drain-then-update a property of the scheduler rather than of
+whoever ran the deploy script.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mac.sandbox_rollout import (
+    ROLLOUT_METADATA_KEY,
+    RolloutError,
+    plan_rollout,
+    scheduled_rollouts,
+    validate_image_ref,
+)
+from mac.services import ControlPlane
+
+DIGEST = "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+def _agents(count=2):
+    return [{"id": "agent_%d" % index, "name": "worker%d" % index} for index in range(count)]
+
+
+# --------------------------------------------------------------------------
+# What may be rolled out
+# --------------------------------------------------------------------------
+
+
+def test_a_digest_is_accepted():
+    assert validate_image_ref(DIGEST) == DIGEST
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "ghcr.io/jordanhubbard/mac-openshell-runtime:latest",
+        "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:short",
+        "ghcr.io/someone-else/mac-openshell-runtime@sha256:" + "a" * 64,
+        "",
+        None,
+    ],
+)
+def test_anything_but_the_reviewed_digest_is_refused(ref):
+    """A tag can be repointed after review, so what ships and what was reviewed
+    could differ with nothing recording it."""
+    with pytest.raises(RolloutError):
+        validate_image_ref(ref)
+
+
+def test_the_refusal_explains_why_a_tag_is_not_enough():
+    with pytest.raises(RolloutError) as excinfo:
+        validate_image_ref("ghcr.io/jordanhubbard/mac-openshell-runtime:latest")
+
+    assert "repointed" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# Planning
+# --------------------------------------------------------------------------
+
+
+def test_every_agent_gets_its_own_barrier_task():
+    plan = plan_rollout(_agents(3), DIGEST)
+
+    assert len(plan) == 3
+    assert {item["agent_id"] for item in plan} == {"agent_0", "agent_1", "agent_2"}
+
+
+def test_each_rollout_is_a_sync_task_pinned_to_its_agent():
+    """Both halves matter: sync without a target is refused at creation, and a
+    target without sync would replace the sandbox under running work."""
+    item = plan_rollout(_agents(1), DIGEST)[0]
+
+    assert item["metadata"]["execution_mode"] == "sync"
+    assert item["metadata"]["target_agent_id"] == "agent_0"
+
+
+def test_a_busy_agent_is_still_rolled():
+    """Skipping busy agents would roll the idle half of the fleet and leave the
+    working half behind -- the workers doing the most work would be the ones
+    running the oldest sandbox. Draining is the scheduler's job, not a filter
+    applied here."""
+    plan = plan_rollout([{"id": "agent_0", "name": "busy", "status": "busy"}], DIGEST)
+
+    assert len(plan) == 1
+
+
+def test_an_agent_already_scheduled_for_this_image_is_not_queued_twice():
+    """A rollout re-filed each tick would queue a barrier per tick, and barriers
+    quiesce their agent -- the worker would stop taking work permanently."""
+    plan = plan_rollout(_agents(2), DIGEST, already_scheduled={("agent_0", DIGEST)})
+
+    assert [item["agent_id"] for item in plan] == ["agent_1"]
+
+
+def test_an_agent_scheduled_for_a_different_image_is_still_queued():
+    older = "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "b" * 64
+    plan = plan_rollout(_agents(1), DIGEST, already_scheduled={("agent_0", older)})
+
+    assert len(plan) == 1
+
+
+def test_scheduled_rollouts_are_read_from_the_marker_not_the_title():
+    tasks = [
+        {"metadata": {ROLLOUT_METADATA_KEY: {"agent_id": "agent_0", "image": DIGEST}}},
+        {"metadata": {"unrelated": True}},
+        {"no_metadata": True},
+    ]
+
+    assert scheduled_rollouts(tasks) == {("agent_0", DIGEST)}
+
+
+def test_the_task_records_the_bom_it_is_installing():
+    """So a task that later fails on a missing tool can be checked against what
+    the image it ran under was supposed to contain."""
+    item = plan_rollout(_agents(1), DIGEST, bom={"packages": ["cmake"]})[0]
+
+    assert item["metadata"][ROLLOUT_METADATA_KEY]["packages"] == ["cmake"]
+
+
+def test_the_description_tells_the_worker_to_fail_rather_than_fall_back():
+    """A half-rolled fleet that says nothing is worse than an unrolled one:
+    nothing downstream can tell which sandbox a task actually ran in."""
+    item = plan_rollout(_agents(1), DIGEST)[0]
+
+    assert "FAIL the task" in item["description"]
+
+
+# --------------------------------------------------------------------------
+# Filing, through the real control plane
+# --------------------------------------------------------------------------
+
+
+def test_filing_creates_one_barrier_per_registered_agent(cp):
+    machine = cp.register_machine("roll-host")
+    cp.register_agent(machine.id, "worker1")
+
+    report = cp.roll_out_sandbox_image(DIGEST, project="mac")
+
+    assert len(report["filed"]) == 1
+    filed = cp.get_task(report["filed"][0])
+    assert filed.metadata["execution_mode"] == "sync"
+
+
+def test_the_filed_task_quiesces_exactly_that_worker(cp):
+    """The end of the chain: rollout -> sync task -> the agent stops taking
+    async work until it has drained and updated."""
+    machine = cp.register_machine("roll-host")
+    agent = cp.register_agent(machine.id, "worker1")
+    cp.roll_out_sandbox_image(DIGEST, project="mac")
+
+    snapshot = cp.dispatch._v2_snapshot_agent(cp.get_agent(agent.id))
+
+    assert snapshot.sync_barrier_pending
+
+
+def test_rolling_twice_does_not_queue_a_second_barrier(cp):
+    machine = cp.register_machine("roll-host")
+    cp.register_agent(machine.id, "worker1")
+    cp.roll_out_sandbox_image(DIGEST, project="mac")
+
+    second = cp.roll_out_sandbox_image(DIGEST, project="mac")
+
+    assert second["filed"] == []
+
+
+def test_an_invalid_image_files_nothing(cp):
+    machine = cp.register_machine("roll-host")
+    cp.register_agent(machine.id, "worker1")
+
+    with pytest.raises(RolloutError):
+        cp.roll_out_sandbox_image("mac-openshell-runtime:latest", project="mac")
+
+    assert not [task for task in cp.list_tasks() if "Sandbox rollout" in task.title]

--- a/tests/test_sync_barrier_dispatch.py
+++ b/tests/test_sync_barrier_dispatch.py
@@ -1,0 +1,180 @@
+"""The barrier must hold through the real dispatch path, not just in the gate.
+
+test_sync_execution_mode.py covers evaluate_pair against hand-built snapshots.
+That is necessary and not sufficient: the gate is only reached if the snapshot
+builder actually populates execution_mode and the agent's barrier state from
+the ledger. A rule that is correct in a function nothing calls with real data is
+the recurring failure in this codebase, so these tests go through ControlPlane.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.allocator import AGENT_SYNC_BARRIER, EXECUTION_MODE_SYNC, evaluate_pair
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+def _lifecycle(cp):
+    return cp.dispatch
+
+
+def _snapshot(cp, task_id):
+    return cp.dispatch._v2_snapshot_task(
+        cp.get_task(task_id),
+        projects={record.name: record for record in cp.list_project_records()},
+        agent_ids_by_name={},
+    )
+
+
+def test_execution_mode_survives_the_round_trip_through_the_ledger(cp):
+    """Stored in metadata, read back into the allocation snapshot. If this
+    fails the mode is a field nothing downstream ever sees."""
+    task = cp.create_task(
+        "barrier", project="mac", metadata={"execution_mode": "sync"}
+    )
+
+    assert _snapshot(cp, task.id).execution_mode == EXECUTION_MODE_SYNC
+
+
+def test_a_task_with_no_mode_is_async_after_the_round_trip(cp):
+    task = cp.create_task("ordinary", project="mac")
+
+    assert _snapshot(cp, task.id).execution_mode == "async"
+
+
+def test_the_barrier_state_is_derived_from_unfinished_sync_tasks(cp):
+    cp.create_task(
+        "barrier",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": "agent_1"},
+    )
+
+    head, running = _lifecycle(cp)._sync_barrier_state("agent_1")
+
+    assert head is not None
+    assert running is False
+
+
+def test_a_finished_barrier_stops_quiescing_the_agent(cp):
+    """Derived rather than stored precisely for this.
+
+    A stored quiescing flag has to be cleared by whatever finishes the barrier,
+    and a missed path leaves the worker quiesced forever with nothing saying
+    why. Recomputing cannot get stuck.
+    """
+    task = cp.create_task(
+        "barrier",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": "agent_1"},
+    )
+    cp.close_task(task.id, "cancelled", "operator", {"reason": "barrier finished"})
+
+    head, _running = _lifecycle(cp)._sync_barrier_state("agent_1")
+
+    assert head is None
+
+
+def test_a_barrier_for_another_agent_is_not_this_agent_s_barrier(cp):
+    cp.create_task(
+        "barrier",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": "agent_2"},
+    )
+
+    head, _running = _lifecycle(cp)._sync_barrier_state("agent_1")
+
+    assert head is None
+
+
+def test_the_oldest_unfinished_barrier_is_the_head(cp):
+    """FIFO is decided here, so this is where getting it backwards would show."""
+    first = cp.create_task(
+        "first",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": "agent_1"},
+    )
+    cp.create_task(
+        "second",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": "agent_1"},
+    )
+
+    head, _running = _lifecycle(cp)._sync_barrier_state("agent_1")
+
+    assert head == first.id
+
+
+def test_an_ordinary_task_never_creates_a_barrier(cp):
+    """The blast radius check: if async work quiesced its agent, the fleet
+    would deadlock on the first task it accepted."""
+    cp.create_task("ordinary", project="mac", metadata={"target_agent_id": "agent_1"})
+
+    head, _running = _lifecycle(cp)._sync_barrier_state("agent_1")
+
+    assert head is None
+
+
+def _agent(cp, name="worker1"):
+    machine = cp.register_machine("%s-host" % name)
+    return cp.register_agent(machine.id, name)
+
+
+def test_the_agent_snapshot_carries_the_barrier_the_allocator_reads(cp):
+    """The wiring, not the helper.
+
+    Deleting sync_queue_head_task_id from _v2_snapshot_agent left every other
+    test in this file green while making the feature completely inert: the
+    barrier state was computed correctly and then dropped before the allocator
+    ever saw it. Asserting on _sync_barrier_state alone cannot catch that.
+    """
+    agent = _agent(cp)
+    cp.create_task(
+        "barrier",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": agent.id},
+    )
+
+    snapshot = cp.dispatch._v2_snapshot_agent(cp.get_agent(agent.id))
+
+    assert snapshot.sync_queue_head_task_id is not None
+    assert snapshot.sync_barrier_pending
+
+
+def test_an_agent_with_no_barrier_snapshots_clean(cp):
+    agent = _agent(cp, "worker2")
+    cp.create_task("ordinary", project="mac")
+
+    snapshot = cp.dispatch._v2_snapshot_agent(cp.get_agent(agent.id))
+
+    assert snapshot.sync_queue_head_task_id is None
+    assert not snapshot.sync_barrier_pending
+
+
+def test_a_quiesced_agent_refuses_async_work_end_to_end(cp):
+    """The whole chain: ledger -> snapshot -> allocator gate."""
+    agent = _agent(cp, "worker3")
+    cp.create_task(
+        "barrier",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": agent.id},
+    )
+    ordinary = cp.create_task("ordinary", project="mac")
+
+    evaluation = evaluate_pair(
+        _snapshot(cp, ordinary.id),
+        cp.dispatch._v2_snapshot_agent(cp.get_agent(agent.id)),
+    )
+
+    assert not evaluation.allowed
+    assert any(
+        reason.split(":", 1)[0] == AGENT_SYNC_BARRIER
+        for reason in evaluation.agent_rejections
+    )

--- a/tests/test_sync_barrier_dispatch.py
+++ b/tests/test_sync_barrier_dispatch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from mac.allocator import AGENT_SYNC_BARRIER, EXECUTION_MODE_SYNC, evaluate_pair
+from mac.models import ValidationError
 from mac.services import ControlPlane
 
 
@@ -38,7 +39,9 @@ def test_execution_mode_survives_the_round_trip_through_the_ledger(cp):
     """Stored in metadata, read back into the allocation snapshot. If this
     fails the mode is a field nothing downstream ever sees."""
     task = cp.create_task(
-        "barrier", project="mac", metadata={"execution_mode": "sync"}
+        "barrier",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": "agent_1"},
     )
 
     assert _snapshot(cp, task.id).execution_mode == EXECUTION_MODE_SYNC
@@ -178,3 +181,51 @@ def test_a_quiesced_agent_refuses_async_work_end_to_end(cp):
         reason.split(":", 1)[0] == AGENT_SYNC_BARRIER
         for reason in evaluation.agent_rejections
     )
+
+
+# --------------------------------------------------------------------------
+# Refused at the door, not only in the allocator
+# --------------------------------------------------------------------------
+
+
+def test_creating_an_untargeted_barrier_is_refused(cp):
+    """An allocator-only refusal leaves the task sitting in the ledger looking
+    ready forever. Say no while someone is still there to read it."""
+    with pytest.raises(ValidationError) as excinfo:
+        cp.create_task("barrier", project="mac", metadata={"execution_mode": "sync"})
+
+    assert "target_agent_id" in str(excinfo.value)
+
+
+def test_the_refusal_names_the_ambiguity(cp):
+    """"Invalid task" would send someone to look at the title."""
+    with pytest.raises(ValidationError) as excinfo:
+        cp.create_task("barrier", project="mac", metadata={"execution_mode": "sync"})
+
+    assert "single" in str(excinfo.value) and "fleet" in str(excinfo.value)
+
+
+def test_a_targeted_barrier_is_accepted(cp):
+    task = cp.create_task(
+        "barrier",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_id": "agent_1"},
+    )
+
+    assert task.id
+
+
+def test_a_barrier_targeted_by_name_is_accepted(cp):
+    """target_agent_name is resolved later by the snapshot builder, so
+    refusing it here would reject a legitimate route."""
+    task = cp.create_task(
+        "barrier",
+        project="mac",
+        metadata={"execution_mode": "sync", "target_agent_name": "worker5"},
+    )
+
+    assert task.id
+
+
+def test_ordinary_task_creation_is_untouched(cp):
+    assert cp.create_task("ordinary", project="mac").id

--- a/tests/test_sync_execution_mode.py
+++ b/tests/test_sync_execution_mode.py
@@ -1,0 +1,249 @@
+"""A sync task owns its agent; an async task never waits for one.
+
+Every task today is async: take any eligible work, up to capacity, in any
+order. That is right for ordinary work and wrong for work that mutates the
+WORKER -- rolling out a new sandbox image cannot run beside the tasks whose
+sandbox it is replacing.
+
+The barrier is only useful if it holds in the awkward cases, so that is what
+these cover: a barrier that starves behind incoming work, a barrier that
+reorders under priority, a barrier that leaks onto an unrelated agent, and a
+barrier bypassed by break-glass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.allocator import (
+    AGENT_SYNC_BARRIER,
+    EXECUTION_MODE_ASYNC,
+    EXECUTION_MODE_SYNC,
+    TASK_SYNC_UNTARGETED,
+    AllocationAgent,
+    AllocationTask,
+    evaluate_pair,
+    evaluate_task,
+    normalize_execution_mode,
+    rejection_kind,
+)
+
+
+def _task(task_id="task_1", *, mode=EXECUTION_MODE_ASYNC, target=None, priority=1,
+          created_at="2026-08-08T00:00:00+00:00"):
+    return AllocationTask(
+        id=task_id,
+        priority=priority,
+        created_at=created_at,
+        execution_mode=mode,
+        target_agent_id=target,
+    )
+
+
+def _agent(agent_id="agent_1", *, capacity=4, active=0, head=None, running=False):
+    return AllocationAgent(
+        id=agent_id,
+        capacity=capacity,
+        active_leases=active,
+        sync_queue_head_task_id=head,
+        sync_task_running=running,
+    )
+
+
+def _barrier_reasons(evaluation):
+    return [
+        reason
+        for reason in evaluation.agent_rejections
+        if reason.split(":", 1)[0] == AGENT_SYNC_BARRIER
+    ]
+
+
+# --------------------------------------------------------------------------
+# The default is unchanged
+# --------------------------------------------------------------------------
+
+
+def test_ordinary_work_is_async_and_unaffected():
+    """Every existing task takes the default. If this needs a mode set, the
+    change was not backwards compatible."""
+    assert evaluate_pair(_task(), _agent(active=3)).allowed
+
+
+@pytest.mark.parametrize("value", [None, "", "ASYNC", "nonsense", "syncish"])
+def test_an_unrecognized_mode_reads_as_async(value):
+    """Fail-open in this one direction: an unknown mode read as sync would
+    quiesce a worker over a typo."""
+    assert normalize_execution_mode(value) == EXECUTION_MODE_ASYNC
+
+
+def test_sync_is_recognized_case_insensitively():
+    assert normalize_execution_mode("SYNC") == EXECUTION_MODE_SYNC
+
+
+# --------------------------------------------------------------------------
+# A barrier waits for the agent to drain
+# --------------------------------------------------------------------------
+
+
+def test_a_sync_task_does_not_start_until_the_agent_has_drained():
+    evaluation = evaluate_pair(
+        _task(mode=EXECUTION_MODE_SYNC, target="agent_1"),
+        _agent(active=1, head="task_1"),
+    )
+
+    assert not evaluation.allowed
+    assert "%s:not_drained" % AGENT_SYNC_BARRIER in evaluation.agent_rejections
+
+
+def test_a_sync_task_starts_once_the_agent_is_empty():
+    evaluation = evaluate_pair(
+        _task(mode=EXECUTION_MODE_SYNC, target="agent_1"),
+        _agent(active=0, head="task_1"),
+    )
+
+    assert evaluation.allowed
+
+
+def test_capacity_alone_would_not_have_been_enough():
+    """A worker with capacity 4 and one task running has free slots. Only the
+    drain rule stops the barrier landing beside that task."""
+    agent = _agent(capacity=4, active=1, head="task_1")
+    assert agent.free_slots > 0
+
+    assert not evaluate_pair(_task(mode=EXECUTION_MODE_SYNC, target="agent_1"), agent).allowed
+
+
+# --------------------------------------------------------------------------
+# The barrier quiesces the agent, or it starves
+# --------------------------------------------------------------------------
+
+
+def test_a_pending_barrier_stops_the_agent_taking_new_async_work():
+    """The rule the whole thing turns on.
+
+    If the agent kept accepting async work while a barrier waited,
+    active_leases would never reach zero and the barrier would starve -- and
+    the busiest workers, the ones most needing an image update, would be the
+    ones that never got one.
+    """
+    evaluation = evaluate_pair(_task("task_2"), _agent(active=1, head="task_1"))
+
+    assert not evaluation.allowed
+    assert "%s:draining" % AGENT_SYNC_BARRIER in evaluation.agent_rejections
+
+
+def test_a_running_barrier_stops_new_async_work_and_says_so():
+    """Distinguished from draining on purpose: "waiting for this worker to
+    finish" and "this worker is being updated right now" are different answers
+    to an operator asking why nothing is dispatching."""
+    evaluation = evaluate_pair(
+        _task("task_2"), _agent(active=1, head="task_1", running=True)
+    )
+
+    assert "%s:running" % AGENT_SYNC_BARRIER in evaluation.agent_rejections
+
+
+def test_an_agent_with_no_barrier_takes_async_work_normally():
+    assert evaluate_pair(_task("task_2"), _agent(active=1)).allowed
+
+
+# --------------------------------------------------------------------------
+# Barriers run serially, oldest first
+# --------------------------------------------------------------------------
+
+
+def test_two_barriers_run_oldest_first_even_when_the_younger_outranks_it():
+    """FIFO, not priority. A barrier that reorders under priority is not a
+    barrier: the update that was supposed to run last would run first."""
+    younger_but_urgent = _task(
+        "task_2", mode=EXECUTION_MODE_SYNC, target="agent_1",
+        priority=99, created_at="2026-08-08T12:00:00+00:00",
+    )
+    agent = _agent(active=0, head="task_1")  # task_1 is older
+
+    evaluation = evaluate_pair(younger_but_urgent, agent)
+
+    assert not evaluation.allowed
+    assert "%s:fifo" % AGENT_SYNC_BARRIER in evaluation.agent_rejections
+
+
+def test_the_oldest_barrier_is_the_one_that_runs():
+    agent = _agent(active=0, head="task_1")
+
+    assert evaluate_pair(
+        _task("task_1", mode=EXECUTION_MODE_SYNC, target="agent_1"), agent
+    ).allowed
+
+
+# --------------------------------------------------------------------------
+# A barrier is one agent's business
+# --------------------------------------------------------------------------
+
+
+def test_a_barrier_on_one_agent_does_not_quiesce_another():
+    """Otherwise a rolling image update stops the entire fleet at once, which
+    is the opposite of rolling."""
+    other = _agent("agent_2", active=1)
+
+    assert evaluate_pair(_task("task_2"), other).allowed
+
+
+def test_a_barrier_targeted_elsewhere_is_not_placeable_here():
+    evaluation = evaluate_pair(
+        _task(mode=EXECUTION_MODE_SYNC, target="agent_2"), _agent("agent_1")
+    )
+
+    assert not evaluation.allowed
+
+
+# --------------------------------------------------------------------------
+# A barrier must name its agent
+# --------------------------------------------------------------------------
+
+
+def test_an_untargeted_barrier_is_refused():
+    """"Wait for all tasks to complete" is ambiguous between one worker and the
+    fleet, and the fleet reading is a global stop-the-world. Refuse rather than
+    let whichever code path runs first decide."""
+    evaluation = evaluate_task(_task(mode=EXECUTION_MODE_SYNC))
+
+    assert TASK_SYNC_UNTARGETED in evaluation.task_rejections
+
+
+def test_a_targeted_barrier_is_not_refused_for_that_reason():
+    evaluation = evaluate_task(_task(mode=EXECUTION_MODE_SYNC, target="agent_1"))
+
+    assert TASK_SYNC_UNTARGETED not in evaluation.task_rejections
+
+
+# --------------------------------------------------------------------------
+# Break-glass does not open the barrier
+# --------------------------------------------------------------------------
+
+
+def test_break_glass_does_not_run_work_inside_a_sandbox_being_replaced():
+    """Break-glass forces a task past ROUTING bars. Running it beside a sync
+    task would put it in a sandbox being swapped underneath it, which is host
+    safety -- the same reason capacity and health are checked unconditionally.
+    """
+    task = AllocationTask(
+        id="task_2",
+        priority=1,
+        created_at="2026-08-08T00:00:00+00:00",
+        break_glass_agent_id="agent_1",
+    )
+
+    evaluation = evaluate_pair(task, _agent(head="task_1", running=True))
+
+    assert not evaluation.allowed
+    assert _barrier_reasons(evaluation)
+
+
+def test_a_barrier_is_transient_not_a_fleet_requirement_gap():
+    """It clears when the agent drains. Classified as anything else, the
+    eligibility diagnostic reports a fleet that cannot meet the task's
+    requirements when the real answer is "this worker is being updated" --
+    the same misdirection the :excluded / :pinned split was added to fix.
+    """
+    assert rejection_kind("%s:draining" % AGENT_SYNC_BARRIER) == "transient"
+    assert rejection_kind("%s:not_drained" % AGENT_SYNC_BARRIER) == "transient"


### PR DESCRIPTION
The OpenShell image's package list was maintained by hand, and its comments
are a ledger of incidents transcribed after the fact:

> libssl-dev: nanolang's src/sign.c #includes <openssl/evp.h> ... without it a
> coding agent will destructively stub sign.c just to compile

Every one names a project whose contract already declared the tool. The
contract was authoritative and nothing read it, so the answer to "when do we
permute the environment" was "when someone notices a repo broke".

## What this adds

**`mac sandbox bom`** derives the union from every repository contract plus the
commands mac itself needs, and writes a reviewed manifest that is added to the
image's frozen inputs — so a contract gaining a tool changes the published
image identity.

**A sync execution mode.** A sync task is a per-agent barrier: it starts only
once the agent drains, runs alone, and quiesces the agent from the moment it is
queued. Several on one agent run FIFO by creation, not priority.

**`mac sandbox rollout --image <digest>`** files one barrier task per worker, so
drain-then-update is a property of the scheduler rather than of whoever ran the
deploy script. The fleet rolls instead of stopping.

**Drift detection** on the two events that can change the union of contracts —
registering a repository and deleting a project.

## The gap it found immediately

Deriving from registrations rather than projects was not cosmetic. The
per-project version dropped three contracts: two OrcaSlicer repos are registered
under no project `project list` returns, and `GET /projects/{project}` 404s on
the branch-qualified name `isaacsim7-poc@feat/ros-sim` however it is escaped
(filed separately as task_4f29da07). That project requires **cmake** and
**ninja**, neither of which the image installed — the first real gap this found,
and one no incident had yet reported. Both are now in the Containerfile.

## What it deliberately does not do

Publish an image. An automatic path from "someone registered a repo" to "every
worker is running a new image" is the supply-chain hole the frozen-input hash
exists to close. A reviewed digest is an input here, and a tag is refused: a tag
can be repointed after review, so what ships and what was reviewed could differ
with nothing recording it.

## Defects caught by mutating the tests

- The BOM gap check was a substring search over the Containerfile, so deleting
  `cmake` from the apt line still passed — the comment above it said "cmake".
  It now parses what the apt lines actually install.
- Deleting `sync_queue_head_task_id` from the agent snapshot left every test
  green while making the barrier completely inert.
- `node` was mapped to Debian's `nodejs`, which the image deliberately does not
  install (v22 LTS from NodeSource; current pnpm refuses Node < v22.13).
- The drift check's blanket `except` hid a bug of its own: an unsupported
  `json_dumps` kwarg made every check report "no drift" while looking healthy.
- The existing dispatch suite caught that drift tasks were dispatchable — an
  agent would have edited the Containerfile and published an image. Now staged.

110 focused tests; allocator/dispatch regression run clean at 2467 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)