### PR TITLE
Stop building 2.3GB of indexes nothing has ever read

### DIFF
--- a/src/mac/data/postgres/schema.sql
+++ b/src/mac/data/postgres/schema.sql
@@ -436,8 +436,6 @@ CREATE TABLE IF NOT EXISTS evidence_artifacts (
 -- Live DBs predate content_uri (CREATE TABLE IF NOT EXISTS skips them);
 -- idempotent ALTER mirrors the SQLite _ensure_column migration.
 ALTER TABLE evidence_artifacts ADD COLUMN IF NOT EXISTS content_uri TEXT NOT NULL DEFAULT '';
-CREATE INDEX IF NOT EXISTS idx_evidence_artifacts_evidence
-    ON evidence_artifacts (evidence_id, created_at, id);
 CREATE INDEX IF NOT EXISTS idx_evidence_artifacts_task
     ON evidence_artifacts (task_id, created_at, id);
 
@@ -961,8 +959,6 @@ CREATE TABLE IF NOT EXISTS observability_events (
 );
 CREATE INDEX IF NOT EXISTS idx_observability_events_created
     ON observability_events (created_at, sequence);
-CREATE INDEX IF NOT EXISTS idx_observability_events_kind_layer
-    ON observability_events (kind, layer, created_at);
 CREATE INDEX IF NOT EXISTS idx_observability_events_name_created
     ON observability_events (name, created_at);
 CREATE INDEX IF NOT EXISTS idx_observability_events_subject_sequence
@@ -985,8 +981,6 @@ CREATE TABLE IF NOT EXISTS operator_notifications (
 );
 CREATE INDEX IF NOT EXISTS idx_operator_notifications_status_created
     ON operator_notifications (status, created_at);
-CREATE INDEX IF NOT EXISTS idx_operator_notifications_subject
-    ON operator_notifications (subject_type, subject_id, created_at);
 
 CREATE TABLE IF NOT EXISTS notifier_channels (
     id TEXT PRIMARY KEY,
@@ -1139,18 +1133,8 @@ CREATE TABLE IF NOT EXISTS action_events (
 );
 CREATE INDEX IF NOT EXISTS idx_action_events_timestamp
     ON action_events (timestamp, event_id);
-CREATE INDEX IF NOT EXISTS idx_action_events_agent_timestamp
-    ON action_events (agent_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_action_events_task_timestamp
     ON action_events (task_id, timestamp);
-CREATE INDEX IF NOT EXISTS idx_action_events_session_timestamp
-    ON action_events (session_id, timestamp);
-CREATE INDEX IF NOT EXISTS idx_action_events_sandbox_timestamp
-    ON action_events (sandbox_id, timestamp);
-CREATE INDEX IF NOT EXISTS idx_action_events_policy_timestamp
-    ON action_events (policy_id, policy_version, timestamp);
-CREATE INDEX IF NOT EXISTS idx_action_events_type_outcome
-    ON action_events (action_type, outcome, timestamp);
 
 CREATE TABLE IF NOT EXISTS openshell_policies (
     id TEXT PRIMARY KEY,
@@ -1490,8 +1474,6 @@ CREATE TABLE IF NOT EXISTS secret_access_audit (
     revealed_at TEXT,
     created_at TEXT NOT NULL
 );
-CREATE INDEX IF NOT EXISTS idx_secret_audit_secret_created
-    ON secret_access_audit (secret_id, created_at);
 
 CREATE TABLE IF NOT EXISTS conversation_threads (
     id TEXT PRIMARY KEY,
@@ -1518,7 +1500,6 @@ CREATE TABLE IF NOT EXISTS memory_records (
     created_by TEXT NOT NULL,
     created_at TEXT NOT NULL
 );
-CREATE INDEX IF NOT EXISTS idx_memory_task_created ON memory_records (task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_memory_subject ON memory_records (subject_type, subject_id);
 
 CREATE TABLE IF NOT EXISTS vector_refs (
@@ -6059,10 +6040,6 @@ CREATE TABLE IF NOT EXISTS task_flow_spans (
 );
 CREATE INDEX IF NOT EXISTS idx_task_flow_spans_task
     ON task_flow_spans (task_id, attempt);
-CREATE INDEX IF NOT EXISTS idx_task_flow_spans_project
-    ON task_flow_spans (project, stage, started_at);
-CREATE INDEX IF NOT EXISTS idx_task_flow_spans_stage_time
-    ON task_flow_spans (stage, started_at);
 
 CREATE TABLE IF NOT EXISTS task_completions (
     id TEXT PRIMARY KEY,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6772,6 +6772,22 @@ class ControlPlane:
             tasks = [task for task in tasks if self._task_tenant_id(task) == tenant_id]
         return tasks
 
+    def _non_terminal_tasks(self) -> List[Task]:
+        """Every task that is not in a terminal state, filtered in SQL.
+
+        The positive state list is deliberate: `state IN (...)` uses
+        idx_tasks_state_priority, while `state NOT IN (...)` does not. Measured
+        on the fleet hub, the two forms of the same question differed by 4.5x.
+        """
+        active = sorted({state.value for state in TaskState} - set(TERMINAL_TASK_STATES))
+        placeholders = ", ".join("?" for _ in active)
+        rows = self.store.query_all(
+            "SELECT * FROM tasks WHERE state IN (%s) "
+            "ORDER BY priority DESC, created_at" % placeholders,
+            tuple(active),
+        )
+        return [self._task_from_row(row) for row in rows]
+
     def ready_tasks(
         self,
         *,
@@ -7009,9 +7025,11 @@ class ControlPlane:
             agents,
             image_ref,
             bom=bom or {},
-            already_scheduled=scheduled_rollouts(
-                [task for task in self.list_tasks() if task.state not in TERMINAL_TASK_STATES]
-            ),
+            # Ask SQL for the non-terminal tasks rather than reading all of
+            # them and discarding most in Python. On the fleet hub the table is
+            # 8,372 rows / 116MB and ~89% of it is terminal, so this fetched
+            # (and detoasted) roughly nine rows for every one it kept.
+            already_scheduled=scheduled_rollouts(self._non_terminal_tasks()),
         )
         filed: List[str] = []
         skipped: List[str] = []
@@ -8662,7 +8680,10 @@ class ControlPlane:
 
     def delete_project(self, name_or_id: str, *, force: bool = False, actor: str = "human") -> None:
         project = self.get_project_record(name_or_id)
-        tasks = [task for task in self.list_tasks() if task.project == project.name]
+        # project= is pushed into SQL; list_tasks() already supports it. Reading
+        # every task in every project to keep one project's is the same
+        # whole-table scan that made a one-row insert take 100s (task_e3caa954).
+        tasks = self.list_tasks(project=project.name)
         repo_rows = self.store.query_all(
             "SELECT id FROM project_repositories WHERE project = ?",
             (project.name,),

--- a/tests/test_no_dead_indexes.py
+++ b/tests/test_no_dead_indexes.py
@@ -1,0 +1,87 @@
+"""Indexes that are never scanned are pure cost, and they came back for free.
+
+Measured on the fleet hub 2026-08-15 (PostgreSQL 17.10, stats never reset, so
+idx_scan=0 means never used since the database was created):
+
+    unused indexes                        407
+    their total size                     2682 MB
+    database size                        7652 MB
+
+A third of the database was index that only ever cost writes, concentrated on
+the two highest-write-rate tables:
+
+    action_events          8 indexes  2775 MB  (69 MB heap, 148k rows)
+    observability_events   6 indexes  2480 MB  (201 MB heap, 500k rows)
+
+5.25 GB of index on 270 MB of heap, maintained on every firehose insert. This
+is the same failure mode as the action_events incident that wedged the hub at
+16 GB: an index per column, added speculatively, never queried.
+
+Twelve were dropped, reclaiming 2296 MB (7652 MB -> 5356 MB). This test exists
+because dropping them from the DATABASE is not enough: initialize() re-applies
+the packaged schema on every hub start, so leaving the CREATE INDEX statements
+in schema.sql would have silently rebuilt all of it on the next restart, and
+the next measurement would have looked like the drops simply never worked.
+
+Constraint-backing indexes are deliberately NOT in this list even when unused.
+observability_events_id_key has never been scanned and stays: a unique index is
+enforced on write, and its scan count says nothing about whether it is needed.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+SCHEMA = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "src" / "mac" / "data" / "postgres" / "schema.sql"
+)
+
+# name -> size it occupied on the fleet hub when it was dropped
+DROPPED_INDEXES = {
+    "idx_observability_events_kind_layer": "496 MB",
+    "idx_action_events_type_outcome": "371 MB",
+    "idx_action_events_agent_timestamp": "326 MB",
+    "idx_action_events_policy_timestamp": "324 MB",
+    "idx_action_events_sandbox_timestamp": "324 MB",
+    "idx_action_events_session_timestamp": "324 MB",
+    "idx_secret_audit_secret_created": "56 MB",
+    "idx_memory_task_created": "38 MB",
+    "idx_operator_notifications_subject": "16 MB",
+    "idx_evidence_artifacts_evidence": "8.6 MB",
+    "idx_task_flow_spans_project": "6.6 MB",
+    "idx_task_flow_spans_stage_time": "6.0 MB",
+}
+
+
+@pytest.mark.parametrize("name", sorted(DROPPED_INDEXES), ids=sorted(DROPPED_INDEXES))
+def test_a_dropped_index_is_not_recreated_by_the_schema(name):
+    """Re-adding one of these to schema.sql rebuilds it on the next hub start."""
+    schema = SCHEMA.read_text(encoding="utf-8")
+
+    assert name not in schema, (
+        "%s was dropped from the fleet hub (%s reclaimed) because it had never "
+        "been scanned. Putting it back in schema.sql recreates it on every "
+        "initialize(). If it is genuinely needed now, say so here and delete "
+        "this entry -- do not add it back silently."
+        % (name, DROPPED_INDEXES[name])
+    )
+
+
+def test_the_indexes_that_earn_their_keep_are_still_there():
+    """The counterweight: this must not become an argument for having no
+    indexes. Each of these was measured in active use on the hub."""
+    schema = SCHEMA.read_text(encoding="utf-8")
+
+    for name in (
+        "idx_observability_events_subject_sequence",  # 33,820 scans
+        "idx_observability_events_name_created",      # 2,043 scans
+        "idx_observability_events_created",           # 2,937 scans
+        "idx_action_events_timestamp",                # 353 scans
+        "idx_action_events_task_timestamp",           # 993 scans
+        "idx_tasks_state_priority",                   # 13,692 scans
+        "idx_tasks_owner",                            # 575,667 scans
+    ):
+        assert name in schema, "%s is in active use and must not be dropped" % name


### PR DESCRIPTION
Part of `task_22b5eadb`. Applied to the fleet hub during an authorized maintenance window.

`pg_stat_database.stats_reset` is NULL on the hub, so `idx_scan=0` means **never used since the database was created** — not "not used lately".

| | before | after |
|---|---|---|
| database size | 7652 MB | **5356 MB** |
| unused index waste | 2682 MB | 386 MB |
| `action_events` indexes | 8 / 2775 MB | 3 / 1106 MB |
| `observability_events` indexes | 6 / 2480 MB | 5 / 1984 MB |

5.25 GB of index sat on 270 MB of heap, maintained on every firehose insert. Same failure mode as the `action_events` incident that wedged the hub at 16 GB: an index per column, added speculatively, never queried.

### Removing them from schema.sql is the point

`initialize()` re-applies the packaged schema on every hub start, so dropping the indexes from the *database* alone would have silently rebuilt all 2.3 GB on the next restart — and the next measurement would have looked like the drops simply never worked.

### Constraints excluded on purpose

`observability_events_id_key` (299 MB) has never been scanned and **stays**. A unique index is enforced on write; its scan count says nothing about whether it's needed. Any "unused index" tooling will happily recommend dropping it.

### Also: two whole-table reads pushed into SQL

Both fetched every task and discarded most in Python — 8,372 rows / 116 MB on the hub, ~89% terminal. The new `_non_terminal_tasks()` helper uses a **positive** state list because only that form uses `idx_tasks_state_priority`; the negative form measured 4.5× slower.

Tests pin each dropped index by name (with the size it occupied), and separately assert the seven indexes measured in active use are still present — so this can't become an argument for having no indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)