### PR TITLE
Give the sandbox the database its own test gate requires

### DIFF
--- a/.mac/project.yaml
+++ b/.mac/project.yaml
@@ -141,6 +141,15 @@ toolchain:
     - python3
     - git
     - gh
+    # The suite runs against PostgreSQL because the fleet does, and
+    # scripts/run-contract-tests.sh fails fast without MAC_TEST_PG_URL rather
+    # than skipping. Undeclared, the derived sandbox BOM could not know the
+    # repository needs it, so the image shipped without it and EVERY code task
+    # failed verification with "repository verifier exited with status 1" --
+    # after doing its work correctly. Proven 2026-08-12 by driving one through.
+    - initdb
+    - pg_ctl
+    - postgres
 bootstrap:
   command: python3 scripts/bootstrap-project.py
   creates:

--- a/deploy/openshell/mac-hermes.Containerfile
+++ b/deploy/openshell/mac-hermes.Containerfile
@@ -98,6 +98,7 @@ RUN printf '%s\n' 'deb http://deb.debian.org/debian bookworm-backports main' > /
     && chmod 0755 /usr/local/bin/mac-verify-bash-contract \
     && /usr/local/bin/mac-verify-bash-contract \
     && apt-get install -y --no-install-recommends iproute2 iptables git procps make cmake ninja-build build-essential libssl-dev openjdk-17-jre-headless clang llvm lld \
+    && apt-get install -y --no-install-recommends postgresql postgresql-client \
     && apt-get install -y --no-install-recommends -t bookworm-backports qemu-system-misc \
     && command -v ps >/dev/null \
     && command -v cmake >/dev/null \

--- a/src/mac/sandbox_bom.py
+++ b/src/mac/sandbox_bom.py
@@ -74,6 +74,13 @@ COMMAND_PACKAGES: Dict[str, Tuple[str, ...]] = {
     "make": ("make",),
     # cmake/ninja arrived from isaacsim7-poc's contract, which the first
     # derivation could not read at all -- see _derive_sandbox_bom in cli.py.
+    # PostgreSQL. The mac suite runs against it because the fleet does, and the
+    # server binaries live in postgresql-common + the versioned server package;
+    # `postgresql` pulls both on Debian, which is again why command != package.
+    "postgres": ("postgresql",),
+    "pg_ctl": ("postgresql",),
+    "initdb": ("postgresql",),
+    "psql": ("postgresql-client",),
     "cmake": ("cmake",),
     "ninja": ("ninja-build",),
     "clang": ("clang",),

--- a/tests/test_sandbox_bom.py
+++ b/tests/test_sandbox_bom.py
@@ -220,3 +220,47 @@ def test_an_apt_suite_is_not_read_as_a_package():
     )
 
     assert installed == {"qemu-system-misc"}
+
+
+def test_the_repository_contract_declares_its_database():
+    """The mac suite runs against PostgreSQL because the fleet does, and
+    run-contract-tests.sh fails fast without MAC_TEST_PG_URL rather than
+    skipping.
+
+    Undeclared, the derived BOM could not know the repository needed it, so the
+    sandbox image shipped without it and EVERY code task failed verification --
+    after doing its work correctly. Proven 2026-08-12 by driving one through:
+    the agent wrote the change, the gate could not start, the work was
+    discarded.
+    """
+    import pathlib
+
+    import yaml
+
+    contract = yaml.safe_load(
+        (pathlib.Path(__file__).resolve().parents[1] / ".mac" / "project.yaml")
+        .read_text(encoding="utf-8")
+    )
+    commands = set((contract.get("toolchain") or {}).get("required_commands") or [])
+    assert {"postgres", "pg_ctl", "initdb"} <= commands
+
+
+def test_the_database_commands_map_to_a_package():
+    """A declared command with no mapping is reported as a gap and silently
+    absent from the image, which is the same failure one step later."""
+    from mac.sandbox_bom import COMMAND_PACKAGES
+
+    for command in ("postgres", "pg_ctl", "initdb"):
+        assert COMMAND_PACKAGES.get(command), command
+
+
+def test_the_image_installs_it():
+    """The BOM is advisory until the Containerfile actually installs the
+    package; the derivation existing is not the same as the image having it."""
+    import pathlib
+
+    containerfile = (
+        pathlib.Path(__file__).resolve().parents[1]
+        / "deploy" / "openshell" / "mac-hermes.Containerfile"
+    ).read_text(encoding="utf-8")
+    assert "postgresql" in containerfile


### PR DESCRIPTION
Every code task in this repository failed verification — **after doing its work correctly** — with `repository verifier exited with status 1`. The cause is one line of under-declaration.

The suite runs against PostgreSQL because the fleet does, and `run-contract-tests.sh` **fails fast** without `MAC_TEST_PG_URL` rather than skipping. But `.mac/project.yaml` declared `toolchain.required_commands` as `python3, git, gh` — no database. The derived sandbox BOM reads contracts, so it could not know the repository needed one, and the image shipped without it.

**Proven by driving one task end to end (2026-08-12).** Inside a live task sandbox, `command -v postgres pg_ctl initdb` returns nothing. The agent diagnosed it unprompted in its own summary:

> *"the suite itself requires a PostgreSQL that this sandbox lacks"*

## Three changes, one per layer

A gap at any layer reproduces the same silent absence:

1. **the contract** declares `initdb`, `pg_ctl`, `postgres` — so the BOM can see the requirement at all
2. **`sandbox_bom`** maps those to the `postgresql` package — a declared command with no mapping is reported as a gap and *still* absent from the image
3. **the Containerfile** installs it — a derived BOM is advisory until something acts on it

## The chain this completes

Five blockers in series, each hiding the next:

| # | failure | fix |
|---|---|---|
| 1 | verifier never started (stdin inherited) | #334 |
| 2 | exited 1 — unresolvable base SHA escalated the gate | #336 |
| 3 | `.profile: Permission denied` | policy re-rendered (nothing does it on deploy) |
| 4 | `init_import_site` | policy needs `--image-runtime` |
| 5 | **gate can't run: no PostgreSQL** | this PR |

Only after clearing 1–4 does the gate actually run, and then it cannot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)