### PR TITLE
Bind a caller's identity to the hub, and let the ledger record who filed what

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -127,12 +127,13 @@ Migration:
   convert-ticketing  one-way convert a detected foreign source (e.g. beads) into MAC ledger tasks plus optional local compatibility files (run after the user agrees)
 
 Other:
-  wait    wait for a project's tasks to finish, streaming each transition
-  edit    answer a parked task in $EDITOR; saving submits it back to the queue
-  select  preview the group of tasks a selector expression names
-  batch   apply one operation to every task a selector names (dry by default)
-  group   named, saved task groups
-  egress  declare which hosts a task's sandbox may reach
+  wait      wait for a project's tasks to finish, streaming each transition
+  reassign  re-file tasks under a person (backfills a ledger with no filers)
+  edit      answer a parked task in $EDITOR; saving submits it back to the queue
+  select    preview the group of tasks a selector expression names
+  batch     apply one operation to every task a selector names (dry by default)
+  group     named, saved task groups
+  egress    declare which hosts a task's sandbox may reach
 
 Run `mac task help <subcommand>` for the arguments one takes.
 ```

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -116,6 +116,11 @@ class TokenPrincipal:
     scopes: frozenset = field(default_factory=frozenset)
     tenant_id: Optional[str] = None
     agent_id: Optional[str] = None
+    #: WHICH PERSON this token speaks for, bound when the credential was issued
+    #: on the hub over SSH. Without it the hub cannot answer "who is calling",
+    #: so anything derived from a caller-supplied identity is a claim rather
+    #: than a fact -- and an ownership gate built on a claim gates nothing.
+    human_id: Optional[str] = None
     client_id: Optional[str] = None
     principal_kind: Optional[str] = None
     credential_fingerprint: Optional[str] = None
@@ -247,10 +252,12 @@ def _coerce_principal(value: Union[List[str], Dict[str, Any], TokenPrincipal]) -
         tenant = value.get("tenant_id")
         agent = value.get("agent_id")
         client = value.get("client_id")
+        human = value.get("human_id")
         return TokenPrincipal(
             scopes=scopes,
             tenant_id=tenant,
             agent_id=agent,
+            human_id=str(human) if human else None,
             client_id=str(client) if client else None,
             principal_kind=str(value.get("principal_kind") or "") or None,
             credential_fingerprint=(
@@ -5550,6 +5557,17 @@ def create_app(
         _ensure_payload_bounded(body.metadata, "task.metadata")
         data = _data(body)
         actor = data.pop("actor", "human")
+        # WHO filed this is taken from the authenticated caller, not from the
+        # request body. A body-supplied filer is a claim: anyone could name
+        # anyone, which would let a stranger's task target YOUR private agent
+        # simply by asserting your id. Naming someone else is impersonation and
+        # is therefore admin-only, kept for backfills and operator repairs.
+        claimed_human = data.pop("created_by_human", None)
+        if claimed_human and claimed_human != principal.human_id:
+            principal.require_admin()
+            data["created_by_human"] = claimed_human
+        elif principal.human_id:
+            data["created_by_human"] = principal.human_id
         metadata = dict(data.get("metadata") or {})
         publication_lane_policy = data.pop("publication_lane_policy", None)
         if publication_lane_policy is not None:

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -330,6 +330,45 @@ def _resolve_principal(
     return matched
 
 
+def _agent_filed_on_behalf_of(
+    cp: Any, agent_id: str, *, metadata_hint: Optional[Mapping[str, Any]] = None
+) -> Optional[str]:
+    """The human an agent's newly filed task belongs to.
+
+    Chain of custody, preferred in this order:
+
+    1. The PARENT task's filer. If an agent splits work while executing
+       someone's task, the children are still that person's work -- this is
+       provenance in the strict sense, and it survives the agent being
+       re-owned or replaced.
+    2. The agent's own owner. Covers work an agent originates itself (repair
+       sweeps, dreams, curiosity) where there is no parent to inherit from.
+
+    Returns None when neither is known, which leaves the task unowned exactly
+    as it is today rather than guessing at a responsible person.
+    """
+    parent_id = None
+    if isinstance(metadata_hint, Mapping):
+        relationships = metadata_hint.get("relationships")
+        if isinstance(relationships, Mapping):
+            parent_id = relationships.get("parent_task_id")
+        parent_id = parent_id or metadata_hint.get("parent_task_id")
+    if parent_id:
+        try:
+            parent = cp.get_task(str(parent_id))
+        except Exception:
+            parent = None
+        filer = getattr(parent, "created_by_human", None) if parent else None
+        if filer:
+            return str(filer)
+    try:
+        agent = cp.get_agent(agent_id)
+    except Exception:
+        return None
+    owner = getattr(agent, "owner_human_id", None)
+    return str(owner) if owner else None
+
+
 def _get_principal(request: Request) -> TokenPrincipal:
     principal = getattr(request.state, "principal", None)
     if principal is None:
@@ -5571,6 +5610,20 @@ def create_app(
             data["created_by_human"] = claimed_human
         elif principal.human_id:
             data["created_by_human"] = principal.human_id
+        elif principal.agent_id:
+            # An agent works on someone's behalf, so its work is filed under
+            # THEM. Agents have no independent identity today -- no hostname of
+            # their own, no key, nobody to hold responsible -- and a task with
+            # no responsible human is a task nobody can be asked about.
+            #
+            # It is also load-bearing rather than merely tidy: a private agent
+            # runs only its owner's tasks, so agent-filed work with no filer is
+            # invisible to exactly the workers meant to pick it up. Without
+            # this, every machine-generated task would arrive unowned and the
+            # backlog would go unrunnable again a day after being repaired.
+            derived = _agent_filed_on_behalf_of(cp, principal.agent_id, metadata_hint=body.metadata)
+            if derived:
+                data["created_by_human"] = derived
         metadata = dict(data.get("metadata") or {})
         publication_lane_policy = data.pop("publication_lane_policy", None)
         if publication_lane_policy is not None:

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -498,6 +498,9 @@ class ProjectRegister(BaseModel):
 class TaskUpdate(BaseModel):
     title: Optional[str] = None
     description: Optional[str] = None
+    #: Re-file under a different person. The route is admin-only, which is what
+    #: makes this impersonation-with-authority rather than a claim.
+    created_by_human: Optional[str] = None
     project: Optional[str] = None
     priority: Optional[int] = None
     required_capabilities: Optional[List[str]] = None

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -456,6 +456,11 @@ class TaskCreate(BaseModel):
     publication_lane_policy: Optional[Literal["auto", "managed", "legacy"]] = None
     idempotency_key: Optional[str] = Field(default=None, min_length=1, max_length=200)
     max_attempts: int = 3
+    #: WHO filed this task. Declared explicitly because pydantic DROPS
+    #: undeclared fields without complaint: the CLI sent it, the hub ignored
+    #: it, and every task was recorded with no filer -- which makes an
+    #: ownership gate that compares against it refuse everything, forever.
+    created_by_human: Optional[str] = None
     actor: str = "human"
 
     @model_validator(mode="before")
@@ -5593,8 +5598,18 @@ def create_app(
         view: Optional[str] = Query(default=None),
         project: Optional[str] = Query(default=None),
         limit: Optional[int] = Query(default=None),
+        created_by_human: Optional[str] = Query(default=None),
     ) -> List[Dict[str, Any]]:
-        tasks = [task.to_dict() for task in cp.list_tasks(state, tenant_id, project=project, limit=limit)]
+        tasks = [
+            task.to_dict()
+            for task in cp.list_tasks(
+                state,
+                tenant_id,
+                project=project,
+                limit=limit,
+                created_by_human=created_by_human,
+            )
+        ]
         routes = cp.task_publication_routes(
             (task["id"] for task in tasks), compact=True
         )

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -28,6 +28,7 @@ from mac.models import (
     EVIDENCE_KIND_CHOICES,
     MACError,
     NotFoundError,
+    ValidationError,
     REPORT_DELIVERABLE,
     normalize_deliverable_kind,
     normalize_evidence_kind,
@@ -958,6 +959,59 @@ def _enrolling_human_id(args: argparse.Namespace) -> str:
     # account name is recorded as the username because that is what was
     # actually authenticated.
     return cp.register_human(username=username).id
+
+
+def cmd_task_reassign(args: argparse.Namespace) -> None:
+    """Re-file tasks under a person, for a ledger that predates recorded filers.
+
+    Every task created before the filer existed has none, and a private agent
+    runs only its owner's tasks -- so without this, marking a worker private
+    makes it refuse the entire existing backlog. That is not a hypothetical:
+    doing exactly that took three of eight workers out of service.
+
+    Defaults to only the tasks that have no filer, because overwriting one that
+    is already recorded is a different and much less reversible act.
+    """
+    cp = _plane(args)
+    human = cp.get_human_by_username(args.human) if args.human else None
+    if human is None:
+        raise MACError("--human is required: name who these tasks belong to")
+    tasks = cp.list_tasks(
+        args.state, project=args.project, limit=args.limit or 100000
+    )
+    targets = []
+    for task in tasks:
+        record = task.to_dict() if hasattr(task, "to_dict") else dict(task)
+        existing = record.get("created_by_human")
+        if existing and not args.overwrite:
+            continue
+        if existing == human.id:
+            continue
+        targets.append(record["id"])
+    if args.dry_run:
+        _print({
+            "schema": "mac.task_reassign.v1",
+            "human": human.id,
+            "would_reassign": len(targets),
+            "examined": len(tasks),
+        })
+        return
+    reassigned, failed = [], []
+    for task_id in targets:
+        try:
+            cp.update_task(task_id, created_by_human=human.id, actor=args.actor)
+            reassigned.append(task_id)
+        except (MACError, ValidationError, NotFoundError) as exc:
+            # Reported, never swallowed: a partial backfill that looks total
+            # leaves tasks that will quietly never run on a private agent.
+            failed.append({"task_id": task_id, "error": str(exc)})
+    _print({
+        "schema": "mac.task_reassign.v1",
+        "human": human.id,
+        "reassigned": len(reassigned),
+        "failed": failed[:20],
+        "failed_count": len(failed),
+    })
 
 
 def cmd_client_renew(args: argparse.Namespace) -> None:
@@ -7706,6 +7760,22 @@ def build_parser() -> argparse.ArgumentParser:
              "its children are still running.",
     )
     _set(cmd_task_wait, wait)
+
+    reassign = task.add_parser(
+        "reassign",
+        help="re-file tasks under a person (backfills a ledger with no filers)",
+    )
+    reassign.add_argument("--human", required=True, help="username or human id")
+    reassign.add_argument("--project", default=None)
+    reassign.add_argument("--state", default=None)
+    reassign.add_argument("--limit", type=int, default=None)
+    reassign.add_argument(
+        "--overwrite", action="store_true",
+        help="also re-file tasks that already record a different person",
+    )
+    reassign.add_argument("--dry-run", action="store_true")
+    reassign.add_argument("--actor", default="human")
+    _set(cmd_task_reassign, reassign)
     create.add_argument(
         "--decompose",
         dest="decompose",

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -910,10 +910,54 @@ def cmd_client_enroll(args: argparse.Namespace) -> None:
             allow_elevated=args.allow_elevated,
             rotate=args.rotate,
             actor=args.actor,
+            human_id=_enrolling_human_id(args),
         )
     except ClientPrincipalError as exc:
         raise MACError(str(exc)) from exc
     _print(enrollment_manifest(issued))
+
+
+def _enrolling_human_id(args: argparse.Namespace) -> str:
+    """The human this credential will speak for.
+
+    `mac client enroll` runs ON THE HUB, reached over SSH -- that is the whole
+    trust root. Whoever sshd authenticated is the account this process runs as,
+    so the local unix account IS the evidence of who is enrolling. Nothing the
+    remote caller sends is trusted for this.
+
+    The unix name is evidence, not identity. It is resolved once, here, to a
+    durable human id and never re-derived per request: accounts get renamed and
+    recycled, and re-deriving would silently hand a recreated account the
+    previous holder's work.
+    """
+    import getpass
+
+    requested = str(getattr(args, "human", "") or "").strip()
+    account = ""
+    try:
+        account = getpass.getuser()
+    except Exception:  # pragma: no cover - no controlling terminal / passwd entry
+        account = ""
+    username = requested or account
+    if not username:
+        return ""
+    cp = _plane(args)
+    try:
+        return cp.get_human_by_username(username).id
+    except NotFoundError:
+        pass
+    if requested and requested != account:
+        # Naming someone OTHER than the authenticated account is an operator
+        # act, so it must reference a principal that already exists rather
+        # than conjuring one from a free-text string.
+        raise MACError(
+            "no such human %r; register them first with `mac admin human register`"
+            % requested
+        )
+    # First login for this account: enrolment IS the introduction. The unix
+    # account name is recorded as the username because that is what was
+    # actually authenticated.
+    return cp.register_human(username=username).id
 
 
 def cmd_client_renew(args: argparse.Namespace) -> None:
@@ -7342,6 +7386,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     client_enroll.add_argument("client_id")
     client_enroll.add_argument("--name")
+    client_enroll.add_argument(
+        "--human",
+        help=(
+            "the person this credential speaks for (defaults to the unix "
+            "account that authenticated over SSH, which is the trust root)"
+        ),
+    )
     client_enroll.add_argument("--fleet", dest="fleet_name", default="")
     client_enroll.add_argument("--profile", dest="profile_name")
     client_enroll.add_argument("--scopes", default=",".join(("read", "write", "dispatch")))

--- a/src/mac/client_principals.py
+++ b/src/mac/client_principals.py
@@ -291,6 +291,7 @@ class ClientPrincipalStore:
         ssh_host_ca: str,
         capabilities: Iterable[str],
         agent_id: str = "",
+        human_id: str = "",
         principal_kind: str = "client",
         credential_metadata: Optional[Mapping[str, Any]] = None,
         token_prefix: str = "mac_client_",
@@ -299,6 +300,7 @@ class ClientPrincipalStore:
     ) -> IssuedCredential:
         now = _now()
         bound_agent_id = _validate_agent_id(agent_id) if agent_id else ""
+        bound_human_id = str(human_id or "").strip()
         normalized_kind = str(principal_kind or "client").strip().lower()
         if normalized_kind not in {"client", "worker"}:
             raise ClientPrincipalError("principal kind must be client or worker")
@@ -332,6 +334,13 @@ class ClientPrincipalStore:
         }
         if bound_agent_id:
             record["agent_id"] = bound_agent_id
+        if bound_human_id:
+            # WHICH PERSON this credential speaks for, recorded at issue time
+            # -- on the hub, reached over SSH. That makes it a fact about who
+            # authenticated rather than a claim the caller makes later in a
+            # request body, which is the whole point: a self-asserted filer
+            # cannot gate anything, because anyone can assert it.
+            record["human_id"] = bound_human_id
         if credential_metadata:
             # Metadata is deliberately secret-free lifecycle state.  Callers
             # must never place bearer material here: unlike ``token`` it is
@@ -360,6 +369,7 @@ class ClientPrincipalStore:
         ssh_host_ca: str = "",
         capabilities: Iterable[str] = (),
         agent_id: str = "",
+        human_id: str = "",
         principal_kind: str = "client",
         credential_metadata: Optional[Mapping[str, Any]] = None,
         token_prefix: str = "mac_client_",
@@ -392,6 +402,7 @@ class ClientPrincipalStore:
                 ssh_host_ca=ssh_host_ca,
                 capabilities=capabilities,
                 agent_id=agent_id,
+                human_id=human_id,
                 principal_kind=principal_kind,
                 credential_metadata=credential_metadata,
                 token_prefix=token_prefix,
@@ -535,10 +546,20 @@ def _active_mapping_from_registry(
         scopes = [str(scope) for scope in record.get("scopes") or []]
         if not token_hash.startswith("sha256:") or not scopes:
             continue
-        result[token_hash] = {
+        principal: Dict[str, Any] = {
             "scopes": scopes,
             "client_id": str(record.get("id") or "") or None,
         }
+        for field in ("agent_id", "principal_kind", "human_id"):
+            # This mapping is what the hub authenticates AGAINST, so anything
+            # missing here is missing from the request no matter what
+            # enrolment recorded. human_id in particular: without it the hub
+            # cannot tell who is calling, and every ownership decision falls
+            # back to trusting whatever the caller claims.
+            value = record.get(field)
+            if value:
+                principal[field] = str(value)
+        result[token_hash] = principal
     return result
 
 

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -347,9 +347,18 @@ class RemoteDispatch:
         project: Optional[str] = None,
         limit: Optional[int] = None,
         view: Optional[str] = None,
+        created_by_human: Optional[str] = None,
     ) -> List[_Dictish]:
         return _wrap_list(
-            self._get("/tasks", state=state, tenant_id=tenant_id, view=view, project=project, limit=limit)
+            self._get(
+                "/tasks",
+                state=state,
+                tenant_id=tenant_id,
+                view=view,
+                project=project,
+                limit=limit,
+                created_by_human=created_by_human,
+            )
         )
 
     def ready_tasks(

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -1699,6 +1699,30 @@ class RemoteDispatch:
     def get_machine(self, machine_id: str) -> _Dictish:
         return _Dictish(self._get("/machines/%s" % quote(machine_id, safe="")))
 
+    # /humans has existed since the multi-user slice and RemoteDispatch never
+    # wrapped it, so `mac admin human ...` worked against --db and failed
+    # against a hub -- which is the only mode an operator actually uses. An
+    # agent's owner must be a registered principal, so without these there was
+    # no way to name one on a live fleet at all.
+    def register_human(self, *args: Any, **kw: Any) -> _Dictish:
+        if args:
+            kw.setdefault("username", args[0])
+        return _Dictish(self._post("/humans", _drop_none(kw)))
+
+    def list_humans(self, *args: Any, **kw: Any) -> List[_Dictish]:
+        group = kw.get("group") if "group" in kw else (args[0] if args else None)
+        return [_Dictish(row) for row in self._get("/humans", group=group)]
+
+    def get_human(self, human_id: str) -> _Dictish:
+        return _Dictish(self._get("/humans/%s" % quote(human_id, safe="")))
+
+    def get_human_by_username(self, username: str) -> _Dictish:
+        # Resolved through the hub's own resolver rather than by listing and
+        # filtering here: the hub decides what an anchor means, and a client
+        # that reimplements that guess disagrees with it the first time the
+        # rule changes.
+        return _Dictish(self._get("/humans/resolve", anchor=username))
+
     def register_agent(self, **kw: Any) -> _Dictish:
         return _Dictish(self._post("/agents", _drop_none(kw)))
 

--- a/src/mac/fleet_creds.py
+++ b/src/mac/fleet_creds.py
@@ -236,6 +236,12 @@ def _principal_dict(value) -> Dict:
             out["tenant_id"] = value["tenant_id"]
         if value.get("agent_id"):
             out["agent_id"] = value["agent_id"]
+        if value.get("human_id"):
+            # Carried through with the rest of the binding. Dropping it here
+            # would leave the hub unable to tell who is calling even though
+            # enrolment recorded it -- the field would exist everywhere except
+            # the one place that reads it.
+            out["human_id"] = value["human_id"]
         return out
     return {"scopes": [str(s) for s in value]}
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -7300,6 +7300,7 @@ class ControlPlane:
         dependencies: Optional[Iterable[str]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         max_attempts: Optional[int] = None,
+        created_by_human: Optional[str] = None,
         actor: str = "human",
         _preserve_control_plane_publication_metadata: bool = False,
     ) -> Task:
@@ -7327,6 +7328,18 @@ class ControlPlane:
             updates.append("description = ?")
             params.append(str(description or ""))
             detail["description_changed"] = True
+        if created_by_human is not None:
+            # Re-filing a task under a different person. Admin-only at the API,
+            # because the filer decides which private agents may run it, and it
+            # is needed for exactly two operator jobs: backfilling a ledger
+            # that predates recorded filers, and repairing a mis-filed task.
+            owner_value = str(created_by_human).strip()
+            resolved_owner = (
+                self._resolve_agent_owner(owner_value) if owner_value else None
+            )
+            updates.append("created_by_human = ?")
+            params.append(resolved_owner)
+            detail["created_by_human"] = resolved_owner
         if project is not None:
             new_project = str(project).strip() or None
             updates.append("project = ?")

--- a/tests/api/test_caller_identity.py
+++ b/tests/api/test_caller_identity.py
@@ -1,0 +1,101 @@
+"""WHO is calling, and why the hub must decide it rather than the caller.
+
+`created_by_human` gates dispatch: a private agent runs only tasks filed by
+its owner. If the filer comes from the request body, that gate is decorative --
+anyone can name anyone, so a stranger's task can be aimed at your private
+worker just by asserting your id.
+
+So the filer is taken from the authenticated principal, and the principal
+carries a human because the credential was issued on the hub over SSH, where
+the unix account that sshd authenticated is the evidence of who is enrolling.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from mac.api import TokenPrincipal, create_app
+from mac.services import ControlPlane
+
+
+def _fixture(principal_human=None, admin=False):
+    cp = ControlPlane.in_memory()
+    cp.create_project("mac", dispatch_paused=False)
+    alice = cp.register_human(username="alice")
+    bob = cp.register_human(username="bob")
+    scopes = frozenset({"admin"} if admin else {"write"})
+    token = "t0ken"
+    app = create_app(
+        control_plane=cp,
+        auth_tokens={
+            token: TokenPrincipal(
+                scopes=scopes,
+                human_id=(alice.id if principal_human == "alice" else None),
+            )
+        },
+    )
+    client = TestClient(app)
+    client.headers.update({"Authorization": "Bearer %s" % token})
+    return cp, client, alice, bob
+
+
+def test_the_filer_is_the_authenticated_caller():
+    """Not supplied, yet recorded: the hub knows who called."""
+    _cp, client, alice, _bob = _fixture(principal_human="alice")
+
+    response = client.post("/tasks", json={"title": "mine", "project": "mac"})
+
+    assert response.status_code in (200, 201), response.text
+    assert response.json()["created_by_human"] == alice.id
+
+
+def test_a_caller_cannot_file_a_task_as_someone_else():
+    """The security property. Without this, marking an agent private protects
+    nothing: aim a task at its owner by claiming to be them."""
+    _cp, client, _alice, bob = _fixture(principal_human="alice")
+
+    response = client.post(
+        "/tasks",
+        json={"title": "not mine to file", "project": "mac", "created_by_human": bob.id},
+    )
+
+    assert response.status_code == 403, response.text
+
+
+def test_naming_yourself_explicitly_is_allowed():
+    """It agrees with the principal, so it asserts nothing new."""
+    _cp, client, alice, _bob = _fixture(principal_human="alice")
+
+    response = client.post(
+        "/tasks",
+        json={"title": "mine", "project": "mac", "created_by_human": alice.id},
+    )
+
+    assert response.status_code in (200, 201), response.text
+    assert response.json()["created_by_human"] == alice.id
+
+
+def test_an_admin_may_file_on_behalf_of_someone_else():
+    """Impersonation is an operator act -- needed to backfill the ledger and to
+    repair a mis-filed task -- so it is admin-scoped rather than forbidden."""
+    _cp, client, _alice, bob = _fixture(principal_human="alice", admin=True)
+
+    response = client.post(
+        "/tasks",
+        json={"title": "on behalf", "project": "mac", "created_by_human": bob.id},
+    )
+
+    assert response.status_code in (200, 201), response.text
+    assert response.json()["created_by_human"] == bob.id
+
+
+def test_an_unbound_token_files_an_unowned_task():
+    """Automation and pre-existing credentials have no human. They keep
+    working; their tasks simply belong to nobody, which is what they were
+    before this existed."""
+    _cp, client, _alice, _bob = _fixture(principal_human=None)
+
+    response = client.post("/tasks", json={"title": "automation", "project": "mac"})
+
+    assert response.status_code in (200, 201), response.text
+    assert response.json()["created_by_human"] is None

--- a/tests/api/test_caller_identity.py
+++ b/tests/api/test_caller_identity.py
@@ -128,3 +128,83 @@ def test_a_non_admin_cannot_refile_a_task():
     response = client.put("/tasks/%s" % task_id, json={"created_by_human": bob.id})
 
     assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Chain of custody: an agent's work belongs to the person it works for.
+#
+# Agents have no independent identity today -- no hostname of their own, no
+# key, nobody who can be held responsible for a mistake. So a task an agent
+# files is filed under the human behind it, and the trail leads back to a
+# person who can actually be asked about it.
+#
+# This is also load-bearing. A private agent runs only its owner's tasks, so
+# agent-filed work with no filer is invisible to exactly the workers meant to
+# pick it up -- and most of the ledger is agent-filed.
+# ---------------------------------------------------------------------------
+
+
+def _agent_fixture():
+    cp = ControlPlane.in_memory()
+    cp.create_project("mac", dispatch_paused=False)
+    alice = cp.register_human(username="alice")
+    machine = cp.register_machine("host")
+    agent = cp.register_agent(machine.id, "rocky", owner_human_id=alice.id)
+    token = "agent-token"
+    app = create_app(
+        control_plane=cp,
+        auth_tokens={
+            token: TokenPrincipal(scopes=frozenset({"write"}), agent_id=agent.id)
+        },
+    )
+    client = TestClient(app)
+    client.headers.update({"Authorization": "Bearer %s" % token})
+    return cp, client, alice, agent
+
+
+def test_an_agents_task_is_filed_under_its_owner():
+    _cp, client, alice, _agent = _agent_fixture()
+
+    response = client.post("/tasks", json={"title": "repair sweep", "project": "mac"})
+
+    assert response.status_code in (200, 201), response.text
+    assert response.json()["created_by_human"] == alice.id
+
+
+def test_a_child_task_inherits_the_parents_filer():
+    """Strict provenance: work split out of someone's task is still theirs,
+    and stays theirs even if the agent is later re-owned or replaced."""
+    cp, client, alice, _agent = _agent_fixture()
+    other = cp.register_human(username="someone-else")
+    parent = cp.create_task("the real work", project="mac", created_by_human=other.id)
+
+    response = client.post(
+        "/tasks",
+        json={
+            "title": "subtask",
+            "project": "mac",
+            "metadata": {"parent_task_id": parent.id},
+        },
+    )
+
+    assert response.json()["created_by_human"] == other.id
+    assert response.json()["created_by_human"] != alice.id
+
+
+def test_an_unowned_agent_files_an_unowned_task():
+    """No guessing at a responsible person: if nobody owns the agent and there
+    is no parent, the task stays unowned exactly as it is today."""
+    cp = ControlPlane.in_memory()
+    cp.create_project("mac", dispatch_paused=False)
+    machine = cp.register_machine("host")
+    agent = cp.register_agent(machine.id, "orphan")
+    app = create_app(
+        control_plane=cp,
+        auth_tokens={"t": TokenPrincipal(scopes=frozenset({"write"}), agent_id=agent.id)},
+    )
+    client = TestClient(app)
+    client.headers.update({"Authorization": "Bearer t"})
+
+    response = client.post("/tasks", json={"title": "orphan work", "project": "mac"})
+
+    assert response.json()["created_by_human"] is None

--- a/tests/api/test_caller_identity.py
+++ b/tests/api/test_caller_identity.py
@@ -99,3 +99,32 @@ def test_an_unbound_token_files_an_unowned_task():
 
     assert response.status_code in (200, 201), response.text
     assert response.json()["created_by_human"] is None
+
+
+def test_an_admin_can_refile_an_existing_task():
+    """The operator path the backfill needs: a ledger of 7,984 tasks predates
+    recorded filers, and without this none of them can ever run on a private
+    agent -- the gate would refuse work that is unambiguously its owner's."""
+    _cp, client, _alice, bob = _fixture(principal_human="alice", admin=True)
+    task_id = client.post(
+        "/tasks", json={"title": "historic", "project": "mac"}
+    ).json()["id"]
+
+    response = client.put(
+        "/tasks/%s" % task_id, json={"created_by_human": bob.id}
+    )
+
+    assert response.status_code in (200, 201), response.text
+    assert response.json()["created_by_human"] == bob.id
+
+
+def test_a_non_admin_cannot_refile_a_task():
+    _cp, client, _alice, bob = _fixture(principal_human="alice")
+    cp2, admin_client, _a, _b = _fixture(principal_human="alice", admin=True)
+    task_id = admin_client.post(
+        "/tasks", json={"title": "historic", "project": "mac"}
+    ).json()["id"]
+
+    response = client.put("/tasks/%s" % task_id, json={"created_by_human": bob.id})
+
+    assert response.status_code == 403

--- a/tests/api/test_task_filer_over_http.py
+++ b/tests/api/test_task_filer_over_http.py
@@ -1,0 +1,95 @@
+"""A task's filer has to survive the HTTP boundary.
+
+Everything else in the ownership chain was built and tested: the column, the
+allocator gate, the CLI flag, the marking. The one link nobody exercised was
+POST /tasks, and pydantic DROPS undeclared fields without complaint -- so the
+CLI sent `created_by_human`, the hub ignored it, and every task was stored with
+no filer.
+
+That is not a cosmetic loss. A private agent runs only tasks filed by its
+owner, so with no filer ever recorded, marking a worker private makes it refuse
+every task in the ledger, permanently, with a rejection that reads like an
+authorization decision rather than a dropped field.
+
+These tests go over HTTP for exactly that reason: the service-layer tests
+passed the whole time.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+def _client():
+    cp = ControlPlane.in_memory()
+    cp.create_project("mac", dispatch_paused=False)
+    human = cp.register_human(username="jordanh", display_name="Jordan Hubbard")
+    return cp, TestClient(create_app(control_plane=cp)), human
+
+
+def test_the_filer_survives_task_creation():
+    _cp, client, human = _client()
+
+    response = client.post(
+        "/tasks",
+        json={"title": "owned work", "project": "mac", "created_by_human": human.id},
+    )
+
+    assert response.status_code in (200, 201), response.text
+    assert response.json()["created_by_human"] == human.id
+
+
+def test_a_task_filed_without_one_still_works():
+    """Most callers do not name a filer, and refusing them would break every
+    existing automation."""
+    _cp, client, _human = _client()
+
+    response = client.post("/tasks", json={"title": "unowned", "project": "mac"})
+
+    assert response.status_code in (200, 201), response.text
+    assert response.json()["created_by_human"] is None
+
+
+def test_the_filer_is_readable_back_from_the_list():
+    """The allocator reads it off the task record; if it only existed on the
+    create response the gate would still compare against None."""
+    _cp, client, human = _client()
+    client.post(
+        "/tasks",
+        json={"title": "owned work", "project": "mac", "created_by_human": human.id},
+    )
+
+    rows = client.get("/tasks", params={"project": "mac"}).json()
+
+    assert any(row.get("created_by_human") == human.id for row in rows)
+
+
+def test_tasks_can_be_filtered_to_one_persons_work():
+    _cp, client, human = _client()
+    client.post(
+        "/tasks",
+        json={"title": "mine", "project": "mac", "created_by_human": human.id},
+    )
+    client.post("/tasks", json={"title": "not mine", "project": "mac"})
+
+    rows = client.get(
+        "/tasks", params={"project": "mac", "created_by_human": human.id}
+    ).json()
+
+    assert [row["title"] for row in rows] == ["mine"]
+
+
+def test_an_unknown_filer_is_refused_rather_than_stored():
+    """A free-text filer would never match a real owner, so the task would be
+    invisible to exactly the private agent it was meant for."""
+    _cp, client, _human = _client()
+
+    response = client.post(
+        "/tasks",
+        json={"title": "typo", "project": "mac", "created_by_human": "nobody"},
+    )
+
+    assert response.status_code >= 400, response.text

--- a/tests/cli/test_cli_task_reassign.py
+++ b/tests/cli/test_cli_task_reassign.py
@@ -1,0 +1,90 @@
+"""Backfilling a ledger that predates recorded filers.
+
+A private agent runs only its owner's tasks, so tasks with no filer can never
+run on one. With 7,984 such tasks on the live hub, marking a worker private
+takes it out of service entirely -- which is exactly what happened.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from mac.cli import main
+from mac.test_support import control_plane_on, dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, (json.loads(raw) if raw else None)
+
+
+def _seed(tmp_path, count=3):
+    cp = control_plane_on(dsn_for(tmp_path))
+    cp.create_project("mac", dispatch_paused=False)
+    human = cp.register_human(username="jordanh")
+    for index in range(count):
+        cp.create_task("historic %d" % index, project="mac")
+    return cp, human
+
+
+def test_unowned_tasks_are_reassigned(tmp_path):
+    cp, human = _seed(tmp_path)
+
+    rc, out = _run(tmp_path, "task", "reassign", "--human", "jordanh")
+
+    assert rc in (None, 0)
+    assert out["reassigned"] == 3
+    assert all(t.created_by_human == human.id for t in cp.list_tasks(None, project="mac"))
+
+
+def test_a_dry_run_changes_nothing(tmp_path):
+    """A bulk re-file over thousands of records is worth previewing."""
+    cp, _human = _seed(tmp_path)
+
+    rc, out = _run(tmp_path, "task", "reassign", "--human", "jordanh", "--dry-run")
+
+    assert rc in (None, 0)
+    assert out["would_reassign"] == 3
+    assert all(t.created_by_human is None for t in cp.list_tasks(None, project="mac"))
+
+
+def test_a_task_already_filed_by_someone_else_is_left_alone(tmp_path):
+    """Overwriting a recorded filer is a different and less reversible act."""
+    cp, _human = _seed(tmp_path, count=1)
+    other = cp.register_human(username="someone-else")
+    owned = cp.create_task("theirs", project="mac", created_by_human=other.id)
+
+    _rc, out = _run(tmp_path, "task", "reassign", "--human", "jordanh")
+
+    assert out["reassigned"] == 1
+    assert cp.get_task(owned.id).created_by_human == other.id
+
+
+def test_overwrite_refiles_everything(tmp_path):
+    cp, human = _seed(tmp_path, count=1)
+    other = cp.register_human(username="someone-else")
+    owned = cp.create_task("theirs", project="mac", created_by_human=other.id)
+
+    _rc, out = _run(tmp_path, "task", "reassign", "--human", "jordanh", "--overwrite")
+
+    assert out["reassigned"] == 2
+    assert cp.get_task(owned.id).created_by_human == human.id
+
+
+def test_rerunning_it_reassigns_nothing(tmp_path):
+    """Idempotent, so a backfill interrupted halfway can simply be run again."""
+    _cp, _human = _seed(tmp_path)
+    _run(tmp_path, "task", "reassign", "--human", "jordanh")
+
+    _rc, out = _run(tmp_path, "task", "reassign", "--human", "jordanh")
+
+    assert out["reassigned"] == 0

--- a/tests/test_client_human_binding.py
+++ b/tests/test_client_human_binding.py
@@ -1,0 +1,86 @@
+"""A credential remembers which person it speaks for.
+
+`mac client enroll` runs on the hub, reached over SSH. Whoever sshd
+authenticated is the account the process runs as, so the local unix account is
+the evidence of who is enrolling -- nothing the remote caller sends is trusted
+for it. That evidence is resolved ONCE, here, to a durable id.
+
+Resolving it per-request instead would be a trap: unix accounts get renamed and
+recycled, so a recreated account would silently inherit the previous holder's
+agents and work.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.client_principals import ClientPrincipalStore
+
+
+@pytest.fixture()
+def store(tmp_path):
+    return ClientPrincipalStore(tmp_path / "clients.json")
+
+
+def test_an_enrolled_credential_records_its_human(store):
+    issued = store.enroll("laptop", human_id="human_abc", actor="test")
+
+    assert issued.record["human_id"] == "human_abc"
+
+
+def test_a_credential_without_a_human_is_still_valid(store):
+    """Worker and automation credentials speak for no person. They must keep
+    working -- their tasks simply belong to nobody."""
+    issued = store.enroll("ci-runner", actor="test")
+
+    assert "human_id" not in issued.record
+
+
+def test_the_binding_survives_a_rotation(store):
+    """Rotating a credential replaces the secret, not the person holding it."""
+    store.enroll("laptop", human_id="human_abc", actor="test")
+
+    rotated = store.enroll("laptop", human_id="human_abc", rotate=True, actor="test")
+
+    assert rotated.record["human_id"] == "human_abc"
+    assert rotated.record["credential_version"] == 2
+
+
+def test_the_token_itself_is_never_the_identity(store):
+    """The record binds a person to a credential; the credential is a secret
+    that can be rotated without the person changing."""
+    first = store.enroll("laptop", human_id="human_abc", actor="test")
+    second = store.enroll("laptop", human_id="human_abc", rotate=True, actor="test")
+
+    assert first.token != second.token
+    assert first.record["human_id"] == second.record["human_id"]
+
+
+def test_the_hub_sees_the_human_on_the_authenticated_principal(tmp_path):
+    """The link that makes the rest of it real.
+
+    Enrolment can record a human perfectly and it changes nothing unless the
+    mapping the hub AUTHENTICATES AGAINST carries it -- that mapping is built
+    separately, and it previously kept only scopes and the client id.
+    """
+    from mac.client_principals import ClientPrincipalProvider
+
+    store = ClientPrincipalStore(tmp_path / "clients.json")
+    issued = store.enroll("laptop", human_id="human_abc", actor="test")
+
+    mapping = ClientPrincipalProvider(tmp_path / "clients.json").tokens()
+
+    principal = mapping[issued.record["token_hash"]]
+    assert principal["human_id"] == "human_abc"
+
+
+def test_the_principal_the_api_builds_carries_the_human(tmp_path):
+    """One step further: through the API's own coercion, because that is what
+    the request handler receives."""
+    from mac.api import _coerce_principal
+
+    principal = _coerce_principal(
+        {"scopes": ["write"], "client_id": "laptop", "human_id": "human_abc"}
+    )
+
+    assert principal.human_id == "human_abc"

--- a/tests/test_dispatch_remote_contract.py
+++ b/tests/test_dispatch_remote_contract.py
@@ -249,3 +249,52 @@ def test_observability_prune_uses_hub_endpoint_and_returns_count() -> None:
             "keep_last": 100,
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# The humans wrappers, by path.
+#
+# /humans existed on the hub from the multi-user slice and RemoteDispatch never
+# wrapped it, so `mac admin human ...` worked against --db and failed against a
+# hub with "not yet supported in hub mode". Since an agent's owner has to be a
+# registered principal, that made it impossible to name an owner on a live
+# fleet at all -- the ownership model shipped with no way to use it.
+# ---------------------------------------------------------------------------
+
+
+def test_registering_a_human_posts_to_humans():
+    client = RecordingClient()
+    dispatch = RemoteDispatch(client)
+
+    dispatch.register_human("jordanh", display_name="Jordan Hubbard")
+
+    method, path, body = client.calls[-1]
+    assert (method, path) == ("POST", "/humans")
+    assert body["username"] == "jordanh"
+
+
+def test_listing_humans_gets_humans():
+    client = RecordingClient()
+    dispatch = RemoteDispatch(client)
+
+    dispatch.list_humans()
+
+    method, path, _body = client.calls[-1]
+    assert method == "GET"
+    assert path.startswith("/humans")
+
+
+def test_a_username_is_resolved_by_the_hub_not_by_the_client():
+    """The hub decides what an anchor means. A client that reimplemented that
+    rule by listing and filtering would disagree with it the moment the rule
+    changed -- and ownership fields store ids, so a wrong resolution silently
+    points an agent at the wrong principal."""
+    client = RecordingClient()
+    dispatch = RemoteDispatch(client)
+
+    dispatch.get_human_by_username("jordanh")
+
+    method, path, _body = client.calls[-1]
+    assert method == "GET"
+    assert path.startswith("/humans/resolve")
+    assert "anchor=jordanh" in path


### PR DESCRIPTION
Three linked gaps that together made agent ownership a label rather than a boundary.

## 1. The CLI could not reach `/humans`

`mac admin human register` failed with *"not yet supported in hub mode"* — against the only mode an operator uses. The route has existed since the multi-user slice; `RemoteDispatch` never wrapped it. So no owner could be created on a live fleet at all.

## 2. The hub silently discarded a task's filer

`TaskCreate` never declared `created_by_human`, and **pydantic drops undeclared fields without complaint**. The CLI sent it, the hub ignored it, and all 7,984 tasks were stored with no filer. Tests go over HTTP for that reason — every service-layer test passed the whole time.

## 3. The filer was self-asserted, so the gate gated nothing

`created_by_human` decides which private agents may run a task. Read from the request body, that is a *claim*: anyone could name anyone, and a stranger's task could be aimed at your private worker by asserting your id.

The filer now comes from the **authenticated principal**. Naming someone else requires admin, which keeps the operator paths that need it.

### Where the principal's human comes from

`mac client enroll` runs **on the hub, reached over SSH** — that trust root already existed. Whoever sshd authenticated is the account the process runs as, so the local unix account is the evidence of who is enrolling. It is resolved **once**, at enrolment, to a durable id and never re-derived per request: accounts get renamed and recycled, and re-deriving would silently hand a recreated account the previous holder's agents and work.

The unix name is *evidence*, not identity. Humans stay keyed by an opaque id; username and email are attributes, so the same person can have different account names on different machines.

Two places rebuild the principal from scratch with a fixed field set — `fleet_creds._principal_dict` and `_active_mapping_from_registry`. The hub authenticates against the second, so a human recorded at enrolment and dropped there is a human the hub cannot see. Hence the chain is tested end to end, not per layer.

## 4. Repairing the existing ledger

`mac task reassign` backfills tasks that have no filer. Idempotent, dry-runnable, and it leaves already-filed tasks alone unless `--overwrite`.

Credentials without a human keep working — workers and automation speak for no person, and their tasks belong to nobody, exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)