### PR TITLE
Pin the fleet target at current main instead of an orphaned revision

### DIFF
--- a/deploy/openclaw/fleet-target.json
+++ b/deploy/openclaw/fleet-target.json
@@ -1,15 +1,15 @@
 {
-  "schema": "mac.fleet_target.v1",
   "roles": {
     "gateway": {
-      "source": "0f55d49b1faf1fd2e6a884fc8b4f80f625ca7031",
       "openclaw": {
-        "version": "2026.6.11",
-        "revision": "19"
-      }
+        "revision": "19",
+        "version": "2026.6.11"
+      },
+      "source": "44820d4a610f40ce76df5d17321dd241154c7367"
     },
     "worker": {
-      "source": "0f55d49b1faf1fd2e6a884fc8b4f80f625ca7031"
+      "source": "44820d4a610f40ce76df5d17321dd241154c7367"
     }
-  }
+  },
+  "schema": "mac.fleet_target.v1"
 }


### PR DESCRIPTION
The checked-in fleet target pinned both `gateway` and `worker` at
`0f55d49b1faf` — a revision that is **not an ancestor of main and is not in the
repository at all** (`git log 0f55d49b1faf` → unknown).

Meanwhile the live fleet was actually running `68602744` (three commits before
v1.0.0). The pin and reality had drifted apart with nothing reconciling them,
so the pin was documenting a version nobody could deploy.

Repointed both roles at `44820d4a` (current main), preserving the OpenClaw
`2026.6.11` / revision `19` gateway pin. Written by `mac admin fleet target set`,
whose `--manifest` defaults to this checked-in file; the key reordering is that
command's canonical sort.

Also unblocks fleet mutation: `setup.py` refuses to deploy when the working tree
differs from the frozen commit, so an uncommitted local pin change blocks every
deploy with

```
ERROR: deployment executable inputs differ from frozen commit ...
       commit or restore deploy/, scripts/, and src/mac before fleet mutation
```

Verified live: with this pin, `mac admin fleet refresh-source` moved natasha and
bullwinkle from `68602744` to `44820d4a` (both recording
`worker.agentbus.repo_update.updated` with a rebuilt runtime image), and rocky
followed after its stale digest-managed markers were cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)