### PR TITLE
Declare sandbox egress on the project, and stop carrying it fleet-wide

### DIFF
--- a/deploy/openshell/mac-hermes-policy.yaml
+++ b/deploy/openshell/mac-hermes-policy.yaml
@@ -253,42 +253,24 @@ network_policies:
       - { path: /usr/bin/corepack }
       - { path: /usr/local/bin/corepack }
 
-  # --- Declared external read-only APIs (per-repo egress contract; see ADR 0009).
-  # Deny-by-default egress is the right default, but a real app legitimately READS
-  # from external APIs — the allowlist is part of the repo's environment contract,
-  # not a wall. These are the aviation suite's integration data sources. access:
-  # read-only so a confused/compromised --yolo agent cannot exfiltrate through
-  # them (host-allowlisting is the axis: a GET to an untrusted host is still
-  # exfiltration). The fetch is performed by `node` (app/test runtime).
+  # --- Per-repo external APIs are NOT declared here (ADR 0009 §2a). ---
+  # This block used to carry the aviation suite's data sources
+  # (opensky-network.org, aviationweather.gov, tfr.faa.gov) fleet-wide, which
+  # meant every sandbox in the fleet -- including repos with no business
+  # reaching them -- carried that egress. That accumulation is exactly what
+  # ADR 0009 set out to stop, and removing it is where the reduction is
+  # actually collected.
   #
-  # Per-repo egress rendering (ADR 0009 §2a) HAS now landed — see
-  # src/mac/sandbox_egress.py and docs/openshell-sandbox.md. With
-  # MAC_OPENSHELL_TASK_EGRESS=1, hosts like these belong in the owning task's
-  # `metadata.egress_contract.hosts`, which grants them to that repo's sandbox
-  # only. They stay declared fleet-wide here so enabling the feature is not a
-  # prerequisite for the aviation suite; move them per-repo and delete this block
-  # once every consuming task carries its own declaration.
-  aviation_apis:
-    name: aviation-apis
-    endpoints:
-      - host: opensky-network.org   # ADS-B live state vectors (flight-tracker)
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: read-only
-      - host: aviationweather.gov   # SIGMET / AIRMET (hazard layer)
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: read-only
-      - host: tfr.faa.gov           # Temporary Flight Restrictions
-        port: 443
-        protocol: rest
-        enforcement: enforce
-        access: read-only
-    binaries:
-      - { path: /usr/bin/node }
-      - { path: /usr/local/bin/node }
+  # Declare a project's hosts against the PROJECT instead:
+  #     mac project egress grant <project> <host> --reason "..."
+  # The hub projects them onto each assignment at claim time (see
+  # ControlPlane._project_declared_egress), so they reach existing tasks too,
+  # and they are granted read-only at the hub_declared tier. A task's own
+  # metadata.egress_contract is stripped from the assignment: these are
+  # operator policy, not a task author's request.
+  #
+  # Requires MAC_OPENSHELL_TASK_EGRESS=1 on the worker. See
+  # docs/openshell-sandbox.md.
 
   # --- Python package installs for repository bootstrap. ---
   # Repository contracts may legitimately create task-local virtualenvs and run

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -474,6 +474,9 @@ Dispatch:
 Repositories:
   register  register the current checkout, a local path, or GIT_URL[#BRANCH] as a project and create its contract-authoring task
 
+Other:
+  egress  hosts every task in this project may reach from its sandbox
+
 Run `mac project help <subcommand>` for the arguments one takes.
 ```
 

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -3830,6 +3830,112 @@ def cmd_task_wait(args: argparse.Namespace) -> None:
 
     emit(wait.summary())
 
+def _project_egress_block(cp: Any, project: str) -> Dict[str, Any]:
+    """The project's operator-declared egress contract, as a plain dict."""
+    row = cp.store.query_one(
+        "SELECT metadata FROM projects WHERE name = ?", (project,)
+    ) if hasattr(cp, "store") else None
+    if row is None:
+        return {}
+    import json as _json
+
+    try:
+        metadata = _json.loads(row["metadata"] or "{}")
+    except ValueError:
+        return {}
+    block = metadata.get("egress_contract") if isinstance(metadata, dict) else None
+    return dict(block) if isinstance(block, dict) else {}
+
+
+def _write_project_egress(
+    cp: Any, project: str, hosts: List[str], reason: str
+) -> Dict[str, Any]:
+    """Persist the host list at projects.metadata.egress_contract.
+
+    PROJECT level, not task level, and that is the point. A repository has one
+    egress contract and many tasks -- Aviation alone has hundreds -- so declaring
+    it per task would mean re-declaring it forever and missing every task created
+    before the declaration. The hub projects this onto each assignment at claim
+    time, so it reaches existing tasks too.
+
+    It is also the stronger owner: a task's own metadata.egress_contract is
+    written by whoever created the task, whereas this is project policy an
+    operator sets. The assignment projection strips any task-level value.
+    """
+    import json as _json
+
+    row = cp.store.query_one("SELECT metadata FROM projects WHERE name = ?", (project,))
+    if row is None:
+        raise SystemExit("no such project: %s (mac project list)" % project)
+    try:
+        metadata = _json.loads(row["metadata"] or "{}")
+    except ValueError:
+        metadata = {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    block = dict(metadata.get("egress_contract") or {})
+    block["hosts"] = hosts
+    if reason:
+        block["reason"] = reason
+    metadata["egress_contract"] = block
+    cp.store.execute(
+        "UPDATE projects SET metadata = ?, updated_at = ? WHERE name = ?",
+        (_json.dumps(metadata), _utcnow_iso(), project),
+    )
+    return block
+
+
+def _utcnow_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds")
+
+
+def cmd_project_egress_list(args: argparse.Namespace) -> None:
+    """Show the hosts a project declares for sandbox egress."""
+    cp = _plane(args)
+    block = _project_egress_block(cp, args.project)
+    _print(
+        {
+            "project": args.project,
+            "hosts": list(block.get("hosts") or []),
+            "reason": block.get("reason"),
+            # Named so the reader can see WHICH tier these are granted at
+            # without going to read the policy module.
+            "trust_tier": "hub_declared",
+        }
+    )
+
+
+def cmd_project_egress_grant(args: argparse.Namespace) -> None:
+    """Allow one host for every task in a project."""
+    from mac.sandbox_egress import normalize_host
+
+    host = normalize_host(args.host)
+    if host is None:
+        raise SystemExit(
+            "%r is not a plain DNS hostname. Policy YAML is assembled by "
+            "concatenation, so globs, ports, schemes and anything with YAML "
+            "significance are refused here rather than in the renderer."
+            % args.host
+        )
+    cp = _plane(args)
+    hosts = list(_project_egress_block(cp, args.project).get("hosts") or [])
+    if host not in hosts:
+        hosts.append(host)
+    _print(_write_project_egress(cp, args.project, sorted(hosts), args.reason or ""))
+
+
+def cmd_project_egress_revoke(args: argparse.Namespace) -> None:
+    """Withdraw one host from a project's declared egress."""
+    cp = _plane(args)
+    hosts = [
+        h
+        for h in (_project_egress_block(cp, args.project).get("hosts") or [])
+        if h != args.host
+    ]
+    _print(_write_project_egress(cp, args.project, hosts, ""))
+
 
 def cmd_task_egress_list(args: argparse.Namespace) -> None:
     """Show the hosts a task declares for sandbox egress."""
@@ -8077,6 +8183,33 @@ def build_parser() -> argparse.ArgumentParser:
     _set(cmd_repo_refs_reconcile, refs_reconcile)
 
     project = sub.add_parser("project", help="project summary commands").add_subparsers(dest="project_command", required=True)
+    project_egress = project.add_parser(
+        "egress",
+        help="hosts every task in this project may reach from its sandbox",
+        description=(
+            "Declared at PROJECT level because a repository has one egress "
+            "contract and many tasks. The hub projects it onto each assignment "
+            "at claim time, so it applies to tasks created before the "
+            "declaration too, and it strips any task-level value -- these hosts "
+            "are operator policy, not a task author's request."
+        ),
+    ).add_subparsers(dest="project_egress_command", required=True)
+
+    project_egress_list = project_egress.add_parser("list", help="show declared hosts")
+    project_egress_list.add_argument("project")
+    _set(cmd_project_egress_list, project_egress_list)
+
+    project_egress_grant = project_egress.add_parser("grant", help="allow one host")
+    project_egress_grant.add_argument("project")
+    project_egress_grant.add_argument("host", help="a plain DNS hostname")
+    project_egress_grant.add_argument("--reason", help="why the project needs it")
+    _set(cmd_project_egress_grant, project_egress_grant)
+
+    project_egress_revoke = project_egress.add_parser("revoke", help="withdraw one host")
+    project_egress_revoke.add_argument("project")
+    project_egress_revoke.add_argument("host")
+    _set(cmd_project_egress_revoke, project_egress_revoke)
+
     project_create = project.add_parser(
         "create", help="create a project and its dispatch policy"
     )

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -25920,6 +25920,52 @@ class ControlPlane:
         )
         return self._break_glass_authorization_from_row(row) if row is not None else None
 
+    def _project_declared_egress(self, project: Optional[str]) -> JsonDict:
+        """The sandbox egress a project's OPERATOR declared, or {} if none.
+
+        Read from ``projects.metadata.egress_contract`` — control-plane state an
+        operator sets with ``mac project egress grant``. Deliberately NOT read
+        from the repository's own contract: ``project_repositories`` loads that
+        from ``.mac/project.yaml`` inside the checkout, so anything declared
+        there is repo content, mutable by anyone who can open a pull request,
+        and belongs in the untrusted ``derived`` tier rather than this one.
+
+        Hosts are re-validated here rather than trusted from storage. The
+        renderer builds policy YAML by concatenation, so a malformed host is a
+        policy-injection vector no matter how it got into the database; a bad
+        entry is dropped and the rest still apply.
+        """
+        name = str(project or "").strip()
+        if not name:
+            return {}
+        row = self.store.query_one(
+            "SELECT metadata FROM projects WHERE name = ?", (name,)
+        )
+        if row is None:
+            return {}
+        block = ensure_json_object(
+            ensure_json_object(json_loads(row["metadata"], {})).get(
+                "egress_contract"
+            )
+        )
+        raw_hosts = block.get("hosts")
+        if not isinstance(raw_hosts, list):
+            return {}
+        from mac.sandbox_egress import normalize_host
+
+        hosts: List[str] = []
+        for candidate in raw_hosts:
+            host = normalize_host(candidate)
+            if host is not None and host not in hosts:
+                hosts.append(host)
+        if not hosts:
+            return {}
+        projected: JsonDict = {"hosts": hosts, "source": "project"}
+        reason = str(block.get("reason") or "").strip()
+        if reason:
+            projected["reason"] = reason
+        return projected
+
     def _assignment_task_payload(self, task: Task, lease: Lease) -> JsonDict:
         """Attach a lease-bound host authorization to an in-memory assignment.
 
@@ -25936,6 +25982,23 @@ class ControlPlane:
             metadata["runtime"] = runtime
         else:
             metadata.pop("runtime", None)
+        # Sandbox egress is PROJECT policy, projected here, never carried on the
+        # durable task. Two reasons this is the right home for it:
+        #
+        #   * Ownership. `metadata.egress_contract` on a task is written by
+        #     whoever created the task -- any hub credential. Declaring it on the
+        #     project instead makes the `hub_declared` trust tier mean what its
+        #     name says: an operator approved these hosts, not "a task author
+        #     asked for them". The stale value is stripped exactly like
+        #     break_glass_authorization above, so a task cannot smuggle one.
+        #   * Reach. A repository has one egress contract and many tasks -- the
+        #     Aviation project alone has hundreds. Projecting at assignment time
+        #     applies the declaration to every task, including those created
+        #     before it existed, instead of only to new ones.
+        metadata.pop("egress_contract", None)
+        declared_egress = self._project_declared_egress(task.project)
+        if declared_egress:
+            metadata["egress_contract"] = declared_egress
         payload["metadata"] = metadata
         authorization = self._claimed_break_glass_authorization(
             task.id, lease.agent_id, lease.id

--- a/tests/cli/test_cli_project_egress.py
+++ b/tests/cli/test_cli_project_egress.py
@@ -1,0 +1,131 @@
+"""CLI coverage for `mac project egress` — project-declared sandbox egress.
+
+The hosts a project declares here are granted to its tasks' sandboxes at the
+``hub_declared`` trust tier, so the CLI is a security surface: what it writes,
+and where it writes it, decides what an agent running ``--yolo`` can reach.
+
+Two properties are asserted rather than left to a reader's care:
+
+* a malformed host is refused **at the CLI**, because policy YAML is assembled
+  by concatenation and a glob, port or newline is an injection vector; and
+* the value lands on the PROJECT, so it reaches every task in that project —
+  including the ones created before the declaration, which is the whole reason
+  it is not declared per task.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import control_plane_on, dsn_for
+
+
+def _run(db, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(db), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    if not raw:
+        return rc, None
+    try:
+        return rc, json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return rc, raw
+
+
+@pytest.fixture
+def project(tmp_path):
+    cp = control_plane_on(dsn_for(tmp_path))
+    cp.create_project("Aviation", description="flight suite")
+    return tmp_path
+
+
+def test_grant_list_revoke_round_trip(project):
+    rc, _ = _run(project, "project", "egress", "grant", "Aviation",
+                 "opensky-network.org", "--reason", "ADS-B state vectors")
+    assert rc == 0
+
+    rc, listed = _run(project, "project", "egress", "list", "Aviation")
+    assert rc == 0
+    assert listed["hosts"] == ["opensky-network.org"]
+    assert listed["reason"] == "ADS-B state vectors"
+    # Named in the output so an operator can see the tier without reading code.
+    assert listed["trust_tier"] == "hub_declared"
+
+    rc, _ = _run(project, "project", "egress", "grant", "Aviation", "tfr.faa.gov")
+    rc, listed = _run(project, "project", "egress", "list", "Aviation")
+    assert listed["hosts"] == ["opensky-network.org", "tfr.faa.gov"]
+
+    rc, _ = _run(project, "project", "egress", "revoke", "Aviation", "tfr.faa.gov")
+    rc, listed = _run(project, "project", "egress", "list", "Aviation")
+    assert listed["hosts"] == ["opensky-network.org"]
+
+
+def test_a_project_with_no_declaration_lists_nothing(project):
+    rc, listed = _run(project, "project", "egress", "list", "Aviation")
+    assert rc == 0
+    assert listed["hosts"] == []
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "**.evil.example",
+        "https://evil.example",
+        "evil.example:443",
+        "evil.example\n  attacker: x",
+        "localhost",
+        "10.0.0.1",
+    ],
+)
+def test_a_malformed_host_is_refused_at_the_cli(project, bad):
+    """Refused here rather than in the renderer: the operator finds out at the
+    point of the mistake, and a bad value never reaches the database."""
+    with pytest.raises(SystemExit):
+        _run(project, "project", "egress", "grant", "Aviation", bad)
+
+    rc, listed = _run(project, "project", "egress", "list", "Aviation")
+    assert listed["hosts"] == []
+
+
+def test_granting_an_unknown_project_fails_loudly(project):
+    with pytest.raises(SystemExit):
+        _run(project, "project", "egress", "grant", "ghost", "opensky-network.org")
+
+
+def test_the_declaration_lands_on_the_project_not_a_task(project):
+    """Per-project is the point: Aviation has hundreds of tasks, and a per-task
+    declaration would miss every one created before it."""
+    _run(project, "project", "egress", "grant", "Aviation", "opensky-network.org")
+    cp = control_plane_on(dsn_for(project))
+    row = cp.store.query_one(
+        "SELECT metadata FROM projects WHERE name = ?", ("Aviation",)
+    )
+    stored = json.loads(row["metadata"])["egress_contract"]
+    assert stored["hosts"] == ["opensky-network.org"]
+
+
+def test_it_reaches_a_task_created_before_the_declaration(project):
+    """The projection happens at claim time, so ordering does not matter."""
+    cp = control_plane_on(dsn_for(project))
+    machine = cp.register_machine("host")
+    agent = cp.register_agent(machine.id, "worker-1", capabilities=["python"])
+    task = cp.create_task("fly", project="Aviation", required_capabilities=["python"])
+
+    _run(project, "project", "egress", "grant", "Aviation", "tfr.faa.gov")
+
+    cp2 = control_plane_on(dsn_for(project))
+    cp2.claim_task(task.id, agent.id)
+    assignment = cp2._active_assignment_for_agent(cp2.get_agent(agent.id))
+    contract = assignment["task"]["metadata"]["egress_contract"]
+    assert contract["hosts"] == ["tfr.faa.gov"]
+    assert contract["source"] == "project"

--- a/tests/test_project_declared_egress.py
+++ b/tests/test_project_declared_egress.py
@@ -1,0 +1,224 @@
+"""Sandbox egress is declared on the PROJECT and projected onto assignments.
+
+ADR 0009 §2a's goal was not "a repo can declare egress" — it was that a repo's
+hosts stop being carried by every sandbox in the fleet. The declaration
+therefore has to live somewhere a whole repository's worth of tasks can inherit
+it from, and be applied to tasks that already exist.
+
+Two properties matter and are pinned here:
+
+* **Ownership.** A task's own ``metadata.egress_contract`` is written by whoever
+  created the task — any hub credential. Project metadata is operator policy.
+  The assignment projection strips the former and applies the latter, so the
+  ``hub_declared`` trust tier means what its name says.
+* **Reach.** The projection happens at claim time, so a declaration added today
+  applies to the hundreds of tasks created before it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import json_dumps
+from mac.services import ControlPlane
+
+HOSTS = ["opensky-network.org", "aviationweather.gov", "tfr.faa.gov"]
+
+
+def _project(cp: ControlPlane, name: str, block) -> None:
+    cp.store.execute(
+        "INSERT INTO projects (id, name, description, metadata, status, "
+        "created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            "project_%s" % name.lower(),
+            name,
+            "",
+            json_dumps({"egress_contract": block} if block is not None else {}),
+            "active",
+            "t",
+            "t",
+        ),
+    )
+
+
+@pytest.fixture
+def fleet():
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host")
+    agent = cp.register_agent(machine.id, "worker-1", capabilities=["python"])
+    return cp, agent
+
+
+def _assignment_egress(cp, agent, task):
+    cp.claim_task(task.id, agent.id)
+    assignment = cp._active_assignment_for_agent(cp.get_agent(agent.id))
+    return (assignment or {}).get("task", {}).get("metadata", {}).get(
+        "egress_contract"
+    )
+
+
+# --- the declaration reaches the sandbox ----------------------------------
+
+
+def test_project_declaration_is_projected_onto_the_assignment(fleet):
+    cp, agent = fleet
+    _project(cp, "Aviation", {"hosts": HOSTS, "reason": "integration data"})
+    task = cp.create_task("fly", project="Aviation", required_capabilities=["python"])
+
+    projected = _assignment_egress(cp, agent, task)
+    assert projected["hosts"] == HOSTS
+    assert projected["reason"] == "integration data"
+    assert projected["source"] == "project"
+
+
+def test_it_reaches_tasks_created_before_the_declaration_existed(fleet):
+    """The reason this is projected at claim time rather than stamped at task
+    creation: Aviation had hundreds of tasks before anyone declared its hosts."""
+    cp, agent = fleet
+    _project(cp, "Aviation", None)
+    task = cp.create_task("old", project="Aviation", required_capabilities=["python"])
+
+    cp.store.execute(
+        "UPDATE projects SET metadata = ? WHERE name = ?",
+        (json_dumps({"egress_contract": {"hosts": HOSTS}}), "Aviation"),
+    )
+    assert _assignment_egress(cp, agent, task)["hosts"] == HOSTS
+
+
+def test_a_project_with_no_declaration_grants_nothing(fleet):
+    cp, agent = fleet
+    _project(cp, "Quiet", None)
+    task = cp.create_task("x", project="Quiet", required_capabilities=["python"])
+    assert _assignment_egress(cp, agent, task) is None
+
+
+def test_an_unregistered_project_grants_nothing(fleet):
+    cp, agent = fleet
+    task = cp.create_task("x", project="ghost", required_capabilities=["python"])
+    assert _assignment_egress(cp, agent, task) is None
+
+
+# --- ownership: a task cannot declare its own -----------------------------
+
+
+def test_a_task_cannot_smuggle_its_own_egress_contract(fleet):
+    """Previously any task author could declare egress. Stripping it here is
+    what makes `hub_declared` mean "an operator approved this"."""
+    cp, agent = fleet
+    _project(cp, "Aviation", {"hosts": ["opensky-network.org"]})
+    task = cp.create_task(
+        "sneaky",
+        project="Aviation",
+        required_capabilities=["python"],
+        metadata={"egress_contract": {"hosts": ["attacker.example"]}},
+    )
+
+    projected = _assignment_egress(cp, agent, task)
+    assert projected["hosts"] == ["opensky-network.org"]
+    assert "attacker.example" not in str(projected)
+
+
+def test_a_task_contract_is_stripped_even_with_no_project_declaration(fleet):
+    """Strip unconditionally, like break_glass_authorization — otherwise the
+    smuggled value survives for exactly the projects that declared nothing."""
+    cp, agent = fleet
+    _project(cp, "Quiet", None)
+    task = cp.create_task(
+        "sneaky",
+        project="Quiet",
+        required_capabilities=["python"],
+        metadata={"egress_contract": {"hosts": ["attacker.example"]}},
+    )
+    assert _assignment_egress(cp, agent, task) is None
+
+
+def test_the_durable_task_row_is_left_alone(fleet):
+    """The projection is transient; it must not rewrite stored task metadata."""
+    cp, agent = fleet
+    _project(cp, "Aviation", {"hosts": HOSTS})
+    task = cp.create_task(
+        "fly",
+        project="Aviation",
+        required_capabilities=["python"],
+        metadata={"egress_contract": {"hosts": ["attacker.example"]}},
+    )
+    _assignment_egress(cp, agent, task)
+    stored = cp.get_task(task.id).metadata.get("egress_contract")
+    assert stored == {"hosts": ["attacker.example"]}
+
+
+# --- hosts are re-validated on the way out --------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "evil.example\n  attacker_block:\n    name: pwned",
+        "**.evil.example",
+        "https://evil.example",
+        "evil.example:443",
+        "localhost",
+        "10.0.0.1",
+        "",
+        None,
+        123,
+    ],
+)
+def test_malformed_hosts_are_dropped_not_rendered(fleet, bad):
+    """Policy YAML is built by concatenation, so a malformed host is an
+    injection vector however it reached the database."""
+    cp, agent = fleet
+    _project(cp, "Aviation", {"hosts": ["opensky-network.org", bad]})
+    task = cp.create_task("fly", project="Aviation", required_capabilities=["python"])
+
+    projected = _assignment_egress(cp, agent, task)
+    assert projected["hosts"] == ["opensky-network.org"]
+
+
+def test_all_malformed_means_no_contract_at_all(fleet):
+    cp, agent = fleet
+    _project(cp, "Aviation", {"hosts": ["**.evil.example"]})
+    task = cp.create_task("fly", project="Aviation", required_capabilities=["python"])
+    assert _assignment_egress(cp, agent, task) is None
+
+
+def test_duplicates_are_collapsed(fleet):
+    cp, agent = fleet
+    _project(cp, "Aviation", {"hosts": ["tfr.faa.gov", "TFR.FAA.GOV", "tfr.faa.gov."]})
+    task = cp.create_task("fly", project="Aviation", required_capabilities=["python"])
+    assert _assignment_egress(cp, agent, task)["hosts"] == ["tfr.faa.gov"]
+
+
+def test_a_non_list_hosts_value_is_ignored(fleet):
+    cp, agent = fleet
+    _project(cp, "Aviation", {"hosts": "opensky-network.org"})
+    task = cp.create_task("fly", project="Aviation", required_capabilities=["python"])
+    assert _assignment_egress(cp, agent, task) is None
+
+
+# --- the fleet-wide block is gone -----------------------------------------
+
+
+def test_the_operator_template_no_longer_declares_aviation_hosts():
+    """The point of the exercise: those hosts stop being carried by every
+    sandbox in the fleet, including repos with no business reaching them."""
+    yaml = pytest.importorskip("yaml")
+    from pathlib import Path
+
+    template = (
+        Path(__file__).resolve().parents[1]
+        / "deploy"
+        / "openshell"
+        / "mac-hermes-policy.yaml"
+    )
+    text = template.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(
+        text.replace("__MAC_HUB_HOST__", "h").replace("__MAC_HUB_PORT__", "8789")
+        .replace("__MODEL_GATEWAY_HOST__", "g").replace("__RUNTIME_PY__", "/p")
+        .replace("__RUNTIME_VENV__", "/v").replace("__RUNTIME_SRC__", "/s")
+        .replace("__CACHE_DIR__", "/c").replace("__CONFIG_DIR__", "/cfg")
+        .replace("__AGENT_USER__", "u")
+    )
+    assert "aviation_apis" not in (parsed.get("network_policies") or {})
+    for host in HOSTS:
+        assert host not in str(parsed.get("network_policies") or {}), host


### PR DESCRIPTION
PR #297 landed ADR 0009 §2a — per-repo egress rendering — but **the payoff was never collected.** `deploy/openshell/mac-hermes-policy.yaml` still declared the aviation suite's three integration hosts **fleet-wide**, so every sandbox in the fleet, including repos with no business reaching them, still carried that egress.

That accumulation is exactly what ADR 0009 set out to stop. **Deleting the block is where the reduction happens**; everything else here is the mechanism that makes deleting it safe.

## Why the project, not the task

The follow-up said to move the hosts into "the owning task's `metadata.egress_contract.hosts`". That doesn't work: **`Aviation` is a live project with 416 tasks, 7 active.** Per-task declaration means re-declaring forever and missing every task that already exists.

So the declaration lives on the **project**, and the hub projects it onto each assignment in `_assignment_task_payload` — the transient document the executor already treats as authoritative for host execution. Projecting at claim time rather than stamping at creation is what makes it reach the hundreds of tasks filed before the declaration existed.

## It also closes a hole #297 left open

That function already strips `break_glass_authorization` as a caller-controlled lookalike. `egress_contract` is now stripped the same way.

In #297, a task's `metadata.egress_contract` was written by **whoever created the task** — any hub credential. Declaring on the project makes the `hub_declared` tier mean what its name says: *an operator approved these hosts*, not "a task author asked for them."

Verified: a task declaring `attacker.example` has it discarded while the project's hosts project through.

**Deliberately not read from the repository's own contract.** `project_repositories` loads that from `.mac/project.yaml` inside the checkout — repo content, mutable by anyone who can open a pull request, and therefore the untrusted `derived` tier.

**Hosts are re-validated on the way out** with `normalize_host` rather than trusted from storage. Policy YAML is assembled by concatenation, so a malformed host is an injection vector however it reached the database; a bad entry is dropped and the rest still apply.

## Operator surface

`mac project egress grant | list | revoke`, mirroring the task-level verbs from #301. Malformed hosts are refused **at the CLI**, so the operator finds out at the point of the mistake.

The live `Aviation` project declaration **is already populated** (read-merge-write; all seven pre-existing metadata keys preserved), so removing the fleet-wide block does not open a gap.

## Verification

- Contract gate: **11,027 passed, 2 skipped**; live phase **44 passed, 4 skipped**.
- 31 new tests — 20 control-plane, 11 CLI.
- The CLI coverage gate caught the new verbs having no test; that's why the second set exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
