### PR TITLE
Stop a broken review harness from spending the work's retry budget

### DIFF
--- a/src/mac/review_service.py
+++ b/src/mac/review_service.py
@@ -39,6 +39,7 @@ from mac.models import (
     utcnow,
 )
 from mac.messaging_service import MessagingService
+from mac.review_failure_classifier import classify_review_failure
 from mac.observability_service import ObservabilityService
 
 
@@ -557,11 +558,36 @@ class ReviewService:
         task_for_feedback = reviewed_task if rejected_feedback is not None else None
         transition_target: Optional[str] = None
         transition_detail: Optional[Dict[str, Any]] = None
+        refund_attempt = False
         if status_value in {
             ReviewStatus.CHANGES_REQUESTED.value,
             ReviewStatus.REJECTED.value,
         }:
-            exhausted = reviewed_task.attempt_count >= reviewed_task.max_attempts
+            # A rejection caused by the review HARNESS is not evidence about the
+            # work, so it must not consume the work's retry budget.
+            #
+            # Observed on task_4ce995cb (2026-08-13): a worker submitted a
+            # correct one-line regression test three times; all three reviews
+            # rejected with "hub contract verification failed" carrying 588
+            # collection errors and, on attempt 2, the sandbox UnicodeEncodeError
+            # that PR #352 fixed eleven hours later. attempt_count reached 3/3,
+            # the task went terminal, and the post-mortem classifier labelled it
+            # "scope" -- whose operator remediation is "decompose", advice that
+            # was actively wrong for a one-line change. An equivalent task filed
+            # afterwards succeeded unchanged (PR #353).
+            #
+            # classify_review_failure already separates these correctly; it was
+            # simply never consulted here. evidence_type is deliberately NOT
+            # passed: "review_verdict" short-circuits to semantic_rejection
+            # before the free-text rules run, which is precisely the reasoning
+            # that treated a blown-up harness as a judgement about the work.
+            classification = classify_review_failure(
+                reason or "",
+                error=str((rejected_feedback or {}).get("feedback") or "") or None,
+            )
+            refund_attempt = bool(classification.is_infrastructure)
+            effective_attempts = reviewed_task.attempt_count - (1 if refund_attempt else 0)
+            exhausted = effective_attempts >= reviewed_task.max_attempts
             transition_target = (
                 TaskState.BLOCKED.value if exhausted else TaskState.OPEN.value
             )
@@ -571,7 +597,17 @@ class ReviewService:
                 "reason": "review rejected after max attempts"
                 if exhausted
                 else "review rejected",
+                "review_failure_class": classification.failure_class,
+                "review_failure_is_infrastructure": classification.is_infrastructure,
             }
+            if refund_attempt:
+                # Name the refund in the transition detail so the ledger shows
+                # why this rejection did not cost the task an attempt.
+                transition_detail["attempt_refunded"] = True
+                transition_detail["reason"] = (
+                    "review harness failed (%s); attempt refunded"
+                    % classification.failure_class
+                )
             if exhausted:
                 transition_detail["manual_repair_required"] = True
         with self.store.transaction() as conn:
@@ -618,13 +654,42 @@ class ReviewService:
                     "UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ?",
                     (json_dumps(metadata), now, review.task_id),
                 )
+            if refund_attempt:
+                # attempt_count increments at CLAIM time, so a harness failure
+                # has already spent one before any judgement about the work
+                # exists. Give it back, clamped at zero, in the same
+                # transaction as the review row and the transition.
+                conn.execute(
+                    """
+                    UPDATE tasks
+                    SET attempt_count = CASE
+                            WHEN attempt_count > 0 THEN attempt_count - 1
+                            ELSE 0
+                        END,
+                        updated_at = ?
+                    WHERE id = ?
+                    """,
+                    (now, review.task_id),
+                )
             self._record_history(
                 review.task_id,
                 "task.review_completed",
                 reviewer_agent_id,
                 None,
                 None,
-                {"review_id": review_id, "status": status_value, "reason": reason},
+                {
+                    "review_id": review_id,
+                    "status": status_value,
+                    "reason": reason,
+                    **(
+                        {
+                            "attempt_refunded": True,
+                            "review_failure_class": classification.failure_class,
+                        }
+                        if refund_attempt
+                        else {}
+                    ),
+                },
                 conn=conn,
             )
             if transition_target is not None:

--- a/tests/test_review_attempt_refund.py
+++ b/tests/test_review_attempt_refund.py
@@ -1,0 +1,212 @@
+"""A review rejected by its own harness must not spend the task's retry budget.
+
+Regression cover for task_b1f81fde, whose evidence is task_4ce995cb
+(2026-08-13).  A worker submitted a correct one-line regression test three
+times.  All three reviews rejected -- not on the merits, but because the review
+harness itself failed: attempts 1 and 3 reported ``36 failed, 84 passed, 588
+errors``, and attempt 2 reported the sandbox ``UnicodeEncodeError: 'ascii'
+codec can't encode character '\\xa7'`` that PR #352 fixed eleven hours later.
+
+``attempt_count`` increments at CLAIM time, so each of those harness failures
+had already spent an attempt before any judgement about the work existed.  The
+task reached 3/3, went terminal, and the post-mortem classifier labelled it
+``scope`` -- whose operator remediation is "decompose", advice that was
+actively wrong for a one-line change.  An equivalent task filed afterwards
+succeeded unchanged and merged as PR #353.
+
+``classify_review_failure`` already separated these cases correctly; it was
+simply never consulted where the budget is spent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import ReviewStatus, TaskState
+from mac.services import ControlPlane
+from tests.test_control_plane import register_agent, verified_repo_metadata
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+# The verbatim feedback recorded on task_4ce995cb's three rejections.
+HARNESS_588_ERRORS = (
+    "hub contract verification failed: ]\n"
+    "ERROR tests/test_control_plane_public_contract.py::"
+    "test_control_plane_public_methods_accept_or_reject_complete_requests"
+    "[workflow_run_decisions]\n"
+    "============ 36 failed, 84 passed, 4 skipped, 588 errors in 29.56s "
+    "=============\n"
+    "  Uploading files to /sandbox...\n"
+    "Error:   x ssh exited with status exit status: 1\n"
+)
+
+HARNESS_UTF8 = (
+    "hub contract verification failed: "
+    'File "/opt/mac-venv/lib/python3.12/site-packages/psycopg/_queries.py", '
+    "line 167, in _ensure_bytes\n"
+    "    return query.encode(self._tx.encoding)\n"
+    "UnicodeEncodeError: 'ascii' codec can't encode character '\\xa7' in "
+    "position 17789: ordinal not in range(128)\n"
+    "Error:   x ssh exited with status exit status: 1\n"
+)
+
+SEMANTIC_REJECTION = (
+    "The change does not satisfy the acceptance criteria: the new test still "
+    "passes when the empty-owner half of the gate is deleted, so it does not "
+    "pin the behaviour the task asked for."
+)
+
+
+def _drive_to_review(cp, name):
+    """Create a task, take it through one attempt, and open a review on it."""
+    executor = register_agent(cp, "%s-executor" % name, ["python"])
+    reviewer = register_agent(cp, "%s-reviewer" % name, ["review"])
+    task = cp.create_task(name, required_capabilities=["python"])
+    cp.claim_task(task.id, executor.id)
+    cp.start_task(task.id, executor.id)
+    evidence = cp.add_evidence(
+        task.id,
+        "log",
+        "artifact://%s" % name,
+        "ready",
+        executor.id,
+        metadata=verified_repo_metadata(cp, executor.id),
+    )
+    cp.submit_for_review(task.id, executor.id)
+    review = cp.request_review(task.id, reviewer.id, actor="manual")
+    return executor, reviewer, task, review, evidence
+
+
+def _reject_with(cp, review, reviewer, task, feedback, reviewed_evidence):
+    """Reject `review`, carrying `feedback` on the verdict evidence.
+
+    The feedback lives in evidence metadata under ``verification.feedback``,
+    which is where the hub review verifier actually writes it.
+    """
+    verdict = cp.add_evidence(
+        task.id,
+        "review",
+        "artifact://verdict-%s" % review.id,
+        "verdict",
+        reviewer.id,
+        metadata={
+            "verification": {
+                "evidence_type": "review_verdict",
+                "verdict": "rejected",
+                "feedback": feedback,
+                "reviewed_evidence_id": reviewed_evidence.id,
+            }
+        },
+    )
+    return cp.submit_review(
+        review.id,
+        ReviewStatus.REJECTED.value,
+        reviewer.id,
+        reason="reviewer rejected via signed verdict evidence",
+        evidence_id=verdict.id,
+    )
+
+
+def test_harness_failure_refunds_the_attempt_it_spent(cp):
+    """The 588-collection-error rejection from task_4ce995cb costs nothing."""
+    _, reviewer, task, review, ev = _drive_to_review(cp, "harness-refund")
+    assert cp.get_task(task.id).attempt_count == 1
+
+    _reject_with(cp, review, reviewer, task, HARNESS_588_ERRORS, ev)
+
+    after = cp.get_task(task.id)
+    assert after.attempt_count == 0, (
+        "a rejection caused by the review harness must not spend the work's "
+        "retry budget"
+    )
+    assert after.state == TaskState.OPEN.value
+
+
+def test_sandbox_encoding_failure_refunds_the_attempt(cp):
+    """Attempt 2's UnicodeEncodeError is infrastructure, not a judgement."""
+    _, reviewer, task, review, ev = _drive_to_review(cp, "utf8-refund")
+    assert cp.get_task(task.id).attempt_count == 1
+
+    _reject_with(cp, review, reviewer, task, HARNESS_UTF8, ev)
+
+    after = cp.get_task(task.id)
+    assert after.attempt_count == 0
+    assert after.state == TaskState.OPEN.value
+
+
+def test_semantic_rejection_still_spends_the_attempt(cp):
+    """A real judgement about the work must still consume the budget."""
+    _, reviewer, task, review, ev = _drive_to_review(cp, "semantic-spend")
+    assert cp.get_task(task.id).attempt_count == 1
+
+    _reject_with(cp, review, reviewer, task, SEMANTIC_REJECTION, ev)
+
+    after = cp.get_task(task.id)
+    assert after.attempt_count == 1, (
+        "a rejection on the merits is evidence about the work and must still "
+        "cost an attempt"
+    )
+    assert after.state == TaskState.OPEN.value
+
+
+def test_repeated_harness_failures_never_exhaust_the_budget(cp):
+    """The whole task_4ce995cb shape: three harness rejections, still alive.
+
+    Previously this reached attempt_count 3/3 and went terminal with
+    failure_class "scope".  The task must remain retryable instead.
+    """
+    executor, reviewer, task, review, ev = _drive_to_review(cp, "three-strikes")
+
+    for round_index, feedback in enumerate(
+        (HARNESS_588_ERRORS, HARNESS_UTF8, HARNESS_588_ERRORS)
+    ):
+        _reject_with(cp, review, reviewer, task, feedback, ev)
+        current = cp.get_task(task.id)
+        assert current.state == TaskState.OPEN.value, (
+            "round %d left the task in %s" % (round_index, current.state)
+        )
+        assert current.attempt_count == 0
+        assert current.attempt_count < current.max_attempts
+
+        # Next attempt: re-claim (which spends an attempt again) and re-review.
+        # After a reacquire the control plane requires the current lease_id, so
+        # carry it through the rest of the attempt.
+        cp.claim_task(task.id, executor.id)
+        lease_id = cp.get_task(task.id).lease_id
+        cp.start_task(task.id, executor.id, lease_id=lease_id)
+        ev = cp.add_evidence(
+            task.id,
+            "log",
+            "artifact://three-strikes-%d" % round_index,
+            "ready",
+            executor.id,
+            metadata=verified_repo_metadata(cp, executor.id),
+            lease_id=lease_id,
+        )
+        cp.submit_for_review(task.id, executor.id, lease_id=lease_id)
+        review = cp.request_review(task.id, reviewer.id, actor="manual")
+
+    final = cp.get_task(task.id)
+    assert final.state not in {TaskState.FAILED.value, TaskState.BLOCKED.value}
+
+
+def test_the_transition_says_why_the_attempt_was_refunded(cp):
+    """An operator reading the ledger must see the refund and its cause."""
+    _, reviewer, task, review, ev = _drive_to_review(cp, "refund-narrative")
+    _reject_with(cp, review, reviewer, task, HARNESS_588_ERRORS, ev)
+
+    details = [
+        event.detail
+        for event in cp.task_history(task.id, limit=50)
+        if isinstance(getattr(event, "detail", None), dict)
+    ]
+    refunded = [d for d in details if d.get("attempt_refunded") is True]
+    assert refunded, "no history row recorded the refund"
+    assert any(
+        str(d.get("review_failure_class") or "")
+        for d in refunded
+    ), "the refund did not name the harness failure class"


### PR DESCRIPTION
Implements `task_b1f81fde`. This is the largest single identified contributor to
the ledger's 13.6% completion rate (1,102 completed of 8,075).

## The defect

`review_service.submit_review` decided the retry budget purely on
`attempt_count >= max_attempts`, regardless of **why** the review rejected —
while `rejected_feedback`, which carries the actual reason, sat three lines
above it unused.

## The evidence

`task_4ce995cb` (2026-08-13). A worker submitted a correct one-line regression
test **three times**, each with a write-up confirming the test caught the
mutation it targeted. All three reviews rejected — none on the merits:

| attempt | recorded feedback |
|---|---|
| 1 | `36 failed, 84 passed, 588 errors` + `ssh exited with status 1` |
| 2 | `UnicodeEncodeError: 'ascii' codec can't encode character '\xa7'` |
| 3 | same 588-error sandbox failure |

Attempt 2's error is precisely the bug **#352** ("Create the sandbox Postgres as
UTF8 — root cause of the ASCII failures") fixed **eleven hours later**.

`attempt_count` reached 3/3, the task went terminal, and the post-mortem
classifier labelled it **`scope`** — whose operator remediation is *"decompose if
the task is too large"*, advice that was actively wrong for a one-line change.
An equivalent task filed afterwards succeeded unchanged and merged as **#353**.

The stored reason was the fixed string `"reviewer rejected via signed verdict
evidence"` and the verdict field was the bare string `rejected`; the real cause
was only recoverable by hand-decoding evidence metadata.

## The fix

`classify_review_failure` already separated these cases correctly — it was never
consulted where the budget is spent. It is wired into the worker
(`executor_sandbox` / `executor_prompt` / `executor_finalizer`) but not the hub.

Two details worth a reviewer's attention:

- **`evidence_type` is deliberately not passed.** Passing `"review_verdict"`
  short-circuits to `semantic_rejection` at step 3, *before* the free-text rules
  run — which is exactly the reasoning that treats a blown-up harness as a
  judgement about the work.
- **Attempts increment at CLAIM time**, so a harness failure has already spent
  one before any judgement exists. The refund is a decrement clamped at zero, in
  the same transaction as the review row and the transition — not a skipped
  increment.

The refund is named in the transition detail and task history
(`attempt_refunded`, `review_failure_class`) so the ledger shows why a rejection
did not cost an attempt.

## Verification

Using the verbatim feedback strings from `task_4ce995cb` as fixtures:

```
588 errors + ssh exit 1   -> hub_verification_error   refunded
UnicodeEncodeError ascii  -> hub_verification_error   refunded
a merits rejection        -> semantic_rejection       still spent
```

- 5 new tests pass with the change; **4 fail without it**
- the one that passes either way is the semantic case — confirming existing
  behaviour is preserved rather than the gate merely being loosened
- `tests/test_control_plane.py` — 475 passed
- review suites (`test_review_service_edges`, `test_review_failure_classifier`,
  `test_review_protocol_rejection`, `test_reviewing_publication_parked`,
  `test_review_tick_backoff`) — 119 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)