### PR TITLE
Fix the CLI spelling that failed the fleet deploy

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -10986,7 +10986,7 @@ retire_spoke_local_control_plane_database() {
   [ -f "$source" ] || return 0
 
   log "spoke has a legacy local control-plane database; inspecting before retirement"
-  "$VENV/bin/mac" --json migrate local-ledger --source-db "$source" > "$plan"
+  "$VENV/bin/mac" --json admin migrate local-ledger --source-db "$source" > "$plan"
   active="$("$PY" - "$plan" <<'PY'
 import json
 import sys
@@ -11001,7 +11001,7 @@ PY
   fi
 
   retirement="$LOG_DIR/spoke-local-ledger-retirement.json"
-  "$VENV/bin/mac" --json migrate local-ledger \
+  "$VENV/bin/mac" --json admin migrate local-ledger \
     --source-db "$source" \
     --archive-dir "$MAC_HOME/archive" \
     --retire-inactive > "$retirement"

--- a/deploy/openshell/bootstrap-openshell.sh
+++ b/deploy/openshell/bootstrap-openshell.sh
@@ -1321,7 +1321,7 @@ EOF
   case "$HUB_HOST" in 127.0.0.1|localhost|0.0.0.0|"") POLICY_HUB=host.openshell.internal;; *) POLICY_HUB="$HUB_HOST";; esac
   HUB_PORT="$(printf '%s' "$HUB_URL" | grep -oE ':[0-9]+' | tr -d : | head -1)"; HUB_PORT="${HUB_PORT:-8789}"
   log "policy egress hub: $POLICY_HUB:$HUB_PORT"
-  "$MAC_HOME/venv/bin/mac" openshell render-policy \
+  "$MAC_HOME/venv/bin/mac" admin openshell render-policy \
     --template "$(cd "$(dirname "$0")" && pwd)/mac-hermes-policy.yaml" \
     --agent-user "$USER" --hub-host "$POLICY_HUB" --hub-port "$HUB_PORT" \
     --image-runtime /opt/mac-venv --into "$MAC_HOME/openshell-policy.yaml" >/dev/null
@@ -1986,7 +1986,7 @@ HUB_HOST="$(printf '%s' "$HUB_URL" | sed -E 's#^https?://##; s#[:/].*##')"
 case "$HUB_HOST" in 127.0.0.1|localhost|0.0.0.0|"") POLICY_HUB=host.openshell.internal;; *) POLICY_HUB="$HUB_HOST";; esac
 HUB_PORT="$(printf '%s' "$HUB_URL" | grep -oE ':[0-9]+' | tr -d : | head -1)"; HUB_PORT="${HUB_PORT:-8789}"
 log "policy egress hub: $POLICY_HUB:$HUB_PORT"
-"$MAC_HOME/venv/bin/mac" openshell render-policy \
+"$MAC_HOME/venv/bin/mac" admin openshell render-policy \
   --template "$(cd "$(dirname "$0")" && pwd)/mac-hermes-policy.yaml" \
   --agent-user "$USER" --hub-host "$POLICY_HUB" --hub-port "$HUB_PORT" \
   --image-runtime /opt/mac-venv --into "$MAC_HOME/openshell-policy.yaml" >/dev/null

--- a/src/mac/executor_prompt.py
+++ b/src/mac/executor_prompt.py
@@ -829,7 +829,7 @@ def _coordination_section(task: Dict[str, Any]) -> str:
             "repository and the paths. Keep it to that -- a peer can act on "
             "\"I am editing src/mac/api.py\"; nobody can act on a status update.",
             "- Start a watcher in the BACKGROUND and keep working while it runs: "
-            "`mac agentbus wait %s`. It blocks until someone messages you, prints "
+            "`mac admin agentbus wait %s`. It blocks until someone messages you, prints "
             "the message, and exits. Restart it after acting, passing "
             "`--after-cursor` from the previous run so nothing is missed."
             % agent_id,

--- a/src/mac/hermes_runtime.py
+++ b/src/mac/hermes_runtime.py
@@ -736,7 +736,7 @@ def render_runtime_markdown(context: Dict[str, Any]) -> str:
         "- Before you start changing a repository, say which one and which paths, "
         "so a peer can avoid colliding with you.",
         "- Watch your own inbox in the BACKGROUND while you work: "
-        "`mac agentbus wait %s`. It blocks until someone messages you, prints it, "
+        "`mac admin agentbus wait %s`. It blocks until someone messages you, prints it, "
         "and exits; restart it afterwards with `--after-cursor` from the previous "
         "run. A message may be a correction, so read it before continuing."
         % agent["agent_id"],

--- a/tests/test_deploy_uses_current_cli_spelling.py
+++ b/tests/test_deploy_uses_current_cli_spelling.py
@@ -1,0 +1,102 @@
+"""Deploy scripts must invoke the CLI as it is actually spelled.
+
+The administrative commands moved under `mac admin`. Every in-repo caller was
+migrated -- three times, because each pass matched one invocation SHAPE and
+missed the next:
+
+    mac fleet ...                     the literal word
+    mac --db "$DSN" init ...          options before the command
+    "$MAC_HOME/venv/bin/mac" openshell ...   a quoted path, so the closing
+                                             quote sat between `mac` and the
+                                             subcommand
+
+The third one shipped. It failed the fleet deploy at phase 2 on every node --
+`bootstrap_enabled_openshell` called `mac openshell render-policy`, got the
+redirect, and exited 2 -- leaving seven nodes under dispatch hold. A grep would
+have caught it in a second; nothing was grepping.
+
+This is that grep. It is deliberately shape-agnostic: it looks for a moved
+command following ANY reference to the mac binary on the same line.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from mac.cli import build_parser
+from mac.cli_surface import _MOVED_TO_ADMIN
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCANNED = ("deploy", "scripts")
+SUFFIXES = {".sh", ".py", ".yaml", ".yml", ".service", ".plist"}
+
+
+def _moved_names():
+    build_parser()  # populates the moved set
+    return sorted(_MOVED_TO_ADMIN)
+
+
+def _offenders():
+    names = "|".join(re.escape(n) for n in _moved_names())
+    # Any way of naming the binary: bare word, a path, a quoted path, or a
+    # variable holding one -- then optional global options, then the command.
+    invocation = re.compile(
+        r'(?:"[^"\n]*/mac"|\'[^\'\n]*/mac\'|[\w./${}-]*/mac|\bmac)'
+        r'\s+(?:--[\w-]+(?:=\S+)?\s+|"\$[\w{}]+"\s+|\$[\w{}]+\s+)*'
+        r'(%s)\b' % names
+    )
+    found = []
+    for directory in SCANNED:
+        for path in sorted((REPO_ROOT / directory).rglob("*")):
+            if not path.is_file() or path.suffix not in SUFFIXES:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except (UnicodeDecodeError, OSError):
+                continue
+            for number, line in enumerate(text.splitlines(), 1):
+                if line.lstrip().startswith("#"):
+                    continue
+                match = invocation.search(line)
+                if not match:
+                    continue
+                # `mac admin <cmd>` is the correct spelling.
+                if re.search(r'\badmin\s+%s\b' % re.escape(match.group(1)), line):
+                    continue
+                found.append(
+                    "%s:%d: %s" % (path.relative_to(REPO_ROOT), number, line.strip()[:100])
+                )
+    return found
+
+
+def test_no_deploy_script_uses_a_pre_admin_cli_spelling():
+    offenders = _offenders()
+
+    assert offenders == [], (
+        "these invoke a command that now lives under `mac admin`; on a fleet "
+        "node they get the redirect and exit 2:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_scan_would_actually_catch_the_shape_that_shipped(tmp_path):
+    """A guard that cannot detect the bug it was written for is decoration.
+
+    The exact line from bootstrap-openshell.sh that failed the deploy.
+    """
+    names = "|".join(re.escape(n) for n in _moved_names())
+    invocation = re.compile(
+        r'(?:"[^"\n]*/mac"|\'[^\'\n]*/mac\'|[\w./${}-]*/mac|\bmac)'
+        r'\s+(?:--[\w-]+(?:=\S+)?\s+|"\$[\w{}]+"\s+|\$[\w{}]+\s+)*'
+        r'(%s)\b' % names
+    )
+
+    assert invocation.search('"$MAC_HOME/venv/bin/mac" openshell render-policy \\')
+    assert invocation.search('mac fleet doctor')
+    assert invocation.search('mac --db "$DOCS_DB" init')
+    # And does not fire on the corrected spelling.
+    line = '"$MAC_HOME/venv/bin/mac" admin openshell render-policy'
+    match = invocation.search(line)
+    assert match is None or re.search(r'\badmin\s+%s\b' % match.group(1), line)


### PR DESCRIPTION
The fleet deploy failed at phase 2 on every node: `bootstrap_enabled_openshell` calls `"$MAC_HOME/venv/bin/mac" openshell render-policy`, which now redirects and exits 2. Seven nodes are under dispatch hold awaiting roll-forward.

My migration matched the literal word `mac`; here the binary is a quoted path, so the closing quote sits between `mac` and the subcommand. Third shape to slip three passes.

Adds a shape-agnostic guard that scans deploy/ and scripts/, and asserts it catches the exact line that shipped.

Not changed: `"$cli" sandbox …` is openshell's CLI, not mac's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)