### PR TITLE
Select on the work the task actually did, not on its commits

### DIFF
--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -563,12 +563,51 @@ def _resolve_sha(ref: str | None, repo_root: Path) -> str | None:
     return sha if result.returncode == 0 and sha else None
 
 
+def _nothing_is_committed_on_top(base: str | None, repo_root: Path) -> bool:
+    """True when HEAD is the base itself, so a commit-range diff is empty.
+
+    This is the ordinary state of a task sandbox. The agent is given a
+    worktree whose `.git` was rebuilt by `git init` plus a single baseline
+    commit, and it does its work in the working tree without committing --
+    the host finalizer is what commits and publishes. So HEAD IS the base,
+    `base...HEAD` is empty, and the selector concluded that the task changed
+    nothing and therefore everything had to run.
+    """
+
+    if not base:
+        return False
+    head = _git(["rev-parse", "--verify", "HEAD^{commit}"], repo_root)
+    resolved = _resolve_sha(base, repo_root)
+    return (
+        head.returncode == 0
+        and resolved is not None
+        and head.stdout.strip() == resolved
+    )
+
+
 def git_changed_files(base: str | None, repo_root: Path) -> list[str]:
     rng = f"{base}...HEAD" if base else "HEAD"
     result = _git(["diff", "--name-only", rng], repo_root)
     if result.returncode != 0:
         raise RuntimeError((result.stdout + result.stderr).strip())
-    return sorted({line.strip() for line in result.stdout.splitlines() if line.strip()})
+    changed = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    if not changed and _nothing_is_committed_on_top(base, repo_root):
+        # Compare the base to what is actually on disk. Two-dot against the
+        # working tree, plus untracked files, because a task that ADDS a test
+        # leaves it untracked and `git diff` alone would not see it.
+        worktree = _git(["diff", "--name-only", base], repo_root)
+        if worktree.returncode == 0:
+            changed |= {
+                line.strip() for line in worktree.stdout.splitlines() if line.strip()
+            }
+        untracked = _git(
+            ["ls-files", "--others", "--exclude-standard"], repo_root
+        )
+        if untracked.returncode == 0:
+            changed |= {
+                line.strip() for line in untracked.stdout.splitlines() if line.strip()
+            }
+    return sorted(changed)
 
 
 def changed_base_lines(
@@ -581,6 +620,11 @@ def changed_base_lines(
     records their insertion POINTS so the resolver can charge them to the scope
     they land in rather than to the whole file."""
     rng = f"{base}...HEAD" if base else "HEAD"
+    if base and _nothing_is_committed_on_top(base, repo_root):
+        # Same reason as git_changed_files: the work is in the working tree,
+        # so a commit-range diff reports no lines and every changed file
+        # falls back to whole-file charging.
+        rng = base
     result = _git(
         ["diff", "-U0", "--no-color", "--no-ext-diff", rng], repo_root
     )

--- a/tests/test_resolve_impacted_tests.py
+++ b/tests/test_resolve_impacted_tests.py
@@ -567,3 +567,87 @@ def test_a_known_line_is_still_answered_by_line(repo, policy, impact_map, monkey
 
     assert "tests/test_foo.py::test_a" in result["tests"]
     assert "tests/test_foo.py::test_b" not in result["tests"]
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    )
+
+
+def _sandbox_shaped_repo(tmp_path: Path) -> tuple[Path, str]:
+    """A worktree shaped the way a task sandbox shapes one.
+
+    `git init`, one baseline commit, and the agent's work left UNCOMMITTED --
+    which is the real arrangement: the host finalizer is what commits, so
+    inside the sandbox HEAD is the baseline itself.
+    """
+    repo = tmp_path / "sandbox"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "mac-sandbox@invalid")
+    _git(repo, "config", "user.name", "MAC OpenShell sandbox")
+    (repo / "src").mkdir()
+    (repo / "tests").mkdir()
+    (repo / "src" / "thing.py").write_text("value = 1\n", encoding="utf-8")
+    (repo / "tests" / "test_thing.py").write_text("def test_a():\n    pass\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "MAC OpenShell sandbox baseline")
+    baseline = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    return repo, baseline
+
+
+def test_uncommitted_work_is_still_this_task_s_changes(tmp_path: Path):
+    """The live failure: every task selected `full` because its diff looked
+    empty.
+
+    `base...HEAD` compares COMMITS. In a sandbox the agent's work is in the
+    working tree and HEAD is the base, so the range is empty, the selector
+    reports no changed files, and the gate escalates to the whole repository --
+    which then dies in its parallel phase. The task's work is real; only the
+    range was wrong.
+    """
+    repo, baseline = _sandbox_shaped_repo(tmp_path)
+    (repo / "tests" / "test_thing.py").write_text(
+        "def test_a():\n    pass\n\n\ndef test_b():\n    pass\n", encoding="utf-8"
+    )
+
+    assert R.git_changed_files(baseline, repo) == ["tests/test_thing.py"]
+
+
+def test_an_added_file_counts_even_though_it_is_untracked(tmp_path: Path):
+    """A task told to ADD a test leaves it untracked, and `git diff` alone
+    never mentions it -- so the selection would silently omit the very file
+    the task exists to create."""
+    repo, baseline = _sandbox_shaped_repo(tmp_path)
+    (repo / "tests" / "test_new.py").write_text("def test_c():\n    pass\n", encoding="utf-8")
+
+    assert R.git_changed_files(baseline, repo) == ["tests/test_new.py"]
+
+
+def test_committed_work_still_wins(tmp_path: Path):
+    """CI commits before it selects. The working-tree fallback must not
+    displace the commit range there, or an unrelated dirty file on a developer's
+    machine would widen the selection."""
+    repo, baseline = _sandbox_shaped_repo(tmp_path)
+    (repo / "src" / "thing.py").write_text("value = 2\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "the agent's work")
+    (repo / "tests" / "test_thing.py").write_text("def test_z():\n    pass\n", encoding="utf-8")
+
+    assert R.git_changed_files(baseline, repo) == ["src/thing.py"]
+
+
+def test_changed_lines_are_charged_for_uncommitted_work(tmp_path: Path):
+    """Without the same range fix, every changed file resolves with no line
+    information and is charged whole-file -- which selects far more than the
+    diff touched, for exactly the tasks the impact path exists to keep small."""
+    repo, baseline = _sandbox_shaped_repo(tmp_path)
+    (repo / "src" / "thing.py").write_text("value = 1\nextra = 2\n", encoding="utf-8")
+
+    lines, additions = R.changed_base_lines(baseline, repo)
+
+    assert lines or additions


### PR DESCRIPTION
With the base finally resolvable (#345), the impact path ran for the first time — and answered `full (no_changed_file_scope)`: **the selector believed the task had changed nothing.**

It compares `base...HEAD`, a *commit* range. Inside a task sandbox the agent works in the working tree and does not commit — the host finalizer commits and publishes. So `HEAD` **is** the base, the range is empty, and a task that rewrote a file looks identical to one that touched nothing. The gate then escalates to the whole repository and dies in its parallel phase (`task_2a28e4a9`).

When nothing is committed on top of the base, compare the base to what is on disk. **Untracked files are included deliberately:** a task told to ADD a test leaves it untracked, and `git diff` alone would never mention the one file the task exists to create.

The fallback is conditional on HEAD being the base, so CI — which commits before selecting — keeps the commit range exactly as before, and an unrelated dirty file on a developer's machine cannot widen a selection.

`changed_base_lines()` takes the same range, or every changed file resolves with no line information and is charged whole-file — the over-selection the impact path exists to prevent.

**Verified against a sandbox-shaped repository** (init, one baseline commit, work left uncommitted). Reverting the fallback fails `test_uncommitted_work_is_still_this_task_s_changes` and `test_an_added_file_counts_even_though_it_is_untracked`, and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)