### PR TITLE
Serve `mac sandbox rollout` over the hub, not only --db

### DIFF
--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -317,6 +317,7 @@ request and response definitions.
 | `POST` | `/runtime-runs/{run_id}/complete` | Complete Runtime Run |
 | `GET` | `/runtimes` | List Runtimes |
 | `POST` | `/runtimes` | Create Runtime |
+| `POST` | `/sandbox/rollout` | Roll Out Sandbox Image |
 | `GET` | `/secret-audits` | List Secret Audits |
 | `GET` | `/secrets` | List Secrets |
 | `POST` | `/secrets` | Create Secret |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1666,6 +1666,13 @@ class DashboardTerminalClose(BaseModel):
     sender_agent_id: Optional[str] = None
 
 
+class SandboxRolloutRequest(BaseModel):
+    image: str
+    bom: Optional[Dict[str, Any]] = None
+    project: Optional[str] = None
+    actor: Optional[str] = None
+
+
 class ObservabilityMetricCreate(BaseModel):
     name: str
     value: float
@@ -8303,6 +8310,21 @@ def create_app(
             since=since,
             until=until,
             limit=limit,
+        )
+
+    @app.post("/sandbox/rollout")
+    def roll_out_sandbox_image(body: SandboxRolloutRequest) -> Dict[str, Any]:
+        """File one drained-worker barrier task per agent for a reviewed image.
+
+        Served over HTTP because the hub is how the fleet is actually operated.
+        Without this the command worked only against a direct --db authority,
+        which is the maintenance path, not the one anybody uses.
+        """
+        return cp.roll_out_sandbox_image(
+            body.image,
+            bom=body.bom or {},
+            actor=body.actor or "human",
+            project=body.project,
         )
 
     @app.get("/events/stream")

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -2792,6 +2792,26 @@ class RemoteDispatch:
     def list_human_messages(self, **kw: Any) -> List[_Dictish]:
         return _wrap_list(self._get("/communication/deliveries", **kw))
 
+    def roll_out_sandbox_image(
+        self,
+        image_ref: str,
+        *,
+        bom: Optional[Dict[str, Any]] = None,
+        actor: str = "human",
+        project: Optional[str] = None,
+    ) -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/sandbox/rollout",
+                {
+                    "image": image_ref,
+                    "bom": bom or {},
+                    "actor": actor,
+                    "project": project,
+                },
+            )
+        )
+
     def stream_events(self, **kw: Any) -> Any:
         """Follow /events/stream, yielding each record as it arrives.
 

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -1595,6 +1595,14 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
         return RequestCase(path, kwargs, expected)
 
     bodies: Dict[RouteKey, Dict[str, Any]] = {
+        # A syntactically valid reviewed digest. The endpoint refuses anything
+        # that is not one, so a placeholder here would exercise only the
+        # rejection path and leave the route effectively uncovered.
+        ("POST", "/sandbox/rollout"): {
+            "image": "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:%s" % ("a" * 64),
+            "bom": {},
+            "actor": "route-coverage",
+        },
         # Dry run: exercise the route without re-supervising live tasks in the
         # coverage fixture.
         ("POST", "/tasks/recover-stranded"): {"dry_run": True, "limit": 1},

--- a/tests/test_sandbox_rollout_hub_parity.py
+++ b/tests/test_sandbox_rollout_hub_parity.py
@@ -1,0 +1,89 @@
+"""`mac sandbox rollout` must work through the hub, not only against --db.
+
+LocalDispatch forwards unknown methods to ControlPlane via __getattr__, so a
+new control-plane method is reachable in --db mode the moment it exists.
+RemoteDispatch has explicit methods only, so the same method is missing over
+HTTP until someone adds it.
+
+That asymmetry made `mac sandbox rollout` work in every test (they all use
+--db) and fail against the hub, which is how the fleet is actually operated.
+These tests close it for the rollout and assert the shape of the gap so the
+next command does not repeat it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.dispatch import RemoteDispatch
+from mac.sandbox_rollout import ROLLOUT_METADATA_KEY
+from mac.services import ControlPlane
+
+DIGEST = "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64
+
+
+class _ClientOverHttp:
+    """HubClient surface backed by the in-process app."""
+
+    def __init__(self, client):
+        self._client = client
+
+    def request(self, method, path, body=None):
+        response = self._client.request(method, path, json=body)
+        response.raise_for_status()
+        return response.json()
+
+
+@pytest.fixture()
+def remote():
+    cp = ControlPlane.in_memory()
+    cp.create_project("mac", dispatch_paused=False)
+    machine = cp.register_machine("parity-host")
+    cp.register_agent(machine.id, "worker1")
+    app = create_app(control_plane=cp)
+    return cp, RemoteDispatch(_ClientOverHttp(TestClient(app)))
+
+
+def test_the_rollout_is_reachable_over_http(remote):
+    """The failure this file exists for: AttributeError against a real hub."""
+    _cp, dispatch = remote
+
+    result = dispatch.roll_out_sandbox_image(DIGEST)
+
+    assert len(result["filed"]) == 1
+
+
+def test_the_barrier_task_is_real_on_the_hub_side(remote):
+    """Filed through HTTP must produce the same sync task as filing locally --
+    otherwise the endpoint is a stub that reports success."""
+    cp, dispatch = remote
+
+    result = dispatch.roll_out_sandbox_image(DIGEST)
+    task = cp.get_task(result["filed"][0])
+
+    assert task.metadata["execution_mode"] == "sync"
+    assert task.metadata[ROLLOUT_METADATA_KEY]["image"] == DIGEST
+
+
+def test_a_bad_image_is_refused_over_http_too(remote):
+    """The digest rule must not be enforced only on the client side, or the
+    hub becomes the weaker door into the security boundary."""
+    _cp, dispatch = remote
+
+    with pytest.raises(Exception):
+        dispatch.roll_out_sandbox_image("ghcr.io/jordanhubbard/mac-openshell-runtime:latest")
+
+
+def test_remote_dispatch_exposes_the_sandbox_surface_the_cli_calls():
+    """A guard on the asymmetry itself.
+
+    Every ControlPlane method the sandbox CLI invokes has to exist on
+    RemoteDispatch; --db mode gets them for free and hides their absence.
+    """
+    for name in ("roll_out_sandbox_image", "list_project_repositories"):
+        assert hasattr(RemoteDispatch, name), (
+            "%s is missing from RemoteDispatch, so `mac sandbox` breaks against "
+            "a hub while passing every --db test" % name
+        )


### PR DESCRIPTION
Found while trying to run the rollout against the live fleet: `mac sandbox
rollout` raises `AttributeError` against a hub.

`LocalDispatch` forwards unknown methods to `ControlPlane` via `__getattr__`, so
`roll_out_sandbox_image` worked in `--db` mode the moment it existed.
`RemoteDispatch` has explicit methods only, and I never added one. **Every CLI
test for the command used `--db`**, so the whole suite passed while the command
was unusable in the mode anyone actually operates in.

Adds `POST /sandbox/rollout`, the matching `RemoteDispatch` method, and — more
importantly — a test asserting the sandbox surface exists on `RemoteDispatch`,
so the next command added this way fails loudly rather than silently.

The digest rule is enforced hub-side too; validating only in the client would
make the HTTP path the weaker door into the security boundary.

Mutation-tested: removing the remote method (the original bug) fails 3 of the 4
tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)