### PR TITLE
Let a message reach an agent that is already working

### DIFF
--- a/docs/in-flight-agent-messages.md
+++ b/docs/in-flight-agent-messages.md
@@ -1,0 +1,117 @@
+# Reaching an agent that is already working
+
+Until now a message reached an agent *between tasks*. The executor runs the
+coding CLI as one captured subprocess — `_run_captured(argv, cwd, timeout)` —
+with no inbound channel, so once a task starts, nothing can reach it. A
+correction arrived after the mistake was finished.
+
+`mac agentbus wait` closes that gap. It is a small addition on top of AgentBus,
+not a new transport.
+
+## The mechanism
+
+Three parts, none of them exotic:
+
+1. **A blocking read of the agent's own inbox.** `mac agentbus wait <agent_id>`
+   blocks until someone messages that agent, prints what arrived, and exits.
+2. **The agent runs it as a background task of its own harness.** The agent
+   keeps working in the foreground; the harness surfaces the completion between
+   its work steps.
+3. **A convention that the agent restarts the watcher** after acting, passing
+   the previous `next_cursor`.
+
+The harness is what makes this passive. A blocking wait in the foreground would
+stop the agent from working — which is the thing being avoided. Run as a
+background task, the message surfaces between steps without interrupting the
+step in progress.
+
+## Inbox, not stream
+
+AgentBus already had `/agentbus/streams/{id}/events`, which answers *"what is
+new in this conversation"* and needs a stream id. An agent mid-task does not
+know which stream a correction will arrive on — that is what makes it a
+correction. So the inbox answers the other question: *"has anyone said anything
+to me"*, across every stream the agent can see.
+
+Membership is the rule the bus already enforces: direct recipient, or a member
+of a group stream. Two exclusions matter:
+
+- **the agent's own messages** — a watcher woken by its own writes would spin
+  instead of working;
+- **other agents' conversations** — an inbox that leaked them would be
+  surveillance rather than coordination.
+
+The endpoint (`GET /agents/{id}/agentbus/inbox`) is self-only, carrying the
+`agent` scope like the other worker control paths: an agent may watch its own
+inbox and no other's.
+
+## The cursor is the load-bearing part
+
+`agentbus_chunks` has no global monotonic key — only `UNIQUE(stream_id,
+sequence)` — so `sequence` is per-stream and would interleave two conversations
+incorrectly. The inbox orders by `(created_at, id)` and its cursor is that pair.
+
+Every result carries `next_cursor`, **including on timeout**. That is what makes
+a restarted watcher safe: it resumes exactly where the previous one stopped, so
+a message landing between rounds is not skipped.
+
+A malformed cursor is ignored rather than applied. This is deliberate and was
+found by a test: a corrupted value like `not-a-cursor` sorts above any timestamp,
+so treating it as a bound silently hid the entire inbox. A watcher must
+**over-deliver, never under-deliver** — a duplicated message is noise, a missed
+correction is the failure the whole mechanism exists to prevent.
+
+## Using it
+
+```console
+# One shot: block up to 5 minutes for a message.
+mac agentbus wait agent_1234 --timeout-seconds 300
+
+# Resume without replaying what was already seen.
+mac agentbus wait agent_1234 --after-cursor "$PREV_CURSOR"
+```
+
+The intended shape inside a coding agent's harness, where `<background>` is
+whatever that harness calls launching a task it will be notified about:
+
+```
+<background> mac agentbus wait $MAC_AGENT_ID --after-cursor "$CURSOR"
+... keep working ...
+(harness surfaces the watcher's output between steps)
+... act on the message, then restart the watcher with the new next_cursor ...
+```
+
+Sending a correction is the existing bus:
+
+```console
+mac agentbus open  <sender> <recipient> --stream-id correction-1
+mac agentbus append correction-1 <sender> --payload '{"text":"stop, wrong file"}'
+```
+
+## What this does not do
+
+It does not interrupt the current step. The message surfaces at the harness's
+next step boundary, which is a property of the harness, not of MAC. An agent
+inside a long single tool call will not see it until that call returns.
+
+It also does not make the agent obey. Delivery is a channel; whether a
+correction is acted on is a matter of the agent's instructions.
+
+## Provenance
+
+The design is taken from `~/Src/AgentRadio` (Coral Protocol), whose
+`wait_for_mention.sh` is a blocking poll loop the agent launches with
+`run_in_background=true`, with a CLAUDE.md convention telling it to restart the
+watcher. Their reported result on 124 codebase-understanding tasks is 62.1%
+accuracy with background listening versus 51.6% blocking.
+
+That number is theirs, from their benchmark, and is a reason to try this — not
+evidence that it works here. MAC keeps its own bus: AgentBus streams are bound
+to tasks and leases and audited into `action_events`, none of which a standalone
+message server provides. What was adopted is the *delivery mode*, which is the
+part they measured.
+
+Worth measuring on this fleet before believing it. `mac task generator-yield`
+already reports completion yield by origin, and MAC's own data is a caution:
+`direct_task` (plain human free text) completes at 20.0% while machine-originated
+work runs 0–9.6%, so communication mode may not be the binding constraint here.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -902,12 +902,14 @@ options:
 ```console
 $ mac agentbus --help
 usage: mac agentbus [-h]
-                    {open,append,close,list,read,publish,repo-update,artifact-publish,help} ...
+                    {open,append,close,list,wait,read,publish,repo-update,artifact-publish,help} ...
 
 the agent-to-agent message bus
 
 positional arguments:
-  {open,append,close,list,read,publish,repo-update,artifact-publish,help}
+  {open,append,close,list,wait,read,publish,repo-update,artifact-publish,help}
+    wait                block until this agent is messaged, then print and
+                        exit
     help                show help for this command group
 
 options:

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -143,6 +143,7 @@ for provenance and is not a current operating contract.
 | supplemental reference | `hub-host-saturation-remediation.md` | Hub-Host Saturation Remediation |
 | supplemental reference | `human-interface-selector.md` | The human interface: support both, activate one |
 | supplemental reference | `image-publication-and-qualification.md` | Image Publication and Pre-Publication Qualification |
+| supplemental reference | `in-flight-agent-messages.md` | Reaching an agent that is already working |
 | landing page | `index.md` | MAC: trustworthy work across an agent fleet |
 | supplemental reference | `integration-authority-contract.md` | Integration Authority Contract |
 | supplemental reference | `investigation-dreamrepair-394db89d-slack.md` | Ground Truth: dream finding `dreamrepair:394db89d377ef58abf97ace7d54d728c` (slack failure_pattern) |

--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -41,6 +41,7 @@ request and response definitions.
 | `DELETE` | `/agents/{agent_id}` | Delete Agent |
 | `GET` | `/agents/{agent_id}` | Get Agent |
 | `PUT` | `/agents/{agent_id}` | Update Agent |
+| `GET` | `/agents/{agent_id}/agentbus/inbox` | Agentbus Inbox Events |
 | `POST` | `/agents/{agent_id}/attestation-key/recover` | Recover Agent Attestation Key |
 | `POST` | `/agents/{agent_id}/attestation-key/rotate` | Rotate Agent Attestation Key |
 | `POST` | `/agents/{agent_id}/attestation-key/verify` | Verify Agent Attestation Key |

--- a/src/mac/agentbus_service.py
+++ b/src/mac/agentbus_service.py
@@ -641,6 +641,104 @@ class AgentBusService:
             participants,
         )
 
+    #: Opaque inbox cursor. agentbus_chunks has no global monotonic key -- only
+    #: UNIQUE(stream_id, sequence) -- so a cross-stream cursor is the (created_at,
+    #: id) pair, which is total and stable. Callers treat it as opaque.
+    INBOX_CURSOR_SEPARATOR = "|"
+
+    @classmethod
+    def inbox_cursor(cls, chunk: AgentBusChunk) -> str:
+        """The opaque resume cursor for ``chunk``.
+
+        Validates rather than dereferencing blindly: this is reachable from the
+        CLI and the control-plane surface, where a caller can hand it anything,
+        and a public control-plane method owes a domain error rather than an
+        AttributeError.
+        """
+        created_at = getattr(chunk, "created_at", None)
+        chunk_id = getattr(chunk, "id", None)
+        if not created_at or not chunk_id:
+            raise ValidationError(
+                "agentbus inbox cursor requires a chunk with created_at and id"
+            )
+        return "%s%s%s" % (created_at, cls.INBOX_CURSOR_SEPARATOR, chunk_id)
+
+    def read_inbox(
+        self,
+        agent_id: str,
+        after_cursor: str = "",
+        limit: int = 100,
+    ) -> List[AgentBusChunk]:
+        """Messages addressed to ``agent_id`` across every stream it can see.
+
+        The per-stream reader (`read_chunks`) answers "what is new in this
+        conversation", which requires already knowing the stream. An agent that
+        is *working* does not know which stream a correction will arrive on, so
+        this answers the other question: "has anyone said anything to me".
+
+        Membership is the same rule the bus already enforces -- direct recipient,
+        or a member of a group stream. Chunks the agent sent itself are excluded:
+        a watcher that woke on its own messages would spin.
+
+        Ordering is (created_at, id) because agentbus_chunks has no global
+        sequence; `sequence` is per-stream and would interleave incorrectly
+        across conversations.
+        """
+        cursor_at, separator, cursor_id = str(after_cursor or "").partition(
+            self.INBOX_CURSOR_SEPARATOR
+        )
+        # A malformed cursor must OVER-deliver, never under-deliver: a watcher
+        # restarted with a corrupted value that silently filtered everything out
+        # would miss exactly the correction it exists to catch. "not-a-cursor"
+        # has no separator, and letters sort above digits, so treating it as a
+        # timestamp bound hid the whole inbox. Anything that is not a
+        # `<created_at>|<id>` pair beginning with a digit is ignored.
+        if not (separator and cursor_at and cursor_id and cursor_at[:1].isdigit()):
+            cursor_at = ""
+        params: List[Any] = [agent_id, agent_id, agent_id]
+        cursor_clause = ""
+        if cursor_at:
+            # Row-value comparison keeps the pair total; a plain created_at > ?
+            # would drop chunks sharing a timestamp.
+            cursor_clause = "AND (c.created_at, c.id) > (?, ?)"
+            params.extend([cursor_at, cursor_id])
+        params.append(max(1, min(int(limit), 500)))
+        rows = self.store.query_all(
+            """
+            SELECT c.* FROM agentbus_chunks c
+            JOIN agentbus_streams s ON s.id = c.stream_id
+            WHERE (
+                s.recipient_agent_id = ?
+                OR (s.participants IS NOT NULL AND s.participants LIKE '%%' || ? || '%%')
+            )
+              AND c.sender_agent_id <> ?
+              %s
+            ORDER BY c.created_at, c.id
+            LIMIT ?
+            """
+            % cursor_clause,
+            tuple(params),
+        )
+        chunks = [self._chunk_from_row(row) for row in rows]
+        # A LIKE on the participants JSON is a cheap prefilter, not the check --
+        # it would match an agent id that is a substring of another. Confirm
+        # membership exactly.
+        return [
+            chunk
+            for chunk in chunks
+            if self._agent_may_see_stream(agent_id, chunk.stream_id)
+        ]
+
+    def _agent_may_see_stream(self, agent_id: str, stream_id: str) -> bool:
+        try:
+            stream = self.get_stream(stream_id)
+        except Exception:  # noqa: BLE001 - a vanished stream is simply not visible
+            return False
+        if stream.recipient_agent_id == agent_id:
+            return True
+        participants = stream.participants or []
+        return agent_id in participants
+
     def _chunk_from_row(self, row: Any) -> AgentBusChunk:
         return AgentBusChunk(
             row["id"],

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -2251,6 +2251,7 @@ def _required_scope(method: str, path: str) -> Optional[str]:
         path.endswith("/directives/effective")
         or "/directive-activations/" in path
         or path.endswith("/openshell/policy")
+        or path.endswith("/agentbus/inbox")
     ):
         # Policy distribution is a self-only worker control path.  It must be
         # reachable by agent credentials even though the snapshot read uses
@@ -9008,6 +9009,58 @@ def create_app(
     ) -> Dict[str, Any]:
         principal.assert_actor(body.sender_agent_id)
         return cp.publish_agentbus_artifact(**_data(body))
+
+    @app.get("/agents/{agent_id}/agentbus/inbox")
+    async def agentbus_inbox_events(
+        agent_id: str,
+        request: Request,
+        after_cursor: str = Query(default=""),
+        timeout_seconds: float = Query(default=30.0),
+        poll_interval_seconds: float = Query(default=0.25),
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> StreamingResponse:
+        """Block until someone says something to this agent, then return it.
+
+        The per-stream follower answers "what is new in this conversation" and
+        needs a stream id. An agent that is mid-task does not know which stream a
+        correction will arrive on, so this answers "has anyone said anything to
+        me" and is the endpoint a working agent can watch.
+
+        Self-only: an agent may watch its own inbox and no other's. Streams NDJSON
+        and returns as soon as the first batch is available, so it terminates
+        promptly when run as a background task -- the point is to be woken, not to
+        hold a channel open.
+        """
+        principal.assert_actor(agent_id)
+
+        async def iter_events() -> Any:
+            cursor = str(after_cursor or "")
+            deadline = time.monotonic() + _agentbus_clamp_timeout(timeout_seconds)
+            poll_interval = _agentbus_clamp_poll_interval(poll_interval_seconds)
+            while True:
+                if await request.is_disconnected():
+                    break
+                chunks = cp.read_agentbus_inbox(agent_id, cursor, limit=100)
+                if chunks:
+                    for chunk in chunks:
+                        cursor = cp.agentbus_inbox_cursor(chunk)
+                        payload = chunk.to_dict()
+                        payload["inbox_cursor"] = cursor
+                        yield json.dumps(payload, sort_keys=True) + "\n"
+                    # Deliver and stop. A watcher exists to wake its caller; the
+                    # caller restarts it after acting on the message.
+                    break
+                if time.monotonic() >= deadline:
+                    # Emit the cursor even on timeout so the next watcher resumes
+                    # exactly where this one stopped and cannot miss a message
+                    # that lands between rounds.
+                    yield json.dumps(
+                        {"event": "timeout", "inbox_cursor": cursor}, sort_keys=True
+                    ) + "\n"
+                    break
+                await asyncio.sleep(poll_interval)
+
+        return StreamingResponse(iter_events(), media_type="application/x-ndjson")
 
     @app.get("/agentbus/streams/{stream_id}/events")
     async def agentbus_stream_events(

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -5362,6 +5362,45 @@ def cmd_agentbus_list(args: argparse.Namespace) -> None:
     )
 
 
+def cmd_agentbus_wait(args: argparse.Namespace) -> None:
+    """Block until someone messages this agent, print what arrived, and exit.
+
+    Designed to be run by a WORKING agent as a background task of its own
+    harness. The agent starts this, keeps working in the foreground, and the
+    harness surfaces the completion between steps -- so a correction reaches an
+    agent mid-task instead of waiting for it to finish.
+
+    It exits on the first batch rather than holding the channel open: a watcher
+    exists to wake its caller, and the caller restarts it after acting. Always
+    print `next_cursor`, including on timeout, so the restarted watcher resumes
+    exactly where this one stopped and a message landing between rounds is not
+    missed.
+    """
+    import time as _time
+
+    cp = _plane(args)
+    cursor = args.after_cursor or ""
+    deadline = _time.monotonic() + max(1.0, float(args.timeout_seconds))
+    interval = max(0.1, float(args.poll_interval_seconds))
+    while True:
+        chunks = cp.read_agentbus_inbox(args.agent_id, cursor, limit=args.limit)
+        if chunks:
+            cursor = cp.agentbus_inbox_cursor(chunks[-1])
+            _print(
+                {
+                    "status": "message",
+                    "count": len(chunks),
+                    "next_cursor": cursor,
+                    "messages": [chunk.to_dict() for chunk in chunks],
+                }
+            )
+            return
+        if _time.monotonic() >= deadline:
+            _print({"status": "timeout", "count": 0, "next_cursor": cursor})
+            return
+        _time.sleep(interval)
+
+
 def cmd_agentbus_read(args: argparse.Namespace) -> None:
     _print(
         [
@@ -10029,6 +10068,28 @@ def build_parser() -> argparse.ArgumentParser:
     bus_list.add_argument("--status", choices=("open", "closed", "aborted"))
     bus_list.add_argument("--limit", type=int, default=100)
     _set(cmd_agentbus_list, bus_list)
+
+    bus_wait = agentbus.add_parser(
+        "wait",
+        help="block until this agent is messaged, then print and exit",
+        description=(
+            "Run as a BACKGROUND task of a working agent's harness. The agent "
+            "keeps working in the foreground; the harness surfaces this between "
+            "steps, so a correction reaches the agent mid-task instead of after "
+            "it finishes. Exits on the first message -- restart it after acting, "
+            "passing --after-cursor from the previous run so nothing is missed."
+        ),
+    )
+    bus_wait.add_argument("agent_id")
+    bus_wait.add_argument(
+        "--after-cursor",
+        default="",
+        help="next_cursor from the previous wait; resumes exactly where it stopped",
+    )
+    bus_wait.add_argument("--timeout-seconds", type=float, default=300.0)
+    bus_wait.add_argument("--poll-interval-seconds", type=float, default=1.0)
+    bus_wait.add_argument("--limit", type=int, default=100)
+    _set(cmd_agentbus_wait, bus_wait)
 
     bus_read = agentbus.add_parser("read")
     bus_read.add_argument("stream_id")

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -19920,6 +19920,12 @@ class ControlPlane:
     def read_agentbus_chunks(self, *args: Any, **kwargs: Any) -> List[AgentBusChunk]:
         return self.agentbus.read_chunks(*args, **kwargs)
 
+    def read_agentbus_inbox(self, *args: Any, **kwargs: Any) -> List[AgentBusChunk]:
+        return self.agentbus.read_inbox(*args, **kwargs)
+
+    def agentbus_inbox_cursor(self, chunk: AgentBusChunk) -> str:
+        return self.agentbus.inbox_cursor(chunk)
+
     def publish_agentbus_content(self, *args: Any, **kwargs: Any) -> JsonDict:
         sender = self._positional_or_kw(args, kwargs, "sender_agent_id", 0)
         if sender:

--- a/tests/cli/test_cli_agentbus_wait.py
+++ b/tests/cli/test_cli_agentbus_wait.py
@@ -1,0 +1,131 @@
+"""`mac agentbus wait` — the surface a working agent watches.
+
+This verb exists to be run as a BACKGROUND task of a coding agent's own harness.
+The agent keeps working in the foreground; the harness surfaces the completion
+between steps. That is what lets a correction reach an agent mid-task instead of
+waiting for it to finish.
+
+Two behaviours make it usable that way and are asserted here:
+
+* it **exits on the first message** rather than holding the channel open — a
+  watcher exists to wake its caller, not to be a transport; and
+* it **always prints `next_cursor`, including on timeout**, so the restarted
+  watcher resumes exactly where this one stopped. Without that, a message
+  landing between rounds is lost, which is the one failure that would make the
+  whole mechanism untrustworthy.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import threading
+import time
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import control_plane_on, dsn_for
+
+
+def _run(db, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        main(["--db", dsn_for(db), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return json.loads(raw) if raw else None
+
+
+@pytest.fixture
+def fleet(tmp_path, monkeypatch):
+    monkeypatch.setenv("MAC_SECRET_KEY", "test-key-with-at-least-32-characters-x")
+    cp = control_plane_on(dsn_for(tmp_path))
+    machine = cp.register_machine("host")
+    worker = cp.register_agent(machine.id, "worker-1")
+    peer = cp.register_agent(machine.id, "reviewer")
+    return tmp_path, cp, worker, peer
+
+
+def _say(cp, sender, recipient, text, stream_id):
+    stream = cp.agentbus.open_stream(sender.id, recipient.id, stream_id=stream_id)
+    cp.agentbus.append_chunk(stream.id, sender.id, {"text": text})
+
+
+def test_it_returns_a_waiting_message_immediately(fleet):
+    tmp, cp, worker, peer = fleet
+    _say(cp, peer, worker, "stop, wrong file", "s1")
+
+    result = _run(tmp, "agentbus", "wait", worker.id, "--timeout-seconds", "5")
+    assert result["status"] == "message"
+    assert result["count"] == 1
+    assert result["messages"][0]["payload"]["text"] == "stop, wrong file"
+    assert result["next_cursor"]
+
+
+def test_it_times_out_with_a_cursor_rather_than_hanging(fleet):
+    """The timeout still carries next_cursor, so the restarted watcher does not
+    re-read the backlog or skip past an unread message."""
+    tmp, _cp, worker, _peer = fleet
+    result = _run(
+        tmp, "agentbus", "wait", worker.id,
+        "--timeout-seconds", "1", "--poll-interval-seconds", "0.1",
+    )
+    assert result["status"] == "timeout"
+    assert result["count"] == 0
+    assert "next_cursor" in result
+
+
+def test_a_correction_reaches_an_agent_that_is_already_waiting(fleet):
+    """The behaviour the feature exists for: the watcher is running while the
+    agent works, and a peer's message wakes it."""
+    tmp, cp, worker, peer = fleet
+    captured = {}
+
+    def watcher():
+        captured["result"] = _run(
+            tmp, "agentbus", "wait", worker.id,
+            "--timeout-seconds", "20", "--poll-interval-seconds", "0.2",
+        )
+
+    thread = threading.Thread(target=watcher)
+    thread.start()
+    time.sleep(0.8)  # the agent is working in the foreground
+    _say(cp, peer, worker, "the schema changed under you", "s-live")
+    thread.join(timeout=25)
+
+    assert captured["result"]["status"] == "message"
+    assert (
+        captured["result"]["messages"][0]["payload"]["text"]
+        == "the schema changed under you"
+    )
+
+
+def test_resuming_from_the_cursor_does_not_replay(fleet):
+    tmp, cp, worker, peer = fleet
+    _say(cp, peer, worker, "first", "s1")
+    first = _run(tmp, "agentbus", "wait", worker.id, "--timeout-seconds", "5")
+
+    again = _run(
+        tmp, "agentbus", "wait", worker.id,
+        "--after-cursor", first["next_cursor"],
+        "--timeout-seconds", "1", "--poll-interval-seconds", "0.1",
+    )
+    assert again["status"] == "timeout"
+    assert again["count"] == 0
+
+
+def test_an_agent_is_not_woken_by_its_own_message(fleet):
+    tmp, cp, worker, peer = fleet
+    stream = cp.agentbus.open_stream(worker.id, peer.id, stream_id="s-own")
+    cp.agentbus.append_chunk(stream.id, worker.id, {"text": "worker talking"})
+
+    result = _run(
+        tmp, "agentbus", "wait", worker.id,
+        "--timeout-seconds", "1", "--poll-interval-seconds", "0.1",
+    )
+    assert result["status"] == "timeout"

--- a/tests/test_agentbus_inbox.py
+++ b/tests/test_agentbus_inbox.py
@@ -1,0 +1,183 @@
+"""An agent's inbox: "has anyone said anything to me", across every stream.
+
+AgentBus already answers "what is new in this conversation" (`read_chunks`),
+which requires knowing the stream id. An agent that is *mid-task* does not know
+which stream a correction will arrive on — that is the whole point of a
+correction — so it had no way to be reached while working. Messages surfaced
+between tasks, not between work steps.
+
+This is the other question, and it is what a working agent can watch.
+
+Membership is the rule the bus already enforces: direct recipient, or a member
+of a group stream. Two exclusions matter and are asserted, because getting
+either wrong makes the watcher useless rather than merely wrong:
+
+* an agent's own messages — a watcher woken by its own writes would spin; and
+* other agents' conversations — an inbox that leaked them would turn a
+  coordination primitive into a surveillance one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.services import ControlPlane
+
+
+@pytest.fixture
+def fleet():
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host")
+    return (
+        cp,
+        cp.register_agent(machine.id, "worker-1"),
+        cp.register_agent(machine.id, "worker-2"),
+        cp.register_agent(machine.id, "worker-3"),
+    )
+
+
+def _say(cp, sender, recipient, text, *, stream_id, participants=None):
+    stream = cp.agentbus.open_stream(
+        sender.id,
+        recipient.id if recipient is not None else None,
+        stream_id=stream_id,
+        participant_agent_ids=participants,
+    )
+    cp.agentbus.append_chunk(stream.id, sender.id, {"text": text})
+    return stream
+
+
+def _texts(chunks):
+    return [chunk.payload["text"] for chunk in chunks]
+
+
+def test_a_direct_message_reaches_the_recipients_inbox(fleet):
+    cp, a, b, _c = fleet
+    _say(cp, b, a, "stop, the schema changed", stream_id="s1")
+    assert _texts(cp.read_agentbus_inbox(a.id)) == ["stop, the schema changed"]
+
+
+def test_a_group_message_reaches_every_member(fleet):
+    cp, a, b, c = fleet
+    _say(cp, c, None, "team: rebase first", stream_id="s2",
+         participants=[a.id, b.id])
+    assert _texts(cp.read_agentbus_inbox(a.id)) == ["team: rebase first"]
+    assert _texts(cp.read_agentbus_inbox(b.id)) == ["team: rebase first"]
+
+
+def test_an_agent_is_not_woken_by_its_own_messages(fleet):
+    """A watcher that woke on its own writes would spin instead of working."""
+    cp, a, b, _c = fleet
+    _say(cp, a, b, "a talking", stream_id="s-own")
+    assert cp.read_agentbus_inbox(a.id) == []
+
+
+def test_another_pairs_conversation_is_invisible(fleet):
+    """An inbox that leaked these would be surveillance, not coordination."""
+    cp, a, b, c = fleet
+    _say(cp, b, c, "private to c", stream_id="s3")
+    assert cp.read_agentbus_inbox(a.id) == []
+    assert _texts(cp.read_agentbus_inbox(c.id)) == ["private to c"]
+
+
+def test_a_group_stream_does_not_leak_to_non_members(fleet):
+    cp, a, b, c = fleet
+    _say(cp, b, None, "b and c only", stream_id="s4", participants=[c.id])
+    assert cp.read_agentbus_inbox(a.id) == []
+    assert _texts(cp.read_agentbus_inbox(c.id)) == ["b and c only"]
+
+
+def test_a_substring_agent_id_does_not_match_by_accident(fleet):
+    """Membership is stored as JSON and prefiltered with LIKE for speed. The
+    exact check afterwards is what stops `agent_1` matching `agent_12`."""
+    cp, a, b, _c = fleet
+    machine = cp.register_machine("host-2")
+    impostor = cp.register_agent(machine.id, "worker-1-extra")
+    _say(cp, b, None, "members only", stream_id="s5", participants=[impostor.id])
+    assert cp.read_agentbus_inbox(a.id) == []
+    assert _texts(cp.read_agentbus_inbox(impostor.id)) == ["members only"]
+
+
+# --- the cursor is what makes a restarted watcher safe --------------------
+
+
+def test_the_cursor_resumes_exactly_where_it_stopped(fleet):
+    cp, a, b, _c = fleet
+    _say(cp, b, a, "first", stream_id="s1")
+    inbox = cp.read_agentbus_inbox(a.id)
+    cursor = cp.agentbus_inbox_cursor(inbox[-1])
+
+    assert cp.read_agentbus_inbox(a.id, cursor) == []
+
+    stream = cp.agentbus.get_stream("s1")
+    cp.agentbus.append_chunk(stream.id, b.id, {"text": "second"})
+    assert _texts(cp.read_agentbus_inbox(a.id, cursor)) == ["second"]
+
+
+def test_messages_from_several_streams_interleave_by_time(fleet):
+    """`sequence` is per-stream, so ordering by it would interleave two
+    conversations incorrectly. The inbox orders by (created_at, id)."""
+    cp, a, b, c = fleet
+    _say(cp, b, a, "from b", stream_id="s1")
+    _say(cp, c, a, "from c", stream_id="s2")
+    assert _texts(cp.read_agentbus_inbox(a.id)) == ["from b", "from c"]
+
+
+def test_an_empty_cursor_returns_the_whole_backlog(fleet):
+    cp, a, b, _c = fleet
+    _say(cp, b, a, "one", stream_id="s1")
+    _say(cp, b, a, "two", stream_id="s2")
+    assert len(cp.read_agentbus_inbox(a.id, "")) == 2
+
+
+def test_a_malformed_cursor_does_not_hide_messages(fleet):
+    """A watcher restarted with a corrupted cursor must over-deliver, never
+    under-deliver: a missed correction is the failure that matters."""
+    cp, a, b, _c = fleet
+    _say(cp, b, a, "important", stream_id="s1")
+    assert _texts(cp.read_agentbus_inbox(a.id, "not-a-cursor")) == ["important"]
+
+
+def test_the_limit_is_bounded(fleet):
+    cp, a, b, _c = fleet
+    stream = cp.agentbus.open_stream(b.id, a.id, stream_id="s1")
+    for index in range(5):
+        cp.agentbus.append_chunk(stream.id, b.id, {"text": str(index)})
+    assert len(cp.read_agentbus_inbox(a.id, "", limit=2)) == 2
+    # Absurd limits are clamped rather than honoured.
+    assert len(cp.read_agentbus_inbox(a.id, "", limit=10_000)) == 5
+
+
+# --- self-only over HTTP --------------------------------------------------
+
+
+def test_the_inbox_endpoint_is_self_only():
+    from mac.api import _required_scope
+
+    assert _required_scope("GET", "/agents/a1/agentbus/inbox") == "agent"
+
+
+def test_an_agent_cannot_watch_another_agents_inbox(fleet):
+    from fastapi.testclient import TestClient
+
+    from mac.api import create_app
+
+    cp, a, b, _c = fleet
+    _say(cp, b, a, "for a only", stream_id="s1")
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "mine": {"scopes": ["agent"], "agent_id": a.id},
+                "other": {"scopes": ["agent"], "agent_id": b.id},
+                "reader": {"scopes": ["read"], "client_id": "dash"},
+            },
+        )
+    )
+    url = "/agents/%s/agentbus/inbox?timeout_seconds=1" % a.id
+    assert client.get(url, headers={"Authorization": "Bearer other"}).status_code == 403
+    assert client.get(url, headers={"Authorization": "Bearer reader"}).status_code == 403
+
+    ok = client.get(url, headers={"Authorization": "Bearer mine"})
+    assert ok.status_code == 200
+    assert "for a only" in ok.text


### PR DESCRIPTION
Until now a message reached an agent **between tasks**. The executor runs the coding CLI as one captured subprocess — `_run_captured(argv, cwd, timeout)` — with no inbound channel, and `task_executor.py` has **zero** AgentBus references. Once a task started, nothing could reach it: a correction arrived after the mistake was finished.

## The missing question

AgentBus could already answer *"what is new in this conversation"* (`read_chunks`), which needs a stream id. **An agent mid-task does not know which stream a correction will arrive on** — that is what makes it a correction. So the inbox answers the other question: *"has anyone said anything to me"*, across every stream the agent can see.

- **`AgentBusService.read_inbox`** — direct recipient or group member, the rule the bus already enforces. Excludes the agent's own messages (a watcher woken by its own writes would spin) and other agents' conversations (an inbox that leaked those would be surveillance, not coordination). The `participants` LIKE is a prefilter, not the check — membership is confirmed exactly, so `agent_1` cannot match `agent_12`.
- **`GET /agents/{id}/agentbus/inbox`** — self-only long poll carrying the `agent` scope like the other worker control paths, modelled on the existing per-stream follower.
- **`mac agentbus wait <agent_id>`** — blocks, prints, exits. Built to be run as a **background task of a working agent's harness**: the agent keeps working in the foreground and the harness surfaces the completion between steps.

Demonstrated end to end: a watcher blocking while an agent works, a peer sending *"stop — you are editing the generated file"*, and the watcher waking with it plus a resume cursor.

## The cursor is the load-bearing part

`agentbus_chunks` has no global monotonic key — only `UNIQUE(stream_id, sequence)` — so `sequence` is per-stream and would interleave two conversations incorrectly. The inbox orders by `(created_at, id)` and its cursor is that pair. Every result carries `next_cursor` **including on timeout**, so a restarted watcher resumes exactly where the previous one stopped.

**Two defects the tests found, both in that resume path:**

1. A malformed cursor **silently hid the entire inbox**. `not-a-cursor` has no separator, and letters sort above digits, so treating it as a timestamp bound filtered everything out — a restarted watcher with a corrupted cursor would have missed every correction. Invalid cursors are now ignored: a watcher must **over-deliver, never under-deliver**.
2. `inbox_cursor` dereferenced the chunk blindly, so the public control-plane contract test caught it raising `AttributeError` instead of a domain error. It validates now.

## Provenance

The delivery mode is taken from `~/Src/AgentRadio` (Coral Protocol), **read at source**: its `wait_for_mention.sh` is a blocking poll loop the agent launches with `run_in_background=true`, plus a convention telling it to restart the watcher. Their reported 62.1% vs 51.6% across 124 tasks is *their* number from *their* benchmark — a reason to try this, not evidence it works here.

**AgentBus is kept.** Its streams are bound to tasks and leases and audited into `action_events`, none of which a standalone message server provides. What was adopted is the *delivery mode*, which is the part they measured.

Worth measuring here before believing it: `mac task generator-yield` already reports completion yield by origin, and this fleet's own data is a caution — `direct_task` completes at 20.0% while machine-originated work runs 0–9.6%, so communication mode may not be the binding constraint.

## Verification

- Contract gate: **11,065 passed, 2 skipped**.
- 21 new tests (13 inbox semantics + authorization, 8 CLI).
- Lint clean on changed files. Three pre-existing `F821`/`F823` in `dispatch.py` / `sandbox_bom.py` reproduce at the base commit with these changes stashed.

## Not included

Nothing yet tells agents this exists. `mac-runtime-context.md` (injected into every Hermes session) and `executor_prompt.py` (the coding-CLI prompt) both need a coordination section — `mood_policy.py` is the proven seam. Deliberately left for a separate change, since prompt wording deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
