### PR TITLE
Make the repository verifier say why it failed

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -2331,6 +2331,28 @@ def _sandbox_step(args: List[str], *, timeout: float) -> "tuple[bool, str]":
         return False, str(exc)
 
 
+def _verifier_output_excerpt(stdout_file, stderr_file, *, limit: int = 600) -> str:
+    """A bounded excerpt of what the verifier actually said.
+
+    stderr first: a launcher that refuses says so there. Both streams are
+    temporary files the caller already holds open, so this only has to rewind
+    and read -- which is precisely what the failure path never did.
+    """
+    parts = []
+    for label, handle in (("stderr", stderr_file), ("stdout", stdout_file)):
+        try:
+            handle.seek(0)
+            text = handle.read().strip()
+        except Exception:  # noqa: BLE001 - diagnostics must not raise
+            continue
+        if not text:
+            continue
+        if len(text) > limit:
+            text = text[:limit] + "... (truncated)"
+        parts.append("%s=%s" % (label, text.replace("\n", " | ")))
+    return "; ".join(parts)
+
+
 def _terminate_sandbox_client(proc: subprocess.Popen[Any]) -> None:
     """Terminate an OpenShell client and every local helper it spawned."""
     import signal
@@ -2457,12 +2479,38 @@ def _sandbox_run_repository_verification_exec(
                     timeout=10.0,
                 )
             if not marker_seen:
+                # Say what actually happened. Both streams were captured all
+                # along and this branch returned without reading either, so
+                # every failure looked like the same 120s timeout -- three
+                # canaries reported it verbatim and none of them said why.
+                #
+                # The two cases need telling apart, because they lead opposite
+                # ways: a verifier that EXITED immediately did not time out at
+                # all, and reporting a timeout for it sends the next person to
+                # raise the limit again, which is what already happened once
+                # (45s -> 120s changed nothing).
+                exit_code = proc.poll()
                 _terminate_sandbox_client(proc)
+                detail = _verifier_output_excerpt(stdout_file, stderr_file)
+                elapsed = time.monotonic() - started_at
+                if exit_code is not None:
+                    message = (
+                        "OpenShell repository verifier exited immediately "
+                        "(rc=%s after %.1fs, start budget %.1fs)"
+                        % (exit_code, elapsed, start_timeout)
+                    )
+                else:
+                    message = (
+                        "OpenShell repository verifier did not start within "
+                        "%.1fs (still running; marker never appeared)"
+                        % start_timeout
+                    )
+                if detail:
+                    message = "%s: %s" % (message, detail)
                 return _SandboxRepositoryVerificationResult(
                     False,
                     "verifier_infrastructure",
-                    "OpenShell repository verifier did not start within %.1fs"
-                    % start_timeout,
+                    message,
                     retryable=True,
                 )
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -584,6 +584,11 @@ _SHARED_TRANSIENT_FAILURE_MARKERS = (
 )
 _OPENSHELL_VERIFIER_INFRASTRUCTURE_MARKERS = (
     "openshell repository verifier did not start",
+    # The same infrastructure fault, reported honestly: a verifier that dies on
+    # launch never timed out. Both spellings must classify identically, or
+    # making the message more accurate would silently turn a retryable
+    # infrastructure failure into a permanent one.
+    "openshell repository verifier exited immediately",
     "could not launch openshell repository verifier",
     "resource temporarily unavailable",
     "sandbox repository verification upload failed",

--- a/tests/test_verifier_diagnostics.py
+++ b/tests/test_verifier_diagnostics.py
@@ -1,0 +1,91 @@
+"""When the repository verifier fails, say what happened.
+
+Three canary tasks failed with the identical line:
+
+    OpenShell repository verifier did not start within 120.0s
+
+Every one had run its work successfully first -- the agents did the job, and
+the result was discarded at the gate. The message named a timeout and nothing
+else, so the previous response was to raise the timeout (45s -> 120s), which
+changed nothing, because the verifier was not slow.
+
+Both output streams were captured all along. The failure path returned without
+reading either.
+"""
+
+from __future__ import annotations
+
+import io
+
+from mac.executor_sandbox import _verifier_output_excerpt
+
+
+class _Stream(io.StringIO):
+    pass
+
+
+def test_stderr_is_reported():
+    excerpt = _verifier_output_excerpt(_Stream(""), _Stream("openshell: no such image"))
+
+    assert "openshell: no such image" in excerpt
+    assert excerpt.startswith("stderr=")
+
+
+def test_stdout_is_reported_when_stderr_is_empty():
+    """A launcher that fails politely may say so on stdout."""
+    excerpt = _verifier_output_excerpt(_Stream("could not resolve sandbox"), _Stream(""))
+
+    assert "could not resolve sandbox" in excerpt
+
+
+def test_silence_produces_no_noise():
+    """Nothing to add is better than an empty `stderr=` suffix on every line."""
+    assert _verifier_output_excerpt(_Stream(""), _Stream("   ")) == ""
+
+
+def test_a_flood_is_truncated():
+    """The message lands in task evidence and a diagnosis event; a megabyte of
+    output there helps nobody and costs everybody."""
+    excerpt = _verifier_output_excerpt(_Stream(""), _Stream("x" * 10000))
+
+    assert len(excerpt) < 1000
+    assert "truncated" in excerpt
+
+
+def test_newlines_are_flattened():
+    """Evidence is read one line at a time in `mac task show`."""
+    excerpt = _verifier_output_excerpt(_Stream(""), _Stream("first\nsecond"))
+
+    assert "\n" not in excerpt
+    assert "first" in excerpt and "second" in excerpt
+
+
+def test_a_broken_stream_does_not_raise():
+    """Diagnostics run on the failure path; raising there would replace a
+    reported failure with an unreported crash."""
+
+    class Broken:
+        def seek(self, _pos):
+            raise OSError("closed")
+
+        def read(self):
+            raise OSError("closed")
+
+    assert _verifier_output_excerpt(Broken(), Broken()) == ""
+
+
+def test_both_spellings_are_retryable_infrastructure():
+    """The failure is the same fault whichever way it is reported. Without
+    this, making the message more accurate would reclassify a retryable
+    infrastructure failure as a permanent one and burn the task's attempts."""
+    from mac.services import _OPENSHELL_VERIFIER_INFRASTRUCTURE_MARKERS
+
+    for message in (
+        "OpenShell repository verifier did not start within 120.0s",
+        "OpenShell repository verifier exited immediately (rc=1 after 0.3s, "
+        "start budget 120.0s): stderr=openshell: no such image",
+    ):
+        assert any(
+            marker in message.lower()
+            for marker in _OPENSHELL_VERIFIER_INFRASTRUCTURE_MARKERS
+        ), message


### PR DESCRIPTION
Three canary tasks filed to test whether the fleet can complete any work at all came back with the identical line:

```
OpenShell repository verifier did not start within 120.0s
```

In each case **the agent had already done the work.** Canary A ran all five probes, verified every exit code, confirmed the worktree was unmodified, and wrote an honest report — 12.6 minutes of commands — and the result was discarded at the gate.

The message names a timeout and nothing else. So the previous response was to raise the timeout, 45s → 120s, which changed nothing, because the verifier is not slow.

Both output streams were captured all along. **The failure path returned without reading either.**

## What changes

- the verifier's own stderr/stdout are included, bounded and flattened, so the evidence says what actually went wrong;
- a verifier that **exited** is reported as having exited, with its return code, rather than as a timeout it never hit. Those lead opposite ways, and conflating them is what sent someone to raise the limit;
- the new wording is added to the retryable-infrastructure markers. Without that, making the message more accurate would have reclassified a retryable infrastructure fault as a permanent one and burned the task's remaining attempts — the failure mode this repo keeps producing: a correct change with a missing consumer.

This does not fix the verifier. It makes the next canary tell us the cause instead of the symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)