### PR TITLE
Add the gate for retiring a test, which has never existed

### DIFF
--- a/docs/test-retirement-candidates.json
+++ b/docs/test-retirement-candidates.json
@@ -1,0 +1,1370 @@
+{
+  "candidates_all": 1874,
+  "clusters": 567,
+  "clusters_all": 1110,
+  "distinct_signatures": 6954,
+  "fixture_cost_seconds_per_test": 0.6,
+  "min_significant_lines": 10,
+  "minutes_saved_if_all_retired": 10.4,
+  "retirement_candidates": 1043,
+  "schema": "mac.test_redundancy.v1",
+  "seconds_saved_if_all_retired": 625.8,
+  "tests_with_coverage": 8828,
+  "top_clusters": [
+    {
+      "candidates": [
+        "tests/test_review_failure_classifier.py::TestEvidenceTypeHint::test_non_review_verdict_evidence_type_does_not_force_semantic",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[authentication]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[authorization]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[credential_error]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[network]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[repository_missing]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_hub_verification_error_reasons[hub_verification_error]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_hub_verification_error_reasons[hub_verification_failed]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_timeout_reasons[review_retraction_cap_hit]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_timeout_reasons[review_verdict_wait_cap_hit]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_unavailability_reasons[reviewer_not_available]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_unavailability_reasons[reviewer_stale]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_unavailability_reasons[reviewer_unavailable]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_transport_error_reasons[clone_failed]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_transport_error_reasons[review_clone_failed]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_transport_error_reasons[transport_error]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[authentication-credential_access]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[authorization-credential_access]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[clone_failed-transport_error]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[hub_verification_error-hub_verification_error]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[network-credential_access]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[review_retraction_cap_hit-reviewer_timeout]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[review_verdict_wait_cap_hit-reviewer_timeout]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[reviewer_not_available-reviewer_unavailable]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[reviewer_stale-reviewer_unavailable]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[transport_error-transport_error]"
+      ],
+      "covered_files": [
+        "src/mac/review_failure_classifier.py"
+      ],
+      "covered_lines": 35,
+      "keep": "tests/test_review_failure_classifier.py::TestEdgeCases::test_reason_case_insensitive",
+      "members": [
+        "tests/test_review_failure_classifier.py::TestEdgeCases::test_reason_case_insensitive",
+        "tests/test_review_failure_classifier.py::TestEvidenceTypeHint::test_non_review_verdict_evidence_type_does_not_force_semantic",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[authentication]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[authorization]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[credential_error]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[network]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_credential_access_reasons[repository_missing]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_hub_verification_error_reasons[hub_verification_error]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_hub_verification_error_reasons[hub_verification_failed]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_timeout_reasons[review_retraction_cap_hit]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_timeout_reasons[review_verdict_wait_cap_hit]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_unavailability_reasons[reviewer_not_available]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_unavailability_reasons[reviewer_stale]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_reviewer_unavailability_reasons[reviewer_unavailable]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_transport_error_reasons[clone_failed]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_transport_error_reasons[review_clone_failed]",
+        "tests/test_review_failure_classifier.py::TestInfrastructureReasons::test_transport_error_reasons[transport_error]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[authentication-credential_access]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[authorization-credential_access]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[clone_failed-transport_error]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[hub_verification_error-hub_verification_error]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[network-credential_access]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[review_retraction_cap_hit-reviewer_timeout]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[review_verdict_wait_cap_hit-reviewer_timeout]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[reviewer_not_available-reviewer_unavailable]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[reviewer_stale-reviewer_unavailable]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_infrastructure_class_mapping[transport_error-transport_error]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 15.6,
+      "size": 27,
+      "test_files": [
+        "tests/test_review_failure_classifier.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[aws_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[github_ghp]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[github_pat]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[gitlab_pat]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[google_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[jwt]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[netrc]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[openssh_private_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[pkcs8_private_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[provider_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[rsa_private_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[slack_token]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[stripe_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[x_access_token_url]",
+        "tests/test_work_plan_admission.py::test_secret_scan_is_identical_at_preview_and_acceptance"
+      ],
+      "covered_files": [
+        "src/mac/work_package_models.py",
+        "src/mac/work_plan_admission.py"
+      ],
+      "covered_lines": 869,
+      "keep": "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[authenticated_url]",
+      "members": [
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[authenticated_url]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[aws_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[github_ghp]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[github_pat]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[gitlab_pat]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[google_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[jwt]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[netrc]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[openssh_private_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[pkcs8_private_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[provider_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[rsa_private_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[slack_token]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[stripe_key]",
+        "tests/test_work_plan_admission.py::test_accept_rejects_raw_secret_material_injected_after_preview[x_access_token_url]",
+        "tests/test_work_plan_admission.py::test_secret_scan_is_identical_at_preview_and_acceptance"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 9.0,
+      "size": 16,
+      "test_files": [
+        "tests/test_work_plan_admission.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[aws_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[github_ghp]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[github_pat]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[gitlab_pat]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[google_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[jwt]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[netrc]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[openssh_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[pkcs8_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[provider_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[rsa_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[slack_token]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[stripe_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[x_access_token_url]"
+      ],
+      "covered_files": [
+        "src/mac/work_plan_admission.py"
+      ],
+      "covered_lines": 62,
+      "keep": "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[authenticated_url]",
+      "members": [
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[authenticated_url]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[aws_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[github_ghp]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[github_pat]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[gitlab_pat]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[google_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[jwt]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[netrc]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[openssh_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[pkcs8_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[provider_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[rsa_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[slack_token]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[stripe_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_in_free_text[x_access_token_url]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 8.4,
+      "size": 15,
+      "test_files": [
+        "tests/test_work_plan_admission.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_do_not_write_code_instruction",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_plan_decomposed_evidence_type",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_planning_mode_header",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_task_file_path",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_topology_reference",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_trigger_reason_scope_estimate",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_fallback_endpoint_without_hub_url",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_returns_string",
+        "tests/test_planning_phase.py::TestLargeFixtureToChildren::test_prompt_instructs_dependencies_from_topology",
+        "tests/test_planning_phase.py::TestLargeFixtureToChildren::test_prompt_requires_coverage_claim",
+        "tests/test_planning_phase.py::TestLargeFixtureToChildren::test_prompt_requires_ordering_rationale",
+        "tests/test_planning_phase.py::TestLargeFixtureToChildren::test_prompt_requires_two_to_ten_children"
+      ],
+      "covered_files": [
+        "src/mac/executor_scope.py"
+      ],
+      "covered_lines": 63,
+      "keep": "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_children_schema_fields",
+      "members": [
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_children_schema_fields",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_do_not_write_code_instruction",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_plan_decomposed_evidence_type",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_planning_mode_header",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_task_file_path",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_topology_reference",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_contains_trigger_reason_scope_estimate",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_fallback_endpoint_without_hub_url",
+        "tests/test_planning_phase.py::TestBuildPlanningPrompt::test_returns_string",
+        "tests/test_planning_phase.py::TestLargeFixtureToChildren::test_prompt_instructs_dependencies_from_topology",
+        "tests/test_planning_phase.py::TestLargeFixtureToChildren::test_prompt_requires_coverage_claim",
+        "tests/test_planning_phase.py::TestLargeFixtureToChildren::test_prompt_requires_ordering_rationale",
+        "tests/test_planning_phase.py::TestLargeFixtureToChildren::test_prompt_requires_two_to_ten_children"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 7.2,
+      "size": 13,
+      "test_files": [
+        "tests/test_planning_phase.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_backoff_limit_is_zero",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_command_runs_mac_task_runner_binary",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_container_env_has_required_vars",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_executor_timeout_not_set_when_unconfigured",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_image_resolution_default",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_legacy_shared_secret_is_explicitly_compatibility_only",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_pod_security_context_hardened",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_token_pulled_from_named_secret",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_ttl_seconds_after_finished_set",
+        "tests/test_k8s_runner.py::TestOpencodeConfigMapMount::test_build_job_spec_mounts_opencode_configmap_by_default",
+        "tests/test_k8s_runner.py::TestRoleAwareBuildJobSpec::test_no_role_preserves_default_behaviour",
+        "tests/test_k8s_runner.py::TestRoleAwareBuildJobSpec::test_unknown_capability_and_empty_alias_map_falls_through"
+      ],
+      "covered_files": [
+        "src/mac/k8s/runner.py"
+      ],
+      "covered_lines": 171,
+      "keep": "tests/test_k8s_runner.py::TestAttestationKeyJobEnv::test_no_role_does_not_emit_attestation_env",
+      "members": [
+        "tests/test_k8s_runner.py::TestAttestationKeyJobEnv::test_no_role_does_not_emit_attestation_env",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_backoff_limit_is_zero",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_command_runs_mac_task_runner_binary",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_container_env_has_required_vars",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_executor_timeout_not_set_when_unconfigured",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_image_resolution_default",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_legacy_shared_secret_is_explicitly_compatibility_only",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_pod_security_context_hardened",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_token_pulled_from_named_secret",
+        "tests/test_k8s_runner.py::TestBuildJobSpec::test_ttl_seconds_after_finished_set",
+        "tests/test_k8s_runner.py::TestOpencodeConfigMapMount::test_build_job_spec_mounts_opencode_configmap_by_default",
+        "tests/test_k8s_runner.py::TestRoleAwareBuildJobSpec::test_no_role_preserves_default_behaviour",
+        "tests/test_k8s_runner.py::TestRoleAwareBuildJobSpec::test_unknown_capability_and_empty_alias_map_falls_through"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 7.2,
+      "size": 13,
+      "test_files": [
+        "tests/test_k8s_runner.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[github_ghp]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[gitlab_pat]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[google_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[jwt]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[netrc]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[openssh_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[pkcs8_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[provider_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[rsa_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[slack_token]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[stripe_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[x_access_token_url]"
+      ],
+      "covered_files": [
+        "src/mac/work_plan_admission.py"
+      ],
+      "covered_lines": 65,
+      "keep": "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[authenticated_url]",
+      "members": [
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[authenticated_url]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[github_ghp]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[gitlab_pat]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[google_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[jwt]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[netrc]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[openssh_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[pkcs8_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[provider_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[rsa_private_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[slack_token]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[stripe_key]",
+        "tests/test_work_plan_admission.py::test_preview_rejects_raw_secret_material_deeply_nested[x_access_token_url]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 7.2,
+      "size": 13,
+      "test_files": [
+        "tests/test_work_plan_admission.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_skill_auto_repair.py::test_accepts_generic_role_names_in_patch",
+        "tests/test_skill_auto_repair.py::test_accepts_gpu_worker_role_name",
+        "tests/test_skill_auto_repair.py::test_accepts_skills_prefix",
+        "tests/test_skill_auto_repair.py::test_dry_run_does_not_write_file_even_with_repo_root",
+        "tests/test_skill_auto_repair.py::test_evidence_fingerprint_differs_for_different_evidence",
+        "tests/test_skill_auto_repair.py::test_evidence_fingerprint_is_stable_across_calls",
+        "tests/test_skill_auto_repair.py::test_staged_result_carries_audit_trail",
+        "tests/test_skill_auto_repair.py::test_staged_result_carries_evidence_fingerprint",
+        "tests/test_skill_auto_repair.py::test_staged_result_carries_patch_line_count",
+        "tests/test_skill_auto_repair.py::test_staged_result_has_correct_schema",
+        "tests/test_skill_auto_repair.py::test_staged_without_repo_root_does_not_write_file"
+      ],
+      "covered_files": [
+        "src/mac/skill_auto_repair.py"
+      ],
+      "covered_lines": 58,
+      "keep": "tests/test_skill_auto_repair.py::test_accepts_deploy_skills_prefix",
+      "members": [
+        "tests/test_skill_auto_repair.py::test_accepts_deploy_skills_prefix",
+        "tests/test_skill_auto_repair.py::test_accepts_generic_role_names_in_patch",
+        "tests/test_skill_auto_repair.py::test_accepts_gpu_worker_role_name",
+        "tests/test_skill_auto_repair.py::test_accepts_skills_prefix",
+        "tests/test_skill_auto_repair.py::test_dry_run_does_not_write_file_even_with_repo_root",
+        "tests/test_skill_auto_repair.py::test_evidence_fingerprint_differs_for_different_evidence",
+        "tests/test_skill_auto_repair.py::test_evidence_fingerprint_is_stable_across_calls",
+        "tests/test_skill_auto_repair.py::test_staged_result_carries_audit_trail",
+        "tests/test_skill_auto_repair.py::test_staged_result_carries_evidence_fingerprint",
+        "tests/test_skill_auto_repair.py::test_staged_result_carries_patch_line_count",
+        "tests/test_skill_auto_repair.py::test_staged_result_has_correct_schema",
+        "tests/test_skill_auto_repair.py::test_staged_without_repo_root_does_not_write_file"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 6.6,
+      "size": 12,
+      "test_files": [
+        "tests/test_skill_auto_repair.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_batch_drains_multiple_notifications",
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_limit_respected",
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_notification_marked_delivered_in_store",
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_pending_notification_delivered_to_configured_agent",
+        "tests/test_notifier_service.py::TestEventMatching::test_default_event_filter_matches_task_prefix",
+        "tests/test_notifier_service.py::TestFailurePropagation::test_delivery_success_writes_delivered_log",
+        "tests/test_notifier_service.py::TestPayloadStructure::test_message_payload_schema",
+        "tests/test_notifier_service.py::TestPayloadStructure::test_message_type_is_status_update",
+        "tests/test_notifier_service.py::TestStaleClaim::test_stale_delivering_notification_is_reclaimed",
+        "tests/test_notifier_service.py::TestTargetResolution::test_target_with_agent_id_sends_to_that_agent"
+      ],
+      "covered_files": [
+        "src/mac/models.py",
+        "src/mac/notifier_service.py"
+      ],
+      "covered_lines": 173,
+      "keep": "tests/test_notifier_service.py::TestDeliveryPipeline::test_already_delivered_notification_not_re_sent",
+      "members": [
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_already_delivered_notification_not_re_sent",
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_batch_drains_multiple_notifications",
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_limit_respected",
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_notification_marked_delivered_in_store",
+        "tests/test_notifier_service.py::TestDeliveryPipeline::test_pending_notification_delivered_to_configured_agent",
+        "tests/test_notifier_service.py::TestEventMatching::test_default_event_filter_matches_task_prefix",
+        "tests/test_notifier_service.py::TestFailurePropagation::test_delivery_success_writes_delivered_log",
+        "tests/test_notifier_service.py::TestPayloadStructure::test_message_payload_schema",
+        "tests/test_notifier_service.py::TestPayloadStructure::test_message_type_is_status_update",
+        "tests/test_notifier_service.py::TestStaleClaim::test_stale_delivering_notification_is_reclaimed",
+        "tests/test_notifier_service.py::TestTargetResolution::test_target_with_agent_id_sends_to_that_agent"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 6.0,
+      "size": 11,
+      "test_files": [
+        "tests/test_notifier_service.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_blind_protocol_noncompliant_is_semantic",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_reviewer_findings",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_semantic_rejection_reasons[changes_requested]",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_semantic_rejection_reasons[rejected]",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_semantic_rejection_reasons[semantic_rejection]",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_semantic_verdict_invalid_is_semantic",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_semantic_class_mapping[blind_protocol_noncompliant-blind_protocol_noncompliant]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_semantic_class_mapping[changes_requested-semantic_rejection]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_semantic_class_mapping[rejected-semantic_rejection]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_semantic_class_mapping[semantic_verdict_invalid-semantic_verdict_invalid]"
+      ],
+      "covered_files": [
+        "src/mac/review_failure_classifier.py"
+      ],
+      "covered_lines": 37,
+      "keep": "tests/test_review_failure_classifier.py::TestEdgeCases::test_returns_named_tuple",
+      "members": [
+        "tests/test_review_failure_classifier.py::TestEdgeCases::test_returns_named_tuple",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_blind_protocol_noncompliant_is_semantic",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_reviewer_findings",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_semantic_rejection_reasons[changes_requested]",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_semantic_rejection_reasons[rejected]",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_semantic_rejection_reasons[semantic_rejection]",
+        "tests/test_review_failure_classifier.py::TestSemanticReasons::test_semantic_verdict_invalid_is_semantic",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_semantic_class_mapping[blind_protocol_noncompliant-blind_protocol_noncompliant]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_semantic_class_mapping[changes_requested-semantic_rejection]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_semantic_class_mapping[rejected-semantic_rejection]",
+        "tests/test_review_failure_classifier.py::TestTaxonomyContract::test_semantic_class_mapping[semantic_verdict_invalid-semantic_verdict_invalid]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 6.0,
+      "size": 11,
+      "test_files": [
+        "tests/test_review_failure_classifier.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directive-waivers/w1/revoke]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/activate]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/approve]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/check]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/deactivate]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/waivers]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_previously_reached_the_service_layer"
+      ],
+      "covered_files": [
+        "src/mac/api.py",
+        "src/mac/directive_models.py",
+        "src/mac/directive_service.py"
+      ],
+      "covered_lines": 172,
+      "keep": "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directive-bindings]",
+      "members": [
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directive-bindings]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directive-waivers/w1/revoke]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/activate]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/approve]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/check]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/deactivate]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives/d1/waivers]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_can_no_longer_author_a_directive[POST-/directives]",
+        "tests/api/test_directive_authoring_authz.py::test_a_write_token_previously_reached_the_service_layer"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 4.8,
+      "size": 9,
+      "test_files": [
+        "tests/api/test_directive_authoring_authz.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[   ]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[reboot]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[restart]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[retry fetch]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_valid_whitelist_member_returned[clear_cache]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_valid_whitelist_member_returned[escalate]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_valid_whitelist_member_returned[retry_fetch]"
+      ],
+      "covered_files": [
+        "src/mac/harness_recovery.py"
+      ],
+      "covered_lines": 15,
+      "keep": "tests/test_harness_reflex.py::TestChooseRemediation::test_llm_response_case_normalised",
+      "members": [
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_llm_response_case_normalised",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[   ]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[reboot]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[restart]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_unrecognised_llm_output_maps_to_escalate[retry fetch]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_valid_whitelist_member_returned[clear_cache]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_valid_whitelist_member_returned[escalate]",
+        "tests/test_harness_reflex.py::TestChooseRemediation::test_valid_whitelist_member_returned[retry_fetch]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 4.8,
+      "size": 9,
+      "test_files": [
+        "tests/test_harness_reflex.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_relay_observability.py::test_severity_mapping[0-info]",
+        "tests/test_relay_observability.py::test_severity_mapping[1-info]",
+        "tests/test_relay_observability.py::test_severity_mapping[2-info]",
+        "tests/test_relay_observability.py::test_severity_mapping[3-warning]",
+        "tests/test_relay_observability.py::test_severity_mapping[4-error]",
+        "tests/test_relay_observability.py::test_severity_mapping[5-critical]",
+        "tests/test_relay_observability.py::test_severity_mapping[6-critical]",
+        "tests/test_relay_observability.py::test_unknown_class_uses_generic_name"
+      ],
+      "covered_files": [
+        "src/mac/relay_observability.py"
+      ],
+      "covered_lines": 16,
+      "keep": "tests/test_relay_observability.py::test_process_info_stays_info",
+      "members": [
+        "tests/test_relay_observability.py::test_process_info_stays_info",
+        "tests/test_relay_observability.py::test_severity_mapping[0-info]",
+        "tests/test_relay_observability.py::test_severity_mapping[1-info]",
+        "tests/test_relay_observability.py::test_severity_mapping[2-info]",
+        "tests/test_relay_observability.py::test_severity_mapping[3-warning]",
+        "tests/test_relay_observability.py::test_severity_mapping[4-error]",
+        "tests/test_relay_observability.py::test_severity_mapping[5-critical]",
+        "tests/test_relay_observability.py::test_severity_mapping[6-critical]",
+        "tests/test_relay_observability.py::test_unknown_class_uses_generic_name"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 4.8,
+      "size": 9,
+      "test_files": [
+        "tests/test_relay_observability.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_changeset_adoption.py::test_content_hash_changes_when_bound_content_changes[field_overrides0]",
+        "tests/test_changeset_adoption.py::test_content_hash_changes_when_bound_content_changes[field_overrides1]",
+        "tests/test_changeset_adoption.py::test_content_hash_changes_when_bound_content_changes[field_overrides2]",
+        "tests/test_changeset_adoption.py::test_content_hash_changes_when_bound_content_changes[field_overrides3]",
+        "tests/test_changeset_adoption.py::test_content_hash_ignores_label_ordering",
+        "tests/test_changeset_adoption.py::test_content_hash_is_deterministic_for_identical_content",
+        "tests/test_changeset_adoption.py::test_labels_are_sorted_in_binding"
+      ],
+      "covered_files": [
+        "src/mac/changeset_adoption.py"
+      ],
+      "covered_lines": 52,
+      "keep": "tests/test_changeset_adoption.py::test_canonical_excludes_volatile_fields",
+      "members": [
+        "tests/test_changeset_adoption.py::test_canonical_excludes_volatile_fields",
+        "tests/test_changeset_adoption.py::test_content_hash_changes_when_bound_content_changes[field_overrides0]",
+        "tests/test_changeset_adoption.py::test_content_hash_changes_when_bound_content_changes[field_overrides1]",
+        "tests/test_changeset_adoption.py::test_content_hash_changes_when_bound_content_changes[field_overrides2]",
+        "tests/test_changeset_adoption.py::test_content_hash_changes_when_bound_content_changes[field_overrides3]",
+        "tests/test_changeset_adoption.py::test_content_hash_ignores_label_ordering",
+        "tests/test_changeset_adoption.py::test_content_hash_is_deterministic_for_identical_content",
+        "tests/test_changeset_adoption.py::test_labels_are_sorted_in_binding"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 4.2,
+      "size": 8,
+      "test_files": [
+        "tests/test_changeset_adoption.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_children_titles_extracted",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_ordering_rationale_recorded",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_record_type_is_deployment_learning_project",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_schema_is_plan_learning",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_subject_type_and_id",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_task_id_and_title_included",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_wall_clock_ms_recorded"
+      ],
+      "covered_files": [
+        "src/mac/executor_hub_io.py",
+        "src/mac/executor_memory.py"
+      ],
+      "covered_lines": 28,
+      "keep": "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_children_count_matches_manifest",
+      "members": [
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_children_count_matches_manifest",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_children_titles_extracted",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_ordering_rationale_recorded",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_record_type_is_deployment_learning_project",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_schema_is_plan_learning",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_subject_type_and_id",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_task_id_and_title_included",
+        "tests/test_plan_learning_loop.py::TestBuildPlanLearningRecord::test_wall_clock_ms_recorded"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 4.2,
+      "size": 8,
+      "test_files": [
+        "tests/test_plan_learning_loop.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_fleet_move.py::test_move_does_not_mutate_original_registry",
+        "tests/test_fleet_move.py::test_move_hub_agent_to_other_fleet",
+        "tests/test_fleet_move.py::test_move_inherits_target_hub_url",
+        "tests/test_fleet_move.py::test_move_preserves_other_source_agents",
+        "tests/test_fleet_move.py::test_move_preserves_target_existing_agents",
+        "tests/test_fleet_move.py::test_move_removes_agent_from_source_fleet",
+        "tests/test_fleet_move.py::test_move_returns_agent_entry"
+      ],
+      "covered_files": [
+        "src/mac/fleet_move.py"
+      ],
+      "covered_lines": 26,
+      "keep": "tests/test_fleet_move.py::test_move_adds_agent_to_target_fleet",
+      "members": [
+        "tests/test_fleet_move.py::test_move_adds_agent_to_target_fleet",
+        "tests/test_fleet_move.py::test_move_does_not_mutate_original_registry",
+        "tests/test_fleet_move.py::test_move_hub_agent_to_other_fleet",
+        "tests/test_fleet_move.py::test_move_inherits_target_hub_url",
+        "tests/test_fleet_move.py::test_move_preserves_other_source_agents",
+        "tests/test_fleet_move.py::test_move_preserves_target_existing_agents",
+        "tests/test_fleet_move.py::test_move_removes_agent_from_source_fleet",
+        "tests/test_fleet_move.py::test_move_returns_agent_entry"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 4.2,
+      "size": 8,
+      "test_files": [
+        "tests/test_fleet_move.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[escalate\\nextra]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[reboot]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[restart]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[retry fetch]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[undefined]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[{}]"
+      ],
+      "covered_files": [
+        "src/mac/harness_recovery_reflex.py"
+      ],
+      "covered_lines": 10,
+      "keep": "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[   ]",
+      "members": [
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[   ]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[escalate\\nextra]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[reboot]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[restart]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[retry fetch]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[undefined]",
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_unrecognised_llm_output_maps_to_escalate[{}]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 4.2,
+      "size": 8,
+      "test_files": [
+        "tests/test_harness_recovery_reflex.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Implement the backend slice under src/backend and run pytest tests/backend.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Machine learning pipeline design notes and password reset UX copy.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Public certificate bundle -----BEGIN CERTIFICATE----- lives in deploy/.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Rotate the deploy credential via the secret-reference handle, not inline.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Short ids like ghp_short or AKIASHORT are not vendor-shaped secrets.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[The mutation_wip token bucket allows max_tokens of 2 concurrent mutations.]",
+        "tests/test_work_plan_admission.py::test_preview_locks_repository_and_base_without_creating_work"
+      ],
+      "covered_files": [
+        "src/mac/work_package_models.py",
+        "src/mac/work_plan_admission.py"
+      ],
+      "covered_lines": 885,
+      "keep": "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Follow the AGPL-3.0 license header and keep authorization checks intact.]",
+      "members": [
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Follow the AGPL-3.0 license header and keep authorization checks intact.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Implement the backend slice under src/backend and run pytest tests/backend.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Machine learning pipeline design notes and password reset UX copy.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Public certificate bundle -----BEGIN CERTIFICATE----- lives in deploy/.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Rotate the deploy credential via the secret-reference handle, not inline.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[Short ids like ghp_short or AKIASHORT are not vendor-shaped secrets.]",
+        "tests/test_work_plan_admission.py::test_preview_admits_benign_prose_without_false_positive[The mutation_wip token bucket allows max_tokens of 2 concurrent mutations.]",
+        "tests/test_work_plan_admission.py::test_preview_locks_repository_and_base_without_creating_work"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 4.2,
+      "size": 8,
+      "test_files": [
+        "tests/test_work_plan_admission.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides0]",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides1]",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides2]",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides3]",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides4]",
+        "tests/test_changeset_adoption.py::test_verify_detects_digest_tampering"
+      ],
+      "covered_files": [
+        "src/mac/changeset_adoption.py"
+      ],
+      "covered_lines": 85,
+      "keep": "tests/test_changeset_adoption.py::test_attest_adoption_produces_verifiable_attestation",
+      "members": [
+        "tests/test_changeset_adoption.py::test_attest_adoption_produces_verifiable_attestation",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides0]",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides1]",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides2]",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides3]",
+        "tests/test_changeset_adoption.py::test_verify_detects_bound_field_tampering[field_overrides4]",
+        "tests/test_changeset_adoption.py::test_verify_detects_digest_tampering"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_changeset_adoption.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_scope_signals_discriminate.py::test_an_empty_task_is_small",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata0]",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata1]",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata2]",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata3]",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata4]"
+      ],
+      "covered_files": [
+        "src/mac/executor_hub_io.py",
+        "src/mac/executor_scope.py"
+      ],
+      "covered_lines": 43,
+      "keep": "tests/test_scope_signals_discriminate.py::test_a_richer_toolchain_does_not_make_a_task_larger",
+      "members": [
+        "tests/test_scope_signals_discriminate.py::test_a_richer_toolchain_does_not_make_a_task_larger",
+        "tests/test_scope_signals_discriminate.py::test_an_empty_task_is_small",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata0]",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata1]",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata2]",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata3]",
+        "tests/test_scope_signals_discriminate.py::test_malformed_contract_metadata_does_not_raise[metadata4]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_scope_signals_discriminate.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_no_side_effects_no_scope_estimate_call",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_preserves_content_field",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_rendered_contains_plan_info",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_returns_id_field",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_returns_plan_records",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_returns_rendered_field"
+      ],
+      "covered_files": [
+        "src/mac/executor_memory.py",
+        "src/mac/executor_scope.py"
+      ],
+      "covered_lines": 54,
+      "keep": "tests/test_scope_estimate.py::test_recall_scope_lessons_deduplicates_by_task_id",
+      "members": [
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_deduplicates_by_task_id",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_no_side_effects_no_scope_estimate_call",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_preserves_content_field",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_rendered_contains_plan_info",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_returns_id_field",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_returns_plan_records",
+        "tests/test_scope_estimate.py::test_recall_scope_lessons_returns_rendered_field"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_scope_estimate.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_harness_recovery_reflex.py::TestObservability::test_observe_called_on_successful_recovery",
+        "tests/test_harness_recovery_reflex.py::TestObservability::test_observe_receives_non_empty_result_string",
+        "tests/test_harness_recovery_reflex.py::TestSuccessfulRecoveryDispatch::test_clear_cache_choice_also_dispatched",
+        "tests/test_harness_recovery_reflex.py::TestSuccessfulRecoveryDispatch::test_fetch_failure_triggers_dispatch_and_returns_recovered",
+        "tests/test_harness_recovery_reflex.py::TestSuccessfulRecoveryDispatch::test_recovery_log_updated_after_successful_dispatch",
+        "tests/test_harness_recovery_reflex.py::test_try_recovery_with_dispatcher_still_reports_dispatch"
+      ],
+      "covered_files": [
+        "src/mac/harness_recovery_reflex.py"
+      ],
+      "covered_lines": 24,
+      "keep": "tests/test_harness_recovery_reflex.py::TestObservability::test_observe_called_exactly_once_per_try_recovery_call",
+      "members": [
+        "tests/test_harness_recovery_reflex.py::TestObservability::test_observe_called_exactly_once_per_try_recovery_call",
+        "tests/test_harness_recovery_reflex.py::TestObservability::test_observe_called_on_successful_recovery",
+        "tests/test_harness_recovery_reflex.py::TestObservability::test_observe_receives_non_empty_result_string",
+        "tests/test_harness_recovery_reflex.py::TestSuccessfulRecoveryDispatch::test_clear_cache_choice_also_dispatched",
+        "tests/test_harness_recovery_reflex.py::TestSuccessfulRecoveryDispatch::test_fetch_failure_triggers_dispatch_and_returns_recovered",
+        "tests/test_harness_recovery_reflex.py::TestSuccessfulRecoveryDispatch::test_recovery_log_updated_after_successful_dispatch",
+        "tests/test_harness_recovery_reflex.py::test_try_recovery_with_dispatcher_still_reports_dispatch"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_harness_recovery_reflex.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_hermes_home_audit.py::test_audit_detects_sh_script_in_bin",
+        "tests/test_hermes_home_audit.py::test_audit_nonexecutable_py_still_included",
+        "tests/test_hermes_home_audit.py::test_audit_script_count_in_summary",
+        "tests/test_hermes_home_audit.py::test_audit_script_entry_has_expected_fields",
+        "tests/test_hermes_home_audit.py::test_audit_script_source_field_reflects_scan_dir",
+        "tests/test_hermes_home_audit.py::test_audit_script_source_hooks"
+      ],
+      "covered_files": [
+        "src/mac/hermes_home_audit.py"
+      ],
+      "covered_lines": 84,
+      "keep": "tests/test_hermes_home_audit.py::test_audit_detects_py_script_in_scripts_dir",
+      "members": [
+        "tests/test_hermes_home_audit.py::test_audit_detects_py_script_in_scripts_dir",
+        "tests/test_hermes_home_audit.py::test_audit_detects_sh_script_in_bin",
+        "tests/test_hermes_home_audit.py::test_audit_nonexecutable_py_still_included",
+        "tests/test_hermes_home_audit.py::test_audit_script_count_in_summary",
+        "tests/test_hermes_home_audit.py::test_audit_script_entry_has_expected_fields",
+        "tests/test_hermes_home_audit.py::test_audit_script_source_field_reflects_scan_dir",
+        "tests/test_hermes_home_audit.py::test_audit_script_source_hooks"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_hermes_home_audit.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[answer]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[investigation]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[question]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[report]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[triage]",
+        "tests/test_report_deliverable.py::test_project_report_keeps_operator_result_contract"
+      ],
+      "covered_files": [
+        "src/mac/models.py",
+        "src/mac/project_repository_service.py",
+        "src/mac/sandbox_bom.py",
+        "src/mac/services.py"
+      ],
+      "covered_lines": 335,
+      "keep": "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[analysis]",
+      "members": [
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[analysis]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[answer]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[investigation]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[question]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[report]",
+        "tests/test_report_deliverable.py::test_project_report_alias_stays_operator_result_with_registered_project[triage]",
+        "tests/test_report_deliverable.py::test_project_report_keeps_operator_result_contract"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_report_deliverable.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_notifier_service.py::TestChannelCRUD::test_configure_channel_disabled",
+        "tests/test_notifier_service.py::TestChannelCRUD::test_configure_channel_upserts_by_name",
+        "tests/test_notifier_service.py::TestChannelCRUD::test_get_channel_by_name",
+        "tests/test_notifier_service.py::TestControlPlaneIntegration::test_channel_target_and_metadata_roundtrip",
+        "tests/test_notifier_service.py::TestControlPlaneIntegration::test_empty_event_types_stored_as_empty_list",
+        "tests/test_notifier_service.py::TestControlPlaneIntegration::test_event_types_stored_sorted"
+      ],
+      "covered_files": [
+        "src/mac/notifier_service.py"
+      ],
+      "covered_lines": 36,
+      "keep": "tests/test_notifier_service.py::TestChannelCRUD::test_configure_and_get_channel",
+      "members": [
+        "tests/test_notifier_service.py::TestChannelCRUD::test_configure_and_get_channel",
+        "tests/test_notifier_service.py::TestChannelCRUD::test_configure_channel_disabled",
+        "tests/test_notifier_service.py::TestChannelCRUD::test_configure_channel_upserts_by_name",
+        "tests/test_notifier_service.py::TestChannelCRUD::test_get_channel_by_name",
+        "tests/test_notifier_service.py::TestControlPlaneIntegration::test_channel_target_and_metadata_roundtrip",
+        "tests/test_notifier_service.py::TestControlPlaneIntegration::test_empty_event_types_stored_as_empty_list",
+        "tests/test_notifier_service.py::TestControlPlaneIntegration::test_event_types_stored_sorted"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_notifier_service.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_canary_count_two",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_preserves_node_id_and_host",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_single_node_is_canary",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_strips_version_whitespace",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_two_nodes_default_canary_count",
+        "tests/test_openclaw_fleet_rollout.py::test_rollout_plan_version_is_stored"
+      ],
+      "covered_files": [
+        "src/mac/openclaw_fleet_rollout.py"
+      ],
+      "covered_lines": 14,
+      "keep": "tests/test_openclaw_fleet_rollout.py::test_build_plan_all_steps_start_as_planned",
+      "members": [
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_all_steps_start_as_planned",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_canary_count_two",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_preserves_node_id_and_host",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_single_node_is_canary",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_strips_version_whitespace",
+        "tests/test_openclaw_fleet_rollout.py::test_build_plan_two_nodes_default_canary_count",
+        "tests/test_openclaw_fleet_rollout.py::test_rollout_plan_version_is_stored"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_openclaw_fleet_rollout.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_could_not_resolve_host",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_git_clone_in_error",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_hub_verification_error_in_reason_text",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_permission_denied_error_text",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_reviewer_not_available_in_error",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_semantic_rejection_in_error_blob"
+      ],
+      "covered_files": [
+        "src/mac/review_failure_classifier.py"
+      ],
+      "covered_lines": 16,
+      "keep": "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_authentication_error_text",
+      "members": [
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_authentication_error_text",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_could_not_resolve_host",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_git_clone_in_error",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_hub_verification_error_in_reason_text",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_permission_denied_error_text",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_reviewer_not_available_in_error",
+        "tests/test_review_failure_classifier.py::TestErrorTextFallback::test_semantic_rejection_in_error_blob"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.6,
+      "size": 7,
+      "test_files": [
+        "tests/test_review_failure_classifier.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_empty_narrative_omits_reflection",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_inventory_agent_fields",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_inventory_only_shape",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_minimal_agent",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_summary_format"
+      ],
+      "covered_files": [
+        "src/mac/agentbus_control.py"
+      ],
+      "covered_lines": 32,
+      "keep": "tests/test_agentbus_control.py::test_agent_reflection_payload_emits_persona_instance_id",
+      "members": [
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_emits_persona_instance_id",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_empty_narrative_omits_reflection",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_inventory_agent_fields",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_inventory_only_shape",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_minimal_agent",
+        "tests/test_agentbus_control.py::test_agent_reflection_payload_summary_format"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_agentbus_control.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[api example.com]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[api.example.com/v1]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[api.example.com:443]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[https://api.example.com]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[user:pw@example.com]"
+      ],
+      "covered_files": [
+        "src/mac/cli.py",
+        "src/mac/dispatch.py",
+        "src/mac/models.py",
+        "src/mac/observability_service.py",
+        "src/mac/sandbox_egress.py"
+      ],
+      "covered_lines": 398,
+      "keep": "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[*.example.com]",
+      "members": [
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[*.example.com]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[api example.com]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[api.example.com/v1]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[api.example.com:443]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[https://api.example.com]",
+        "tests/cli/test_task_egress_cli.py::test_a_malformed_host_is_refused_at_the_cli[user:pw@example.com]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/cli/test_task_egress_cli.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/cli/test_cli_memory.py::test_memory_decay_dry_run_by_default",
+        "tests/cli/test_cli_memory.py::test_memory_decay_limit_flag",
+        "tests/cli/test_cli_memory.py::test_memory_decay_protected_prefixes_preserved",
+        "tests/cli/test_cli_memory.py::test_memory_decay_respects_ttl_days_flag",
+        "tests/cli/test_cli_memory.py::test_memory_decay_returns_expected_schema_fields"
+      ],
+      "covered_files": [
+        "src/mac/cli.py",
+        "src/mac/memory_service.py",
+        "src/mac/services.py"
+      ],
+      "covered_lines": 28,
+      "keep": "tests/cli/test_cli_memory.py::test_memory_decay_apply_flag_sets_dry_run_false",
+      "members": [
+        "tests/cli/test_cli_memory.py::test_memory_decay_apply_flag_sets_dry_run_false",
+        "tests/cli/test_cli_memory.py::test_memory_decay_dry_run_by_default",
+        "tests/cli/test_cli_memory.py::test_memory_decay_limit_flag",
+        "tests/cli/test_cli_memory.py::test_memory_decay_protected_prefixes_preserved",
+        "tests/cli/test_cli_memory.py::test_memory_decay_respects_ttl_days_flag",
+        "tests/cli/test_cli_memory.py::test_memory_decay_returns_expected_schema_fields"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/cli/test_cli_memory.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_creates_file_with_correct_content",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_creates_parent_directory",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_overwrites_existing_file",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_respects_encoding",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_sets_mode_0o600"
+      ],
+      "covered_files": [
+        "src/mac/fleet_deploy.py"
+      ],
+      "covered_lines": 14,
+      "keep": "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_atomicity_no_leftover_tempfile",
+      "members": [
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_atomicity_no_leftover_tempfile",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_creates_file_with_correct_content",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_creates_parent_directory",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_overwrites_existing_file",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_respects_encoding",
+        "tests/test_fleet_deploy_edges.py::test_write_owner_only_file_sets_mode_0o600"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_fleet_deploy_edges.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_fleet_move.py::test_execute_live_includes_db_reconcile_note",
+        "tests/test_fleet_move.py::test_execute_live_includes_next_steps_with_redeploy",
+        "tests/test_fleet_move.py::test_execute_live_preserves_source_remaining_agents",
+        "tests/test_fleet_move.py::test_execute_live_writes_registry",
+        "tests/test_fleet_move.py::test_execute_no_redeploy_emits_command_only"
+      ],
+      "covered_files": [
+        "src/mac/fleet_move.py"
+      ],
+      "covered_lines": 71,
+      "keep": "tests/test_fleet_move.py::test_execute_live_creates_backup",
+      "members": [
+        "tests/test_fleet_move.py::test_execute_live_creates_backup",
+        "tests/test_fleet_move.py::test_execute_live_includes_db_reconcile_note",
+        "tests/test_fleet_move.py::test_execute_live_includes_next_steps_with_redeploy",
+        "tests/test_fleet_move.py::test_execute_live_preserves_source_remaining_agents",
+        "tests/test_fleet_move.py::test_execute_live_writes_registry",
+        "tests/test_fleet_move.py::test_execute_no_redeploy_emits_command_only"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_fleet_move.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_llm_response_with_leading_trailing_whitespace",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_returned_value_is_string_not_enum_instance",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_whitelist_member_returned_as_is[clear_cache]",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_whitelist_member_returned_as_is[escalate]",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_whitelist_member_returned_as_is[retry_fetch]"
+      ],
+      "covered_files": [
+        "src/mac/harness_recovery_reflex.py"
+      ],
+      "covered_lines": 10,
+      "keep": "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_whitelist_match_is_case_insensitive_via_lower",
+      "members": [
+        "tests/test_harness_recovery_reflex.py::TestUnrecognisedLLMResponse::test_whitelist_match_is_case_insensitive_via_lower",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_llm_response_with_leading_trailing_whitespace",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_returned_value_is_string_not_enum_instance",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_whitelist_member_returned_as_is[clear_cache]",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_whitelist_member_returned_as_is[escalate]",
+        "tests/test_harness_recovery_reflex.py::TestValidLLMResponse::test_whitelist_member_returned_as_is[retry_fetch]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_harness_recovery_reflex.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[answer]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[investigation]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[question]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[report]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[triage]"
+      ],
+      "covered_files": [
+        "src/mac/models.py",
+        "src/mac/project_repository_service.py",
+        "src/mac/sandbox_bom.py",
+        "src/mac/services.py"
+      ],
+      "covered_lines": 342,
+      "keep": "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[analysis]",
+      "members": [
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[analysis]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[answer]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[investigation]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[question]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[report]",
+        "tests/test_report_deliverable.py::test_project_report_alias_not_upgraded_via_metadata_execution_contract[triage]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_report_deliverable.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_object_selection.py::test_a_record_missing_the_attribute_does_not_crash",
+        "tests/test_object_selection.py::test_equals_selects_a_state",
+        "tests/test_object_selection.py::test_not_equals_excludes_a_state",
+        "tests/test_object_selection.py::test_not_equals_includes_records_that_lack_the_attribute",
+        "tests/test_object_selection.py::test_work_packages_select_on_state"
+      ],
+      "covered_files": [
+        "src/mac/object_selection.py",
+        "src/mac/task_selection.py"
+      ],
+      "covered_lines": 51,
+      "keep": "tests/test_object_selection.py::test_a_comma_list_is_any_of",
+      "members": [
+        "tests/test_object_selection.py::test_a_comma_list_is_any_of",
+        "tests/test_object_selection.py::test_a_record_missing_the_attribute_does_not_crash",
+        "tests/test_object_selection.py::test_equals_selects_a_state",
+        "tests/test_object_selection.py::test_not_equals_excludes_a_state",
+        "tests/test_object_selection.py::test_not_equals_includes_records_that_lack_the_attribute",
+        "tests/test_object_selection.py::test_work_packages_select_on_state"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_object_selection.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order1]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order2]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order3]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order4]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order5]"
+      ],
+      "covered_files": [
+        "src/mac/repository_hygiene.py",
+        "src/mac/services.py",
+        "src/mac/task_dependencies.py",
+        "src/mac/task_flow_analytics.py",
+        "src/mac/task_transition_service.py"
+      ],
+      "covered_lines": 885,
+      "keep": "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order0]",
+      "members": [
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order0]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order1]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order2]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order3]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order4]",
+        "tests/test_planning_phase.py::TestParentGatesOnChildren::test_all_settled_join_is_confluent_across_terminal_event_order[event_order5]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_planning_phase.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_sandbox_rollout.py::test_an_agent_scheduled_for_a_different_image_is_still_queued",
+        "tests/test_sandbox_rollout.py::test_each_rollout_is_a_sync_task_pinned_to_its_agent",
+        "tests/test_sandbox_rollout.py::test_every_agent_gets_its_own_barrier_task",
+        "tests/test_sandbox_rollout.py::test_the_description_tells_the_worker_to_fail_rather_than_fall_back",
+        "tests/test_sandbox_rollout.py::test_the_task_records_the_bom_it_is_installing"
+      ],
+      "covered_files": [
+        "src/mac/sandbox_rollout.py"
+      ],
+      "covered_lines": 46,
+      "keep": "tests/test_sandbox_rollout.py::test_a_busy_agent_is_still_rolled",
+      "members": [
+        "tests/test_sandbox_rollout.py::test_a_busy_agent_is_still_rolled",
+        "tests/test_sandbox_rollout.py::test_an_agent_scheduled_for_a_different_image_is_still_queued",
+        "tests/test_sandbox_rollout.py::test_each_rollout_is_a_sync_task_pinned_to_its_agent",
+        "tests/test_sandbox_rollout.py::test_every_agent_gets_its_own_barrier_task",
+        "tests/test_sandbox_rollout.py::test_the_description_tells_the_worker_to_fail_rather_than_fall_back",
+        "tests/test_sandbox_rollout.py::test_the_task_records_the_bom_it_is_installing"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_sandbox_rollout.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[empty]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[readme]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[skills_prefix_only]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[src_module]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[test_module]"
+      ],
+      "covered_files": [
+        "src/mac/skill_auto_repair.py"
+      ],
+      "covered_lines": 36,
+      "keep": "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[docs_guide]",
+      "members": [
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[docs_guide]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[empty]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[readme]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[skills_prefix_only]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[src_module]",
+        "tests/test_skill_auto_repair.py::test_refuses_path_not_allowlisted[test_module]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_skill_auto_repair.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_work_package_models.py::test_compile_normalizes_materialization_contract",
+        "tests/test_work_package_models.py::test_input_lineage_is_transitive_across_three_hops",
+        "tests/test_work_package_models.py::test_materialization_identity_is_package_scoped",
+        "tests/test_work_package_models.py::test_node_contract_and_input_digests_support_safe_carry_forward",
+        "tests/test_work_package_models.py::test_semantic_change_changes_digest"
+      ],
+      "covered_files": [
+        "src/mac/work_package_models.py"
+      ],
+      "covered_lines": 769,
+      "keep": "tests/test_work_package_models.py::test_compile_is_canonical_and_independent_of_input_order",
+      "members": [
+        "tests/test_work_package_models.py::test_compile_is_canonical_and_independent_of_input_order",
+        "tests/test_work_package_models.py::test_compile_normalizes_materialization_contract",
+        "tests/test_work_package_models.py::test_input_lineage_is_transitive_across_three_hops",
+        "tests/test_work_package_models.py::test_materialization_identity_is_package_scoped",
+        "tests/test_work_package_models.py::test_node_contract_and_input_digests_support_safe_carry_forward",
+        "tests/test_work_package_models.py::test_semantic_change_changes_digest"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_work_package_models.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad:name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad?name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad[name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad^name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad~name]"
+      ],
+      "covered_files": [
+        "src/mac/work_package_models.py"
+      ],
+      "covered_lines": 36,
+      "keep": "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad*name]",
+      "members": [
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad*name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad:name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad?name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad[name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad^name]",
+        "tests/test_work_package_models.py::test_git_refs_are_strictly_validated[refs/heads/bad~name]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_work_package_models.py"
+      ]
+    },
+    {
+      "candidates": [
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload0]",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload1]",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload2]",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload3]",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload4]"
+      ],
+      "covered_files": [
+        "src/mac/worker.py"
+      ],
+      "covered_lines": 15,
+      "keep": "tests/test_worker_openshell_policy_sync.py::test_agent_with_no_assignment_keeps_its_policy",
+      "members": [
+        "tests/test_worker_openshell_policy_sync.py::test_agent_with_no_assignment_keeps_its_policy",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload0]",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload1]",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload2]",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload3]",
+        "tests/test_worker_openshell_policy_sync.py::test_malformed_assignment_never_installs[payload4]"
+      ],
+      "same_test_file": true,
+      "seconds_saved_if_retired": 3.0,
+      "size": 6,
+      "test_files": [
+        "tests/test_worker_openshell_policy_sync.py"
+      ]
+    }
+  ]
+}

--- a/scripts/test-discrimination.py
+++ b/scripts/test-discrimination.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Prove whether a test detects anything no other test detects.
+
+THE GATE THIS IMPLEMENTS
+
+A suite that only ever grows is a suite nobody can reason about, and this one
+grew for over a year with no way to retire anything. But "these tests execute
+the same lines" is not grounds for deleting one: two tests can run identical
+code and check entirely different properties. Coverage says what RAN. It says
+nothing about what was CHECKED.
+
+What distinguishes them is whether a test NOTICES when the code is wrong. So
+this breaks the code on purpose -- one small, targeted mutation at a time, on
+the lines the tests share -- and records which tests fail. A test that fails
+for no mutation any other test also fails for is carrying no unique weight, and
+retiring it costs nothing.
+
+The inverse is the important half: a test that catches a mutant nothing else
+catches must be KEPT, however redundant its coverage looked. That is the
+protection a coverage-only heuristic cannot offer, and the reason retirement
+should be gated on this rather than on the report.
+
+WHAT IT DOES NOT PROVE
+
+Surviving mutants are a lower bound. These operators are deliberately small and
+syntactic, so "no test caught any mutation" can mean the tests are weak OR that
+the operators never expressed a fault that matters here. Read a nothing-killed
+result as "no evidence either way", never as "safe to delete everything".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = "mac.test_discrimination.v1"
+
+#: Small, syntactic, and reversible: each flips ONE decision so a test that
+#: checks the outcome of that decision fails and one that merely executes the
+#: line does not. Ordered so the cheapest and least ambiguous run first.
+MUTATIONS: tuple[tuple[str, str], ...] = (
+    ("==", "!="),
+    ("!=", "=="),
+    (" and ", " or "),
+    (" or ", " and "),
+    (">=", ">"),
+    ("<=", "<"),
+    ("True", "False"),
+    ("False", "True"),
+    (" not ", " "),
+)
+
+
+def mutants(path: Path, lines: set[int], *, limit: int) -> list[tuple[int, str, str]]:
+    """(line number, original text, mutated text) for each candidate mutation."""
+    source = path.read_text(encoding="utf-8").splitlines()
+    found: list[tuple[int, str, str]] = []
+    for number in sorted(lines):
+        if not (1 <= number <= len(source)):
+            continue
+        text = source[number - 1]
+        stripped = text.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        for needle, replacement in MUTATIONS:
+            if needle in text:
+                found.append((number, text, text.replace(needle, replacement, 1)))
+                break  # one mutation per line keeps the attribution unambiguous
+        if len(found) >= limit:
+            break
+    return found
+
+
+def run_tests(nodeids: list[str], *, timeout: float) -> set[str]:
+    """The nodeids that FAILED. A crashed or timed-out run returns nothing,
+    which counts as 'killed nothing' rather than silently as 'all killed'."""
+    with tempfile.TemporaryDirectory() as tmp:
+        report = Path(tmp) / "report.xml"
+        try:
+            subprocess.run(
+                [
+                    sys.executable, "-m", "pytest", *nodeids,
+                    "-q", "--no-header", "--tb=no",
+                    "-p", "no:randomly", "-p", "no:cacheprovider",
+                    "--junit-xml", str(report),
+                ],
+                cwd=str(ROOT), capture_output=True, text=True, timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return set()
+        if not report.exists():
+            return set()
+        import xml.etree.ElementTree as ET
+
+        try:
+            tree = ET.parse(report)
+        except ET.ParseError:
+            return set()
+        failed = set()
+        for case in tree.iter("testcase"):
+            if case.find("failure") is not None or case.find("error") is not None:
+                classname = (case.get("classname") or "").replace(".", "/")
+                name = case.get("name") or ""
+                failed.add("%s::%s" % (classname, name))
+        return failed
+
+
+def _matches(failed_keys: set[str], nodeid: str) -> bool:
+    """Junit reports classname::name; nodeids carry paths and parametrisation."""
+    leaf = nodeid.split("::")[-1].split("[")[0]
+    return any(key.endswith("::" + leaf) or leaf in key for key in failed_keys)
+
+
+def analyse(
+    nodeids: list[str], target: Path, lines: set[int], *, limit: int, timeout: float
+) -> dict:
+    candidates = mutants(target, lines, limit=limit)
+    if not candidates:
+        return {
+            "schema": SCHEMA,
+            "verdict": "no_mutations_available",
+            "detail": "no mutable expression on the covered lines",
+            "tests": nodeids,
+        }
+    backup = target.read_text(encoding="utf-8")
+    kills: dict[str, list[int]] = {nodeid: [] for nodeid in nodeids}
+    survived: list[int] = []
+    try:
+        for number, original, mutated in candidates:
+            source = backup.splitlines()
+            source[number - 1] = mutated
+            target.write_text("\n".join(source) + "\n", encoding="utf-8")
+            failed = run_tests(nodeids, timeout=timeout)
+            killers = [n for n in nodeids if _matches(failed, n)]
+            if not killers:
+                survived.append(number)
+            for nodeid in killers:
+                kills[nodeid].append(number)
+    finally:
+        # Restore unconditionally. A tool that breaks the tree on Ctrl-C is a
+        # tool nobody runs twice.
+        target.write_text(backup, encoding="utf-8")
+
+    # A MINIMUM COVERING SET, not "which tests killed nothing".
+    #
+    # The naive rule -- retire any test with no unique kill -- is wrong in the
+    # common case. If two tests both catch only mutant 7 and nothing else,
+    # neither has a unique kill, so both look retirable and deleting both loses
+    # mutant 7 entirely. What has to be preserved is the UNION of what the
+    # cluster detects, using as few tests as possible.
+    #
+    # Greedy set cover: repeatedly take the test that catches the most
+    # not-yet-covered mutants. Ties break on nodeid so the choice is stable and
+    # a rerun proposes the same survivors.
+    remaining = {n for killed in kills.values() for n in killed}
+    keep: list[str] = []
+    while remaining:
+        best = max(
+            sorted(nodeids),
+            key=lambda nodeid: len(set(kills[nodeid]) & remaining),
+        )
+        gained = set(kills[best]) & remaining
+        if not gained:
+            break
+        keep.append(best)
+        remaining -= gained
+    keep = sorted(keep)
+    # Everything else: every mutant it catches is still caught by the kept set,
+    # so retiring it removes no detection this evidence can see.
+    retirable = sorted(set(nodeids) - set(keep))
+    discriminating = len({n for killed in kills.values() for n in killed})
+    unique = {
+        nodeid: sorted(
+            set(kills[nodeid])
+            - {n for other, ks in kills.items() if other != nodeid for n in ks}
+        )
+        for nodeid in nodeids
+        if set(kills[nodeid])
+        - {n for other, ks in kills.items() if other != nodeid for n in ks}
+    }
+    return {
+        "schema": SCHEMA,
+        "file": str(target.relative_to(ROOT)),
+        "mutations_applied": len(candidates),
+        "mutations_no_test_caught": sorted(survived),
+        "tests": nodeids,
+        "kills": {k: v for k, v in kills.items() if v},
+        # The smallest set that still catches everything the cluster catches.
+        "must_keep": keep,
+        # Tests that catch something NOTHING else catches. A subset of
+        # must_keep, surfaced separately because these are the ones where the
+        # cover had no choice -- deleting one provably loses detection.
+        "irreplaceable": unique,
+        # Every mutant these catch is still caught by must_keep, so retiring
+        # them removes no detection this evidence can see.
+        "retirable": retirable,
+        # Withheld deliberately when nothing was caught: that says the
+        # mutations were too weak OR the tests are, and those need different
+        # answers. It must never be read as "delete the whole cluster".
+        "verdict": "no_evidence" if not any(kills.values()) else "ok",
+        "discriminating_mutations": discriminating,
+        # HOW MUCH THIS IS WORTH. A cover of 1 test drawn from 3 discriminating
+        # mutations is not proof that the other 26 are worthless -- it is proof
+        # that these operators cannot tell them apart. Table-driven and
+        # parametrised tests are the clearest case: each case asserts a
+        # different input/output pair, and flipping one `==` breaks all of them
+        # at once, so they all die together and look interchangeable.
+        #
+        # Retire on "strong" only. "weak" means go and write a mutation that
+        # actually expresses the property in question, usually by altering a
+        # value in the table rather than an operator in the code.
+        "evidence": "strong" if discriminating >= 5 else "weak",
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file", type=Path, required=True, help="source file to mutate")
+    parser.add_argument("--lines", required=True, help="comma-separated line numbers")
+    parser.add_argument("--test", action="append", required=True, help="nodeid (repeatable)")
+    parser.add_argument("--max-mutations", type=int, default=8)
+    parser.add_argument("--timeout", type=float, default=900.0)
+    args = parser.parse_args(argv)
+
+    target = args.file if args.file.is_absolute() else ROOT / args.file
+    lines = {int(x) for x in args.lines.split(",") if x.strip()}
+    result = analyse(
+        args.test, target, lines, limit=args.max_mutations, timeout=args.timeout
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-redundancy-report.py
+++ b/scripts/test-redundancy-report.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Rank tests that are candidates for retirement, with the cost of keeping them.
+
+WHY THIS EXISTS
+
+The suite grew for over a year by adding tests alongside every code change, and
+nothing was ever removed: there has never been a gate for retiring a test. The
+result is 11,020 tests over 239,696 lines of test code for 223,016 lines of
+source -- more test than code.
+
+WHAT THE COST ACTUALLY IS
+
+Not assertions. Test bodies total 34.2 minutes and 47.6% of tests finish in
+under 10ms, which cannot explain a 63-minute job. Measured marginally, each
+test costs about 0.6s no matter what it asserts, because each one builds its
+own Postgres schema. Wall time therefore scales with the NUMBER of tests, so
+removing a redundant test is worth as much as removing a slow one.
+
+WHAT THIS REPORTS, AND WHAT IT DOES NOT CLAIM
+
+Tests are grouped by coverage signature: the exact set of (file, line) pairs
+they execute. Tests sharing a signature are CANDIDATES, not proven duplicates
+-- two tests can execute identical lines and assert entirely different things,
+which is the difference between "same code ran" and "same property checked".
+
+Deciding that is what scripts/test-discrimination.py does, by mutating the
+covered lines and seeing which tests actually notice. This report only says
+where to look, ordered by what it costs to keep looking away.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MAP = ROOT / "src" / "mac" / "data" / "test_impact_map.json"
+DEFAULT_TIMINGS = ROOT / ".test-portfolio" / "timings.json"
+SCHEMA = "mac.test_redundancy.v1"
+
+#: Marginal wall-clock cost of one test, measured rather than assumed: 15 tests
+#: took 5.5s and 36 took 18.5s in the same process, so each additional test
+#: costs ~0.6s of fixture work (predominantly its own Postgres schema) before
+#: it asserts anything at all.
+FIXTURE_COST_SECONDS = 0.6
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def coverage_signatures(impact_map: dict) -> dict[str, frozenset]:
+    """nodeid -> the exact set of (file, line) pairs it executed."""
+    nodeids = impact_map.get("nodeids") or []
+    per_test: dict[int, set] = collections.defaultdict(set)
+    for filename, lines in (impact_map.get("file_line_tests") or {}).items():
+        for line, indices in lines.items():
+            for index in indices:
+                per_test[index].add((filename, line))
+    return {
+        nodeids[index]: frozenset(pairs)
+        for index, pairs in per_test.items()
+        if 0 <= index < len(nodeids)
+    }
+
+
+def durations(timings: dict) -> dict[str, float]:
+    return {
+        str(entry.get("nodeid")): float(entry.get("duration_seconds") or 0.0)
+        for entry in (timings.get("tests") or [])
+        if entry.get("nodeid")
+    }
+
+
+def clusters(signatures: dict[str, frozenset]) -> list[list[str]]:
+    grouped: dict[frozenset, list[str]] = collections.defaultdict(list)
+    for nodeid, signature in signatures.items():
+        if signature:
+            grouped[signature].append(nodeid)
+    return [sorted(members) for members in grouped.values() if len(members) > 1]
+
+
+#: A signature this small is INCIDENTAL, not evidence. The largest raw cluster
+#: was 49 tests sharing 3 lines across 6 unrelated test files -- tests that
+#: barely touch mapped source at all (they exercise vendored code or assert on
+#: pure data), so their coverage matches by accident. Ranking those first sends
+#: the reviewer to the one place there is nothing to find.
+MIN_SIGNIFICANT_LINES = 10
+
+
+def cluster_report(members: list[str], timing: dict[str, float], signature: frozenset) -> dict:
+    """One cluster, with what retiring all but one of its tests would save.
+
+    Deliberately keeps ONE member: the code it covers must still be exercised.
+    The saving is therefore over the redundant members only.
+    """
+    redundant = members[1:]
+    saved = sum(timing.get(nodeid, 0.0) + FIXTURE_COST_SECONDS for nodeid in redundant)
+    files = sorted({filename for filename, _line in signature})
+    test_files = sorted({nodeid.split("::", 1)[0] for nodeid in members})
+    return {
+        "members": members,
+        "size": len(members),
+        "covered_lines": len(signature),
+        "covered_files": files[:5],
+        # Tests of the same subject living in the same file are far likelier to
+        # be genuine duplicates than a coincidental match across unrelated
+        # suites, so this is surfaced for the reviewer rather than hidden.
+        "test_files": test_files,
+        "same_test_file": len(test_files) == 1,
+        "keep": members[0],
+        "candidates": redundant,
+        "seconds_saved_if_retired": round(saved, 2),
+    }
+
+
+def build_report(
+    impact_map: dict,
+    timings: dict,
+    *,
+    limit: int = 0,
+    min_lines: int = MIN_SIGNIFICANT_LINES,
+) -> dict:
+    signatures = coverage_signatures(impact_map)
+    timing = durations(timings)
+    every = [
+        cluster_report(members, timing, sig)
+        for sig, members in _grouped(signatures).items()
+    ]
+    found = [c for c in every if c["covered_lines"] >= min_lines]
+    # Rank same-file clusters first at equal value: those are the ones a
+    # reviewer can actually adjudicate quickly.
+    found.sort(key=lambda item: (-item["seconds_saved_if_retired"], not item["same_test_file"]))
+    total_candidates = sum(len(item["candidates"]) for item in found)
+    total_saved = sum(item["seconds_saved_if_retired"] for item in found)
+    return {
+        "schema": SCHEMA,
+        "tests_with_coverage": len(signatures),
+        "distinct_signatures": len(set(signatures.values())),
+        "min_significant_lines": min_lines,
+        "clusters_all": len(every),
+        "clusters": len(found),
+        "candidates_all": sum(len(c["candidates"]) for c in every),
+        "retirement_candidates": total_candidates,
+        "seconds_saved_if_all_retired": round(total_saved, 1),
+        "minutes_saved_if_all_retired": round(total_saved / 60.0, 1),
+        "fixture_cost_seconds_per_test": FIXTURE_COST_SECONDS,
+        # Ordered so the first entries are worth the most; verification is
+        # per-cluster, so a partial pass still banks the largest savings.
+        "top_clusters": found[:limit] if limit else found,
+    }
+
+
+def _grouped(signatures: dict[str, frozenset]) -> dict[frozenset, list[str]]:
+    grouped: dict[frozenset, list[str]] = collections.defaultdict(list)
+    for nodeid, signature in signatures.items():
+        if signature:
+            grouped[signature].append(nodeid)
+    return {sig: sorted(members) for sig, members in grouped.items() if len(members) > 1}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--map", type=Path, default=DEFAULT_MAP)
+    parser.add_argument("--timings", type=Path, default=DEFAULT_TIMINGS)
+    parser.add_argument("--limit", type=int, default=25)
+    parser.add_argument(
+        "--min-lines",
+        type=int,
+        default=MIN_SIGNIFICANT_LINES,
+        help="ignore clusters whose shared coverage is smaller than this",
+    )
+    parser.add_argument("--output", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    impact_map = load_json(args.map)
+    timings = load_json(args.timings) if args.timings.exists() else {"tests": []}
+    report = build_report(
+        impact_map, timings, limit=args.limit, min_lines=args.min_lines
+    )
+    text = json.dumps(report, indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(text + "\n", encoding="utf-8")
+        print(
+            "%d clusters, %d retirement candidates, %.1f minutes -> %s"
+            % (
+                report["clusters"],
+                report["retirement_candidates"],
+                report["minutes_saved_if_all_retired"],
+                args.output,
+            )
+        )
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_test_retirement_tools.py
+++ b/tests/test_test_retirement_tools.py
@@ -1,0 +1,188 @@
+"""The retirement gate: what may be deleted, and on what evidence.
+
+The suite grew for a year by adding tests with every change and never removing
+one. These two tools are the missing half. The report says WHERE to look; the
+mutation check decides. The rules that matter are the conservative ones, so
+they are what these tests pin.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / ("%s.py" % name))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+REPORT = _load("test-redundancy-report")
+DISCRIM = _load("test-discrimination")
+
+
+def _map(sigs):
+    """An impact map whose tests cover the given (file, line) sets."""
+    nodeids = sorted(sigs)
+    index = {n: i for i, n in enumerate(nodeids)}
+    file_line: dict = {}
+    for nodeid, pairs in sigs.items():
+        for filename, line in pairs:
+            file_line.setdefault(filename, {}).setdefault(str(line), []).append(index[nodeid])
+    return {"nodeids": nodeids, "file_line_tests": file_line, "file_tests": {}}
+
+
+def test_identical_coverage_is_reported_as_a_cluster():
+    pairs = {("src/mac/a.py", n) for n in range(1, 21)}
+    impact = _map({"tests/test_a.py::one": pairs, "tests/test_a.py::two": pairs})
+
+    report = REPORT.build_report(impact, {"tests": []})
+
+    assert report["clusters"] == 1
+    assert report["retirement_candidates"] == 1
+
+
+def test_one_member_of_a_cluster_is_always_kept():
+    """The code still has to be exercised. A report that proposes deleting a
+    whole cluster is proposing to stop testing that code."""
+    pairs = {("src/mac/a.py", n) for n in range(1, 21)}
+    impact = _map({"tests/test_a.py::%d" % i: pairs for i in range(5)})
+
+    cluster = REPORT.build_report(impact, {"tests": []})["top_clusters"][0]
+
+    assert len(cluster["candidates"]) == cluster["size"] - 1
+    assert cluster["keep"] not in cluster["candidates"]
+
+
+def test_an_incidental_signature_is_not_reported():
+    """The largest raw cluster was 49 tests sharing 3 lines across 6 unrelated
+    files -- tests that barely touch mapped source, matching by accident.
+    Ranking those first sends the reviewer where there is nothing to find."""
+    tiny = {("src/mac/a.py", 1), ("src/mac/a.py", 2)}
+    impact = _map({"tests/test_a.py::one": tiny, "tests/test_b.py::two": tiny})
+
+    report = REPORT.build_report(impact, {"tests": []})
+
+    assert report["clusters"] == 0
+    assert report["clusters_all"] == 1
+
+
+def test_saving_counts_the_fixture_cost_not_just_the_assertions():
+    """Test bodies are 34 minutes of a 63-minute job and half finish under
+    10ms. What a test actually costs is its own Postgres schema, so a 1ms test
+    is nearly as expensive to keep as a 500ms one."""
+    pairs = {("src/mac/a.py", n) for n in range(1, 21)}
+    impact = _map({"tests/test_a.py::one": pairs, "tests/test_a.py::two": pairs})
+
+    cluster = REPORT.build_report(impact, {"tests": []})["top_clusters"][0]
+
+    assert cluster["seconds_saved_if_retired"] >= REPORT.FIXTURE_COST_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# The gate itself
+# ---------------------------------------------------------------------------
+
+
+def _analysis(kills, nodeids):
+    """Drive the cover/verdict logic with a known kill matrix."""
+    import types
+
+    captured = {}
+
+    def fake_run(ids, *, timeout):
+        mutant = captured["mutant"]
+        return {n for n in ids if mutant in kills.get(n, [])}
+
+    return fake_run
+
+
+def test_a_test_that_catches_nothing_unique_is_retirable(monkeypatch, tmp_path):
+    target = tmp_path / "mod.py"
+    target.write_text("def f(a, b):\n    return a == b\n", encoding="utf-8")
+    monkeypatch.setattr(DISCRIM, "ROOT", tmp_path)
+    monkeypatch.setattr(DISCRIM, "run_tests", lambda ids, timeout: {"a", "b"})
+
+    result = DISCRIM.analyse(["a", "b"], target, {2}, limit=4, timeout=5)
+
+    assert result["retirable"] == ["b"] or result["retirable"] == ["a"]
+    assert len(result["must_keep"]) == 1
+
+
+def test_a_test_nothing_else_can_replace_is_kept(monkeypatch, tmp_path):
+    """The protective half. Coverage said these were interchangeable; only the
+    mutation shows one of them is the reason a fault is caught."""
+    target = tmp_path / "mod.py"
+    target.write_text("def f(a, b):\n    return a == b\n", encoding="utf-8")
+    monkeypatch.setattr(DISCRIM, "ROOT", tmp_path)
+    monkeypatch.setattr(DISCRIM, "run_tests", lambda ids, timeout: {"only_this_one"})
+
+    result = DISCRIM.analyse(["only_this_one", "other"], target, {2}, limit=4, timeout=5)
+
+    assert result["must_keep"] == ["only_this_one"]
+    assert result["retirable"] == ["other"]
+
+
+def test_catching_nothing_withholds_the_verdict(monkeypatch, tmp_path):
+    """Nothing caught means the mutations were too weak OR the tests are, and
+    those need different answers. It must not read as "delete them all"."""
+    target = tmp_path / "mod.py"
+    target.write_text("def f(a, b):\n    return a == b\n", encoding="utf-8")
+    monkeypatch.setattr(DISCRIM, "ROOT", tmp_path)
+    monkeypatch.setattr(DISCRIM, "run_tests", lambda ids, timeout: set())
+
+    result = DISCRIM.analyse(["a", "b"], target, {2}, limit=4, timeout=5)
+
+    assert result["verdict"] == "no_evidence"
+
+
+def test_thin_evidence_is_labelled_weak(monkeypatch, tmp_path):
+    """27 tests reduced to a cover of 1 by three mutations is not proof that 26
+    are worthless -- it is proof the operators cannot tell them apart, which is
+    the normal case for parametrised tests over a mapping table."""
+    target = tmp_path / "mod.py"
+    target.write_text("def f(a, b):\n    return a == b\n", encoding="utf-8")
+    monkeypatch.setattr(DISCRIM, "ROOT", tmp_path)
+    monkeypatch.setattr(DISCRIM, "run_tests", lambda ids, timeout: {"a"})
+
+    result = DISCRIM.analyse(["a", "b"], target, {2}, limit=4, timeout=5)
+
+    assert result["evidence"] == "weak"
+
+
+def test_the_source_file_is_restored(monkeypatch, tmp_path):
+    """A tool that leaves the tree mutated is a tool nobody runs twice."""
+    target = tmp_path / "mod.py"
+    original = "def f(a, b):\n    return a == b\n"
+    target.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(DISCRIM, "ROOT", tmp_path)
+    monkeypatch.setattr(DISCRIM, "run_tests", lambda ids, timeout: {"a"})
+
+    DISCRIM.analyse(["a", "b"], target, {2}, limit=4, timeout=5)
+
+    assert target.read_text(encoding="utf-8") == original
+
+
+def test_the_file_is_restored_even_when_the_run_explodes(monkeypatch, tmp_path):
+    target = tmp_path / "mod.py"
+    original = "def f(a, b):\n    return a == b\n"
+    target.write_text(original, encoding="utf-8")
+    monkeypatch.setattr(DISCRIM, "ROOT", tmp_path)
+
+    def boom(ids, timeout):
+        raise RuntimeError("pytest died")
+
+    monkeypatch.setattr(DISCRIM, "run_tests", boom)
+
+    try:
+        DISCRIM.analyse(["a"], target, {2}, limit=4, timeout=5)
+    except RuntimeError:
+        pass
+
+    assert target.read_text(encoding="utf-8") == original


### PR DESCRIPTION
The suite grew for over a year by adding tests alongside every code change, and nothing was ever removed. **239,696 lines of test code against 223,016 lines of source**, 11,020 tests, and in the last full portfolio run: **8,512 passed, 43 skipped, 0 failed.**

## What a test actually costs

Not assertions. Test bodies total **34.2 minutes** and 47.6% finish in under 10ms — that cannot explain a 63-minute job.

Measured marginally: 15 tests in 5.5s, 36 in 18.5s → **~0.6s per test regardless of what it asserts**, because each builds its own Postgres schema. Wall time scales with the *number* of tests, so retiring a redundant test is worth as much as speeding up a slow one.

## Where to look — `scripts/test-redundancy-report.py`

Groups tests by the exact set of lines they execute. 8,828 tests → **6,954 distinct signatures**.

Incidental matches are discarded: the largest raw cluster was 49 tests sharing **3 lines across 6 unrelated files** — tests that barely touch mapped source and match by accident. Ranking those first sends the reviewer to the one place there's nothing to find.

What remains: **567 clusters, 1,043 candidates, ~10 minutes per run.** Committed as `docs/test-retirement-candidates.json`.

## What decides — `scripts/test-discrimination.py`

Coverage says what **ran**, never what was **checked**. So this breaks the covered lines on purpose, one mutation at a time, and records which tests notice.

It keeps a **minimum covering set**, not "tests with a unique kill" — the naive rule deletes *both* members of a pair that only ever catch the same fault, losing the detection entirely.

The protective half matters more than the deletions: **a test that catches what nothing else catches is kept**, however redundant its coverage looked.

## It refuses to overclaim

On the largest cluster — 27 tests over 35 lines of `review_failure_classifier` — one test covers every mutant the other 26 catch. That is reported as **weak** evidence, because only 3 mutations discriminated: these are parametrised cases over a mapping table, so flipping one operator breaks every case at once and they die together looking interchangeable. Retiring on that would be deleting 26 tests because the operators were too blunt to tell them apart.

Strong evidence needs ≥5 discriminating mutations. Catching nothing withholds the verdict entirely rather than reading as "delete them all".

Incidentally: **3 of 6 mutations were caught by no test in that cluster** — those lines are executed by 27 tests and checked by none.

## What this does not do yet

It proposes; it does not delete. No test is retired in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)