### PR TITLE
Resolve preflight's --as-human to an id, so an owner matches their own agents

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -1010,6 +1010,48 @@ def cmd_task_transcript(args: argparse.Namespace) -> None:
         return
     _print(turns)
 
+def _preflight_filer_id(plane: Any, requested: Any) -> Optional[str]:
+    """Resolve ``--as-human`` to the stable human id preflight compares against.
+
+    ``dispatch_preflight`` blocks a private agent when its ``owner_human_id``
+    differs from the filer, and that field is an id. Passing the CLI string
+    through meant a username could never match: "jordanh" != the owner's
+    "human_c2ad...", so preflight reported every private agent as "private to
+    another owner" -- including to its actual owner -- and under-reported fleet
+    capacity, which is the exact failure preflight exists to prevent.
+
+    Observed 2026-08-17: `--as-human jordanh` returned 4 eligible agents while
+    `--as-human <that human's id>` returned 7, the difference being the three
+    private static hosts the caller owns.
+
+    ``task create --as-human`` accepts a username because the hub resolves it
+    server-side; preflight computes locally, so it must resolve here to keep
+    the two commands meaning the same thing.
+    """
+    value = str(requested or "").strip()
+    if not value:
+        return None
+    for lookup in (
+        getattr(plane, "get_human_by_username", None),
+        getattr(plane, "get_human", None),
+    ):
+        if lookup is None:
+            continue
+        try:
+            human = lookup(value)
+        except Exception:  # noqa: BLE001 - try the next resolution, then refuse
+            continue
+        resolved = human.get("id") if isinstance(human, Mapping) else getattr(human, "id", None)
+        if resolved:
+            return str(resolved)
+    # Failing loudly matters more here than elsewhere: silently treating an
+    # unresolvable filer as "no filer" is what makes preflight under-report.
+    raise SystemExit(
+        "no such human %r: --as-human takes a registered username or human id"
+        % value
+    )
+
+
 def cmd_task_preflight(args: argparse.Namespace) -> None:
     """Would a task with these requirements ever be claimed?
 
@@ -1018,11 +1060,12 @@ def cmd_task_preflight(args: argparse.Namespace) -> None:
     """
     from mac.dispatch_preflight import explain, preflight
 
+    plane = _plane(args)
     result = preflight(
-        _plane(args).list_agents(),
+        plane.list_agents(),
         required_capabilities=_csv(args.capabilities),
         required_hardware=_json_arg(args.hardware, {}),
-        created_by_human=args.as_human,
+        created_by_human=_preflight_filer_id(plane, args.as_human),
     )
     result["explanation"] = explain(result)
     _print(result)

--- a/tests/test_dispatch_preflight.py
+++ b/tests/test_dispatch_preflight.py
@@ -114,3 +114,96 @@ def test_an_empty_fleet_is_not_dispatchable():
 
     assert result["dispatchable"] is False
     assert result["agents_considered"] == 0
+
+
+# ---------------------------------------------------------------------------
+# --as-human must resolve to the id preflight actually compares
+# ---------------------------------------------------------------------------
+
+
+class _FakeHuman:
+    def __init__(self, human_id):
+        self.id = human_id
+
+
+class _FakePlane:
+    """Just enough of the plane surface that _preflight_filer_id uses.
+
+    Both the direct ControlPlane and the HTTP shim expose these two lookups,
+    so resolving through them keeps `mac task preflight` agreeing with
+    `mac task create` in either mode.
+    """
+
+    def __init__(self, *, username=None, human_id=None):
+        self._username = username
+        self._human_id = human_id
+
+    def get_human_by_username(self, value):
+        if self._username is not None and value == self._username:
+            return _FakeHuman(self._human_id)
+        raise KeyError(value)
+
+    def get_human(self, value):
+        if self._human_id is not None and value == self._human_id:
+            return _FakeHuman(self._human_id)
+        raise KeyError(value)
+
+
+def test_as_human_username_resolves_to_the_owner_id():
+    """A username must reach the owner comparison as the owner's id.
+
+    Passing the raw CLI string through meant "jordanh" was compared against
+    "human_c2ad...", so a private agent was reported "private to another owner"
+    to its own owner. Live on 2026-08-17 that under-reported the fleet by three
+    static hosts (4 eligible by username vs 7 by id).
+    """
+    from mac.cli import _preflight_filer_id
+
+    plane = _FakePlane(username="jordanh", human_id="human_c2ad4885")
+    assert _preflight_filer_id(plane, "jordanh") == "human_c2ad4885"
+
+
+def test_as_human_accepts_the_id_form_unchanged():
+    from mac.cli import _preflight_filer_id
+
+    plane = _FakePlane(username="jordanh", human_id="human_c2ad4885")
+    assert _preflight_filer_id(plane, "human_c2ad4885") == "human_c2ad4885"
+
+
+def test_both_forms_give_the_same_eligibility_for_a_private_owner():
+    """The username and id forms must not disagree about capacity."""
+    from mac.cli import _preflight_filer_id
+
+    plane = _FakePlane(username="jordanh", human_id="human_c2ad4885")
+    fleet = [_agent("rocky", ("python",), visibility="private", owner="human_c2ad4885")]
+
+    by_name = preflight(
+        fleet,
+        required_capabilities=["python"],
+        created_by_human=_preflight_filer_id(plane, "jordanh"),
+    )
+    by_id = preflight(
+        fleet,
+        required_capabilities=["python"],
+        created_by_human=_preflight_filer_id(plane, "human_c2ad4885"),
+    )
+    assert by_name["eligible_agents"] == by_id["eligible_agents"] == ["rocky"]
+
+
+def test_an_unresolvable_filer_refuses_rather_than_under_reporting():
+    """Silently degrading to "no filer" is what hides owned capacity."""
+    import pytest
+
+    from mac.cli import _preflight_filer_id
+
+    plane = _FakePlane(username="jordanh", human_id="human_c2ad4885")
+    with pytest.raises(SystemExit):
+        _preflight_filer_id(plane, "nobody")
+
+
+def test_absent_as_human_still_means_no_filer():
+    from mac.cli import _preflight_filer_id
+
+    plane = _FakePlane(username="jordanh", human_id="human_c2ad4885")
+    assert _preflight_filer_id(plane, None) is None
+    assert _preflight_filer_id(plane, "  ") is None


### PR DESCRIPTION
`mac task preflight --as-human <username>` can never match a private agent's
owner, so preflight reports *"agent is private to another owner"* **even to the
actual owner** — and under-reports fleet capacity, which is the exact failure
preflight exists to prevent.

## The defect

`cmd_task_preflight` passed the raw CLI string through:

```python
created_by_human=args.as_human      # a USERNAME, e.g. "jordanh"
```

while `dispatch_preflight.py:135` compares it against the agent's
`owner_human_id`, which is an **id**:

```python
private_block = (
    str(view["visibility"]).lower() == "private"
    and (not view["owner_human_id"] or view["owner_human_id"] != created_by_human)
)
```

`"jordanh" != "human_c2ad4885..."`, so the block always fires.

`mac task create --as-human` accepts a username because the **hub** resolves it
server-side. Preflight computes **locally**, so nothing ever resolved it — the
two commands disagreed about what `--as-human` means.

## Live evidence (2026-08-17)

```
mac task preflight --capabilities python --as-human jordanh
  -> dispatchable: 4 agent(s)          [k8s workers only]

mac task preflight --capabilities python --as-human human_c2ad4885...
  -> dispatchable: 7 agent(s)          [+ natasha, rocky, bullwinkle]
```

The three extra agents are static bare-metal hosts **that caller owns**.

This actively misled a fleet diagnosis: preflight was used to conclude the
static agents were structurally unable to claim work and that only the k8s tier
(which was entirely down) could execute anything. That conclusion was wrong —
idle, usable capacity was sitting there the whole time, and a canary later ran
on `natasha` without issue.

## The fix

Resolve through `get_human_by_username` then `get_human`. Both exist on the
direct `ControlPlane` **and** the HTTP shim, so this works in either mode and
accepts the id form unchanged.

An unresolvable filer now **refuses loudly** rather than silently degrading to
"no filer" — that silent degradation is what makes preflight under-report.

## Tests

5 new cases in `tests/test_dispatch_preflight.py`:
- a username resolves to the owner id
- the id form passes through unchanged
- **both forms yield identical `eligible_agents`** for a private-owner fleet
- an unresolvable filer raises rather than under-reporting
- absent `--as-human` still means "no filer"

`tests/test_dispatch_preflight.py` + `tests/cli/test_dispatch_submit.py` — 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)