### PR TITLE
Report what the gate said, not just that it failed

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -2455,6 +2455,74 @@ def _verifier_output_excerpt(stdout_file, stderr_file, *, limit: int = 600) -> s
     return "; ".join(parts)
 
 
+def _sandbox_verification_report_detail(
+    name: str, sub: str, *, limit: int = 1200
+) -> str:
+    """Recover what the gate said from the report the sandbox wrote.
+
+    The in-sandbox verifier deliberately prints nothing: it captures the gate's
+    stdout and stderr into ``mac-sandbox-verification.json`` and exits with the
+    gate's status. So on the host both streams are empty and the failure detail
+    degrades to "repository verifier exited with status N" -- a bare number, for
+    a run that produced a full pytest report. Every gate failure has therefore
+    looked identical, naming neither the failing test nor the reason, which is
+    why five separate causes were diagnosed one at a time by hand.
+
+    The report is downloaded with the workspace, but only after verification
+    returns, so the host cannot wait for it. Read it out of the sandbox, which
+    is still alive at this point.
+    """
+
+    argv = [
+        _openshell_bin(),
+        "sandbox",
+        "exec",
+        "--name",
+        name,
+        "--workdir",
+        sub,
+        "--no-tty",
+        "--timeout",
+        "30",
+        "--",
+        "/bin/cat",
+        _SANDBOX_VERIFICATION_FILE,
+    ]
+    try:
+        proc = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            stdin=subprocess.DEVNULL,
+        )
+    except Exception:  # noqa: BLE001 - diagnostics must not raise
+        return ""
+    raw = (proc.stdout or "").strip()
+    if not raw:
+        return ""
+    try:
+        payload = json.loads(raw[raw.index("{") : raw.rindex("}") + 1])
+    except Exception:  # noqa: BLE001 - a partial report is not a failure
+        return ""
+    if not isinstance(payload, Mapping):
+        return ""
+    parts = []
+    error = str(payload.get("error") or "").strip()
+    if error:
+        parts.append("error=%s" % error)
+    # stdout before stderr, unlike the launcher excerpt: pytest names the failing
+    # tests and prints its summary line there, while stderr is usually warnings.
+    for label in ("stdout", "stderr"):
+        text = str(payload.get(label) or "").strip()
+        if not text:
+            continue
+        if len(text) > limit:
+            text = "... (head omitted) " + text[-limit:]
+        parts.append("%s=%s" % (label, text.replace("\n", " | ")))
+    return "; ".join(parts)
+
+
 def _terminate_sandbox_client(proc: subprocess.Popen[Any]) -> None:
     """Terminate an OpenShell client and every local helper it spawned."""
     import signal
@@ -3685,6 +3753,16 @@ def _sandbox_run_repository_verification(
             time.sleep(0.5)
     assert verification is not None
     if not verification.passed:
+        # The gate's own output lives in the sandbox's report, not on the
+        # streams this failure was built from, so a plain non-zero exit
+        # arrives here as a number with nothing attached. Recover the report
+        # while the sandbox still exists.
+        report_detail = _sandbox_verification_report_detail(name, sub)
+        if report_detail:
+            verification = replace(
+                verification,
+                detail="%s: %s" % (verification.detail, report_detail),
+            )
         sys.stderr.write(
             "[executor] WARNING: sandbox repository verification failed "
             "(%s, attempt %d): %s\n"

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -2511,6 +2511,24 @@ def _sandbox_verification_report_detail(
     error = str(payload.get("error") or "").strip()
     if error:
         parts.append("error=%s" % error)
+    # A failed bootstrap is reported as the whole run's status, so the exit code
+    # says "the tests failed" when dependency setup never finished and no test
+    # ran at all. Those lead opposite ways -- one is a regression to fix, the
+    # other an environment to repair -- so name the phase explicitly.
+    bootstrap = payload.get("bootstrap")
+    if isinstance(bootstrap, Mapping) and bootstrap.get("returncode") not in (0, None):
+        detail = str(
+            bootstrap.get("stderr") or bootstrap.get("stdout") or ""
+        ).strip()
+        if len(detail) > limit:
+            detail = "... (head omitted) " + detail[-limit:]
+        parts.append(
+            "bootstrap failed (rc=%s)%s"
+            % (
+                bootstrap.get("returncode"),
+                ": " + detail.replace("\n", " | ") if detail else "",
+            )
+        )
     # stdout before stderr, unlike the launcher excerpt: pytest names the failing
     # tests and prints its summary line there, while stderr is usually warnings.
     for label in ("stdout", "stderr"):

--- a/tests/test_verifier_diagnostics.py
+++ b/tests/test_verifier_diagnostics.py
@@ -89,3 +89,69 @@ def test_both_spellings_are_retryable_infrastructure():
             marker in message.lower()
             for marker in _OPENSHELL_VERIFIER_INFRASTRUCTURE_MARKERS
         ), message
+
+
+def test_a_failing_gate_reports_what_the_gate_said(monkeypatch):
+    """A non-zero gate arrived as a bare exit status.
+
+    The in-sandbox verifier writes the gate's stdout/stderr into
+    mac-sandbox-verification.json and exits with the gate's status, printing
+    nothing. So the host's excerpt of the two streams is empty and the detail
+    degrades to "repository verifier exited with status 3" -- a number, for a
+    run that produced a full pytest report. Five distinct causes were
+    diagnosed by hand off that one message.
+    """
+    import json as _json
+    import subprocess as _subprocess
+
+    from mac import executor_sandbox
+
+    report = {
+        "returncode": 3,
+        "status": "fail",
+        "stdout": "FAILED tests/test_thing.py::test_case - AssertionError\n"
+        "1 failed, 900 passed in 1200.00s",
+        "stderr": "",
+    }
+
+    def fake_run(argv, **_kwargs):
+        assert executor_sandbox._SANDBOX_VERIFICATION_FILE in argv
+        return _subprocess.CompletedProcess(
+            argv, 0, stdout=_json.dumps(report), stderr=""
+        )
+
+    monkeypatch.setattr(executor_sandbox.subprocess, "run", fake_run)
+
+    detail = executor_sandbox._sandbox_verification_report_detail(
+        "mac-task-abc", "/sandbox/task"
+    )
+
+    assert "test_thing.py::test_case" in detail
+    assert "1 failed, 900 passed" in detail
+
+
+def test_an_unreadable_report_leaves_the_original_failure_intact(monkeypatch):
+    """Recovery runs on the failure path. A sandbox that has already died, or
+    a truncated report, must not turn a reported gate failure into a crash --
+    the original exit status is still the answer."""
+    import subprocess as _subprocess
+
+    from mac import executor_sandbox
+
+    def fake_run(argv, **_kwargs):
+        return _subprocess.CompletedProcess(argv, 1, stdout="not json{", stderr="")
+
+    monkeypatch.setattr(executor_sandbox.subprocess, "run", fake_run)
+    assert (
+        executor_sandbox._sandbox_verification_report_detail("gone", "/sandbox/task")
+        == ""
+    )
+
+    def exploding_run(argv, **_kwargs):
+        raise OSError("sandbox is gone")
+
+    monkeypatch.setattr(executor_sandbox.subprocess, "run", exploding_run)
+    assert (
+        executor_sandbox._sandbox_verification_report_detail("gone", "/sandbox/task")
+        == ""
+    )

--- a/tests/test_verifier_diagnostics.py
+++ b/tests/test_verifier_diagnostics.py
@@ -155,3 +155,37 @@ def test_an_unreadable_report_leaves_the_original_failure_intact(monkeypatch):
         executor_sandbox._sandbox_verification_report_detail("gone", "/sandbox/task")
         == ""
     )
+
+
+def test_a_failed_bootstrap_is_named_as_such(monkeypatch):
+    """Bootstrap failure is reported as the run's exit status, so "the tests
+    failed" is what the host says when dependency setup never finished and no
+    test ran. The two lead opposite ways -- fix a regression, or repair an
+    environment -- so the phase has to be named."""
+    import json as _json
+    import subprocess as _subprocess
+
+    from mac import executor_sandbox
+
+    report = {
+        "returncode": 3,
+        "status": "fail",
+        "stdout": "",
+        "stderr": "",
+        "bootstrap": {
+            "returncode": 3,
+            "status": "fail",
+            "stderr": "error: pg_config executable not found",
+        },
+    }
+
+    def fake_run(argv, **_kwargs):
+        return _subprocess.CompletedProcess(
+            argv, 0, stdout=_json.dumps(report), stderr=""
+        )
+
+    monkeypatch.setattr(executor_sandbox.subprocess, "run", fake_run)
+    detail = executor_sandbox._sandbox_verification_report_detail("s", "/sandbox/task")
+
+    assert "bootstrap failed (rc=3)" in detail
+    assert "pg_config executable not found" in detail


### PR DESCRIPTION
A failing repository gate arrives on the host as a bare exit status:

```
repository_test_failed: repository verifier exited with status 3
```

That is the whole message, for a run that produced a complete pytest report.

The cause is structural, not accidental: the in-sandbox verifier captures the gate's stdout/stderr into `mac-sandbox-verification.json` and exits with the gate's status, **printing nothing**. The host builds its detail from those two streams, finds both empty, and falls back to the exit code. So every gate failure — a missing database, a real regression, a crashed worker — renders as the same sentence with a different integer.

That is why the last five causes were each diagnosed by hand, by ssh-ing to a worker and reading files that no longer exist by the time anyone looks. Status 3 today named neither a test nor a reason.

The report is downloaded with the workspace, but only *after* verification returns, so the host cannot wait for it — read it out of the sandbox, which is still alive at that point. `stdout` is reported before `stderr` (inverting the launcher excerpt's order) because pytest names the failing tests and prints its summary there.

Recovery runs on the failure path, so it cannot fail loudly: a dead sandbox, a truncated report, or an unreadable one all leave the original exit status as the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)