### PR TITLE
Let an approved task actually publish

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -21981,9 +21981,37 @@ class ControlPlane:
                 }
                 raise merge_gate_error
 
-            full_test_command = (
-                _repository_contract_test_command_for_task(task)
-                or "scripts/run-contract-tests.sh"
+            # Scope the projected gate the way the REVIEW verifier scopes its
+            # own, for the same reason and from the same helper.
+            #
+            # This ran the whole contract suite -- ~45 minutes -- under
+            # MAC_HUB_VERIFY_TIMEOUT, which defaults to 1200s. It could not
+            # finish, so no approved task could ever publish: it failed, retried
+            # ~1200s later, failed again, and the task sat in REVIEWING,
+            # approved and unpublished. Measured on task_de42aa6c: approved
+            # 19:36:51, publication failed 20:02:44 and again 20:23:43.
+            #
+            # The projected tree differs from the tree review already gated only
+            # by however far main moved, so the changed-file selection is the
+            # honest question to ask of it. An unresolvable diff falls back to
+            # the full command, exactly as the review helper does.
+            projected_changed: list[str] = []
+            try:
+                projected_diff = self._git_output(
+                    root,
+                    ["diff", "--name-only", "%s...%s" % (base_sha, head_sha)],
+                    timeout=60,
+                )
+                if int(projected_diff.get("returncode") or 1) == 0:
+                    projected_changed = [
+                        line.strip()
+                        for line in str(projected_diff.get("stdout") or "").splitlines()
+                        if line.strip()
+                    ]
+            except Exception:  # noqa: BLE001 - an unreadable diff means "run everything"
+                projected_changed = []
+            full_test_command = self._hub_review_test_command(
+                task, {"files_changed": projected_changed}
             )
             publication_test_runner = getattr(
                 self, "_publication_merge_test_runner", None
@@ -22004,9 +22032,8 @@ class ControlPlane:
             if not contract_gate.passed:
                 diagnosis = contract_gate.error or contract_gate.output_tail
                 raise ValidationError(
-                    "git publication full repository contract gate failed on the "
-                    "projected current-main merge: %s"
-                    % (diagnosis or "unknown failure")
+                    "git publication contract gate failed on the projected "
+                    "current-main merge: %s" % (diagnosis or "unknown failure")
                 )
 
             publication_mode = "fast_forward"
@@ -27975,7 +28002,12 @@ class ControlPlane:
         image = (os.environ.get("MAC_HUB_VERIFY_IMAGE") or "localhost/mac-hermes:net").strip()
         policy = (os.environ.get("MAC_OPENSHELL_POLICY") or "").strip()
         try:
-            timeout = float(os.environ.get("MAC_HUB_VERIFY_TIMEOUT", "1200"))
+            # 1200s could not cover even a scoped run once cloning, uploading
+            # and dependency bootstrap are counted: the scoped gate alone takes
+            # ~15 minutes on this repository. A cap the work cannot meet reads
+            # as a gate failure, which is how a timeout came to look like an
+            # OpenShell fault for a day.
+            timeout = float(os.environ.get("MAC_HUB_VERIFY_TIMEOUT", "2400"))
         except ValueError:
             timeout = 1200.0
         if _truthy_env("MAC_OPENSHELL_GC"):

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -8372,8 +8372,10 @@ def test_git_publication_full_contract_failure_does_not_push_main(cp, tmp_path):
 
     del cp._publication_merge_test_runner
     cp._hub_verify_runner = fail_gate
+    # The gate is scoped now, so it is no longer "full"; what this test is
+    # about is that a FAILING gate does not push main.
     with pytest.raises(
-        ValidationError, match="full repository contract gate failed"
+        ValidationError, match="contract gate failed on the projected"
     ):
         cp.publish_task(
             task.id, "git://main", reviewer.id, evidence_id=evidence.id

--- a/tests/test_publication_gate_scope.py
+++ b/tests/test_publication_gate_scope.py
@@ -1,0 +1,59 @@
+"""An approved task has to be able to publish.
+
+Publication re-runs a repository contract gate on the projected current-main
+merge, inside a sandbox, under MAC_HUB_VERIFY_TIMEOUT. That gate ran the WHOLE
+suite -- about 45 minutes on this repository -- against a 1200-second cap. It
+could not finish, so no approved task could publish at all: the gate was
+killed, publication failed, it retried ~1200s later and failed again, and the
+task sat in REVIEWING, approved and unpublished.
+
+Measured on task_de42aa6c: review approved at 19:36:51, publication failed at
+20:02:44, and again at 20:23:43.
+
+The failure surfaced as a truncated CalledProcessError naming the openshell
+argv, which reads like a sandbox fault. It is not one: `openshell sandbox
+create ... -- <cmd>` works on that host. A day went into the wrong suspect.
+
+The projected tree differs from the tree review already gated only by however
+far main moved, so the changed-file selection is the honest question to ask of
+it -- and it is the same question the review verifier asks, through the same
+helper.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from mac import services
+
+
+def test_publication_scopes_its_gate_the_way_review_does():
+    """Hardcoding the full command is what made the cap unmeetable."""
+    source = inspect.getsource(services.ControlPlane._publish_git_target_attempt)
+
+    assert "_hub_review_test_command" in source, (
+        "the projected-merge gate must scope its command like the review "
+        "verifier; running the whole suite cannot finish inside "
+        "MAC_HUB_VERIFY_TIMEOUT"
+    )
+
+
+def test_an_unreadable_diff_still_runs_everything():
+    """Fail closed. If the projected diff cannot be read, the scoped question
+    is unanswerable and the whole suite is the only honest gate."""
+    source = inspect.getsource(services.ControlPlane._publish_git_target_attempt)
+
+    assert "projected_changed = []" in source
+    assert "except Exception" in source
+
+
+def test_the_timeout_can_cover_the_work_it_gates():
+    """A cap the work cannot meet is not a gate, it is an outage that reports
+    itself as a gate failure. The scoped run alone takes ~15 minutes before
+    clone, upload and dependency bootstrap."""
+    source = inspect.getsource(services.ControlPlane._hub_verify_run_contract_test)
+
+    assert '"2400"' in source, (
+        "MAC_HUB_VERIFY_TIMEOUT's default must cover a scoped gate plus its "
+        "setup; 1200s did not"
+    )


### PR DESCRIPTION
Publication re-runs a repository contract gate on the projected current-main merge, in a sandbox, under `MAC_HUB_VERIFY_TIMEOUT`. It ran the **whole suite** — ~45 minutes here — against a **1200s** cap.

It could not finish, so **no approved task could publish at all**: the gate was killed, publication failed, it retried ~1200s later and failed again, and the task sat in `REVIEWING` — approved, verified, unpublished.

Measured on `task_de42aa6c`:

```
19:36:51  review approves
20:02:44  publication fails
20:23:43  publication fails   (~1200s later)
```

### Two changes, because either alone still fails

**Scope the gate** the way the review verifier already scopes its own, through the same helper. The projected tree differs from the tree review just gated only by however far `main` moved, so the changed-file selection is the honest question to ask of it. An unresolvable diff falls back to the full command, exactly as the review helper does.

**Size the timeout to the work.** The scoped gate alone takes ~15 minutes on this repository, before cloning, uploading, and dependency bootstrap. 1200s could not cover that either.

### How this hid

The failure surfaced as a truncated `CalledProcessError` naming the `openshell` argv, so it read as a sandbox fault. **It is not one.** `openshell sandbox create … -- <cmd>` works fine on that host; without a trailing command it attaches an interactive shell and cannot run under launchd — a different thing entirely. A day went into the wrong suspect.

Collateral found while triaging, filed separately: a 2-day-old orphaned `ssh -L 127.0.0.1:17671` tunnel (with `ExitOnForwardFailure=yes`, it fails every create while it exists), 10 leaked `mac-hubverify-*` sandboxes, and the fact that the hub's sandboxes execute on **madmax**, not the hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)