### PR TITLE
Pin the unowned-private-agent rejection with a regression test

### DIFF
--- a/tests/test_agent_ownership.py
+++ b/tests/test_agent_ownership.py
@@ -174,6 +174,19 @@ def test_an_unclaimed_private_agent_is_nobodys_capacity():
     assert AGENT_PRIVATE_TO_OTHER_OWNER in result.rejections
 
 
+def test_an_unclaimed_private_agent_refuses_an_unfiled_task_too():
+    """The empty-owner clause is what makes an unowned private agent
+    unclaimable, and this is the only pairing that needs it: every named filer
+    already differs from an absent owner. Drop the clause and an agent nobody
+    claimed compares equal to a task nobody filed, so the fleet's unowned
+    private hardware quietly becomes capacity for unattributed work."""
+    from mac.allocator import AGENT_PRIVATE_TO_OTHER_OWNER
+
+    result = _pair(visibility="private", owner=None, filer=None)
+
+    assert AGENT_PRIVATE_TO_OTHER_OWNER in result.rejections
+
+
 def test_the_refusal_is_authorization_not_a_capability_gap():
     """Capability gaps drive the 'become capable' machinery -- an agent that
     tried to LEARN its way past an ownership boundary would retry forever."""


### PR DESCRIPTION
**This is fleet work.** `task_de42aa6c`, executed by `agent_jordanh-worker6`, reviewed and **approved** by the fleet's review stage, with the repository contract gate passing inside the task sandbox.

It is being landed by an operator because auto-publish cannot run on the hub: the publication step re-runs the full contract gate on the projected merge inside an OpenShell sandbox, and `openshell sandbox create` does not return on the hub host (the container comes up; the CLI blocks). Ten `mac-hubverify-*` sandboxes are currently leaked there, several running 7-8 hours. That is filed separately; the reviewed work should not wait on it.

### On the change itself

The task asked for the case "private agent, owner unset, filer set". The agent pointed out that case is already covered — *"every named filer already differs from an absent owner"* — and pinned the pairing that actually needs the empty-owner clause: **owner absent and filer absent**, where the two would otherwise compare equal and an unowned private agent would become capacity for unattributed work.

That is a better test than the one requested.

**Verified independently before landing:** removing `not agent.owner_human_id or` from `evaluate_pair` fails exactly this test and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)