### PR TITLE
Fix retention: cap the candidate window before the exclusion query binds it

### DIFF
--- a/src/mac/retention_service.py
+++ b/src/mac/retention_service.py
@@ -102,6 +102,13 @@ def _size_sql(cfg: Dict[str, Any]) -> str:
 # Maximum rows deleted in a single DELETE statement (bounded batch).
 DEFAULT_BATCH_SIZE = 500
 
+#: PostgreSQL binds at most 65535 parameters per statement. The exclusion
+#: queries bind one per candidate id, so the candidate window is clamped below
+#: that regardless of how large an operator sets batch_size -- otherwise a
+#: generous policy silently reintroduces the failure this constant exists to
+#: prevent. Well under the limit so a future extra bind cannot creep over it.
+MAX_BIND_PARAMETERS = 20_000
+
 
 # ---------------------------------------------------------------------------
 # Data models
@@ -588,19 +595,42 @@ class RetentionService:
             )
 
         # ---------------------------------------------------------------
-        # Step 2: apply hard exclusions
+        # Step 2: cap the candidate window BEFORE excluding
         # ---------------------------------------------------------------
+        # Step 1 is deliberately unbounded -- it selects every row past the
+        # cutoff so `batch_capped` can report an honest backlog. The exclusion
+        # queries below bind one parameter per candidate, and PostgreSQL caps a
+        # statement at 65535 of them, so passing the raw candidate list made
+        # prune fail outright once a table had ~65k prunable rows:
+        #
+        #   retention.prune_tick_failed
+        #     "sending query and params failed: number of parameters must be
+        #      between 0 and 65535"
+        #
+        # fired on EVERY tick (~20s) on the live hub, and it was
+        # self-perpetuating: prune fails -> rows accumulate -> the list grows ->
+        # prune fails harder. That is the mechanism behind the 16GB / 10.4M-row
+        # action_events incident, where retention was wired but never pruned.
+        #
+        # Candidates are ordered oldest-first, so taking the head keeps prune
+        # working on the oldest rows and the backlog still drains across ticks
+        # via retention_prune_tick's max_batches loop.
+        total_candidates = len(candidate_ids)
+        window_size = min(policy.batch_size, MAX_BIND_PARAMETERS)
+        window = candidate_ids[:window_size]
+
         excluded_ids, exclusion_reasons = self._apply_exclusions(
-            record_class, candidate_ids, exclusion_reasons
+            record_class, window, exclusion_reasons
         )
 
-        eligible_ids = [i for i in candidate_ids if i not in excluded_ids]
+        eligible_ids = [i for i in window if i not in excluded_ids]
 
         # ---------------------------------------------------------------
-        # Step 3: cap at batch_size
+        # Step 3: report whether more remains beyond this batch
         # ---------------------------------------------------------------
-        batch_capped = len(eligible_ids) > policy.batch_size
-        eligible_ids = eligible_ids[: policy.batch_size]
+        # Reported against the FULL candidate count, not the window, so the
+        # tick loop keeps draining while a real backlog exists.
+        batch_capped = total_candidates > window_size
 
         # ---------------------------------------------------------------
         # Step 4: measure bytes for the eligible set

--- a/tests/test_retention_service.py
+++ b/tests/test_retention_service.py
@@ -694,3 +694,109 @@ class TestControlPlaneFacade:
             for p in policies
             if p["record_class"] not in {"action_events", "observability_events"}
         )
+
+
+class TestBindParameterCeiling:
+    """Prune must survive a backlog larger than PostgreSQL's parameter limit.
+
+    Step 1 of prune() is deliberately unbounded so `batch_capped` can report an
+    honest backlog. The exclusion queries bind ONE PARAMETER PER CANDIDATE, and
+    PostgreSQL caps a statement at 65535, so passing the raw candidate list made
+    prune fail outright once a table held ~65k prunable rows:
+
+        retention.prune_tick_failed
+          "sending query and params failed: number of parameters must be
+           between 0 and 65535"
+
+    Observed on the live hub 2026-08-17 firing on EVERY tick (~20s),
+    continuously. It is self-perpetuating -- prune fails, rows accumulate, the
+    candidate list grows, prune fails harder -- and it is the mechanism behind
+    the 16GB / 10.4M-row action_events incident where retention was believed
+    wired but the store kept growing.
+    """
+
+    def test_the_exclusion_query_never_binds_more_than_the_ceiling(self):
+        """The candidate window, not the full backlog, reaches the SQL."""
+        from mac.retention_service import (
+            MAX_BIND_PARAMETERS,
+            RetentionPolicy,
+            RetentionService,
+        )
+
+        seen: List[int] = []
+
+        class _Store:
+            def query_all(self, sql: str, params: tuple = ()) -> List[Dict[str, Any]]:
+                if " IN (" in sql:
+                    seen.append(len(params))
+                    return []
+                # Step 1: a backlog far larger than the bind ceiling.
+                return [
+                    {"pk_val": "row%d" % i, "ts_val": "2020-01-01T00:00:00+00:00", "sz": 1}
+                    for i in range(MAX_BIND_PARAMETERS * 3)
+                ]
+
+            def transaction(self):  # pragma: no cover - dry_run never executes
+                raise AssertionError("dry run must not delete")
+
+        service = RetentionService(_Store())
+        service.set_policy(
+            RetentionPolicy(
+                "observability_events",
+                enabled=True,
+                max_age_seconds=1,
+                # an operator asking for a window larger than the bind ceiling
+                batch_size=MAX_BIND_PARAMETERS * 2,
+            )
+        )
+        report = service.dry_run("observability_events", actor="test")
+
+        assert seen, "no exclusion query ran"
+        assert max(seen) <= MAX_BIND_PARAMETERS, (
+            "bound %d parameters; PostgreSQL rejects anything over 65535 and the "
+            "ceiling exists to stay well clear" % max(seen)
+        )
+        assert report.batch_capped is True, (
+            "a backlog beyond the window must still report as capped so the tick "
+            "loop keeps draining"
+        )
+
+    def test_a_backlog_still_drains_oldest_first(self):
+        """Clamping must not change WHICH rows go: candidates are ordered
+        oldest-first and the window takes the head."""
+        from mac.retention_service import (
+            MAX_BIND_PARAMETERS,
+            RetentionPolicy,
+            RetentionService,
+        )
+
+        captured: List[tuple] = []
+
+        class _Store:
+            def query_all(self, sql: str, params: tuple = ()) -> List[Dict[str, Any]]:
+                if " IN (" in sql:
+                    captured.append(params)
+                    return []
+                return [
+                    {"pk_val": "row%05d" % i, "ts_val": "2020-01-01T00:00:00+00:00", "sz": 1}
+                    for i in range(MAX_BIND_PARAMETERS + 500)
+                ]
+
+            def transaction(self):  # pragma: no cover
+                raise AssertionError("dry run must not delete")
+
+        service = RetentionService(_Store())
+        service.set_policy(
+            RetentionPolicy(
+                "observability_events",
+                enabled=True,
+                max_age_seconds=1,
+                batch_size=MAX_BIND_PARAMETERS + 500,
+            )
+        )
+        service.dry_run("observability_events", actor="test")
+
+        assert captured, "no exclusion query ran"
+        first_batch = captured[0]
+        assert first_batch[0] == "row00000", "the oldest row must be in the window"
+        assert len(first_batch) <= MAX_BIND_PARAMETERS


### PR DESCRIPTION
`retention.prune_tick_failed` fires on **every tick (~20s), continuously**, on
the live hub:

```
"sending query and params failed: number of parameters must be between 0 and 65535"
```

It is **self-perpetuating**: prune fails → rows accumulate → the candidate list
grows → prune fails harder. This is the mechanism behind the 16GB / 10.4M-row
`action_events` incident, where retention was believed wired but the store kept
growing.

Retention being *wired* is not retention *succeeding* — and the only signal that
it wasn't succeeding is an event nothing reads.

## Root cause — not where it looks

The DELETE is **bounded** (`batch_size` defaults to 500), so the failing
statement isn't the delete.

Step 1 of `_execute_prune` collects candidates **unbounded** — every row past the
cutoff — and step 2 passes that whole list into the exclusion queries, which bind
**one parameter per candidate**:

```sql
SELECT oe.id FROM observability_events oe
  INNER JOIN tasks t ON t.id = oe.subject_id
 WHERE oe.id IN (?, ?, ... one per candidate ...)
```

The batch cap was applied at **step 3 — after** that query had already been
built. So a table with ~65k prunable rows could never be pruned at all.

## Fix

- Cap the candidate window **before** excluding.
- Report `batch_capped` against the **full** candidate count, so
  `retention_prune_tick`'s `max_batches` loop still drains a real backlog across
  ticks. Candidates are ordered oldest-first, so the window takes the oldest rows.
- Clamp to `MAX_BIND_PARAMETERS` (20,000) **independently of `policy.batch_size`**
  — a generous operator policy would otherwise silently reintroduce this exact
  failure. Set well under 65535 so a future extra bind can't creep over it.

## Tests

2 new regression tests, both failing without the change:
- drive a backlog **3× the ceiling** and assert the exclusion query never binds
  more than `MAX_BIND_PARAMETERS`
- assert a backlog still reports `batch_capped` so draining continues
- assert the window still takes the **oldest** rows (clamping must not change
  *which* rows go)

76 existing retention tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)