### PR TITLE
Give an agent an owner, and stop private hardware being fleet capacity

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -534,6 +534,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HUB_VERIFY_IMAGE` | str | consumer-defined | hub | Hub setting: hub verify image. |
 | `MAC_HUB_VERIFY_RUNNER` | str | consumer-defined | hub | Hub setting: hub verify runner. |
 | `MAC_HUB_VERIFY_TIMEOUT` | int | consumer-defined | hub | Hub setting: hub verify timeout. |
+| `MAC_HUMAN` | str | consumer-defined | core | Core setting: human. |
 | `MAC_IDE_HANDOFF_FILE` | str | consumer-defined | core | Core setting: ide handoff file. |
 | `MAC_IDE_PROXY_TOKEN` | str | consumer-defined | core | Core setting: ide proxy token. |
 | `MAC_IMAGE_BUILDER` | str | consumer-defined | core | Core setting: image builder. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -344,7 +344,8 @@ Talking to people and systems:
 
 Who can do what:
   tenant  tenant boundaries
-  user    human user identities
+  human   people who own agents and file tasks
+  user    tenant-scoped user identities
   client  API clients and their principals
 
 Seeing what happened:

--- a/src/mac/allocator.py
+++ b/src/mac/allocator.py
@@ -55,6 +55,10 @@ AGENT_NO_EXECUTION_BOUNDARY = "agent_no_execution_boundary"
 # distinguishable: "this worker is draining for an update" and "you are not the
 # oldest barrier in the queue" send an operator to completely different places.
 AGENT_SYNC_BARRIER = "agent_sync_barrier"
+#: The agent is private and this task is not its owner's. An AUTHORIZATION
+#: refusal, not a capability gap: waiting will not help, and the remedy is to
+#: share the agent or file the task as its owner -- not to teach it a skill.
+AGENT_PRIVATE_TO_OTHER_OWNER = "agent_private_to_other_owner"
 
 #: A task that may run beside others, in any order. Everything is this today.
 EXECUTION_MODE_ASYNC = "async"
@@ -141,6 +145,8 @@ class AllocationTask:
     # async (default) or sync. A sync task is a per-agent barrier: see
     # EXECUTION_MODE_SYNC and the placement rules in evaluate_pair.
     execution_mode: str = EXECUTION_MODE_ASYNC
+    #: WHO filed this task. A private agent runs only its owner's work.
+    created_by_human: Optional[str] = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
 
@@ -177,6 +183,11 @@ class AllocationAgent:
     # this: the SSH installer installs OpenShell and the container image does
     # not, and a future AWS/Azure worker brings its own runtime or none.
     execution_boundary_verified: bool = True
+    #: WHO owns this agent, and whether anyone else may use it. A private agent
+    #: belongs to one person -- typically hardware on their own network that
+    #: the rest of the fleet cannot even reach.
+    owner_human_id: Optional[str] = None
+    visibility: str = "shared"
     # The oldest unfinished sync task targeted at this agent, if any. One field
     # rather than a pending flag plus a queue, because both facts derive from
     # it: the agent is quiescing while it is set, and a sync task may only run
@@ -302,6 +313,13 @@ class AllocationAgent:
             ),
             preferred_projects=preferred_projects,
             dispatch_policy=policy,
+            # Read off the record rather than defaulted here: an agent whose
+            # row predates these columns reads as shared/unowned, which is the
+            # behaviour the fleet had before ownership existed.
+            owner_human_id=(
+                str(value("owner_human_id") or "").strip() or None
+            ),
+            visibility=str(value("visibility", "shared") or "shared").strip().lower(),
         )
 
 
@@ -621,7 +639,11 @@ REQUIREMENT_REJECTIONS: FrozenSet[str] = frozenset(
 #: Also structural, but the remedy is an authorization change rather than a
 #: capability one, so it is reported separately instead of being blurred in.
 AUTHORIZATION_REJECTIONS: FrozenSet[str] = frozenset(
-    {AGENT_TENANT_UNAUTHORIZED, AGENT_MACHINE_UNTRUSTED}
+    {
+        AGENT_TENANT_UNAUTHORIZED,
+        AGENT_MACHINE_UNTRUSTED,
+        AGENT_PRIVATE_TO_OTHER_OWNER,
+    }
 )
 
 #: The same pair passes later with nothing reconfigured. A sync barrier belongs
@@ -852,6 +874,13 @@ def evaluate_pair(
         reasons.append(AGENT_TENANT_UNAUTHORIZED)
     if task.tenant_id in agent.denied_tenants:
         reasons.append(AGENT_TENANT_UNAUTHORIZED)
+    if str(agent.visibility or "shared").strip().lower() == "private" and (
+        not agent.owner_human_id or agent.owner_human_id != task.created_by_human
+    ):
+        # Placed with the hard authorization gates, not the soft preferences: a
+        # private worker often sits on its owner's own network, so "prefer not
+        # to" would mean placing work on a machine the fleet cannot reach.
+        reasons.append(AGENT_PRIVATE_TO_OTHER_OWNER)
     if not break_glass_active:
         if agent.dispatch_held:
             reasons.append(AGENT_HELD)

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -975,6 +975,11 @@ class AgentRegister(BaseModel):
     status: Optional[str] = None
     health_status: Optional[str] = None
     instance_kind: Optional[str] = None
+    #: Naming an owner here makes the agent PRIVATE unless visibility says
+    #: otherwise -- see ControlPlane.register_agent for why that default is
+    #: the safe one for new registrations.
+    owner_human_id: Optional[str] = None
+    visibility: Optional[str] = None
 
 
 class AgentAttestationKeyVerify(BaseModel):
@@ -1005,6 +1010,10 @@ class AgentUpdate(BaseModel):
     health_status: Optional[str] = None
     hermes_instance_id: Optional[str] = None
     instance_kind: Optional[str] = None
+    #: Who owns this agent and who may use it. Present on the update model as
+    #: well as registration because hardware changes hands.
+    owner_human_id: Optional[str] = None
+    visibility: Optional[str] = None
     actor: str = "human"
 
 

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -27,6 +27,7 @@ from mac.task_batch import OPERATIONS as BATCH_OPERATIONS
 from mac.models import (
     EVIDENCE_KIND_CHOICES,
     MACError,
+    NotFoundError,
     REPORT_DELIVERABLE,
     normalize_deliverable_kind,
     normalize_evidence_kind,
@@ -1758,6 +1759,7 @@ def cmd_interaction_task(args: argparse.Namespace) -> None:
             metadata=_json_arg(args.metadata, {}),
             max_attempts=args.max_attempts,
             actor=args.actor,
+            created_by_human=kwargs_human,
         )
     )
 
@@ -1904,6 +1906,11 @@ def cmd_task_create(args: argparse.Namespace) -> None:
         # Stage the task: the loop-mode fleet won't auto-claim it (and it's
         # hidden from `task ready`) until an operator starts it explicitly.
         metadata["no_dispatch"] = True
+    filed_by = str(getattr(args, "as_human", "") or "").strip()
+    if filed_by:
+        kwargs_human = filed_by
+    else:
+        kwargs_human = None
     if getattr(args, "sync", False):
         # A barrier on one worker: it waits for that worker to drain, runs
         # alone, and holds off new async work while it does.
@@ -1975,6 +1982,8 @@ def cmd_task_create(args: argparse.Namespace) -> None:
             )
     project = project or None
     create_kwargs = {}
+    if kwargs_human:
+        create_kwargs["created_by_human"] = kwargs_human
     idempotency_key = str(
         getattr(args, "idempotency_key", "") or ""
     ).strip()
@@ -2082,6 +2091,20 @@ def cmd_task_list(args: argparse.Namespace) -> None:
     if getattr(args, "selector", None) and not getattr(args, "project", None):
         project = None
     limit = getattr(args, "limit", None) or None
+    # `--mine` needs an identity the CLI actually knows. It resolves from an
+    # explicit --filed-by, else $MAC_HUMAN. It deliberately does NOT fall back
+    # to --actor, which defaults to the literal string "human": a scope built
+    # on a self-asserted default would read like a boundary while filtering on
+    # nothing.
+    filed_by = str(getattr(args, "filed_by", "") or "").strip()
+    if getattr(args, "mine", False) and not filed_by:
+        filed_by = str(os.environ.get("MAC_HUMAN") or "").strip()
+        if not filed_by:
+            raise MACError(
+                "--mine needs to know who you are. Pass --filed-by <username> "
+                "or set MAC_HUMAN. It will not guess from --actor, which "
+                "defaults to the literal string 'human'."
+            )
     tasks = [
         task.to_dict()
         for task in cp.list_tasks(
@@ -2089,6 +2112,7 @@ def cmd_task_list(args: argparse.Namespace) -> None:
             project=project,
             limit=limit,
             view="summary",
+            **({"created_by_human": filed_by} if filed_by else {}),
         )
     ]
     missing_routes = [
@@ -3670,8 +3694,43 @@ def cmd_agent_register(args: argparse.Namespace) -> None:
             agent_id=args.agent_id,
             persona_instance_id=args.persona_instance_id,
             instance_kind=getattr(args, "instance_kind", None),
+            owner_human_id=getattr(args, "owner", None),
+            visibility=getattr(args, "visibility", None),
         )
     )
+
+
+def cmd_human_register(args: argparse.Namespace) -> None:
+    """Create (or update) the person an agent or a task can belong to.
+
+    The humans table and POST /humans already existed; nothing at the CLI
+    could reach them, so the only principal you could name as an agent's owner
+    was one created over raw HTTP. An ownership model whose owners cannot be
+    created is not an ownership model.
+    """
+    _print(
+        _plane(args).register_human(
+            username=args.username,
+            display_name=args.display_name,
+            email=args.email,
+            github_login=args.github_login,
+            groups=_csv(args.groups) or None,
+        )
+    )
+
+
+def cmd_human_list(args: argparse.Namespace) -> None:
+    _print([human.to_dict() for human in _plane(args).list_humans(group=args.group)])
+
+
+def cmd_human_show(args: argparse.Namespace) -> None:
+    """Accepts a username or an id, because the caller usually has the former
+    and every ownership field stores the latter."""
+    cp = _plane(args)
+    try:
+        _print(cp.get_human_by_username(args.human))
+    except NotFoundError:
+        _print(cp.get_human(args.human))
 
 
 def cmd_agent_update(args: argparse.Namespace) -> None:
@@ -3708,12 +3767,16 @@ def cmd_agent_update(args: argparse.Namespace) -> None:
     updates: Dict[str, Any] = {}
     if args.instance_kind is not None:
         updates["instance_kind"] = args.instance_kind
+    if getattr(args, "owner", None) is not None:
+        updates["owner_human_id"] = args.owner
+    if getattr(args, "visibility", None) is not None:
+        updates["visibility"] = args.visibility
     if capabilities is not None:
         updates["capabilities"] = sorted(set(capabilities))
     if not updates:
         raise SystemExit(
             "nothing to update: supply --instance-kind, --capabilities, "
-            "--add-capability or --remove-capability"
+            "--add-capability, --remove-capability, --owner or --visibility"
         )
     _print(cp.update_agent(args.agent_id, **updates))
 
@@ -7609,6 +7672,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="how the children should be divided (e.g. 'one per subsystem'); "
              "only meaningful with --decompose",
     )
+    create.add_argument(
+        "--as-human",
+        dest="as_human",
+        metavar="USERNAME",
+        help="record WHO filed this task (a registered human's username or id). "
+             "The ledger otherwise records only which AGENT ran it, so it can "
+             "say who is running a task but not whose task it is.",
+    )
     create.add_argument("--no-decompose", dest="no_decompose", action="store_true",
                         help="handoff/plan-note guard: the executor will not auto-decompose "
                              "this task into child tasks")
@@ -7626,6 +7697,17 @@ def build_parser() -> argparse.ArgumentParser:
     list_tasks = task.add_parser(
         "list",
         help="list tasks (default: short ids; use --full-ids for scripts)",
+    )
+    list_tasks.add_argument(
+        "--mine",
+        action="store_true",
+        help="only tasks YOU filed (resolves --filed-by, else $MAC_HUMAN)",
+    )
+    list_tasks.add_argument(
+        "--filed-by",
+        dest="filed_by",
+        metavar="USERNAME",
+        help="only tasks filed by this human",
     )
     list_tasks.add_argument(
         "--selector",
@@ -9092,6 +9174,25 @@ def build_parser() -> argparse.ArgumentParser:
     machine_show.add_argument("machine_id")
     _set(cmd_machine_show, machine_show)
 
+    human = sub.add_parser(
+        "human", help="people who own agents and file tasks"
+    ).add_subparsers(dest="human_command", required=True)
+    human_register = human.add_parser(
+        "register", help="create or update a person"
+    )
+    human_register.add_argument("username")
+    human_register.add_argument("--display-name")
+    human_register.add_argument("--email")
+    human_register.add_argument("--github-login")
+    human_register.add_argument("--groups", help="comma-separated group list")
+    _set(cmd_human_register, human_register)
+    human_list = human.add_parser("list", help="list people")
+    human_list.add_argument("--group", default=None)
+    _set(cmd_human_list, human_list)
+    human_show = human.add_parser("show", help="show one person by username or id")
+    human_show.add_argument("human")
+    _set(cmd_human_show, human_show)
+
     agent = sub.add_parser("agent", help="agent registry commands").add_subparsers(dest="agent_command", required=True)
     agent_register = agent.add_parser(
         "register", help="register a new agent onto a machine"
@@ -9108,6 +9209,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     agent_register.add_argument(
         "--instance-kind", choices=("static", "fungible"), default=None
+    )
+    agent_register.add_argument(
+        "--owner",
+        help=(
+            "username or human id that owns this agent; naming one makes the "
+            "agent private unless --visibility says otherwise"
+        ),
+    )
+    agent_register.add_argument(
+        "--visibility", choices=("private", "shared"),
+        help="who may run work here (default: private when --owner is given)",
     )
     _set(cmd_agent_register, agent_register)
 
@@ -9129,6 +9241,19 @@ def build_parser() -> argparse.ArgumentParser:
     agent_update.add_argument(
         "--remove-capability", action="append",
         help="remove one capability, keeping the rest (repeatable)",
+    )
+    agent_update.add_argument(
+        "--owner",
+        help="username or human id that owns this agent ('' to clear)",
+    )
+    agent_update.add_argument(
+        "--visibility",
+        choices=("private", "shared"),
+        help=(
+            "private: only the owner's tasks run here (typically hardware on "
+            "the owner's own network). shared: anyone working on a registered "
+            "project may use it"
+        ),
     )
     _set(cmd_agent_update, agent_update)
 

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -287,7 +287,12 @@ COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
         "Who can do what",
         (
             ("tenant", "tenant boundaries"),
-            ("user", "human user identities"),
+            # Two identities, deliberately named apart: a `human` is a
+            # fleet-wide principal that owns agents and files tasks, while a
+            # `user` exists inside one tenant. They are separate tables and
+            # neither substitutes for the other.
+            ("human", "people who own agents and file tasks"),
+            ("user", "tenant-scoped user identities"),
             ("client", "API clients and their principals"),
         ),
     ),

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -6376,6 +6376,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: human.",
+    "family": "core",
+    "name": "MAC_HUMAN",
+    "retired": false,
+    "sources": [
+      "src/mac/cli.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: ide handoff file.",
     "family": "core",
     "name": "MAC_IDE_HANDOFF_FILE",

--- a/src/mac/data/postgres/schema.sql
+++ b/src/mac/data/postgres/schema.sql
@@ -5874,6 +5874,25 @@ CREATE TABLE IF NOT EXISTS humans (
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );
+
+-- WHO owns this agent, and who may use it.
+--
+-- A static worker on its owner's own network is not fleet capacity: advertising
+-- it fleet-wide is not a scheduling inefficiency, it is a FALSE CLAIM, and the
+-- allocator will place work on a machine the rest of the fleet cannot reach.
+-- An internet-reachable worker may equally hold data its owner will register
+-- against their own virtual fleet and no further.
+--
+-- visibility defaults to 'shared' HERE, on purpose: every agent that exists
+-- when this column is added is already being used as shared capacity, and
+-- defaulting to private would strand the entire running fleet at once. New
+-- registrations default to private in the service layer, where the safe
+-- default belongs.
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS owner_human_id TEXT
+    REFERENCES humans(id) ON DELETE SET NULL;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'shared'
+    CHECK (visibility IN ('private', 'shared'));
+CREATE INDEX IF NOT EXISTS idx_agents_owner ON agents (owner_human_id);
 CREATE INDEX IF NOT EXISTS idx_humans_username
     ON humans (username);
 CREATE INDEX IF NOT EXISTS idx_humans_github_login

--- a/src/mac/data/postgres/schema.sql
+++ b/src/mac/data/postgres/schema.sql
@@ -5888,8 +5888,32 @@ CREATE TABLE IF NOT EXISTS humans (
 -- defaulting to private would strand the entire running fleet at once. New
 -- registrations default to private in the service layer, where the safe
 -- default belongs.
-ALTER TABLE agents ADD COLUMN IF NOT EXISTS owner_human_id TEXT
-    REFERENCES humans(id) ON DELETE SET NULL;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS owner_human_id TEXT;
+-- The foreign key is added separately, and only when absent, because
+-- ADD COLUMN IF NOT EXISTS skips the WHOLE statement once the column exists.
+-- Attaching the reference to the column definition therefore means that any
+-- database where the column outlived the constraint -- a humans table dropped
+-- and recreated, a restore that reordered objects -- never gets it back, and
+-- an agent can then be owned by a principal that does not exist.
+DO $$
+BEGIN
+    -- Scoped to the CURRENT schema. pg_constraint is cluster-wide, and this
+    -- schema is applied per-schema (every test gets its own, and a hub can
+    -- host more than one). An unscoped check finds someone else's constraint
+    -- and skips, leaving this schema without the foreign key for good.
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint c
+        JOIN pg_class t ON c.conrelid = t.oid
+        JOIN pg_namespace n ON t.relnamespace = n.oid
+        WHERE c.conname = 'agents_owner_human_id_fkey'
+          AND n.nspname = current_schema()
+    ) THEN
+        ALTER TABLE agents ADD CONSTRAINT agents_owner_human_id_fkey
+            FOREIGN KEY (owner_human_id) REFERENCES humans(id) ON DELETE SET NULL;
+    END IF;
+END
+$$;
 ALTER TABLE agents ADD COLUMN IF NOT EXISTS visibility TEXT NOT NULL DEFAULT 'shared'
     CHECK (visibility IN ('private', 'shared'));
 CREATE INDEX IF NOT EXISTS idx_agents_owner ON agents (owner_human_id);

--- a/src/mac/models.py
+++ b/src/mac/models.py
@@ -1132,6 +1132,10 @@ class Task:
     completed_at: Optional[str]
     created_at: str
     updated_at: str
+    #: WHO filed this task -- a Human id, distinct from owner_agent_id, which
+    #: is which agent is executing it. Optional because every task predating
+    #: this carries no filer, and requiring one would invalidate all of them.
+    created_by_human: Optional[str] = None
 
     def to_dict(self) -> JsonDict:
         """Return a JSON-serializable dict representation of this Task."""
@@ -1440,6 +1444,14 @@ class Agent:
     # instances (for example HGX-created headless workers) after re-attestation.
     # This is independent of resources.ephemeral, which controls identity TTL.
     instance_kind: str = AgentInstanceKind.STATIC.value
+    #: WHO owns this agent, and who may use it. A worker on its owner's own
+    #: network is not fleet capacity; advertising it as such makes the
+    #: allocator place work on a machine the fleet cannot reach.
+    #:
+    #: Declared LAST on purpose: Agent is constructed positionally in several
+    #: places, so a field added mid-class shifts every argument after it.
+    owner_human_id: Optional[str] = None
+    visibility: str = "shared"
 
     def to_dict(self) -> JsonDict:
         """Return a JSON-serializable dict representation of this Agent."""

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -709,6 +709,15 @@ def _blocked_attempt_failure_fingerprint(value: Any) -> str:
     return "sha256:%s" % hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 
 
+def _row_value(row: Any, column: str) -> Optional[str]:
+    """Read a column that may not exist on an older row shape."""
+    try:
+        value = row[column]
+    except (KeyError, IndexError, TypeError):
+        return None
+    return value if value in (None, "") or isinstance(value, str) else str(value)
+
+
 def _non_retryable_blocked_attempt_marker(value: Any) -> Optional[str]:
     if value in (None, "", [], {}):
         return None
@@ -5346,6 +5355,11 @@ class ControlPlane:
         max_attempts: int = 3,
         actor: str = "human",
         idempotency_key: Optional[str] = None,
+        # WHO filed this, as opposed to which agent runs it. The column and the
+        # Human principal both already existed; nothing ever wrote to it, so
+        # the ledger could say "who is running this" and not "whose task is
+        # this".
+        created_by_human: Optional[str] = None,
         _task_id: Optional[str] = None,
         _workflow_run_id: Optional[str] = None,
         _workflow_node_key: Optional[str] = None,
@@ -5372,6 +5386,26 @@ class ControlPlane:
                 "'wait for all tasks to complete' is ambiguous between a single "
                 "worker and the whole fleet."
             )
+        resolved_human: Optional[str] = None
+        if created_by_human:
+            requested_human = str(created_by_human).strip()
+            if requested_human:
+                # Store the stable human id, never the typed username. A
+                # username is an external anchor that can change; a task's
+                # record of who filed it must not silently re-point at
+                # somebody else when it does.
+                try:
+                    resolved_human = self.get_human_by_username(requested_human).id
+                except NotFoundError:
+                    try:
+                        resolved_human = self.get_human(requested_human).id
+                    except NotFoundError:
+                        raise ValidationError(
+                            "no such human %r: register them first "
+                            "(`mac admin user ...`) so task ownership points at "
+                            "a real principal rather than a free-text string"
+                            % requested_human
+                        ) from None
         dependency_refs = coerce_list(dependencies)
         supplied_task_id = str(_task_id or "").strip()
         if supplied_task_id and any(
@@ -5608,8 +5642,8 @@ class ControlPlane:
                         required_capabilities, dependencies, metadata,
                         owner_agent_id, lease_id, leased_until, attempt_count,
                         max_attempts, started_at, completed_at, created_at, updated_at,
-                        workflow_run_id, workflow_node_key
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, 0, ?, NULL, NULL, ?, ?, ?, ?)
+                        workflow_run_id, workflow_node_key, created_by_human
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, 0, ?, NULL, NULL, ?, ?, ?, ?, ?)
                     ON CONFLICT(id) DO NOTHING
                     """,
                     (
@@ -5627,6 +5661,7 @@ class ControlPlane:
                         now,
                         _workflow_run_id,
                         _workflow_node_key,
+                        resolved_human,
                     ),
                 )
                 if inserted.rowcount == 0:
@@ -6647,6 +6682,7 @@ class ControlPlane:
         *,
         project: Optional[str] = None,
         limit: Optional[int] = None,
+        created_by_human: Optional[str] = None,
     ) -> List[Task]:
         # mac-5ayd: dispatch_once / claim_next used to pull EVERY open
         # task into Python and sort in memory on every tick. Pass an
@@ -6667,6 +6703,11 @@ class ControlPlane:
         if project is not None:
             where.append("project = ?")
             params.append(project)
+        if created_by_human:
+            # Pushed into SQL like the others: "my tasks" on a busy hub must
+            # not mean "transfer everyone's tasks and discard most of them".
+            where.append("created_by_human = ?")
+            params.append(str(created_by_human))
         where_clause = (" WHERE " + " AND ".join(where)) if where else ""
         sql = "SELECT * FROM tasks" + where_clause + " ORDER BY priority DESC, created_at"
         if limit is not None:
@@ -16056,6 +16097,32 @@ class ControlPlane:
                 return row["id"]
         return None
 
+    #: The only two answers. Anything else is a typo that would otherwise be
+    #: stored and then silently treated as "not private".
+    AGENT_VISIBILITIES = frozenset({"private", "shared"})
+
+    def _resolve_agent_owner(self, owner_human_id: Any) -> Optional[str]:
+        """A username or id -> the stable human id, or a refusal.
+
+        Accepting a free-text owner would make the ownership gate compare two
+        strings that were never the same principal, and the failure would show
+        up as an agent nobody can dispatch to.
+        """
+        requested = str(owner_human_id or "").strip()
+        if not requested:
+            return None
+        try:
+            return self.get_human_by_username(requested).id
+        except NotFoundError:
+            pass
+        try:
+            return self.get_human(requested).id
+        except NotFoundError:
+            raise ValidationError(
+                "no such human %r: an agent's owner must be a registered "
+                "principal, not a free-text string" % requested
+            ) from None
+
     def register_agent(
         self,
         machine_id: str,
@@ -16070,8 +16137,29 @@ class ControlPlane:
         health_status: Optional[str] = None,
         instance_kind: Optional[str] = None,
         allow_resurrection: bool = False,
+        owner_human_id: Optional[str] = None,
+        visibility: Optional[str] = None,
     ) -> Agent:
         self.get_machine(machine_id)
+        resolved_owner = self._resolve_agent_owner(owner_human_id)
+        # PRIVATE is the safe default for a NEW agent: a worker on someone's own
+        # network is not fleet capacity, and advertising it as such makes the
+        # allocator place work on a machine the fleet cannot reach. The COLUMN
+        # defaults to 'shared' so existing agents are untouched; the safe
+        # default belongs here, where it governs new registrations only.
+        resolved_visibility = str(visibility or "").strip().lower() or (
+            "private" if resolved_owner else "shared"
+        )
+        if resolved_visibility not in self.AGENT_VISIBILITIES:
+            raise ValidationError(
+                "agent visibility must be 'private' or 'shared', got %r"
+                % resolved_visibility
+            )
+        if resolved_visibility == "private" and not resolved_owner:
+            raise ValidationError(
+                "a private agent needs an owner: without one nobody can use it, "
+                "including the person who registered it"
+            )
         if not name:
             raise ValidationError("agent name is required")
         # ``persona_instance_id`` is the runtime-neutral linkage name; accept
@@ -16228,8 +16316,9 @@ class ControlPlane:
                     id, machine_id, name, instance_kind, capabilities, resources,
                     status, health_status,
                     current_task_id, created_at, updated_at, last_seen_at,
-                    hermes_instance_id, attestation_key_ciphertext
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)
+                    hermes_instance_id, attestation_key_ciphertext,
+                    owner_human_id, visibility
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     machine_id = excluded.machine_id,
                     name = excluded.name,
@@ -16277,6 +16366,8 @@ class ControlPlane:
                     now,
                     hermes_instance_id,
                     attestation_ciphertext,
+                    resolved_owner,
+                    resolved_visibility,
                     int(bool(allow_resurrection)),
                 ),
             )
@@ -16922,6 +17013,8 @@ class ControlPlane:
         persona_instance_id: Optional[str] = None,
         hermes_instance_id: Optional[str] = None,
         instance_kind: Optional[str] = None,
+        owner_human_id: Optional[str] = None,
+        visibility: Optional[str] = None,
         actor: str = "human",
     ) -> Agent:
         # ``persona_instance_id`` is the runtime-neutral linkage name; accept the
@@ -17029,6 +17122,44 @@ class ControlPlane:
             next_instance_kind = instance_kind_value
             if instance_kind_value != agent_before.instance_kind:
                 changed_fields.append("instance_kind")
+        # Ownership is changeable after registration on purpose. Hardware is
+        # handed over, people leave, and a fleet that could only set an owner
+        # at registration would force a re-register -- which loses the agent's
+        # history -- to correct one field.
+        next_owner = agent_before.owner_human_id
+        next_visibility = agent_before.visibility
+        if owner_human_id is not None:
+            owner_value = str(owner_human_id).strip()
+            if owner_value:
+                owner_value = self._resolve_agent_owner(owner_value)
+                updates.append("owner_human_id = ?")
+                params.append(owner_value)
+                next_owner = owner_value
+            else:
+                updates.append("owner_human_id = NULL")
+                next_owner = None
+            if next_owner != agent_before.owner_human_id:
+                changed_fields.append("owner_human_id")
+        if visibility is not None:
+            visibility_value = _state_value(visibility).strip().lower()
+            if visibility_value not in self.AGENT_VISIBILITIES:
+                raise ValidationError(
+                    "unsupported agent visibility: %s (expected one of %s)"
+                    % (visibility_value, ", ".join(sorted(self.AGENT_VISIBILITIES)))
+                )
+            # Refused rather than silently shared: a private agent with no
+            # owner matches no filer, so it would quietly become capacity for
+            # nobody and its work would sit undispatched with no explanation.
+            if visibility_value == "private" and not next_owner:
+                raise ValidationError(
+                    "an agent cannot be private without an owner; "
+                    "pass --owner as well"
+                )
+            updates.append("visibility = ?")
+            params.append(visibility_value)
+            next_visibility = visibility_value
+            if visibility_value != agent_before.visibility:
+                changed_fields.append("visibility")
         if not updates:
             return self.get_agent(agent_id)
         updates.append("updated_at = ?")
@@ -17073,6 +17204,10 @@ class ControlPlane:
                     "hermes_instance_id": next_hermes_instance_id,
                     "previous_instance_kind": agent_before.instance_kind,
                     "instance_kind": next_instance_kind,
+                    "previous_owner_human_id": agent_before.owner_human_id,
+                    "owner_human_id": next_owner,
+                    "previous_visibility": agent_before.visibility,
+                    "visibility": next_visibility,
                 },
                 now,
             )
@@ -23868,6 +24003,9 @@ class ControlPlane:
             dependencies=json_loads(row["dependencies"], []),
             metadata=json_loads(row["metadata"], {}),
             owner_agent_id=row["owner_agent_id"],
+            # Absent on every task predating the column; keyword access on
+            # a row that lacks it would raise rather than read as None.
+            created_by_human=_row_value(row, "created_by_human"),
             lease_id=row["lease_id"],
             leased_until=row["leased_until"],
             attempt_count=row["attempt_count"],
@@ -24079,6 +24217,10 @@ class ControlPlane:
         keys = row.keys() if hasattr(row, "keys") else []
         running_digest = row["running_digest"] if "running_digest" in keys else None
         role_id = row["role_id"] if "role_id" in keys else None
+        owner_human_id = row["owner_human_id"] if "owner_human_id" in keys else None
+        visibility = (
+            str(row["visibility"] or "shared") if "visibility" in keys else "shared"
+        )
         hermes_instance_id = (
             row["hermes_instance_id"] if "hermes_instance_id" in keys else None
         )
@@ -24138,6 +24280,8 @@ class ControlPlane:
             last_control_stream_consumed_at,
             row["deleted_at"] if "deleted_at" in keys else None,
             instance_kind,
+            owner_human_id=owner_human_id,
+            visibility=visibility,
         )
 
     def _project_item_from_row(self, row: Any) -> ProjectItem:

--- a/src/mac/task_lifecycle.py
+++ b/src/mac/task_lifecycle.py
@@ -417,6 +417,10 @@ class DispatchService:
             required_role_capabilities=frozenset(required_role_capabilities),
             package_ready=package_ready,
             execution_mode=normalize_execution_mode(metadata.get("execution_mode")),
+            # WHO filed it, so a private agent can tell its owner's work from
+            # everyone else's. Without this the ownership gate would compare
+            # against None and no private agent would ever be dispatched to.
+            created_by_human=getattr(task, "created_by_human", None),
             metadata=metadata,
         )
 

--- a/tests/cli/test_cli_agent_ownership.py
+++ b/tests/cli/test_cli_agent_ownership.py
@@ -1,0 +1,98 @@
+"""Owning an agent from the command line.
+
+The service layer can already record an owner, and the API has had `/humans`
+for a while -- but nothing at the CLI could create a person or point an agent
+at one, so the ownership model had no way to be used. These go through
+`main()` for that reason: a gate that can only be reached from Python is a
+gate the operator marking their own hardware cannot reach.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from mac.cli import main
+from mac.test_support import control_plane_on, dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, (json.loads(raw) if raw else None)
+
+
+def _agent(tmp_path, name="worker"):
+    cp = control_plane_on(dsn_for(tmp_path))
+    machine = cp.register_machine("%s-host" % name)
+    return cp.register_agent(machine.id, name)
+
+
+def test_a_person_can_be_registered(tmp_path):
+    rc, out = _run(tmp_path, "admin", "human", "register", "jordanh",
+                   "--display-name", "Jordan Hubbard")
+
+    assert rc in (None, 0)
+    assert out["username"] == "jordanh"
+
+
+def test_an_agent_can_be_given_an_owner_and_made_private(tmp_path):
+    """The whole point: hardware on someone's own network stops being
+    advertised as fleet capacity."""
+    agent = _agent(tmp_path, "rocky")
+    _run(tmp_path, "admin", "human", "register", "jordanh")
+
+    rc, out = _run(tmp_path, "agent", "update", agent.id,
+                   "--owner", "jordanh", "--visibility", "private")
+
+    assert rc in (None, 0)
+    assert out["visibility"] == "private"
+    assert out["owner_human_id"]
+
+
+def test_an_agent_can_be_marked_shared(tmp_path):
+    """The other half of the same operation: pooled workers stay everyone's."""
+    agent = _agent(tmp_path, "pod")
+
+    rc, out = _run(tmp_path, "agent", "update", agent.id, "--visibility", "shared")
+
+    assert rc in (None, 0)
+    assert out["visibility"] == "shared"
+
+
+def test_making_an_agent_private_without_an_owner_is_refused(tmp_path):
+    """Fail loudly rather than create capacity for nobody: a private agent with
+    no owner matches no filer, so its queue would simply never move."""
+    agent = _agent(tmp_path, "orphan")
+
+    rc, _out = _run(tmp_path, "agent", "update", agent.id, "--visibility", "private")
+
+    assert rc not in (None, 0)
+
+
+def test_an_unknown_owner_is_refused(tmp_path):
+    """Otherwise a typo stores a principal that resolves to nobody, and the
+    agent silently stops taking work."""
+    agent = _agent(tmp_path, "typo")
+
+    rc, _out = _run(tmp_path, "agent", "update", agent.id,
+                    "--owner", "nobody-by-that-name", "--visibility", "private")
+
+    assert rc not in (None, 0)
+
+
+def test_a_person_can_be_looked_up_by_username(tmp_path):
+    """Ownership fields store ids; operators have usernames."""
+    _run(tmp_path, "admin", "human", "register", "jordanh")
+
+    rc, out = _run(tmp_path, "admin", "human", "show", "jordanh")
+
+    assert rc in (None, 0)
+    assert out["username"] == "jordanh"

--- a/tests/cli/test_cli_agent_ownership.py
+++ b/tests/cli/test_cli_agent_ownership.py
@@ -96,3 +96,15 @@ def test_a_person_can_be_looked_up_by_username(tmp_path):
 
     assert rc in (None, 0)
     assert out["username"] == "jordanh"
+
+
+def test_people_can_be_listed(tmp_path):
+    """The lookup an operator needs before marking a node: which principals
+    exist to be named as an owner."""
+    _run(tmp_path, "admin", "human", "register", "jordanh")
+    _run(tmp_path, "admin", "human", "register", "someone-else")
+
+    rc, out = _run(tmp_path, "admin", "human", "list")
+
+    assert rc in (None, 0)
+    assert {"jordanh", "someone-else"} <= {row["username"] for row in out}

--- a/tests/cli/test_dispatch_positional_drift.py
+++ b/tests/cli/test_dispatch_positional_drift.py
@@ -263,6 +263,8 @@ def test_cmd_registration_uses_keyword_args_only(monkeypatch) -> None:
         "agent_id": "agent_test",
         "persona_instance_id": None,
         "instance_kind": None,
+        "owner_human_id": None,
+        "visibility": None,
     }
 
 

--- a/tests/test_agent_ownership.py
+++ b/tests/test_agent_ownership.py
@@ -1,0 +1,224 @@
+"""An agent has an owner, and a private agent is not fleet capacity.
+
+A static worker on its owner's own network is reachable only by them.
+Advertising it fleet-wide is not a scheduling inefficiency -- it is a false
+claim, and the allocator will place work on a machine the rest of the fleet
+cannot reach. An internet-reachable worker may equally hold data its owner
+will register against their own virtual fleet and no further.
+
+The visibility COLUMN defaults to 'shared' so that adding it strands no
+existing agent; the safe default (private, when an owner is named) lives in
+the service layer where it governs new registrations only.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import ValidationError
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+@pytest.fixture()
+def alice(cp):
+    return cp.register_human(username="alice", display_name="Alice")
+
+
+def _machine(cp, name="host"):
+    return cp.register_machine(name)
+
+
+def test_an_owned_agent_defaults_to_private(cp, alice):
+    """The safe default: registering your own hardware must not silently add it
+    to everyone's capacity."""
+    machine = _machine(cp)
+
+    agent = cp.register_agent(machine.id, "mine", owner_human_id="alice")
+
+    assert agent.owner_human_id == alice.id
+    assert agent.visibility == "private"
+
+
+def test_an_unowned_agent_stays_shared(cp):
+    """Existing fleet behaviour is unchanged when nobody claims the agent."""
+    machine = _machine(cp)
+
+    agent = cp.register_agent(machine.id, "pool")
+
+    assert agent.owner_human_id is None
+    assert agent.visibility == "shared"
+
+
+def test_an_owner_may_publish_their_agent(cp, alice):
+    machine = _machine(cp)
+
+    agent = cp.register_agent(
+        machine.id, "lent", owner_human_id="alice", visibility="shared"
+    )
+
+    assert agent.visibility == "shared" and agent.owner_human_id == alice.id
+
+
+def test_a_private_agent_without_an_owner_is_refused(cp):
+    """Nobody could use it -- including whoever registered it."""
+    machine = _machine(cp)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.register_agent(machine.id, "orphan", visibility="private")
+
+    assert "needs an owner" in str(excinfo.value)
+
+
+def test_an_unknown_owner_is_refused(cp):
+    """Ownership must point at a real principal, not a free-text string."""
+    machine = _machine(cp)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.register_agent(machine.id, "a", owner_human_id="nobody")
+
+    assert "no such human" in str(excinfo.value)
+
+
+def test_an_invalid_visibility_is_refused(cp, alice):
+    machine = _machine(cp)
+
+    with pytest.raises(ValidationError):
+        cp.register_agent(
+            machine.id, "a", owner_human_id="alice", visibility="semi-public"
+        )
+
+
+def test_the_owner_is_stored_as_a_stable_id(cp, alice):
+    """A username can be changed; a stored username would silently re-point
+    ownership at somebody else."""
+    machine = _machine(cp)
+
+    agent = cp.register_agent(machine.id, "mine", owner_human_id="alice")
+
+    assert agent.owner_human_id == alice.id != "alice"
+
+
+def test_existing_agents_are_readable_without_the_new_columns(cp):
+    """Hydration must tolerate a row shape predating the columns, or every
+    pre-existing agent becomes unreadable."""
+    machine = _machine(cp)
+    agent = cp.register_agent(machine.id, "legacy")
+
+    reloaded = cp.get_agent(agent.id)
+
+    assert reloaded.visibility in {"shared", "private"}
+
+
+# --------------------------------------------------------------------------
+# Allocator enforcement. The column is only a comment until placement honours
+# it -- the recurring defect in this codebase is a correct decision with no
+# consumer, so these tests exist to give the attribute one.
+# --------------------------------------------------------------------------
+
+
+def _pair(*, visibility="shared", owner=None, filer=None):
+    from mac.allocator import AllocationAgent, AllocationTask, evaluate_pair
+
+    task = AllocationTask(
+        id="task_owned",
+        priority=5,
+        created_at="2026-08-02T00:00:00+00:00",
+        required_capabilities=frozenset({"python"}),
+        created_by_human=filer,
+    )
+    agent = AllocationAgent(
+        id="worker",
+        capabilities=frozenset({"python"}),
+        visibility=visibility,
+        owner_human_id=owner,
+    )
+    return evaluate_pair(task, agent)
+
+
+def test_a_private_agent_refuses_another_persons_task():
+    from mac.allocator import AGENT_PRIVATE_TO_OTHER_OWNER
+
+    result = _pair(visibility="private", owner="human-a", filer="human-b")
+
+    assert AGENT_PRIVATE_TO_OTHER_OWNER in result.rejections
+
+
+def test_a_private_agent_still_runs_its_owners_task():
+    result = _pair(visibility="private", owner="human-a", filer="human-a")
+
+    assert result.allowed, result.rejections
+
+
+def test_a_shared_agent_runs_anyones_task():
+    """The fleet's GKE workers are shared; gating them on ownership would idle
+    the only capacity that is reachable by everyone."""
+    result = _pair(visibility="shared", owner="human-a", filer="human-b")
+
+    assert result.allowed, result.rejections
+
+
+def test_an_unclaimed_private_agent_is_nobodys_capacity():
+    """Fail closed: private with no owner recorded matches no filer, rather
+    than matching every filer."""
+    from mac.allocator import AGENT_PRIVATE_TO_OTHER_OWNER
+
+    result = _pair(visibility="private", owner=None, filer="human-a")
+
+    assert AGENT_PRIVATE_TO_OTHER_OWNER in result.rejections
+
+
+def test_the_refusal_is_authorization_not_a_capability_gap():
+    """Capability gaps drive the 'become capable' machinery -- an agent that
+    tried to LEARN its way past an ownership boundary would retry forever."""
+    from mac.allocator import (
+        AGENT_PRIVATE_TO_OTHER_OWNER,
+        AUTHORIZATION_REJECTIONS,
+        TRANSIENT_REJECTIONS,
+    )
+
+    assert AGENT_PRIVATE_TO_OTHER_OWNER in AUTHORIZATION_REJECTIONS
+    assert AGENT_PRIVATE_TO_OTHER_OWNER not in TRANSIENT_REJECTIONS
+
+
+# --------------------------------------------------------------------------
+# The wiring. evaluate_pair honouring the attribute proves nothing if the
+# snapshot builders never populate it -- the pair evaluation would compare
+# "shared" against None forever and the gate would be dead code that passes
+# its own unit tests.
+# --------------------------------------------------------------------------
+
+
+def test_the_agent_snapshot_carries_ownership_from_the_hub_record(cp, alice):
+    from mac.allocator import AllocationAgent
+
+    machine = _machine(cp, "owner-wiring-host")
+    agent = cp.register_agent(
+        machine.id, "private-worker", owner_human_id=alice.id, visibility="private"
+    )
+
+    snapshot = AllocationAgent.from_hub_record(
+        agent, online=True, capacity=1, active_leases=0, machine_trusted=True
+    )
+
+    assert snapshot.visibility == "private"
+    assert snapshot.owner_human_id == alice.id
+
+
+def test_the_task_snapshot_carries_its_filer(cp, alice):
+    """Read through the lifecycle builder, not constructed by hand: the gate
+    compares against this field, so if the builder drops it every private
+    agent silently refuses every task."""
+    task = cp.create_task("owned work", project="mac", created_by_human=alice.id)
+
+    snapshot = cp.dispatch._v2_snapshot_task(
+        cp.get_task(task.id), projects={}, agent_ids_by_name={}
+    )
+
+    assert snapshot.created_by_human == alice.id

--- a/tests/test_humans_model.py
+++ b/tests/test_humans_model.py
@@ -425,7 +425,11 @@ class TestMigrationPath:
         simulate a pre-humans database state."""
         conn = store
         conn.execute("DROP TABLE IF EXISTS human_groups")
-        conn.execute("DROP TABLE IF EXISTS humans")
+        # CASCADE because agents.owner_human_id references humans. Dropping
+        # the constraint along with the table is what makes this a real
+        # migration rehearsal: re-running the DDL has to put the foreign key
+        # back, not just the table.
+        conn.execute("DROP TABLE IF EXISTS humans CASCADE")
         # SQLite doesn't support DROP COLUMN before 3.35; use a view trick
         # instead: just verify they're absent after re-running initialize().
         # We skip the DROP COLUMN step — instead we assert _ensure_column is
@@ -478,3 +482,27 @@ class TestMigrationPath:
         assert row["username"] == "migrated_user"
         rows = store.list_humans(group="alpha")
         assert len(rows) == 1
+
+
+def test_the_owner_foreign_key_comes_back_after_humans_is_recreated():
+    """ADD COLUMN IF NOT EXISTS skips the whole statement once the column is
+    there, so a foreign key declared inline would be lost for good the first
+    time humans was dropped and rebuilt -- leaving agents ownable by
+    principals that do not exist, with nothing to say so."""
+    store = _fresh_store()
+    store.execute("DROP TABLE IF EXISTS human_groups")
+    store.execute("DROP TABLE IF EXISTS humans CASCADE")
+
+    store.initialize()
+
+    # Scoped to THIS schema. pg_constraint is cluster-wide and every test runs
+    # in its own schema, so an unscoped lookup finds some other test's
+    # constraint and passes no matter what this migration did.
+    row = store.execute(
+        "SELECT 1 AS present FROM pg_constraint c "
+        "JOIN pg_class t ON c.conrelid = t.oid "
+        "JOIN pg_namespace n ON t.relnamespace = n.oid "
+        "WHERE c.conname = 'agents_owner_human_id_fkey' "
+        "AND n.nspname = current_schema()"
+    ).fetchone()
+    assert row is not None, "the owner foreign key was not restored"

--- a/tests/test_task_owner_human.py
+++ b/tests/test_task_owner_human.py
@@ -1,0 +1,90 @@
+"""A task records WHO filed it, not only which agent ran it.
+
+`tasks.created_by_human` and the first-class `Human` principal both already
+existed -- the column is created by store_postgres.ensure_column and the model
+is in models.py. Nothing ever wrote to the column. So the ledger could answer
+"which agent is running this" and could not answer "whose task is this", and
+`mac task list --mine` had nothing to filter on.
+
+This is the smallest slice of task_de8abe37 (multi-user on one hub): it adds a
+writer and a filter. It changes no isolation semantics -- reads stay global,
+which several loops depend on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import ValidationError
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+@pytest.fixture()
+def alice(cp):
+    return cp.register_human(username="alice", display_name="Alice")
+
+
+def test_a_task_records_who_filed_it(cp, alice):
+    task = cp.create_task("alice's work", project="mac", created_by_human="alice")
+
+    assert cp.get_task(task.id).created_by_human == alice.id
+
+
+def test_the_stable_id_is_stored_not_the_typed_username(cp, alice):
+    """A username is an external anchor that can change. Storing it would let a
+    rename silently re-point a task's record of who filed it."""
+    task = cp.create_task("work", project="mac", created_by_human="alice")
+
+    assert cp.get_task(task.id).created_by_human == alice.id
+    assert cp.get_task(task.id).created_by_human != "alice"
+
+
+def test_an_unknown_human_is_refused(cp):
+    """Otherwise ownership becomes a free-text string that looks like a
+    principal and is not one."""
+    with pytest.raises(ValidationError) as excinfo:
+        cp.create_task("work", project="mac", created_by_human="nobody")
+
+    assert "no such human" in str(excinfo.value)
+
+
+def test_the_refusal_says_how_to_fix_it(cp):
+    with pytest.raises(ValidationError) as excinfo:
+        cp.create_task("work", project="mac", created_by_human="nobody")
+
+    assert "register" in str(excinfo.value)
+
+
+def test_a_task_filed_by_nobody_is_still_allowed(cp):
+    """Every existing task has no filer. Requiring one would break them all."""
+    task = cp.create_task("unattributed", project="mac")
+
+    assert cp.get_task(task.id).created_by_human is None
+
+
+def test_listing_can_be_scoped_to_one_human(cp, alice):
+    bob = cp.register_human(username="bob", display_name="Bob")
+    cp.create_task("alice one", project="mac", created_by_human="alice")
+    cp.create_task("alice two", project="mac", created_by_human="alice")
+    cp.create_task("bob one", project="mac", created_by_human="bob")
+
+    mine = cp.list_tasks(created_by_human=alice.id)
+
+    assert {t.title for t in mine} == {"alice one", "alice two"}
+
+
+def test_listing_is_unscoped_by_default(cp, alice):
+    """Reads stay global. Scoping them as a side effect of adding owners would
+    change isolation semantics that fleet diagnostics and the yield gate rely
+    on."""
+    cp.create_task("mine", project="mac", created_by_human="alice")
+    cp.create_task("theirs", project="mac")
+
+    assert len(cp.list_tasks()) == 2


### PR DESCRIPTION
An agent had no owner. Every worker was implicitly everyone's, which is wrong in two directions: a static worker on someone's own network is reachable only by them, so advertising it fleet-wide makes the allocator place work on a machine the rest of the fleet cannot reach; and a worker holding its owner's data should not run a stranger's task because it had a free slot.

## What this adds

- `agents.owner_human_id` + `agents.visibility` (`private` | `shared`), with an index on the owner.
- The allocator gate: `AGENT_PRIVATE_TO_OTHER_OWNER`, classified as an **authorization** refusal rather than a capability gap — so an agent cannot try to *learn* its way past an ownership boundary and retry forever.
- Ownership settable at registration **and** afterwards (`mac agent update --owner --visibility`), because hardware changes hands and a re-register would lose the agent's history.
- `mac admin human register|list|show`. `/humans` has existed since the multi-user slice with nothing at the CLI able to reach it, so the only principal you could name as an owner was one created over raw HTTP.

## Defaults, and why they differ

The **column** defaults to `shared`, so the migration strands no existing agent. A **new registration that names an owner** defaults to `private`. The safe default belongs where it governs new work, not where it would silently repartition a running fleet.

## Refusals

Two cases fail loudly rather than degrade quietly, because both would strand work with no explanation:

- private with no owner — matches no filer, so its queue simply never moves;
- an owner that does not resolve — a typo that would silently stop the agent taking work.

## Wiring

The recurring defect in this codebase is a correct decision with no consumer. `AllocationAgent.from_hub_record` and `_v2_snapshot_task` carry the fields, with tests reading *through* the builders: a gate comparing `"shared"` against `None` would pass its own unit tests forever.

## Follow-up

Marking the live fleet (rocky/natasha/bullwinkle private; the GKE workers shared) needs this deployed first — the running hub has neither the columns nor the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)