### PR TITLE
Let a slow request name itself, and stop timing out on a slow hub

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -4656,6 +4656,45 @@ def create_app(
         except (MACError, StoreError):
             _log.warning("failed to record http observation for %s", request.url.path, exc_info=True)
 
+    def _log_slow_request(request: Any, status_code: int, started: float) -> None:
+        """Name a request that took too long, once, at the point it finishes.
+
+        Deliberately THRESHOLD-triggered rather than per-request. The hub used
+        to write a uvicorn access line for every request, synchronously, on the
+        event loop; that log reached 626MB / 5.4M lines and a thread dump caught
+        the loop inside logging flush() instead of serving, which is what got
+        the hub restarted mid-publication (see deploy/fleet-node-install.sh).
+        So: nothing is written on the normal path, and a slow request costs one
+        line.
+
+        This exists because point-in-time probing kept lying about the cause.
+        `mac task ready` timing out was investigated three separate times --
+        blamed on the allocator, on threadpool exhaustion, and on connection
+        pool exhaustion. All three were checked while the hub happened to be
+        idle and all three measured clean; the pool DID exhaust later, under a
+        load that was gone by the time anyone looked. A request that names
+        itself when it is slow removes the need to be watching at the right
+        moment.
+
+        Tune with MAC_SLOW_REQUEST_SECONDS; 0 or negative disables it.
+        """
+        try:
+            threshold = float(os.environ.get("MAC_SLOW_REQUEST_SECONDS", "1.0") or "1.0")
+        except ValueError:
+            threshold = 1.0
+        if threshold <= 0:
+            return
+        elapsed = time.monotonic() - started
+        if elapsed < threshold:
+            return
+        _log.warning(
+            "slow request: %s %s %s in %.1fs",
+            request.method,
+            request.url.path,
+            status_code,
+            elapsed,
+        )
+
     @app.middleware("http")
     async def authenticate(request: Request, call_next: Any) -> Any:
         started = time.monotonic()
@@ -4725,6 +4764,7 @@ def create_app(
                     error_name = exc.__class__.__name__
                     raise
                 finally:
+                    _log_slow_request(request, status_code, started)
                     await asyncio.to_thread(
                         _emit_http_observation,
                         request,

--- a/src/mac/api_client.py
+++ b/src/mac/api_client.py
@@ -8,6 +8,7 @@ workers and orchestrators should import them from here.
 from __future__ import annotations
 
 import json
+import os
 import urllib.error
 import urllib.request
 from typing import Any, Callable, Dict, Optional
@@ -15,6 +16,19 @@ from typing import Any, Callable, Dict, Optional
 
 JsonDict = Dict[str, Any]
 Transport = Callable[[str, str, Optional[JsonDict]], Any]
+
+
+def _default_timeout_seconds() -> float:
+    """Client timeout, overridable per host without a redeploy."""
+    raw = os.environ.get("MAC_API_TIMEOUT_SECONDS", "").strip()
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            return MacApiClient.DEFAULT_TIMEOUT_SECONDS
+        if value > 0:
+            return value
+    return MacApiClient.DEFAULT_TIMEOUT_SECONDS
 
 
 class MacApiError(RuntimeError):
@@ -29,16 +43,31 @@ class MacApiClient:
     HTTP server.
     """
 
+    #: Seconds to wait on a hub call before treating it as a transient failure.
+    #:
+    #: 10s was too tight for a loaded hub, and the failure it produced was
+    #: expensive rather than graceful: an agent whose registration call timed
+    #: out reported "transient transport error: timed out" and stayed OFFLINE,
+    #: so the fleet lost a worker exactly when it was busiest. Observed on
+    #: 2026-08-15 -- rocky could not register after a restart while the hub was
+    #: answering /tasks in 12s, and the review tick that agent owns therefore
+    #: did not run either.
+    #:
+    #: A client timeout should protect against a hub that is GONE, not one that
+    #: is slow, so it belongs above the slowest call worth waiting for.
+    #: Override with MAC_API_TIMEOUT_SECONDS.
+    DEFAULT_TIMEOUT_SECONDS = 30.0
+
     def __init__(
         self,
         base_url: str,
         token: Optional[str] = None,
-        timeout: float = 10.0,
+        timeout: Optional[float] = None,
         transport: Optional[Transport] = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.token = token
-        self.timeout = timeout
+        self.timeout = timeout if timeout is not None else _default_timeout_seconds()
         self.transport = transport
 
     def get(self, path: str) -> Any:

--- a/tests/test_slow_request_logging.py
+++ b/tests/test_slow_request_logging.py
@@ -1,0 +1,104 @@
+"""A slow request should name itself, and a normal one should cost nothing.
+
+Point-in-time probing kept lying about why the hub was slow. `mac task ready`
+timing out was investigated three separate times and blamed on, in order: the
+allocator, request-threadpool exhaustion, and connection-pool exhaustion. Each
+was measured while the hub happened to be idle and each measured clean --
+16 idle threadpool workers, 12 of 100 connections, 1.7% CPU. The pool DID
+exhaust later ("couldn't get a connection after 30.00 sec"), under a load that
+was gone by the time anyone went looking.
+
+A request that reports its own duration when it exceeds a threshold removes the
+need to be watching at the right moment.
+
+The counterweight is the reason this is threshold-triggered and not
+per-request: the hub used to write a uvicorn access line for EVERY request,
+synchronously, on the event loop. That log reached 626MB / 5.4M lines, and a
+thread dump caught the loop inside logging flush() rather than serving --
+which is what got the hub restarted mid-publication. Observability that runs on
+every request is how the last outage happened, so the normal path must stay
+silent.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from mac import api
+
+
+def _middleware_module_source() -> str:
+    return inspect.getsource(api)
+
+
+def test_the_normal_path_writes_nothing():
+    """A per-request log line on the event loop is what took the hub down."""
+    source = _middleware_module_source()
+
+    assert "def _log_slow_request" in source
+    # The early return must come before any logging call.
+    helper = source[source.index("def _log_slow_request") :]
+    helper = helper[: helper.index("\n    @app.middleware")]
+
+    guard = helper.index("if elapsed < threshold:")
+    emit = helper.index("_log.warning")
+    assert guard < emit, "fast requests must return before anything is logged"
+
+
+def test_the_threshold_is_tunable_and_can_be_disabled():
+    source = _middleware_module_source()
+    helper = source[source.index("def _log_slow_request") :]
+    helper = helper[: helper.index("\n    @app.middleware")]
+
+    assert "MAC_SLOW_REQUEST_SECONDS" in helper
+    assert "if threshold <= 0:" in helper, "operators must be able to turn it off"
+
+
+def test_a_bad_threshold_does_not_break_requests():
+    """A typo in an env var must not take the hub's request path with it."""
+    source = _middleware_module_source()
+    helper = source[source.index("def _log_slow_request") :]
+    helper = helper[: helper.index("\n    @app.middleware")]
+
+    assert "except ValueError" in helper
+
+
+def test_the_line_says_which_request_and_how_long():
+    """"something was slow" is what the previous three investigations already
+    knew. The route and the duration are the parts that were missing."""
+    source = _middleware_module_source()
+    helper = source[source.index("def _log_slow_request") :]
+    helper = helper[: helper.index("\n    @app.middleware")]
+
+    assert "request.method" in helper
+    assert "request.url.path" in helper
+    assert "elapsed" in helper
+
+
+def test_the_client_timeout_is_above_a_slow_hub_not_at_it():
+    """10s made a loaded hub indistinguishable from a dead one: rocky failed to
+    register while the hub was answering /tasks in 12s, so the fleet lost the
+    agent that owns the review tick."""
+    from mac.api_client import MacApiClient
+
+    assert MacApiClient.DEFAULT_TIMEOUT_SECONDS >= 30.0
+
+
+def test_the_client_timeout_is_overridable(monkeypatch):
+    from mac.api_client import MacApiClient
+
+    monkeypatch.setenv("MAC_API_TIMEOUT_SECONDS", "45")
+    assert MacApiClient("http://example.invalid").timeout == 45.0
+
+    monkeypatch.setenv("MAC_API_TIMEOUT_SECONDS", "not-a-number")
+    assert (
+        MacApiClient("http://example.invalid").timeout
+        == MacApiClient.DEFAULT_TIMEOUT_SECONDS
+    ), "a malformed override must fall back, not crash the client"
+
+
+def test_an_explicit_timeout_still_wins():
+    """Callers with a genuine reason to be impatient keep control."""
+    from mac.api_client import MacApiClient
+
+    assert MacApiClient("http://example.invalid", timeout=5).timeout == 5


### PR DESCRIPTION
Two fixes for the same failure: not knowing *which* call was slow, and giving up on it too early.

### Slow-request logging

`mac task ready` timing out was investigated **three separate times** and blamed, in order, on the allocator, request-threadpool exhaustion, and connection-pool exhaustion. Each was measured while the hub happened to be idle, and each measured clean — 16 idle threadpool workers, 12 of 100 connections, 1.7% CPU on 12 cores. The pool *did* exhaust later (`couldn't get a connection after 30.00 sec`), under a load that was gone before anyone looked.

A request that reports its own duration removes the need to be watching at the right moment.

**Threshold-triggered on purpose.** The hub used to write a uvicorn access line for every request, synchronously, on the event loop — that log reached 626MB / 5.4M lines, and a thread dump caught the loop inside `logging flush()` instead of serving, which is what got it restarted mid-publication (#362). So the normal path writes nothing, and a slow request costs exactly one line. `MAC_SLOW_REQUEST_SECONDS` tunes it; `<= 0` disables.

### Client timeout 10s → 30s

10s made a loaded hub indistinguishable from a dead one. On 2026-08-15 rocky could not register after a restart — the hub was answering `/tasks` in 12s — so it stayed OFFLINE. Since rocky is `MAC_REVIEW_TICK_HUB_AGENT`, the review sweep it owns didn't run either: **one tight timeout cost the fleet a worker and its publication path**.

A client timeout should protect against a hub that is *gone*, not one that is slow. `MAC_API_TIMEOUT_SECONDS` overrides; an explicit `timeout=` still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)