### PR TITLE
Stop the verifier inheriting a stdin nobody will ever write to

### DIFF
--- a/src/mac/executor_prompt.py
+++ b/src/mac/executor_prompt.py
@@ -179,10 +179,16 @@ from mac.executor_scope import (  # noqa: E402,F401 - compatibility re-exports
 
 def _run_captured(argv: List[str], cwd: Path, timeout: Optional[float]):
     """Run a subprocess and kill its complete process group on timeout."""
+    # DEVNULL rather than inherited: every openshell lifecycle step goes through
+    # here, and `openshell sandbox exec` reads stdin. Under a supervisor the
+    # agent's stdin is an open pipe that never delivers, so an inherited stdin
+    # turns a fast command into one that hangs until its timeout with nothing on
+    # either stream to say why.
     proc = subprocess.Popen(
         argv,
         cwd=str(cwd),
         text=True,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         start_new_session=True,
@@ -251,9 +257,13 @@ def run_with_stall_watchdog(
     stall = stall_timeout if stall_timeout is not None else _env_float("MAC_TEST_STALL_TIMEOUT", 300.0)
     hard = hard_timeout if hard_timeout is not None else _env_float("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", 1800.0)
 
+    # The streaming runner: this one has a stall timeout, so an inherited stdin
+    # turns "the command is waiting for input" into "the command stalled", which
+    # is reported as a timeout rather than as the deadlock it is.
     proc = subprocess.Popen(
         argv,
         cwd=str(cwd),
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         start_new_session=True,

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -1698,10 +1698,14 @@ def run_bounded_bash(command, timeout):
     """
     with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stdout_file:
         with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stderr_file:
+            # Same hazard as the verifier launch: a repository test command that
+            # reads stdin would block on the supervisor's pipe forever instead of
+            # seeing EOF and carrying on.
             proc = subprocess.Popen(
                 ["/bin/bash", "-lc", _TC_PATH_PREFIX + command],
                 cwd=worktree,
                 env=os.environ.copy(),
+                stdin=subprocess.DEVNULL,
                 stdout=stdout_file,
                 stderr=stderr_file,
                 text=True,
@@ -2417,10 +2421,21 @@ def _sandbox_run_repository_verification_exec(
     with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stdout_file:
         with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as stderr_file:
             try:
+                # stdin is DEVNULL, not inherited. `openshell sandbox exec`
+                # READS STDIN, and the agent runs under a supervisor whose
+                # stdin is an open pipe that never delivers. The child then
+                # blocks before running anything: no output on either stream,
+                # no marker written, and the poll loop reports a 120s start
+                # timeout for a process that was never going to start.
+                #
+                # Measured on a worker: with stdin an open pipe the exec hangs
+                # until killed (rc=124, zero output); with DEVNULL the same
+                # command returns in one second.
                 proc = subprocess.Popen(
                     argv,
                     cwd=str(Path.cwd()),
                     text=True,
+                    stdin=subprocess.DEVNULL,
                     stdout=stdout_file,
                     stderr=stderr_file,
                     start_new_session=True,
@@ -3118,7 +3133,10 @@ def _git_for_read_only_verifier(
         }
     )
     return subprocess.run(
-        [
+        # git can prompt (credentials, editors) and would then wait on a stdin
+        # nobody will ever write to.
+        stdin=subprocess.DEVNULL,
+        args=[
             git,
             "--no-optional-locks",
             "--git-dir=%s" % git_control,
@@ -4890,7 +4908,13 @@ def _openshell_probe(create_argv: List[str], *, timeout: float) -> "tuple[int, s
     """Run a one-shot ``sandbox create`` probe; return (returncode, combined output).
     Best-effort: any failure returns a non-zero code (never raises)."""
     try:
-        proc = subprocess.run(create_argv, capture_output=True, text=True, timeout=timeout)
+        proc = subprocess.run(
+            create_argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
         return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
     except Exception as exc:  # noqa: BLE001 - a probe failure must mean "not ready", not a crash
         return 1, str(exc)

--- a/tests/test_verifier_stdin.py
+++ b/tests/test_verifier_stdin.py
@@ -1,0 +1,98 @@
+"""The verifier must not inherit the agent's stdin.
+
+THE BUG THIS CLOSES
+
+Every task the fleet ran completed its work and then had it discarded, with:
+
+    OpenShell repository verifier did not start within 120.0s
+
+`openshell sandbox exec` READS STDIN. The agent runs under a supervisor whose
+stdin is an open pipe that never delivers, and the verifier was launched
+without redirecting stdin, so it inherited that pipe and blocked before running
+anything: no stdout, no stderr, no marker file, and a start-timeout reported for
+a process that was never going to start.
+
+Measured on a worker: with stdin an open pipe the exec hangs until killed
+(rc=124, zero output); with stdin on /dev/null the identical command returns in
+one second.
+
+The lesson generalises past this one call, which is why every launch site is
+covered here rather than just the verifier: a subprocess that might read stdin
+and is given a stdin nobody will ever write to is a subprocess that hangs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from mac import executor_prompt, executor_sandbox
+
+
+class _Recorder:
+    def __init__(self):
+        self.kwargs = {}
+
+    def __call__(self, argv, **kwargs):
+        self.kwargs = kwargs
+        raise RuntimeError("stop here: the launch is what is under test")
+
+
+def test_the_repository_verifier_launches_with_stdin_closed(monkeypatch, tmp_path):
+    recorder = _Recorder()
+    monkeypatch.setattr(subprocess, "Popen", recorder)
+
+    executor_sandbox._sandbox_run_repository_verification_exec(
+        "sandbox-name",
+        "/workspace/repo",
+        "/workspace/repo/verify.sh",
+        "/tmp/marker",
+        timeout=5.0,
+    )
+
+    assert recorder.kwargs.get("stdin") is subprocess.DEVNULL
+
+
+def test_the_shared_capture_helper_closes_stdin(monkeypatch, tmp_path):
+    """Every openshell lifecycle step -- upload, download, delete -- goes
+    through here, so an inherited stdin is the same hang with a different
+    symptom."""
+    recorder = _Recorder()
+    monkeypatch.setattr(subprocess, "Popen", recorder)
+
+    with pytest.raises(RuntimeError):
+        executor_prompt._run_captured(["openshell", "sandbox", "list"], tmp_path, 5.0)
+
+    assert recorder.kwargs.get("stdin") is subprocess.DEVNULL
+
+
+def test_no_openshell_launch_inherits_stdin():
+    """A source-level guard, because the failure is invisible in review: the
+    call looks complete, stdout and stderr are both handled, and the only thing
+    missing is the stream nobody thinks about."""
+    import ast
+    import pathlib
+
+    root = pathlib.Path(executor_sandbox.__file__).parent
+    offenders = []
+    for path in (root / "executor_sandbox.py", root / "executor_prompt.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            target = getattr(node.func, "attr", "")
+            if target not in {"Popen", "run"}:
+                continue
+            names = {kw.arg for kw in node.keywords}
+            # Only launches that capture output are process launches we own;
+            # anything else is a helper call with a matching name.
+            if not ({"stdout", "stderr", "capture_output"} & names):
+                continue
+            if "stdin" not in names:
+                offenders.append("%s:%d" % (path.name, node.lineno))
+
+    assert not offenders, (
+        "these subprocess launches inherit the agent's stdin and will hang if "
+        "the child reads it: %s" % ", ".join(offenders)
+    )


### PR DESCRIPTION
**This is why the fleet completed no work.** Every task ran correctly and had its result discarded with:

```
OpenShell repository verifier did not start within 120.0s
```

## The cause

`openshell sandbox exec` **reads stdin**. The agent runs under a supervisor whose stdin is an open pipe that never delivers, and the verifier was launched without redirecting stdin — so it inherited that pipe and blocked *before running anything*: no stdout, no stderr, no marker file, and a start-timeout reported for a process that was never going to start.

Measured on bullwinkle:

| stdin | result |
|---|---|
| open pipe (as under the supervisor) | hangs until killed — `rc=124`, zero output |
| `/dev/null` | returns in **1 second** |

## Why it took three attempts

The message named a timeout, so both previous attempts treated it as slowness.

1. Raise the timeout 45s → 120s. Changed nothing; the verifier was never slow.
2. Make the failure report the process's own output (#332). That is what identified it: *"still running; marker never appeared"* with **both streams empty** says the child never executed — and a child that neither runs nor speaks is a child blocked on input.

## Scope

Every launch site is closed, not just the verifier:

- the repository test command
- the shared capture helper behind every openshell lifecycle step (upload/download/delete)
- the streaming runner, where an inherited stdin surfaces as a *stall timeout* rather than a deadlock
- the sandbox-create probe
- the git helper (git prompts, and would wait forever)

A **source-level guard test** fails on any launch that captures output and doesn't name `stdin`. It caught two I had missed by hand.