### PR TITLE
Judge the task's work, not the sandbox's git history

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -1640,7 +1640,48 @@ command = os.environ.get("MAC_REPO_TEST_COMMAND", "").strip()
 # executor's gate_detect_test_command and the hub-review verifier, which already
 # prefer the sanity contract; the report/worker sandbox path had been left on the
 # whole-repo gate, so every code task paid the full ~34-60min suite.
+# NOTHING CHANGED => NOTHING TO VERIFY.
+#
+# A read-only task leaves the worktree exactly as it was uploaded. Running a
+# repository test gate over an unchanged tree cannot say anything about the
+# task's work: it can only report on the state of the repository, which the
+# task did not touch. It is also how a read-only canary came to run the entire
+# ~11,000-test contract suite inside a sandbox with no Postgres and fail.
+#
+# Detected against the sandbox's own baseline commit, which is what the agent
+# was given -- not against the host's history, which is not present here.
+_no_changes = False
+try:
+    _status = subprocess.run(
+        ["git", "-C", worktree, "status", "--porcelain", "-uall"],
+        capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL,
+    )
+    _no_changes = _status.returncode == 0 and not _status.stdout.strip()
+except Exception:
+    _no_changes = False
+
 _repo_base_sha = os.environ.get("MAC_TASK_REPO_BASE_SHA", "").strip()
+if _repo_base_sha:
+    # The sandbox replaces the uploaded `.git` with a fresh single-commit
+    # repository (the host worktree's `.git` is a pointer into a host-only
+    # directory and its credentials must not be copied in). So the host's base
+    # SHA usually DOES NOT EXIST here, and asking for a diff against it fails.
+    #
+    # The selector answers that failure with mode=full, and run-sanity-tests.sh
+    # answers mode=full by exec'ing the whole contract gate. An unresolvable
+    # base therefore quietly escalated "run the tests this task touched" into
+    # "run everything", which is both the slowest possible answer and, in a
+    # sandbox without Postgres, a guaranteed failure.
+    try:
+        _has_base = subprocess.run(
+            ["git", "-C", worktree, "cat-file", "-e", _repo_base_sha + "^{commit}"],
+            capture_output=True, timeout=60, stdin=subprocess.DEVNULL,
+        ).returncode == 0
+    except Exception:
+        _has_base = False
+    if not _has_base:
+        _repo_base_sha = ""
+
 if command in ("scripts/run-contract-tests.sh", "./scripts/run-contract-tests.sh") and _repo_base_sha:
     _sanity = os.path.join(worktree, "scripts", "run-sanity-tests.sh")
     if os.path.isfile(_sanity) and os.access(_sanity, os.X_OK):
@@ -1819,6 +1860,24 @@ elif bootstrap is not None and bootstrap.get("returncode") != 0:
         "worktree": worktree,
         "environment_delta": delta,
         "bootstrap": bootstrap,
+    }
+elif _no_changes:
+    # The task touched nothing, so the gate has nothing of the task's to judge.
+    # Reported as a pass with an explicit reason rather than skipped silently:
+    # "we did not test this, and here is why" is evidence; an absent result is
+    # indistinguishable from a gate that never ran.
+    payload = {
+        "schema": "mac.sandbox_verification.v1",
+        "status": "pass",
+        "command": command,
+        "returncode": 0,
+        "stdout": "",
+        "stderr": "",
+        "skipped": True,
+        "skipped_reason": "no repository changes to verify",
+        "duration_ms": 0,
+        "worktree": worktree,
+        "environment_delta": delta,
     }
 else:
     started = time.time()

--- a/tests/test_verifier_verdict.py
+++ b/tests/test_verifier_verdict.py
@@ -1,0 +1,86 @@
+"""The repository gate must judge the task's work, not the sandbox's git history.
+
+WHAT WENT WRONG
+
+A read-only canary that changed nothing failed with "repository verifier exited
+with status 1". The chain:
+
+  1. the sandbox replaces the uploaded `.git` with a fresh single-commit repo
+     (the host worktree's `.git` is a pointer into a host-only directory, and
+     its credentials must not be copied in)
+  2. the verifier rewrites its command to `run-sanity-tests.sh --base <SHA>`
+     using the HOST's base SHA
+  3. that SHA does not exist in the sandbox, so the selector answers
+     mode=full / reason=selection_error
+  4. run-sanity-tests.sh answers mode=full by exec'ing the whole contract gate
+  5. the full suite needs Postgres, the sandbox has none, exit 1
+
+So an unresolvable base quietly escalated "run the tests this task touched"
+into "run everything", and a task that changed nothing was failed for it.
+
+Three workers reported the underlying fact unprompted across four canaries:
+the worktree HEAD is a squashed sandbox baseline commit, not the declared base.
+"""
+
+from __future__ import annotations
+
+from mac.executor_sandbox import _sandbox_repository_verification_shell
+
+
+def _script() -> str:
+    return _sandbox_repository_verification_shell(
+        {"MAC_TASK_WORKSPACE": "/workspace/repo", "MAC_REPO_TEST_COMMAND": "scripts/run-contract-tests.sh"}
+    )
+
+
+def test_an_unresolvable_base_is_not_passed_to_the_selector():
+    """Otherwise the selector fails, answers `full`, and the gate escalates to
+    the entire suite -- the slowest possible answer and, without Postgres in
+    the sandbox, a guaranteed failure."""
+    script = _script()
+
+    assert "cat-file" in script
+    assert "^{commit}" in script
+    # The escalation is what must be prevented, so the guard has to clear the
+    # base rather than merely warn about it.
+    assert '_repo_base_sha = ""' in script
+
+
+def test_an_unchanged_worktree_skips_the_gate():
+    """A task that touched nothing leaves the gate nothing of the task's to
+    judge: it can only report on the repository, which the task did not touch."""
+    script = _script()
+
+    assert "status" in script and "--porcelain" in script
+    assert "no repository changes to verify" in script
+
+
+def test_the_skip_is_recorded_rather_than_silent():
+    """"We did not test this, and here is why" is evidence. An absent result is
+    indistinguishable from a gate that never ran -- which is exactly the
+    ambiguity that made the original failure take three attempts to read."""
+    script = _script()
+
+    assert '"skipped": True' in script
+    assert '"skipped_reason"' in script
+
+
+def test_the_skip_reports_a_pass_not_a_failure():
+    """A skipped gate must not fail the task; nothing was wrong with the work."""
+    script = _script()
+
+    head, _sep, tail = script.partition("elif _no_changes:")
+    assert tail, "the no-change branch is missing"
+    branch = tail.split("else:", 1)[0]
+    assert '"status": "pass"' in branch
+    assert '"returncode": 0' in branch
+
+
+def test_git_probes_do_not_inherit_stdin():
+    """The lesson from the verifier hang: a subprocess given a stdin nobody
+    will write to is a subprocess that can block forever."""
+    script = _script()
+
+    for probe in ("status", "cat-file"):
+        assert probe in script
+    assert script.count("stdin=subprocess.DEVNULL") >= 2


### PR DESCRIPTION
A read-only canary that changed nothing failed with `repository verifier exited with status 1`. The chain:

1. the sandbox replaces the uploaded `.git` with a fresh single-commit repository — the host worktree's `.git` is a pointer into a host-only directory and its credentials must not be copied in
2. the verifier rewrites its command to `run-sanity-tests.sh --base <SHA>` using the **host's** base SHA
3. that SHA does not exist in the sandbox, so the selector answers `mode=full`, `reason=selection_error`
4. `run-sanity-tests.sh` answers `mode=full` by exec'ing the whole contract gate
5. the full suite needs Postgres, the sandbox has none → **exit 1**

An unresolvable base quietly escalated *"run the tests this task touched"* into *"run everything"*, and a task that changed nothing was failed for it.

Three workers reported the underlying fact unprompted across four canaries: the worktree HEAD is a squashed sandbox baseline commit, not the declared base.

## Two guards

- the base SHA is used **only if it resolves in the sandbox**, so an absent one falls back to the configured command instead of escalating
- a worktree with **no changes skips the gate entirely**: a task that touched nothing leaves the gate nothing of the task's to judge — only the repository, which the task did not touch

The skip is **recorded, not silent**: `status: pass`, `skipped: true`, and a reason. "We did not test this, and here is why" is evidence; an absent result is indistinguishable from a gate that never ran — exactly the ambiguity that made the original hang take three attempts to read.

Both git probes pass `stdin=DEVNULL`, per the verifier hang.

## On the third question in the ticket

Why exit 1 is non-retryable at attempt 1 of 3: **that classification is correct and unchanged.** Re-running the same tests over the same code returns the same answer, so retrying a genuine test failure only burns attempts. The defect was an *environmental* failure being reported **as** a test failure, which these guards stop at source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)