### PR TITLE
Let the sandbox name the commit the agent started from

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -1699,28 +1699,50 @@ try:
 except Exception:
     _no_changes = False
 
-_repo_base_sha = os.environ.get("MAC_TASK_REPO_BASE_SHA", "").strip()
-if _repo_base_sha:
-    # The sandbox replaces the uploaded `.git` with a fresh single-commit
-    # repository (the host worktree's `.git` is a pointer into a host-only
-    # directory and its credentials must not be copied in). So the host's base
-    # SHA usually DOES NOT EXIST here, and asking for a diff against it fails.
-    #
-    # The selector answers that failure with mode=full, and run-sanity-tests.sh
-    # answers mode=full by exec'ing the whole contract gate. An unresolvable
-    # base therefore quietly escalated "run the tests this task touched" into
-    # "run everything", which is both the slowest possible answer and, in a
-    # sandbox without Postgres, a guaranteed failure.
-    try:
-        _has_base = subprocess.run(
-            ["git", "-C", worktree, "cat-file", "-e", _repo_base_sha + "^{commit}"],
-            capture_output=True, timeout=60, stdin=subprocess.DEVNULL,
-        ).returncode == 0
-    except Exception:
-        _has_base = False
-    if not _has_base:
-        _repo_base_sha = ""
+# --- baseline-resolver (extracted verbatim by tests/test_sandbox_baseline.py) ---
+def _resolve_baseline_sha(subprocess, worktree, env_base):
+    """The commit the agent started from, as this repository can name it.
 
+    The host's base SHA is preferred, but it is usually absent here: the
+    sandbox runs `git init` and makes its own "MAC OpenShell sandbox
+    baseline" commit, whose SHA is newly generated and cannot equal the
+    host's. Clearing the base on that miss is what silently escalated every
+    task to the whole-repo gate.
+
+    The sandbox's own baseline commit IS the pre-task state -- it is exactly
+    what was uploaded -- so name it by the message we wrote, which no other
+    commit carries. A preserved .git has no such commit and yields "", which
+    is the old behaviour and the safe one.
+    """
+
+    def _git(*args):
+        try:
+            return subprocess.run(
+                ["git", "-C", worktree, *args],
+                capture_output=True, text=True, timeout=60,
+                stdin=subprocess.DEVNULL,
+            )
+        except Exception:
+            return None
+
+    if env_base:
+        probe = _git("cat-file", "-e", env_base + "^{commit}")
+        if probe is not None and probe.returncode == 0:
+            return env_base
+    found = _git(
+        "log", "--format=%H", "--fixed-strings",
+        "--grep=MAC OpenShell sandbox baseline", "-1",
+    )
+    if found is not None and found.returncode == 0:
+        return (found.stdout or "").strip().splitlines()[0].strip() if (
+            found.stdout or ""
+        ).strip() else ""
+    return ""
+# --- end baseline-resolver ---
+
+_repo_base_sha = _resolve_baseline_sha(
+    subprocess, worktree, os.environ.get("MAC_TASK_REPO_BASE_SHA", "").strip()
+)
 if command in ("scripts/run-contract-tests.sh", "./scripts/run-contract-tests.sh") and _repo_base_sha:
     _sanity = os.path.join(worktree, "scripts", "run-sanity-tests.sh")
     if os.path.isfile(_sanity) and os.access(_sanity, os.X_OK):

--- a/tests/test_sandbox_baseline.py
+++ b/tests/test_sandbox_baseline.py
@@ -1,0 +1,121 @@
+"""The sandbox has to be able to name the commit the agent started from.
+
+Every code task ran the whole-repo contract gate, no matter how small its
+diff. The reason was not the selector: it was that the base SHA never
+resolved inside the sandbox, so the impact-scoped path was unreachable.
+
+The sandbox replaces the uploaded `.git` with `git init` plus its own
+"MAC OpenShell sandbox baseline" commit, whose SHA is newly generated. The
+host's base SHA therefore cannot exist there, `cat-file -e` always missed,
+the base was cleared, and run-sanity-tests.sh answered the empty base with
+mode=full -- escalating "run the tests this task touched" into "run
+everything" on every single task.
+
+These tests exercise the resolver as it actually ships, by extracting it
+from the generated sandbox script, so the two cannot drift apart.
+"""
+
+import subprocess
+
+from mac import executor_sandbox
+
+_BEGIN = "# --- baseline-resolver (extracted verbatim by tests/test_sandbox_baseline.py) ---"
+_END = "# --- end baseline-resolver ---"
+
+
+def _shipped_resolver():
+    """Return the resolver function exactly as the sandbox will run it."""
+    script = executor_sandbox._sandbox_repository_verification_shell({})
+    assert _BEGIN in script and _END in script, (
+        "the sandbox script no longer carries the baseline resolver sentinels; "
+        "this test extracts the shipped source and cannot silently pass"
+    )
+    source = script[script.index(_BEGIN) + len(_BEGIN) : script.index(_END)]
+    namespace: dict = {}
+    exec(source, namespace)  # noqa: S102 - executing our own shipped source
+    return namespace["_resolve_baseline_sha"]
+
+
+def _git(repo, *args):
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _sandbox_style_repo(tmp_path):
+    """A worktree shaped the way the sandbox shapes one: fresh init, baseline
+    commit, then the agent's own work committed on top."""
+    repo = tmp_path / "worktree"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "mac-sandbox@invalid")
+    _git(repo, "config", "user.name", "MAC OpenShell sandbox")
+    (repo / "shipped.py").write_text("value = 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "MAC OpenShell sandbox baseline")
+    baseline = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    (repo / "shipped.py").write_text("value = 2\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "the agent's work")
+    return repo, baseline
+
+
+def test_an_absent_host_base_falls_back_to_the_sandbox_baseline(tmp_path):
+    """This is the live case: the host SHA is real but names a commit that
+    does not exist in the sandbox. Returning "" here is what escalated every
+    task to the whole-repo gate."""
+    repo, baseline = _sandbox_style_repo(tmp_path)
+    resolve = _shipped_resolver()
+
+    resolved = resolve(subprocess, str(repo), "0" * 40)
+
+    assert resolved == baseline
+
+
+def test_a_resolvable_host_base_is_preferred(tmp_path):
+    """When the host's base does exist -- a preserved .git -- it is the more
+    accurate answer and must win over our own baseline commit."""
+    repo, baseline = _sandbox_style_repo(tmp_path)
+    head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    resolve = _shipped_resolver()
+
+    assert resolve(subprocess, str(repo), head) == head
+    assert head != baseline
+
+
+def test_a_repo_without_a_sandbox_baseline_resolves_to_nothing(tmp_path):
+    """A preserved .git carries no baseline commit of ours. Inventing one
+    would diff against an unrelated commit; "" restores the old behaviour,
+    which is the whole-repo gate -- slow, but not wrong."""
+    repo = tmp_path / "plain"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "someone@invalid")
+    _git(repo, "config", "user.name", "Someone")
+    (repo / "f.py").write_text("x = 1\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "ordinary history")
+    resolve = _shipped_resolver()
+
+    assert resolve(subprocess, str(repo), "") == ""
+
+
+def test_a_git_failure_is_not_an_exception(tmp_path):
+    """The resolver runs at the head of verification. Raising here would
+    replace a reported gate result with an unreported crash."""
+    resolve = _shipped_resolver()
+
+    assert resolve(subprocess, str(tmp_path / "does-not-exist"), "") == ""

--- a/tests/test_verifier_verdict.py
+++ b/tests/test_verifier_verdict.py
@@ -20,6 +20,17 @@ into "run everything", and a task that changed nothing was failed for it.
 
 Three workers reported the underlying fact unprompted across four canaries:
 the worktree HEAD is a squashed sandbox baseline commit, not the declared base.
+
+WHAT CHANGED SINCE
+
+Clearing the base prevented the bogus SHA from reaching the selector, but an
+empty base IS mode=full, so the escalation this module describes kept
+happening on every task. The base is now resolved to the sandbox's own
+baseline commit -- the same pre-task state, under a name this repository can
+resolve. tests/test_sandbox_baseline.py pins that behaviourally, against a
+real git repository, so the assertion that used to live here (that the script
+contains `_repo_base_sha = ""`) has been retired rather than rewritten: it
+pinned the implementation of a fix that has been superseded.
 """
 
 from __future__ import annotations
@@ -31,19 +42,6 @@ def _script() -> str:
     return _sandbox_repository_verification_shell(
         {"MAC_TASK_WORKSPACE": "/workspace/repo", "MAC_REPO_TEST_COMMAND": "scripts/run-contract-tests.sh"}
     )
-
-
-def test_an_unresolvable_base_is_not_passed_to_the_selector():
-    """Otherwise the selector fails, answers `full`, and the gate escalates to
-    the entire suite -- the slowest possible answer and, without Postgres in
-    the sandbox, a guaranteed failure."""
-    script = _script()
-
-    assert "cat-file" in script
-    assert "^{commit}" in script
-    # The escalation is what must be prevented, so the guard has to clear the
-    # base rather than merely warn about it.
-    assert '_repo_base_sha = ""' in script
 
 
 def test_an_unchanged_worktree_skips_the_gate():


### PR DESCRIPTION
Every code task ran the whole-repo contract gate, however small its diff. The selector was not at fault: **the base SHA never resolved inside the sandbox**, so the impact-scoped path could not be reached at all.

The sandbox replaces the uploaded `.git` (the host worktree's is a pointer into a host-only directory, and its credentials must not be copied in) with `git init` plus its own `MAC OpenShell sandbox baseline` commit. That commit's SHA is newly generated, so it can never equal the host's base SHA. `cat-file -e` missed every time, the base was cleared, and `run-sanity-tests.sh` answers an empty base with `mode=full`.

The code already carried a comment saying the host SHA *"usually DOES NOT EXIST here"* — and then cleared the base anyway, which is exactly the escalation the comment describes.

That is not merely slow. The whole-repo gate's parallel bulk phase dies inside a sandbox (`task_2a28e4a9`), so the escalation converted every code task into a **guaranteed** verification failure — work done correctly, then discarded at the gate. Four canaries in a row failed this way, with `repository verifier exited with status 3`.

The sandbox's own baseline commit *is* the pre-task state — it is precisely what was uploaded. Name it by the message we wrote, which no other commit carries. A preserved `.git` has no such commit and still resolves to `""`, which is the previous behaviour and the safe one.

**On the tests:** the resolver is fenced by sentinel comments and the test extracts it from the generated sandbox script, so shipped source and tested source cannot drift. Verified the test catches the bug: reverting the fallback fails `test_an_absent_host_base_falls_back_to_the_sandbox_baseline` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)