### PR TITLE
Stop the hub vouching for an agent it merely decided to use

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -12821,14 +12821,38 @@ class ControlPlane:
                     raise ValidationError(
                         "break-glass authorization expired or changed during claim"
                     )
-            conn.execute(
-                """
-                UPDATE agents
-                SET status = ?, current_task_id = ?, updated_at = ?, last_seen_at = ?
-                WHERE id = ?
-                """,
-                (AgentStatus.BUSY.value, task_id, now, now, agent_id),
-            )
+            # Assignment is the HUB acting, not the agent reporting. Stamping
+            # last_seen_at here let the hub vouch for an agent's liveness on the
+            # strength of its own decision to use it, which closes a loop: a
+            # worker whose host is gone still looks idle, the tick assigns to
+            # it, the assignment refreshes last_seen, the staleness sweep never
+            # fires, and it keeps drawing work forever.
+            #
+            # Seen live: three HGX runners were stopped and their pods deleted,
+            # and the hub went on reporting them busy, with fresh last_seen
+            # values and real tasks attached -- tasks that could not run and
+            # would sit until their leases expired.
+            #
+            # An agent-initiated claim is different: the agent is demonstrably
+            # there, so it still refreshes its own liveness.
+            if str(assignment_allocator or "").strip() == "authoritative-hub":
+                conn.execute(
+                    """
+                    UPDATE agents
+                    SET status = ?, current_task_id = ?, updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (AgentStatus.BUSY.value, task_id, now, agent_id),
+                )
+            else:
+                conn.execute(
+                    """
+                    UPDATE agents
+                    SET status = ?, current_task_id = ?, updated_at = ?, last_seen_at = ?
+                    WHERE id = ?
+                    """,
+                    (AgentStatus.BUSY.value, task_id, now, now, agent_id),
+                )
             detail = {"lease_id": lease_id, "expires_at": expires_at}
             if break_glass is not None:
                 detail["break_glass_authorization_id"] = break_glass.id

--- a/tests/test_liveness_is_not_assignment.py
+++ b/tests/test_liveness_is_not_assignment.py
@@ -1,0 +1,89 @@
+"""The hub must not vouch for an agent it merely decided to use.
+
+Three HGX runners were stopped and their pods deleted. The hub went on
+reporting them `busy`, with `last_seen_at` values seconds old and real tasks
+attached -- tasks that could not run, on hosts that no longer existed.
+
+The loop:
+
+    a dead worker still looks idle (its silence has not aged out yet)
+      -> the tick assigns it a task
+        -> the assignment stamps last_seen_at = now
+          -> the staleness sweep never fires, because the agent looks fresh
+            -> it keeps drawing work, forever
+
+Assignment is the hub acting. It is not evidence about the agent. Only the
+agent can supply that: its own heartbeat, or a lease renewal it asked for.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+def _agent(cp, name="probe"):
+    machine = cp.register_machine("host-%s" % name)
+    return cp.register_agent(machine.id, name)
+
+
+def test_hub_assignment_does_not_refresh_liveness(cp):
+    """The live failure. Without this the hub's own dispatch decision is
+    laundered into evidence that the worker is alive."""
+    agent = _agent(cp)
+    task = cp.create_task(title="probe", project="mac")
+    before = cp.get_agent(agent.id).last_seen_at
+
+    cp.claim_task(
+        task.id,
+        agent.id,
+        sync_beads=False,
+        assignment_allocator="authoritative-hub",
+        assignment_allocator_version="mac.dispatch.allocator.v2",
+    )
+
+    after = cp.get_agent(agent.id).last_seen_at
+    assert after == before, (
+        "hub-side assignment refreshed the agent's liveness; a worker whose "
+        "host is gone would keep looking alive and keep drawing work"
+    )
+
+
+def test_an_agent_initiated_claim_still_refreshes_liveness(cp):
+    """An agent that claims is demonstrably there. Withholding the refresh
+    would age out workers that are working."""
+    agent = _agent(cp, name="selfclaim")
+    task = cp.create_task(title="probe", project="mac")
+    before = cp.get_agent(agent.id).last_seen_at
+
+    cp.claim_task(task.id, agent.id, sync_beads=False)
+
+    after = cp.get_agent(agent.id).last_seen_at
+    assert after >= before
+    assert after != before or before is None
+
+
+def test_the_agent_still_becomes_busy_either_way(cp):
+    """Liveness and assignment are separate facts; only the first is in
+    dispute. The task still has to be attached."""
+    agent = _agent(cp, name="busycheck")
+    task = cp.create_task(title="probe", project="mac")
+
+    cp.claim_task(
+        task.id,
+        agent.id,
+        sync_beads=False,
+        assignment_allocator="authoritative-hub",
+    )
+
+    refreshed = cp.get_agent(agent.id)
+    assert refreshed.current_task_id == task.id
+    assert str(refreshed.status) == "busy"


### PR DESCRIPTION
Three HGX runners were stopped and their pods deleted. **The hub went on reporting them `busy`**, with `last_seen_at` values seconds old and real tasks attached — tasks that could not run, on hosts that no longer existed.

The loop:

```
a dead worker still looks idle (its silence has not aged out yet)
  -> the tick assigns it a task
    -> the assignment stamps last_seen_at = now
      -> the staleness sweep never fires, because it looks fresh
        -> it keeps drawing work, forever
```

Assignment is the **hub** acting. It is not evidence about the agent — and using it as evidence made the staleness sweep unreachable for precisely the agents it exists to catch: the ones still being dispatched to.

An agent-initiated claim is different: the agent is demonstrably there, so that path still refreshes liveness, as does lease renewal (which the agent also asks for). Only the hub's own committed proposal — `assignment_allocator="authoritative-hub"`, i.e. `claim_task_v2` — stops speaking for the worker.

The agent still becomes `busy` with the task attached either way. Liveness and assignment are separate facts; only the first was in dispute.

Verified: forcing the old behaviour fails `test_hub_assignment_does_not_refresh_liveness` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)