### PR TITLE
Record what a reviewer said, not just which way it voted

### DIFF
--- a/src/mac/data/postgres/schema.sql
+++ b/src/mac/data/postgres/schema.sql
@@ -1437,7 +1437,12 @@ CREATE TABLE IF NOT EXISTS reviews (
     reason TEXT,
     evidence_id TEXT,
     created_at TEXT NOT NULL,
-    completed_at TEXT
+    completed_at TEXT,
+    -- WHAT the reviewer said, not merely which way it voted. `reason` is a
+    -- caller-chosen template, so without this the row carried a boolean and
+    -- nothing auditable: a sample of 52 reviews on 2026-08-17 held exactly
+    -- four distinct reason strings and zero findings.
+    findings TEXT NOT NULL DEFAULT '{}'
 );
 CREATE INDEX IF NOT EXISTS idx_reviews_task_status ON reviews (task_id, status);
 

--- a/src/mac/models.py
+++ b/src/mac/models.py
@@ -2586,6 +2586,21 @@ class Review:
     evidence_id: Optional[str]
     created_at: str
     completed_at: Optional[str]
+    #: WHAT the reviewer actually said: its summary and its per-finding list,
+    #: as recorded on the verdict evidence.
+    #:
+    #: ``reason`` is a template chosen by the caller ("reviewer rejected via
+    #: signed verdict evidence"), so before this existed the durable review row
+    #: held a boolean and nothing else. Sampling 22 reviews on 2026-08-17
+    #: returned exactly four distinct reason strings and not one finding, which
+    #: means the question "do reviewers make corrections that improve the
+    #: result?" was unanswerable from the ledger -- you could not tell a review
+    #: that caught a real defect from one that rubber-stamped, or from one that
+    #: merely relayed a harness failure.
+    #:
+    #: Declared last, with a default, because Review is constructed positionally
+    #: in several places.
+    findings: JsonDict = field(default_factory=dict)
 
     def to_dict(self) -> JsonDict:
         """Return a JSON-serializable dict representation of this Review."""

--- a/src/mac/review_service.py
+++ b/src/mac/review_service.py
@@ -35,6 +35,7 @@ from mac.models import (
     TransitionError,
     ValidationError,
     json_dumps,
+    json_loads,
     new_id,
     utcnow,
 )
@@ -550,6 +551,14 @@ class ReviewService:
         rejected_feedback = None
         if status_value in {ReviewStatus.CHANGES_REQUESTED.value, ReviewStatus.REJECTED.value}:
             rejected_feedback = self._review_feedback_from_evidence(review, evidence_id)
+        # Capture what the reviewer SAID for every terminal verdict, approvals
+        # included. `reason` is a caller-chosen template, so the review row
+        # otherwise records only which way the vote went: a sample of 52
+        # reviews on 2026-08-17 held four distinct reason strings and not one
+        # finding, which made "did this reviewer improve the result?"
+        # unanswerable from the ledger. An approval that cites nothing is
+        # itself the interesting datum, so approvals are recorded too.
+        verdict_findings = self._verdict_findings(review, evidence_id, status_value)
         now = utcnow()
         # mac-p5a4: the review status UPDATE and the task.review_completed
         # history row were two bare store.execute calls — a crash between
@@ -625,7 +634,8 @@ class ReviewService:
             changed = conn.execute(
                 """
                 UPDATE reviews
-                SET status = ?, reason = ?, evidence_id = ?, completed_at = ?
+                SET status = ?, reason = ?, evidence_id = ?, completed_at = ?,
+                    findings = ?
                 WHERE id = ? AND status = ?
                 """,
                 (
@@ -633,6 +643,7 @@ class ReviewService:
                     reason,
                     evidence_id,
                     now,
+                    json_dumps(verdict_findings),
                     review_id,
                     ReviewStatus.PENDING.value,
                 ),
@@ -1033,6 +1044,58 @@ class ReviewService:
         trimmed_latest["findings"] = []
         return {"latest": trimmed_latest, "history": []}
 
+    def _verdict_findings(
+        self,
+        review: Review,
+        evidence_id: Optional[str],
+        status_value: str,
+    ) -> Dict[str, Any]:
+        """What the reviewer said, distilled onto the review row.
+
+        Deliberately small and comparable across reviews so reviewer value can
+        actually be measured: `finding_count` answers "did this review cite
+        anything specific?" without re-reading evidence metadata, and
+        `cited_specifics` separates a reasoned verdict from a rubber stamp or a
+        relayed harness failure.
+
+        Returns ``{}`` when there is no verdict evidence to read, so an absent
+        record stays distinguishable from a review that genuinely said nothing.
+        """
+        if not evidence_id:
+            return {}
+        try:
+            evidence = self._get_evidence(evidence_id)
+        except Exception:  # noqa: BLE001 - findings must never block a verdict
+            return {}
+        manifest = (
+            evidence.metadata.get("verification")
+            if isinstance(evidence.metadata, dict)
+            else None
+        )
+        if not isinstance(manifest, dict):
+            return {}
+        items = self._bounded_review_findings(manifest.get("findings"))
+        summary = str(manifest.get("summary") or "")[:4000]
+        feedback = str(manifest.get("feedback") or "")[:8000]
+        record: Dict[str, Any] = {
+            "schema": "mac.review_findings.v1",
+            "status": status_value,
+            "verdict": str(manifest.get("verdict") or ""),
+            "verdict_evidence_id": evidence.id,
+            "summary": summary,
+            "feedback": feedback,
+            "findings": items,
+            "finding_count": len(items),
+            # A verdict that names nothing specific is the case worth counting.
+            "cited_specifics": bool(items or summary.strip()),
+        }
+        classification = classify_review_failure(
+            str(review.reason or ""), error=feedback or None
+        )
+        record["failure_class"] = classification.failure_class
+        record["is_infrastructure"] = bool(classification.is_infrastructure)
+        return record
+
     def _review_feedback_from_evidence(self, review: Review, evidence_id: Optional[str]) -> Optional[Dict[str, Any]]:
         if not evidence_id:
             return None
@@ -1064,7 +1127,21 @@ class ReviewService:
             row["evidence_id"],
             row["created_at"],
             row["completed_at"],
+            findings=json_loads(self._row_value(row, "findings"), {}),
         )
+
+    @staticmethod
+    def _row_value(row: Any, key: str) -> Any:
+        """Read a column that older rows may not carry.
+
+        The migration backfills a default, but a row hydrated from a snapshot
+        taken before it ran should degrade to "no findings recorded" rather
+        than raise.
+        """
+        try:
+            return row[key]
+        except (KeyError, IndexError, TypeError):
+            return None
 
     def _publication_from_row(self, row: Any) -> Publication:
         return Publication(

--- a/src/mac/store_postgres.py
+++ b/src/mac/store_postgres.py
@@ -359,6 +359,12 @@ class PostgresStore(StoreHelpersMixin):
             "last_control_stream_consumed_at",
             "last_control_stream_consumed_at TEXT",
         )
+        # reviews.findings: what the reviewer actually said. Additive and
+        # idempotent, so an existing hub keeps every stored review and simply
+        # starts recording judgement alongside the verdict.
+        self.ensure_column(
+            "reviews", "findings", "findings TEXT NOT NULL DEFAULT '{}'"
+        )
         # fleet_release_admission_episodes: the base table is created by the
         # bundled schema (CREATE TABLE IF NOT EXISTS). These additive column
         # migrations upgrade any database that already has an earlier, partial

--- a/tests/test_review_findings_persisted.py
+++ b/tests/test_review_findings_persisted.py
@@ -1,0 +1,229 @@
+"""A review must record WHAT the reviewer said, not only which way it voted.
+
+`reviews.reason` is a caller-chosen template ("reviewer rejected via signed
+verdict evidence"), so the durable review row used to carry a boolean and
+nothing else. Sampling the live ledger on 2026-08-17 returned **52 reviews
+across 38 tasks and exactly four distinct reason strings**:
+
+    27  reviewer approved via signed verdict evidence
+    22  reviewer rejected via signed verdict evidence
+     2  reviewer_unavailable:reviewer_not_available
+     1  reviewer_unavailable:reviewer_stale
+
+Not one carried a finding. That makes the only question worth asking about a
+reviewer -- does it make corrections that improve the result? -- unanswerable
+from the ledger: a review that caught a real defect is indistinguishable from
+one that rubber-stamped, and from one that merely relayed a harness failure.
+
+The evidence already held `summary`, `feedback` and `findings`; they were
+extracted into task metadata and dropped from the review row. These tests pin
+that they now survive on the row itself, and that the derived counters needed
+to measure reviewer value are present.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import ReviewStatus, TaskState
+from mac.services import ControlPlane
+from tests.test_control_plane import (
+    CODEGRAPH_AUDIT_SCHEMA,
+    _sign,
+    codegraph_relevant_files,
+    register_agent,
+    verified_repo_metadata,
+)
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+def _to_review(cp, name):
+    executor = register_agent(cp, "%s-exec" % name, ["python"])
+    reviewer = register_agent(cp, "%s-rev" % name, ["review"])
+    task = cp.create_task(name, required_capabilities=["python"])
+    cp.claim_task(task.id, executor.id)
+    cp.start_task(task.id, executor.id)
+    evidence = cp.add_evidence(
+        task.id,
+        "log",
+        "artifact://%s" % name,
+        "ready",
+        executor.id,
+        metadata=verified_repo_metadata(cp, executor.id),
+    )
+    cp.submit_for_review(task.id, executor.id)
+    review = cp.request_review(task.id, reviewer.id, actor="manual")
+    return reviewer, task, review, evidence
+
+
+def _verdict(cp, reviewer, task, review, evidence, *, status, verification):
+    manifest = _sign(
+        cp,
+        reviewer.id,
+        {
+            "schema": "mac.worker_evidence.v1",
+            "status": "complete",
+            "reviewed_evidence_id": evidence.id,
+            "executor_evidence_id": evidence.id,
+            "returncode": 0,
+            "worktree_digest": "sha256:" + ("c" * 64),
+            "repo": {
+                "head_sha": "abcdef1234567890abcdef1234567890abcdef12",
+                "pushed": True,
+                "remote_ref": "refs/heads/task/example",
+                "dirty": False,
+                "files_changed": ["src/example.py"],
+            },
+            "tests": [{"command": "pytest tests/test_example.py", "returncode": 0}],
+            "codegraph": {
+                "schema": CODEGRAPH_AUDIT_SCHEMA,
+                "status": "pass",
+                "reason": "test_fixture",
+                "relevant_files": codegraph_relevant_files(["src/example.py"]),
+                "commands": [
+                    {"argv": ["codegraph", "sync"], "returncode": 0},
+                    {"argv": ["codegraph", "affected"], "returncode": 0},
+                ],
+            },
+            **verification,
+        },
+    )
+    verdict = cp.add_evidence(
+        task.id,
+        "review",
+        "artifact://verdict-%s" % review.id,
+        "verdict",
+        reviewer.id,
+        metadata={"returncode": 0, "verification": manifest},
+    )
+    return cp.submit_review(
+        review.id,
+        status,
+        reviewer.id,
+        reason="reviewer %s via signed verdict evidence"
+        % ("rejected" if status == ReviewStatus.REJECTED.value else "approved"),
+        evidence_id=verdict.id,
+    )
+
+
+def test_a_rejection_records_the_findings_it_cited(cp):
+    reviewer, task, review, evidence = _to_review(cp, "cited-rejection")
+
+    done = _verdict(
+        cp, reviewer, task, review, evidence,
+        status=ReviewStatus.REJECTED.value,
+        verification={
+            "evidence_type": "review_verdict",
+            "verdict": "rejected",
+            "summary": "the new test does not fail under the described mutation",
+            "findings": [
+                {"file": "tests/test_agent_ownership.py", "detail": "assertion never flips"},
+            ],
+        },
+    )
+
+    assert done.findings, "the review row recorded no findings at all"
+    assert done.findings["finding_count"] == 1
+    assert done.findings["cited_specifics"] is True
+    assert "described mutation" in done.findings["summary"]
+
+
+def test_an_approval_records_its_findings_too(cp):
+    """An approval that cites nothing is itself the interesting datum."""
+    reviewer, task, review, evidence = _to_review(cp, "cited-approval")
+
+    done = _verdict(
+        cp, reviewer, task, review, evidence,
+        status=ReviewStatus.APPROVED.value,
+        verification={
+            "evidence_type": "review_verdict",
+            "verdict": "approved",
+            "summary": "test pins the behaviour and fails without the fix",
+        },
+    )
+
+    assert done.findings["status"] == ReviewStatus.APPROVED.value
+    assert done.findings["cited_specifics"] is True
+    assert done.findings["finding_count"] == 0
+
+
+def test_a_rubber_stamp_is_distinguishable_from_a_reasoned_verdict(cp):
+    """The whole point: an empty verdict must be visibly empty."""
+    reviewer, task, review, evidence = _to_review(cp, "rubber-stamp")
+
+    done = _verdict(
+        cp, reviewer, task, review, evidence,
+        status=ReviewStatus.APPROVED.value,
+        verification={"evidence_type": "review_verdict", "verdict": "approved"},
+    )
+
+    assert done.findings["cited_specifics"] is False
+    assert done.findings["finding_count"] == 0
+
+
+def test_a_relayed_harness_failure_is_marked_infrastructure(cp):
+    """A rejection that is really a harness fault must not read as judgement.
+
+    This is the shape that destroyed task_4ce995cb: three rejections whose
+    stored reason was the standard template while the actual cause was a
+    sandbox with 588 collection errors.
+    """
+    reviewer, task, review, evidence = _to_review(cp, "harness-relay")
+
+    done = _verdict(
+        cp, reviewer, task, review, evidence,
+        status=ReviewStatus.REJECTED.value,
+        verification={
+            "evidence_type": "review_verdict",
+            "verdict": "rejected",
+            "feedback": (
+                "hub contract verification failed: 36 failed, 84 passed, "
+                "588 errors\nError: ssh exited with status exit status: 1"
+            ),
+        },
+    )
+
+    assert done.findings["is_infrastructure"] is True
+    assert done.findings["failure_class"] == "hub_verification_error"
+    assert done.findings["cited_specifics"] is False, (
+        "a relayed harness failure cites nothing about the work and must not "
+        "be counted as a reasoned verdict"
+    )
+
+
+def test_findings_survive_a_reload_from_the_store(cp):
+    """Persisted on the row, not merely returned by the call that wrote it."""
+    reviewer, task, review, evidence = _to_review(cp, "reload")
+    _verdict(
+        cp, reviewer, task, review, evidence,
+        status=ReviewStatus.REJECTED.value,
+        verification={
+            "evidence_type": "review_verdict",
+            "verdict": "rejected",
+            "summary": "does not satisfy the acceptance criteria",
+        },
+    )
+
+    reloaded = cp.get_review(review.id)
+    assert reloaded.findings["summary"] == "does not satisfy the acceptance criteria"
+
+    listed = [r for r in cp.list_reviews(task.id) if r.id == review.id]
+    assert listed and listed[0].findings["summary"]
+
+
+def test_a_review_with_no_verdict_evidence_records_nothing_rather_than_lying(cp):
+    """Absent must stay distinguishable from "said nothing"."""
+    reviewer, task, review, evidence = _to_review(cp, "no-evidence")
+
+    done = cp.submit_review(
+        review.id,
+        ReviewStatus.REJECTED.value,
+        reviewer.id,
+        reason="reviewer rejected via signed verdict evidence",
+    )
+
+    assert done.findings == {}


### PR DESCRIPTION
## The measurement problem

`reviews.reason` is a caller-chosen template, so the durable review row carried
a boolean and nothing else. Sampling the live ledger on 2026-08-17 returned **52
reviews across 38 tasks and exactly four distinct reason strings**:

```
27  reviewer approved via signed verdict evidence
22  reviewer rejected via signed verdict evidence
 2  reviewer_unavailable:reviewer_not_available
 1  reviewer_unavailable:reviewer_stale
```

**Not one carried a finding.**

So the only question worth asking about a reviewer — *does it make corrections
that improve the result?* — is unanswerable from the ledger. A review that
caught a real defect is indistinguishable from one that rubber-stamped, and from
one that merely relayed a harness failure.

That last case is not hypothetical. `task_4ce995cb` was destroyed by three
rejections whose stored reason was the standard template, while the actual cause
was a sandbox with 588 collection errors and the `UnicodeEncodeError` that #352
fixed eleven hours later.

## The data already existed

`_review_feedback_from_evidence` pulled `summary`, `feedback` and `findings` out
of the verdict evidence and wrote them into **task metadata** — the review row
dropped them. This keeps them on the row, for every terminal verdict **including
approvals**: an approval that cites nothing is itself the datum worth counting.

Recorded per review (`mac.review_findings.v1`):

| field | answers |
|---|---|
| `summary` / `feedback` / `findings` | what the reviewer actually wrote |
| `finding_count` | did it cite anything specific? |
| `cited_specifics` | reasoned verdict vs rubber stamp |
| `failure_class` / `is_infrastructure` | judgement vs relayed harness fault |

The two derived counters exist so that measuring reviewer value doesn't require
re-reading evidence metadata for every review.

## Migration

Additive and idempotent (`ADD COLUMN IF NOT EXISTS` with a `'{}'` default), so an
existing hub keeps every stored review and simply starts recording judgement
alongside the verdict. A review with **no** verdict evidence records `{}`, so
"absent" stays distinguishable from "said nothing".

## Tests

6 new, pinning the distinctions that make the measurement meaningful:

- a rejection records the findings it cited
- an approval records its findings too
- **a rubber stamp is distinguishable from a reasoned verdict**
- **a relayed harness failure is marked infrastructure and does not count as a reasoned verdict**
- findings survive a reload from the store (persisted, not just returned)
- a review with no verdict evidence records `{}` rather than lying

Plus 53 passing across the existing review suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)