### PR TITLE
Stop holding the publication barrier across the publication

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1068,15 +1068,37 @@ def _serialize_runtime_source_publication(function: Callable[..., Optional[JsonD
             return function(self, task_id, target, evidence_id)
         if not self._publication_targets_runtime_source(task_id):
             return function(self, task_id, target, evidence_id)
+        # Hold the barrier only long enough to READ it. It used to wrap the
+        # publication itself, and a publication runs a contract gate in a
+        # sandbox for 45-90 minutes.
+        #
+        # Thread dump taken on the hub mid-hang, 2026-08-14:
+        #
+        #   one thread:  publish_task -> validate_projected_merge_contract
+        #                -> _hub_verify_run_contract_test -> subprocess wait
+        #                (holding _PUBLICATION_BARRIER_THREAD_LOCK)
+        #   seven more:  publish_task -> publication_serialization (blocked),
+        #                one of them the hub TICK thread
+        #
+        # The waiters occupy the request threadpool, /health stops being
+        # answered, the supervisor restarts the process after its probes fail,
+        # and the in-flight gate dies without recording anything. 147
+        # consecutive failed probes and 225 restarts were logged before this
+        # was found; every publication attempt in this session died that way.
+        #
+        # The docstring of publication_serialization already says the epoch row
+        # "remains the durable barrier after this short creation critical
+        # section ends" -- so the long tail never needed the lock. The read is
+        # what must be atomic against epoch creation.
         with self.fleet_release_epochs.publication_serialization():
             barrier = self.fleet_release_epochs.active_publication_barrier()
-            if barrier is not None:
-                raise PublicationDeferredError(
-                    "git publication is deferred while fleet release epoch %s is %s"
-                    % (barrier["epoch_id"], barrier["state"]),
-                    barrier=barrier,
-                )
-            return function(self, task_id, target, evidence_id)
+        if barrier is not None:
+            raise PublicationDeferredError(
+                "git publication is deferred while fleet release epoch %s is %s"
+                % (barrier["epoch_id"], barrier["state"]),
+                barrier=barrier,
+            )
+        return function(self, task_id, target, evidence_id)
 
     return wrapped
 

--- a/tests/test_publication_barrier_scope.py
+++ b/tests/test_publication_barrier_scope.py
@@ -1,0 +1,89 @@
+"""The publication barrier must not be held across the publication.
+
+Thread dump taken on the hub while it was unresponsive, 2026-08-14:
+
+    Thread A   publish_task -> validate_projected_merge_contract
+               -> _hub_verify_run_contract_test -> subprocess wait
+               ...holding _PUBLICATION_BARRIER_THREAD_LOCK
+
+    Threads B..H  publish_task -> publication_serialization  (blocked)
+                  one of them the hub TICK thread
+
+One publication held the barrier for the whole contract gate -- a clone, an
+upload, a dependency bootstrap and a test suite inside a sandbox, 45 to 90
+minutes. Every other publication queued behind it, the waiters occupied the
+request threadpool, /health went unanswered, and the supervisor restarted the
+process after its probes failed. That killed the gate, which recorded nothing,
+and the cycle repeated: 147 consecutive failed probes and 225 restarts were
+logged before the dump was taken.
+
+The lock's own docstring says the epoch row "remains the durable barrier after
+this short creation critical section ends". Only the READ has to be atomic
+against epoch creation; the publication that follows does not.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+from mac import services
+
+
+def _serializer_source() -> str:
+    return inspect.getsource(services._serialize_runtime_source_publication)
+
+
+def test_the_publication_runs_outside_the_barrier():
+    """The live failure: the gate ran inside the `with`, so the lock was held
+    for its entire duration and every peer publication blocked on it."""
+    source = _serializer_source()
+
+    with_line = None
+    call_line = None
+    for index, line in enumerate(source.splitlines()):
+        if "publication_serialization()" in line:
+            with_line = index
+        if re.search(r"return function\(self, task_id, target, evidence_id\)", line):
+            call_line = index
+
+    assert with_line is not None and call_line is not None
+    body_indent = len(source.splitlines()[with_line]) - len(
+        source.splitlines()[with_line].lstrip()
+    )
+    call_indent = len(source.splitlines()[call_line]) - len(
+        source.splitlines()[call_line].lstrip()
+    )
+
+    assert call_indent <= body_indent, (
+        "the publication is still inside the barrier's `with` block; holding it "
+        "across a 45-90 minute contract gate starves the request threadpool and "
+        "gets the hub restarted mid-publication"
+    )
+
+
+def test_the_barrier_is_still_consulted():
+    """Releasing the lock early must not skip the check. A publication during
+    an open release epoch is exactly what the barrier exists to defer."""
+    source = _serializer_source()
+
+    assert "publication_serialization()" in source
+    assert "active_publication_barrier()" in source
+    assert "PublicationDeferredError" in source
+
+
+def test_the_deferral_still_raises_outside_the_lock():
+    """The raise moved out of the `with`, so it must still happen -- a deferred
+    publication that proceeded anyway would mutate the deployed checkout during
+    a release."""
+    source = _serializer_source()
+    lines = source.splitlines()
+
+    raise_idx = next(
+        i for i, line in enumerate(lines) if "PublicationDeferredError" in line
+    )
+    guard_idx = next(
+        i for i, line in enumerate(lines) if "if barrier is not None:" in line
+    )
+
+    assert guard_idx < raise_idx


### PR DESCRIPTION
Thread dump from the hub while it was unresponsive (2026-08-14), captured with py-spy at the moment `/health` stopped answering:

```
one thread    publish_task -> validate_projected_merge_contract
              -> _hub_verify_run_contract_test -> subprocess wait
              ...holding _PUBLICATION_BARRIER_THREAD_LOCK

seven more    publish_task -> publication_serialization  (blocked)
              one of them the hub TICK thread
```

A publication runs a contract gate in a sandbox — clone, upload, dependency bootstrap, test suite — for **45 to 90 minutes**, and the barrier was held for all of it. Every peer publication queued behind it, the waiters occupied the request threadpool, `/health` stopped being answered, and the supervisor restarted the process after its probes failed. That killed the gate, which recorded nothing, and the next tick began the same cycle.

Measured before the dump: **147** consecutive failed probes in a single hang, **225** supervisor restarts, **194** shutdowns.

### Why this matters beyond the hang

Every publication attempt in this session died this way, and each death was reported as something else — a gate timeout, an OpenShell fault, a stale branch base. A gate timeout was raised from 1200s to 2400s to fix a 44-minute failure that was actually this.

### The change

The lock's own docstring says the epoch row *"remains the durable barrier after this short creation critical section ends"*. Only the **read** has to be atomic against epoch creation; the publication that follows does not. Holding it there turned a serialization primitive into a fleet-wide outage.

The deferral check is unchanged — a publication during an open release epoch still raises `PublicationDeferredError`, now just outside the lock.

Verified: putting the publication back inside the `with` fails `test_the_publication_runs_outside_the_barrier` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)