### PR TITLE
Write down how the mac CLI is actually shaped, and enforce it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,21 @@
 # Agent Instructions
 
+## Skills: read these first
+
+`skills/` holds the durable guidance that would otherwise live in someone's
+memory of a previous session. Read the one that matches what you are about to
+do, before you do it:
+
+| skill | read it when |
+| --- | --- |
+| `skills/mac-cli/SKILL.md` | running any `mac` command — the object groups, the `admin` re-parenting, and the verbs that are not what you would guess |
+| `skills/record-user-directed-work/SKILL.md` | acting on user direction, or finding a defect while working — conversation is not a record |
+| `skills/setup-mac-fleet/SKILL.md` | standing up or reconfiguring fleet hosts |
+| `skills/mac-agent-terminal-timeout/SKILL.md` | an agent terminal hangs or times out |
+
+The CLI skill is enforced: `tests/test_mac_cli_skill.py` fails if it names a
+command the parser does not have, so it cannot rot into confident nonsense.
+
 ## Working checkout: use your own worktree
 
 **Do not edit `~/Src/mac` directly.** Multiple agents run against this

--- a/skills/mac-cli/SKILL.md
+++ b/skills/mac-cli/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: mac-cli
+description: How the mac CLI is actually shaped — object groups, the admin re-parenting, and the verbs that are not what you would guess. Read this before running mac commands.
+---
+
+# The mac CLI
+
+`mac <object> <verb> [args]`. Everything is an object with verbs, and the
+objects that matter day to day are `project`, `task`, `work-package` and
+`agent`. Everything else lives under `admin`.
+
+`--json` works in any position: `mac task list --json` and `mac --json task
+list` are the same command.
+
+## The traps
+
+These are not hypothetical. Each one cost a wrong command against a live fleet.
+
+**Everything unfamiliar is under `admin`.** The top level was deliberately
+reduced to the four objects above. `dispatch`, `human`, `memory`, `machine`,
+`fleet`, `client`, `openshell`, `secret` and the rest all moved. `mac dispatch`
+prints a redirect rather than working, so if a command "used to exist", try
+`mac admin <thing>` before assuming it was removed.
+
+**A paused project is `activate`d, not `resume`d.** `mac project resume` does
+not exist. Agents use the opposite pair: `mac agent hold` / `mac agent resume`.
+So the verb depends on the object, and guessing from the other one is wrong.
+
+**`mac agent update` cannot change status.** It takes `--capabilities`,
+`--add-capability`, `--remove-capability`, `--instance-kind`, `--owner`,
+`--visibility`. To clear a `draining` agent, PUT `{"status": "idle"}` to
+`/agents/{id}` on the hub.
+
+**`mac project pause` only reaches REGISTERED projects.** A project name that
+came from task metadata rather than `mac project create` returns `Not Found`,
+so pausing "the fleet" by walking the project list silently misses work. To
+stop dispatch fleet-wide, hold the agents.
+
+**Pausing a project does not drain it.** In-flight tasks keep running. A deploy
+started at that moment fails with `active work attached while release
+compensation ran`. Wait until no agent reports `current_task_id`.
+
+**`delete` is usually a rename of something gentler.** `mac project delete` is
+`unregister`; with `--force` it sets `tasks.project = NULL` rather than
+destroying tasks. `mac work-package delete` is `cancel`. Read the help before
+assuming a delete is destructive — or that it is not.
+
+## Finding things
+
+    mac help                      the object list
+    mac <object> help             verbs for one object
+    mac admin help                everything that moved under admin
+    mac <object> <verb> --help    arguments
+
+`mac task create help` is intercepted and prints help; it does not file a task
+called "help".
+
+## The commands that come up most
+
+    mac task list --state=open          mac task show <id>
+    mac task ready --limit 10           mac task why-unclaimed <id>
+    mac task create "title" --description-file=f.txt
+    mac task reopen <id>                recovery: terminal/stuck -> open
+    mac agent list                      mac agent hold/resume <id>
+    mac project pause/activate <name>
+    mac admin human register <username>
+    mac admin dispatch submit <file>    literate-ai execution requests
+
+## Requirements: capabilities versus hardware
+
+Capabilities are set membership over a DECLARED vocabulary — agents advertise
+`python`, `testing`, `review`. Host facts are NOT capabilities: `os` and
+`cpu_arch` are probed into `resources.hardware`, and no agent will ever
+advertise `linux`. Asking for one as a capability produces a task that is
+created and never claimed.
+
+    WRONG   --capabilities linux
+    RIGHT   --hardware '{"os": ["linux"], "cpu_arch": ["x86_64"]}'
+
+A preflight that answers whether the fleet could ever claim a task -- and
+names this mapping error specifically -- is in review, not yet on main. Until
+it lands, compare the task's requirements against `mac agent list --json` and
+the `resources.hardware` of each agent.
+
+## Where mac is talking to
+
+Resolution order: `--db` (direct Postgres, prints a redacted banner), then
+`--hub-url`, then `$MAC_API_URL`/`$MAC_URL`/`$MAC_HUB_URL`, then `--fleet` via
+`~/.mac/fleets.yaml`. Nothing configured is an error, never a silent default.
+
+Not every ControlPlane method is wrapped for hub mode. "`X` is not yet
+supported in hub mode" means the RemoteDispatch wrapper is missing, not that
+the feature is absent — the hub route usually exists.

--- a/skills/record-user-directed-work/SKILL.md
+++ b/skills/record-user-directed-work/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: record-user-directed-work
+description: Turn user direction, corrections, and discovered defects into durable ledger tasks before implementing them. Use whenever you change this repository or the fleet in response to a conversation, or find follow-up work while executing.
+---
+
+# Record user-directed work
+
+Convert conversation into durable state before changing anything. A plausible
+reading of a request is not permission to improvise, and a finding that lives
+only in a chat reply is a finding that is lost.
+
+For mac the durable store is the **task ledger** (`mac task`), not a roadmap
+file. `.tickets/` is a gitignored local mirror and is never the record.
+
+## Record before implementing
+
+1. Separate the outcome the user wants from the implementation they proposed.
+   Say which you are acting on.
+2. File it: `mac task create "title" --description-file=f.txt --as-human <user>`.
+   Use `--description-file` for anything with parentheses, backticks, `$VAR` or
+   newlines — shell quoting will otherwise mangle it.
+3. The description carries the reasoning, not just the request: what was
+   observed, what it implies, the scope boundary, and what evidence would show
+   it fixed. A title alone is a reminder, not a record.
+4. Prefer updating an existing task when the direction refines it. A second
+   task about the same defect splits its evidence.
+
+Diagnosis may precede recording — you often cannot describe the work until you
+have looked. Do not change source, policy, or fleet state first.
+
+**Emergency containment is the one exception.** If the fleet is degraded and a
+reversible action restores it, act, then record in the same turn and say why
+the order was inverted.
+
+## While executing
+
+- File newly discovered defects as their own tasks **at the moment you find
+  them**. Do not carry them to the end of the turn: a defect described only in
+  a final summary is one the reader has to re-derive from prose, and it will be
+  lost the moment the session ends. If you catch yourself writing "worth a
+  ticket", file it instead of writing that.
+- Record what you tried and rejected when it is not obvious, especially a
+  hypothesis that testing disproved. The next reader will otherwise repeat it.
+- Never let chat memory be the only place a decision exists.
+
+## Fleet-affecting work has an ordering rule
+
+Deploy the fix before releasing work that depends on it. Reopening tasks into
+a fleet that still carries the defect converts recoverable tasks into
+permanently failed ones — `repository_test_failed` and its relatives are
+classified non-retryable and burn the attempt immediately.
+
+The order is: fix -> merge -> deploy -> verify one canary completes -> release
+the backlog. Skipping the verification step is how a fleet gets a second
+outage from the repair.
+
+## Closing
+
+1. Run the evidence the task named, at the scope it claimed.
+2. `mac task close <id> --reason="..."` with the durable result — a test
+   target, a commit, an observed state — not "done".
+3. Leave partial work open across commits and sessions. An unchecked item is
+   information; a checked one that was not verified is a lie the next agent
+   will act on.

--- a/tests/test_mac_cli_skill.py
+++ b/tests/test_mac_cli_skill.py
@@ -1,0 +1,177 @@
+"""The CLI skill must describe the CLI that exists.
+
+A hand-written command reference drifts the moment someone renames a verb, and
+a reference that is confidently wrong is worse than none: it sends the reader
+to run something that fails, on a live fleet, during an incident.
+
+Every `mac ...` command the skill mentions is therefore checked against the
+real parser. The claims about traps are prose and cannot be tested; the
+commands can be, and those are what get typed.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "skills" / "mac-cli" / "SKILL.md"
+
+
+def _command_tree() -> set[tuple[str, ...]]:
+    """Every valid command path in the real parser."""
+    sys.argv = ["mac"]
+    from mac import cli as C
+
+    parser = C.build_parser()
+    found: set[tuple[str, ...]] = set()
+
+    def walk(node, prefix: tuple[str, ...]) -> None:
+        for action in node._actions:
+            mapping = getattr(action, "_name_parser_map", None)
+            if not mapping:
+                continue
+            for name, sub in mapping.items():
+                path = prefix + (name,)
+                found.add(path)
+                walk(sub, path)
+
+    walk(parser, ())
+    return found
+
+
+def _mentioned_commands(text: str) -> set[tuple[str, ...]]:
+    """Commands the skill tells you to RUN, from its indented code blocks.
+
+    Prose is excluded deliberately, for two reasons. It contains sentences that
+    happen to start with the word mac ("Where mac is talking to"), and it names
+    commands precisely BECAUSE they do not work -- `mac dispatch` prints a
+    redirect, and warning about that is the point. Checking prose would force
+    the skill to stop documenting the traps it exists to document.
+    """
+    commands: set[tuple[str, ...]] = set()
+    for line in text.splitlines():
+        if not line.startswith("    "):
+            continue
+        # Column-aligned trailing comments are prose, not arguments, so a run
+        # of two or more spaces ends the command. Without this the description
+        # beside a command is parsed as more subcommands.
+        for chunk in re.split(r"\s{2,}", line.strip()):
+            chunk = chunk.strip()
+            if not chunk.startswith("mac "):
+                continue
+            parts: list[str] = []
+            for token in chunk.split()[1:]:
+                if not re.fullmatch(r"[a-z][a-z0-9-]*", token):
+                    break
+                parts.append(token)
+            if parts:
+                commands.add(tuple(parts))
+    return commands
+
+
+@pytest.fixture(scope="module")
+def tree() -> set[tuple[str, ...]]:
+    return _command_tree()
+
+
+def test_the_skill_exists():
+    assert SKILL.is_file(), "the mac CLI skill is missing"
+
+
+def test_every_command_the_skill_names_exists(tree):
+    """The whole point. Each miss here is a command someone would have typed."""
+    text = SKILL.read_text(encoding="utf-8")
+    missing = []
+    for parts in sorted(_mentioned_commands(text)):
+        # EXACT match required. An earlier version accepted any resolving
+        # prefix, to tolerate trailing arguments -- which made the test
+        # vacuous: `mac task unblock` passed because `mac task` exists. The
+        # extractor already stops at the first non-word token, so the path it
+        # produces is the command and nothing else.
+        if parts not in tree:
+            missing.append("mac " + " ".join(parts))
+    assert not missing, (
+        "the skill names commands that do not exist: %s" % ", ".join(missing)
+    )
+
+
+def test_the_traps_it_documents_are_real(tree):
+    """Each of these cost a wrong command against a live fleet, so each is
+    pinned: if the CLI changes to match the guess, the skill must stop warning
+    about it."""
+    # A paused project is activated, not resumed.
+    assert ("project", "activate") in tree
+    assert ("project", "resume") not in tree
+    # Agents use the opposite pair.
+    assert ("agent", "hold") in tree and ("agent", "resume") in tree
+    # The four first-class objects stayed at the top level.
+    for obj in ("project", "task", "work-package", "agent"):
+        assert (obj,) in tree
+    # And the rest really did move under admin.
+    for moved in ("dispatch", "human", "memory", "machine", "fleet"):
+        assert ("admin", moved) in tree, "admin %s should exist" % moved
+        assert (moved,) not in tree, "%s should have moved under admin" % moved
+
+
+def test_agent_update_still_cannot_set_status():
+    """The skill tells the reader to use the hub API for this. If a --status
+    flag is ever added, that advice becomes wrong."""
+    sys.argv = ["mac"]
+    from mac import cli as C
+
+    parser = C.build_parser()
+
+    def find(node, path):
+        for action in node._actions:
+            mapping = getattr(action, "_name_parser_map", None)
+            if not mapping:
+                continue
+            if path[0] in mapping:
+                sub = mapping[path[0]]
+                return find(sub, path[1:]) if path[1:] else sub
+        return None
+
+    update = find(parser, ("agent", "update"))
+    assert update is not None
+    flags = {opt for action in update._actions for opt in action.option_strings}
+    assert "--status" not in flags
+
+
+# ---------------------------------------------------------------------------
+# AGENTS.md is the entry point. A skill it does not name is a skill nobody
+# reads, and a skill it names that does not exist is a broken instruction at
+# the top of the file every agent starts from.
+# ---------------------------------------------------------------------------
+
+AGENTS = ROOT / "AGENTS.md"
+SKILLS_DIR = ROOT / "skills"
+
+
+def test_agents_md_points_at_every_skill():
+    text = AGENTS.read_text(encoding="utf-8")
+    for skill in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        rel = skill.relative_to(ROOT).as_posix()
+        assert rel in text, "AGENTS.md does not mention %s" % rel
+
+
+def test_agents_md_does_not_name_a_missing_skill():
+    """The failure mode is worse than omission: an agent follows the pointer,
+    finds nothing, and improvises."""
+    text = AGENTS.read_text(encoding="utf-8")
+    for match in re.finditer(r"skills/[A-Za-z0-9_-]+/SKILL\.md", text):
+        assert (ROOT / match.group(0)).is_file(), "%s does not exist" % match.group(0)
+
+
+def test_every_skill_declares_what_it_is_for():
+    """Frontmatter name/description is how a skill is selected. Without it the
+    file is only findable by someone who already knows it exists."""
+    for skill in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        head = skill.read_text(encoding="utf-8").split("---")
+        assert len(head) >= 3, "%s has no frontmatter" % skill.name
+        assert "name:" in head[1] and "description:" in head[1], (
+            "%s must declare name and description" % skill.name
+        )


### PR DESCRIPTION
Over one session I ran `mac project resume` (it's `activate`), `mac agent update --status` (no such flag), `mac human register` (moved under `admin`) and `mac dispatch` (likewise). Each was a guess from a plausible symmetry, each failed against a live fleet, and each cost a round trip during an incident.

## `skills/mac-cli/SKILL.md`

Records the shape — four first-class objects, everything else under `admin` — then the **traps**, because the traps are what cost time:

- a project is **activated**, an agent is **resumed**; the verb depends on the object, and guessing from the other one is wrong
- `mac project pause` only reaches **registered** projects, so pausing "the fleet" by walking the project list silently misses work
- **pausing does not drain**: in-flight tasks keep running, and a deploy started then dies on `active work attached while release compensation ran`
- `delete` is usually a rename of something gentler (`project delete` → `unregister`; `--force` unassigns tasks rather than destroying them)
- **host facts are not capabilities**: asking for `linux` as a capability creates a task nobody can ever claim

## It is enforced

`tests/test_mac_cli_skill.py` walks the real argparse tree and fails if the skill names a command that doesn't exist — the failure mode that makes a stale reference *worse* than none.

It caught one immediately: the skill described `mac task preflight`, which is still in review (#337) and not on main.

The check is **exact**, not prefix-tolerant. My first version accepted any resolving prefix so trailing arguments wouldn't trip it — which made it vacuous: `mac task unblock` passed because `mac task` exists. Verified in both directions.

## `skills/record-user-directed-work/SKILL.md`

mac's version of literate-ai's planning guard, using the **task ledger** as the durable store rather than a roadmap file:

- file the task **before** implementing
- file discovered defects **at the moment you find them**, not in a closing summary
- **deploy a fix before releasing work that depends on it** — reopening tasks into a fleet that still carries the defect converts recoverable tasks into permanently failed ones

Every rule in it is one I broke today.

## AGENTS.md

Now points at all four skills, and that pointer is enforced too: a skill it fails to name is a skill nobody reads, and one it names that doesn't exist is a broken instruction at the top of the file every agent starts from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)