### PR TITLE
Rename `mac sandbox` to `mac sandbox-image`

### DIFF
--- a/deploy/openshell/mac-hermes.Containerfile
+++ b/deploy/openshell/mac-hermes.Containerfile
@@ -49,9 +49,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 #   code (e.g. nanolang's 3-stage `make build`); Debian-slim ships none.
 # cmake/ninja-build: isaacsim7-poc@feat/ros-sim's contract requires them. This
 #   is the first entry here that was NOT transcribed from an incident: the
-#   contract said so and `mac sandbox bom` read it. Everything above this line
+#   contract said so and `mac admin sandbox-image bom` read it. Everything above this line
 #   is the same fact, learned the expensive way.  Do not hand-edit this list --
-#   run `mac sandbox bom --containerfile` and let the contracts say what belongs.
+#   run `mac admin sandbox-image bom --containerfile` and let the contracts say what belongs.
 # libssl-dev: OpenSSL headers + libcrypto. nanolang's src/sign.c #includes
 #   <openssl/evp.h>/<sha.h>/<err.h> and the build links -lcrypto; without it
 #   `make build` fails and a coding agent will destructively stub sign.c just to

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -296,17 +296,17 @@ Getting started:
   diagnostics  run read-only control-plane health checks
 
 Fleet and machines:
-  fleet      deploy, inspect and maintain the fleet as a whole
-  machine    hosts that agents run on
-  hgx        HGX / GPU capacity management
-  openshell  sandboxed execution environments for agents
-  sandbox    the sandbox image: its bill of materials and its rollout
-  runtime    runtime images and environment definitions
-  rollout    staged rollout of a runtime or configuration
-  env        environment variables projected onto fleet hosts
-  secret     secret storage, rotation and access audit
-  database   control-plane database maintenance
-  migrate    schema and data migrations
+  fleet          deploy, inspect and maintain the fleet as a whole
+  machine        hosts that agents run on
+  hgx            HGX / GPU capacity management
+  openshell      sandboxed execution environments for agents
+  sandbox-image  the sandbox IMAGE: its bill of materials and its rollout
+  runtime        runtime images and environment definitions
+  rollout        staged rollout of a runtime or configuration
+  env            environment variables projected onto fleet hosts
+  secret         secret storage, rotation and access audit
+  database       control-plane database maintenance
+  migrate        schema and data migrations
 
 Getting work done:
   dispatch      the loop that matches ready tasks to eligible agents

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -8343,10 +8343,20 @@ def build_parser() -> argparse.ArgumentParser:
     project_activate.add_argument("project")
     project_activate.add_argument("--actor", default="human")
     _set(cmd_project_activate, project_activate)
+    # `sandbox-image`, not `sandbox`. The bare noun already belongs to two
+    # other things -- openshell's own `sandbox create|delete|list`, and
+    # `mac admin openshell sandbox-gc` -- and neither of those operates on the
+    # IMAGE. The collision is not theoretical: a bulk migration of CLI call
+    # sites nearly rewrote openshell's `"$cli" sandbox create` because the word
+    # matched.
     sandbox = sub.add_parser(
-        "sandbox",
-        help="derive, check, and roll out the OpenShell sandbox image",
-        description="derive, check, and roll out the OpenShell sandbox image",
+        "sandbox-image",
+        help="derive and roll out the OpenShell sandbox IMAGE (not sandboxes)",
+        description=(
+            "derive and roll out the OpenShell sandbox image. Individual "
+            "sandboxes are openshell's own `sandbox` verbs; policy delivery is "
+            "`mac admin openshell`."
+        ),
     ).add_subparsers(dest="sandbox_command", required=True)
     sandbox_bom_cmd = sandbox.add_parser(
         "bom",

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -231,7 +231,7 @@ COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
             ("machine", "hosts that agents run on"),
             ("hgx", "HGX / GPU capacity management"),
             ("openshell", "sandboxed execution environments for agents"),
-            ("sandbox", "the sandbox image: its bill of materials and its rollout"),
+            ("sandbox-image", "the sandbox IMAGE: its bill of materials and its rollout"),
             ("runtime", "runtime images and environment definitions"),
             ("rollout", "staged rollout of a runtime or configuration"),
             ("env", "environment variables projected onto fleet hosts"),

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6824,7 +6824,7 @@ class ControlPlane:
             # fired constantly in any control plane whose registrations differ
             # from the reviewed manifest, which is every dev and test hub.
             #
-            # Removal drift is surfaced by `mac admin sandbox bom --compare`, which
+            # Removal drift is surfaced by `mac admin sandbox-image bom --compare`, which
             # exits non-zero on drift in either direction, so CI still catches
             # a stale manifest.
             if not (drift.get("added_commands") or drift.get("added_packages")):
@@ -6858,11 +6858,11 @@ class ControlPlane:
                         "or -- worse -- edit the source until it builds without it.",
                         "",
                         "To resolve:",
-                        "  1. mac admin sandbox bom --containerfile deploy/openshell/mac-hermes.Containerfile",
+                        "  1. mac admin sandbox-image bom --containerfile deploy/openshell/mac-hermes.Containerfile",
                         "  2. add anything it reports to the Containerfile, and",
-                        "     mac admin sandbox bom --write deploy/openshell/sandbox-bom.json",
+                        "     mac admin sandbox-image bom --write deploy/openshell/sandbox-bom.json",
                         "  3. publish the image through the reviewed workflow, then",
-                        "     mac admin sandbox rollout --image <digest> --manifest deploy/openshell/sandbox-bom.json",
+                        "     mac admin sandbox-image rollout --image <digest> --manifest deploy/openshell/sandbox-bom.json",
                         "",
                         "Step 3 is a barrier task per worker: each one drains before it "
                         "updates, so the fleet rolls rather than stopping.",

--- a/tests/cli/test_cli_sandbox.py
+++ b/tests/cli/test_cli_sandbox.py
@@ -1,4 +1,4 @@
-"""Behavioral tests for `mac sandbox bom` and `mac sandbox rollout`.
+"""Behavioral tests for `mac admin sandbox-image bom` and `mac admin sandbox-image rollout`.
 
 Both commands are the operator-facing end of the contract-derived image: one
 answers "what does the fleet's sandbox need", the other puts a reviewed image
@@ -35,7 +35,7 @@ def _run(tmp_path, *args):
 def test_bom_derives_the_commands_mac_itself_needs(tmp_path):
     """With no project registered the answer is not empty: the executor's own
     tools are in every sandbox regardless of what any contract says."""
-    rc, out = _run(tmp_path, "admin", "sandbox", "bom")
+    rc, out = _run(tmp_path, "admin", "sandbox-image", "bom")
 
     assert rc in (None, 0)
     assert {"git", "python3", "bash"} <= set(out["commands"])
@@ -45,7 +45,7 @@ def test_bom_reports_gaps_against_a_containerfile(tmp_path):
     image = tmp_path / "Containerfile"
     image.write_text("FROM debian\nRUN apt-get install -y git\n", encoding="utf-8")
 
-    _rc, out = _run(tmp_path, "admin", "sandbox", "bom", "--containerfile", str(image))
+    _rc, out = _run(tmp_path, "admin", "sandbox-image", "bom", "--containerfile", str(image))
 
     assert "gaps" in out
     assert "tar" in out["gaps"]["missing_packages"]
@@ -54,7 +54,7 @@ def test_bom_reports_gaps_against_a_containerfile(tmp_path):
 def test_bom_writes_a_manifest_that_can_be_committed(tmp_path):
     target = tmp_path / "sandbox-bom.json"
 
-    _rc, out = _run(tmp_path, "admin", "sandbox", "bom", "--write", str(target))
+    _rc, out = _run(tmp_path, "admin", "sandbox-image", "bom", "--write", str(target))
 
     assert out["written"] == str(target)
     assert json.loads(target.read_text(encoding="utf-8"))["schema"]
@@ -67,16 +67,16 @@ def test_bom_compare_exits_nonzero_on_drift(tmp_path):
     stale.write_text(json.dumps({"commands": ["nothing-like-reality"]}), encoding="utf-8")
 
     with pytest.raises(SystemExit) as excinfo:
-        _run(tmp_path, "admin", "sandbox", "bom", "--compare", str(stale))
+        _run(tmp_path, "admin", "sandbox-image", "bom", "--compare", str(stale))
 
     assert excinfo.value.code == 1
 
 
 def test_bom_compare_is_quiet_when_the_manifest_matches(tmp_path):
     current = tmp_path / "current.json"
-    _run(tmp_path, "admin", "sandbox", "bom", "--write", str(current))
+    _run(tmp_path, "admin", "sandbox-image", "bom", "--write", str(current))
 
-    rc, out = _run(tmp_path, "admin", "sandbox", "bom", "--compare", str(current))
+    rc, out = _run(tmp_path, "admin", "sandbox-image", "bom", "--compare", str(current))
 
     assert rc in (None, 0)
     assert out["has_drift"] is False
@@ -87,7 +87,7 @@ def test_rollout_files_a_barrier_task_for_each_worker(tmp_path):
     machine = cp.register_machine("cli-roll-host")
     cp.register_agent(machine.id, "worker1")
 
-    rc, out = _run(tmp_path, "admin", "sandbox", "rollout", "--image", DIGEST)
+    rc, out = _run(tmp_path, "admin", "sandbox-image", "rollout", "--image", DIGEST)
 
     assert rc in (None, 0)
     assert len(out["filed"]) == 1
@@ -98,7 +98,7 @@ def test_rollout_refuses_a_tag(tmp_path):
     reviewed could differ with nothing recording it."""
     rc, out = _run(
         tmp_path,
-        "admin", "sandbox",
+        "admin", "sandbox-image",
         "rollout",
         "--image",
         "ghcr.io/jordanhubbard/mac-openshell-runtime:latest",

--- a/tests/test_sandbox_bom_drift_trigger.py
+++ b/tests/test_sandbox_bom_drift_trigger.py
@@ -79,7 +79,7 @@ def test_the_report_names_the_tool_and_the_next_step(cp, tmp_path):
 
     description = _drift_tasks(cp)[0].description
     assert "zig" in description
-    assert "mac admin sandbox rollout" in description
+    assert "mac admin sandbox-image rollout" in description
 
 
 def test_the_same_drift_is_not_filed_twice(cp, tmp_path):
@@ -177,7 +177,7 @@ def test_deleting_a_project_does_not_leave_an_ownerless_task(cp, tmp_path):
 
 
 def test_removal_only_drift_is_reported_even_though_it_is_not_filed(cp):
-    """Not filing is not the same as not noticing. `mac sandbox bom --compare`
+    """Not filing is not the same as not noticing. `mac admin sandbox-image bom --compare`
     exits non-zero on drift in either direction, so CI still catches a stale
     manifest; this just does not manufacture a ticket for it."""
     report = cp.check_sandbox_bom_drift()

--- a/tests/test_sandbox_rollout_hub_parity.py
+++ b/tests/test_sandbox_rollout_hub_parity.py
@@ -1,11 +1,11 @@
-"""`mac sandbox rollout` must work through the hub, not only against --db.
+"""`mac admin sandbox-image rollout` must work through the hub, not only against --db.
 
 LocalDispatch forwards unknown methods to ControlPlane via __getattr__, so a
 new control-plane method is reachable in --db mode the moment it exists.
 RemoteDispatch has explicit methods only, so the same method is missing over
 HTTP until someone adds it.
 
-That asymmetry made `mac sandbox rollout` work in every test (they all use
+That asymmetry made `mac admin sandbox-image rollout` work in every test (they all use
 --db) and fail against the hub, which is how the fleet is actually operated.
 These tests close it for the rollout and assert the shape of the gap so the
 next command does not repeat it.


### PR DESCRIPTION
`sandbox` already means two other things — openshell's own `sandbox create|delete|list` (individual sandboxes on a host) and `mac admin openshell sandbox-gc` (MAC-owned sandbox hygiene). This command operates on the **image**: what goes in it, derived from repository contracts, and rolling a reviewed digest to workers.

The collision wasn't theoretical — a bulk migration nearly rewrote openshell's `"$cli" sandbox create` because the word matched, which would have broken the sandbox tooling.

Cheap to fix now: the command is days old and nothing outside this repo calls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)