### PR TITLE
Say why the publication gate failed, and which gate ran

### DIFF
--- a/src/mac/merge_queue.py
+++ b/src/mac/merge_queue.py
@@ -204,6 +204,29 @@ def validate_projected_merge(
     )
 
 
+
+def _failure_excerpt(exc: BaseException, *, head: int = 220, tail: int = 320) -> str:
+    """Keep the head AND tail of a gate failure.
+
+    Taking the first 500 characters spent every one of them on the argv --
+    `openshell sandbox create --no-auto-providers --policy ... --label ...` is
+    itself about that long -- so the part that says what actually happened
+    ("timed out after 2400 seconds", "returned non-zero exit status 3") was cut
+    off every time. Two separate debugging sessions ended with the same
+    unfinished sentence, and one of them chased an OpenShell bug that did not
+    exist.
+    """
+
+    text = str(exc).strip()
+    if len(text) <= head + tail:
+        return text
+    return "%s ... [%d chars omitted] ... %s" % (
+        text[:head],
+        len(text) - head - tail,
+        text[-tail:],
+    )
+
+
 def validate_projected_merge_contract(
     repo_dir: str,
     base_ref: str,
@@ -349,7 +372,9 @@ def validate_projected_merge_contract(
                 output_tail=tail,
             )
     except Exception as exc:  # noqa: BLE001 - publication gate must fail closed.
-        return verdict(False, error="projected contract gate failed: %s" % str(exc)[:500])
+        return verdict(
+            False, error="projected contract gate failed: %s" % _failure_excerpt(exc)
+        )
 
 
 __all__ = [

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -22037,6 +22037,19 @@ class ControlPlane:
             full_test_command = self._hub_review_test_command(
                 task, {"files_changed": projected_changed}
             )
+            # Say which question was asked. The scoped and full commands take
+            # ~15 and ~45 minutes, and only one of them fits the timeout -- so
+            # a silent fallback to full looks exactly like a gate that hung,
+            # and the timeout message says nothing about which ran.
+            commands.append(
+                {
+                    "name": "publication_gate_scope",
+                    "changed_files": len(projected_changed),
+                    "scoped": bool(projected_changed)
+                    and "run-sanity-tests.sh" in full_test_command,
+                    "command": full_test_command[:200],
+                }
+            )
             publication_test_runner = getattr(
                 self, "_publication_merge_test_runner", None
             )

--- a/tests/test_publication_gate_scope.py
+++ b/tests/test_publication_gate_scope.py
@@ -57,3 +57,43 @@ def test_the_timeout_can_cover_the_work_it_gates():
         "MAC_HUB_VERIFY_TIMEOUT's default must cover a scoped gate plus its "
         "setup; 1200s did not"
     )
+
+
+def test_the_gate_failure_keeps_the_part_that_says_why():
+    """Taking the first 500 characters spent all of them on the argv.
+
+    `openshell sandbox create --no-auto-providers --policy ... --label ...` is
+    itself about that long, so the part that says what happened -- "timed out
+    after 2400 seconds", "returned non-zero exit status 3" -- was cut off every
+    single time. Two debugging sessions ended on the same unfinished sentence,
+    and one of them chased an OpenShell bug that did not exist.
+    """
+    from mac.merge_queue import _failure_excerpt
+
+    argv = "Command '%s'" % (["/Users/jkh/.mac/bin/openshell", "sandbox", "create"] * 30)
+    exc = RuntimeError("%s timed out after 2400 seconds" % argv)
+
+    excerpt = _failure_excerpt(exc)
+
+    assert "timed out after 2400 seconds" in excerpt
+    assert "openshell" in excerpt
+
+
+def test_a_short_failure_is_not_mangled():
+    """Most failures are short enough to read whole; eliding them would add
+    noise for nothing."""
+    from mac.merge_queue import _failure_excerpt
+
+    assert _failure_excerpt(RuntimeError("boom")) == "boom"
+
+
+def test_the_chosen_gate_command_is_recorded():
+    """The scoped and full commands take ~15 and ~45 minutes, and only one fits
+    the timeout. A silent fallback to full is indistinguishable from a hang."""
+    import inspect
+
+    from mac import services
+
+    source = inspect.getsource(services.ControlPlane._publish_git_target_attempt)
+
+    assert "publication_gate_scope" in source


### PR DESCRIPTION
The gate's failure was truncated to its first 500 characters — and the argv alone is about that long:

```
Command '['/Users/jkh/.mac/bin/openshell', 'sandbox', 'create',
'--no-auto-providers', '--policy', ..., '--label',
```

Every failure ended on that unfinished sentence. What got cut is the only part that distinguishes the cases — `timed out after 2400 seconds` versus `returned non-zero exit status 3`. Two debugging sessions ran blind on it, and one chased an OpenShell bug that did not exist. Now it keeps the head **and** the tail.

### Second: record which gate ran

Scoped and full runs take roughly **15** and **45** minutes, and only the scoped one fits the timeout. An unreadable projected diff falls back to the whole suite *by design* — and nothing said so, which makes that fallback indistinguishable from a hang.

Today's autonomous canary failed publication after **44 minutes against a 40-minute cap**. That is exactly what the fallback looks like, and there was no way to confirm it from the evidence. The gate now records `changed_files`, whether it scoped, and the command it chose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)