### PR TITLE
Stop rebuilding the schema for every public-contract case

### DIFF
--- a/src/mac/test_support.py
+++ b/src/mac/test_support.py
@@ -144,15 +144,151 @@ def ephemeral_dsn(dsn: Optional[str] = None) -> str:
     return str(store.path)
 
 
-def ephemeral_store(dsn: Optional[str] = None, *, pool_size: int = 2):
-    """A `PostgresStore` on its own schema, with the full DDL applied."""
+def ephemeral_store(dsn: Optional[str] = None, *, pool_size: int = 2, swept: bool = True):
+    """A `PostgresStore` on its own schema, with the full DDL applied.
+
+    `swept=False` withholds the store from the per-test sweep in
+    tests/conftest.py, which closes every open store and drops every created
+    schema after EACH test. That sweep is right for the default per-test store,
+    but it makes a longer-lived one impossible: a module-scoped schema is
+    dropped and its pool closed after the first test in the module, and every
+    later use fails on a closed pool.
+
+    A caller that passes swept=False owns the cleanup and must call
+    `drop_store` in its own teardown.
+    """
     from mac.store_postgres import PostgresStore
 
-    _, scoped = create_schema(dsn)
+    schema, scoped = create_schema(dsn)
     store = PostgresStore(scoped, pool_size=pool_size, min_size=1)
     store.initialize()
-    _OPEN_STORES.append(store)
+    store._mac_test_schema = schema
+    if swept:
+        _OPEN_STORES.append(store)
+    else:
+        # create_schema registered it; take it back out so the sweep leaves it.
+        try:
+            _CREATED_SCHEMAS.remove(schema)
+        except ValueError:
+            pass
     return store
+
+
+def drop_store(store) -> None:
+    """Close `store` and drop the schema it owns. The teardown counterpart to
+    `ephemeral_store(swept=False)`."""
+    schema = getattr(store, "_mac_test_schema", "")
+    try:
+        store.close()
+    except Exception:  # noqa: BLE001 - a wedged pool must not block cleanup
+        pass
+    if not schema:
+        return
+    import psycopg
+
+    resolved = os.environ.get(DEFAULT_TEST_DSN_ENV, "").strip()
+    if not resolved:
+        return
+    try:
+        with psycopg.connect(resolved, autocommit=True) as conn:
+            conn.execute('DROP SCHEMA IF EXISTS "%s" CASCADE' % schema)
+    except Exception:  # noqa: BLE001 - best-effort cleanup
+        pass
+
+
+# Tables the packaged DDL leaves populated: the migration ledgers. A reset must
+# preserve them, because "just initialized" includes their rows -- wiping them
+# would make the next test look like a database whose migrations never ran.
+_RESET_PRESERVED_TABLES = frozenset(
+    {"task_dependency_migrations", "telemetry_data_migrations"}
+)
+
+
+def reset_store_data(store) -> bool:
+    """Return `store` to its just-initialized state WITHOUT re-running the DDL.
+
+    A per-test `ephemeral_store()` pays a real CREATE SCHEMA plus the packaged
+    DDL -- 164 tables and 219 indexes, about 1.2s. Across the ~500 parametrized
+    cases in the control-plane public contract that was 670 of the file's 745
+    seconds: the gate's dominant cost was schema setup, not testing.
+
+    Emptying the tables instead is the same isolation for a fraction of the
+    cost, but only if it is done with DELETE:
+
+        TRUNCATE tasks CASCADE          6.4s   (tasks is an FK target for dozens
+                                                of tables; CASCADE pulls them all)
+        TRUNCATE <all 161 tables>       2.0s
+        probe + DELETE of dirty tables  0.03s
+
+    So this probes for the tables that actually hold rows -- nearly always a
+    handful -- and deletes only those. FK triggers are suppressed for the
+    duration so the deletes need no dependency ordering.
+
+    Returns False if the reset cannot be done safely (most likely because the
+    connected role may not set session_replication_role). The caller must then
+    fall back to a fresh schema: a partial reset would leak one test's rows
+    into the next, which is worse than being slow.
+    """
+    tables = getattr(store, "_reset_tables", None)
+    probe = getattr(store, "_reset_probe", None)
+    sequences = getattr(store, "_reset_sequences", None)
+    try:
+        with store._pool.connection() as conn:
+            with conn.cursor() as cur:
+                if tables is None:
+                    cur.execute(
+                        "SELECT table_name FROM information_schema.tables "
+                        "WHERE table_schema = current_schema() "
+                        "AND table_type = 'BASE TABLE'"
+                    )
+                    tables = sorted(row[0] for row in cur.fetchall())
+                    # One round trip that names every non-empty table. EXISTS
+                    # stops at the first row, and an empty table is a zero-page
+                    # scan, so this stays ~20ms across 161 tables.
+                    probe = " UNION ALL ".join(
+                        'SELECT %s AS t WHERE EXISTS (SELECT 1 FROM "%s")'
+                        % (_sql_literal(name), name)
+                        for name in tables
+                    )
+                    cur.execute(
+                        "SELECT sequence_name FROM information_schema.sequences "
+                        "WHERE sequence_schema = current_schema()"
+                    )
+                    sequences = sorted(row[0] for row in cur.fetchall())
+                    store._reset_tables = tables
+                    store._reset_probe = probe
+                    store._reset_sequences = sequences
+
+                # Suppressing FK triggers is what lets the deletes run in any
+                # order. If the role cannot, say so rather than deleting a
+                # subset and reporting success.
+                cur.execute("SET session_replication_role = replica")
+
+                cur.execute(probe)
+                dirty = [
+                    row[0]
+                    for row in cur.fetchall()
+                    if row[0] not in _RESET_PRESERVED_TABLES
+                ]
+                for name in dirty:
+                    cur.execute('DELETE FROM "%s"' % name)
+
+                # DELETE leaves sequences advanced where TRUNCATE ... RESTART
+                # IDENTITY would have rewound them, so a reused schema would
+                # hand out observability_events.sequence values that a fresh
+                # one never would.
+                for name in sequences:
+                    cur.execute('ALTER SEQUENCE "%s" RESTART' % name)
+
+                cur.execute("SET session_replication_role = DEFAULT")
+            conn.commit()
+    except Exception:
+        return False
+    return True
+
+
+def _sql_literal(value: str) -> str:
+    return "'%s'" % value.replace("'", "''")
 
 
 def store_on(dsn: str, *, pool_size: int = 2, initialize: bool = False):

--- a/tests/test_control_plane_public_contract.py
+++ b/tests/test_control_plane_public_contract.py
@@ -24,19 +24,48 @@ from mac.test_support import ephemeral_store
 _SECRET_KEY = "test-key-with-enough-entropy-32+chars"
 
 
+@pytest.fixture(scope="module")
+def _contract_schema():
+    """One schema for the whole file, built once.
+
+    swept=False because tests/conftest.py drops every created schema and closes
+    every open store after each test; without it this schema would not survive
+    its first case.
+    """
+    from mac.test_support import drop_store, ephemeral_store
+
+    store = ephemeral_store(swept=False)
+    try:
+        yield store
+    finally:
+        drop_store(store)
+
+
 @pytest.fixture
-def plane() -> ControlPlane:
+def plane(_contract_schema) -> ControlPlane:
     """A fresh, empty, initialized ``ControlPlane`` for a single case.
 
     This used to clone a module-scoped empty schema with SQLite's online backup
     API, because re-running the full DDL for each of ~500 parametrized cases
     dominated the file. PostgreSQL has no equivalent cheap clone of a schema,
-    so each case now pays a real CREATE SCHEMA plus DDL. That is the cost of
-    testing against the engine the fleet runs.
-    """
-    from mac.test_support import ephemeral_control_plane
+    so each case paid a real CREATE SCHEMA plus DDL -- 164 tables and 219
+    indexes, ~1.2s a case, 670 of this file's 745 seconds.
 
-    return ephemeral_control_plane(secret_key=_SECRET_KEY)
+    That cost was setup, not testing, and it was the whole reason the
+    in-sandbox gate could not finish: this file is in the selector's
+    `always_run` set, so every task -- however small its diff -- paid it.
+
+    So the schema is now built once for the file and emptied between cases (see
+    `reset_store_data`, which measures ~30ms). The ControlPlane itself is still
+    rebuilt per case, so no in-memory state crosses between them. If the reset
+    cannot be performed safely the fixture falls back to the old fresh-schema
+    behaviour: slow is acceptable, leaking one case's rows into the next is not.
+    """
+    from mac import test_support
+
+    if not test_support.reset_store_data(_contract_schema):
+        return test_support.ephemeral_control_plane(secret_key=_SECRET_KEY)
+    return ControlPlane(_contract_schema, secret_key=_SECRET_KEY)
 
 
 _NAMED_VALUES: dict[str, Any] = {

--- a/tests/test_store_reset.py
+++ b/tests/test_store_reset.py
@@ -1,0 +1,133 @@
+"""Emptying a schema between tests must be as isolating as rebuilding it.
+
+The control-plane public contract file parametrizes ~500 cases, each of which
+took a fresh schema: a real CREATE SCHEMA plus the packaged DDL, 164 tables and
+219 indexes, ~1.2s. That was 670 of the file's 745 seconds -- the file is in the
+selector's `always_run` set, so EVERY task paid it, and it alone was most of the
+in-sandbox gate that kept timing out.
+
+Reusing one schema and emptying it between cases took the file from 670s to
+28s with all 578 tests still passing. The danger in that trade is that a reset
+which quietly leaves rows behind still looks green: the cases would pass on
+state they did not create. These tests exist to make that failure loud.
+
+Why DELETE and not TRUNCATE, measured on this schema:
+
+    TRUNCATE tasks CASCADE          6.4s  (tasks is an FK target for dozens of
+                                           tables, so CASCADE takes them all)
+    TRUNCATE <all 161 tables>       2.0s
+    probe + DELETE of dirty tables  0.03s
+
+TRUNCATE is the usual answer and here it is slower than the schema creation it
+was meant to replace.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac import test_support
+
+
+@pytest.fixture()
+def store():
+    created = test_support.ephemeral_store(swept=False)
+    try:
+        yield created
+    finally:
+        test_support.drop_store(created)
+
+
+def _tables_with_rows(store) -> set[str]:
+    with store._pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = current_schema() AND table_type = 'BASE TABLE'"
+            )
+            names = sorted(row[0] for row in cur.fetchall())
+            found = set()
+            for name in names:
+                cur.execute('SELECT 1 FROM "%s" LIMIT 1' % name)
+                if cur.fetchone():
+                    found.add(name)
+            return found
+
+
+def test_reset_removes_rows_a_test_wrote(store):
+    """The whole point: one case's writes must not reach the next one."""
+    baseline = _tables_with_rows(store)
+
+    with store._pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO tasks (id, title, description, state,"
+                " required_capabilities, dependencies, metadata,"
+                " created_at, updated_at) VALUES"
+                " ('task_reset_probe', 't', 'd', 'open', '[]', '[]', '{}',"
+                " '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')"
+            )
+        conn.commit()
+
+    assert "tasks" in _tables_with_rows(store)
+
+    assert test_support.reset_store_data(store) is True
+
+    assert "tasks" not in _tables_with_rows(store)
+    assert _tables_with_rows(store) == baseline
+
+
+def test_reset_keeps_the_migration_ledgers(store):
+    """"Just initialized" includes the migration ledger rows. Wiping them would
+    hand the next case a database whose migrations look like they never ran."""
+    before = _tables_with_rows(store)
+    assert "telemetry_data_migrations" in before
+
+    assert test_support.reset_store_data(store) is True
+
+    assert _tables_with_rows(store) == before
+
+
+def test_reset_rewinds_the_sequence(store):
+    """DELETE leaves sequences advanced where TRUNCATE ... RESTART IDENTITY
+    would rewind them, so a reused schema would hand out
+    observability_events.sequence values a fresh schema never would."""
+    with store._pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT nextval('observability_events_sequence_seq')")
+            cur.execute("SELECT nextval('observability_events_sequence_seq')")
+            advanced = cur.fetchone()[0]
+        conn.commit()
+    assert advanced > 1
+
+    assert test_support.reset_store_data(store) is True
+
+    with store._pool.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT nextval('observability_events_sequence_seq')")
+            assert cur.fetchone()[0] == 1
+
+
+def test_an_unswept_store_survives_the_per_test_sweep():
+    """tests/conftest.py closes every open store and drops every created schema
+    after EACH test. A module-scoped schema registered normally is therefore
+    dead by the second case -- which is exactly what happened on the first cut
+    of this change: the reset failed on a closed pool, the fixture fell back to
+    building a fresh schema, and the file was still slow while looking fixed."""
+    kept = test_support.ephemeral_store(swept=False)
+    try:
+        test_support.drop_created_schemas()
+
+        # Still usable: the sweep did not touch it.
+        assert test_support.reset_store_data(kept) is True
+    finally:
+        test_support.drop_store(kept)
+
+
+def test_a_swept_store_is_still_swept():
+    """The exemption must be opt-in. A default store that outlived the sweep
+    would leak schemas for the life of the database."""
+    store = test_support.ephemeral_store()
+    schema = store._mac_test_schema
+
+    assert schema in test_support._CREATED_SCHEMAS


### PR DESCRIPTION
`tests/test_control_plane_public_contract.py` parametrizes ~500 cases and gave each one a fresh schema — a real `CREATE SCHEMA` plus the packaged DDL, 164 tables and 219 indexes, ~1.2s a case.

Measured, that was **670 of the file's 745 seconds**. The file is in the selector's `always_run` set, so every task paid it however small its diff, and it was most of the in-sandbox repository gate that kept hitting its timeout. The gate's dominant cost was schema setup, not testing.

**578 passed in 28.1s, from 670s.** No test dropped, no assertion weakened.

### Why DELETE and not TRUNCATE

Measured on this schema:

| approach | cost |
|---|---|
| `TRUNCATE tasks CASCADE` | 6.4s (`tasks` is an FK target for dozens of tables; CASCADE takes them all) |
| `TRUNCATE` all 161 tables | 2.0s |
| probe + `DELETE` of dirty tables | **0.03s** |

TRUNCATE is the usual answer and here it is slower than the schema creation it would replace. `reset_store_data` instead asks which tables actually hold rows (one round trip, `EXISTS` per table, ~20ms across 161) and deletes only those, with FK triggers suppressed so no dependency ordering is needed. It preserves the migration ledgers — part of "just initialized" — and rewinds the one sequence, which `DELETE` would otherwise leave advanced.

### The trap this hit first

`tests/conftest.py` closes every open store and drops every created schema after **each** test, so a module-scoped schema registered normally is dead by the second case. The first cut of this change did exactly that: the reset failed on a closed pool, the fixture fell back to building a fresh schema, and the file stayed slow while looking fixed. Hence `ephemeral_store(swept=False)` and a test pinning it.

If the reset cannot run safely, the fixture still falls back to a fresh schema — slow is acceptable, leaking one case's rows into the next is not.

`tests/test_store_reset.py` pins the isolation itself, since a reset that quietly leaves rows behind still looks green. Verified those tests fail when the deletes are disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)