### PR TITLE
Repair main: a reloaded principal, and enrolment needing a ledger

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -272,6 +272,24 @@ def _coerce_principal(value: Union[List[str], Dict[str, Any], TokenPrincipal]) -
                 str(value.get("worker_credential_state") or "") or None
             ),
         )
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        # A principal-like object whose class is NOT this module's, which
+        # happens after importlib.reload(mac.api): the dataclass is redefined,
+        # so an instance built from the pre-reload class fails isinstance even
+        # though it is the same shape. Rebuild it rather than falling through
+        # and trying to iterate it as a list of scope strings, which raises
+        # "TokenPrincipal object is not iterable" a long way from the cause.
+        return TokenPrincipal(
+            scopes=frozenset(str(s) for s in getattr(value, "scopes", ()) or ()),
+            tenant_id=getattr(value, "tenant_id", None),
+            agent_id=getattr(value, "agent_id", None),
+            human_id=getattr(value, "human_id", None),
+            client_id=getattr(value, "client_id", None),
+            principal_kind=getattr(value, "principal_kind", None),
+            credential_fingerprint=getattr(value, "credential_fingerprint", None),
+            worker_credential_version=getattr(value, "worker_credential_version", None),
+            worker_credential_state=getattr(value, "worker_credential_state", None),
+        )
     return TokenPrincipal(scopes=frozenset(str(s) for s in value))
 
 

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -919,17 +919,22 @@ def cmd_client_enroll(args: argparse.Namespace) -> None:
 
 
 def _enrolling_human_id(args: argparse.Namespace) -> str:
-    """The human this credential will speak for.
+    """The human this credential will speak for, or "" when unknown.
 
     `mac client enroll` runs ON THE HUB, reached over SSH -- that is the whole
     trust root. Whoever sshd authenticated is the account this process runs as,
     so the local unix account IS the evidence of who is enrolling. Nothing the
-    remote caller sends is trusted for this.
+    remote caller sends is trusted for it.
 
-    The unix name is evidence, not identity. It is resolved once, here, to a
-    durable human id and never re-derived per request: accounts get renamed and
-    recycled, and re-deriving would silently hand a recreated account the
-    previous holder's work.
+    The unix name is evidence, not identity: it is resolved ONCE, here, to a
+    durable id and never re-derived per request, because accounts get renamed
+    and recycled and re-deriving would hand a recreated account the previous
+    holder's agents and work.
+
+    Binding is BEST EFFORT unless --human was asked for explicitly. Enrolment
+    is a credential operation, and making it depend on a reachable ledger would
+    mean a hub you cannot query is a hub you cannot mint the credential to
+    reach. An unbound credential is exactly what every credential is today.
     """
     import getpass
 
@@ -937,28 +942,36 @@ def _enrolling_human_id(args: argparse.Namespace) -> str:
     account = ""
     try:
         account = getpass.getuser()
-    except Exception:  # pragma: no cover - no controlling terminal / passwd entry
+    except Exception:  # pragma: no cover - no passwd entry / no controlling tty
         account = ""
     username = requested or account
     if not username:
         return ""
-    cp = _plane(args)
     try:
-        return cp.get_human_by_username(username).id
-    except NotFoundError:
-        pass
-    if requested and requested != account:
-        # Naming someone OTHER than the authenticated account is an operator
-        # act, so it must reference a principal that already exists rather
-        # than conjuring one from a free-text string.
-        raise MACError(
-            "no such human %r; register them first with `mac admin human register`"
-            % requested
-        )
-    # First login for this account: enrolment IS the introduction. The unix
-    # account name is recorded as the username because that is what was
-    # actually authenticated.
-    return cp.register_human(username=username).id
+        cp = _plane(args)
+        try:
+            return cp.get_human_by_username(username).id
+        except Exception:
+            if requested and requested != account:
+                # Naming someone OTHER than the authenticated account is an
+                # operator act, so it must reference a principal that already
+                # exists rather than conjuring one from a free-text string.
+                raise MACError(
+                    "no such human %r; register them first with "
+                    "`mac admin human register`" % requested
+                ) from None
+            # First login for this account: enrolment IS the introduction, and
+            # the unix account name is recorded as the username because that is
+            # what was actually authenticated.
+            return cp.register_human(username=username).id
+    except MACError:
+        raise
+    except (Exception, SystemExit):
+        # No reachable ledger. Bind nothing rather than failing the enrolment,
+        # unless the caller named someone specific and is owed an answer.
+        if requested:
+            raise
+        return ""
 
 
 def cmd_task_reassign(args: argparse.Namespace) -> None:

--- a/tests/api/test_caller_identity.py
+++ b/tests/api/test_caller_identity.py
@@ -208,3 +208,29 @@ def test_an_unowned_agent_files_an_unowned_task():
     response = client.post("/tasks", json={"title": "orphan work", "project": "mac"})
 
     assert response.json()["created_by_human"] is None
+
+
+def test_a_principal_from_a_reloaded_module_is_still_understood():
+    """tests/api/test_api.py calls importlib.reload(mac.api), which redefines
+    the TokenPrincipal dataclass. An instance built from the pre-reload class
+    then fails isinstance against the new one, falls through to the
+    "iterate it as a list of scopes" branch, and raises `'TokenPrincipal'
+    object is not iterable` a long way from the cause.
+
+    It passed in isolation and took mainline down on main, because only a
+    full-suite run puts the reload before this file.
+    """
+    import importlib
+
+    import mac.api as api_module
+
+    stale = api_module.TokenPrincipal(
+        scopes=frozenset({"admin"}), human_id="human_abc"
+    )
+    api_module.__dict__.pop("app", None)
+    importlib.reload(api_module)
+
+    coerced = api_module._coerce_principal(stale)
+
+    assert coerced.human_id == "human_abc"
+    assert "admin" in coerced.scopes


### PR DESCRIPTION
Two regressions from #329. **Both passed in isolation** and only appeared in a full-suite run, which is why they reached main.

## `'TokenPrincipal' object is not iterable`

`tests/api/test_api.py` calls `importlib.reload(mac.api)`, which redefines the `TokenPrincipal` dataclass. An instance built from the *pre-reload* class then fails `isinstance` against the new one, falls through to the "iterate it as a list of scope strings" branch, and raises a `TypeError` a long way from the cause.

Only a full-suite run puts the reload before the affected file, so it was invisible locally. A principal-shaped object is now rebuilt rather than iterated, and there's a test that performs the reload directly.

## `mac client enroll` began requiring a reachable control plane

Resolving the enrolling unix account to a human went through the control plane. Two things wrong with that:

- enrolment is a **credential** operation, so a hub you cannot query became a hub you cannot mint the credential to reach;
- with a default fleet configured, it made a **live hub call from a unit test**.

The binding is now best-effort — an unbound credential is exactly what every credential is today — unless `--human` was asked for explicitly, in which case the caller is owed an answer rather than a silent skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)