### PR TITLE
Make new admin surface justify itself

### DIFF
--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -969,3 +969,36 @@ def install(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     install_admin_help(parser)
     install_top_level_help(parser)
     return parser
+
+
+
+# ---------------------------------------------------------------------------
+# Completeness of the `admin` catalogue
+#
+# COMMAND_GROUPS already carries a one-line description for every command, and
+# a test rejects entries naming commands that do not exist. Only that
+# direction was checked. The reverse -- a NEW `admin` group that nobody
+# catalogued -- passed silently, which is how the operational surface grew to
+# 53 groups and roughly 245 leaves, about two thirds of the CLI, while the
+# object model above it stayed at six deliberate commands.
+# ---------------------------------------------------------------------------
+
+
+def admin_group_names(parser: argparse.ArgumentParser) -> Tuple[str, ...]:
+    """Return each distinct `mac admin` group once, under its registered name.
+
+    Aliases share a parser object, so `comm` is not a second group; counting
+    it as one would demand a second catalogue entry for one surface, and the
+    next reader would "fix" that duplication by deleting a working alias.
+    """
+
+    root = _subparsers_of(parser)
+    if root is None or "admin" not in root.choices:
+        return ()
+    admin = _subparsers_of(root.choices["admin"])
+    if admin is None:
+        return ()
+    first_name_for: Dict[int, str] = {}
+    for name, sub in admin.choices.items():
+        first_name_for.setdefault(id(sub), name)
+    return tuple(first_name_for.values())

--- a/tests/cli/test_admin_surface_is_governed.py
+++ b/tests/cli/test_admin_surface_is_governed.py
@@ -1,0 +1,62 @@
+"""`mac admin` must justify itself the way the top level already does.
+
+The object-model layer collapsed 55 top-level commands to six, and five test
+modules keep them that way. But that layer was deliberately additive --
+"nothing is renamed and nothing is removed" -- so the operational surface did
+not shrink, it moved. `mac admin` now carries 53 groups and roughly 245 leaf
+commands: about two thirds of the whole CLI.
+
+COMMAND_GROUPS already describes every command in one line, and
+test_every_grouped_command_actually_exists rejects a catalogue entry naming a
+command that is gone. Only that direction was ever checked. The reverse -- a
+NEW `admin` group that nobody catalogued -- passed silently, which is how the
+surface grew unremarked while the object model above it stayed at six
+deliberate commands.
+
+This does not judge whether a group deserves to exist; that is a product
+decision. It makes the decision visible: adding operational surface now costs
+one line saying what it is for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.cli import build_parser
+from mac.cli_surface import admin_group_names, command_descriptions
+
+# `help` is installed by the surface layer at every level rather than
+# registered as a group, so it has no catalogue entry of its own and needs
+# none -- its purpose is the same wherever it appears.
+_INSTALLED_BY_THE_SURFACE_LAYER = {"help"}
+
+
+@pytest.fixture(scope="module")
+def parser():
+    return build_parser()
+
+
+def test_every_admin_group_is_catalogued(parser):
+    """An uncatalogued group is surface nobody has said the purpose of. It is
+    also invisible in `mac admin --help`, which renders from the catalogue --
+    so it is reachable, undocumented, and unmentioned."""
+    groups = set(admin_group_names(parser)) - _INSTALLED_BY_THE_SURFACE_LAYER
+
+    uncatalogued = sorted(groups - set(command_descriptions()))
+
+    assert not uncatalogued, (
+        "these `mac admin` groups exist but COMMAND_GROUPS does not describe "
+        "them: %s\nAdd a one-line description in src/mac/cli_surface.py, or "
+        "remove the group." % ", ".join(uncatalogued)
+    )
+
+
+def test_an_alias_is_not_counted_as_a_second_group(parser):
+    """`comm` and `communication` share one parser object. Counting both would
+    demand two catalogue entries for one surface, and the next reader would
+    "fix" the duplication by deleting a working alias."""
+    groups = admin_group_names(parser)
+
+    assert "communication" in groups
+    assert "comm" not in groups
+    assert len(groups) == len(set(groups))


### PR DESCRIPTION
`mac` looks clean at the top — six commands, five test modules keeping it that way. Underneath, `mac admin` carries **53 groups and ~245 leaf commands: about two thirds of the entire CLI.**

That happened because the object-model cleanup was deliberately additive — its own docstring says *"nothing is renamed and nothing is removed"* — so the operational surface did not shrink, it moved.

`COMMAND_GROUPS` already describes every command in one line, and `test_every_grouped_command_actually_exists` rejects an entry naming a command that is gone. **Only that direction was ever checked.** A new `admin` group that nobody catalogued passed silently — and since `mac admin --help` renders *from* the catalogue, such a group is reachable, undescribed, and unmentioned anywhere.

This adds the other direction. It does not judge whether a group deserves to exist (a product decision); it makes the decision visible, at a cost of one line saying what the group is for.

**Aliases are counted once.** `comm` and `communication` share a parser object, so demanding an entry for each would describe one surface twice and invite the next reader to "fix" the duplication by deleting a working alias.

**Verified it catches the bug:** adding an uncatalogued group to the parser fails the test and names it. Measured while writing: 53 groups, 52 catalogued, `help` excluded because the surface layer installs it at every level rather than registering it.

Two findings from the same survey are *not* in this PR, because they are yours to call:

- six groups (`artifact`, `command-audit`, `env`, `interaction`, `mood`, `plan`) have **no test touching their handlers** and no mention in docs, tests, scripts, deploy or skills
- the generated CLI reference renders only the six top-level helps, so no `admin` group is documented there at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)