### PR TITLE
Tell agents the bus exists, and tell them to use it narrowly

### DIFF
--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -314,6 +314,7 @@
       "src/mac/evidence_cli.py",
       "src/mac/executor_finalizer.py",
       "src/mac/executor_hub_io.py",
+      "src/mac/executor_prompt.py",
       "src/mac/executor_sandbox.py",
       "src/mac/hermes_runtime.py",
       "src/mac/journal.py",

--- a/src/mac/executor_prompt.py
+++ b/src/mac/executor_prompt.py
@@ -802,6 +802,46 @@ def _cooperative_integration_section(task: Dict[str, Any]) -> str:
 
 
 
+def _coordination_section(task: Dict[str, Any]) -> str:
+    """Tell the executor it is one of several agents, and how to say so.
+
+    Deliberately narrow. The collision this fleet actually records is two agents
+    editing the same checkout -- CLAUDE.md documents one nearly sweeping 1,200
+    lines of another's work into an unrelated commit, and a second that did. So
+    the announcement is scoped to "the repo and paths I am about to modify",
+    which is the fact a peer can act on. General status narration would make the
+    inbox noise, agents would learn to ignore it, and every message is durable
+    and audited into action_events -- it is not free.
+
+    Returns "" when MAC_AGENT_ID is unset. Without an identity the agent cannot
+    address the bus or watch its own inbox, and instructions it cannot follow are
+    worse than silence: they invite invented commands and wasted turns.
+    """
+    agent_id = str(os.environ.get("MAC_AGENT_ID") or "").strip()
+    if not agent_id:
+        return ""
+    return "\n".join(
+        [
+            "Coordination: you are one of several agents that may be working at "
+            "the same time, possibly in the same repository.",
+            "",
+            "- BEFORE your first edit, announce what you are about to touch: the "
+            "repository and the paths. Keep it to that -- a peer can act on "
+            "\"I am editing src/mac/api.py\"; nobody can act on a status update.",
+            "- Start a watcher in the BACKGROUND and keep working while it runs: "
+            "`mac agentbus wait %s`. It blocks until someone messages you, prints "
+            "the message, and exits. Restart it after acting, passing "
+            "`--after-cursor` from the previous run so nothing is missed."
+            % agent_id,
+            "- A message may be a correction. Read it before continuing, and if a "
+            "peer says they own a file you were about to change, believe them and "
+            "adjust rather than racing.",
+            "- Do not narrate progress. Announce what you will touch, answer "
+            "direct questions, and otherwise stay quiet.",
+        ]
+    )
+
+
 def build_task_prompt(task: Dict[str, Any], task_file: Path, lessons: Optional[List[str]] = None) -> str:
     """Build the full executor prompt text for the given task."""
     metadata = task.get("metadata") if isinstance(task, dict) else {}
@@ -827,6 +867,9 @@ def build_task_prompt(task: Dict[str, Any], task_file: Path, lessons: Optional[L
         ),
         "Repository runtime contract:\n%s" % repository_contract_section(task),
     ]
+    coordination_section = _coordination_section(task)
+    if coordination_section:
+        parts.append(coordination_section)
     integration_section = _cooperative_integration_section(task)
     if integration_section:
         parts.append(integration_section)

--- a/src/mac/hermes_runtime.py
+++ b/src/mac/hermes_runtime.py
@@ -725,6 +725,24 @@ def render_runtime_markdown(context: Dict[str, Any]) -> str:
         "- Identity boundary: answer only as `%s`; never claim to be, proxy for, or relay as another agent. If a channel message clearly addresses a different agent, stay silent and let that agent answer."
         % agent["name"],
         "",
+        "## Coordination",
+        "",
+        # The bus existed and nothing told agents it did -- the same failure
+        # mood-01 fixed for mood overlays. Scoped to what a peer can act on:
+        # "I am editing these paths", not a status feed. Every message is
+        # durable and audited, so narration has a real cost.
+        "- You are one of several agents. Others may be working at the same time, "
+        "possibly in the same repository.",
+        "- Before you start changing a repository, say which one and which paths, "
+        "so a peer can avoid colliding with you.",
+        "- Watch your own inbox in the BACKGROUND while you work: "
+        "`mac agentbus wait %s`. It blocks until someone messages you, prints it, "
+        "and exits; restart it afterwards with `--after-cursor` from the previous "
+        "run. A message may be a correction, so read it before continuing."
+        % agent["agent_id"],
+        "- Announce what you will touch and answer direct questions. Do not narrate "
+        "progress -- an inbox of status updates is one everybody learns to ignore.",
+        "",
         "## Authority",
         "",
         "- Fleets, agents, tasks, projects: `%s`, `%s`, `%s`, `%s`"

--- a/tests/test_agent_coordination_prompt.py
+++ b/tests/test_agent_coordination_prompt.py
@@ -1,0 +1,140 @@
+"""Agents are told the bus exists, and told to use it narrowly.
+
+AgentBus has been shippable for a long time and nothing in an agent's context
+mentioned it — the same failure mood-01 fixed for mood overlays, whose docstring
+says it plainly: "mac already stores per-agent mood overlays ... but nothing ever
+rendered them into the agent's prompt, so a set mood had no effect."
+
+Two populations, two separate surfaces, neither of which previously said
+anything about coordinating:
+
+* `mac-runtime-context.md` — injected into every Hermes session;
+* `build_task_prompt` — the coding CLI the executor launches per task.
+
+The scope is the point. This fleet's recorded collision is two agents editing
+the same checkout (CLAUDE.md: one nearly swept ~1,200 lines of another's work
+into an unrelated commit; a second did). So agents are told to announce *the
+repository and paths they are about to modify* — a fact a peer can act on — and
+explicitly told NOT to narrate progress. Every message is durable and audited
+into action_events; an inbox of status updates is one everybody learns to
+ignore, which would make the whole channel worthless.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mac.executor_prompt import build_task_prompt
+
+TASK = {
+    "id": "task_1",
+    "metadata": {
+        "origin": {"repository_contract": {"schema": "mac.repository_contract.v1"}}
+    },
+}
+
+
+def _prompt(monkeypatch, agent_id: str | None) -> str:
+    if agent_id is None:
+        monkeypatch.delenv("MAC_AGENT_ID", raising=False)
+    else:
+        monkeypatch.setenv("MAC_AGENT_ID", agent_id)
+    return build_task_prompt(TASK, Path("/tmp/task.json"))
+
+
+# --- the executor prompt --------------------------------------------------
+
+
+def test_the_executor_is_told_it_is_one_of_several_agents(monkeypatch):
+    text = _prompt(monkeypatch, "agent_abc")
+    assert "Coordination:" in text
+    assert "one of several agents" in text
+
+
+def test_it_names_the_actual_command_with_the_agents_own_id(monkeypatch):
+    """A generic 'coordinate with peers' instruction invites invented commands."""
+    text = _prompt(monkeypatch, "agent_abc")
+    assert "mac agentbus wait agent_abc" in text
+    assert "--after-cursor" in text
+
+
+def test_it_is_absent_without_an_agent_identity(monkeypatch):
+    """Without MAC_AGENT_ID the agent cannot address the bus or watch its own
+    inbox. An instruction it cannot follow is worse than silence."""
+    assert "Coordination:" not in _prompt(monkeypatch, None)
+    assert "agentbus" not in _prompt(monkeypatch, None)
+
+
+def test_the_announcement_is_scoped_to_paths_not_status(monkeypatch):
+    """The recorded collision is two agents editing the same checkout, so the
+    announcement is the repo and paths — and progress narration is refused."""
+    text = _prompt(monkeypatch, "agent_abc")
+    assert "paths" in text
+    assert "Do not narrate progress" in text
+
+
+def test_it_tells_the_agent_a_message_may_be_a_correction(monkeypatch):
+    """Delivery is pointless if the agent treats an inbound message as trivia."""
+    text = _prompt(monkeypatch, "agent_abc")
+    assert "correction" in text
+
+
+def test_it_does_not_disturb_the_rest_of_the_prompt(monkeypatch):
+    """The coordination block is additive; the standing contract must survive."""
+    text = _prompt(monkeypatch, "agent_abc")
+    for expected in (
+        "You are running as a MAC fleet worker",
+        "Repository runtime contract:",
+        "Read the full task from:",
+    ):
+        assert expected in text, expected
+
+
+# --- the Hermes runtime context ------------------------------------------
+
+
+def _runtime_markdown(agent_id: str = "agent_xyz") -> str:
+    from mac.hermes_runtime import build_runtime_context, render_runtime_markdown
+
+    context = build_runtime_context(
+        agent_name="worker-1",
+        fleet_name="test-fleet",
+        mac_url="http://127.0.0.1:8789",
+        hermes_home=Path("/tmp/hermes-home"),
+        mac_home=Path("/tmp/mac-home"),
+        agent_id=agent_id,
+    )
+    return render_runtime_markdown(context)
+
+
+def test_every_hermes_session_gets_a_coordination_section():
+    text = _runtime_markdown()
+    assert "## Coordination" in text
+    assert "one of several agents" in text
+
+
+def test_the_runtime_section_names_the_command_with_the_agents_id():
+    assert "mac agentbus wait agent_xyz" in _runtime_markdown("agent_xyz")
+
+
+def test_the_runtime_section_also_refuses_progress_narration():
+    assert "Do not narrate" in _runtime_markdown()
+
+
+def test_it_sits_beside_the_existing_sections_without_replacing_them():
+    text = _runtime_markdown()
+    for heading in ("## Identity", "## Authority", "## Coordination"):
+        assert heading in text, heading
+    # Identity must still come first: the agent has to know who it is before it
+    # is told to speak as itself on a shared bus.
+    assert text.index("## Identity") < text.index("## Coordination")
+
+
+@pytest.mark.parametrize("phrase", ["status update", "narrate"])
+def test_both_surfaces_warn_against_noise(monkeypatch, phrase):
+    """Said in both places deliberately. A bus that fills with narration is one
+    agents learn to ignore, and the messages are durable and audited."""
+    combined = _prompt(monkeypatch, "agent_abc") + _runtime_markdown()
+    assert phrase in combined


### PR DESCRIPTION
> **Stacked on #318**, so the command these instructions name actually exists.

AgentBus has been shippable for a long time and **nothing in an agent's context mentioned it.** That is the same failure `mood-01` fixed for mood overlays, whose docstring says it plainly:

> mac already stores per-agent mood overlays … but **nothing ever rendered them into the agent's prompt, so a set mood had no effect**

A capability nobody is told about is not a capability.

## There is no skill to change

`skills/` holds two entries (`mac-agent-terminal-timeout`, `setup-mac-fleet`), both operator-facing; neither is injected into a session. There are **two** instruction surfaces, for two different agent populations, and neither said anything about coordinating:

| Surface | Reaches |
| --- | --- |
| `mac-runtime-context.md` (`hermes_runtime.render_runtime_markdown`) | every Hermes session |
| `build_task_prompt` | the coding CLI the executor launches per task |

The second matters more for the failure this fleet actually records. Both now carry a coordination block.

## Scope is the point

CLAUDE.md documents the collision: two agents sharing a checkout, one **moments from sweeping ~1,200 lines** of another's half-finished work into an unrelated commit, and a second that *did* — silent, tests passing, visible only later in `git log`.

So agents are told to announce **the repository and paths they are about to modify** — a fact a peer can act on — and explicitly told **not to narrate progress**.

That refusal is deliberate and asserted in the tests. Every bus message is durable and audited into `action_events`, so narration is not free, and an inbox of status updates is one everybody learns to ignore — which would make the channel worthless exactly when a real correction arrives.

Both surfaces name the concrete command with the agent's own id (`mac agentbus wait <agent_id>`), because a vague "coordinate with peers" instruction invites invented commands and wasted turns.

## One deliberate refusal

The executor block is **absent when `MAC_AGENT_ID` is unset**, with a test pinning it. Without an identity the agent cannot address the bus or watch its own inbox; an instruction it cannot follow is worse than silence.

In the runtime context the section sits **after Identity**, so an agent knows who it is before being told to speak as itself on a shared bus.

## Verification

- Contract gate: **11,077 passed, 2 skipped**.
- 12 new tests, including that both surfaces warn against noise and that the standing prompt contract survives.
- 221 passing across the touched modules; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
