### PR TITLE
Reap a sandbox whose creator is proven dead, without waiting a day

### DIFF
--- a/src/mac/openshell_sandbox_gc.py
+++ b/src/mac/openshell_sandbox_gc.py
@@ -79,12 +79,22 @@ def stale_sandbox_candidates(
         if created is None:
             continue
         age_seconds = max(0.0, (current - created).total_seconds())
-        if age_seconds < minimum_age:
-            continue
 
         labels_value = row.get("labels")
         labels = dict(labels_value) if isinstance(labels_value, Mapping) else {}
         owner = str(labels.get("mac.owner") or "").strip().lower()
+        # A dead creator is PROOF the sandbox is garbage; age is only a guess
+        # for the sandboxes we cannot prove anything about. Testing age first
+        # inverted that: a sandbox whose creator had demonstrably exited was
+        # protected for a full day anyway.
+        #
+        # That is a leak, not an inefficiency. The hub creates one sandbox per
+        # verification, ticks every 30 seconds, and kills the creator when the
+        # gate exceeds its timeout -- so every tick left a Ready sandbox that
+        # nothing would collect for 24 hours. Observed on the hub: 10
+        # abandoned sandboxes, then 87 within a few hours of the tick
+        # resuming, each holding a container.
+        proven_abandoned = False
         if owner:
             if owner != "mac" or _truthy(labels.get("mac.keep")):
                 continue
@@ -93,9 +103,15 @@ def stale_sandbox_candidates(
                 try:
                     if pid_is_alive(int(raw_pid)):
                         continue
+                    proven_abandoned = True
                 except ValueError:
                     continue
         elif not include_legacy:
+            continue
+
+        # Unlabelled or still-unproven sandboxes keep the age heuristic: a
+        # creator we cannot identify might yet be working.
+        if not proven_abandoned and age_seconds < minimum_age:
             continue
 
         row["age_seconds"] = int(age_seconds)

--- a/tests/test_openshell_sandbox_gc.py
+++ b/tests/test_openshell_sandbox_gc.py
@@ -341,3 +341,56 @@ def test_reaper_list_failure_raises(monkeypatch):
 
     with pytest.raises(RuntimeError):
         reap_orphaned_task_sandboxes(apply=True)
+
+
+def test_a_sandbox_whose_creator_is_dead_is_reaped_immediately():
+    """The leak. A dead creator PID is PROOF the sandbox is garbage, but the
+    age gate was tested first, so a provably abandoned sandbox was protected
+    for a full day anyway.
+
+    That is not an inefficiency. The hub creates one sandbox per verification,
+    ticks every 30 seconds, and kills the creator when the gate exceeds its
+    timeout -- so every tick left a Ready sandbox nothing would collect for 24
+    hours. Observed on the hub: 10 abandoned sandboxes, then 87 within a few
+    hours of the tick resuming, each holding a container.
+    """
+    rows = [
+        _sandbox(
+            "mac-hubverify-1059c4c10c254",
+            age_hours=0,
+            labels={"mac.owner": "mac", "mac.kind": "hubverify", "mac.pid": "424242"},
+        )
+    ]
+
+    candidates = stale_sandbox_candidates(
+        rows, now=NOW, pid_is_alive=lambda pid: False
+    )
+
+    assert [row["name"] for row in candidates] == ["mac-hubverify-1059c4c10c254"]
+
+
+def test_a_live_creator_still_protects_a_brand_new_sandbox():
+    """The reason the age gate existed. A verification in flight must not have
+    its sandbox pulled out from under it."""
+    rows = [
+        _sandbox(
+            "mac-hubverify-inflight0000000",
+            age_hours=0,
+            labels={"mac.owner": "mac", "mac.kind": "hubverify", "mac.pid": "1"},
+        )
+    ]
+
+    candidates = stale_sandbox_candidates(rows, now=NOW, pid_is_alive=lambda pid: True)
+
+    assert candidates == []
+
+
+def test_an_unlabelled_sandbox_still_waits_out_the_age_threshold():
+    """No creator to prove anything about, so the heuristic is all there is.
+    Reaping these on sight would delete work belonging to something we cannot
+    see."""
+    rows = [_sandbox("mac-task-abcdef0123456789", age_hours=0, labels={})]
+
+    candidates = stale_sandbox_candidates(rows, now=NOW, pid_is_alive=lambda pid: False)
+
+    assert candidates == []


### PR DESCRIPTION
The garbage collector already had the right signal — a creator PID that no longer exists means nobody is coming back for this sandbox — and **never reached it**:

```python
if age_seconds < minimum_age:      # 24 hours
    continue                       # returns before the PID check below
...
if pid_is_alive(int(raw_pid)):
    continue
```

So a sandbox we could *prove* was abandoned got protected by the age heuristic anyway, for a full day.

### Why that is a leak, not an inefficiency

The hub creates one sandbox per verification, ticks every 30 seconds, and kills the creator when the gate exceeds its timeout. Every tick therefore left a `Ready` sandbox that nothing would collect for 24 hours.

Measured on the hub: **10** abandoned sandboxes, then **87** within a few hours of the tick resuming — each holding a container.

### The change

Age is a guess for the sandboxes we cannot prove anything about. Proof should not be overruled by a guess, so the proof is evaluated first, and the age gate now applies only where no proof exists:

- unlabelled legacy sandboxes (no creator to reason about)
- sandboxes whose creator is still alive (already protected on their own merits — an in-flight verification must not have its sandbox pulled out from under it)

Verified the test catches the bug: restoring the original ordering fails `test_a_sandbox_whose_creator_is_dead_is_reaped_immediately` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)