### PR TITLE
Give the review-tick loop backoff and one escalation

### DIFF
--- a/src/mac/k8s/orchestrator.py
+++ b/src/mac/k8s/orchestrator.py
@@ -23,6 +23,89 @@ review_tick_loop_failures = 0
 _sleep = time.sleep
 
 
+#: How many CONSECUTIVE failures before a loop stops repeating itself and says
+#: one operator-visible thing instead. 172 identical warnings is what this
+#: replaces: a loop that has failed 172 times is not going to succeed on 173.
+LOOP_ESCALATE_AFTER = 10
+
+#: Upper bound on the backoff. The loop must keep trying -- the condition may
+#: be a hub restart that resolves itself -- but polling a broken endpoint every
+#: `interval` seconds forever helps nobody.
+LOOP_BACKOFF_CEILING_SECONDS = 300.0
+
+
+class _LoopBackoff:
+    """Consecutive-failure backoff with a one-shot escalation.
+
+    Separate from the total failure counters, which are cumulative and are read
+    by tests and operators as "has this ever failed". What decides backoff is
+    the CONSECUTIVE run: a loop that fails, recovers, and fails again is
+    healthy-ish and should not inherit the previous episode's delay.
+    """
+
+    def __init__(
+        self,
+        interval: float,
+        name: str,
+        log: logging.Logger,
+        *,
+        escalate_after: int = LOOP_ESCALATE_AFTER,
+        ceiling: float = LOOP_BACKOFF_CEILING_SECONDS,
+    ) -> None:
+        self.interval = max(0.0, float(interval))
+        self.name = name
+        self.log = log
+        self.escalate_after = max(1, int(escalate_after))
+        self.ceiling = max(self.interval, float(ceiling))
+        self.consecutive = 0
+        self._escalated = False
+
+    def success(self) -> float:
+        """Reset after a good iteration, and say so if we had escalated.
+
+        Announcing recovery matters: an operator who was paged by the
+        escalation otherwise has no way to learn it cleared except by going
+        and looking.
+        """
+        if self._escalated:
+            self.log.warning(
+                "%s recovered after %d consecutive failures", self.name, self.consecutive
+            )
+        self.consecutive = 0
+        self._escalated = False
+        return self.interval
+
+    def failure(self, total: int) -> float:
+        """Record a failed iteration and return how long to sleep."""
+        self.consecutive += 1
+        delay = min(self.ceiling, self.interval * (2 ** (self.consecutive - 1)))
+        if self.consecutive < self.escalate_after:
+            self.log.warning(
+                "%s iteration failed (retrying in %.0fs): consecutive=%d total=%d",
+                self.name,
+                delay,
+                self.consecutive,
+                total,
+            )
+        elif not self._escalated:
+            # ONE operator-visible line per episode, not one per iteration.
+            self._escalated = True
+            self.log.error(
+                "%s has failed %d consecutive times and is not recovering on its "
+                "own; backing off to %.0fs between attempts and suppressing "
+                "per-iteration warnings until it recovers. total=%d",
+                self.name,
+                self.consecutive,
+                delay,
+                total,
+            )
+        else:
+            self.log.debug(
+                "%s still failing: consecutive=%d total=%d", self.name, self.consecutive, total
+            )
+        return delay
+
+
 def _truthy(value: Optional[str]) -> bool:
     return str(value or "").strip().lower() not in {"", "0", "false", "no", "off"}
 
@@ -52,6 +135,7 @@ def _run_review_tick_loop_forever(
         max(1, int(limit)),
         quote(actor, safe=""),
     )
+    backoff = _LoopBackoff(interval, "review-tick", log)
     try:
         while True:
             try:
@@ -62,12 +146,10 @@ def _run_review_tick_loop_forever(
                         log.info("review-tick: processed=%s", processed)
             except Exception:  # noqa: BLE001
                 review_tick_loop_failures += 1
-                log.warning(
-                    "review-tick iteration failed (will retry): "
-                    "review_tick_loop_failures=%d",
-                    review_tick_loop_failures,
-                )
-            sleep_fn(interval)
+                delay = backoff.failure(review_tick_loop_failures)
+            else:
+                delay = backoff.success()
+            sleep_fn(delay)
     except Exception:  # noqa: BLE001
         review_tick_loop_failures += 1
         log.exception(

--- a/tests/test_review_tick_backoff.py
+++ b/tests/test_review_tick_backoff.py
@@ -1,0 +1,149 @@
+"""A failing loop must back off and escalate once, not narrate forever.
+
+Observed in a contract gate run: review_tick_loop_failures reached 172, one
+stderr line per iteration, no backoff and no ceiling. Cosmetic that day. But it
+is the same shape as the hub self-tick crash loop that made the entire backlog
+undispatchable -- a loop that has failed 172 times is not going to succeed on
+173, and nothing was going to tell a human otherwise.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from mac.k8s.orchestrator import (
+    LOOP_BACKOFF_CEILING_SECONDS,
+    LOOP_ESCALATE_AFTER,
+    _LoopBackoff,
+)
+
+
+@pytest.fixture()
+def log(caplog):
+    caplog.set_level(logging.DEBUG)
+    return logging.getLogger("test-loop")
+
+
+def test_the_first_failure_waits_the_normal_interval(log):
+    backoff = _LoopBackoff(10.0, "review-tick", log)
+
+    assert backoff.failure(1) == 10.0
+
+
+def test_delay_grows_with_consecutive_failures(log):
+    """Polling a broken endpoint every interval forever helps nobody."""
+    backoff = _LoopBackoff(10.0, "review-tick", log)
+
+    delays = [backoff.failure(n) for n in range(1, 5)]
+
+    assert delays == [10.0, 20.0, 40.0, 80.0]
+
+
+def test_the_delay_is_capped(log):
+    """It must keep TRYING -- the cause may be a hub restart that resolves --
+    just not faster than the ceiling."""
+    backoff = _LoopBackoff(10.0, "review-tick", log)
+
+    for n in range(1, 40):
+        delay = backoff.failure(n)
+
+    assert delay == LOOP_BACKOFF_CEILING_SECONDS
+
+
+def test_success_resets_the_delay(log):
+    """A loop that fails, recovers, and fails again is healthy-ish; it should
+    not inherit the previous episode's penalty."""
+    backoff = _LoopBackoff(10.0, "review-tick", log)
+    for n in range(1, 5):
+        backoff.failure(n)
+
+    backoff.success()
+
+    assert backoff.failure(5) == 10.0
+
+
+def test_it_escalates_exactly_once_per_episode(log, caplog):
+    """The 172-line stderr wall is what this replaces."""
+    backoff = _LoopBackoff(1.0, "review-tick", log)
+
+    for n in range(1, 60):
+        backoff.failure(n)
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(errors) == 1, "escalation should be one signal, not one per iteration"
+
+
+def test_the_escalation_says_it_is_not_recovering(log, caplog):
+    backoff = _LoopBackoff(1.0, "review-tick", log)
+
+    for n in range(1, LOOP_ESCALATE_AFTER + 2):
+        backoff.failure(n)
+
+    errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert "not recovering" in errors[0]
+
+
+def test_warnings_stop_once_escalated(log, caplog):
+    """Otherwise escalation adds a line rather than replacing the stream."""
+    backoff = _LoopBackoff(1.0, "review-tick", log)
+    for n in range(1, LOOP_ESCALATE_AFTER + 1):
+        backoff.failure(n)
+    caplog.clear()
+
+    for n in range(LOOP_ESCALATE_AFTER + 1, LOOP_ESCALATE_AFTER + 20):
+        backoff.failure(n)
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert warnings == []
+
+
+def test_recovery_after_an_escalation_is_announced(log, caplog):
+    """An operator paged by the escalation otherwise has no way to learn it
+    cleared except by going to look."""
+    backoff = _LoopBackoff(1.0, "review-tick", log)
+    for n in range(1, LOOP_ESCALATE_AFTER + 2):
+        backoff.failure(n)
+    caplog.clear()
+
+    backoff.success()
+
+    assert any("recovered" in r.getMessage() for r in caplog.records)
+
+
+def test_a_quiet_recovery_is_not_announced(log, caplog):
+    """A single blip that resolves must not page anyone."""
+    backoff = _LoopBackoff(1.0, "review-tick", log)
+    backoff.failure(1)
+    caplog.clear()
+
+    backoff.success()
+
+    assert not any("recovered" in r.getMessage() for r in caplog.records)
+
+
+def test_the_loop_itself_uses_the_backoff(monkeypatch):
+    """The wiring, not the helper. A backoff nothing calls is decoration.
+
+    The loop must sleep for the BACKED-OFF delay, not the fixed interval.
+    """
+    from mac.k8s import orchestrator
+
+    slept: list = []
+
+    class _AlwaysFails:
+        def post(self, *args, **kwargs):
+            raise RuntimeError("hub down")
+
+    def fake_sleep(seconds):
+        slept.append(seconds)
+        if len(slept) >= 4:
+            raise KeyboardInterrupt  # break the infinite loop
+
+    with pytest.raises(KeyboardInterrupt):
+        orchestrator._run_review_tick_loop_forever(
+            _AlwaysFails(), 5.0, 1, "tester", logging.getLogger("wire"), fake_sleep
+        )
+
+    assert slept == [5.0, 10.0, 20.0, 40.0], slept


### PR DESCRIPTION
`review_tick_loop_failures` reached **172** in a contract gate run, emitting one stderr line per iteration with no backoff and no ceiling. Cosmetic that day — but it's the shape of the hub self-tick crash loop that made the whole backlog undispatchable, and a loop that has failed 172 times isn't going to succeed on 173.

- Exponential backoff on **consecutive** failures, capped at 300s (it must keep trying — the cause may be a hub restart — just not every interval forever)
- **One** operator-visible escalation at 10 consecutive failures, then quiet
- Recovery announced, so whoever was paged learns it cleared; a single blip says nothing

Mutation-tested: ignoring the backoff, escalating every iteration, and removing the ceiling each fail a test. The wiring test asserts the loop sleeps the backed-off delay — a backoff nothing calls is decoration.

Closes `task_f4cf026f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)