### PR TITLE
Let the submitter decide whether a task becomes several tasks

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -1911,6 +1911,16 @@ def cmd_task_create(args: argparse.Namespace) -> None:
     target_agent = str(getattr(args, "target_agent", "") or "").strip()
     if target_agent:
         metadata["target_agent_id"] = target_agent
+    decompose = getattr(args, "decompose", None)
+    if decompose is not None:
+        # The submitter says whether this becomes several tasks, and how many.
+        # The framework used to decide, on every task, and over-split trivial
+        # ones -- machine-originated work completes at 0-9.6% here against 20%
+        # for human-filed.
+        metadata["decomposition"] = {"max_children": int(decompose)}
+        kind = str(getattr(args, "decompose_kind", "") or "").strip()
+        if kind:
+            metadata["decomposition"]["kind"] = kind
     if getattr(args, "no_decompose", False):
         # Handoff / plan-note guard: the executor will not auto-decompose this
         # task into child tasks (add_child_tasks refuses with no_decompose).
@@ -7582,6 +7592,23 @@ def build_parser() -> argparse.ArgumentParser:
              "its children are still running.",
     )
     _set(cmd_task_wait, wait)
+    create.add_argument(
+        "--decompose",
+        dest="decompose",
+        type=int,
+        metavar="N",
+        help="AUTHORISE this task to be split into at most N child tasks. "
+             "Without this, the task is atomic and the executor is told not to "
+             "create children -- decomposition is the submitter's call, not the "
+             "framework's.",
+    )
+    create.add_argument(
+        "--decompose-kind",
+        dest="decompose_kind",
+        metavar="TEXT",
+        help="how the children should be divided (e.g. 'one per subsystem'); "
+             "only meaningful with --decompose",
+    )
     create.add_argument("--no-decompose", dest="no_decompose", action="store_true",
                         help="handoff/plan-note guard: the executor will not auto-decompose "
                              "this task into child tasks")

--- a/src/mac/executor_hub_io.py
+++ b/src/mac/executor_hub_io.py
@@ -359,33 +359,11 @@ def _plan_detection_section(task: Dict[str, Any]) -> str:
     description = str(task.get("description") or "")
     is_plan, signals = detect_plan_signals(title, description)
 
-    plan_notice = ""
-    if is_plan:
-        plan_notice = (
-            "TASK-SIZING ALERT: This task has been flagged as a likely PLAN "
-            "(signals: %s). " % ", ".join(signals)
-        )
+    # The five-step fan-out recipe used to be printed on EVERY task, with the
+    # sizing verdict only ever adding a prefix when it fired. A task the
+    # detector scored as atomic still got the recipe and one hedged sentence
+    # permitting it not to split -- and split anyway. Decomposition is now the
+    # submitter's declaration, and this section says so either way.
+    from mac.task_decomposition import prompt_section
 
-    task_id = str(task.get("id") or "")
-    project = str(task.get("project") or "")
-    mac_url = resolve_env_chain("MAC_HUB_URL", "MAC_URL").rstrip("/")
-    children_endpoint = "%s/tasks/%s/children" % (mac_url, task_id) if mac_url and task_id else "/tasks/{task_id}/children"
-
-    return "\n".join([
-        "Task Sizing and Plan Detection:",
-        "%sIf you determine — from the title, description, or early investigation — that this"
-        " task represents a PLAN (multiple independent deliverables, phased work, or a"
-        " collection of steps each requiring its own evidence trail) rather than a single"
-        " atomic work item:" % plan_notice,
-        "  1. Do NOT attempt to implement all steps in one run.",
-        "  2. Break the work into 2-10 focused child tasks. Each child must be independently"
-        "     completable and verifiable by a different agent.",
-        "  3. Post the children to the MAC API: POST %s" % children_endpoint,
-        "     with JSON body: {\"children\": [{\"title\": \"...\", \"description\": \"...\"},...]}",
-        "     The MAC token is in the MAC_TOKEN / MAC_WORKER_TOKEN environment variable.",
-        "  4. Write mac-evidence.json with evidence_type=operator_result, a summary field,"
-        "     and a result field listing the child task titles you created.",
-        "  5. Exit — the parent task will automatically block on its children.",
-        "If the task IS a single atomic work item (< 1 day effort, single deliverable,"
-        " one clear verification command), execute it directly and skip step 1-5.",
-    ])
+    return prompt_section(task, is_plan=is_plan, signals=signals)

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -253,6 +253,7 @@ from mac.task_batch import (
     UnsatisfiableTaskParker,
 )
 from mac.allocator import EXECUTION_MODE_SYNC, normalize_execution_mode
+from mac.task_decomposition import check_children_allowed
 from mac.sandbox_bom import (
     BOM_SCHEMA,
     committed_manifest_path,
@@ -7658,6 +7659,18 @@ class ControlPlane:
             parent.id,
             operation="ad-hoc child creation",
         )
+        # Decomposition is the SUBMITTER's declaration, enforced here rather
+        # than only described in the executor prompt: prompt text is advice to
+        # a model, and this is the part that holds when the model decides
+        # otherwise.
+        #
+        # Scoped to UNTRUSTED callers -- an executing agent acting under a
+        # lease. An operator or an internal coordinator adding children IS the
+        # submitter declaring, and work-package assembly legitimately builds
+        # its own graph. The defect was an agent splitting a task nobody asked
+        # to split; it was not "children are bad".
+        requested = list(children)
+        children = requested
         fenced_lease_id: Optional[str] = None
         if not trusted_internal:
             if parent.state not in {TaskState.CLAIMED.value, TaskState.RUNNING.value}:
@@ -7666,6 +7679,14 @@ class ControlPlane:
                 )
             self._require_exact_lease_actor(parent, actor, lease_id)
             fenced_lease_id = str(lease_id or "").strip()
+            # Only now that the caller is proven to hold this task's lease:
+            # decomposition is the submitter's declaration, and an executing
+            # agent may not overrule it. Authorization first, policy second --
+            # otherwise a worker probing a peer task learns its policy instead
+            # of being told it has no business asking.
+            allowed, refusal = check_children_allowed(parent, len(requested))
+            if not allowed:
+                raise ValidationError("cannot add child tasks: %s" % refusal)
         if parent.state not in {
             TaskState.OPEN.value,
             TaskState.WAITING.value,

--- a/src/mac/task_decomposition.py
+++ b/src/mac/task_decomposition.py
@@ -177,7 +177,8 @@ def prompt_section(task: Any, *, is_plan: bool, signals: Any = ()) -> str:
         lines = [
             "Task Sizing:",
             "This task is ATOMIC. Do NOT create child tasks; do NOT post to the "
-            "children endpoint. Execute it and record evidence.",
+            "children endpoint. Execute it and write your evidence to "
+            "mac-evidence.json.",
         ]
         if is_plan:
             # The heuristic disagrees. That is a question for the submitter,

--- a/src/mac/task_decomposition.py
+++ b/src/mac/task_decomposition.py
@@ -1,0 +1,218 @@
+"""Who decides that a task should become several tasks.
+
+Until now: the framework did, on every task. The executor prompt carried five
+numbered steps explaining how to fan out, unconditionally, followed by one
+hedged sentence permitting the agent not to:
+
+    1. Do NOT attempt to implement all steps in one run.
+    2. Break the work into 2-10 focused child tasks.
+    ...
+    If the task IS a single atomic work item ... execute it directly and skip
+    step 1-5.
+
+Five imperatives for splitting, one conditional for not splitting. The sizing
+heuristic that could have counterweighted it only ever spoke when it detected a
+plan; when it decided a task was atomic it said nothing at all, so the agent
+read a fan-out recipe with no opposing evidence.
+
+The measured result: a task whose description read "run `command -v` on these
+sixteen commands and report what you find" -- and which the detector correctly
+scored as NOT a plan, zero signals -- was split into five child tasks. Machine
+-originated work in this ledger completes at 0-9.6% against 20% for
+human-filed, and over-decomposition is one of the things manufacturing it.
+
+So the default inverts. The framework no longer proposes decomposition; the
+SUBMITTER declares it, with a budget:
+
+    metadata.decomposition = {"max_children": 6, "kind": "one per subsystem"}
+
+Absent that, the task is atomic and the agent is told so plainly. The heuristic
+survives as an OBSERVATION -- when it thinks a task is really a plan and nobody
+authorised splitting, it says so and asks the agent to report it, which is a
+question for the submitter rather than a licence to fan out.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+#: Where a submitter declares intent.
+DECOMPOSITION_KEY = "decomposition"
+
+#: The pre-existing hard "never split this" flag. It still wins over
+#: everything, including an explicit budget: a task carrying both is
+#: contradictory, and refusing is the safe reading.
+NO_DECOMPOSE_KEY = "no_decompose"
+
+#: A ceiling on what a submitter may authorise. Not a policy about good task
+#: design -- a bound on blast radius, so a typo in a budget cannot enqueue a
+#: thousand tasks.
+MAX_AUTHORISED_CHILDREN = 20
+
+
+class DecompositionBudget:
+    """What the submitter authorised, if anything."""
+
+    def __init__(
+        self,
+        *,
+        authorised: bool,
+        max_children: int = 0,
+        kind: str = "",
+        reason: str = "",
+    ) -> None:
+        self.authorised = bool(authorised)
+        self.max_children = int(max_children)
+        self.kind = str(kind or "")
+        self.reason = str(reason or "")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "authorised": self.authorised,
+            "max_children": self.max_children,
+            "kind": self.kind,
+            "reason": self.reason,
+        }
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "DecompositionBudget(%r)" % self.to_dict()
+
+
+def _metadata_of(task: Any) -> Mapping[str, Any]:
+    record = task.to_dict() if hasattr(task, "to_dict") else task
+    if not isinstance(record, Mapping):
+        return {}
+    metadata = record.get("metadata")
+    return metadata if isinstance(metadata, Mapping) else {}
+
+
+def decomposition_budget(task: Any) -> DecompositionBudget:
+    """What this task's submitter authorised.
+
+    Default is NOT authorised. That is the whole change: a task is one task
+    unless somebody said otherwise.
+    """
+    metadata = _metadata_of(task)
+
+    if metadata.get(NO_DECOMPOSE_KEY):
+        return DecompositionBudget(
+            authorised=False, reason="the task carries no_decompose"
+        )
+
+    raw = metadata.get(DECOMPOSITION_KEY)
+    if raw is None:
+        return DecompositionBudget(
+            authorised=False,
+            reason="the submitter did not authorise decomposition",
+        )
+
+    # A bare integer is the obvious shorthand for "at most this many".
+    if isinstance(raw, bool):
+        # `decomposition: true` says split but not how much. Refuse rather than
+        # invent a budget -- inventing one is how the framework got here.
+        return DecompositionBudget(
+            authorised=False,
+            reason="decomposition must state max_children, not just true",
+        )
+    if isinstance(raw, int):
+        return _budget_from(raw, "")
+    if isinstance(raw, Mapping):
+        return _budget_from(raw.get("max_children"), str(raw.get("kind") or ""))
+
+    return DecompositionBudget(
+        authorised=False, reason="decomposition metadata is not readable"
+    )
+
+
+def _budget_from(max_children: Any, kind: str) -> DecompositionBudget:
+    try:
+        limit = int(max_children)
+    except (TypeError, ValueError):
+        return DecompositionBudget(
+            authorised=False, reason="max_children is not a number"
+        )
+    if limit <= 0:
+        return DecompositionBudget(
+            authorised=False, reason="max_children is not positive"
+        )
+    if limit > MAX_AUTHORISED_CHILDREN:
+        limit = MAX_AUTHORISED_CHILDREN
+    return DecompositionBudget(authorised=True, max_children=limit, kind=kind)
+
+
+def check_children_allowed(task: Any, count: int) -> Tuple[bool, str]:
+    """Whether *count* children may be created for *task*, and why not.
+
+    Enforced at the control plane, not only described in the prompt. Prompt
+    text is advice to a model; this is the part that holds when the model
+    decides otherwise.
+    """
+    budget = decomposition_budget(task)
+    if not budget.authorised:
+        return False, (
+            "this task did not authorise decomposition (%s). The submitter "
+            "declares it: metadata.decomposition = {\"max_children\": N, "
+            "\"kind\": \"...\"}. Splitting work nobody asked to split is how a "
+            "one-command task becomes five tasks."
+            % budget.reason
+        )
+    if count > budget.max_children:
+        return False, (
+            "this task authorised at most %d child task(s); %d were requested"
+            % (budget.max_children, count)
+        )
+    return True, ""
+
+
+def prompt_section(task: Any, *, is_plan: bool, signals: Any = ()) -> str:
+    """The decomposition text for the executor prompt.
+
+    Unauthorised is the common case and gets the SHORT, unambiguous answer.
+    The five-step recipe appears only when somebody asked for it.
+    """
+    budget = decomposition_budget(task)
+    signal_text = ", ".join(str(s) for s in (signals or ()))
+
+    if not budget.authorised:
+        lines = [
+            "Task Sizing:",
+            "This task is ATOMIC. Do NOT create child tasks; do NOT post to the "
+            "children endpoint. Execute it and record evidence.",
+        ]
+        if is_plan:
+            # The heuristic disagrees. That is a question for the submitter,
+            # not a licence to fan out.
+            lines.append(
+                "NOTE: automated sizing thinks this may really be a plan (%s). "
+                "Do not act on that by splitting it. Do the part that is "
+                "unambiguous, and say so in your evidence summary so the "
+                "submitter can decide whether to re-file it with a "
+                "decomposition budget." % (signal_text or "no signals recorded")
+            )
+        return "\n".join(lines)
+
+    lines = [
+        "Task Sizing and Plan Decomposition:",
+        "The submitter AUTHORISED decomposition: at most %d child task(s)."
+        % budget.max_children,
+    ]
+    if budget.kind:
+        lines.append("They asked for them to be split by: %s" % budget.kind)
+    if is_plan and signal_text:
+        lines.append("Automated sizing agrees this is a plan (%s)." % signal_text)
+    lines.extend(
+        [
+            "If -- and only if -- the work genuinely has independent deliverables:",
+            "  1. Do NOT attempt to implement all of them in one run.",
+            "  2. Create at most %d focused child tasks. Each must be independently"
+            " completable and verifiable by a different agent."
+            % budget.max_children,
+            "  3. Post them to the MAC API children endpoint for this task.",
+            "  4. Write mac-evidence.json with evidence_type=operator_result, a summary,"
+            " and a result listing the child task titles you created.",
+            "  5. Exit -- the parent will block on its children.",
+            "If it is really one item, execute it directly. An authorised budget is a"
+            " ceiling, not a quota: creating fewer children, or none, is a valid outcome.",
+        ]
+    )
+    return "\n".join(lines)

--- a/tests/test_executor_hub_io.py
+++ b/tests/test_executor_hub_io.py
@@ -244,11 +244,20 @@ def test_detect_plan_signals_returns_empty_for_atomic_task():
 # ---------------------------------------------------------------------------
 
 
-def test_plan_detection_section_returns_string_for_plain_task():
+def test_plan_detection_section_tells_a_plain_task_it_is_atomic():
+    """This used to assert the section said "Task Sizing and Plan Detection"
+    -- the header of a five-step fan-out recipe printed on EVERY task.
+
+    Decomposition is now the submitter's declaration. An unauthorised task is
+    told plainly that it is atomic, and the recipe is not shown at all.
+    """
     task = {"id": "t1", "title": "Fix a bug", "description": "Small fix."}
     result = hub_io._plan_detection_section(task)
+
     assert isinstance(result, str)
-    assert "Task Sizing and Plan Detection" in result
+    assert "ATOMIC" in result
+    assert "Do NOT create child tasks" in result
+    assert "Break the work into" not in result
 
 
 def test_plan_detection_section_empty_for_child_task():
@@ -273,15 +282,35 @@ def test_plan_detection_section_empty_for_no_decompose():
     assert hub_io._plan_detection_section(task) == ""
 
 
-def test_plan_detection_section_includes_alert_for_plan_task():
-    """A task that scores 2+ signals should include the alert in the section."""
+def test_a_plan_scoring_task_is_reported_not_split_when_unauthorised():
+    """The heuristic is now an OBSERVATION, not a licence.
+
+    It used to emit a TASK-SIZING ALERT that sat above a fan-out recipe. If the
+    submitter did not authorise decomposition, disagreeing with them is a
+    question to raise, not an action to take.
+    """
     task = {
         "id": "t4",
         "title": "Build end-to-end pipeline",
         "description": "1. Do X\n2. Do Y\n3. Do Z\n4. Do W",
     }
     result = hub_io._plan_detection_section(task)
-    assert "TASK-SIZING ALERT" in result
+
+    assert "Do not act on that by splitting it" in result
+    assert "submitter can decide" in result
+
+
+def test_a_plan_scoring_task_gets_the_recipe_when_authorised():
+    task = {
+        "id": "t5",
+        "title": "Build end-to-end pipeline",
+        "description": "1. Do X\n2. Do Y\n3. Do Z\n4. Do W",
+        "metadata": {"decomposition": {"max_children": 4}},
+    }
+    result = hub_io._plan_detection_section(task)
+
+    assert "at most 4 child task(s)" in result
+    assert "Automated sizing agrees this is a plan" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_submitter_declared_decomposition.py
+++ b/tests/test_submitter_declared_decomposition.py
@@ -232,3 +232,14 @@ def test_an_operator_adding_children_is_not_blocked(cp):
     parent = cp.create_task("operator plan", project="mac")
 
     assert cp.add_child_tasks(parent.id, [{"title": "a", "description": "x"}])
+
+
+def test_an_atomic_task_is_still_told_where_to_write_evidence():
+    """Regression: the evidence FILENAME only ever appeared inside the
+    five-step recipe. Removing the recipe for atomic tasks removed the one
+    place the prompt named mac-evidence.json -- so the agent was told to
+    record evidence without being told where.
+    """
+    section = _plan_detection_section(_task())
+
+    assert "mac-evidence.json" in section

--- a/tests/test_submitter_declared_decomposition.py
+++ b/tests/test_submitter_declared_decomposition.py
@@ -1,0 +1,234 @@
+"""Decomposition is the submitter's declaration, not the framework's default.
+
+The executor prompt used to carry five numbered steps explaining how to fan a
+task out -- on EVERY task -- followed by one hedged sentence permitting the
+agent not to. The sizing heuristic that could have counterweighted it only
+spoke when it DETECTED a plan; when it decided a task was atomic it said
+nothing, so the agent read a fan-out recipe with no opposing evidence.
+
+Measured: a task whose description was "run `command -v` on these sixteen
+commands and report what you find", which the detector scored as NOT a plan
+with zero signals, was split into five children. Machine-originated work in
+this ledger completes at 0-9.6% against 20% for human-filed, and
+over-decomposition is one of the things manufacturing it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.executor_hub_io import _plan_detection_section, detect_plan_signals
+from mac.models import ValidationError
+from mac.services import ControlPlane
+from mac.task_decomposition import (
+    MAX_AUTHORISED_CHILDREN,
+    check_children_allowed,
+    decomposition_budget,
+)
+
+
+def _task(**metadata):
+    return {
+        "id": "task_1",
+        "project": "mac",
+        "title": "Report the sandbox toolchain",
+        "description": "run command -v for each and report",
+        "metadata": metadata,
+    }
+
+
+# --------------------------------------------------------------------------
+# The default inverts
+# --------------------------------------------------------------------------
+
+
+def test_a_task_is_atomic_unless_the_submitter_says_otherwise():
+    assert not decomposition_budget(_task()).authorised
+
+
+def test_the_prompt_tells_an_unauthorised_task_not_to_split():
+    section = _plan_detection_section(_task())
+
+    assert "ATOMIC" in section
+    assert "Do NOT create child tasks" in section
+
+
+def test_the_five_step_recipe_is_absent_when_unauthorised():
+    """The actual defect: the recipe printed on every task, always."""
+    section = _plan_detection_section(_task())
+
+    assert "Break the work into" not in section
+    assert "children endpoint" not in section or "do NOT post" in section
+
+
+def test_an_authorised_task_gets_the_recipe_with_its_budget():
+    section = _plan_detection_section(
+        _task(decomposition={"max_children": 3, "kind": "one per subsystem"})
+    )
+
+    assert "at most 3 child task(s)" in section
+    assert "one per subsystem" in section
+
+
+def test_the_budget_is_a_ceiling_not_a_quota():
+    """Authorising 5 children must not read as 'produce 5 children'."""
+    section = _plan_detection_section(_task(decomposition={"max_children": 5}))
+
+    assert "ceiling, not a quota" in section
+
+
+# --------------------------------------------------------------------------
+# The heuristic becomes an observation
+# --------------------------------------------------------------------------
+
+
+def test_a_plan_verdict_without_authorisation_asks_rather_than_splits():
+    """The detector disagreeing is a question for the submitter, not a licence."""
+    section = _plan_detection_section(_task(), )
+    # Force the plan branch directly, since the fixture text is deliberately atomic.
+    from mac.task_decomposition import prompt_section
+
+    noted = prompt_section(_task(), is_plan=True, signals=["numbered_steps:4"])
+
+    assert "Do not act on that by splitting it" in noted
+    assert "submitter can decide" in noted
+    assert "ATOMIC" in section
+
+
+def test_the_canary_that_caused_this_is_scored_atomic():
+    """Regression on the real case: the detector was right, and was ignored."""
+    is_plan, signals = detect_plan_signals(
+        "Canary: verify the sandbox toolchain matches the derived BOM",
+        "Report which of the contract-derived toolchain commands are actually "
+        "present inside your OpenShell sandbox. Run command -v for each.",
+    )
+
+    assert is_plan is False and signals == []
+
+
+# --------------------------------------------------------------------------
+# Enforcement, not just advice
+# --------------------------------------------------------------------------
+
+
+def test_unauthorised_children_are_refused():
+    allowed, why = check_children_allowed(_task(), 3)
+
+    assert not allowed
+    assert "did not authorise decomposition" in why
+
+
+def test_the_refusal_says_how_to_authorise_it():
+    """A refusal that does not say the remedy just gets worked around."""
+    _allowed, why = check_children_allowed(_task(), 3)
+
+    assert "max_children" in why
+
+
+def test_a_budget_is_a_hard_ceiling():
+    allowed, why = check_children_allowed(_task(decomposition={"max_children": 2}), 5)
+
+    assert not allowed and "at most 2" in why
+
+
+def test_within_budget_is_allowed():
+    allowed, _ = check_children_allowed(_task(decomposition={"max_children": 5}), 5)
+
+    assert allowed
+
+
+def test_no_decompose_still_wins_over_a_budget():
+    """A task carrying both is contradictory; refusing is the safe reading."""
+    allowed, _ = check_children_allowed(
+        _task(no_decompose=True, decomposition={"max_children": 5}), 1
+    )
+
+    assert not allowed
+
+
+def test_a_bare_true_is_refused_rather_than_given_an_invented_budget():
+    """Inventing a number is how the framework got here in the first place."""
+    budget = decomposition_budget(_task(decomposition=True))
+
+    assert not budget.authorised
+    assert "max_children" in budget.reason
+
+
+def test_an_absurd_budget_is_capped():
+    """A typo must not enqueue a thousand tasks."""
+    budget = decomposition_budget(_task(decomposition={"max_children": 10_000}))
+
+    assert budget.max_children == MAX_AUTHORISED_CHILDREN
+
+
+# --------------------------------------------------------------------------
+# The control plane holds the line
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+def _agent_adds_children(cp, parent, children):
+    """What an executing agent does: untrusted, under its own lease.
+
+    The guard is scoped to this path deliberately. An operator adding children
+    IS the submitter declaring, and work-package assembly builds its own graph;
+    the defect was an AGENT splitting a task nobody asked to split.
+    """
+    machine = cp.register_machine("decomp-host")
+    agent = cp.register_agent(machine.id, "decomp-worker")
+    _task, lease = cp.claim_task(parent.id, agent.id)   # returns (Task, Lease)
+    lease_id = lease.id
+    return cp.add_child_tasks(
+        parent.id,
+        children,
+        actor=agent.id,
+        lease_id=lease_id,
+        trusted_internal=False,
+    )
+
+
+def test_an_agent_cannot_split_an_unauthorised_task(cp):
+    parent = cp.create_task("atomic work", project="mac")
+
+    with pytest.raises(ValidationError) as excinfo:
+        _agent_adds_children(cp, parent, [{"title": "child", "description": "x"}])
+
+    assert "did not authorise decomposition" in str(excinfo.value)
+
+
+def test_an_agent_may_split_an_authorised_task(cp):
+    parent = cp.create_task(
+        "real plan", project="mac", metadata={"decomposition": {"max_children": 2}}
+    )
+
+    assert _agent_adds_children(
+        cp, parent, [{"title": "a", "description": "x"}, {"title": "b", "description": "y"}]
+    )
+
+
+def test_an_agent_cannot_exceed_the_ceiling(cp):
+    parent = cp.create_task(
+        "real plan", project="mac", metadata={"decomposition": {"max_children": 1}}
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        _agent_adds_children(
+            cp, parent,
+            [{"title": "a", "description": "x"}, {"title": "b", "description": "y"}],
+        )
+
+    assert "at most 1" in str(excinfo.value)
+
+
+def test_an_operator_adding_children_is_not_blocked(cp):
+    """The operator IS the submitter. Blocking them would break work-package
+    assembly and every deliberate decomposition."""
+    parent = cp.create_task("operator plan", project="mac")
+
+    assert cp.add_child_tasks(parent.id, [{"title": "a", "description": "x"}])

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -4239,8 +4239,19 @@ def test_plan_detection_section_included_in_prompt_when_plan_signals_present():
     )
     task = {"id": "t1", "title": title, "description": description}
     prompt = te.build_task_prompt(task, Path("/tmp/task.json"), lessons=[])
-    assert "Task Sizing and Plan Detection" in prompt
-    assert "add_child_tasks" in prompt or "children" in prompt
+
+    # Plan SIGNALS alone no longer produce a fan-out recipe. Decomposition is
+    # the submitter's declaration; the heuristic agreeing with itself is an
+    # observation to report, not authority to split.
+    assert "Do not act on that by splitting it" in prompt
+    assert "submitter can decide" in prompt
+
+    authorised = dict(task, metadata={"decomposition": {"max_children": 5}})
+    prompt = te.build_task_prompt(authorised, Path("/tmp/task.json"), lessons=[])
+
+    assert "Task Sizing and Plan Decomposition" in prompt
+    assert "children" in prompt
+    assert "at most 5 child task(s)" in prompt
 
 
 def test_plan_detection_section_omitted_for_atomic_task():


### PR DESCRIPTION
The executor prompt printed a five-step fan-out recipe on **every** task, with one hedged sentence permitting the agent not to split. The sizing heuristic only spoke when it *detected* a plan — when it judged a task atomic it said nothing, so the agent read a decomposition recipe with no opposing evidence.

**Measured:** a canary whose description was "run `command -v` on these sixteen commands and report what you find" — scored by `detect_plan_signals` as **not** a plan, zero signals — was split into five children. Machine-originated work completes at 0–9.6% here against 20% for human-filed.

Now: a task is one task unless its submitter says otherwise.

```
mac task create "..." --decompose 6 --decompose-kind "one per subsystem"
```

- Unauthorised → two lines saying the task is atomic; the recipe isn't shown
- Authorised → the recipe, bounded, described as a **ceiling, not a quota**
- The heuristic becomes an *observation*: disagreeing with the submitter is a question to raise, not an action to take
- Enforced at the control plane, **scoped to agent callers** (an operator adding children is the submitter declaring), and placed **after** the lease fence so a peer-task probe still gets 403 rather than 400

18 new tests; mutation-tested (flipping the default back, removing enforcement, removing the cap each fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)