### PR TITLE
Build the sync-barrier map once per round, not once per agent

### DIFF
--- a/src/mac/task_lifecycle.py
+++ b/src/mac/task_lifecycle.py
@@ -452,7 +452,54 @@ class DispatchService:
                 running = task.lease_id is not None
         return head_id, running
 
-    def _v2_snapshot_agent(self, agent: Any) -> AllocationAgent:
+    def _sync_barrier_states(self) -> Dict[str, Tuple[Optional[str], bool]]:
+        """Every agent's sync-barrier head, from ONE pass over the tasks.
+
+        :meth:`_sync_barrier_state` answers for a single agent by scanning the
+        whole task table, and the allocator called it once per agent while
+        building a round. On this fleet that was ~8,000 tasks loaded and
+        JSON-parsed per agent, ten agents deep, on `claim-next` -- the single
+        hottest endpoint in the system, which every worker polls continuously.
+
+        Caught in a thread dump taken while `mac task ready` was outstanding:
+
+            _materialize -> query_all -> list_tasks
+            -> _sync_barrier_state -> _v2_snapshot_agent
+            -> _allocation_v2_inputs -> claim_next_for_agent   (active+gil)
+
+        The request never returned; the CLI's 30s deadline fired instead, so
+        claims hung, dispatch stalled, and the hub stayed saturated enough that
+        its own health probes failed and the supervisor restarted it.
+
+        The same lesson is already recorded a few lines below, where bulk
+        dependency truth replaced a per-task `get_task` loop for exactly this
+        reason. This is that fix, for agents.
+        """
+
+        heads: Dict[str, Tuple[Optional[str], bool]] = {}
+        earliest: Dict[str, str] = {}
+        for task in self.control_plane.list_tasks():
+            if task.state in TERMINAL_TASK_STATES:
+                continue
+            metadata = ensure_json_object(task.metadata)
+            if normalize_execution_mode(
+                metadata.get("execution_mode")
+            ) != EXECUTION_MODE_SYNC:
+                continue
+            agent_id = str(metadata.get("target_agent_id") or "")
+            if not agent_id:
+                continue
+            created_at = str(task.created_at or "")
+            if agent_id not in earliest or created_at < earliest[agent_id]:
+                earliest[agent_id] = created_at
+                heads[agent_id] = (task.id, task.lease_id is not None)
+        return heads
+
+    def _v2_snapshot_agent(
+        self,
+        agent: Any,
+        sync_states: Optional[Mapping[str, Tuple[Optional[str], bool]]] = None,
+    ) -> AllocationAgent:
         try:
             machine = self.control_plane.get_machine(agent.machine_id)
         except NotFoundError:
@@ -517,7 +564,12 @@ class DispatchService:
                     hardware_ok
                     and self.control_plane.roles.soul_accepts_role(agent, role)
                 )
-        sync_head_id, sync_running = self._sync_barrier_state(agent.id)
+        # A caller building a whole round passes the bulk map; anyone
+        # asking about one agent still gets the single-agent scan.
+        if sync_states is None:
+            sync_head_id, sync_running = self._sync_barrier_state(agent.id)
+        else:
+            sync_head_id, sync_running = sync_states.get(agent.id, (None, False))
         return replace(
             snapshot,
             sync_queue_head_task_id=sync_head_id,
@@ -789,7 +841,10 @@ class DispatchService:
             )
             for task in tasks
         ]
-        agent_snapshots = [self._v2_snapshot_agent(agent) for agent in agents]
+        sync_states = self._sync_barrier_states()
+        agent_snapshots = [
+            self._v2_snapshot_agent(agent, sync_states) for agent in agents
+        ]
         return task_snapshots, agent_snapshots, task_records, agent_records
 
     def _allocate_v2_round(

--- a/tests/test_sync_barrier_dispatch.py
+++ b/tests/test_sync_barrier_dispatch.py
@@ -229,3 +229,55 @@ def test_a_barrier_targeted_by_name_is_accepted(cp):
 
 def test_ordinary_task_creation_is_untouched(cp):
     assert cp.create_task("ordinary", project="mac").id
+
+
+def test_the_bulk_barrier_map_matches_the_per_agent_scan(cp):
+    """The optimisation must be invisible in its answers.
+
+    _sync_barrier_state scans every task to answer for ONE agent, and the
+    allocator called it once per agent while building a round -- ~8,000 tasks
+    loaded and JSON-parsed per agent, on the endpoint every worker polls. The
+    bulk map answers for all agents in one pass, so it has to agree with the
+    scan exactly, including which task is the head when an agent has several.
+    """
+    lifecycle = _lifecycle(cp)
+
+    bulk = lifecycle._sync_barrier_states()
+
+    for agent in cp.list_agents():
+        assert bulk.get(agent.id, (None, False)) == lifecycle._sync_barrier_state(
+            agent.id
+        ), agent.id
+
+
+def test_a_round_asks_the_task_table_once_not_once_per_agent(cp, monkeypatch):
+    """The property that was actually broken, exercised through the round
+    builder rather than the helpers -- calling the helpers directly would pass
+    even with the per-agent scan restored, which is how a first version of this
+    test managed to prove nothing.
+
+    Correct answers arrived at by scanning the whole ledger per agent still
+    hang claim-next, which is what stalled dispatch and kept the hub saturated
+    enough to be restarted."""
+    machine = cp.register_machine("scanhost")
+    for name in ("scan_a", "scan_b", "scan_c"):
+        cp.register_agent(machine.id, name)
+
+    lifecycle = _lifecycle(cp)
+    calls = {"n": 0}
+    real = cp.list_tasks
+
+    def counting_list_tasks(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(cp, "list_tasks", counting_list_tasks)
+
+    lifecycle._allocation_v2_inputs()
+
+    agents = cp.list_agents()
+    assert len(agents) >= 2, "need several agents for the per-agent scan to show"
+    assert calls["n"] <= 2, (
+        "the round scanned the task table %d times for %d agents; the barrier "
+        "map must be built once per round" % (calls["n"], len(agents))
+    )


### PR DESCRIPTION
`claim-next` did not return. Three consecutive measurements: **30.67s, 30.60s, 30.68s** — three decimal places of agreement is a *deadline*, not a workload, and `http_client.py`'s `urlopen(timeout=30)` is the one that fired. A simple read on the same hub took 3.4s.

Thread dump taken while `mac task ready` was outstanding:

```
_materialize -> query_all -> list_tasks
  -> _sync_barrier_state -> _v2_snapshot_agent
  -> _allocation_v2_inputs -> claim_next_for_agent      (active+gil)
```

`_sync_barrier_state` answers for **one** agent by loading every task and JSON-parsing its metadata. The round called it **once per agent** — on this fleet, ~8,000 tasks × 10 agents per poll, on the endpoint every worker polls continuously, holding the GIL throughout.

### The consequences were not local

Claims hung, so dispatch stalled with idle healthy workers and unclaimed tasks. The stuck request threads kept the hub saturated, its own health probes failed, and the supervisor restarted it — killing whatever publication was in flight and recording nothing. **Most of the failures chased in this session were downstream of this.**

### The fix

Exactly the one already applied a few lines below for dependency truth, where bulk-once replaced a per-task `get_task` loop *for this same reason*. `_v2_snapshot_agent` still accepts a single-agent scan for its other callers; only the round builder passes the map.

### On the test

The first version called the helpers directly and **passed with the per-agent scan restored** — it proved nothing. It now goes through `_allocation_v2_inputs` and counts scans, and fails when the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)