### PR TITLE
Say why a hub review rejected, and survive a server it did not start

### DIFF
--- a/scripts/start-test-postgres.sh
+++ b/scripts/start-test-postgres.sh
@@ -108,6 +108,35 @@ if [ -n "$PGBIN" ]; then
       exit 1
     fi
   fi
+  # A data directory that survived an earlier run in the same environment is
+  # the common case wherever TMPDIR persists -- a reused sandbox, a developer's
+  # second invocation. Two states have to be told apart, because they lead
+  # opposite ways:
+  #
+  #   already running -> use it, and say nothing
+  #   stopped, but holding a postmaster.pid naming a PID that is gone ->
+  #       pg_ctl refuses to start ("lock file postmaster.pid already exists"),
+  #       and the whole gate then fails for want of a database that is sitting
+  #       right there
+  #
+  # Observed live inside a hub verification sandbox: the second run in one
+  # sandbox failed with exactly that, and the failure surfaced as hundreds of
+  # unrelated test errors.
+  if "$PGBIN/pg_ctl" -D "$DATADIR" status >/dev/null 2>&1; then
+    # A server is attached to this directory. If it answers on the port we are
+    # about to advertise, it IS the answer.
+    if command -v pg_isready >/dev/null 2>&1 \
+        && pg_isready -h 127.0.0.1 -p "$PORT" >/dev/null 2>&1; then
+      "$PGBIN/createdb" -h 127.0.0.1 -p "$PORT" "$DB" 2>/dev/null || true
+      emit "postgresql://$(id -un)@127.0.0.1:$PORT/$DB"
+      exit 0
+    fi
+    # Running, but not reachable at 127.0.0.1:$PORT -- a server started with
+    # different options (socket-only is the one seen live) answers nothing we
+    # can hand to the suite, while still holding the lock that stops us
+    # starting our own. Stop it and start one we can describe.
+    "$PGBIN/pg_ctl" -D "$DATADIR" -m fast stop >/dev/null 2>&1 || true
+  fi
   # -w waits for readiness, so returning success means the emitted DSN resolves.
   if ! start_log=$("$PGBIN/pg_ctl" -D "$DATADIR" -l "$LOGFILE" -w -t 60 start \
       -o "-p $PORT -c listen_addresses=127.0.0.1 -c unix_socket_directories=$DATADIR -c max_locks_per_transaction=$LOCKS -c max_connections=$CONNS" 2>&1); then

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -979,6 +979,32 @@ REPOSITORY_CONTRACT_FILES = (
     Path(".mac") / "project.yaml",
     Path(".mac") / "project.yml",
 )
+
+def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 1500) -> str:
+    """Keep the head AND the tail of a rejected verification's output.
+
+    The tail alone was kept, and the tail of a pytest run is its summary line:
+    "36 failed, 84 passed, 588 errors". That says the gate failed, which the
+    verdict already said. WHY it failed is announced once, at the top -- an
+    unprovisionable database, a bootstrap that never finished, a collection
+    error -- and 500 characters of tail cannot reach it.
+
+    Diagnosing one such rejection took a hub-side archaeology session that
+    ended in the evidence being gone: the sandbox that produced it had been
+    cleaned up, and nothing else recorded the run.
+    """
+
+    text = (output or "").strip()
+    if len(text) <= head + tail:
+        return text
+    omitted = len(text) - head - tail
+    return "%s\n... [%d chars omitted] ...\n%s" % (
+        text[:head],
+        omitted,
+        text[-tail:],
+    )
+
+
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
 #: Marker recorded on a task that was approved but has no publication
 #: destination, so the task itself says why it is sitting in REVIEWING instead
@@ -28438,7 +28464,9 @@ class ControlPlane:
         if isinstance(exec_codegraph, dict) and exec_codegraph:
             manifest["codegraph"] = exec_codegraph
         if verdict == "rejected":
-            manifest["feedback"] = "hub contract verification failed: %s" % (output[-500:] or "nonzero exit")
+            manifest["feedback"] = "hub contract verification failed: %s" % (
+                _hub_review_failure_excerpt(output) or "nonzero exit"
+            )
         manifest["signature"] = sign_verification_manifest(key, manifest)
         evidence = self.add_evidence(
             task.id,

--- a/tests/test_start_test_postgres_stale_lock.py
+++ b/tests/test_start_test_postgres_stale_lock.py
@@ -1,0 +1,141 @@
+"""A data directory left behind must not cost the whole gate.
+
+scripts/start-test-postgres.sh can start a server from installed binaries when
+nothing else is available, which is what a task sandbox has. That path assumed
+a clean slate: if the data directory already existed it went straight to
+`pg_ctl start`, and pg_ctl refuses to start over a postmaster.pid naming a PID
+that is gone --
+
+    FATAL: lock file "postmaster.pid" already exists
+    HINT:  Is another postmaster (PID 84) running in data directory ...?
+
+-- so the helper exited 1, the gate ran with no MAC_TEST_PG_URL, and the
+failure surfaced as hundreds of unrelated test errors with the real cause
+hundreds of lines above them. Observed live in a hub verification sandbox on
+its second run.
+
+Directories survive wherever TMPDIR does: a reused sandbox, a developer's
+second invocation, a CI job with a warm workspace.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import shutil
+import socket
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "start-test-postgres.sh"
+
+
+def _pg_bin() -> Path | None:
+    """Locate server binaries the way the script does."""
+    candidates = []
+    found = shutil.which("pg_ctl")
+    if found:
+        candidates.append(Path(found))
+    candidates += [Path(p) for p in sorted(glob.glob("/usr/lib/postgresql/*/bin/pg_ctl"))]
+    candidates.append(Path("/usr/local/pgsql/bin/pg_ctl"))
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            if (candidate.parent / "initdb").is_file():
+                return candidate.parent
+    return None
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+pytestmark = pytest.mark.skipif(
+    _pg_bin() is None,
+    reason="no PostgreSQL server binaries; the binary-start path is unreachable here",
+)
+
+
+
+@pytest.fixture()
+def short_tmp():
+    """A short temp dir: a unix socket path is capped near 104 bytes, and
+    pytest's tmp_path on macOS is deeper than that all by itself."""
+    import tempfile
+
+    path = Path(tempfile.mkdtemp(prefix="/tmp/macpg-"))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def test_a_socket_only_server_does_not_cost_the_gate_its_database(short_tmp):
+    """The live failure, exactly.
+
+    A previous run in the same environment left a server attached to the data
+    directory that listens on its unix socket but NOT on the TCP port the
+    suite is told to use. `pg_isready -h 127.0.0.1` therefore fails, so the
+    "already listening" branch does not fire -- and the server still holds the
+    lock, so starting our own dies with:
+
+        FATAL: lock file "postmaster.pid" already exists
+
+    The helper exits 1, the gate runs with no MAC_TEST_PG_URL, and hundreds of
+    database-backed tests error with the real cause far above them.
+    """
+    pg_bin = _pg_bin()
+    assert pg_bin is not None
+    tmp_path = short_tmp
+    datadir = tmp_path / "pgdata"
+    port = _free_port()
+
+    initdb = subprocess.run(
+        [str(pg_bin / "initdb"), "-D", str(datadir), "-U", os.environ.get("USER") or "postgres",
+         "--auth=trust"],
+        capture_output=True, text=True,
+    )
+    assert initdb.returncode == 0, initdb.stderr
+
+    # Socket-only: no listen_addresses, so nothing answers on the TCP port.
+    started = subprocess.run(
+        [str(pg_bin / "pg_ctl"), "-D", str(datadir), "-l", str(tmp_path / "pg.log"),
+         "-w", "-t", "60", "start",
+         "-o", "-p %d -c listen_addresses= -c unix_socket_directories=%s" % (port, datadir)],
+        capture_output=True, text=True,
+    )
+    assert started.returncode == 0, started.stderr + (tmp_path / "pg.log").read_text()
+
+    # Hide any container engine: this test is about the binary-start path,
+    # which only runs where nothing else can serve. A PATH carrying just the
+    # postgres binaries and the base system tools is exactly a task sandbox.
+    env = {
+        **os.environ,
+        "PATH": "%s:/usr/bin:/bin" % pg_bin,
+        "MAC_TEST_PG_DATADIR": str(datadir),
+        "MAC_TEST_PG_PORT": str(port),
+        "MAC_TEST_PG_DB": "mac_socket_only_probe",
+    }
+    env.pop("MAC_TEST_PG_URL", None)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)], capture_output=True, text=True, env=env, timeout=180
+    )
+    try:
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "export MAC_TEST_PG_URL=" in result.stdout
+        # And the DSN has to actually answer, which is the whole point.
+        ready = subprocess.run(
+            [str(pg_bin / "pg_isready"), "-h", "127.0.0.1", "-p", str(port)],
+            capture_output=True, text=True,
+        )
+        assert ready.returncode == 0, ready.stdout + ready.stderr
+    finally:
+        subprocess.run(
+            [str(pg_bin / "pg_ctl"), "-D", str(datadir), "-m", "immediate", "stop"],
+            capture_output=True, text=True,
+        )

--- a/tests/test_start_test_postgres_stale_lock.py
+++ b/tests/test_start_test_postgres_stale_lock.py
@@ -74,7 +74,7 @@ def short_tmp():
         shutil.rmtree(path, ignore_errors=True)
 
 
-def test_a_socket_only_server_does_not_cost_the_gate_its_database(short_tmp):
+def test_a_socket_only_server_does_not_cost_the_gate_its_database(short_tmp, tmp_path):
     """The live failure, exactly.
 
     A previous run in the same environment left a server attached to the data
@@ -110,12 +110,20 @@ def test_a_socket_only_server_does_not_cost_the_gate_its_database(short_tmp):
     )
     assert started.returncode == 0, started.stderr + (tmp_path / "pg.log").read_text()
 
-    # Hide any container engine: this test is about the binary-start path,
-    # which only runs where nothing else can serve. A PATH carrying just the
-    # postgres binaries and the base system tools is exactly a task sandbox.
+    # Force the binary-start path, which is the code under test and only runs
+    # where nothing else can serve. Dropping the engine from PATH is not enough
+    # -- GitHub runners keep docker in /usr/bin alongside everything the script
+    # needs -- so shadow it with shims that fail, which is what `docker info`
+    # does on a machine with no daemon.
+    shims = tmp_path / "shims"
+    shims.mkdir()
+    for engine in ("docker", "podman"):
+        shim = shims / engine
+        shim.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        shim.chmod(0o755)
     env = {
         **os.environ,
-        "PATH": "%s:/usr/bin:/bin" % pg_bin,
+        "PATH": "%s:%s:/usr/bin:/bin" % (shims, pg_bin),
         "MAC_TEST_PG_DATADIR": str(datadir),
         "MAC_TEST_PG_PORT": str(port),
         "MAC_TEST_PG_DB": "mac_socket_only_probe",


### PR DESCRIPTION
Two faults, one story: a review rejected a task **whose gate had passed**, and the reason could not be recovered afterwards.

### What the hub said

```
hub contract verification failed: ... 36 failed, 84 passed, 588 errors in 28.84s
```

That is the *tail* of the output, because the tail is all that was kept (`output[-500:]`). The tail of a pytest run is its summary line, which restates the verdict. **Why** it failed is announced once, at the top. Chasing one such rejection ended with the evidence gone — the sandbox that produced it had been cleaned up, and nothing else recorded the run. So: keep the head as well as the tail.

### What actually broke

A server left attached to the data directory by an earlier run in the same environment, listening on its unix socket but **not** on the TCP port the suite is told to use. `pg_isready -h 127.0.0.1` fails, so the "already listening" branch does not fire — and that server still holds the lock, so starting our own dies with `lock file "postmaster.pid" already exists`. The helper exits 1, the gate runs with no `MAC_TEST_PG_URL`, and hundreds of database-backed tests error with the real cause far above them.

Now: ask `pg_ctl` whether a server is attached. If it answers where we are about to advertise it, use it. If it is attached but unreachable there, stop it and start one we can describe. **Proven in the sandbox that failed** — the same invocation that exited 1 now exits 0 with a working DSN.

### On the test

It hides any container engine, because the binary-start path only runs where nothing else can serve — which is exactly a task sandbox. It also uses a short temp directory: a unix socket path is capped near 104 bytes and pytest's `tmp_path` on macOS exceeds that unaided. Removing the recovery fails it.

Found while debugging, filed separately rather than fixed here: the container branch reuses an existing `mac-test-postgres` container **regardless of which port it publishes**, so a run with a non-default `MAC_TEST_PG_PORT` gets a DSN nothing answers on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)