### PR TITLE
Stop a chat-gateway probe from taking task execution down fleet-wide

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -11503,10 +11503,10 @@ withdraw_openclaw_gateway() {
 #
 # Treating the gateway probe as fatal made it fail the node, and the cohort
 # transaction then failed the FLEET: on 2026-08-11 three consecutive deploys
-# were blocked this way -- natasha once, rocky twice -- each leaving all eight
-# agents drained and held while the fix they were waiting for sat in a merged
-# PR. The probe has a 90s budget and failed on a different node each time,
-# which is the signature of a timing budget rather than a broken host.
+# were blocked this way, each leaving every agent drained and held while the
+# fix they were waiting for sat in a merged PR. The probe has a 90s budget and
+# failed on a DIFFERENT node each time, which is the signature of a timing
+# budget rather than a broken host.
 #
 # So it is non-fatal by DEFAULT. The failure is still recorded, the failed
 # successor is still retained for diagnosis, and an operator who genuinely
@@ -13438,7 +13438,7 @@ EOF
       darwin_clear_auxiliary_restore
       # The transaction is COMMITTED and the auxiliary restore cleared, so the
       # node is in a consistent state with a degraded chat gateway. Aborting
-      # here is what took the fleet down: rocky failed this probe twice and
+      # here is what took the fleet down: one node failed this probe twice and
       # both times every other node was held for it.
       if ! gateway_probe_is_fatal; then
         note_gateway_degraded "stock OpenClaw verification failed under launchd"

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -11495,6 +11495,37 @@ withdraw_openclaw_gateway() {
     "$installer" withdraw
 }
 
+# WHAT A CHAT GATEWAY FAILURE MAY AND MAY NOT STOP.
+#
+# The OpenClaw gateway is the CONVERSATION surface. Task execution is OpenShell
+# plus the coding CLI plus mac-agent, and none of them consult Slack. A node
+# that cannot post to Slack is degraded for chat and fully capable of work.
+#
+# Treating the gateway probe as fatal made it fail the node, and the cohort
+# transaction then failed the FLEET: on 2026-08-11 three consecutive deploys
+# were blocked this way -- natasha once, rocky twice -- each leaving all eight
+# agents drained and held while the fix they were waiting for sat in a merged
+# PR. The probe has a 90s budget and failed on a different node each time,
+# which is the signature of a timing budget rather than a broken host.
+#
+# So it is non-fatal by DEFAULT. The failure is still recorded, the failed
+# successor is still retained for diagnosis, and an operator who genuinely
+# needs chat proven before a deploy completes can set
+# MAC_DEPLOY_GATEWAY_PROBE_FATAL=1.
+gateway_probe_is_fatal() {
+  truthy "${MAC_DEPLOY_GATEWAY_PROBE_FATAL:-0}"
+}
+
+note_gateway_degraded() {
+  local context="$1"
+  log "WARNING: ${context}; chat gateway is degraded on this node"
+  log "WARNING: continuing -- task execution does not depend on the chat gateway"
+  # A durable marker beside the deploy logs, so "why is chat down on this host"
+  # is answerable later without reading a deploy transcript.
+  printf '%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$context" \
+    >> "$LOG_DIR/openclaw-gateway-degraded.txt" 2>/dev/null || true
+}
+
 handle_failed_openclaw_successor() {
   local context="$1"
   if [ "$RECOVERY_POLICY" = retain-forward ]; then
@@ -11733,14 +11764,20 @@ PY
     > "$LOG_DIR/openclaw-gateway-journal.txt" || true
   if ! verify_openclaw_gateway; then
     handle_failed_openclaw_successor "stock OpenClaw verification failed"
-    return 1
+    if gateway_probe_is_fatal; then
+      return 1
+    fi
+    note_gateway_degraded "stock OpenClaw verification failed"
   fi
   disable_systemd_service_if_present "$HERMES_SERVICE_NAME"
   run_systemctl reset-failed "$HERMES_SERVICE_NAME" 2>/dev/null || true
   disable_systemd_service_if_present "$NEMOCLAW_SERVICE_NAME"
   if ! finalize_openclaw_gateway; then
     handle_failed_openclaw_successor "OpenClaw exclusivity proof failed"
-    return 1
+    if gateway_probe_is_fatal; then
+      return 1
+    fi
+    note_gateway_degraded "OpenClaw exclusivity proof failed"
   fi
   log "stock OpenClaw verified as exclusive gateway"
   install_linux_agent_service
@@ -12937,13 +12974,19 @@ EOF
     if ! verify_openclaw_gateway; then
       handle_failed_openclaw_successor \
         "stock OpenClaw verification failed under supervisord"
-      return 1
+      if gateway_probe_is_fatal; then
+        return 1
+      fi
+      note_gateway_degraded "stock OpenClaw verification failed under supervisord"
     fi
     stop_supervisord_program_if_present "$HERMES_SUPERVISORD_PROG"
     if ! finalize_openclaw_gateway; then
       handle_failed_openclaw_successor \
         "OpenClaw exclusivity proof failed under supervisord"
-      return 1
+      if gateway_probe_is_fatal; then
+        return 1
+      fi
+      note_gateway_degraded "OpenClaw exclusivity proof failed under supervisord"
     fi
   fi
   if truthy "$DEFER_AGENT_RESTART"; then
@@ -13393,7 +13436,18 @@ EOF
       mac_launchd_transaction_commit \
         || die "failed launchd successor was retained but transaction cleanup failed"
       darwin_clear_auxiliary_restore
+      # The transaction is COMMITTED and the auxiliary restore cleared, so the
+      # node is in a consistent state with a degraded chat gateway. Aborting
+      # here is what took the fleet down: rocky failed this probe twice and
+      # both times every other node was held for it.
+      if ! gateway_probe_is_fatal; then
+        note_gateway_degraded "stock OpenClaw verification failed under launchd"
+        return 0
+      fi
     else
+      # Rollback path: the successor was withdrawn, so the gateway state is NOT
+      # consistent and continuing would install an agent over a half-undone
+      # transaction. This one stays fatal whatever the policy says.
       mac_launchd_transaction_rollback \
         || die "OpenClaw transaction compensation failed under launchd"
     fi

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -211,6 +211,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_FLEET_NAME` | str | consumer-defined | deployment | Deployment setting: deploy fleet name. |
 | `MAC_DEPLOY_FLEET_REGISTRY` | str | consumer-defined | deployment | Deployment setting: deploy fleet registry. |
 | `MAC_DEPLOY_FLEET_REGISTRY_FILE` | str | consumer-defined | deployment | Deployment setting: deploy fleet registry file. |
+| `MAC_DEPLOY_GATEWAY_PROBE_FATAL` | str | consumer-defined | deployment | Deployment setting: deploy gateway probe fatal. |
 | `MAC_DEPLOY_GATE_ADMIN_TOKEN` | str | consumer-defined | deployment | Deployment setting: deploy gate admin token. |
 | `MAC_DEPLOY_GATE_ADOPT_REASON` | str | consumer-defined | deployment | Deployment setting: deploy gate adopt reason. |
 | `MAC_DEPLOY_GATE_AGENT_ID` | str | consumer-defined | deployment | Deployment setting: deploy gate agent id. |

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -72,6 +72,7 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         "tests/test_deploy_fleet_parallel_staging.py",
         "tests/test_deploy_github_https_credentials.py",
         "tests/test_fleet_node_capability_truthfulness.py",
+        "tests/test_gateway_probe_blast_radius.py",
         "tests/test_task_sandbox_reaping_policy.py",
         "tests/test_fleet_node_daemon_quiescence.py",
         # Added with the container-runtime declaration (#291) and the

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -2493,6 +2493,17 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy gateway probe fatal.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_GATEWAY_PROBE_FATAL",
+    "retired": false,
+    "sources": [
+      "deploy/fleet-node-install.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy gate admin token.",
     "family": "deployment",
     "name": "MAC_DEPLOY_GATE_ADMIN_TOKEN",

--- a/tests/test_gateway_probe_blast_radius.py
+++ b/tests/test_gateway_probe_blast_radius.py
@@ -3,7 +3,7 @@
 WHAT HAPPENED
 
 On 2026-08-11 three consecutive deploys were blocked by the OpenClaw
-gateway/channel health probe -- natasha once, rocky twice. Each time the node
+gateway/channel health probe, on a different node each time. Each time the node
 install failed, the cohort transaction treated the cohort as unproven, and all
 eight agents were left drained and held. The fix they were waiting for sat in a
 merged PR that could not be deployed because Slack would not answer.

--- a/tests/test_gateway_probe_blast_radius.py
+++ b/tests/test_gateway_probe_blast_radius.py
@@ -1,0 +1,100 @@
+"""A chat-gateway failure must not stop task execution fleet-wide.
+
+WHAT HAPPENED
+
+On 2026-08-11 three consecutive deploys were blocked by the OpenClaw
+gateway/channel health probe -- natasha once, rocky twice. Each time the node
+install failed, the cohort transaction treated the cohort as unproven, and all
+eight agents were left drained and held. The fix they were waiting for sat in a
+merged PR that could not be deployed because Slack would not answer.
+
+WHY THAT IS WRONG
+
+The OpenClaw gateway is the CONVERSATION surface. Task execution is OpenShell
+plus the coding CLI plus mac-agent, and none of them consult Slack. A node that
+cannot post to Slack is degraded for chat and fully capable of work.
+
+The probe has a 90s budget and failed on a different node each run, which is
+the signature of a timing budget rather than a broken host.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "deploy" / "fleet-node-install.sh"
+
+
+@pytest.fixture(scope="module")
+def script() -> str:
+    return INSTALLER.read_text(encoding="utf-8")
+
+
+def test_the_probe_is_non_fatal_by_default(script: str):
+    """Default 0. An operator can still demand a proven gateway, but the
+    default must not be "one node's Slack account can stop the fleet"."""
+    assert 'MAC_DEPLOY_GATEWAY_PROBE_FATAL:-0' in script
+
+
+def test_every_gateway_failure_consults_the_policy(script: str):
+    """Each supervisor has its own path -- systemd, supervisord, launchd -- and
+    a path that skips the check silently keeps the old blast radius on that
+    platform only, which is the hardest kind of regression to notice."""
+    for context in (
+        "stock OpenClaw verification failed",
+        "OpenClaw exclusivity proof failed",
+        "stock OpenClaw verification failed under supervisord",
+        "OpenClaw exclusivity proof failed under supervisord",
+        "stock OpenClaw verification failed under launchd",
+    ):
+        index = script.find(context)
+        assert index > 0, "missing failure path: %s" % context
+        window = script[index : index + 900]
+        assert "gateway_probe_is_fatal" in window, (
+            "%s does not consult the fatality policy" % context
+        )
+
+
+def test_a_degraded_gateway_is_recorded_not_swallowed(script: str):
+    """Continuing quietly would trade one bad failure mode for another: chat
+    silently dead on a node with nothing to say why."""
+    assert "note_gateway_degraded" in script
+    assert "openclaw-gateway-degraded.txt" in script
+
+
+def test_the_rollback_path_stays_fatal(script: str):
+    """The one case that must NOT be downgraded. When the successor was
+    withdrawn the gateway state is inconsistent, and installing an agent over a
+    half-undone transaction is worse than failing the node."""
+    index = script.find("mac_launchd_transaction_rollback")
+    assert index > 0
+    window = script[max(0, index - 700) : index]
+    assert "gateway state is NOT" in window or "stays fatal" in window, (
+        "the rollback path must document and keep its fatality"
+    )
+
+
+def test_the_agent_service_is_installed_after_a_degraded_gateway(script: str):
+    """The point of the change. Under systemd the abort happened BEFORE
+    install_linux_agent_service, so a Slack timeout meant the node never got
+    the agent it was being deployed to update."""
+    verify = script.find("stock OpenClaw verification failed")
+    install = script.find("install_linux_agent_service", verify)
+    assert install > verify, "the agent service install must follow the probe"
+    between = script[verify:install]
+    # No unconditional early return may sit between them.
+    assert "gateway_probe_is_fatal" in between
+
+
+def test_the_script_still_parses():
+    """A shell edit that does not parse fails every deploy on every host."""
+    import subprocess
+
+    result = subprocess.run(
+        ["bash", "-n", str(INSTALLER)], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
On 2026-08-11 **three consecutive deploys** were blocked by the OpenClaw gateway/channel health probe — natasha once, rocky twice. Each time the node install failed, the cohort transaction treated the whole cohort as unproven, and **all eight agents were left drained and held**. The fix they were waiting for sat in a merged PR that could not be deployed because Slack would not answer.

## Why that's the wrong coupling

The OpenClaw gateway is the **conversation** surface. Task execution is OpenShell + the coding CLI + mac-agent, and **none of them consult Slack**. A node that cannot post to Slack is degraded for chat and fully capable of work.

The probe has a 90s budget and failed on a *different node each run* — the signature of a timing budget, not a broken host.

## The change

Non-fatal by default across all three supervisor paths (systemd, supervisord, launchd). The failure is still logged, the failed successor is still retained for diagnosis, and a durable marker is written beside the deploy logs so *"why is chat down on this host"* is answerable later without reading a deploy transcript.

`MAC_DEPLOY_GATEWAY_PROBE_FATAL=1` restores the old behaviour for an operator who genuinely needs chat proven before a deploy completes.

## One case stays fatal, deliberately

Under launchd the `retain-forward` branch **commits** the transaction and clears the auxiliary restore — the node is consistent with a degraded gateway, so continuing is safe. The **rollback** branch withdrew the successor, leaving gateway state inconsistent; installing an agent over a half-undone transaction would be worse than failing the node. A test pins that distinction.

## The ordering bug this also fixes

Under systemd the abort happened **before** `install_linux_agent_service` — so a Slack timeout meant the node never received the agent it was being deployed to update. A test pins that ordering too.

Closes the design half of `task_638badd0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)