### PR TITLE
Ask the database for the drift dedup instead of reading every task

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6930,14 +6930,48 @@ class ControlPlane:
                 "removed_commands": drift.get("removed_commands") or [],
             }
             signature = json_dumps(marker)
-            for task in self.list_tasks():
-                if task.state in TERMINAL_TASK_STATES:
-                    continue
-                existing = ensure_json_object(task.metadata).get("sandbox_bom_drift")
-                if isinstance(existing, Mapping) and json_dumps(dict(existing)) == signature:
-                    # Same drift already reported. Re-filing per registration
-                    # would bury the one report that matters.
-                    return {"checked": True, "drift": drift, "filed": None}
+            # Ask the database the question instead of reading the table.
+            #
+            # This runs on every agent registration. It used to pull EVERY task
+            # into Python -- 8,372 rows, 116MB on the fleet hub -- to look at one
+            # metadata key. Unbounded list_tasks() takes over 200 SECONDS there.
+            #
+            # The state list is POSITIVE (the non-terminal states) rather than
+            # `NOT IN (terminal)`, because only the positive form uses
+            # idx_tasks_state_priority. Measured on the fleet hub:
+            #
+            #   NOT IN (terminal) + `->` equality    1950ms  (seq scan, detoasts
+            #                                                 all 8,062 rows)
+            #   state IN (non-terminal) + equality    427ms  (index scan 0.65ms,
+            #                                                 detoasts only 582)
+            #
+            # Nearly all of the remaining time is detoasting metadata_json for
+            # the surviving rows -- at 14KB/row every `->` reads the whole
+            # document -- which is why narrowing by state FIRST is what matters.
+            #
+            # Deliberately NOT using `@>` here. The GIN index on metadata_json
+            # looks like the right answer and is not: forcing it measured 889ms
+            # against 219ms for a plain sequential scan, and the planner refuses
+            # it on its own. See task_747dbbdf.
+            #
+            # The jsonb equality is also stricter than the string comparison it
+            # replaces: json_dumps(...) == json_dumps(...) depended on key
+            # ordering; jsonb compares by value.
+            active = tuple(
+                sorted({state.value for state in TaskState} - set(TERMINAL_TASK_STATES))
+            )
+            placeholders = ", ".join("?" for _ in active)
+            already_reported = self.store.query_one(
+                "SELECT 1 FROM tasks "
+                "WHERE state IN (%s) "
+                "AND metadata_json -> 'sandbox_bom_drift' = ?::jsonb "
+                "LIMIT 1" % placeholders,
+                active + (signature,),
+            )
+            if already_reported is not None:
+                # Same drift already reported. Re-filing per registration
+                # would bury the one report that matters.
+                return {"checked": True, "drift": drift, "filed": None}
             filed = self.create_task(
                 "Sandbox BOM drift: the reviewed image no longer matches the contracts",
                 description="\n".join(

--- a/tests/test_sandbox_bom_drift_trigger.py
+++ b/tests/test_sandbox_bom_drift_trigger.py
@@ -185,3 +185,66 @@ def test_removal_only_drift_is_reported_even_though_it_is_not_filed(cp):
     assert report["checked"]
     assert report["drift"]["removed_commands"], "removal drift went unreported"
     assert report["filed"] is None
+
+
+def test_a_repeated_check_reports_the_drift_and_declines_to_refile(cp, tmp_path):
+    """test_the_same_drift_is_not_filed_twice covers dedup across two
+    registrations by counting tasks. This covers the return contract of a
+    direct re-check: the drift is still REPORTED, and `filed` is None.
+
+    Those are different failures. Counting tasks catches a duplicate row;
+    it does not catch a check that silently stops reporting drift it has
+    already filed, which is what a caller reading `report["drift"]` relies on.
+    """
+    repo = _repo(tmp_path, "needy-twice", ["zig"])
+    cp.register_project_repository("needy-twice", str(repo), project="mac")
+    assert len(_drift_tasks(cp)) == 1, "registration should have filed the drift once"
+
+    again = cp.check_sandbox_bom_drift()
+
+    assert again["checked"]
+    assert again["drift"]["added_commands"] == ["zig"], "drift must still be reported"
+    assert again["filed"] is None, "the same drift was filed twice"
+    assert len(_drift_tasks(cp)) == 1, "expected exactly one open drift task"
+
+
+def test_the_dedup_query_narrows_by_state_before_touching_metadata():
+    """The ordering is both the correctness rule and the performance rule.
+
+    Correctness: dedup must consider only NON-TERMINAL tasks, or resolving a
+    drift task would permanently silence the report.
+
+    Performance: measured on the fleet hub, where tasks averages 14KB/row, the
+    two forms of the same question differ by 4.5x --
+
+        NOT IN (terminal) + jsonb equality   1950ms  (seq scan; detoasts all
+                                                      8,062 rows)
+        IN (non-terminal) + jsonb equality    427ms  (index scan 0.65ms; only
+                                                      582 rows detoasted)
+
+    Only the POSITIVE list uses idx_tasks_state_priority. Both facts point the
+    same way, so this pins the shape rather than trusting it to survive an edit
+    for either reason.
+
+    It also pins the absence of `@>`: the GIN index on metadata_json looks like
+    the right answer and measured 889ms against 219ms for a plain sequential
+    scan. The planner declines it unprompted. See task_747dbbdf.
+    """
+    import inspect
+
+    from mac.services import ControlPlane
+
+    source = inspect.getsource(ControlPlane.check_sandbox_bom_drift)
+
+    assert "state IN (" in source, "dedup must narrow by state in SQL"
+    assert "TERMINAL_TASK_STATES" in source
+    assert "state NOT IN" not in source, (
+        "the negative form cannot use idx_tasks_state_priority"
+    )
+    # Matches the SQL, not the comment that explains why the SQL avoids it.
+    assert "metadata_json @>" not in source, (
+        "the GIN index on metadata_json is slower than a seq scan here"
+    )
+    assert "for task in self.list_tasks()" not in source, (
+        "this runs on every agent registration; it must not read the table"
+    )


### PR DESCRIPTION
First step of `task_747dbbdf` (finishing the SQLite→Postgres port).

`check_sandbox_bom_drift` runs on **every agent registration** and pulled every task into Python to inspect one metadata key. On the fleet hub that's 8,372 rows / 116MB; unbounded `list_tasks()` there takes **over 200 seconds**.

Now one indexed query. Measured on the hub — the same question three ways:

| form | time | plan |
|---|---|---|
| `NOT IN (terminal)` + jsonb equality | 1950ms | seq scan, detoasts all 8,062 rows |
| **`IN (non-terminal)` + jsonb equality** | **427ms** | index scan 0.65ms, only 582 detoasted |
| `metadata_json @>` (GIN forced) | 889ms | vs **219ms** for a plain seq scan |

The state list is **positive** because only that form uses `idx_tasks_state_priority`. Most of the remaining 427ms is detoasting `metadata_json` for surviving rows — at 14KB/row every `->` reads the whole document — which is precisely why narrowing by state *first* is what matters.

### The GIN index is deliberately not used

This is the counterintuitive part, and it's why the commit records it. `idx_tasks_metadata_gin` looks like the right answer for a metadata predicate. It has **never been scanned** (`idx_scan=0`) against 23MB that every write still maintains, and when forced it runs **4× slower than no index at all**. The planner declines it unprompted. Whether to drop it is left to `task_747dbbdf` rather than decided here.

### Correctness

The jsonb equality is stricter than the string comparison it replaces: `json_dumps(...) == json_dumps(...)` depended on key ordering; jsonb compares by value.

### Tests

Adds coverage for the re-check return contract (drift still reported, `filed` is None) and a pin on the query shape — the correctness rule (dedup must see only non-terminal tasks, or resolving a drift task silences the report forever) and the performance rule point at the same ordering.

Both new tests were verified to fail when the dedup query is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)