### PR TITLE
Keep the git credential out of argv on the publish path too

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -21825,7 +21825,12 @@ class ControlPlane:
         # Authentication normalization remains centralized in gitops.  Each
         # attempt clones the remote again so neither a failed merge nor a lost
         # optimistic-concurrency race can poison the following attempt.
-        auth_url = _gitops.inject_git_remote_auth(clone_url)
+        # Clean URL + credential in the child ENVIRONMENT. The URL form put the
+        # whole token in argv, where `ps` exposed it to every user on the hub --
+        # the exposure askpass_remote_auth exists to prevent, and which its own
+        # docstring records as still live on "the hub publish and hub verify
+        # paths". Verify was fixed (#341); this is publish.
+        auth_url, auth_env = _gitops.askpass_remote_auth(clone_url)
         last_base_move: Optional[_PublicationBaseMovedError] = None
         for attempt in range(2):
             try:
@@ -21837,6 +21842,7 @@ class ControlPlane:
                     head_sha=head_sha,
                     clone_url=clone_url,
                     auth_url=auth_url,
+                    auth_env=auth_env,
                     canonical_branch=canonical_branch,
                     attempt=attempt + 1,
                 )
@@ -21863,6 +21869,7 @@ class ControlPlane:
         head_sha: str,
         clone_url: str,
         auth_url: str,
+        auth_env: Mapping[str, str],
         canonical_branch: str,
         attempt: int,
     ) -> JsonDict:
@@ -21883,6 +21890,7 @@ class ControlPlane:
                     ".",
                 ],
                 timeout=240,
+                env=auth_env,
             )
             commands.append(
                 {
@@ -21913,7 +21921,7 @@ class ControlPlane:
                 *,
                 check: bool = True,
             ) -> JsonDict:
-                result = self._git_output(root, args, timeout=timeout)
+                result = self._git_output(root, args, timeout=timeout, env=auth_env)
                 commands.append({"name": name, "args": args, **result})
                 if check and result["returncode"] != 0:
                     raise ValidationError(
@@ -24111,7 +24119,15 @@ class ControlPlane:
 
 
 
-    def _git_output(self, repo_path: Path, args: List[str], timeout: int = 20) -> JsonDict:
+    def _git_output(
+        self,
+        repo_path: Path,
+        args: List[str],
+        timeout: int = 20,
+        env: Optional[Mapping[str, str]] = None,
+    ) -> JsonDict:
+        # A credential belongs in this environment, never in `args`: args
+        # becomes argv, and argv is readable from `ps` by every user on the box.
         completed = subprocess.run(
             ["git", *args],
             cwd=str(repo_path),
@@ -24119,6 +24135,7 @@ class ControlPlane:
             text=True,
             timeout=timeout,
             check=False,
+            env={**os.environ, **env} if env else None,
         )
         return {
             "returncode": int(completed.returncode),

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -8459,7 +8459,7 @@ def test_git_publication_rebuilds_once_when_remote_main_moves(cp, tmp_path, monk
     pushes = 0
     concurrent_head = ""
 
-    def move_main_before_first_push(repo_path, args, timeout=20):
+    def move_main_before_first_push(repo_path, args, timeout=20, env=None):
         nonlocal pushes, concurrent_head
         if args and args[0] == "push" and any(
             str(arg).startswith("--force-with-lease=refs/heads/main:")

--- a/tests/test_token_not_in_argv.py
+++ b/tests/test_token_not_in_argv.py
@@ -79,20 +79,28 @@ def test_the_helper_degrades_rather_than_failing(monkeypatch):
     assert url.startswith("https://")
 
 
-def test_no_hub_git_invocation_interpolates_a_credential_into_argv():
-    """A source-level guard. The failure is invisible in review -- the call
-    looks ordinary, and only a live `ps` shows the token -- so the check has
-    to be mechanical."""
-    import re
+def test_the_hub_never_builds_a_credential_bearing_url():
+    """A source-level guard, because the failure is invisible in review: the
+    call looks ordinary and only a live `ps` shows the token.
+
+    The previous form of this test scanned for a literal `"git", "clone"`
+    argv list. The publish path builds `["clone", ...]` and lets its runner
+    prepend `git`, so the pattern sailed straight past the very call that had
+    been leaking -- observed live on the hub on 2026-08-13, two days after the
+    verify path was fixed:
+
+        git clone --no-tags --branch main -- https://x-access-token:<PAT>@...
+
+    So the rule is now about the credential, not about how the argv happens to
+    be spelled: the hub does not construct a URL with a credential in it at
+    all. askpass_remote_auth returns a clean URL plus the environment that
+    authenticates it, which is the only form that cannot reach argv.
+    """
 
     services = (Path(gitops.__file__).parent / "services.py").read_text(encoding="utf-8")
-    offenders = []
-    for match in re.finditer(r'"git",\s*"clone"[^\]]*\]', services, re.S):
-        block = match.group(0)
-        # auth_url from inject_git_remote_auth carries the credential; the
-        # askpass form is a clean URL and is fine.
-        if "inject_git_remote_auth" in services[: match.start()][-2000:]:
-            offenders.append(block[:80])
-    assert not offenders, (
-        "a git clone is being handed a credential-bearing URL: %s" % offenders
+
+    assert "inject_git_remote_auth" not in services, (
+        "services.py builds a credential-bearing URL; use "
+        "gitops.askpass_remote_auth, which returns a clean URL and the "
+        "environment that authenticates it"
     )


### PR DESCRIPTION
Observed live on the hub today, in `ps` readable by any user on the box:

```
git clone --no-tags --branch main -- https://x-access-token:<PAT>@github.com/...
```

That is the same exposure #341 fixed, on the path #341 did not cover. The docstring of `askpass_remote_auth` already names both: *"the hub publish and hub verify paths never used it."* Verify was fixed. Publish was not.

The credential now travels in the child environment and the URL stays clean. Every later step reaches the remote through `origin`, which the clean clone leaves credential-free, so the environment has to follow them too — otherwise the fix trades an exposed token for a broken push.

### Why the existing guard missed it

`test_no_hub_git_invocation_interpolates_a_credential_into_argv` scanned for a literal `"git", "clone"` argv list. The publish path builds `["clone", ...]` and lets its runner prepend `git`, so the pattern sailed straight past the one call that was leaking.

The rule is now about the credential rather than the spelling of the argv: **the hub does not construct a credential-bearing URL at all**. That is mechanically checkable and cannot be evaded by rearranging a list.

### Worth noting

The exposure was invisible in the audit trail: the recorded command entry uses the redacted `clone_url` while the executed argv used the authenticated one. The ledger looked clean the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)