### PR TITLE
Fix main: refresh env registry, drop stale dropped-index assertions

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -48,6 +48,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_AGENT_ZOMBIE_STREAM_AGE_SECONDS` | int | consumer-defined | agent | Agent setting: agent zombie stream age seconds. |
 | `MAC_ALLOW_UNSANDBOXED_YOLO` | bool | consumer-defined | core | Core setting: allow unsandboxed yolo. |
 | `MAC_API_ALLOW_OPEN` | bool | consumer-defined | api-auth | Api Auth setting: api allow open. |
+| `MAC_API_TIMEOUT_SECONDS` | int | consumer-defined | api-auth | Api Auth setting: api timeout seconds. |
 | `MAC_API_TOKEN` | str | consumer-defined | api-auth | Api Auth setting: api token. |
 | `MAC_API_TOKENS` | str | consumer-defined | api-auth | Api Auth setting: api tokens. |
 | `MAC_API_TOKEN__JORDANH_HUB` | str | consumer-defined | api-auth | Api Auth setting: api token  jordanh hub. |
@@ -1027,6 +1028,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_SHARED_SERVICES_MANAGER_AGENT` | str | consumer-defined | core | Core setting: shared services manager agent. |
 | `MAC_SKIP_SLACK_VERIFY` | str | consumer-defined | core | Core setting: skip slack verify. |
 | `MAC_SKIP_TELEGRAM_VERIFY` | str | consumer-defined | core | Core setting: skip telegram verify. |
+| `MAC_SLOW_REQUEST_SECONDS` | int | consumer-defined | core | Core setting: slow request seconds. |
 | `MAC_SRC` | str | consumer-defined | core | Core setting: src. |
 | `MAC_STARTUP_CLEAR_HOLD` | str | consumer-defined | core | Core setting: startup clear hold. |
 | `MAC_STARTUP_EMIT_CHECKOUT_SHA` | str | consumer-defined | core | Core setting: startup emit checkout sha. |
@@ -1100,6 +1102,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_TEST_REBUILD_MAP` | bool | consumer-defined | core | Core setting: test rebuild map. |
 | `MAC_TEST_SELECT_BASE` | str | consumer-defined | core | Core setting: test select base. |
 | `MAC_TEST_STALL_TIMEOUT` | int | consumer-defined | core | Core setting: test stall timeout. |
+| `MAC_TICK_BLOCKING_HUB_VERIFY` | str | consumer-defined | core | Core setting: tick blocking hub verify. |
 | `MAC_TOKEN` | str | consumer-defined | core | Core setting: token. |
 | `MAC_TOKENHUB_ALLOW_DEGRADED` | bool | consumer-defined | tokenhub-legacy | Tokenhub Legacy setting: tokenhub allow degraded. |
 | `MAC_TOKENHUB_CHECK_TIMEOUT_SECONDS` | int | consumer-defined | tokenhub-legacy | Tokenhub Legacy setting: tokenhub check timeout seconds. |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -547,6 +547,17 @@
   },
   {
     "default": null,
+    "description": "Api Auth setting: api timeout seconds.",
+    "family": "api-auth",
+    "name": "MAC_API_TIMEOUT_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/api_client.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Api Auth setting: api token.",
     "family": "api-auth",
     "name": "MAC_API_TOKEN",
@@ -12173,6 +12184,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: slow request seconds.",
+    "family": "core",
+    "name": "MAC_SLOW_REQUEST_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/api.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Core setting: src.",
     "family": "core",
     "name": "MAC_SRC",
@@ -13060,6 +13082,17 @@
       "src/mac/executor_prompt.py"
     ],
     "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Core setting: tick blocking hub verify.",
+    "family": "core",
+    "name": "MAC_TICK_BLOCKING_HUB_VERIFY",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "str"
   },
   {
     "default": null,

--- a/tests/test_task_flow_analytics_store.py
+++ b/tests/test_task_flow_analytics_store.py
@@ -243,8 +243,6 @@ class TestFreshDatabaseTables:
         indexes = all_index_names(db)
         for name in (
             "idx_task_flow_spans_task",
-            "idx_task_flow_spans_project",
-            "idx_task_flow_spans_stage_time",
             "idx_task_completions_task",
             "idx_task_completions_project",
             "idx_task_completions_outcome_time",
@@ -499,8 +497,6 @@ class TestPostgresSchema:
         text = self._schema_text()
         for name in (
             "idx_task_flow_spans_task",
-            "idx_task_flow_spans_project",
-            "idx_task_flow_spans_stage_time",
             "idx_task_completions_task",
             "idx_task_completions_project",
             "idx_task_completions_outcome_time",


### PR DESCRIPTION
\`main\` has been red since #369 (stale generated env-config registry) and #366
(dropped \`idx_task_flow_spans_project\` / \`idx_task_flow_spans_stage_time\` as
dead indexes but left \`test_task_flow_analytics_store.py\` asserting they
still exist).

- Regenerated \`src/mac/data/env_config_registry.json\` / \`docs/env-config-reference.md\`
- Removed the two dropped-index assertions from \`test_indexes_created\` and
  \`test_indexes_present_in_schema\`, matching what #366 actually did to
  \`schema.sql\` (see \`tests/test_no_dead_indexes.py\` for the documented drop)

Verified locally: \`scripts/run-contract-tests.sh\` (affected + public-contract +
process-E2E sanity scope) passes — 578 passed.