### PR TITLE
Fail over to the other coding agent when a provider says no

### DIFF
--- a/src/mac/coding_agent.py
+++ b/src/mac/coding_agent.py
@@ -40,7 +40,7 @@ import re
 import shlex
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 
 __all__ = [
@@ -556,6 +556,7 @@ def resolve_coding_agent(
     which: Optional[Callable[[str], Optional[str]]] = None,
     accept: Optional[Callable[[CodingAgentChoice], bool]] = None,
     verify_all: bool = False,
+    exclude: Optional[Iterable[str]] = None,
 ) -> CodingAgentChoice:
     """Resolve which coding-agent CLI to prefer, or none (fail closed).
 
@@ -571,6 +572,13 @@ def resolve_coding_agent(
     working primary route cannot leave every fallback permanently unverified.
     An explicit :data:`FORCE_ENV` pin remains strict because it limits the
     candidate set to that one agent.
+
+    ``exclude`` drops agents from the candidate set outright. It exists for
+    failover: a route that just exhausted its credits or met a provider outage
+    mid-task is still perfectly "available" and would be re-selected on the
+    spot, so the caller that watched it fail has to be able to say "not that
+    one". An excluded pin degrades to no route rather than silently ignoring
+    the pin.
     """
     env = os.environ if env is None else env
     home = Path.home() if home is None else home
@@ -594,6 +602,13 @@ def resolve_coding_agent(
     candidates = (forced,) if forced in _DETECTORS else AGENT_PRIORITY
     if forced in _DETECTORS:
         rationale.append("%s pins selection to %s" % (FORCE_ENV, forced))
+    excluded = frozenset(str(name).strip().lower() for name in (exclude or ()) if name)
+    if excluded:
+        candidates = tuple(agent for agent in candidates if agent not in excluded)
+        rationale.append(
+            "excluding %s (failed this task); trying the remaining routes"
+            % ", ".join(sorted(excluded))
+        )
 
     selected: Optional[CodingAgentChoice] = None
     for agent in candidates:

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -66,7 +66,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from mac import mac_paths
 from mac import relay_observability
@@ -4903,6 +4903,21 @@ def _classify_coding_agent_preflight_failure(returncode: int, output: str) -> st
         or "sandbox entered error phase" in text
     ):
         return "sandbox_unavailable"
+    # The subscription behind this route has nothing left to spend. Distinct
+    # from throttling: waiting does not help, and it is not a broken route
+    # either -- the binary, endpoint and credential are all correct. The only
+    # useful response is to run somewhere else, so it gets its own class rather
+    # than being folded into rate limiting or the opaque probe_failed.
+    if (
+        "credit balance" in text
+        or "insufficient_quota" in text
+        or "insufficient credit" in text
+        or "out of credit" in text
+        or "quota exceeded" in text
+        or "usage limit" in text
+        or "billing" in text and "limit" in text
+    ):
+        return "credit_exhausted"
     # Provider throttling. A 429 (or an explicit rate-limit message) is
     # transient: retry with backoff rather than treating the route as broken.
     if "429" in text or "rate limit" in text or "too many requests" in text:
@@ -5014,6 +5029,7 @@ def _coding_agent_binary_status(verified: bool, failure_class: str) -> str:
         return "missing"
     if failure_class in {
         "authentication_failed",
+        "credit_exhausted",
         "endpoint_protocol_mismatch",
         "endpoint_unreachable",
         "provider_server_error",
@@ -5273,7 +5289,15 @@ def _coding_agent_sandbox_ok(choice: Any) -> bool:
     return bool(coding_agent_sandbox_verification(choice).get("verified"))
 
 
-def _agent_argv(prompt: str, workspace: Path, *, confined: bool, task: Any = None) -> List[str]:
+def _agent_argv(
+    prompt: str,
+    workspace: Path,
+    *,
+    confined: bool,
+    task: Any = None,
+    exclude: Optional[Iterable[str]] = None,
+    chosen: Optional[Dict[str, str]] = None,
+) -> List[str]:
     """Pick the agent runner: a coding-agent CLI when one is available + authed
     (and — when OpenShell-confined — verified to actually work inside the sandbox),
     otherwise return a deterministic fail-closed command.
@@ -5309,7 +5333,13 @@ def _agent_argv(prompt: str, workspace: Path, *, confined: bool, task: Any = Non
     choice = _ca.resolve_coding_agent(
         which=coding_agent_sandbox_which if confined else None,
         accept=_accept_sandbox_route if confined else None,
+        exclude=exclude,
     )
+    if chosen is not None:
+        # The caller needs to know which route ran in order to exclude it if
+        # the provider refuses mid-task.
+        chosen["agent"] = choice.agent
+        chosen["fingerprint"] = choice.route_fingerprint()
     rationale = list(choice.rationale)
     if not choice.available:
         reason = (
@@ -5569,6 +5599,55 @@ def _invoke_acp_agent(
     return subprocess.CompletedProcess(argv_label, rc, "".join(text_chunks), stderr)
 
 
+
+#: Failure classes that mean "this route cannot do the work right now, but
+#: another one can". Credit exhaustion and provider outages are properties of
+#: the SUBSCRIPTION or the SERVICE, not of the task or the sandbox: the binary
+#: ran, reached its provider, and was refused. Retrying the same route is the
+#: one thing guaranteed not to help.
+_ROUTE_FAILOVER_CLASSES = frozenset(
+    {
+        "credit_exhausted",
+        "rate_limited",
+        "provider_server_error",
+        "authentication_failed",
+    }
+)
+
+
+def _forget_coding_agent_route(fingerprint: str) -> None:
+    """Drop a route's cached preflight proof.
+
+    A verified route is cached for five minutes. Without this, a route that
+    ran out of credits one minute after passing its preflight keeps being
+    selected for the next four -- every task in that window failing on a
+    provider that has already said no.
+    """
+
+    if not fingerprint:
+        return
+    with _SANDBOX_PREFLIGHT_CACHE_LOCK:
+        _SANDBOX_PREFLIGHT_CACHE.pop(fingerprint, None)
+
+
+def _route_failover_class(result: Any) -> str:
+    """Name the provider-level reason an agent run failed, if that is why.
+
+    Reuses the preflight classifier: the CLIs report an exhausted subscription
+    or a provider outage the same way whether they are probing or working.
+    """
+
+    returncode = int(getattr(result, "returncode", 0) or 0)
+    if returncode == 0:
+        return ""
+    text = "%s\n%s" % (
+        getattr(result, "stdout", "") or "",
+        getattr(result, "stderr", "") or "",
+    )
+    failure_class = _classify_coding_agent_preflight_failure(returncode, text)
+    return failure_class if failure_class in _ROUTE_FAILOVER_CLASSES else ""
+
+
 def _invoke_agent(
     runner: Callable[..., Any], prompt: str, workspace: Path, audit_id: Any, opts: dict
 ) -> Any:
@@ -5618,8 +5697,13 @@ def _invoke_agent(
     confined = (
         wrap or _openshell_required_for_local_agent()
     ) and break_glass_authorization is None
+    route: Dict[str, str] = {}
     agent_argv = _agent_argv(
-        PROMPT_SENTINEL, workspace, confined=confined, task=opts.get("task")
+        PROMPT_SENTINEL,
+        workspace,
+        confined=confined,
+        task=opts.get("task"),
+        chosen=route,
     )
     bundle = _write_agent_command_bundle(workspace, prompt, agent_argv)
     try:
@@ -5628,13 +5712,60 @@ def _invoke_agent(
                 _SANDBOX_WORKDIR,
                 _workspace_basename(workspace),
             )
-            return _run_sandboxed(
+            result = _run_sandboxed(
                 runner,
                 bundle.argv(sandbox_workspace=sandbox_workspace),
                 workspace,
                 audit_id,
                 opts,
             )
+            # Failover. A subscription that ran dry, or a provider that is
+            # down, refuses the run after the route passed its preflight --
+            # the proof was true when taken and is worthless now. Re-running
+            # the same route is the one thing certain not to work, and the
+            # task would otherwise burn an attempt on a provider that has
+            # already said no.
+            failover_class = _route_failover_class(result)
+            failed_agent = route.get("agent") or ""
+            if failover_class and failed_agent and not _manifest_is_complete(workspace):
+                _forget_coding_agent_route(route.get("fingerprint") or "")
+                sys.stderr.write(
+                    "[executor] coding-agent %s failed with %s; "
+                    "re-routing to the next configured agent\n"
+                    % (failed_agent, failover_class)
+                )
+                fallback_route: Dict[str, str] = {}
+                fallback_argv = _agent_argv(
+                    PROMPT_SENTINEL,
+                    workspace,
+                    confined=confined,
+                    task=opts.get("task"),
+                    exclude=(failed_agent,),
+                    chosen=fallback_route,
+                )
+                if fallback_route.get("agent"):
+                    bundle.cleanup()
+                    bundle = _write_agent_command_bundle(
+                        workspace, prompt, fallback_argv
+                    )
+                    _record_runner_choice(
+                        fallback_route["agent"],
+                        [
+                            "%s failed with %s" % (failed_agent, failover_class),
+                            "failing over to %s" % fallback_route["agent"],
+                        ],
+                        task_id=str((opts.get("task") or {}).get("id") or "")
+                        if isinstance(opts.get("task"), dict)
+                        else "",
+                    )
+                    result = _run_sandboxed(
+                        runner,
+                        bundle.argv(sandbox_workspace=sandbox_workspace),
+                        workspace,
+                        audit_id,
+                        opts,
+                    )
+            return result
         return runner(
             _unsandboxed_agent_argv(
                 bundle.argv(),

--- a/tests/test_coding_agent_failover.py
+++ b/tests/test_coding_agent_failover.py
@@ -1,0 +1,139 @@
+"""One coding agent running dry must not stop the fleet.
+
+Claude Code and Codex authenticate against a subscription. Subscriptions run
+out, and providers have outages. Both CLIs are installed in the task image and
+either can do the work, so a task should move to the other one rather than
+burn its attempts on a provider that has already said no.
+
+Selection-time failover already worked: resolve_coding_agent walks
+AGENT_PRIORITY and a route whose in-sandbox preflight fails is skipped. Two
+things were missing.
+
+  1. Credit exhaustion was not recognised AT ALL. The classifier knew about
+     429s and 5xx but not "credit balance too low" or "insufficient_quota", so
+     an exhausted subscription arrived as the opaque probe_failed -- a class
+     that reads like a broken route and steers nobody toward the working one.
+
+  2. There was no failover once a route had been chosen. A verified route is
+     cached for five minutes, so a subscription that ran dry one minute after
+     passing its preflight kept being selected for the next four, with every
+     task in that window failing on it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from mac import coding_agent as ca
+from mac import executor_sandbox as es
+
+
+class TestCreditExhaustionIsItsOwnAnswer:
+    """Waiting does not help and the route is not broken. Only "run somewhere
+    else" is useful, and a class nobody can act on is how that gets missed."""
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Your credit balance is too low to access the Anthropic API",
+            "429 insufficient_quota: You exceeded your current quota",
+            "You've hit your usage limit for this month",
+            "Error: quota exceeded for this organization",
+        ],
+    )
+    def test_an_exhausted_subscription_is_named(self, message):
+        assert (
+            es._classify_coding_agent_preflight_failure(1, message)
+            == "credit_exhausted"
+        )
+
+    def test_throttling_is_still_throttling(self):
+        """A 429 that is rate limiting, not exhaustion, must keep its own class:
+        the remedy is backoff on the same route, not moving to another one."""
+        assert (
+            es._classify_coding_agent_preflight_failure(1, "429 Too Many Requests")
+            == "rate_limited"
+        )
+
+    def test_the_binary_still_counts_as_present(self):
+        """The CLI ran and reached its provider. Reporting the executable as
+        missing would send an operator to rebuild an image that is fine."""
+        assert es._coding_agent_binary_status(False, "credit_exhausted") == "present"
+
+
+class TestTheResolverCanBeToldNotThatOne:
+    def test_an_excluded_agent_is_not_selected(self, monkeypatch):
+        """The caller that watched a route fail is the only one who knows. To
+        the resolver the route still looks perfectly available, so without this
+        it re-selects it immediately."""
+        seen = []
+
+        def _detector(env, home, which):
+            seen.append("called")
+            return True, "/usr/bin/stub", "stub", "stub: available"
+
+        monkeypatch.setitem(ca._DETECTORS, "claude", _detector)
+
+        choice = ca.resolve_coding_agent(
+            env={"PATH": "/usr/bin"}, which=lambda name: "/usr/bin/" + name,
+            exclude=("claude",),
+        )
+
+        assert choice.agent != "claude"
+
+    def test_excluding_everything_fails_closed(self):
+        """Better no route than a route the caller has just proven cannot work."""
+        choice = ca.resolve_coding_agent(
+            env={"PATH": "/usr/bin"},
+            which=lambda name: "/usr/bin/" + name,
+            exclude=ca.AGENT_PRIORITY,
+        )
+
+        assert not choice.available
+
+
+class TestAFailedRouteIsNotReused:
+    def test_the_cached_proof_is_dropped(self):
+        """A verified route is cached for five minutes. Keeping the proof after
+        the provider refuses means every task for the rest of that window picks
+        the same dead route."""
+        es._SANDBOX_PREFLIGHT_CACHE["route:probe"] = {"verified": True}
+
+        es._forget_coding_agent_route("route:probe")
+
+        assert "route:probe" not in es._SANDBOX_PREFLIGHT_CACHE
+
+    def test_forgetting_an_unknown_route_is_harmless(self):
+        """Runs on the failure path; raising there would replace a reported
+        provider failure with an unreported crash."""
+        es._forget_coding_agent_route("")
+        es._forget_coding_agent_route("route:never-seen")
+
+
+class TestOnlyProviderRefusalsFailOver:
+    def _result(self, returncode, text):
+        return subprocess.CompletedProcess([], returncode, text, "")
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "Your credit balance is too low",
+            "503 Service Unavailable",
+            "429 rate limit exceeded",
+        ],
+    )
+    def test_a_provider_refusal_asks_for_another_route(self, text):
+        assert es._route_failover_class(self._result(1, text))
+
+    def test_a_successful_run_asks_for_nothing(self):
+        assert es._route_failover_class(self._result(0, "")) == ""
+
+    def test_the_agents_own_failure_is_not_a_routing_problem(self):
+        """A task that failed on its merits must not be silently re-run on a
+        second provider: that doubles the cost and hides the real failure
+        behind a different agent's output."""
+        result = self._result(1, "AssertionError: expected 3, got 4")
+
+        assert es._route_failover_class(result) == ""

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -3520,7 +3520,7 @@ def test_main_runs_records_telemetry_and_memory(tmp_path, monkeypatch):
     monkeypatch.setattr(
         te,
         "_agent_argv",
-        lambda prompt, workspace, *, confined, task=None: [
+        lambda prompt, workspace, *, confined, task=None, exclude=None, chosen=None: [
             "test-coding-agent",
             te.PROMPT_SENTINEL,
         ],
@@ -3684,7 +3684,7 @@ def test_agent_argv_sandboxed_falls_through_failed_claude_to_codex(
     ]
     attempted = []
 
-    def resolve_for_test(*, accept=None, which=None):
+    def resolve_for_test(*, accept=None, which=None, exclude=None):
         assert accept is not None
         assert which is te.coding_agent_sandbox_which
         for candidate in choices:

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3543,7 +3543,7 @@ def test_worker_publishes_matching_sandbox_route_verification(
         "returncode": 0,
         "failure_class": "",
     }
-    def resolve_for_test(*, accept=None, which=None, verify_all=False):
+    def resolve_for_test(*, accept=None, which=None, verify_all=False, exclude=None):
         assert accept is not None
         assert which is task_executor.coding_agent_sandbox_which
         assert verify_all is True
@@ -3621,7 +3621,7 @@ def test_worker_falls_through_failed_claude_and_publishes_verified_codex(
     ]
     attempted = []
 
-    def resolve_for_test(*, accept=None, which=None, verify_all=False):
+    def resolve_for_test(*, accept=None, which=None, verify_all=False, exclude=None):
         assert accept is not None
         assert which is task_executor.coding_agent_sandbox_which
         assert verify_all is True


### PR DESCRIPTION
Claude Code and Codex both authenticate against a subscription, both are installed in the task image, and either can do the work. A subscription running out — or a provider outage — should move a task to the other one rather than burn its attempts on a provider that has already refused.

**Selection-time failover already worked**: `resolve_coding_agent` walks `AGENT_PRIORITY` and skips a route whose in-sandbox preflight fails. Two things were missing.

### 1. Credit exhaustion was not recognised at all

The classifier knew 429s and 5xx but not `credit balance is too low`, `insufficient_quota`, or `usage limit`. An exhausted subscription arrived as the opaque `probe_failed` — a class that reads like a *broken route* and steers nobody toward the working one.

It now has its own class, kept distinct from rate limiting because the remedies are opposites: **throttling wants backoff on the same route; exhaustion wants a different one.** The binary still reports as `present` — the CLI ran and reached its provider, and reporting it missing would send someone to rebuild an image that is fine.

### 2. There was no failover once a route was chosen

A verified route is cached for **five minutes**, so a subscription that ran dry a minute after passing its preflight kept being selected for the next four — every task in that window failing on it.

A provider refusal now drops the cached proof (it was true when taken and is worthless now), re-resolves with that agent excluded, and runs once on the other. The resolver gained `exclude` because the caller that watched a route fail is the only one who knows: to the resolver, that route still looks perfectly available and would be re-selected on the spot.

### Deliberately narrow

Failover fires only on provider refusals — `credit_exhausted`, `rate_limited`, `provider_server_error`, `authentication_failed`. A task that failed **on its merits** must not be silently re-run on a second provider: that doubles the cost and hides the real failure behind another agent's output. It also requires no completed evidence manifest, so work that finished before the provider quit is never redone.

Verified the tests catch the bug: removing the credit patterns fails 3 of them and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)