### PR TITLE
Collect the sandboxes that FAILED, which nothing ever could

### DIFF
--- a/src/mac/openshell_sandbox_gc.py
+++ b/src/mac/openshell_sandbox_gc.py
@@ -12,6 +12,10 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
 
 
 DEFAULT_STALE_AFTER_SECONDS = 24 * 60 * 60
+#: An errored sandbox is already terminal, so it only needs long enough for
+#: its creator to read the logs -- not the full stale window a working
+#: sandbox is given.
+DEFAULT_ERROR_GRACE_SECONDS = 15 * 60
 MANAGED_NAME_RE = re.compile(
     r"^mac-(?:task|hubverify|codingcap|runtime-smoke|security-probe)-[A-Za-z0-9._-]+$"
 )
@@ -51,6 +55,7 @@ def stale_sandbox_candidates(
     *,
     now: Optional[datetime] = None,
     stale_after_seconds: float = DEFAULT_STALE_AFTER_SECONDS,
+    error_grace_seconds: float = DEFAULT_ERROR_GRACE_SECONDS,
     include_legacy: bool = True,
     pid_is_alive: Callable[[int], bool] = _pid_is_alive,
 ) -> List[Dict[str, Any]]:
@@ -73,8 +78,19 @@ def stale_sandbox_candidates(
         name = str(row.get("name") or "").strip()
         if not MANAGED_NAME_RE.fullmatch(name):
             continue
-        if str(row.get("phase") or "").strip().lower() != "ready":
+        # A sandbox that FAILED is the common leak, and it was the one phase
+        # nothing could ever collect: this filter accepted "ready" only, so a
+        # sandbox that died on its way up stayed forever. Measured on the hub:
+        # 77 sandboxes, 60 of them in Error, 49 of those from hub verification
+        # -- none collectable at any age.
+        #
+        # An errored sandbox will not become useful, so it needs no age
+        # heuristic to prove abandonment; it needs only a grace window long
+        # enough for whoever created it to read its logs.
+        phase = str(row.get("phase") or "").strip().lower()
+        if phase not in {"ready", "error", "failed"}:
             continue
+        errored = phase in {"error", "failed"}
         created = _created_at(row.get("created_at"))
         if created is None:
             continue
@@ -102,16 +118,24 @@ def stale_sandbox_candidates(
             if raw_pid:
                 try:
                     if pid_is_alive(int(raw_pid)):
-                        continue
-                    proven_abandoned = True
+                        # A live creator protects work in progress -- but an
+                        # errored sandbox is terminal, and the hub's creator PID
+                        # is the long-lived hub itself, so honouring it there
+                        # would protect every failure for the hub's whole life.
+                        if not errored:
+                            continue
+                    else:
+                        proven_abandoned = True
                 except ValueError:
                     continue
         elif not include_legacy:
             continue
 
         # Unlabelled or still-unproven sandboxes keep the age heuristic: a
-        # creator we cannot identify might yet be working.
-        if not proven_abandoned and age_seconds < minimum_age:
+        # creator we cannot identify might yet be working. An errored sandbox
+        # is not working by definition, so it waits only the grace window.
+        threshold = error_grace_seconds if errored else minimum_age
+        if not proven_abandoned and age_seconds < threshold:
             continue
 
         row["age_seconds"] = int(age_seconds)
@@ -124,6 +148,7 @@ def reconcile_stale_sandboxes(
     *,
     openshell_bin: str = "openshell",
     stale_after_seconds: float = DEFAULT_STALE_AFTER_SECONDS,
+    error_grace_seconds: float = DEFAULT_ERROR_GRACE_SECONDS,
     include_legacy: bool = True,
     apply: bool = False,
     now: Optional[datetime] = None,
@@ -160,6 +185,7 @@ def reconcile_stale_sandboxes(
         payload,
         now=now,
         stale_after_seconds=stale_after_seconds,
+        error_grace_seconds=error_grace_seconds,
         include_legacy=include_legacy,
         pid_is_alive=pid_is_alive,
     )

--- a/tests/test_openshell_sandbox_gc.py
+++ b/tests/test_openshell_sandbox_gc.py
@@ -394,3 +394,59 @@ def test_an_unlabelled_sandbox_still_waits_out_the_age_threshold():
     candidates = stale_sandbox_candidates(rows, now=NOW, pid_is_alive=lambda pid: False)
 
     assert candidates == []
+
+
+def test_an_errored_sandbox_is_collectable_at_all():
+    """The dominant leak, and the simplest one: the phase filter accepted
+    "ready" and nothing else, so a sandbox that died on its way up could never
+    be collected at any age.
+
+    Measured on the hub: 77 sandboxes, 60 in Error, 49 of those from hub
+    verification -- none collectable, ever.
+    """
+    rows = [
+        _sandbox(
+            "mac-hubverify-b68620c32a5a4a05",
+            age_hours=1,
+            phase="Error",
+            labels={"mac.owner": "mac", "mac.kind": "hubverify", "mac.pid": "1"},
+        )
+    ]
+
+    candidates = stale_sandbox_candidates(rows, now=NOW, pid_is_alive=lambda pid: True)
+
+    assert [row["name"] for row in candidates] == ["mac-hubverify-b68620c32a5a4a05"]
+
+
+def test_an_errored_sandbox_keeps_a_grace_window_for_its_logs():
+    """It will never be useful again, but whoever created it may still be
+    reading why it failed."""
+    rows = [
+        _sandbox(
+            "mac-hubverify-freshfailure00",
+            age_hours=0,
+            phase="Error",
+            labels={"mac.owner": "mac", "mac.kind": "hubverify", "mac.pid": "1"},
+        )
+    ]
+
+    candidates = stale_sandbox_candidates(rows, now=NOW, pid_is_alive=lambda pid: True)
+
+    assert candidates == []
+
+
+def test_a_working_sandbox_still_gets_the_full_stale_window():
+    """The grace window is short because an errored sandbox is terminal. A
+    Ready one may be doing work, and keeps the long threshold."""
+    rows = [
+        _sandbox(
+            "mac-task-workinghard0000",
+            age_hours=1,
+            phase="Ready",
+            labels={"mac.owner": "mac", "mac.pid": "1"},
+        )
+    ]
+
+    candidates = stale_sandbox_candidates(rows, now=NOW, pid_is_alive=lambda pid: True)
+
+    assert candidates == []


### PR DESCRIPTION
The phase filter accepted `"ready"` and nothing else:

```python
if str(row.get("phase") or "").strip().lower() != "ready":
    continue
```

So a sandbox that died on its way up could **not be collected at any age, by any threshold, ever**.

Measured on the hub *after* #355 shipped: **77 sandboxes, 60 in `Error`, 49 of those from hub verification.** `sandbox-gc` scanned all 77 and reported **0 candidates**.

That is also why #355 did not help here — it corrected the age-versus-proof ordering for `Ready` sandboxes, and these never reached the ordering at all. Verifying that fix on the box, rather than assuming it worked, is what surfaced this.

### The rules now

- **An errored sandbox will not become useful**, so it needs no age heuristic to prove abandonment — only a grace window long enough for whoever created it to read the logs. 15 minutes, tunable.
- **A live creator does not protect one either**, for a reason specific to this fleet: the hub labels every sandbox with its *own* pid, and the hub is long-lived — so honouring a live creator would protect every failed verification for as long as the hub runs.
- **A `Ready` sandbox keeps that protection**, because it may be doing work, and keeps the full stale window.

Verified the test catches it: restoring the `ready`-only filter fails `test_an_errored_sandbox_is_collectable_at_all` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)