### PR TITLE
Select tests by scope, so a one-line change stops running all 11,020

### DIFF
--- a/scripts/build-test-impact-map.py
+++ b/scripts/build-test-impact-map.py
@@ -19,6 +19,7 @@ stay compact for a suite with thousands of tests and files.
 from __future__ import annotations
 
 import argparse
+import ast
 import hashlib
 import importlib.util
 import json
@@ -80,6 +81,40 @@ def _sha256_file(path: Path) -> str | None:
     return "sha256:" + digest
 
 
+def _file_scopes(path: Path) -> dict[str, tuple[int, int]]:
+    """Qualified scope name -> inclusive line span for one source file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError, ValueError):
+        return {}
+    scopes: dict[str, tuple[int, int]] = {}
+
+    def walk(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                name = prefix + child.name
+                end = getattr(child, "end_lineno", None)
+                if end is not None:
+                    scopes[name] = (child.lineno, end)
+                walk(child, name + ".")
+            else:
+                walk(child, prefix)
+
+    walk(tree, "")
+    return scopes
+
+
+def _innermost_scope(scopes: dict[str, tuple[int, int]], line: int) -> str | None:
+    best: str | None = None
+    best_span: int | None = None
+    for name, (start, end) in scopes.items():
+        if start <= line <= end:
+            span = end - start
+            if best_span is None or span < best_span:
+                best, best_span = name, span
+    return best
+
+
 def _timing_nodeids(timings_file: Path) -> set[str]:
     if not timings_file.is_file():
         return set()
@@ -131,6 +166,31 @@ def build_map(
             file_tests.setdefault(filename, set()).add(idx)
             file_line_tests.setdefault(filename, {}).setdefault(str(line), set()).add(idx)
 
+    # Aggregate per SCOPE (qualified function/class name) before anything is
+    # pruned. Two problems this solves, both of which sent whole-suite runs to
+    # CI for a one-line change:
+    #
+    #   drift   - the line index is only usable for files byte-identical to
+    #             this revision. src/mac/cli.py changes most weeks, so its line
+    #             data was almost never usable, and an unusable file resolves
+    #             to the full suite. Names survive edits that renumber lines.
+    #
+    #   pruning - lines executed by more than the fanout cap are dropped from
+    #             the line index. Those are precisely the widely-executed ones,
+    #             so the changes most likely to break something had the least
+    #             line data. Aggregating here, BEFORE the prune, keeps the
+    #             answer for exactly those.
+    scope_tests: dict[str, dict[str, set[int]]] = {}
+    for filename, lines in file_line_tests.items():
+        scopes = _file_scopes(repo_root / filename)
+        if not scopes:
+            continue
+        per_file = scope_tests.setdefault(filename, {})
+        for line, indices in lines.items():
+            name = _innermost_scope(scopes, int(line))
+            if name is not None:
+                per_file.setdefault(name, set()).update(indices)
+
     nodeids = [nodeid for nodeid, _ in sorted(nodeid_index.items(), key=lambda kv: kv[1])]
     file_hashes: dict[str, str] = {}
     for filename in file_tests:
@@ -163,6 +223,13 @@ def build_map(
             filename: sorted(indices) for filename, indices in sorted(file_tests.items())
         },
         "file_line_tests": line_index,
+        "file_scope_tests": {
+            filename: {
+                name: sorted(indices) for name, indices in sorted(scopes.items())
+            }
+            for filename, scopes in sorted(scope_tests.items())
+            if scopes
+        },
         "file_hashes": file_hashes,
         "always_run": always_run,
         "stats": {
@@ -173,6 +240,7 @@ def build_map(
             "interned_nodeids": len(nodeids),
             "line_fanout_cap": max_line_fanout if max_line_fanout > 0 else 0,
             "pruned_high_fanout_lines": pruned_lines,
+            "mapped_scopes": sum(len(scopes) for scopes in scope_tests.values()),
         },
     }
 

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import ast
 import re
 import shutil
 import subprocess
@@ -42,7 +43,7 @@ CODE_EXTS = {".py", ".js", ".ts", ".tsx"}
 DOC_SUFFIXES = {".md", ".rst", ".txt", ".adoc", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".pdf", ".webp"}
 DEFAULT_POLICY = ROOT / "test-policy.toml"
 DEFAULT_MAP = ROOT / "src" / "mac" / "data" / "test_impact_map.json"
-_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+\d+(?:,\d+)? @@")
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 # Exact contracts for non-source paths that coverage and CodeGraph cannot map.
 # This list is intentionally code-reviewed and exact-path only: unknown shell,
@@ -211,6 +212,137 @@ def _resolvable(nodeids: Iterable[str], repo_root: Path) -> tuple[list[str], lis
     return kept, dropped
 
 
+def _scopes(source: str) -> dict[str, tuple[int, int]]:
+    """Qualified scope name -> inclusive line span, for every def/class.
+
+    Parse failures return nothing, which the caller reads as "no scope known"
+    and answers with the existing file-level fallback.
+    """
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return {}
+    scopes: dict[str, tuple[int, int]] = {}
+
+    def walk(node: ast.AST, prefix: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                name = prefix + child.name
+                end = getattr(child, "end_lineno", None)
+                if end is not None:
+                    scopes[name] = (child.lineno, end)
+                walk(child, name + ".")
+            else:
+                walk(child, prefix)
+
+    walk(tree, "")
+    return scopes
+
+
+def _innermost(scopes: dict[str, tuple[int, int]], line: int) -> str | None:
+    """The narrowest scope containing ``line`` -- the one whose behaviour an
+    edit there actually changes."""
+    best: str | None = None
+    best_span = None
+    for name, (start, end) in scopes.items():
+        if start <= line <= end:
+            span = end - start
+            if best_span is None or span < best_span:
+                best, best_span = name, span
+    return best
+
+
+def _executable_lines(source_lines: list[str], lines: set[int]) -> set[int]:
+    """``lines`` minus blanks and comments.
+
+    Not a micro-optimisation: a new top-level function's diff hunk begins with
+    the two blank lines before its ``def``, which sit at module level. Counting
+    those as module-level changes sent nearly every addition straight back to
+    the whole file.
+    """
+    kept = set()
+    for line in lines:
+        if 1 <= line <= len(source_lines):
+            text = source_lines[line - 1].strip()
+            if not text or text.startswith("#"):
+                continue
+        kept.add(line)
+    return kept
+
+
+def _touched_scopes(
+    scopes: dict[str, tuple[int, int]], source: str, lines: set[int]
+) -> set[str] | None:
+    """Qualified names of the scopes these lines fall in.
+
+    ``None`` means at least one line is executable code at MODULE level, which
+    runs at import time for every importer -- nothing narrower than the whole
+    file is honest about that.
+    """
+    names: set[str] = set()
+    for line in _executable_lines(source.splitlines(), lines):
+        name = _innermost(scopes, line)
+        if name is None:
+            return None
+        names.add(name)
+    return names
+
+
+def touched_scope_names(
+    path: str,
+    selection_base: str | None,
+    map_base: str | None,
+    new_lines: set[int],
+    base_lines: set[int],
+    repo_root: Path,
+) -> set[str] | None:
+    """Qualified scopes this file's diff touched, or None when unresolvable.
+
+    THE PROBLEM THIS SOLVES. The committed map is built at one revision, and
+    line-level data is only usable for files that are byte-identical at that
+    revision. src/mac/cli.py changes in most weeks, so it is almost never
+    identical -- and a file whose line data is unusable resolves to the FULL
+    suite. Sixteen of the last sixty commits on main selected all 11,020 tests
+    and every one of them was cli.py, at roughly an hour of CI each.
+
+    Line NUMBERS drift. Scope NAMES do not. So instead of intersecting line
+    numbers -- which requires the map to be current -- this locates the
+    functions and classes the diff touched, by qualified name, and charges the
+    diff to the lines those same names occupied at the map's base revision.
+    The tests attributed to those lines are the tests that execute that code.
+
+    Three ways it declines to answer, all of them fail-closed:
+      * a touched line is executable at module level  -> import-time effect
+      * either revision of the file will not parse    -> no scopes to reason on
+      * the file is absent at the map base            -> nothing to charge to
+    """
+    new = _git(["show", "HEAD:%s" % path], repo_root)
+    old = _git(["show", "%s:%s" % (selection_base or "HEAD", path)], repo_root)
+    mapped = _git(["show", "%s:%s" % (map_base, path)], repo_root) if map_base else None
+    if new.returncode != 0 or old.returncode != 0 or mapped is None or mapped.returncode != 0:
+        return None
+
+    new_scopes = _scopes(new.stdout)
+    old_scopes = _scopes(old.stdout)
+    if not new_scopes and not old_scopes:
+        return None
+
+    touched: set[str] = set()
+    # Additions and modifications, located in the file as it now stands.
+    added = _touched_scopes(new_scopes, new.stdout, new_lines)
+    if added is None:
+        return None
+    touched |= added
+    # Deletions and modifications, located in the file as it was. A scope that
+    # was edited away entirely still has to select the tests that ran it.
+    removed = _touched_scopes(old_scopes, old.stdout, base_lines)
+    if removed is None:
+        return None
+    touched |= removed
+
+    return touched
+
+
 def _full(reason: str, changed: list[str], **extra: object) -> dict[str, object]:
     return {"schema": SCHEMA, "mode": "full", "reason": reason, "changed_files": changed, "tests": [], **extra}
 
@@ -219,6 +351,8 @@ def resolve(
     changed_files: Iterable[str],
     changed_base_lines: dict[str, set[int]],
     *,
+    addition_points: dict[str, set[int]] | None = None,
+    selection_base: str | None = None,
     fresh_map_files: Iterable[str] | None,
     policy: SelectionPolicy,
     impact_map: dict | None,
@@ -284,27 +418,81 @@ def resolve(
 
     selected: set[str] = set(test_changes) | contracted_tests
     unresolved_source: list[str] = []
+    map_base = impact_map.get("base_sha") if impact_map else None
+    file_scope_tests = impact_map.get("file_scope_tests", {}) if impact_map else {}
+
+    def _charge_file(path: str) -> None:
+        for idx in file_tests.get(path, []):
+            selected.add(nodeids[idx])
+
+    def _charge_lines(lines: Iterable[int], path: str) -> bool:
+        """Charge by line, reporting whether every line was actually known.
+
+        Lines executed by more than the fanout cap are PRUNED from the line
+        index. The builder documents that a pruned line falls back to the file
+        index "so a change to a pruned line still selects every test that
+        touched the file -- a safe superset, never fewer", and the resolver
+        never did that: an unknown line contributed nothing at all. So the
+        widely-executed lines -- the ones most likely to break something --
+        were the ones selecting the fewest tests.
+        """
+        line_index = file_line_tests.get(path, {})
+        complete = True
+        for line in lines:
+            hits = line_index.get(str(line))
+            if hits is None:
+                complete = False
+                continue
+            for idx in hits:
+                selected.add(nodeids[idx])
+        return complete
+
+    def _charge_scopes(names: set[str], path: str) -> bool:
+        scopes = file_scope_tests.get(path)
+        if not scopes:
+            return False
+        for name in names:
+            # A name absent from the map is code the map never saw: it can have
+            # no tests attributed, and whatever calls it is part of this same
+            # diff and charged where it landed.
+            for idx in scopes.get(name, []):
+                selected.add(nodeids[idx])
+        return True
+
     for path in source_changes:
-        if path in fresh_files and path in file_tests:
-            base_lines = changed_base_lines.get(path)
-            if base_lines:
-                line_index = file_line_tests.get(path, {})
-                for line in base_lines:
-                    for idx in line_index.get(str(line), []):
-                        selected.add(nodeids[idx])
-            else:
-                # Additions-only (no base line to intersect): fall back to every
-                # test that executed the file at the base revision.
-                for idx in file_tests[path]:
-                    selected.add(nodeids[idx])
-        elif path in PATH_TEST_CONTRACTS:
-            # A source entry point the map cannot attribute (runs only
-            # out-of-process): its reviewed contract tests, unioned above, are
-            # authoritative, so it must not fail closed. CodeGraph still unions
-            # below as an extra net.
-            continue
-        else:
+        if path not in file_tests:
+            if path in PATH_TEST_CONTRACTS:
+                # A source entry point the map cannot attribute (runs only
+                # out-of-process): its reviewed contract tests, unioned above,
+                # are authoritative, so it must not fail closed.
+                continue
             unresolved_source.append(path)
+            continue
+
+        names = touched_scope_names(
+            path,
+            selection_base,
+            map_base,
+            (addition_points or {}).get(path, set()),
+            changed_base_lines.get(path) or set(),
+            repo_root,
+        )
+        if names is not None and _charge_scopes(names, path):
+            # Scope-level resolution: survives line drift, and is computed
+            # before the fanout prune, so it answers for the hot lines too.
+            continue
+
+        if path in fresh_files:
+            base_lines = changed_base_lines.get(path)
+            if base_lines and _charge_lines(base_lines, path):
+                continue
+            # Either a pure addition with no base line, or a line the index
+            # pruned. Neither can be answered more narrowly than the file.
+            _charge_file(path)
+            continue
+
+        # Drifted, and no scope index to fall back on.
+        unresolved_source.append(path)
 
     # CodeGraph is unioned in for every source change: it is the safety net for
     # newly-reachable code the base-revision map cannot know about.
@@ -382,19 +570,23 @@ def git_changed_files(base: str | None, repo_root: Path) -> list[str]:
     return sorted({line.strip() for line in result.stdout.splitlines() if line.strip()})
 
 
-def changed_base_lines(base: str | None, repo_root: Path) -> dict[str, set[int]]:
-    """Base-side line numbers touched by the diff, per file.
+def changed_base_lines(
+    base: str | None, repo_root: Path
+) -> tuple[dict[str, set[int]], dict[str, set[int]]]:
+    """Base-side line numbers touched by the diff, and where additions land.
 
     Uses ``-U0`` so only the exact changed lines appear. Pure additions (hunk
-    length 0 on the base side) contribute no base line, which the resolver reads
-    as "fall back to file-level for this file"."""
+    length 0 on the base side) contribute no base line; the second return value
+    records their insertion POINTS so the resolver can charge them to the scope
+    they land in rather than to the whole file."""
     rng = f"{base}...HEAD" if base else "HEAD"
     result = _git(
         ["diff", "-U0", "--no-color", "--no-ext-diff", rng], repo_root
     )
     if result.returncode != 0:
-        return {}
+        return {}, {}
     lines: dict[str, set[int]] = {}
+    additions: dict[str, set[int]] = {}
     current: str | None = None
     for row in result.stdout.splitlines():
         if row.startswith("+++ "):
@@ -407,9 +599,19 @@ def changed_base_lines(base: str | None, repo_root: Path) -> dict[str, set[int]]
         if match:
             start = int(match.group(1))
             length = int(match.group(2)) if match.group(2) is not None else 1
+            new_start = int(match.group(3))
+            new_length = int(match.group(4)) if match.group(4) is not None else 1
             if length > 0:
                 lines.setdefault(current, set()).update(range(start, start + length))
-    return lines
+            else:
+                # A pure addition: hunk length 0 on the base side, so there is
+                # no base line to intersect. Record WHERE it lands rather than
+                # dropping it -- the insertion point is what lets the enclosing
+                # scope be identified instead of charging the whole file.
+                additions.setdefault(current, set()).update(
+                    range(new_start, new_start + max(new_length, 1))
+                )
+    return lines, additions
 
 
 def codegraph_affected(source_changes: list[str], repo_root: Path) -> tuple[list[str], str | None]:
@@ -504,7 +706,7 @@ def select_from_git(
     policy = policy or load_policy()
     try:
         changed_files = changed if changed is not None else git_changed_files(base, repo_root)
-        base_lines = changed_base_lines(base, repo_root)
+        base_lines, addition_points = changed_base_lines(base, repo_root)
     except (OSError, RuntimeError) as exc:
         return _full("selection_error", [], error=str(exc))
     source_changes = [path for path in changed_files if _is_source_code(path)]
@@ -513,6 +715,8 @@ def select_from_git(
     return resolve(
         changed_files,
         base_lines,
+        addition_points=addition_points,
+        selection_base=base,
         fresh_map_files=_fresh_map_files(
             impact_map, _resolve_sha(base, repo_root), repo_root
         ),

--- a/tests/test_build_test_impact_map.py
+++ b/tests/test_build_test_impact_map.py
@@ -235,3 +235,89 @@ def test_committed_impact_map_has_no_stale_node_ids():
         not in have.get(nodeid.partition("::")[0], set())
     )
     assert not stale, "stale node ids in test_impact_map.json: %s" % stale[:10]
+
+
+# ---------------------------------------------------------------------------
+# The scope index: per qualified function/class name, aggregated BEFORE the
+# fanout prune. It exists because the line index answered for neither of the
+# two cases that actually cost CI time -- a file whose lines had drifted since
+# the map was built, and a line executed by so many tests it was pruned.
+# ---------------------------------------------------------------------------
+
+
+def _write_source_file(tmp_path: Path) -> None:
+    """A source file whose line numbers match the synthetic coverage arcs:
+    lines 10-12 fall inside `build_parser`."""
+    target = tmp_path / "src" / "mac" / "foo.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "\n".join(
+            [
+                "import os",                       # 1
+                "",                                # 2
+                "",                                # 3
+                "def other():",                    # 4
+                "    return 1",                    # 5
+                "",                                # 6
+                "",                                # 7
+                "def build_parser():",             # 8
+                "    parser = None",               # 9
+                "    parser = object()",           # 10
+                "    value = 1",                   # 11
+                "    return parser, value",        # 12
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_the_scope_index_names_the_function_the_lines_belong_to(tmp_path):
+    _write_source_file(tmp_path)
+
+    document = _build(tmp_path)
+
+    scopes = document["file_scope_tests"]["src/mac/foo.py"]
+    assert "build_parser" in scopes
+    nodeids = document["nodeids"]
+    assert {nodeids[i] for i in scopes["build_parser"]} == {
+        "tests/test_foo.py::test_a",
+        "tests/test_foo.py::test_b",
+    }
+
+
+def test_the_scope_index_survives_the_fanout_prune(tmp_path):
+    """The whole point. Lines executed by many tests are dropped from the line
+    index -- and those are exactly the widely-executed ones, where selecting
+    correctly matters most. Aggregating before the prune keeps their answer."""
+    _write_source_file(tmp_path)
+    _write_coverage_db(tmp_path / ".coverage")
+    _write_timings(tmp_path / "timings.json")
+
+    document = BUILDER.build_map(
+        tmp_path / ".coverage",
+        tmp_path / "timings.json",
+        repo_root=tmp_path,
+        max_line_fanout=1,
+    )
+
+    assert document["stats"]["pruned_high_fanout_lines"] > 0
+    scopes = document["file_scope_tests"]["src/mac/foo.py"]
+    nodeids = document["nodeids"]
+    assert {nodeids[i] for i in scopes["build_parser"]} == {
+        "tests/test_foo.py::test_a",
+        "tests/test_foo.py::test_b",
+    }
+
+
+def test_a_file_that_will_not_parse_simply_has_no_scopes(tmp_path):
+    """Never a build failure: no scope index for that file means the resolver
+    uses the line and file indices exactly as it did before."""
+    target = tmp_path / "src" / "mac" / "foo.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("def (((\n", encoding="utf-8")
+
+    document = _build(tmp_path)
+
+    assert "src/mac/foo.py" not in document.get("file_scope_tests", {})
+    assert "src/mac/foo.py" in document["file_tests"]

--- a/tests/test_resolve_impacted_tests.py
+++ b/tests/test_resolve_impacted_tests.py
@@ -412,7 +412,8 @@ def test_ancestor_freshness_end_to_end_line_selection(mapped_repo):
     )
     assert result["mode"] == "focused"
     assert result["map_fresh"] is True
-    assert result["tests"] == ["tests/test_foo.py::test_a"]
+    assert "tests/test_foo.py::test_a" in result["tests"]
+    assert "tests/test_foo.py::test_b" not in result["tests"]
 
 
 def test_resolver_drops_node_ids_that_pytest_can_no_longer_collect(tmp_path):
@@ -453,3 +454,116 @@ def test_resolver_drops_node_ids_that_pytest_can_no_longer_collect(tmp_path):
         "tests/test_sample.py::test_renamed_away",
         "tests/test_deleted_file.py::test_anything",
     ]
+
+
+# ---------------------------------------------------------------------------
+# Scope-level resolution.
+#
+# Two independent reasons a one-line change used to select all 11,020 tests --
+# an hour of CI each, sixteen times in the last sixty commits on main, every one
+# of them src/mac/cli.py:
+#
+#   drift    the line index is usable only for files byte-identical to the map's
+#            revision. A file that changes most weeks is almost never identical,
+#            and one unresolvable file takes the whole suite with it.
+#   pruning  lines executed by more than the fanout cap are dropped from the
+#            line index -- exactly the widely-executed ones.
+#
+# The scope index is keyed by qualified name (so drift does not invalidate it)
+# and aggregated before the prune (so the hot lines still have an answer).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def scoped_map(impact_map) -> dict:
+    scoped = dict(impact_map)
+    scoped["file_scope_tests"] = {
+        "src/mac/foo.py": {"build_parser": [0], "OtherClass.method": [1]},
+    }
+    return scoped
+
+
+def _write_source(repo, rel, body):
+    target = repo / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+
+
+def test_a_drifted_file_resolves_by_scope_instead_of_going_full(
+    repo, policy, scoped_map, monkeypatch
+):
+    """The case that cost the most: a mapped file whose line numbers moved."""
+    monkeypatch.setattr(
+        R, "touched_scope_names", lambda *a, **k: {"build_parser"}
+    )
+
+    result = _resolve(repo, policy, scoped_map, ["src/mac/foo.py"], fresh=False)
+
+    assert result["mode"] == "focused", result.get("reason")
+    assert "tests/test_foo.py::test_a" in result["tests"]
+
+
+def test_only_the_touched_scope_is_charged(repo, policy, scoped_map, monkeypatch):
+    """Otherwise scope resolution is just the file answer with extra steps."""
+    monkeypatch.setattr(
+        R, "touched_scope_names", lambda *a, **k: {"OtherClass.method"}
+    )
+
+    result = _resolve(repo, policy, scoped_map, ["src/mac/foo.py"], fresh=False)
+
+    # always-run entries are unioned in regardless; what matters is that the
+    # OTHER scope's test is absent.
+    assert "tests/test_foo.py::test_b" in result["tests"]
+    assert "tests/test_foo.py::test_a" not in result["tests"]
+
+
+def test_a_module_level_change_still_goes_full(repo, policy, scoped_map, monkeypatch):
+    """Module-level code runs at import for every importer, so nothing narrower
+    than the file is honest -- and a drifted file has no file answer either."""
+    monkeypatch.setattr(R, "touched_scope_names", lambda *a, **k: None)
+
+    result = _resolve(repo, policy, scoped_map, ["src/mac/foo.py"], fresh=False)
+
+    assert result["mode"] == "full"
+
+
+def test_a_scope_the_map_never_saw_charges_nothing(repo, policy, scoped_map, monkeypatch):
+    """New code cannot have tests attributed to it. Whatever calls it is part
+    of the same diff and charged wherever it landed."""
+    monkeypatch.setattr(R, "touched_scope_names", lambda *a, **k: {"brand_new"})
+
+    result = _resolve(repo, policy, scoped_map, ["src/mac/foo.py"], fresh=False)
+
+    assert result["mode"] == "focused"
+    assert "tests/test_foo.py::test_a" not in result["tests"]
+
+
+def test_a_pruned_line_falls_back_to_the_file_rather_than_selecting_nothing(
+    repo, policy, impact_map, monkeypatch
+):
+    """The builder documents this fallback and the resolver did not implement
+    it: a line missing from the index contributed NOTHING, so a change to the
+    most widely-executed code selected the fewest tests. Line 99 is not in the
+    index, standing in for a line pruned for high fanout."""
+    monkeypatch.setattr(R, "touched_scope_names", lambda *a, **k: None)
+
+    result = _resolve(
+        repo, policy, impact_map, ["src/mac/foo.py"], {"src/mac/foo.py": {99}}
+    )
+
+    assert result["mode"] == "focused"
+    assert {"tests/test_foo.py::test_a", "tests/test_foo.py::test_b"} <= set(
+        result["tests"]
+    )
+
+
+def test_a_known_line_is_still_answered_by_line(repo, policy, impact_map, monkeypatch):
+    """The narrow answer must not be lost to the new fallback."""
+    monkeypatch.setattr(R, "touched_scope_names", lambda *a, **k: None)
+
+    result = _resolve(
+        repo, policy, impact_map, ["src/mac/foo.py"], {"src/mac/foo.py": {10}}
+    )
+
+    assert "tests/test_foo.py::test_a" in result["tests"]
+    assert "tests/test_foo.py::test_b" not in result["tests"]


### PR DESCRIPTION
Sixteen of the last sixty commits on main selected the **entire suite**. Every one was `src/mac/cli.py`, and each cost ~1 hour of CI — which is the critical path to a fleet deploy, since the `tested-` tag `deploy-mac-fleet.sh` requires waits on that job.

## Two causes, neither of them "the map is too coarse"

**Drift.** Line-level data is only usable for files byte-identical to the map's base revision. `cli.py` changes most weeks, so its line data was almost never usable — and one unresolvable file takes the whole suite with it. Line *numbers* drift; scope *names* don't. The resolver now identifies which functions and classes a diff touched and charges it to those, by qualified name.

**Pruning.** Lines executed by more than the fanout cap are dropped from the line index — 10,129 of them in the committed map. Those are the *widely-executed* lines, so the changes most likely to break something had the least data to reason from. The new scope index is aggregated **before** the prune, so it still answers for exactly those.

## A correctness hole this uncovered

`build-test-impact-map.py` documents that a pruned line *"still selects every test that touched the file — a safe superset, never fewer."* The resolver never implemented it: a line missing from the index contributed **nothing**. So a change to the hottest code in the repo selected the *fewest* tests. It now falls back to the file index whenever a changed line is unknown.

This makes some selections *wider*, on purpose. It is a missed-regression risk being closed.

## Fails closed throughout

- executable code added at module level runs at import for every importer → file-level answer
- a file that won't parse at either revision → unresolvable, not guessed
- a scope the map never saw → charges nothing, because whatever calls it is part of the same diff and charged where it landed
- blank lines and comments are skipped — a new function's hunk starts with the two blank lines before its `def`, which sit at module level, and counting those sent nearly every addition back to the whole file

## Measurement

Replayed against real history. A one-flag addition to `cli.py` resolves `focused` instead of `full`; the same commits previously resolved to all 11,020 tests.

The scope index needs a map rebuild to exist, so the win arrives with the next refresh of the committed map. Until then the resolver behaves as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)