### PR TITLE
Deliver the gate timeout to the process that enforces it

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -3745,13 +3745,13 @@ def _sandbox_run_repository_verification(
     # test command timed out after 1800.0s" while the operator looked at a
     # config that said 5400. A knob that silently does nothing is worse than no
     # knob, because it ends the investigation.
-    for name in (
+    for timeout_name in (
         "MAC_WORKER_REPOSITORY_TEST_TIMEOUT",
         "MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT",
     ):
-        configured = env_str(name)
+        configured = env_str(timeout_name)
         if configured:
-            verification_environment[name] = configured
+            verification_environment[timeout_name] = configured
     script_path.write_text(
         _sandbox_repository_verification_shell(verification_environment) + "\n",
         encoding="utf-8",

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -3735,6 +3735,23 @@ def _sandbox_run_repository_verification(
         "MAC_TASK_FILE": "%s/task.json" % sub,
         "MAC_TASK_WORKSPACE": sub,
     }
+    # The gate's timeout is read INSIDE the sandbox, from the sandbox's own
+    # environment -- which carried only the three names above, so the in-script
+    # default of 1800s applied no matter what the host was configured with.
+    #
+    # Raising MAC_WORKER_REPOSITORY_TEST_TIMEOUT on a worker therefore did
+    # nothing: the host waited the longer time while the script inside kept
+    # killing the run at thirty minutes, and the task failed with "repository
+    # test command timed out after 1800.0s" while the operator looked at a
+    # config that said 5400. A knob that silently does nothing is worse than no
+    # knob, because it ends the investigation.
+    for name in (
+        "MAC_WORKER_REPOSITORY_TEST_TIMEOUT",
+        "MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT",
+    ):
+        configured = env_str(name)
+        if configured:
+            verification_environment[name] = configured
     script_path.write_text(
         _sandbox_repository_verification_shell(verification_environment) + "\n",
         encoding="utf-8",

--- a/tests/test_gate_timeout_reaches_the_sandbox.py
+++ b/tests/test_gate_timeout_reaches_the_sandbox.py
@@ -1,0 +1,102 @@
+"""A timeout the operator sets must reach the code that enforces it.
+
+The repository gate's deadline is read INSIDE the sandbox:
+
+    timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800"))
+
+but the environment handed to the sandbox carried only HOME, MAC_TASK_FILE and
+MAC_TASK_WORKSPACE. So the in-script default of 1800s applied regardless of the
+host's configuration.
+
+Observed on the fleet: a worker with MAC_WORKER_REPOSITORY_TEST_TIMEOUT=5400
+failed three consecutive attempts with
+
+    repository verifier exited with status 124:
+    repository test command timed out after 1800.0s
+
+while the operator read 5400 in mac.env and concluded the setting had been
+applied. The host waited the longer time; the script inside kept killing the
+run at thirty minutes.
+
+A knob that silently does nothing is worse than no knob: it ends the
+investigation at the wrong place.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac import executor_sandbox
+
+
+@pytest.fixture()
+def workspace(tmp_path):
+    path = tmp_path / "task_probe"
+    path.mkdir()
+    return path
+
+
+def _verification_env(monkeypatch, workspace, **env):
+    """Return the environment the sandbox verification script is given."""
+    captured = {}
+
+    def capture(environment=None):
+        captured.update(environment or {})
+        return "# script"
+
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setattr(
+        executor_sandbox, "_sandbox_repository_verification_shell", capture
+    )
+    monkeypatch.setattr(
+        executor_sandbox, "_repository_contract_test_command", lambda task: "run.sh"
+    )
+    monkeypatch.setattr(executor_sandbox, "task_is_repo_coupled", lambda task: True)
+    monkeypatch.setattr(
+        executor_sandbox, "metadata_declares_read_only_report_repository",
+        lambda metadata: False,
+    )
+    monkeypatch.setattr(
+        executor_sandbox,
+        "_sandbox_repository_environment",
+        lambda ws, sub: {"MAC_REPO_TEST_COMMAND": "run.sh"},
+    )
+    monkeypatch.setattr(
+        executor_sandbox, "_sandbox_run_repository_verification_exec",
+        lambda *a, **k: executor_sandbox._SandboxRepositoryVerificationResult(True),
+    )
+    executor_sandbox._sandbox_run_repository_verification(
+        "sandbox-probe", workspace.name, workspace, {"id": "task_probe"}
+    )
+    return captured
+
+
+def test_the_configured_timeout_reaches_the_sandbox(monkeypatch, workspace):
+    """The live failure: the host said 5400, the sandbox enforced 1800."""
+    env = _verification_env(
+        monkeypatch, workspace, MAC_WORKER_REPOSITORY_TEST_TIMEOUT="5400"
+    )
+
+    assert env.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT") == "5400"
+
+
+def test_the_bootstrap_timeout_reaches_it_too(monkeypatch, workspace):
+    """Dependency setup has its own deadline and the same delivery problem."""
+    env = _verification_env(
+        monkeypatch, workspace, MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT="2400"
+    )
+
+    assert env.get("MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT") == "2400"
+
+
+def test_an_unset_timeout_is_not_invented(monkeypatch, workspace):
+    """Forwarding an empty value would override the in-script default with
+    nonsense; absence must stay absent."""
+    monkeypatch.delenv("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", raising=False)
+    monkeypatch.delenv("MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT", raising=False)
+
+    env = _verification_env(monkeypatch, workspace)
+
+    assert "MAC_WORKER_REPOSITORY_TEST_TIMEOUT" not in env
+    assert "MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT" not in env

--- a/tests/test_gate_timeout_reaches_the_sandbox.py
+++ b/tests/test_gate_timeout_reaches_the_sandbox.py
@@ -36,9 +36,19 @@ def workspace(tmp_path):
     return path
 
 
-def _verification_env(monkeypatch, workspace, **env):
-    """Return the environment the sandbox verification script is given."""
+def _verification_env(monkeypatch, workspace, steps=None, **env):
+    """Return the environment the sandbox verification script is given.
+
+    Pass `steps` to also record the openshell argv the verification issues.
+    """
     captured = {}
+
+    if steps is not None:
+        monkeypatch.setattr(
+            executor_sandbox,
+            "_sandbox_step",
+            lambda argv, **kwargs: (steps.append(list(argv)), (True, ""))[1],
+        )
 
     def capture(environment=None):
         captured.update(environment or {})
@@ -100,3 +110,31 @@ def test_an_unset_timeout_is_not_invented(monkeypatch, workspace):
 
     assert "MAC_WORKER_REPOSITORY_TEST_TIMEOUT" not in env
     assert "MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT" not in env
+
+
+def test_forwarding_does_not_clobber_the_sandbox_name(monkeypatch, workspace):
+    """The first cut of this feature wrote `for name in (...)`, which shadowed
+    the `name` parameter holding the sandbox to talk to.
+
+    Every subsequent openshell call then addressed a sandbox called
+    "MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT", so no repository verification
+    could have run anywhere on the fleet. The tests above still passed, because
+    the environment is captured before the upload -- so the timeout arrived
+    correctly at a sandbox that did not exist.
+    """
+    steps = []
+
+    _verification_env(
+        monkeypatch,
+        workspace,
+        steps=steps,
+        MAC_WORKER_REPOSITORY_TEST_TIMEOUT="5400",
+        MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT="2400",
+    )
+
+    uploads = [step for step in steps if step and step[0] == "upload"]
+    assert uploads, "verification issued no upload"
+    for step in uploads:
+        assert step[1] == "sandbox-probe", (
+            "the upload addressed %r instead of the sandbox it was given" % step[1]
+        )


### PR DESCRIPTION
The repository gate's deadline is read **inside** the sandbox:

```python
os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800")
```

but the environment handed to the sandbox carried three names — `HOME`, `MAC_TASK_FILE`, `MAC_TASK_WORKSPACE` — and this was not among them. The in-script default therefore applied **regardless of what the host was configured with**.

### Observed

On rocky: `MAC_WORKER_REPOSITORY_TEST_TIMEOUT=5400` in `mac.env`, agent restarted to pick it up, and three consecutive attempts still failed with

```
repository verifier exited with status 124:
repository test command timed out after 1800.0s
```

The host waited the longer time while the script inside kept killing the run at thirty minutes. Reading `mac.env` said the setting had been applied, so the investigation stopped at the wrong place — twice in this session.

**A knob that silently does nothing is worse than no knob**, because it ends the investigation.

The bootstrap timeout had the same delivery gap and is forwarded too. An unset value is left unset rather than forwarded empty, so the in-script default still governs where nothing was configured.

Verified: removing the forwarding fails both delivery tests and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)