### PR TITLE
Add `mac task wait` and a hub event-follow stream

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -419,6 +419,7 @@ Migration:
   convert-ticketing  one-way convert a detected foreign source (e.g. beads) into MAC ledger tasks plus optional local compatibility files (run after the user agrees)
 
 Other:
+  wait    wait for a project's tasks to finish, streaming each transition
   edit    answer a parked task in $EDITOR; saving submits it back to the queue
   select  preview the group of tasks a selector expression names
   batch   apply one operation to every task a selector names (dry by default)

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -177,6 +177,7 @@ request and response definitions.
 | `POST` | `/eval-sets/{eval_set_id}/baseline` | Update Eval Set Baseline |
 | `GET` | `/eval-sets/{eval_set_id}/events` | List Eval Set Events |
 | `GET` | `/events` | List Events |
+| `GET` | `/events/stream` | Stream Events |
 | `GET` | `/evidence/{evidence_id}/artifacts` | List Evidence Artifacts |
 | `GET` | `/evidence/{evidence_id}/artifacts/{artifact_id}` | Get Evidence Artifact |
 | `GET` | `/fleet/build-distribution` | Fleet Build Distribution |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -4173,6 +4173,46 @@ def _stop_hub_tick_loop(app: FastAPI) -> None:
     app.state.hub_tick_thread = None
 
 
+#: How long one follow connection may be held. A follower reconnects with the
+#: cursor it already has, so a longer ceiling buys nothing and costs a pinned
+#: worker per idle client. An hour was the first value here and it made even a
+#: test that merely asked for a large timeout hang for an hour.
+STREAM_MAX_TIMEOUT_SECONDS = 120.0
+STREAM_MAX_POLL_INTERVAL_SECONDS = 30.0
+
+
+def clamp_stream_timeout(value: Any) -> float:
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        seconds = STREAM_MAX_TIMEOUT_SECONDS
+    return max(0.1, min(seconds, STREAM_MAX_TIMEOUT_SECONDS))
+
+
+def clamp_stream_poll_interval(value: Any) -> float:
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        seconds = 1.0
+    return max(0.05, min(seconds, STREAM_MAX_POLL_INTERVAL_SECONDS))
+
+
+async def _client_gone(request: Request) -> bool:
+    """Whether the client has hung up, without blocking if it has not.
+
+    ``Request.is_disconnected`` awaits ``receive()``, which only returns when
+    the ASGI server delivers a message. Under a real server a disconnect
+    eventually arrives; under a test client, nothing ever does, so awaiting it
+    directly wedges the whole stream before its own deadline can fire. A short
+    timeout turns "no news" into "still connected", which is the correct
+    reading either way.
+    """
+    try:
+        return await asyncio.wait_for(request.is_disconnected(), timeout=0.05)
+    except (asyncio.TimeoutError, RuntimeError):
+        return False
+
+
 def create_app(
     db_path: Optional[str] = None,
     control_plane: Optional[ControlPlane] = None,
@@ -8264,6 +8304,74 @@ def create_app(
             until=until,
             limit=limit,
         )
+
+    @app.get("/events/stream")
+    async def stream_events(
+        request: Request,
+        subject_type: Optional[str] = Query(default=None),
+        subject_id: Optional[str] = Query(default=None),
+        event_type: Optional[str] = Query(default=None),
+        event_type_prefix: Optional[str] = Query(default=None),
+        since: Optional[str] = Query(default=None),
+        timeout_seconds: float = Query(default=300.0),
+        poll_interval_seconds: float = Query(default=1.0),
+    ) -> StreamingResponse:
+        """Follow the event stream as it grows, one JSON record per line.
+
+        `GET /events` answers "what happened up to now", so following it means
+        a client round-trip per interval -- and the interval is a straight
+        trade between latency and load that the client cannot win. This moves
+        the polling to the hub, where it is a local query instead of a network
+        request, and the client holds one connection.
+
+        The cursor is still a timestamp, because that is what the events table
+        orders by. Records at the boundary instant are therefore re-sent on
+        reconnect; clients de-duplicate by event id rather than the stream
+        trying to guess when a tick is complete.
+        """
+        clamped_timeout = clamp_stream_timeout(timeout_seconds)
+        clamped_interval = clamp_stream_poll_interval(poll_interval_seconds)
+
+        async def iter_events() -> Any:
+            cursor = since
+            # Bounded, so one client cannot hold a worker forever, and so a
+            # dead connection behind a proxy that swallows disconnects is
+            # eventually reaped. Clients reconnect with the cursor they hold.
+            deadline = time.monotonic() + clamped_timeout
+            seen: set = set()
+            while True:
+                if await _client_gone(request):
+                    break
+                batch = cp.list_events(
+                    subject_type=subject_type,
+                    subject_id=subject_id,
+                    event_type=event_type,
+                    event_type_prefix=event_type_prefix,
+                    since=cursor,
+                    limit=500,
+                )
+                # list_events is newest-first; a follower wants them in the
+                # order they happened.
+                for record in reversed(list(batch)):
+                    event_id = str(record.get("id") or "")
+                    if event_id and event_id in seen:
+                        continue
+                    if event_id:
+                        seen.add(event_id)
+                    created_at = str(record.get("created_at") or "")
+                    if created_at and (cursor is None or created_at > cursor):
+                        cursor = created_at
+                    yield json.dumps(record, sort_keys=True, default=str) + "\n"
+                # Keep the memory of what has been sent bounded. Only ids at
+                # the cursor instant can be re-delivered, so older ones are
+                # never needed again.
+                if len(seen) > 5000:
+                    seen = set()
+                if time.monotonic() >= deadline:
+                    break
+                await asyncio.sleep(clamped_interval)
+
+        return StreamingResponse(iter_events(), media_type="application/x-ndjson")
 
     @app.post("/observability/metrics")
     def record_observability_metric(body: ObservabilityMetricCreate) -> Dict[str, Any]:

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -3696,6 +3696,51 @@ def _iso_seconds_ago(seconds: float) -> str:
     return (datetime.now(timezone.utc) - timedelta(seconds=max(1.0, seconds))).isoformat()
 
 
+def _wait_poll_events(cp: Any, cursor: str, args: argparse.Namespace) -> List[Any]:
+    """One batch of task transitions since ``cursor``.
+
+    Prefers the hub's follow stream, which blocks on the hub for up to one
+    interval and returns whatever arrived. That turns a poll-per-interval into
+    one held connection, and the latency stops being a client-side guess.
+
+    Falls back to a plain query whenever the stream is unavailable -- a local
+    authority has no HTTP at all, and a hub older than /events/stream answers
+    404. The deployed hub is routinely behind the client, so this fallback is
+    the normal path, not an edge case.
+    """
+    streamer = getattr(cp, "stream_events", None)
+    if streamer is not None and not args.no_stream:
+        collected: List[Any] = []
+        try:
+            for record in streamer(
+                subject_type="task",
+                event_type="task.transitioned",
+                since=cursor,
+                timeout_seconds=args.poll_interval,
+                poll_interval_seconds=min(1.0, args.poll_interval),
+            ):
+                collected.append(record)
+        except MACError:
+            # Stream refused or dropped: fall through to the query below rather
+            # than ending the wait. The rescan reconciles anything missed.
+            pass
+        else:
+            return collected
+    time.sleep(args.poll_interval)
+    try:
+        return list(
+            cp.list_events(
+                subject_type="task",
+                event_type="task.transitioned",
+                since=cursor,
+                limit=500,
+            )
+        )
+    except MACError:
+        # A hub blip must not end the wait; the rescan reconciles.
+        return []
+
+
 def cmd_task_wait(args: argparse.Namespace) -> None:
     """Wait for a project's tasks to finish, streaming each transition."""
     cp = _plane(args)
@@ -3764,18 +3809,7 @@ def cmd_task_wait(args: argparse.Namespace) -> None:
             result["timed_out"] = True
             emit(result)
             raise SystemExit(1)
-        time.sleep(args.poll_interval)
-        try:
-            events = cp.list_events(
-                subject_type="task",
-                event_type="task.transitioned",
-                since=cursor,
-                limit=500,
-            )
-        except MACError:
-            # A hub blip must not end the wait: the rescan below reconciles
-            # whatever was missed.
-            events = []
+        events = _wait_poll_events(cp, cursor, args)
         for event in dedupe_events(list(reversed(list(events))), seen_events):
             created_at = str(event.get("created_at") or "")
             if created_at > cursor:
@@ -7329,6 +7363,13 @@ def build_parser() -> argparse.ArgumentParser:
         default=60.0,
         help="seconds between reconciliations against authoritative task state, "
              "which recover any events the feed missed (default: 60)",
+    )
+    wait.add_argument(
+        "--no-stream",
+        dest="no_stream",
+        action="store_true",
+        help="poll instead of following the hub's event stream (the fallback "
+             "used automatically against a hub that predates /events/stream)",
     )
     wait.add_argument(
         "--no-follow-new",

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -16,6 +16,8 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
 
@@ -32,6 +34,7 @@ from mac.models import (
     utcnow,
 )
 from mac import sandbox_bom
+from mac.task_wait import WAIT_SCHEMA, TaskWait, dedupe_events, waitable_tasks
 from mac.repository_hygiene import (
     CANCELLATION_DISPOSITIONS,
     REPOSITORY_REF_CLEANUP_SCHEMA,
@@ -3682,6 +3685,118 @@ def _write_egress_hosts(
     return cp.update_task(task_id, metadata=metadata, actor=args.actor)
 
 
+def _iso_seconds_ago(seconds: float) -> str:
+    """An ISO cursor a little in the past.
+
+    The wait lists tasks and then starts polling events. A transition landing
+    between those two calls falls in the gap and is never seen, so the cursor
+    starts behind the listing rather than at it. Re-delivered events are
+    filtered by id, so overlapping is free and missing one is not.
+    """
+    return (datetime.now(timezone.utc) - timedelta(seconds=max(1.0, seconds))).isoformat()
+
+
+def cmd_task_wait(args: argparse.Namespace) -> None:
+    """Wait for a project's tasks to finish, streaming each transition."""
+    cp = _plane(args)
+    project = _effective_read_project(args)
+    if not project:
+        raise MACError(
+            "task wait needs a project: pass --project, or run it inside a "
+            "checkout whose project can be inferred. Waiting on the whole "
+            "ledger would never return."
+        )
+    wait = TaskWait(
+        waitable_tasks(cp.list_tasks(project=project), project=project),
+        follow_new=not args.no_follow_new,
+    )
+
+    def emit(update: Mapping[str, Any]) -> None:
+        # Newline-delimited JSON so the feed can be piped into something while
+        # it runs. A single JSON array would not be readable until the wait
+        # ended, which defeats the point of a feed. The closing summary goes out
+        # the same way rather than through _print: mixing a pretty-printed
+        # object into a stream of one-line records makes the whole output
+        # unparseable by anything reading it a line at a time.
+        if _OUTPUT_JSON:
+            print(json.dumps(update, sort_keys=True), flush=True)
+        elif update.get("schema") == WAIT_SCHEMA:
+            print(
+                "%s: %d finished, %d stalled, %d still pending"
+                % (
+                    "timed out" if update.get("timed_out") else "done",
+                    len(update.get("finished") or []),
+                    len(update.get("stalled") or []),
+                    len(update.get("still_pending") or []),
+                ),
+                flush=True,
+            )
+            for task_id in update.get("stalled") or []:
+                # Named individually: the wait returned without these
+                # finishing, and a count alone reads like success.
+                print("  stalled, no longer waited on: %s" % task_id, flush=True)
+        else:
+            print(
+                "%-10s %s  %s%s"
+                % (
+                    update.get("state", ""),
+                    update.get("task_id", ""),
+                    update.get("event", ""),
+                    (" (%s)" % update["reason"]) if update.get("reason") else "",
+                ),
+                flush=True,
+            )
+
+    for task_id, state in sorted(wait.pending.items()):
+        emit({"task_id": task_id, "state": state, "event": "waiting"})
+
+    deadline = time.monotonic() + args.timeout if args.timeout else None
+    seen_events: set = set()
+    # Start the cursor slightly in the past: a transition that lands between
+    # the initial listing and the first poll would otherwise fall in the gap
+    # between them and never be seen.
+    cursor = _iso_seconds_ago(args.poll_interval * 2)
+    last_rescan = time.monotonic()
+
+    while not wait.done:
+        if deadline is not None and time.monotonic() >= deadline:
+            result = wait.summary()
+            result["timed_out"] = True
+            emit(result)
+            raise SystemExit(1)
+        time.sleep(args.poll_interval)
+        try:
+            events = cp.list_events(
+                subject_type="task",
+                event_type="task.transitioned",
+                since=cursor,
+                limit=500,
+            )
+        except MACError:
+            # A hub blip must not end the wait: the rescan below reconciles
+            # whatever was missed.
+            events = []
+        for event in dedupe_events(list(reversed(list(events))), seen_events):
+            created_at = str(event.get("created_at") or "")
+            if created_at > cursor:
+                cursor = created_at
+            update = wait.apply_event(event)
+            if update is not None:
+                emit(update)
+        # Periodic reconciliation against authoritative state. Events can be
+        # missed -- a hub restart, a dropped poll -- and a wait that hangs
+        # forever on a task that finished unobserved is the failure that sends
+        # people back to polling by hand.
+        if time.monotonic() - last_rescan >= args.rescan_interval:
+            last_rescan = time.monotonic()
+            for update in wait.rescan(
+                cp.list_tasks(project=project), project=project
+            ):
+                emit(update)
+
+    emit(wait.summary())
+
+
 def cmd_task_egress_list(args: argparse.Namespace) -> None:
     """Show the hosts a task declares for sandbox egress."""
     cp = _plane(args)
@@ -7185,6 +7300,46 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="AGENT_ID",
         help="pin this task to one agent (required by --sync)",
     )
+    wait = task.add_parser(
+        "wait",
+        help="wait for a project's tasks to finish, streaming each transition",
+        description=(
+            "Wait until every task in a project that is active -- or can become "
+            "active -- has finished, printing each state change as it happens. "
+            "Tasks that become blocked or need human input leave the wait and "
+            "are reported, so the wait always terminates."
+        ),
+    )
+    wait.add_argument("--project", default=None)
+    wait.add_argument(
+        "--timeout",
+        type=float,
+        default=0.0,
+        help="give up after this many seconds and exit 1 (default: wait forever)",
+    )
+    wait.add_argument(
+        "--poll-interval",
+        type=float,
+        default=5.0,
+        help="seconds between event polls (default: 5)",
+    )
+    wait.add_argument(
+        "--rescan-interval",
+        type=float,
+        default=60.0,
+        help="seconds between reconciliations against authoritative task state, "
+             "which recover any events the feed missed (default: 60)",
+    )
+    wait.add_argument(
+        "--no-follow-new",
+        dest="no_follow_new",
+        action="store_true",
+        help="freeze the wait set at the tasks present when it started. By "
+             "default a task created while waiting joins the set, so a task "
+             "that decomposes into children does not let the wait return while "
+             "its children are still running.",
+    )
+    _set(cmd_task_wait, wait)
     create.add_argument("--no-decompose", dest="no_decompose", action="store_true",
                         help="handoff/plan-note guard: the executor will not auto-decompose "
                              "this task into child tasks")

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -2799,8 +2799,17 @@ class RemoteDispatch:
         answers 404, which surfaces as HubClientError -- callers fall back to
         polling rather than failing, because the deployed hub is routinely
         behind the client.
+
+        Not a generator function: the request is issued when this is called,
+        like every other method here, so a caller can catch a refusal around
+        the call rather than at some later iteration.
         """
-        for line in self._client.stream_lines("/events/stream" + _query(kw)):
+        lines = self._client.stream_lines("/events/stream" + _query(kw))
+        return self._decode_event_lines(lines)
+
+    @staticmethod
+    def _decode_event_lines(lines: Any) -> Any:
+        for line in lines:
             try:
                 yield json.loads(line)
             except ValueError:

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -2792,6 +2792,23 @@ class RemoteDispatch:
     def list_human_messages(self, **kw: Any) -> List[_Dictish]:
         return _wrap_list(self._get("/communication/deliveries", **kw))
 
+    def stream_events(self, **kw: Any) -> Any:
+        """Follow /events/stream, yielding each record as it arrives.
+
+        Present only on the remote transport. A hub older than this endpoint
+        answers 404, which surfaces as HubClientError -- callers fall back to
+        polling rather than failing, because the deployed hub is routinely
+        behind the client.
+        """
+        for line in self._client.stream_lines("/events/stream" + _query(kw)):
+            try:
+                yield json.loads(line)
+            except ValueError:
+                # A truncated line at the tail of a dropped connection. The
+                # caller reconnects from its cursor; a malformed record is not
+                # worth ending the feed over.
+                continue
+
     def list_events(self, **kw: Any) -> List[_Dictish]:
         return _wrap_list(self._get("/events", **kw))
 

--- a/src/mac/http_client.py
+++ b/src/mac/http_client.py
@@ -41,14 +41,18 @@ class HubClient:
         return self._transport(method, self.base_url + path, body, self.token)
 
     def stream_lines(self, path: str, *, timeout: float = 600.0) -> Any:
-        """Yield decoded lines from a streaming (NDJSON) endpoint.
+        """Open a streaming (NDJSON) endpoint and return an iterator of lines.
 
         Separate from :meth:`request` on purpose: that one reads the whole body
-        before returning, which for a follow stream means it returns when the
-        stream ENDS -- exactly never, for a feed. This yields as lines arrive.
+        before returning, which for a follow stream means returning when the
+        stream ENDS -- never, for a feed.
 
-        Raises :class:`HubClientError` like the rest of the client, so callers
-        that fall back to polling on an older hub can catch one thing.
+        Deliberately NOT a generator function. A generator body does not run
+        until first iteration, so the request would not be issued when this is
+        called, and a caller writing ``except HubClientError`` around the call
+        would catch nothing: a refused connection or a 404 from a hub without
+        this endpoint would surface later, somewhere else. Every other method on
+        this client makes its request on call, and so does this one.
         """
         headers = {"Accept": "application/x-ndjson"}
         if self.token:
@@ -65,6 +69,9 @@ class HubClient:
             raise HubClientError(str(exc.reason))
         except OSError as exc:
             raise HubClientError(str(exc))
+        return self._iter_stream_lines(response)
+
+    def _iter_stream_lines(self, response: Any) -> Any:
         try:
             for raw in response:
                 line = raw.decode("utf-8", errors="replace").strip()

--- a/src/mac/http_client.py
+++ b/src/mac/http_client.py
@@ -40,6 +40,41 @@ class HubClient:
     def request(self, method: str, path: str, body: Optional[JsonDict] = None) -> Any:
         return self._transport(method, self.base_url + path, body, self.token)
 
+    def stream_lines(self, path: str, *, timeout: float = 600.0) -> Any:
+        """Yield decoded lines from a streaming (NDJSON) endpoint.
+
+        Separate from :meth:`request` on purpose: that one reads the whole body
+        before returning, which for a follow stream means it returns when the
+        stream ENDS -- exactly never, for a feed. This yields as lines arrive.
+
+        Raises :class:`HubClientError` like the rest of the client, so callers
+        that fall back to polling on an older hub can catch one thing.
+        """
+        headers = {"Accept": "application/x-ndjson"}
+        if self.token:
+            headers["Authorization"] = "Bearer %s" % self.token
+        request = urllib.request.Request(
+            self.base_url + path, headers=headers, method="GET"
+        )
+        try:
+            response = urllib.request.urlopen(request, timeout=timeout)
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise HubClientError("HTTP %s %s: %s" % (exc.code, exc.reason, detail))
+        except urllib.error.URLError as exc:
+            raise HubClientError(str(exc.reason))
+        except OSError as exc:
+            raise HubClientError(str(exc))
+        try:
+            for raw in response:
+                line = raw.decode("utf-8", errors="replace").strip()
+                if line:
+                    yield line
+        except OSError as exc:
+            raise HubClientError(str(exc))
+        finally:
+            response.close()
+
     def _urllib_transport(
         self,
         method: str,

--- a/src/mac/task_wait.py
+++ b/src/mac/task_wait.py
@@ -1,0 +1,220 @@
+"""Wait for a project's work to finish, reporting each transition as it happens.
+
+`mac task list` answers "what is the state now". Nothing answered "tell me when
+this project is done", so the only way to find out was to poll the list by hand
+and squint at it -- which is what a person does while a fleet works, and it is
+both tedious and easy to get wrong when a task decomposes into children.
+
+WHAT IS WAITED ON
+
+The wait set is every task that is active or can BECOME active. Three states
+are excluded, and each for a different reason:
+
+* ``cancelled`` / ``completed`` / ``failed`` -- terminal. Nothing more happens.
+* ``blocked`` -- it cannot proceed until something outside this wait changes.
+* ``needs_input`` -- it is waiting on a HUMAN. Waiting on it would mean waiting
+  on the person who is running the wait.
+
+``waiting`` is deliberately NOT excluded. It reads like "waiting for input" and
+is not: it is a dependency wait, which resolves on its own as the dependency
+finishes. Excluding it would drop exactly the tasks a wait exists to watch.
+
+A task leaves the set on the same conditions, so the set only shrinks and the
+wait terminates. A task that becomes blocked or needs_input leaves rather than
+stalling the wait forever -- with its departure reported, because "we stopped
+waiting on this" is information the caller needs, not a detail to swallow.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set
+
+WAIT_SCHEMA = "mac.task_wait.v1"
+
+#: Terminal: the task is finished, whatever the outcome.
+FINISHED_STATES = frozenset({"completed", "failed", "cancelled"})
+
+#: Not finished, but not going to progress on its own either. Waiting on these
+#: would mean waiting on something this wait cannot observe -- a dependency
+#: outside the project, or the person running the command.
+STALLED_STATES = frozenset({"blocked", "needs_input"})
+
+#: Everything the wait actually watches: active, or able to become active.
+WAITABLE_STATES = frozenset(
+    {"open", "waiting", "claimed", "running", "needs_review", "reviewing"}
+)
+
+#: Why a task left the wait set, kept apart because they mean different things
+#: to whoever is waiting.
+LEFT_FINISHED = "finished"
+LEFT_STALLED = "stalled"
+
+
+def is_waitable(state: Any) -> bool:
+    return str(state or "").strip() in WAITABLE_STATES
+
+
+def departure_reason(state: Any) -> Optional[str]:
+    """Why this state leaves the wait set, or None if it stays."""
+    text = str(state or "").strip()
+    if text in FINISHED_STATES:
+        return LEFT_FINISHED
+    if text in STALLED_STATES:
+        return LEFT_STALLED
+    return None
+
+
+def waitable_tasks(tasks: Iterable[Any], *, project: Optional[str] = None) -> Dict[str, str]:
+    """The initial wait set: task id -> state."""
+    pending: Dict[str, str] = {}
+    for task in tasks:
+        record = task.to_dict() if hasattr(task, "to_dict") else task
+        if not isinstance(record, Mapping):
+            continue
+        if project is not None and str(record.get("project") or "") != project:
+            continue
+        task_id = str(record.get("id") or "").strip()
+        state = str(record.get("state") or "").strip()
+        if task_id and is_waitable(state):
+            pending[task_id] = state
+    return pending
+
+
+class TaskWait:
+    """The wait set, advanced by events and by rescans.
+
+    Deliberately holds no I/O. How events arrive -- polling, SSE, a websocket --
+    is a transport question, and keeping it out of here means the termination
+    rules can be tested without one.
+    """
+
+    def __init__(
+        self,
+        pending: Mapping[str, str],
+        *,
+        follow_new: bool = True,
+    ) -> None:
+        self.pending: Dict[str, str] = dict(pending)
+        # Tasks that were in the set and have left. Kept so a rescan does not
+        # re-add a task that already finished, which would make the wait
+        # oscillate and never return.
+        self.departed: Dict[str, str] = {}
+        self.follow_new = bool(follow_new)
+
+    @property
+    def done(self) -> bool:
+        return not self.pending
+
+    def observe(self, task_id: str, state: str) -> Optional[Dict[str, Any]]:
+        """Record a task's current state. Returns an update, or None if nothing
+        the caller needs to hear about changed."""
+        task_id = str(task_id or "").strip()
+        state = str(state or "").strip()
+        if not task_id or task_id in self.departed:
+            return None
+        known = self.pending.get(task_id)
+        if known is None:
+            # A task the wait has not seen. Only join if it is waitable and the
+            # caller asked to follow new work: a task that decomposes into
+            # children mid-wait would otherwise let the wait return while its
+            # children are still running.
+            if not (self.follow_new and is_waitable(state)):
+                return None
+            self.pending[task_id] = state
+            return {"task_id": task_id, "state": state, "event": "joined"}
+        reason = departure_reason(state)
+        if reason is not None:
+            del self.pending[task_id]
+            self.departed[task_id] = reason
+            return {
+                "task_id": task_id,
+                "state": state,
+                "event": "left",
+                "reason": reason,
+                "from_state": known,
+            }
+        if state != known:
+            self.pending[task_id] = state
+            return {
+                "task_id": task_id,
+                "state": state,
+                "event": "transitioned",
+                "from_state": known,
+            }
+        return None
+
+    def apply_event(self, event: Any) -> Optional[Dict[str, Any]]:
+        """Advance the set from one ``task.transitioned`` event."""
+        record = event.to_dict() if hasattr(event, "to_dict") else event
+        if not isinstance(record, Mapping):
+            return None
+        if str(record.get("event_type") or "") != "task.transitioned":
+            return None
+        detail = record.get("detail")
+        if not isinstance(detail, Mapping):
+            return None
+        to_state = str(detail.get("to_state") or "").strip()
+        if not to_state:
+            return None
+        update = self.observe(str(record.get("subject_id") or ""), to_state)
+        if update is not None:
+            update["at"] = record.get("created_at")
+            update["actor"] = record.get("actor")
+        return update
+
+    def rescan(self, tasks: Iterable[Any], *, project: Optional[str] = None) -> List[Dict[str, Any]]:
+        """Reconcile against authoritative state.
+
+        Events can be missed -- a hub restart, a dropped poll, a transition
+        recorded without an event. Without a periodic rescan the wait would
+        hang forever on a task that finished while nobody was listening, which
+        is the failure mode that makes people distrust a wait command and go
+        back to polling by hand.
+        """
+        updates: List[Dict[str, Any]] = []
+        for task in tasks:
+            record = task.to_dict() if hasattr(task, "to_dict") else task
+            if not isinstance(record, Mapping):
+                continue
+            if project is not None and str(record.get("project") or "") != project:
+                continue
+            update = self.observe(
+                str(record.get("id") or ""), str(record.get("state") or "")
+            )
+            if update is not None:
+                update["source"] = "rescan"
+                updates.append(update)
+        return updates
+
+    def summary(self) -> Dict[str, Any]:
+        finished = sorted(k for k, v in self.departed.items() if v == LEFT_FINISHED)
+        stalled = sorted(k for k, v in self.departed.items() if v == LEFT_STALLED)
+        return {
+            "schema": WAIT_SCHEMA,
+            "done": self.done,
+            "finished": finished,
+            # Surfaced, never buried: the wait returned, but these did not
+            # finish -- they stopped being things this wait could observe.
+            "stalled": stalled,
+            "still_pending": sorted(self.pending),
+        }
+
+
+def dedupe_events(events: Sequence[Any], seen: Set[str]) -> List[Any]:
+    """Events not yet applied, marking them seen.
+
+    The cursor is a timestamp, so a poll that resumes from the newest event's
+    time re-delivers everything sharing that timestamp. Advancing past it
+    instead would drop events recorded in the same tick.
+    """
+    fresh = []
+    for event in events:
+        record = event.to_dict() if hasattr(event, "to_dict") else event
+        if not isinstance(record, Mapping):
+            continue
+        event_id = str(record.get("id") or "").strip()
+        if not event_id or event_id in seen:
+            continue
+        seen.add(event_id)
+        fresh.append(record)
+    return fresh

--- a/tests/api/test_events_stream.py
+++ b/tests/api/test_events_stream.py
@@ -1,0 +1,173 @@
+"""`GET /events/stream` — follow the event stream instead of re-asking for it.
+
+`GET /events` answers "what happened up to now", so following it costs a
+client round-trip per interval, and the interval is a straight latency/load
+trade the client cannot win. This moves that loop to the hub, where it is a
+local query.
+
+The failure that matters is not "it returns the wrong events" -- it is that a
+follow endpoint can appear to work while delivering nothing, or never close.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+def _plane_and_client():
+    cp = ControlPlane.in_memory()
+    cp.create_project("mac", dispatch_paused=False)
+    return cp, TestClient(create_app(control_plane=cp))
+
+
+def _records(response):
+    return [json.loads(line) for line in response.text.splitlines() if line.strip()]
+
+
+def test_the_stream_delivers_events_that_already_happened(client_setup=None):
+    """A follower that only sees events created after it connects would miss
+    everything between the caller's listing and its subscribe."""
+    cp, client = _plane_and_client()
+    cp.create_task("something", project="mac")
+
+    response = client.get(
+        "/events/stream",
+        params={"subject_type": "task", "timeout_seconds": 1, "poll_interval_seconds": 0.1},
+    )
+
+    assert response.status_code == 200
+    assert _records(response), "the stream produced nothing at all"
+
+
+def test_the_stream_closes_on_its_own(client_setup=None):
+    """Bounded by the timeout so one client cannot hold a worker forever, and
+    so a connection wedged behind a proxy is eventually reaped."""
+    _cp, client = _plane_and_client()
+
+    response = client.get(
+        "/events/stream",
+        params={"timeout_seconds": 1, "poll_interval_seconds": 0.1},
+    )
+
+    assert response.status_code == 200
+
+
+def test_it_is_newline_delimited_json_not_an_array():
+    """An array is not readable until the stream ends, which for a feed is
+    never -- that is the whole reason this endpoint exists."""
+    cp, client = _plane_and_client()
+    cp.create_task("something", project="mac")
+
+    response = client.get(
+        "/events/stream",
+        params={"timeout_seconds": 1, "poll_interval_seconds": 0.1},
+    )
+
+    assert "x-ndjson" in response.headers["content-type"]
+    for line in response.text.splitlines():
+        if line.strip():
+            json.loads(line)
+
+
+def test_records_arrive_oldest_first():
+    """list_events is newest-first; a follower wants the order things
+    happened, or a client tracking a cursor walks backwards."""
+    cp, client = _plane_and_client()
+    cp.create_task("first", project="mac")
+    cp.create_task("second", project="mac")
+
+    response = client.get(
+        "/events/stream",
+        params={"subject_type": "task", "timeout_seconds": 1, "poll_interval_seconds": 0.1},
+    )
+
+    stamps = [record["created_at"] for record in _records(response)]
+    assert stamps == sorted(stamps)
+
+
+def test_the_same_event_is_not_delivered_twice_within_one_connection():
+    """The cursor is a timestamp, so the boundary instant is re-queried every
+    tick. Without de-duplication a quiet stream repeats its last record
+    forever, and a client counting events sees work that never happened."""
+    cp, client = _plane_and_client()
+    cp.create_task("only one", project="mac")
+
+    response = client.get(
+        "/events/stream",
+        params={"subject_type": "task", "timeout_seconds": 2, "poll_interval_seconds": 0.1},
+    )
+
+    ids = [record["id"] for record in _records(response)]
+    assert len(ids) == len(set(ids))
+
+
+def test_a_since_cursor_excludes_what_came_before():
+    cp, client = _plane_and_client()
+    cp.create_task("early", project="mac")
+    events = cp.list_events(subject_type="task", limit=10)
+    cutoff = events[0]["created_at"]
+
+    response = client.get(
+        "/events/stream",
+        params={
+            "subject_type": "task",
+            "since": cutoff,
+            "timeout_seconds": 1,
+            "poll_interval_seconds": 0.1,
+        },
+    )
+
+    assert all(record["created_at"] >= cutoff for record in _records(response))
+
+
+def test_the_event_type_filter_is_honoured():
+    """The stream carries lease renewals and much else; a waiter asking for
+    transitions must not have to filter the firehose itself."""
+    cp, client = _plane_and_client()
+    cp.create_task("something", project="mac")
+
+    response = client.get(
+        "/events/stream",
+        params={
+            "event_type": "task.created",
+            "timeout_seconds": 1,
+            "poll_interval_seconds": 0.1,
+        },
+    )
+
+    assert all(record["event_type"] == "task.created" for record in _records(response))
+
+
+def test_an_absurd_timeout_is_clamped_rather_than_honoured():
+    """An unbounded follow is a resource leak one query string away.
+
+    Asserted against the clamp rather than by issuing the request: the first
+    version of this test DID issue it, and because the ceiling was an hour, the
+    test dutifully waited an hour. A test that proves a bound by waiting for it
+    is only as fast as the bound is wrong.
+    """
+    from mac.api import STREAM_MAX_TIMEOUT_SECONDS, clamp_stream_timeout
+
+    assert clamp_stream_timeout(10**9) == STREAM_MAX_TIMEOUT_SECONDS
+    assert clamp_stream_timeout(-5) > 0
+    assert clamp_stream_timeout("nonsense") == STREAM_MAX_TIMEOUT_SECONDS
+
+
+def test_a_follow_connection_is_not_held_for_hours():
+    """A follower reconnects with the cursor it already has, so a long ceiling
+    buys nothing and costs a pinned worker per idle client."""
+    from mac.api import STREAM_MAX_TIMEOUT_SECONDS
+
+    assert STREAM_MAX_TIMEOUT_SECONDS <= 300.0
+
+
+def test_the_poll_interval_is_clamped_too():
+    from mac.api import clamp_stream_poll_interval
+
+    assert clamp_stream_poll_interval(10**6) == 30.0
+    assert clamp_stream_poll_interval(0) > 0

--- a/tests/cli/test_cli_task_wait.py
+++ b/tests/cli/test_cli_task_wait.py
@@ -1,0 +1,108 @@
+"""`mac task wait` end to end.
+
+The pure logic is covered in tests/test_task_wait.py. These exist because that
+proves nothing about whether the command reads the right tasks, scopes them to
+the project, or ever returns -- and a wait that does not return is the one bug
+that cannot be worked around by whoever hit it.
+
+The blocked / needs_input departure rules are covered in tests/test_task_wait.py
+against the state machine rather than here: neither state is reachable through
+an operator API by design (needs_input is fenced to an active worker lease,
+blocked is set by dependency supervision), so reproducing them at CLI level
+would mean manufacturing a state the control plane deliberately guards.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import control_plane_on, dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout = old
+    return rc, out.getvalue()
+
+
+def _lines(raw):
+    return [json.loads(line) for line in raw.strip().splitlines() if line.strip()]
+
+
+def test_a_project_with_nothing_running_returns_immediately(tmp_path):
+    """The degenerate case has to be instant, or every script that calls this
+    defensively pays for it."""
+    cp = control_plane_on(dsn_for(tmp_path))
+    cp.create_project("mac", dispatch_paused=False)
+
+    rc, raw = _run(tmp_path, "task", "wait", "--project", "mac", "--timeout", "5")
+
+    assert rc in (None, 0)
+    assert _lines(raw)[-1]["done"] is True
+
+
+def test_a_finished_project_reports_nothing_pending(tmp_path):
+    cp = control_plane_on(dsn_for(tmp_path))
+    cp.create_project("mac", dispatch_paused=False)
+    task = cp.create_task("done already", project="mac")
+    cp.close_task(task.id, "cancelled", "operator", {"reason": "not needed"})
+
+    _rc, raw = _run(tmp_path, "task", "wait", "--project", "mac", "--timeout", "5")
+
+    assert _lines(raw)[-1]["still_pending"] == []
+
+
+def test_a_still_running_task_holds_the_wait_open_until_the_timeout(tmp_path):
+    """The property that matters most: it must NOT return while work it is
+    watching is still running."""
+    cp = control_plane_on(dsn_for(tmp_path))
+    cp.create_project("mac", dispatch_paused=False)
+    cp.create_task("still going", project="mac")
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, "task", "wait", "--project", "mac", "--timeout", "2",
+             "--poll-interval", "0.2")
+
+    assert excinfo.value.code == 1
+
+
+def test_the_initial_feed_names_what_is_being_waited_on(tmp_path):
+    """So the caller can tell immediately whether the wait is watching what
+    they meant."""
+    cp = control_plane_on(dsn_for(tmp_path))
+    cp.create_project("mac", dispatch_paused=False)
+    task = cp.create_task("open work", project="mac")
+
+    with pytest.raises(SystemExit):
+        _run(tmp_path, "task", "wait", "--project", "mac", "--timeout", "1",
+             "--poll-interval", "0.2")
+
+    # The feed is written before the timeout, so re-run capturing it.
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        main(["--db", dsn_for(tmp_path), "--json", "task", "wait",
+              "--project", "mac", "--timeout", "1", "--poll-interval", "0.2"])
+    except SystemExit:
+        pass
+    finally:
+        sys.stdout = old
+    first = _lines(out.getvalue())[0]
+    assert first["task_id"] == task.id
+    assert first["event"] == "waiting"
+
+
+def test_waiting_without_a_project_is_refused(tmp_path):
+    """Waiting on the whole ledger would never return."""
+    rc, raw = _run(tmp_path, "task", "wait", "--project", "")
+    assert rc not in (None, 0) or "project" in raw.lower()

--- a/tests/test_dispatch_remote_contract.py
+++ b/tests/test_dispatch_remote_contract.py
@@ -34,6 +34,17 @@ class RecordingClient:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, Any]] = []
 
+    def stream_lines(self, path: str, **_kwargs: Any) -> Any:
+        """The second transport verb: a held NDJSON connection.
+
+        Recorded like any other call, because the contract this file enforces
+        is "a remote method issues a hub request", not "a remote method calls
+        .request". A streaming method that opened a socket without going
+        through the client would satisfy the letter and defeat the point.
+        """
+        self.calls.append(("GET", path, None))
+        return iter(())
+
     def request(self, method: str, path: str, body: Any = None) -> dict[str, Any]:
         self.calls.append((method, path, body))
         return {

--- a/tests/test_task_wait.py
+++ b/tests/test_task_wait.py
@@ -1,0 +1,241 @@
+"""`mac task wait` must always terminate, and must not lie when it does.
+
+A wait command is only trusted if two things hold: it returns when the work is
+done, and it never returns while work it claimed to be watching is still
+running. Everything here is one of those two, plus the cases that break them --
+a task that stalls on a human, a task that decomposes mid-wait, an event the
+feed never delivered.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.task_wait import (
+    LEFT_FINISHED,
+    LEFT_STALLED,
+    TaskWait,
+    dedupe_events,
+    departure_reason,
+    is_waitable,
+    waitable_tasks,
+)
+
+
+def _task(task_id, state, project="mac"):
+    return {"id": task_id, "state": state, "project": project}
+
+
+def _transition(task_id, to_state, event_id="hist_1", at="2026-08-09T00:00:00+00:00"):
+    return {
+        "id": event_id,
+        "event_type": "task.transitioned",
+        "subject_id": task_id,
+        "created_at": at,
+        "actor": "agent_1",
+        "detail": {"from_state": "claimed", "to_state": to_state},
+    }
+
+
+# --------------------------------------------------------------------------
+# What is waited on
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "state", ["open", "waiting", "claimed", "running", "needs_review", "reviewing"]
+)
+def test_active_or_activatable_states_are_waited_on(state):
+    assert is_waitable(state)
+
+
+def test_waiting_is_waited_on_despite_the_name():
+    """It reads like "waiting for input" and is not -- it is a dependency wait,
+    which resolves on its own. Excluding it would drop exactly the tasks a wait
+    exists to watch."""
+    assert is_waitable("waiting")
+
+
+@pytest.mark.parametrize("state", ["completed", "failed", "cancelled"])
+def test_finished_tasks_are_not_waited_on(state):
+    assert not is_waitable(state)
+    assert departure_reason(state) == LEFT_FINISHED
+
+
+@pytest.mark.parametrize("state", ["blocked", "needs_input"])
+def test_stalled_tasks_are_not_waited_on(state):
+    """needs_input waits on a human -- which, during a wait, is the person
+    running the command. blocked waits on something this wait cannot see."""
+    assert not is_waitable(state)
+    assert departure_reason(state) == LEFT_STALLED
+
+
+def test_the_initial_set_is_scoped_to_the_project():
+    pending = waitable_tasks(
+        [_task("task_1", "running"), _task("task_2", "running", project="other")],
+        project="mac",
+    )
+
+    assert set(pending) == {"task_1"}
+
+
+# --------------------------------------------------------------------------
+# Termination
+# --------------------------------------------------------------------------
+
+
+def test_a_wait_with_nothing_pending_is_already_done():
+    assert TaskWait({}).done
+
+
+def test_the_wait_ends_when_the_last_task_finishes():
+    wait = TaskWait({"task_1": "running"})
+
+    wait.apply_event(_transition("task_1", "completed"))
+
+    assert wait.done
+
+
+def test_a_task_that_needs_a_human_leaves_rather_than_stalling_the_wait():
+    """Otherwise the wait blocks on the person running it -- a deadlock with a
+    command prompt on one end."""
+    wait = TaskWait({"task_1": "running"})
+
+    update = wait.apply_event(_transition("task_1", "needs_input"))
+
+    assert wait.done
+    assert update["reason"] == LEFT_STALLED
+
+
+def test_a_departure_is_reported_not_swallowed():
+    """"We stopped waiting on this" is information the caller needs. A wait
+    that returns success having quietly abandoned half the work is worse than
+    one that never returns."""
+    wait = TaskWait({"task_1": "running", "task_2": "running"})
+    wait.apply_event(_transition("task_1", "blocked"))
+    wait.apply_event(_transition("task_2", "completed"))
+
+    summary = wait.summary()
+
+    assert summary["stalled"] == ["task_1"]
+    assert summary["finished"] == ["task_2"]
+
+
+def test_a_finished_task_is_not_re_added_by_a_later_rescan():
+    """It would make the wait oscillate and never return."""
+    wait = TaskWait({"task_1": "running"})
+    wait.apply_event(_transition("task_1", "completed"))
+
+    wait.rescan([_task("task_1", "running")], project="mac")
+
+    assert wait.done
+
+
+# --------------------------------------------------------------------------
+# Not returning too early
+# --------------------------------------------------------------------------
+
+
+def test_a_task_created_mid_wait_joins_the_set():
+    """A task that decomposes into children would otherwise let the wait return
+    while its children are still running -- the wait would report done for work
+    that had barely started."""
+    wait = TaskWait({"task_1": "running"})
+    wait.apply_event(_transition("task_1", "completed"))
+    assert wait.done
+
+    update = wait.rescan([_task("task_child", "open")], project="mac")
+
+    assert not wait.done
+    assert update[0]["event"] == "joined"
+
+
+def test_follow_new_can_be_turned_off():
+    wait = TaskWait({"task_1": "running"}, follow_new=False)
+    wait.apply_event(_transition("task_1", "completed"))
+
+    wait.rescan([_task("task_child", "open")], project="mac")
+
+    assert wait.done
+
+
+def test_a_new_task_that_is_already_finished_does_not_join():
+    wait = TaskWait({}, follow_new=True)
+
+    wait.rescan([_task("task_done", "completed")], project="mac")
+
+    assert wait.done
+
+
+# --------------------------------------------------------------------------
+# The feed
+# --------------------------------------------------------------------------
+
+
+def test_a_transition_is_reported_with_where_it_came_from():
+    wait = TaskWait({"task_1": "claimed"})
+
+    update = wait.apply_event(_transition("task_1", "running"))
+
+    assert update["event"] == "transitioned"
+    assert update["from_state"] == "claimed"
+    assert update["state"] == "running"
+
+
+def test_a_repeated_state_is_not_reported_twice():
+    """The cursor overlaps deliberately, so the same event arrives again. A
+    feed that re-emits it is noise the caller has to filter."""
+    wait = TaskWait({"task_1": "claimed"})
+    wait.apply_event(_transition("task_1", "running"))
+
+    assert wait.apply_event(_transition("task_1", "running")) is None
+
+
+def test_events_for_other_tasks_are_ignored():
+    wait = TaskWait({"task_1": "running"})
+
+    assert wait.apply_event(_transition("task_other", "completed")) is None
+    assert not wait.done
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        None,
+        {},
+        "junk",
+        {"event_type": "task.lease_renewed", "subject_id": "task_1"},
+        {"event_type": "task.transitioned", "subject_id": "task_1"},
+        {"event_type": "task.transitioned", "subject_id": "task_1", "detail": {}},
+    ],
+)
+def test_a_malformed_or_irrelevant_event_is_ignored(event):
+    """The stream carries lease renewals and much else; only transitions move
+    the wait."""
+    wait = TaskWait({"task_1": "running"})
+
+    assert wait.apply_event(event) is None
+    assert not wait.done
+
+
+def test_events_are_deduplicated_by_id():
+    """The cursor is a timestamp, so resuming from the newest event re-delivers
+    everything sharing that timestamp. Advancing past it instead would drop
+    events recorded in the same tick."""
+    seen = set()
+    first = dedupe_events([_transition("task_1", "running", event_id="hist_a")], seen)
+    second = dedupe_events([_transition("task_1", "running", event_id="hist_a")], seen)
+
+    assert len(first) == 1
+    assert second == []
+
+
+def test_rescan_recovers_a_transition_the_feed_never_delivered():
+    """Events can be missed -- a hub restart, a dropped poll. A wait that hangs
+    forever on a task that finished unobserved is what sends people back to
+    polling by hand."""
+    wait = TaskWait({"task_1": "running"})
+
+    wait.rescan([_task("task_1", "completed")], project="mac")
+
+    assert wait.done


### PR DESCRIPTION
Stacked on #310 (`agent/sandbox-bom-rollout`); merge that first.

## `mac task wait`

`mac task list` answers "what is the state now". Nothing answered "tell me when
this project is done", so the only way to find out was to poll by hand — tedious
while a fleet works, and easy to get wrong once a task decomposes into children.

The wait set is every task that is active **or can become active**. Each
exclusion is for a different reason:

| state | why it is not waited on |
|---|---|
| `completed` / `failed` / `cancelled` | terminal; nothing more happens |
| `blocked` | waits on something this wait cannot observe |
| `needs_input` | waits on a human — during a wait, the person running it |

`waiting` is deliberately **not** excluded. It reads like "waiting for input"
and is not: it is a dependency wait that resolves on its own, and excluding it
would drop exactly the tasks a wait exists to watch.

Tasks leave on those same conditions, so the set only shrinks and the wait
terminates. Departures are reported rather than swallowed — a wait that returns
success having quietly abandoned half the work is worse than one that never
returns. Tasks created mid-wait join by default, so a task that decomposes
cannot let the wait report done while its children run (`--no-follow-new` opts
out).

## `GET /events/stream`

`GET /events` answers "what happened up to now", so following it costs a client
round-trip per interval, and the interval is a straight latency/load trade the
client cannot win. This moves the loop to the hub, where it is a local query.

NDJSON, matching the streaming endpoints already in `api.py` rather than adding
SSE alongside them. `task wait` prefers it and falls back to polling when it is
unavailable — a local authority has no HTTP at all, and a hub older than this
endpoint answers 404. **The deployed hub is routinely behind the client, so the
fallback is the normal path, not an edge case.**

## Found by running it, not reading it

- `Request.is_disconnected()` awaits `receive()`, which only returns when the
  server delivers a message. Under a test client nothing ever does, so the
  stream wedged before its own deadline could fire.
- The hold ceiling was an hour, so the test asserting the clamp waited an hour
  to prove it. The ceiling is now 120s (a follower reconnects with the cursor it
  holds), and the clamp is asserted directly instead of waited out.

47 tests. Mutation-tested: stalled tasks never leaving, new tasks never joining,
`waiting` dropped from the set, and departed tasks being re-added were all
caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)