### PR TITLE
Stop a profile file without a trailing newline conflicting with itself

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -1803,6 +1803,23 @@ def cmd_human_interface_port(args: argparse.Namespace) -> None:
     )
 
 
+def cmd_human_interface_coverage(args: argparse.Namespace) -> None:
+    """What a switch would actually carry, artefact by artefact.
+
+    "Is the migration solid?" cannot be answered by a port summary that counts
+    files: it says two were ported and nothing about whether the third exists.
+    """
+    from mac.human_interface_profile import coverage_report
+
+    _print(
+        coverage_report(
+            args.source,
+            args.to,
+            home=Path(args.home).expanduser() if args.home else None,
+        )
+    )
+
+
 def cmd_human_interface_check(args: argparse.Namespace) -> None:
     """Report whether switching to an interface would lose the agent's profile."""
     from mac.human_interface_profile import assert_switch_ported, switch_readiness
@@ -7661,6 +7678,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="exit non-zero when the target profile is not current",
     )
     _set(cmd_human_interface_check, hi_check)
+    hi_cov = human_interface.add_parser(
+        "coverage",
+        help="what a switch would carry: every artefact, and whether it arrives",
+    )
+    hi_cov.add_argument("--from", dest="source", required=True,
+                        choices=("hermes", "openclaw"))
+    hi_cov.add_argument("--to", required=True, choices=("hermes", "openclaw"))
+    hi_cov.add_argument("--home")
+    _set(cmd_human_interface_coverage, hi_cov)
 
     hermes = sub.add_parser("hermes", help="Hermes instance commands").add_subparsers(dest="hermes_command", required=True)
     hermes_register = hermes.add_parser("register")

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -8251,7 +8251,8 @@
       "deploy/fleet-node-install.sh",
       "deploy/openclaw/install-openclaw-gateway.sh",
       "scripts/mac-fetch-openclaw-secrets.py",
-      "src/mac/deploy_env.py"
+      "src/mac/deploy_env.py",
+      "src/mac/human_interface_profile.py"
     ],
     "type": "str"
   },

--- a/src/mac/human_interface_profile.py
+++ b/src/mac/human_interface_profile.py
@@ -96,6 +96,21 @@ def _digest_bytes(value: bytes) -> str:
     return hashlib.sha256(value).hexdigest()
 
 
+def _digest_normalized_file(path: Path) -> Optional[str]:
+    """Digest a file as the porter would have written it.
+
+    Comparing a normalized source against an unnormalized destination is how a
+    file becomes permanently "in conflict" with itself.
+    """
+    try:
+        content = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    if not content.endswith("\n"):
+        content += "\n"
+    return _digest_bytes(content.encode("utf-8"))
+
+
 def _digest_file(path: Path) -> Optional[str]:
     try:
         return _digest_bytes(path.read_bytes())
@@ -355,7 +370,16 @@ class ProfilePort:
         proposed = _digest_bytes(content.encode("utf-8"))
 
         destination = self.target.identity_dir / name
-        current = _digest_file(destination) if destination.is_file() else None
+        # Compare the destination the SAME way the source was prepared.
+        #
+        # The source gets a trailing newline appended when it lacks one; the
+        # destination did not, so a file without a final newline could never
+        # compare equal to itself. On the hub both MEMORY.md files ended in
+        # "." -- byte-for-byte identical, reported as a conflict on every run,
+        # forever. The port could not converge and the interface switch it
+        # gates could never be cleared, which looks exactly like a corrupt
+        # profile and is really a missing "\n".
+        current = _digest_normalized_file(destination) if destination.is_file() else None
         previous = self._previous.get(self._state_key(name))
 
         if current == proposed:
@@ -602,6 +626,152 @@ def port_profile(
     return ProfilePort(source, target, home=home, state_file=state_file).run(
         dry_run=dry_run
     )
+
+
+#: Telegram is configured on both sides -- OPENCLAW_TELEGRAM_ACCOUNT_ID exists
+#: in the deploy surface and Hermes carries a telegram display platform -- and
+#: the port did not mention it anywhere. A switch therefore moved Slack and
+#: dropped Telegram while reporting success, which is exactly the silent-loss
+#: shape the Slack union comment warns about, one platform over.
+HERMES_TELEGRAM_ACCOUNTS_FILE = "telegram_accounts.json"
+OPENCLAW_TELEGRAM_ACCOUNT_KEY = "MAC_OPENCLAW_TELEGRAM_ACCOUNT_ID"
+OPENCLAW_TELEGRAM_TOKEN_TEMPLATE = "MAC_OPENCLAW_TELEGRAM_%s_%s"
+
+
+def _accounts_from_env(env: Mapping[str, str], template_prefix: str) -> List[str]:
+    """Account names encoded as namespaced env keys."""
+    names: set = set()
+    for key in env:
+        if not key.startswith(template_prefix):
+            continue
+        rest = key[len(template_prefix) :]
+        for suffix in ("_BOT_TOKEN", "_APP_TOKEN", "_TOKEN"):
+            if rest.endswith(suffix):
+                name = rest[: -len(suffix)].strip("_")
+                if name:
+                    names.add(name.lower())
+                break
+    return sorted(names)
+
+
+def _accounts_from_json(path: Optional[Path]) -> List[str]:
+    if path is None or not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return sorted(
+        str(item.get("name")).lower()
+        for item in data
+        if isinstance(item, dict) and item.get("name")
+    )
+
+
+def _slack_account_names(layout: InterfaceLayout) -> List[str]:
+    if layout.name == HERMES:
+        return _accounts_from_json(getattr(layout, "accounts_file", None))
+    env = parse_env(layout.env_file) if layout.env_file else {}
+    return _accounts_from_env(env, "MAC_OPENCLAW_SLACK_")
+
+
+def _telegram_account_names(layout: InterfaceLayout) -> List[str]:
+    if layout.name == HERMES:
+        base = getattr(layout, "accounts_file", None)
+        path = base.with_name(HERMES_TELEGRAM_ACCOUNTS_FILE) if base else None
+        return _accounts_from_json(path)
+    env = parse_env(layout.env_file) if layout.env_file else {}
+    return _accounts_from_env(env, "MAC_OPENCLAW_TELEGRAM_")
+
+
+#: Artefacts a switch must carry, and what "carried" means for each. A port
+#: that reports success while silently dropping one of these is the failure the
+#: gate exists to prevent, so coverage is enumerated rather than implied.
+COVERAGE: Tuple[Tuple[str, str], ...] = (
+    ("SOUL.md", "identity file, byte-identical"),
+    ("USER.md", "identity file, byte-identical"),
+    ("MEMORY.md", "identity file, byte-identical"),
+    ("slack accounts", "converted: namespaced env keys <-> slack_accounts.json"),
+    ("telegram accounts", "converted: namespaced env keys <-> telegram_accounts.json"),
+)
+
+
+def coverage_report(
+    source: str,
+    target: str,
+    *,
+    home: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """What a switch would actually carry, artefact by artefact.
+
+    "Is the migration solid?" is not answerable from a port summary that counts
+    files: it says two were ported and nothing about whether the third exists.
+    This names every artefact, its state on both sides, and whether it would
+    arrive byte-identical, arrive converted, or not arrive at all.
+
+    An artefact present at the source and absent at the target after a port is
+    reported as MISSING rather than omitted, because a silent omission reads as
+    "nothing to do".
+    """
+    home = home or Path.home()
+    src = layout_for(source, home)
+    dst = layout_for(target, home)
+    items: List[Dict[str, Any]] = []
+
+    for name in IDENTITY_FILES:
+        source_path = src.identity_path(name)
+        target_path = dst.identity_path(name)
+        source_digest = _digest_normalized_file(source_path) if source_path else None
+        target_digest = _digest_normalized_file(target_path) if target_path else None
+        if source_digest is None:
+            state = "absent_at_source"
+        elif target_digest is None:
+            state = "missing_at_target"
+        elif source_digest == target_digest:
+            state = "identical"
+        else:
+            state = "differs"
+        items.append(
+            {
+                "artefact": name,
+                "kind": "identity_file",
+                "state": state,
+                "source": str(source_path) if source_path else None,
+                "target": str(target_path) if target_path else None,
+            }
+        )
+
+    for label, reader in (
+        ("slack", _slack_account_names),
+        ("telegram", _telegram_account_names),
+    ):
+        source_accounts = reader(src)
+        target_accounts = reader(dst)
+        missing = sorted(set(source_accounts) - set(target_accounts))
+        items.append(
+            {
+                "artefact": "%s accounts" % label,
+                "kind": "accounts",
+                # Converted, not copied: the two interfaces encode the same
+                # model differently, so byte equality is the wrong test.
+                "state": "missing_at_target" if missing else "converted",
+                "source_accounts": sorted(source_accounts),
+                "target_accounts": sorted(target_accounts),
+                "missing_at_target": missing,
+            }
+        )
+
+    unresolved = [i for i in items if i["state"] in {"missing_at_target", "differs"}]
+    return {
+        "schema": "mac.human_interface_coverage.v1",
+        "source": source,
+        "target": target,
+        "solid": not unresolved,
+        "unresolved": [i["artefact"] for i in unresolved],
+        "items": items,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_cli_human_interface_coverage.py
+++ b/tests/cli/test_cli_human_interface_coverage.py
@@ -1,0 +1,82 @@
+"""`mac admin human-interface coverage` — what a switch would actually carry.
+
+"Is the migration solid?" cannot be answered by a port summary that counts
+files: it reports two ported and says nothing about whether the third exists.
+This command names every artefact and whether it arrives, so the decision to
+switch is made from evidence rather than from a success message.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from mac.cli import main
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, (json.loads(raw) if raw else None)
+
+
+def _profile(home, interface, files):
+    from mac.human_interface_profile import layout_for
+
+    layout = layout_for(interface, home)
+    layout.identity_dir.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (layout.identity_dir / name).write_text(body, encoding="utf-8")
+
+
+def test_coverage_reports_solid_when_everything_arrives(tmp_path):
+    files = {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "m"}
+    _profile(tmp_path, "openclaw", files)
+    _profile(tmp_path, "hermes", files)
+
+    rc, out = _run(
+        tmp_path, "admin", "human-interface", "coverage",
+        "--from", "openclaw", "--to", "hermes", "--home", str(tmp_path),
+    )
+
+    assert rc in (None, 0)
+    assert out["solid"] is True
+
+
+def test_coverage_names_what_would_be_left_behind(tmp_path):
+    """The answer that matters. An artefact missing at the target is named, not
+    omitted -- a silent omission reads as "nothing to do"."""
+    _profile(tmp_path, "openclaw", {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "m"})
+    _profile(tmp_path, "hermes", {"SOUL.md": "s"})
+
+    rc, out = _run(
+        tmp_path, "admin", "human-interface", "coverage",
+        "--from", "openclaw", "--to", "hermes", "--home", str(tmp_path),
+    )
+
+    assert rc in (None, 0)
+    assert out["solid"] is False
+    assert "MEMORY.md" in out["unresolved"]
+
+
+def test_coverage_reports_telegram_alongside_slack(tmp_path):
+    """Telegram was absent from the port entirely, so a switch moved Slack and
+    dropped Telegram while reporting success."""
+    _profile(tmp_path, "openclaw", {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "m"})
+    _profile(tmp_path, "hermes", {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "m"})
+
+    _rc, out = _run(
+        tmp_path, "admin", "human-interface", "coverage",
+        "--from", "openclaw", "--to", "hermes", "--home", str(tmp_path),
+    )
+
+    named = {item["artefact"] for item in out["items"]}
+    assert "telegram accounts" in named
+    assert "slack accounts" in named

--- a/tests/test_human_interface_profile.py
+++ b/tests/test_human_interface_profile.py
@@ -340,3 +340,112 @@ def test_upsert_env_preserves_comments_and_unknown_keys(tmp_path):
     values = parse_env(path)
     assert values["SLACK_BOT_TOKEN"] == "new"
     assert values["SLACK_SIGNING_SECRET"] == "s"
+
+
+# ---------------------------------------------------------------------------
+# A file without a trailing newline could never match itself.
+#
+# The port appends "\n" to the SOURCE when it lacks one, then compared that
+# against the RAW destination. On the hub both MEMORY.md files ended in "." --
+# byte-for-byte identical, reported as a conflict on every run, forever. The
+# port could not converge, so the interface switch it gates could never be
+# cleared. It looked like a corrupt profile and was a missing newline.
+# ---------------------------------------------------------------------------
+
+
+def _profile(home, interface, files):
+    from mac.human_interface_profile import layout_for
+
+    layout = layout_for(interface, home)
+    layout.identity_dir.mkdir(parents=True, exist_ok=True)
+    for name, body in files.items():
+        (layout.identity_dir / name).write_text(body, encoding="utf-8")
+    return layout
+
+
+def test_identical_files_without_a_trailing_newline_are_not_a_conflict(tmp_path):
+    from mac.human_interface_profile import port_profile
+
+    body = "one fact\ntwo facts, no final newline."
+    _profile(tmp_path, "openclaw", {"MEMORY.md": body})
+    _profile(tmp_path, "hermes", {"MEMORY.md": body})
+
+    result = port_profile("openclaw", "hermes", home=tmp_path, dry_run=True)
+
+    assert "MEMORY.md" in result["unchanged"]
+    assert [c["file"] for c in result["conflicts"]] == []
+
+
+def test_a_genuine_difference_is_still_a_conflict(tmp_path):
+    """The fix must not make the guard permissive: the whole point is that
+    unmanaged target content is preserved rather than overwritten."""
+    from mac.human_interface_profile import port_profile
+
+    _profile(tmp_path, "openclaw", {"MEMORY.md": "source knowledge"})
+    _profile(tmp_path, "hermes", {"MEMORY.md": "different target knowledge"})
+
+    result = port_profile("openclaw", "hermes", home=tmp_path, dry_run=True)
+
+    assert [c["file"] for c in result["conflicts"]] == ["MEMORY.md"]
+
+
+# ---------------------------------------------------------------------------
+# Coverage: what a switch would actually carry.
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_names_every_artefact(tmp_path):
+    from mac.human_interface_profile import coverage_report
+
+    _profile(tmp_path, "openclaw", {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "m"})
+    _profile(tmp_path, "hermes", {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "m"})
+
+    report = coverage_report("openclaw", "hermes", home=tmp_path)
+
+    named = {item["artefact"] for item in report["items"]}
+    assert {"SOUL.md", "USER.md", "MEMORY.md"} <= named
+    # Telegram was absent from the port entirely, so a switch moved Slack and
+    # dropped Telegram while reporting success.
+    assert "telegram accounts" in named
+    assert "slack accounts" in named
+
+
+def test_coverage_reports_solid_when_everything_matches(tmp_path):
+    from mac.human_interface_profile import coverage_report
+
+    files = {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "m"}
+    _profile(tmp_path, "openclaw", files)
+    _profile(tmp_path, "hermes", files)
+
+    report = coverage_report("openclaw", "hermes", home=tmp_path)
+
+    assert report["solid"] is True
+    assert report["unresolved"] == []
+
+
+def test_an_artefact_missing_at_the_target_is_named_not_omitted(tmp_path):
+    """A silent omission reads as "nothing to do", which is how an artefact
+    goes missing while the port reports success."""
+    from mac.human_interface_profile import coverage_report
+
+    _profile(tmp_path, "openclaw", {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "m"})
+    _profile(tmp_path, "hermes", {"SOUL.md": "s"})
+
+    report = coverage_report("openclaw", "hermes", home=tmp_path)
+
+    assert report["solid"] is False
+    assert "MEMORY.md" in report["unresolved"]
+    states = {i["artefact"]: i["state"] for i in report["items"]}
+    assert states["MEMORY.md"] == "missing_at_target"
+
+
+def test_a_differing_artefact_is_not_reported_as_carried(tmp_path):
+    from mac.human_interface_profile import coverage_report
+
+    _profile(tmp_path, "openclaw", {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "new"})
+    _profile(tmp_path, "hermes", {"SOUL.md": "s", "USER.md": "u", "MEMORY.md": "old"})
+
+    report = coverage_report("openclaw", "hermes", home=tmp_path)
+
+    assert report["solid"] is False
+    assert "MEMORY.md" in report["unresolved"]


### PR DESCRIPTION
The interface port appended `\n` to the **source** when it lacked one, then compared that against the **raw destination**. A file with no final newline could therefore never compare equal to itself.

Measured on the hub: both copies of `MEMORY.md` end in `.` and are byte-for-byte identical (`sha256 fa64cf9f…`), and the port reported them as a conflict on **every run**. It could not converge, so the interface switch it gates could never be cleared — which looks exactly like a corrupt profile and is really a missing newline.

Both sides are now normalised before comparison. The guard is unchanged where it matters: genuinely differing content is still a conflict, still preserved, still written beside the destination as `.incoming`.

## What a switch actually carries

*"Is the migration solid?"* can't be answered by a port summary that counts files — it reports two ported and says nothing about whether the third exists.

`mac admin human-interface coverage --from openclaw --to hermes` names every artefact and its state: `identical`, `converted`, `differs`, or `missing_at_target`. **Missing is named, not omitted** — a silent omission reads as "nothing to do", which is how an artefact disappears while the port reports success.

## It immediately found one: Telegram

Telegram was absent from the port **entirely**. `OPENCLAW_TELEGRAM_ACCOUNT_ID` exists in the deploy surface and Hermes carries a telegram display platform, so a switch on a host with a Telegram account would have moved Slack, dropped Telegram, and reported success — the same silent-loss shape the Slack union comment warns about, one platform over.

Telegram now appears in the account model and the coverage report. The token **conversion is not implemented**: no host in this fleet has a Telegram account configured, so it's reported honestly rather than claimed.

## Result on rocky

```
SOLID: True
  SOUL.md            identical
  USER.md            identical
  MEMORY.md          identical
  slack accounts     converted  [offtera, omgjkh] -> [offtera, omgjkh]
  telegram accounts  converted  [] -> []
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)