### PR TITLE
Make the gate say what it did, not what it was configured to do

### DIFF
--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -510,11 +510,13 @@ def resolve(
 
     # Cross-cutting guards run alongside any real code/test change, but never
     # for a pure documentation change (which needs no tests at all).
+    always_selected: list[str] = []
     if source_changes or test_changes or contracted_changes:
         always = set(policy.always_run)
         if impact_map:
             always.update(impact_map.get("always_run", []))
-        selected.update(_existing(always, repo_root))
+        always_selected = _existing(always, repo_root)
+        selected.update(always_selected)
 
     if not selected:
         return {
@@ -532,6 +534,14 @@ def resolve(
         # nothing and call it a pass.
         return _full("impact_map_entries_all_stale", changed,
                      stale_tests=sorted(unresolvable))
+    # Where the selection came from, not just how big it is.
+    #
+    # "focused, 11 tests" reads like the map narrowed the work. It did -- but
+    # those 11 paths held 713 tests, and 578 of them came from ONE always_run
+    # entry (tests/test_control_plane_public_contract.py). That decomposition is
+    # what identified the real cost of the in-sandbox gate, and reconstructing
+    # it took hand-instrumentation because the resolver reported only a total.
+    always_set = set(always_selected)
     return {
         "schema": SCHEMA,
         "mode": "focused",
@@ -541,6 +551,10 @@ def resolve(
         "map_fresh": map_fresh,
         "codegraph_problem": codegraph_problem,
         "stale_tests": sorted(unresolvable),
+        "provenance": {
+            "always_run": sorted(t for t in resolvable if t in always_set),
+            "impact": sorted(t for t in resolvable if t not in always_set),
+        },
     }
 
 

--- a/scripts/run-sanity-tests.sh
+++ b/scripts/run-sanity-tests.sh
@@ -21,10 +21,20 @@ trap 'rm -f "$selection"' EXIT
 import json, sys
 doc = json.load(open(sys.argv[1], encoding="utf-8"))
 print("sanity selection: %s (%s)" % (doc["mode"], doc["reason"]))
+# The split matters more than the total: a "focused" selection whose cost is
+# almost entirely cross-cutting guards is not narrowed in any way that helps,
+# and the total alone cannot say so.
+prov = doc.get("provenance") or {}
+if prov:
+    print(
+        "  provenance: %d from the change, %d always_run guards"
+        % (len(prov.get("impact", [])), len(prov.get("always_run", [])))
+    )
 for path in doc.get("changed_files", []):
     print("  changed: " + path)
+always = set(prov.get("always_run", []))
 for path in doc.get("tests", []):
-    print("  test: " + path)
+    print("  test: %s%s" % (path, "  [always_run]" if path in always else ""))
 PY
 
 mode="$("$PY" -c 'import json,sys; print(json.load(open(sys.argv[1]))["mode"])' "$selection")"

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -1665,7 +1665,7 @@ def _sandbox_repository_verification_shell(
             'cd "$MAC_TASK_WORKSPACE"',
             "mac_sandbox_toolchain_setup || true",
             r'''$MAC_SANDBOX_PYTHON - <<'PY'
-import json, os, signal, subprocess, tempfile, time
+import json, os, signal, subprocess, sys, tempfile, time
 workspace = os.environ.get("MAC_TASK_WORKSPACE") or os.getcwd()
 worktree = os.environ.get("MAC_TASK_REPO_WORKTREE") or workspace
 command = os.environ.get("MAC_REPO_TEST_COMMAND", "").strip()
@@ -1748,6 +1748,57 @@ if command in ("scripts/run-contract-tests.sh", "./scripts/run-contract-tests.sh
     if os.path.isfile(_sanity) and os.access(_sanity, os.X_OK):
         command = "scripts/run-sanity-tests.sh --base " + _repo_base_sha
 bootstrap_command = os.environ.get("MAC_REPO_BOOTSTRAP_COMMAND", "").strip()
+
+def _gate_log(message):
+    """One channel for the gate's own narration.
+
+    Goes to stderr so it survives even when the test command's stdout is
+    truncated for evidence, and is prefixed so it can be grepped out of a
+    pytest log that is otherwise thousands of lines long.
+    """
+    sys.stderr.write("[gate] %s\n" % message)
+    sys.stderr.flush()
+
+def _effective_timeout(names, fallback=1800.0):
+    """Resolve a timeout AND say where it came from.
+
+    Reporting the source is the point. MAC_WORKER_REPOSITORY_TEST_TIMEOUT was
+    set to 5400 on the host for three consecutive canary attempts while this
+    process enforced 1800, because the variable was never forwarded into the
+    sandbox. Every attempt failed with "timed out after 1800.0s" against a
+    configuration file that plainly said 5400, and the investigation stopped at
+    the configuration each time. A knob that silently does nothing is worse
+    than no knob.
+    """
+    for name in names:
+        raw = os.environ.get(name)
+        if raw:
+            try:
+                return float(raw), name
+            except ValueError:
+                return fallback, "%s=%r unparseable, using default" % (name, raw)
+    return fallback, "default (%s unset)" % ", ".join(names)
+
+_test_timeout, _test_timeout_source = _effective_timeout(
+    ["MAC_WORKER_REPOSITORY_TEST_TIMEOUT"]
+)
+_bootstrap_timeout, _bootstrap_timeout_source = _effective_timeout(
+    ["MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT", "MAC_WORKER_REPOSITORY_TEST_TIMEOUT"]
+)
+
+# The resolved values, at the point that enforces them -- not the point that
+# configures them. Everything here has been wrong at least once this month
+# while the host-side configuration looked correct.
+_gate_log("effective configuration:")
+_gate_log("  test command:      %s" % (command or "<missing>"))
+_gate_log("  bootstrap command: %s" % (bootstrap_command or "<none>"))
+_gate_log("  test timeout:      %.1fs (%s)" % (_test_timeout, _test_timeout_source))
+_gate_log("  bootstrap timeout: %.1fs (%s)" % (_bootstrap_timeout, _bootstrap_timeout_source))
+_gate_log(
+    "  baseline sha:      %s"
+    % (_repo_base_sha or "<unresolved -- selection cannot be scoped, expect a full run>")
+)
+_gate_log("  worktree:          %s" % worktree)
 # `bash -lc` re-runs the login profile, which resets PATH to the system default
 # and drops the toolchain bin we prepended during setup — so repo bootstrap/test
 # commands would resolve a stale system tool (e.g. pnpm@10 that demands Node 22)
@@ -1872,15 +1923,13 @@ if bootstrap_command:
         }
     else:
         started = time.time()
-        try:
-            timeout = float(
-                os.environ.get("MAC_WORKER_REPOSITORY_BOOTSTRAP_TIMEOUT")
-                or os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT")
-                or "1800"
-            )
-        except ValueError:
-            timeout = 1800.0
+        timeout = _bootstrap_timeout
+        _gate_log("phase bootstrap: start (timeout %.1fs)" % timeout)
         returncode, stdout, stderr, timed_out = run_bounded_bash(bootstrap_command, timeout)
+        _gate_log(
+            "phase bootstrap: %.1fs rc=%s%s"
+            % (time.time() - started, returncode, " TIMED OUT" if timed_out else "")
+        )
         bootstrap = {
             "command": bootstrap_command,
             "creates": bootstrap_creates,
@@ -1942,11 +1991,19 @@ elif _no_changes:
     }
 else:
     started = time.time()
-    try:
-        timeout = float(os.environ.get("MAC_WORKER_REPOSITORY_TEST_TIMEOUT", "1800") or "1800")
-    except ValueError:
-        timeout = 1800.0
+    timeout = _test_timeout
+    _gate_log("phase tests: start (timeout %.1fs) %s" % (timeout, command))
     returncode, stdout, stderr, timed_out = run_bounded_bash(command, timeout)
+    _gate_log(
+        "phase tests: %.1fs rc=%s%s"
+        % (
+            time.time() - started,
+            returncode,
+            (" TIMED OUT at %.1fs (%s)" % (timeout, _test_timeout_source))
+            if timed_out
+            else "",
+        )
+    )
     payload = {
         "schema": "mac.sandbox_verification.v1",
         "status": "pass" if returncode == 0 else "fail",

--- a/tests/test_gate_observability.py
+++ b/tests/test_gate_observability.py
@@ -1,0 +1,125 @@
+"""The gate must say what it actually did, not what it was configured to do.
+
+Three multi-hour investigations this month ended at the same wall: the hub-side
+configuration looked correct, and nothing in the run reported the value that was
+actually enforced, the time actually spent, or where the selected tests actually
+came from. Each one is one log line.
+
+  * MAC_WORKER_REPOSITORY_TEST_TIMEOUT was 5400 on the host for three
+    consecutive canary attempts while the sandbox enforced 1800, because the
+    variable was never forwarded in. Every attempt failed with "timed out after
+    1800.0s" against a file that plainly said 5400, and the investigation
+    stopped at the file each time.
+
+  * "OpenShell hangs on macOS" was the leading suspect for a day. Nothing hung;
+    the test phase was simply longer than its budget. Per-phase elapsed would
+    have said so immediately.
+
+  * A "focused, 11 tests" selection sounded narrowed. Those 11 paths held 713
+    tests, 578 of them from ONE always_run guard. The resolver reported only a
+    total, so the decomposition had to be rebuilt by hand.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from mac import executor_sandbox
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _runner_source() -> str:
+    return executor_sandbox._sandbox_repository_verification_shell(
+        {"MAC_TASK_WORKSPACE": "/sandbox/task", "MAC_TASK_FILE": "/sandbox/task/task.json"}
+    )
+
+
+def test_the_sandbox_reports_the_timeout_it_will_enforce():
+    """Not the configured value -- the resolved one, at the point that
+    enforces it."""
+    source = _runner_source()
+
+    assert "_effective_timeout" in source
+    assert "test timeout:" in source
+    assert "bootstrap timeout:" in source
+
+
+def test_the_timeout_report_names_its_source():
+    """"1800.0s" alone is what made the host configuration look authoritative.
+    "1800.0s (default; MAC_WORKER_REPOSITORY_TEST_TIMEOUT unset)" is the
+    sentence that ends the investigation."""
+    source = _runner_source()
+
+    assert "default (%s unset)" in source
+    assert "_test_timeout_source" in source
+
+
+def test_the_sandbox_reports_the_baseline_it_resolved():
+    """An unresolved baseline silently escalates every task to the whole-repo
+    gate, which is indistinguishable from a slow gate unless it is said out
+    loud."""
+    source = _runner_source()
+
+    assert "baseline sha:" in source
+    assert "unresolved" in source
+
+
+def test_each_phase_reports_its_elapsed_time():
+    """"Is it hung or is it slow" cost a day. The answer is a subtraction."""
+    source = _runner_source()
+
+    assert "phase bootstrap: start" in source
+    assert "phase tests: start" in source
+    assert "phase bootstrap: %.1fs" in source
+    assert "phase tests: %.1fs" in source
+
+
+def test_a_timed_out_phase_says_which_budget_it_blew():
+    source = _runner_source()
+
+    assert "TIMED OUT" in source
+
+
+def test_the_resolver_splits_the_selection_by_provenance():
+    """A selection whose cost is almost entirely cross-cutting guards is not
+    narrowed in any way that helps, and a total cannot say so."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/resolve-impacted-tests.py",
+            "--base",
+            "HEAD",
+            "--changed-file",
+            "tests/test_agent_ownership.py",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    document = json.loads(completed.stdout)
+    if document["mode"] != "focused":
+        return  # a full run has no selection to decompose
+
+    provenance = document.get("provenance")
+    assert provenance is not None
+    assert "tests/test_agent_ownership.py" in provenance["impact"]
+    assert "tests/test_control_plane_public_contract.py" in provenance["always_run"]
+
+    # Every selected test is accounted for by exactly one bucket.
+    assert sorted(provenance["impact"] + provenance["always_run"]) == sorted(
+        document["tests"]
+    )
+
+
+def test_the_sanity_runner_prints_the_split():
+    script = (ROOT / "scripts" / "run-sanity-tests.sh").read_text(encoding="utf-8")
+
+    assert "provenance:" in script
+    assert "always_run guards" in script


### PR DESCRIPTION
Three multi-hour investigations this month ended at the same wall: the host-side configuration looked correct, and nothing in the run reported the value **actually enforced**, the time **actually spent**, or where the selected tests **actually came from**. Each one is one log line.

### 1. Effective configuration, inside the sandbox, at startup

Logged at the point that *enforces* each value, not the point that configures it — and each line names its source:

```
[gate] effective configuration:
[gate]   test command:      scripts/run-sanity-tests.sh --base 55699c59
[gate]   test timeout:      1800.0s (default (MAC_WORKER_REPOSITORY_TEST_TIMEOUT unset))
[gate]   bootstrap timeout: 1800.0s (default (...))
[gate]   baseline sha:      55699c59...
```

`MAC_WORKER_REPOSITORY_TEST_TIMEOUT` was 5400 on the host for **three consecutive canary attempts** while the sandbox enforced 1800, because the variable was never forwarded in (fixed in #361). Every attempt failed with "timed out after 1800.0s" against a config file that plainly said 5400, and the investigation stopped at the config file each time. `1800.0s` alone is what made the host value look authoritative; `1800.0s (default; ... unset)` ends it.

### 2. Per-phase elapsed

```
[gate] phase bootstrap: start (timeout 1800.0s)
[gate] phase bootstrap: 140.2s rc=0
[gate] phase tests: start (timeout 1800.0s) scripts/run-sanity-tests.sh --base ...
[gate] phase tests: 1800.0s rc=124 TIMED OUT at 1800.0s (default (... unset))
```

"Is it hung or is it slow" cost a day of treating *OpenShell on macOS* as the suspect. Nothing hung — the test phase was simply longer than its budget. The answer is a subtraction.

### 3. Selection provenance

```
sanity selection: focused (impact_hybrid_scope)
  provenance: 1 from the change, 10 always_run guards
  test: tests/test_agent_ownership.py
  test: tests/test_control_plane_public_contract.py  [always_run]
```

"focused, 11 tests" sounds narrowed. Those 11 paths held **713 tests**, and **578 of them came from one `always_run` guard** — which is what identified the real cost of the in-sandbox gate (fixed in #363). The resolver reported only a total, so that decomposition had to be rebuilt by hand.

### On not repeating the access-log mistake

All of this narrates a gate that runs for minutes, off the request path. The 626MB access log (#362) is the counterexample: per-event logging on the event loop took the hub down. None of this is per-request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)