### PR TITLE
Write down who owns which authority question, and assert it

### DIFF
--- a/docs/authority-boundary.md
+++ b/docs/authority-boundary.md
@@ -1,0 +1,160 @@
+# Who owns which authority question
+
+MAC has several primitives that all *look* like "is this allowed?" and answer
+different questions. That ambiguity is not theoretical: it produced two
+confirmed holes in one week, and a 34-route audit found that nothing at all was
+blocking a non-admin token on the routes that relied on the wrong one.
+
+This document fixes the boundary. It is descriptive of what the code does
+today, and `tests/api/test_authority_boundary.py` pins the parts that must not
+drift.
+
+The framing is borrowed from `~/Src/literate-ai`'s
+`docs/architecture/agent-ledger-boundary.md`, which draws the same line between
+a ledger and a derivation engine:
+
+> The ledger's customer or organizational consent **is not the execution grant**
+> that authorizes a build, test, or publication step.
+
+MAC is both systems at once, so the line has to be drawn *inside* it.
+
+## The table
+
+| Question | Owner | Not the owner |
+| --- | --- | --- |
+| Who asked for this work, and under whose organizational authority? | the task ledger — `actor`, `origin`, directives, approvals | — |
+| May this principal reach this route at all? | **`_required_scope(method, path)`** | anything in the handler body |
+| Is this principal confined to a tenant? | `TokenPrincipal.refuse_tenant_bound` | — it answers only this |
+| Is this principal acting as itself? | `TokenPrincipal.assert_actor` | — |
+| Does this call need an operator rather than a service? | `TokenPrincipal.require_admin` | — |
+| May this agent execute anything at all on a host? | the allocator's execution-boundary gate (`AGENT_NO_EXECUTION_BOUNDARY`) | capability matching |
+| Under what confinement does the work run? | the OpenShell policy, resolved per host and (optionally) per task | the task body |
+| May this run escape confinement, once? | a lease-bound break-glass authorization | any token scope |
+| What may the sandbox reach on the network? | the project's declared egress + the reviewed registry allowlist | anything the repo says about itself |
+| What did the agent actually do? | `action_events`, `command_audit`, evidence blobs | — |
+
+## The invariant
+
+**Authorization is decided by `_required_scope`. Everything else narrows.**
+
+A route's privilege is the scope it is given there. In-handler guards can refuse
+*more* — a tenant-bound token, a different agent, a non-admin — but they cannot
+supply privilege a route was never given. A route that needs to be operator-only
+says so in `_required_scope`; it does not acquire that property by calling
+something in its body.
+
+There is one deliberate exception, and it is the reason the executable half
+asserts *behaviour* and not only scope. The debug-terminal routes must stay
+reachable by a **worker acting on itself** — a blanket admin scope would forbid
+the legitimate case — so they sit at `read`/`write` and are narrowed in the
+handler by `_require_terminal_principal` (admin, or an agent acting on itself).
+Scope alone therefore does not prove those routes are safe; only a request does.
+Writing this document's tests is what surfaced that, having first asserted the
+tidier claim and watched it fail.
+
+### How this was learned
+
+`refuse_tenant_bound` was called `require_global_fleet`, which reads as "require
+fleet-level authority". It is:
+
+```python
+if self.is_admin or self.tenant_id is None:
+    return
+raise AuthorizationError(...)
+```
+
+It refuses only **tenant-bound** non-admin tokens. An untenanted client token —
+the ordinary `read`/`write` credential — passes untouched. It was relied on at
+61 call sites.
+
+An audit probed all 34 routes where it was the only in-handler gate below admin,
+using the fact that FastAPI validates the request body *before* the handler runs
+(so a `422` proves auth already passed):
+
+```
+REACHABLE past the guard with a non-admin token:  34 / 34
+BLOCKED:                                           0
+```
+
+Two were real holes and are fixed:
+
+- an ordinary `write` token could **open a debug shell on any fleet host and
+  send it keystrokes** (PR #300);
+- the same token could **create, update, delete and assign the OpenShell
+  guardrail policy** every `--yolo` agent runs under — and then be refused when
+  it tried to read back what it had just written (PR #303).
+
+The remaining 22 have legitimate non-admin callers — bootstrap registers
+machines, CI records integration findings, the `deploy` scope promotes runtime
+deltas — so `write`/`deploy` is their correct level and they were never
+vulnerabilities. The method was renamed in PR #305 so the assumption cannot be
+made a 62nd time.
+
+## Consent is not an execution grant
+
+These are separate and must stay separate:
+
+| | Answers | Carried by |
+| --- | --- | --- |
+| **Consent** | "this work was asked for, by someone entitled to ask" | the ledger: task, actor, origin, approval, directive |
+| **Execution grant** | "this exact operation may run, here, now, with these resources" | scope + confinement policy + break-glass, per call |
+
+A task existing in the ledger is not permission to run it on a host. An agent
+holding a lease is not permission to escape its sandbox. The ledger's record of
+*who wanted it* and the runtime's record of *what was allowed* answer different
+questions and are stored separately on purpose.
+
+The clearest live example is break-glass: an operator's organizational decision
+to allow one host execution becomes a **lease-bound, single-use, audited**
+authorization, projected onto exactly one assignment and stripped from every
+other. Consent is durable and human; the grant is narrow, typed and expiring.
+
+MAC enforces this more strictly than "strip it later": a task that tries to
+carry `runtime.break_glass_authorization` in its own metadata is **refused at
+creation** with *"break-glass execution metadata is control-plane-owned"*. The
+assignment-time strip is the second line, not the first. (This document
+originally claimed only the strip; the test found the stronger guarantee.)
+
+## Trust tiers for anything a repository says about itself
+
+Repository content is attacker-controllable — anyone who can open a pull request
+can change it. So a repo's own statements are *proposals*, never grants:
+
+| Tier | Source | Granted when |
+| --- | --- | --- |
+| `derived_trusted_registry` | the repository working tree (`.npmrc`, lockfiles) | it matches a small reviewed registry allowlist |
+| `hub_declared` | control-plane state an operator set | it is well-formed |
+
+This is why sandbox egress is declared on the **project**, not read from the
+repository's own contract: `project_repositories` loads that contract from
+`.mac/project.yaml` inside the checkout, which is repo content and belongs in
+the untrusted tier.
+
+## Current status — what is NOT true yet
+
+Stated plainly, in the spirit of the document this borrows from:
+
+- **`_required_scope` is a path-matching function, not a registry.** It is
+  correct today and pinned by tests, but a new route inherits a scope by where
+  its path happens to fall in a chain of `if`s. Nothing forces an author to
+  make a decision.
+- **22 routes still rely on `refuse_tenant_bound` alone.** That is correct for
+  them — they have legitimate non-admin callers — but "correct by accident of
+  who happens to hold a token" is weaker than "correct by declaration".
+- **There is no derived explanation layer.** MAC has the forensic half —
+  `action_events`, `command_audit`, evidence blobs — and no human-facing
+  account of what was decided and why. literate-ai's boundary document is
+  explicit that the raw journal is forensic evidence, not the default user
+  interface.
+- **Execution grants are not uniformly typed.** Break-glass is a typed,
+  lease-bound record. Confinement is a policy file. Network reach is a projected
+  contract. They are three shapes for one idea.
+
+## References
+
+- `~/Src/literate-ai/docs/architecture/agent-ledger-boundary.md` — the ownership
+  framing, and the consent-versus-grant distinction
+- `docs/structured-task-bodies.md` — the related question (should a task body be
+  a component transition?) and why the answer was no
+- `docs/openshell-sandbox.md` — confinement, policy delivery, per-repo egress
+- `tests/api/test_authority_boundary.py` — the executable half of this document

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -87,6 +87,7 @@ for provenance and is not a current operating contract.
 | historical archive | `archive/index.md` | Historical archive |
 | supplemental reference | `assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | supplemental reference | `audit.md` | MAC Codebase Audit — Active Code, Duplication & Accretion |
+| supplemental reference | `authority-boundary.md` | Who owns which authority question |
 | book | `book/01-system.md` | MAC as a System |
 | book | `book/02-local-start.md` | Install and Start Locally |
 | book | `book/03-projects-and-tasks.md` | Projects and Tasks |

--- a/tests/api/test_authority_boundary.py
+++ b/tests/api/test_authority_boundary.py
@@ -1,0 +1,193 @@
+"""The executable half of `docs/authority-boundary.md`.
+
+The lesson that produced that document is that a prose invariant is not an
+invariant. `require_global_fleet` *read* as "require fleet-level authority" and
+meant "refuse tenant-bound tokens"; the difference was documented nowhere and
+believed at 61 call sites, and two holes followed. So the boundary is asserted
+here rather than described.
+
+Three things are pinned:
+
+1. `refuse_tenant_bound` answers a tenancy question and cannot be an
+   authorization gate — an untenanted token of any scope passes it.
+2. `_required_scope` is therefore the gate, and the routes that hand out an
+   execution grant are admin-only there.
+3. Consent and execution grant are separate: holding a lease is not permission
+   to escape the sandbox.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.api import TokenPrincipal, _required_scope
+from mac.models import AuthorizationError
+
+#: Routes that hand out an execution grant — the ability to run something, or to
+#: author the confinement something else runs under. Each was reachable with a
+#: non-admin token before PR #300 / #303.
+EXECUTION_GRANT_ROUTES = [
+    # Authoring the guardrail policy every --yolo agent runs under.
+    ("POST", "/openshell/policies"),
+    ("GET", "/openshell/policies/p1"),
+    ("PUT", "/openshell/policies/p1"),
+    ("DELETE", "/openshell/policies/p1"),
+    ("GET", "/openshell/policies/p1/versions"),
+    ("POST", "/openshell/policies/p1/render"),
+    ("POST", "/openshell/policies/p1/assignments"),
+    # Directives are operator speech: they change fleet-wide behaviour.
+    ("POST", "/directives"),
+    ("POST", "/directives/d1/approve"),
+    ("POST", "/directives/d1/activate"),
+    ("POST", "/directives/d1/deactivate"),
+    ("POST", "/directives/d1/check"),
+    ("POST", "/directives/d1/waivers"),
+    ("POST", "/directive-bindings"),
+    ("POST", "/directive-waivers/w1/revoke"),
+]
+
+#: Reads that must stay reachable, or drift detection and the dashboard break.
+#: Listed so that tightening the rows above cannot silently take these with it.
+IDENTITY_READS = [
+    ("GET", "/openshell/policies"),
+    ("GET", "/openshell/policies/p1/assignments"),
+    ("GET", "/agents/a1/openshell/status"),
+    ("GET", "/dashboard/state"),
+    ("GET", "/directives"),
+    ("GET", "/directives/d1"),
+]
+
+#: Self-only worker control paths. A worker must keep receiving its own policy
+#: and directives; if this ordering breaks, distribution stops fleet-wide and
+#: silently.
+SELF_ONLY_WORKER_PATHS = [
+    ("GET", "/agents/a1/directives/effective"),
+    ("POST", "/agents/a1/directive-activations/x1/ack"),
+    ("GET", "/agents/a1/openshell/policy"),
+]
+
+
+# --- 1. the tenancy check is not an authorization gate ---------------------
+
+
+@pytest.mark.parametrize("scope", ["read", "write", "deploy", "roles", "workflow"])
+def test_refuse_tenant_bound_lets_any_untenanted_token_through(scope):
+    """The property that makes it unusable as a route's only gate. If this ever
+    starts refusing, the 22 routes that legitimately rely on it break — and if
+    it is ever mistaken for authorization again, this test is the counterexample.
+    """
+    TokenPrincipal(scopes=(scope,), client_id="svc").refuse_tenant_bound()
+
+
+def test_refuse_tenant_bound_refuses_exactly_one_thing():
+    with pytest.raises(AuthorizationError, match="bound to a tenant"):
+        TokenPrincipal(scopes=("write",), tenant_id="tenant-a").refuse_tenant_bound()
+
+
+def test_its_docstring_still_disclaims_being_an_authorization_gate():
+    """Renamed in PR #305 so the assumption cannot be made again; the
+    disclaimer is part of the fix, not decoration."""
+    doc = TokenPrincipal.refuse_tenant_bound.__doc__ or ""
+    assert "NOT an authorization gate" in doc
+    assert "_required_scope" in doc
+
+
+# --- 2. _required_scope is the gate ---------------------------------------
+
+
+@pytest.mark.parametrize("method,path", EXECUTION_GRANT_ROUTES)
+def test_execution_grants_require_admin(method, path):
+    """Each of these was reachable with an ordinary `write` token before
+    PR #300 / #303. A regression here is a privilege escalation, not a style
+    change."""
+    assert _required_scope(method, path) == "admin", (method, path)
+
+
+@pytest.mark.parametrize("method,path", IDENTITY_READS)
+def test_identity_reads_stay_readable(method, path):
+    assert _required_scope(method, path) == "read", (method, path)
+
+
+@pytest.mark.parametrize("method,path", SELF_ONLY_WORKER_PATHS)
+def test_worker_self_service_paths_keep_the_agent_scope(method, path):
+    assert _required_scope(method, path) == "agent", (method, path)
+
+
+#: The debug-terminal routes are the one execution grant enforced in the HANDLER
+#: (`_require_terminal_principal`) rather than at the scope layer -- they must
+#: stay reachable by a worker acting on itself, which a blanket admin scope would
+#: forbid. Two mechanisms for one idea; asserted behaviourally so the guarantee
+#: is pinned wherever it happens to live.
+TERMINAL_ROUTES = [
+    ("GET", "/dashboard/terminal-sessions", None),
+    ("POST", "/dashboard/agents/%s/terminal-sessions", {"shell": "/bin/sh"}),
+]
+
+
+@pytest.mark.parametrize("method,path,body", TERMINAL_ROUTES)
+def test_a_general_write_token_cannot_reach_a_debug_shell(method, path, body):
+    """PR #300. Enforced in the handler, so scope alone does not prove it."""
+    from fastapi.testclient import TestClient
+
+    from mac.api import create_app
+    from mac.services import ControlPlane
+
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host")
+    agent = cp.register_agent(machine.id, "worker-1")
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "writer": {"scopes": ["write"], "client_id": "ci"},
+                "reader": {"scopes": ["read"], "client_id": "dash"},
+                "admin": {"scopes": ["admin"], "client_id": "operator"},
+            },
+        )
+    )
+    target = path % agent.id if "%s" in path else path
+    for token in ("writer", "reader"):
+        response = client.request(
+            method, target, headers={"Authorization": "Bearer %s" % token}, json=body
+        )
+        assert response.status_code == 403, (token, target)
+    ok = client.request(
+        method, target, headers={"Authorization": "Bearer admin"}, json=body
+    )
+    assert ok.status_code == 200, target
+
+
+def test_health_is_the_only_kind_of_route_that_is_public():
+    assert _required_scope("GET", "/health") is None
+    # Nothing that names an agent should ever be public.
+    assert _required_scope("GET", "/agents/a1/openshell/policy") is not None
+
+
+# --- 3. consent is not an execution grant ---------------------------------
+
+
+def test_holding_a_lease_is_not_permission_to_escape_the_sandbox():
+    """The ledger records that work was asked for and claimed. The grant to run
+    it outside confinement is a separate, lease-bound, single-use record — and a
+    task cannot manufacture one by putting it in its own metadata."""
+    from mac.services import ControlPlane
+
+    from mac.models import ValidationError
+
+    cp = ControlPlane.in_memory()
+    # Refused at CREATION, not merely stripped at projection -- a stronger
+    # guarantee than the assignment-time strip, and the one that actually holds.
+    with pytest.raises(ValidationError, match="control-plane-owned"):
+        cp.create_task(
+            "work",
+            project="mac",
+            required_capabilities=["python"],
+            metadata={
+                "runtime": {
+                    "break_glass_authorization": {
+                        "execution_boundary": "host",
+                        "authorized_by": "self",
+                    }
+                }
+            },
+        )


### PR DESCRIPTION
MAC has several primitives that all read like *"is this allowed?"* and answer different questions. That ambiguity produced two confirmed holes in one week, and a 34-route audit in which **nothing at all** was blocking a non-admin token on the routes relying on the wrong one.

## The framing

Borrowed from `~/Src/literate-ai`'s `docs/architecture/agent-ledger-boundary.md`, which draws the same line between a ledger and a derivation engine:

> The ledger's customer or organizational consent **is not the execution grant** that authorizes a build, test, or publication step.

MAC is both systems at once, so the line has to be drawn *inside* it.

## What the document records

| Question | Owner |
| --- | --- |
| Who asked, under whose authority? | the task ledger — actor, origin, approvals |
| **May this principal reach this route at all?** | **`_required_scope`** |
| Is this principal confined to a tenant? | `refuse_tenant_bound` — *only* this |
| Is it acting as itself? | `assert_actor` |
| May this agent execute anything on a host? | the allocator's execution-boundary gate |
| Under what confinement does work run? | the OpenShell policy |
| May this run escape confinement, once? | a lease-bound break-glass record |
| What may the sandbox reach? | project-declared egress + reviewed allowlist |
| What did the agent actually do? | action events, command audit, evidence blobs |

Plus the invariant (*authorization is decided by `_required_scope`; everything else narrows*), the consent-versus-grant split, and the trust tiers for anything a repository says about itself.

There is a **"what is NOT true yet"** section, because the honest version is more useful than the tidy one: `_required_scope` is a chain of `if`s rather than a registry; 22 routes still rely on the tenancy check alone (correctly, but by accident of who holds a token rather than by declaration); there is no derived-explanation layer over the forensic one; and execution grants come in three different shapes.

## The tests are the point

The lesson that produced this document is that **a prose invariant is not an invariant**. `require_global_fleet` *read* as "require fleet-level authority", meant "refuse tenant-bound tokens", and was believed at 61 call sites.

So the boundary is asserted rather than described. `tests/api/test_authority_boundary.py` pins that the tenancy check lets any untenanted token through (the property that makes it unusable as a gate), that execution-grant routes are admin, that identity reads and worker self-service paths keep working, and that consent confers no execution grant.

**Writing those tests corrected the document twice**, which is the argument for having written them:

- The debug-terminal routes are **not** admin at the scope layer. They must stay reachable by a worker acting on itself, so they sit at `read`/`write` and are narrowed in the handler by `_require_terminal_principal`. Scope alone does not prove they are safe; the test now asserts behaviour, and the invariant section records the exception.
- Break-glass metadata is refused at task **creation** — *"break-glass execution metadata is control-plane-owned"* — not merely stripped at projection. A stronger guarantee than the document originally claimed.

36 tests. **No product code changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
