### PR TITLE
Separate building the sandbox image from certifying it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,7 +724,21 @@ jobs:
     concurrency:
       group: mac-openshell-runtime-frozen-image
       cancel-in-progress: false
-    needs: [dead-code, mainline, compatibility, postgres-contract, publication-scope]
+    # Image-scope gates only. Whether an unrelated unit test passes says
+    # nothing about whether this image is well-formed, and gating the BUILD on
+    # the full suite made the fleet undeployable every time main went red --
+    # three times in one night, once for two stale assertions about a prompt
+    # string, while seven nodes sat under dispatch hold waiting for the repair
+    # that could not be delivered.
+    #
+    # Building is cheap and reversible; DEPLOYING is not. The correctness gates
+    # now guard the deploy instead, via the `tested-` tag published below.
+    needs: [publication-scope]
+    outputs:
+      # Consumed by openshell-runtime-tested, which retags this exact digest
+      # once the correctness gates pass.
+      digest: ${{ steps.image-identity.outputs.digest }}
+      frozen_inputs_sha256: ${{ steps.image-plan.outputs.frozen_inputs_sha256 }}
     permissions:
       contents: read
       packages: write
@@ -1090,6 +1104,47 @@ jobs:
   # opens a GitHub issue and keeps commenting on it, so the condition has a
   # consumer instead of only a red square nobody visits. The hub would be a
   # better destination, but it lives on a private network CI cannot reach.
+  openshell-runtime-tested:
+    name: Mark the OpenShell runtime image tested
+    # The other half of the split. The BUILD no longer waits on correctness,
+    # so something has to record that correctness actually held for this exact
+    # image -- otherwise decoupling would just let an untested image deploy
+    # silently, which is worse than the outage it fixes.
+    #
+    # This adds a `tested-<frozen-inputs-sha>` tag pointing at the SAME digest,
+    # only once every code gate is green. deploy-mac-fleet.sh requires it.
+    needs: [openshell-runtime-image, dead-code, mainline, compatibility, postgres-contract]
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.publish_images)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      # actions/checkout v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Authenticate to repository-owned GHCR namespace
+        # docker/login-action v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag the exact digest as tested
+        env:
+          DIGEST: ${{ needs.openshell-runtime-image.outputs.digest }}
+          INPUTS_SHA: ${{ needs.openshell-runtime-image.outputs.frozen_inputs_sha256 }}
+        run: |
+          set -euo pipefail
+          repo=ghcr.io/jordanhubbard/mac-openshell-runtime
+          printf '%s' "$DIGEST" | grep -Eq '^sha256:[0-9a-f]{64}$'
+          # buildx imagetools retags by DIGEST, so the tested tag can never
+          # point at different content than the one that was verified.
+          docker buildx imagetools create \
+            --tag "$repo:tested-${INPUTS_SHA#sha256:}" "$repo@$DIGEST"
+          echo "tested tag published for $DIGEST"
+
   report-main-red:
     name: Surface a red main
     needs:

--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -208,6 +208,39 @@ if [ -n "${MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE:-}" ]; then
     echo "ERROR: MAC_DEPLOY_OPENSHELL_RUNTIME_INPUT_SHA256 must bind the reviewed image inputs" >&2
     exit 2
   }
+  # The image is now BUILT without waiting on the correctness gates, so that a
+  # red test somewhere unrelated cannot make the fleet undeployable. The gates
+  # moved here instead: CI publishes `tested-<frozen-inputs-sha>` against the
+  # same digest only after they pass, and this refuses to roll an image that
+  # was never marked.
+  #
+  # Without this check, decoupling the build would simply let an untested image
+  # ship silently -- worse than the outage it was meant to fix.
+  _tested_tag="tested-${MAC_DEPLOY_OPENSHELL_RUNTIME_INPUT_SHA256#sha256:}"
+  if [ "${MAC_DEPLOY_ALLOW_UNTESTED_IMAGE:-0}" = "1" ]; then
+    echo "WARNING: deploying an image WITHOUT a verified tested tag (MAC_DEPLOY_ALLOW_UNTESTED_IMAGE=1)." >&2
+    echo "WARNING: image=$MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE inputs=$MAC_DEPLOY_OPENSHELL_RUNTIME_INPUT_SHA256 actor=${USER:-unknown}" >&2
+  else
+    _tested_token="$(curl -sS --max-time 30 \
+      "https://ghcr.io/token?scope=repository:jordanhubbard/mac-openshell-runtime:pull&service=ghcr.io" \
+      | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+    _tested_digest="$(curl -sS --max-time 30 -D- -o /dev/null \
+      -H "Authorization: Bearer ${_tested_token}" \
+      -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json" \
+      "https://ghcr.io/v2/jordanhubbard/mac-openshell-runtime/manifests/${_tested_tag}" \
+      | awk 'tolower($1)=="docker-content-digest:"{print $2}' | tr -d '\r')"
+    if [ "${_tested_digest}" != "sha256:${_runtime_digest}" ]; then
+      echo "ERROR: this image has not passed the correctness gates." >&2
+      echo "  image  : $MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE" >&2
+      echo "  expected tag ${_tested_tag} -> sha256:${_runtime_digest}" >&2
+      echo "  resolved     ${_tested_digest:-<absent>}" >&2
+      echo "CI publishes that tag once dead-code, mainline, compatibility and" >&2
+      echo "the PostgreSQL contract pass for these exact inputs. If they have" >&2
+      echo "not finished, wait; if they failed, fix them." >&2
+      echo "To roll anyway (audited, and it will say so): MAC_DEPLOY_ALLOW_UNTESTED_IMAGE=1" >&2
+      exit 2
+    fi
+  fi
 elif [ -n "${MAC_DEPLOY_OPENSHELL_RUNTIME_INPUT_SHA256:-}" ]; then
   echo "ERROR: MAC_DEPLOY_OPENSHELL_RUNTIME_INPUT_SHA256 requires MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE" >&2
   exit 2

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -160,6 +160,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_ALLOW_LEGACY_WORKER_TOKEN` | bool | consumer-defined | deployment | Deployment setting: deploy allow legacy worker token. |
 | `MAC_DEPLOY_ALLOW_LOCAL_OPENSHELL_IMAGE_BUILD` | bool | consumer-defined | deployment | Deployment setting: deploy allow local openshell image build. |
 | `MAC_DEPLOY_ALLOW_SAMPLE_CONFIG` | bool | consumer-defined | deployment | Deployment setting: deploy allow sample config. |
+| `MAC_DEPLOY_ALLOW_UNTESTED_IMAGE` | bool | consumer-defined | deployment | Deployment setting: deploy allow untested image. |
 | `MAC_DEPLOY_API_TIMEOUT_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy api timeout seconds. |
 | `MAC_DEPLOY_ARCHIVE` | str | consumer-defined | deployment | Deployment setting: deploy archive. |
 | `MAC_DEPLOY_ATTESTATION_MANIFEST` | str | consumer-defined | deployment | Deployment setting: deploy attestation manifest. |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -1899,6 +1899,17 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy allow untested image.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_ALLOW_UNTESTED_IMAGE",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "bool"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy api timeout seconds.",
     "family": "deployment",
     "name": "MAC_DEPLOY_API_TIMEOUT_SECONDS",

--- a/tests/test_deployment_image_artifact.py
+++ b/tests/test_deployment_image_artifact.py
@@ -92,10 +92,11 @@ def test_tested_main_publishes_immutable_multiarch_openshell_runtime() -> None:
     job = workflow.split("\n  openshell-runtime-image:\n", 1)[1].split(
         "\n  certifier-image:\n", 1
     )[0]
-    assert (
-        "needs: [dead-code, mainline, compatibility, postgres-contract, publication-scope]"
-        in job
-    )
+    # The BUILD is deliberately NOT gated on the correctness jobs any more.
+    # Building is cheap and reversible; deploying is not, so the gate moved to
+    # the `tested-` tag (see the test below). Asserting the old `needs:` list
+    # here would re-couple the two the moment anyone made this test pass.
+    assert "needs: [publication-scope]" in job
     assert "deploy/openshell/prepare-runtime-image-assets.sh" in job
     assert "file: deploy/openshell/mac-hermes.Containerfile" in job
     assert "platforms: linux/amd64,linux/arm64" in job
@@ -166,11 +167,18 @@ def test_image_publication_is_blocked_on_live_pinned_postgres_contract() -> None
     ) in postgres
     assert "MAC_TEST_PG_URL: postgresql://" in postgres
     assert "pytest -q -m postgres tests/test_postgres_live.py" in postgres
+    # What must stay blocked on the live Postgres contract is the DEPLOYABLE
+    # image, not the build. Both certifier publication and the `tested-` tag
+    # name postgres-contract in their needs; the runtime build no longer does.
+    tested = workflow.split("\n  openshell-runtime-tested:\n", 1)[1].split(
+        "\n  report-main-red:\n", 1
+    )[0]
+    assert "postgres-contract" in tested
     assert (
         workflow.count(
             "needs: [dead-code, mainline, compatibility, postgres-contract, publication-scope]"
         )
-        == 3
+        == 2
     )
 
 

--- a/tests/test_image_publish_is_decoupled_from_tests.py
+++ b/tests/test_image_publish_is_decoupled_from_tests.py
@@ -1,0 +1,97 @@
+"""Building the image and certifying it are different concerns.
+
+The image publish used to carry
+
+    needs: [dead-code, mainline, compatibility, postgres-contract,
+            publication-scope]
+
+so any red test anywhere stopped an image being produced -- and with no image,
+deploy-mac-fleet.sh refuses, so the FLEET became undeployable. That happened
+three times in one night; the last was two stale assertions about a prompt
+string, while seven nodes sat under dispatch hold waiting for the repair that
+could not be delivered.
+
+Building is cheap and reversible. Deploying is not. So the build waits only on
+what decides whether the image may be published, and the correctness gates
+guard the deploy instead, through a `tested-` tag on the same digest.
+
+Decoupling WITHOUT moving the gate would be worse than the problem: an
+untested image would ship silently. Both halves are asserted here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
+DEPLOY = REPO_ROOT / "deploy/deploy-mac-fleet.sh"
+
+CORRECTNESS_GATES = {"dead-code", "mainline", "compatibility", "postgres-contract"}
+
+
+@pytest.fixture(scope="module")
+def jobs():
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+
+
+def test_the_build_does_not_wait_on_unrelated_correctness_gates(jobs):
+    """The defect: one red unit test made the fleet undeployable."""
+    needs = set(jobs["openshell-runtime-image"]["needs"])
+
+    assert not (needs & CORRECTNESS_GATES), (
+        "publishing waits on %s; a failure there blocks image production and "
+        "therefore every fleet deploy" % sorted(needs & CORRECTNESS_GATES)
+    )
+
+
+def test_the_build_still_waits_on_the_publication_scope_gate(jobs):
+    """Decoupling is not the same as ungating. What may be published is still
+    decided before anything is."""
+    assert "publication-scope" in jobs["openshell-runtime-image"]["needs"]
+
+
+def test_the_correctness_gates_moved_to_the_tested_marker(jobs):
+    """They did not disappear -- they now certify a built image."""
+    needs = set(jobs["openshell-runtime-tested"]["needs"])
+
+    assert CORRECTNESS_GATES <= needs
+    assert "openshell-runtime-image" in needs
+
+
+def test_the_tested_marker_retags_by_digest(jobs):
+    """By digest, not by rebuilding: a tag that pointed at different content
+    than the one that was verified would certify the wrong thing."""
+    steps = jobs["openshell-runtime-tested"]["steps"]
+    script = "\n".join(str(step.get("run", "")) for step in steps)
+
+    assert "imagetools create" in script
+    assert "@$DIGEST" in script or '@${DIGEST}' in script
+
+
+def test_the_publish_job_exposes_what_the_marker_consumes(jobs):
+    outputs = jobs["openshell-runtime-image"].get("outputs") or {}
+
+    assert "digest" in outputs and "frozen_inputs_sha256" in outputs
+
+
+def test_the_deploy_refuses_an_image_that_was_never_marked_tested():
+    """The other half. Without this, decoupling just lets an untested image
+    ship silently, which is worse than the outage it fixes."""
+    script = DEPLOY.read_text(encoding="utf-8")
+
+    assert "tested-" in script
+    assert "has not passed the correctness gates" in script
+
+
+def test_the_override_exists_and_announces_itself():
+    """An operator must be able to roll during an Actions outage -- and the
+    record must say they did."""
+    script = DEPLOY.read_text(encoding="utf-8")
+
+    assert "MAC_DEPLOY_ALLOW_UNTESTED_IMAGE" in script
+    assert "WARNING: deploying an image WITHOUT a verified tested tag" in script


### PR DESCRIPTION
The image publish waited on `[dead-code, mainline, compatibility, postgres-contract, publication-scope]`, so **any** red test stopped an image being produced — and with no image, `deploy-mac-fleet.sh` refuses. The fleet became undeployable three times in one night, the last time over two stale assertions about a prompt string, while seven nodes sat under dispatch hold.

Building is cheap and reversible; deploying is not.

- **Build** now waits only on `publication-scope` (what may be published at all)
- **Correctness gates** moved to a new job that retags the *same digest* as `tested-<frozen-inputs-sha>` once they pass — by digest via `imagetools`, so the marker can't point at unverified content
- **`deploy-mac-fleet.sh` requires that marker.** Decoupling without moving the gate would let an untested image ship silently — worse than the outage it fixes
- `MAC_DEPLOY_ALLOW_UNTESTED_IMAGE=1` exists for an Actions outage and announces itself

Refs `task_510da4f3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)