### PR TITLE
Start Postgres from installed binaries when nothing else can

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -1088,6 +1088,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_TEST_DISABLE_GROUPS` | str | consumer-defined | core | Core setting: test disable groups. |
 | `MAC_TEST_JOBS` | str | 2 | core | Core setting: test jobs. |
 | `MAC_TEST_PG_CONTAINER` | str | consumer-defined | core | Core setting: test pg container. |
+| `MAC_TEST_PG_DATADIR` | str | consumer-defined | core | Core setting: test pg datadir. |
 | `MAC_TEST_PG_DB` | str | consumer-defined | core | Core setting: test pg db. |
 | `MAC_TEST_PG_IMAGE` | str | consumer-defined | core | Core setting: test pg image. |
 | `MAC_TEST_PG_MAX_CONNECTIONS` | str | consumer-defined | core | Core setting: test pg max connections. |

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -92,6 +92,17 @@ unset "${!TOKENHUB_@}"
 unset GH_TOKEN GITHUB_TOKEN GITEA_TOKEN GIT_TOKEN
 if [ -n "$_MAC_TEST_PG_URL_REQUESTED" ]; then
     export MAC_TEST_PG_URL="$_MAC_TEST_PG_URL_REQUESTED"
+else
+    # Nobody provisioned a database. CI does, and a developer following
+    # CLAUDE.md does, but a task sandbox runs this gate directly with no
+    # opportunity to -- so it failed with "MAC_TEST_PG_URL is unset" no matter
+    # how complete the sandbox was. Provisioning is this gate's own business:
+    # the helper finds a running server, or a container engine, or starts a
+    # server from installed binaries, and says so on stderr when it cannot.
+    _pg_helper="$(dirname "$0")/start-test-postgres.sh"
+    if [ -x "$_pg_helper" ] && _pg_dsn=$("$_pg_helper"); then
+        eval "$_pg_dsn"
+    fi
 fi
 # Pytest configuration belongs to this repository and the explicit arguments
 # passed to this runner.  In particular, an inherited ``-n auto`` must not make

--- a/scripts/start-test-postgres.sh
+++ b/scripts/start-test-postgres.sh
@@ -81,6 +81,50 @@ for engine in docker podman; do
   fi
 done
 
-echo "error: no local Postgres and no usable container engine (tried podman, docker)." >&2
+# 4. No engine -- start a server from local binaries. This is the task sandbox:
+# it carries the postgresql packages (the derived BOM installs them) but has no
+# container engine to nest and no server already running, so without this branch
+# an environment holding a complete Postgres still reports "no local Postgres"
+# and every code task fails its gate. Debian keeps the server binaries off PATH,
+# under /usr/lib/postgresql/<major>/bin, so look there as well as in PATH.
+PGBIN=""
+for candidate in "$(command -v pg_ctl 2>/dev/null || true)" \
+                 /usr/lib/postgresql/*/bin/pg_ctl \
+                 /usr/local/pgsql/bin/pg_ctl; do
+  if [ -n "$candidate" ] && [ -x "$candidate" ] \
+      && [ -x "$(dirname "$candidate")/initdb" ]; then
+    PGBIN="$(dirname "$candidate")"
+    break
+  fi
+done
+if [ -n "$PGBIN" ]; then
+  DATADIR="${MAC_TEST_PG_DATADIR:-${TMPDIR:-/tmp}/mac-test-pgdata}"
+  LOGFILE="$DATADIR.log"
+  if [ ! -s "$DATADIR/PG_VERSION" ]; then
+    rm -rf "$DATADIR"
+    if ! initdb_log=$("$PGBIN/initdb" -D "$DATADIR" -U "$(id -un)" --auth=trust 2>&1); then
+      echo "error: initdb failed in $DATADIR:" >&2
+      echo "$initdb_log" >&2
+      exit 1
+    fi
+  fi
+  # -w waits for readiness, so returning success means the emitted DSN resolves.
+  if ! start_log=$("$PGBIN/pg_ctl" -D "$DATADIR" -l "$LOGFILE" -w -t 60 start \
+      -o "-p $PORT -c listen_addresses=127.0.0.1 -c unix_socket_directories=$DATADIR -c max_locks_per_transaction=$LOCKS -c max_connections=$CONNS" 2>&1); then
+    echo "error: pg_ctl could not start a server in $DATADIR:" >&2
+    echo "$start_log" >&2
+    tail -20 "$LOGFILE" >&2 2>/dev/null || true
+    exit 1
+  fi
+  "$PGBIN/createdb" -h 127.0.0.1 -p "$PORT" "$DB" 2>/dev/null || true
+  # The superuser is named for the invoking user, not "postgres", so a second
+  # call -- which finds this server listening and takes the branch above --
+  # emits a DSN that authenticates instead of "role does not exist".
+  emit "postgresql://$(id -un)@127.0.0.1:$PORT/$DB"
+  exit 0
+fi
+
+echo "error: no local Postgres, no postgres server binaries, and no usable" >&2
+echo "       container engine (tried podman, docker)." >&2
 echo "Start Docker/Podman, or 'brew services start postgresql@17'." >&2
 exit 1

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -12926,6 +12926,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: test pg datadir.",
+    "family": "core",
+    "name": "MAC_TEST_PG_DATADIR",
+    "retired": false,
+    "sources": [
+      "scripts/start-test-postgres.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: test pg db.",
     "family": "core",
     "name": "MAC_TEST_PG_DB",


### PR DESCRIPTION
The test harness could find a listening Postgres or run a container, and nothing else — it could never start the server it had installed.

That gap stayed invisible because every environment that had exercised it (dev macs, GitHub runners, the workers themselves) has a container engine, so the container branch always won. **A task sandbox has neither**: nothing is listening, and OpenShell passes in no docker socket and is not a nested-container host. The loop fell through to `exit 1`, and the gate failed.

This is why #342 (installing the postgresql packages) was necessary but not sufficient: the binaries arrived and no code path could reach them. Debian also keeps the server binaries off `PATH` under `/usr/lib/postgresql/<major>/bin`, so `command -v postgres` finds nothing in an image that plainly has it.

The new branch runs **last**, so no environment that works today changes behaviour.

Two details are load-bearing, both found by running it in the published image rather than reasoning about it:

- the socket goes in the data directory — the Debian default `/var/run/postgresql` is unwritable to an unprivileged sandbox user, and it fails as a `FATAL` in a log file rather than anything `pg_ctl` prints
- the superuser is named for the invoking user, not `postgres`, so a *second* call — which finds this server listening and takes the branch above — emits a DSN that authenticates instead of `role does not exist`

Verified in `ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:74e5d6b7` as the unprivileged sandbox user: both calls emit a working DSN, `select current_user` returns `sandbox`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)