### PR TITLE
Bound the sync-barrier scans on the claim path

### DIFF
--- a/src/mac/task_lifecycle.py
+++ b/src/mac/task_lifecycle.py
@@ -437,9 +437,9 @@ class DispatchService:
         head_id: Optional[str] = None
         head_created_at: Optional[str] = None
         running = False
-        for task in self.control_plane.list_tasks():
-            if task.state in TERMINAL_TASK_STATES:
-                continue
+        # Non-terminal only, filtered in SQL. Reading every task to discard
+        # ~89% of them in Python is what made claim-next miss its deadline.
+        for task in self.control_plane._non_terminal_tasks():
             metadata = ensure_json_object(task.metadata)
             if normalize_execution_mode(metadata.get("execution_mode")) != EXECUTION_MODE_SYNC:
                 continue
@@ -478,9 +478,9 @@ class DispatchService:
 
         heads: Dict[str, Tuple[Optional[str], bool]] = {}
         earliest: Dict[str, str] = {}
-        for task in self.control_plane.list_tasks():
-            if task.state in TERMINAL_TASK_STATES:
-                continue
+        # Same as above: the state filter belongs in SQL. This runs once per
+        # allocation round on the hottest endpoint in the system.
+        for task in self.control_plane._non_terminal_tasks():
             metadata = ensure_json_object(task.metadata)
             if normalize_execution_mode(
                 metadata.get("execution_mode")


### PR DESCRIPTION
Part of `task_e3caa954`.

Both sync-barrier helpers read **every** task and then skipped terminal ones in Python. On the fleet hub that's 8,372 rows / 116 MB, ~89% terminal — so they fetched and detoasted roughly nine rows for every one they kept, **once per allocation round, on `claim-next`**.

`claim-next` is the endpoint every worker polls continuously. A py-spy dump taken *after* the database maintenance still showed it inside `list_tasks`, which is why this is worth doing separately.

`_non_terminal_tasks()` puts the state filter in SQL with a **positive** state list — the form that uses `idx_tasks_state_priority` (the negative form measured 4.5× slower).

### What is deliberately not changed

`backlog_groomer`, `curiosity_reviewer`, and `github_ingest` also scan unbounded, and they stay that way for now. Each tracks the *latest task per key including terminal ones*, so a non-terminal filter would narrow what they can see and could make them re-file work already done — the same class of silent regression as the drift dedup. Not worth trading for a background timer's latency; they need per-site work instead.

60 allocator/sync-barrier tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)