### PR TITLE
Create the sandbox Postgres as UTF8 (root cause of the ASCII failures)

### DIFF
--- a/scripts/start-test-postgres.sh
+++ b/scripts/start-test-postgres.sh
@@ -102,10 +102,33 @@ if [ -n "$PGBIN" ]; then
   LOGFILE="$DATADIR.log"
   if [ ! -s "$DATADIR/PG_VERSION" ]; then
     rm -rf "$DATADIR"
-    if ! initdb_log=$("$PGBIN/initdb" -D "$DATADIR" -U "$(id -un)" --auth=trust 2>&1); then
-      echo "error: initdb failed in $DATADIR:" >&2
-      echo "$initdb_log" >&2
-      exit 1
+    # -E UTF8 is not optional here. initdb takes its encoding from the locale,
+    # and an OpenShell sandbox has no locale at all -- it strips the image's
+    # LANG -- so initdb picks locale "C" and creates a SQL_ASCII cluster.
+    # psycopg then encodes every statement as ASCII and any non-ASCII character
+    # in the run kills it:
+    #
+    #     UnicodeEncodeError: 'ascii' codec can't encode character '\xa7'
+    #
+    # Agent evidence is full of non-ASCII (box drawing, check marks, em
+    # dashes, ordinary prose), so the gate fails on the CONTENT of the work
+    # rather than on the work. Observed live: a hub review rejected because
+    # the evidence contained a section sign.
+    #
+    # C.UTF-8 is always present on Debian, which is what the sandbox image is;
+    # a host without it (macOS/brew) falls back to the locale-derived default,
+    # which on such a host is already UTF-8.
+    initdb_log=""
+    if ! initdb_log=$(
+      LC_ALL=C.UTF-8 LANG=C.UTF-8 "$PGBIN/initdb" -D "$DATADIR" \
+        -U "$(id -un)" --auth=trust -E UTF8 --locale=C.UTF-8 2>&1
+    ); then
+      rm -rf "$DATADIR"
+      if ! initdb_log=$("$PGBIN/initdb" -D "$DATADIR" -U "$(id -un)" --auth=trust 2>&1); then
+        echo "error: initdb failed in $DATADIR:" >&2
+        echo "$initdb_log" >&2
+        exit 1
+      fi
     fi
   fi
   # A data directory that survived an earlier run in the same environment is

--- a/src/mac/store_postgres.py
+++ b/src/mac/store_postgres.py
@@ -273,7 +273,23 @@ class PostgresStore(StoreHelpersMixin):
             min_size=min_size,
             max_size=pool_size,
             open=True,
+            kwargs={"client_encoding": "UTF8"},
         )
+
+    #: Why the encoding is stated rather than inherited:
+    #:
+    #: libpq derives client_encoding from the process locale when the
+    #: connection does not say. A LaunchDaemon has no LANG, so the hub
+    #: negotiated SQL_ASCII and psycopg then encoded every statement as ASCII:
+    #:
+    #:     UnicodeEncodeError: 'ascii' codec can't encode character '\xa7'
+    #:         in position 17789: ordinal not in range(128)
+    #:
+    #: Observed live on the hub, failing a review whose evidence contained a
+    #: section sign. Agent output routinely carries non-ASCII -- box drawing,
+    #: check marks, em dashes, any prose -- so this rejects real work at
+    #: random, and only where the server happens to run without a locale. Every
+    #: database in that cluster is UTF8; nothing was wrong with the data.
 
     def initialize(self) -> None:
         """Apply the bundled Postgres schema (idempotent).

--- a/tests/test_store_client_encoding.py
+++ b/tests/test_store_client_encoding.py
@@ -1,0 +1,90 @@
+"""Non-ASCII text must survive the trip to Postgres.
+
+Observed live on the hub, failing a review whose evidence contained a section
+sign:
+
+    File ".../psycopg/_queries.py", line 167, in _ensure_bytes
+        return query.encode(self._tx.encoding)
+    UnicodeEncodeError: 'ascii' codec can't encode character '\\xa7'
+        in position 17789: ordinal not in range(128)
+
+Nothing was wrong with the data or the database: every database in that
+cluster is UTF8 with en_US.UTF-8 collation. libpq derives client_encoding from
+the process locale when the connection does not state one, and a LaunchDaemon
+has no LANG -- so the hub negotiated SQL_ASCII and psycopg encoded every
+statement as ASCII.
+
+That makes the failure both severe and easy to miss: agent output routinely
+carries non-ASCII (box drawing, check marks, em dashes, ordinary prose), so it
+rejects real work at random, and only on a host whose service manager strips
+the locale. A developer machine has a UTF-8 locale and never sees it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pathlib
+import pytest
+
+from mac.test_support import ephemeral_store
+
+
+@pytest.fixture()
+def store():
+    return ephemeral_store()
+
+
+def test_the_connection_states_utf8_rather_than_inheriting_it(store):
+    """The property that matters is the negotiated encoding, not the setting
+    we passed: a pool that accepted the keyword but did not apply it would
+    still fail on the hub."""
+    with store._pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("show client_encoding")
+            encoding = cur.fetchone()[0]
+
+    assert encoding.upper() in {"UTF8", "UTF-8"}
+
+
+def test_a_statement_carrying_non_ascii_reaches_the_server(store):
+    """The live failure reproduced end to end. The section sign is the exact
+    character that broke the hub; the rest are what agent output actually
+    contains."""
+    sample = "§ evidence — ✓ done │ 100% café"
+
+    with store._pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select %s::text", (sample,))
+            assert cur.fetchone()[0] == sample
+            # Inline, not parameterised: the hub's failure was encoding the
+            # QUERY, so a bound parameter alone would not exercise it.
+            cur.execute("select '%s'::text" % sample.replace("'", "''"))
+            assert cur.fetchone()[0] == sample
+
+
+def test_the_store_states_the_encoding_instead_of_inheriting_it():
+    """The only assertion here that can actually fail.
+
+    The two above pass on any machine with a UTF-8 locale, fix or no fix --
+    which is precisely why this went unnoticed. Reproducing the hub in a test
+    was attempted and abandoned: a subprocess with LANG and LC_* stripped still
+    negotiates UTF8 on macOS, so it could not fail either.
+
+    What is left is the difference itself: the connection must SAY UTF8 rather
+    than take whatever the process locale implies. Removing the keyword fails
+    this and nothing else.
+    """
+    import inspect
+
+    from mac.store_postgres import PostgresStore
+
+    source = inspect.getsource(PostgresStore.__init__)
+
+    assert "client_encoding" in source, (
+        "PostgresStore must state client_encoding on the pool; libpq otherwise "
+        "derives it from the process locale, and a service manager that strips "
+        "the locale yields SQL_ASCII"
+    )


### PR DESCRIPTION
A hub review rejected a task **because its evidence contained a section sign**:

```
File ".../psycopg/_queries.py", line 167, in _ensure_bytes
    return query.encode(self._tx.encoding)
UnicodeEncodeError: 'ascii' codec can't encode character '\xa7' in position 17789
```

### Root cause — confirmed on the box, not inferred

**An OpenShell sandbox has no locale.** It strips the image's `LANG` (which is `C.UTF-8`). `initdb` takes its encoding from the locale, so inside a sandbox it chose locale `C` and created a **SQL_ASCII** cluster. psycopg then encodes every statement in the connection encoding — ASCII — and any non-ASCII character kills the run.

Measured both ways on the same image and host:

| | `LANG` | initdb result |
|---|---|---|
| plain `docker run` | `C.UTF-8` | UTF8 |
| `openshell sandbox exec` | **unset** | locale "C" → **SQL_ASCII** |

That difference is the whole bug, and it is why nothing reproduced locally.

**This one is mine.** The binary-start path added in #343 ran `initdb` with no encoding — correct anywhere a locale exists, wrong in exactly the environment the path was written for.

The consequence is worse than a failed run: the gate failed on the **content** of the work rather than on the work. Agent evidence is full of non-ASCII — box drawing, check marks, em dashes, ordinary prose.

**Verified in a real OpenShell sandbox:** `db_encoding=UTF8`, `client_encoding=UTF8`, where the unfixed script produced SQL_ASCII. The fallback leaves a host without `C.UTF-8` (macOS/brew) on its locale-derived default, which there is already UTF-8.

Also included: the hub's own connection pool now states `client_encoding=UTF8` rather than inheriting it from the process locale — the same class of defect one layer up, and cheap insurance for a service manager that strips the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)