### PR TITLE
Stop shared-directory writers from splicing each other's temp files

### DIFF
--- a/src/mac/atomic_file.py
+++ b/src/mac/atomic_file.py
@@ -1,0 +1,123 @@
+"""Crash- and concurrency-safe file replacement.
+
+Two distinct hazards are closed here, and both were live in this repository:
+
+1. **A fixed temporary name in a shared directory is not private.** Writing
+   ``<name>.tmp`` next to ``<name>`` is only atomic if exactly one process ever
+   writes it. ``~/.mac`` is a per-*user* directory shared by every worker, CLI
+   invocation and agent startup, and the AgentFS WebDAV share is written by
+   many agents through a threaded server. Two writers that pick the same
+   temporary path truncate and splice each other's bytes, and then one of them
+   renames the mixture into place. ``os.replace`` is atomic; *choosing the same
+   temporary path is not*. Every temporary here comes from
+   :func:`tempfile.mkstemp`, so each writer owns a name nobody else can open.
+
+2. **``os.replace`` is atomic with respect to other processes, not to a
+   crash.** With delayed allocation (ext4 and friends) the rename can reach the
+   journal before the data blocks do, so a power loss leaves a zero-length file
+   where a complete one is expected. Readers in this codebase almost uniformly
+   swallow parse errors and substitute an empty default, which turns that into
+   silent data loss rather than a visible failure. So the data descriptor is
+   fsynced before the rename and the parent directory is fsynced after it.
+
+Modelled on the two writers that already got this right:
+``read_only_report_verifier.atomic_write_result`` and
+``deployment_attestation._atomic_private_json``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import IO, Any, Iterator, Optional
+
+__all__ = [
+    "atomic_write_bytes",
+    "atomic_write_text",
+    "atomic_writer",
+    "fsync_directory",
+]
+
+
+def fsync_directory(directory: Path) -> None:
+    """Durably record a rename in *directory* (best effort on odd platforms)."""
+
+    try:
+        directory_fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(directory_fd)
+    except OSError:
+        # Some filesystems (and some CI overlay mounts) refuse fsync on a
+        # directory descriptor. The rename already happened; durability is the
+        # only thing lost, so this must not fail the write.
+        pass
+    finally:
+        os.close(directory_fd)
+
+
+@contextmanager
+def atomic_writer(
+    path: Path,
+    *,
+    binary: bool = False,
+    mode: Optional[int] = 0o600,
+    encoding: Optional[str] = "utf-8",
+) -> Iterator[IO[Any]]:
+    """Yield a handle whose contents replace *path* atomically on clean exit.
+
+    The temporary is uniquely named inside ``path.parent``, so concurrent
+    writers to the same *path* cannot interleave: each writes its own file and
+    the renames serialize, leaving one writer's bytes intact rather than a
+    splice of both. On any exception the temporary is removed and *path* is
+    left untouched.
+    """
+
+    path = Path(path)
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    descriptor, raw = tempfile.mkstemp(dir=str(parent), prefix="." + path.name + ".", suffix=".tmp")
+    temporary = Path(raw)
+    try:
+        try:
+            if binary:
+                stream: IO[Any] = os.fdopen(descriptor, "wb")
+            else:
+                stream = os.fdopen(descriptor, "w", encoding=encoding)
+        except BaseException:
+            os.close(descriptor)
+            raise
+        with stream:
+            yield stream
+            stream.flush()
+            os.fsync(stream.fileno())
+        if mode is not None:
+            os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+    fsync_directory(parent)
+
+
+def atomic_write_bytes(path: Path, data: bytes, *, mode: Optional[int] = 0o600) -> None:
+    """Replace *path* with *data*, durably and without a shared temp name."""
+
+    with atomic_writer(path, binary=True, mode=mode) as stream:
+        stream.write(data)
+
+
+def atomic_write_text(
+    path: Path,
+    text: str,
+    *,
+    mode: Optional[int] = 0o600,
+    encoding: str = "utf-8",
+) -> None:
+    """Replace *path* with *text*, durably and without a shared temp name."""
+
+    with atomic_writer(path, mode=mode, encoding=encoding) as stream:
+        stream.write(text)

--- a/src/mac/executor_directive.py
+++ b/src/mac/executor_directive.py
@@ -33,6 +33,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from mac.atomic_file import fsync_directory
+
 JsonDict = Dict[str, Any]
 
 # Contract identifiers -------------------------------------------------------
@@ -248,7 +250,13 @@ class ExecutorDirectiveQueue:
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as handle:
                 handle.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+                handle.flush()
+                # The queue's reader returns [] on any parse failure, so a
+                # zero-length file left by a rename that beat its data blocks to
+                # disk silently drops every pending directive.
+                os.fsync(handle.fileno())
             os.replace(tmp_name, self.path)
+            fsync_directory(self.path.parent)
         except Exception:
             try:
                 os.unlink(tmp_name)

--- a/src/mac/executor_finalizer.py
+++ b/src/mac/executor_finalizer.py
@@ -67,6 +67,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
 from mac import relay_observability
+from mac.atomic_file import atomic_write_text
 from mac.agent_command import PROMPT_SENTINEL
 from mac.models import (
     REPORT_REPOSITORY_ACCESS_SCHEMA,
@@ -1061,12 +1062,17 @@ class _FinalizerPhaseContext:
             "budget_seconds": self.timeout,
             **extra,
         }
+        # A fixed "finalizer-progress.json.tmp" is shared by every phase context
+        # writing into this workspace; overlapping phases splice each other and
+        # the watcher reads a mixture. Unique temp name + fsync before/after the
+        # rename (atomic_write_text) closes both the splice and the
+        # rename-before-data crash window.
         path = self.task_workspace / "finalizer-progress.json"
-        temporary = self.task_workspace / "finalizer-progress.json.tmp"
-        temporary.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        atomic_write_text(
+            path,
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            mode=0o600,
         )
-        temporary.replace(path)
 
     def mark_failed(self, reason: str = "") -> None:
         self._status = "fail"

--- a/src/mac/hermes_config_surface.py
+++ b/src/mac/hermes_config_surface.py
@@ -26,6 +26,7 @@ from copy import deepcopy
 from pathlib import Path
 
 from mac import mac_paths
+from mac.atomic_file import fsync_directory
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 import yaml
@@ -115,8 +116,13 @@ def _atomic_yaml_write(path: Path, data: Mapping[str, Any], mode: int = 0o600) -
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             yaml.safe_dump(dict(data), fh, sort_keys=False)
+            fh.flush()
+            # Without this the rename can outrun the data blocks on a crash and
+            # leave an empty YAML file, which parses as "no configuration".
+            os.fsync(fh.fileno())
         tmp.chmod(mode)
         tmp.replace(path)
+        fsync_directory(path.parent)
     finally:
         try:
             tmp.unlink()
@@ -131,8 +137,11 @@ def _atomic_text_write(path: Path, text: str, mode: int = 0o600) -> None:
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
         tmp.chmod(mode)
         tmp.replace(path)
+        fsync_directory(path.parent)
     finally:
         try:
             tmp.unlink()

--- a/src/mac/human_interface_profile.py
+++ b/src/mac/human_interface_profile.py
@@ -49,6 +49,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from mac.atomic_file import fsync_directory
+
 PROFILE_PORT_SCHEMA = "mac.human_interface_profile_port.v1"
 
 #: Identity documents carried between interfaces. SOUL.md is the personality,
@@ -124,8 +126,15 @@ def _atomic_write(path: Path, data: str, mode: int = 0o600) -> None:
     try:
         with os.fdopen(handle, "w", encoding="utf-8") as stream:
             stream.write(data)
+            stream.flush()
+            # os.replace is atomic against other processes but NOT against a
+            # crash: with delayed allocation the rename can be journalled before
+            # the data blocks, leaving a zero-length profile that every reader
+            # here quietly treats as "no profile".
+            os.fsync(stream.fileno())
         os.chmod(temporary, mode)
         os.replace(temporary, path)
+        fsync_directory(path.parent)
     except BaseException:
         try:
             os.unlink(temporary)

--- a/src/mac/webdav_server.py
+++ b/src/mac/webdav_server.py
@@ -20,11 +20,21 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from mac import mac_paths
+from mac.atomic_file import atomic_writer
 from typing import Optional
 
 
 DEFAULT_PUBLIC_PREFIX = "/artifacts/"
 DEFAULT_MAX_UPLOAD_BYTES = 512 * 1024 * 1024
+
+#: Mode for uploaded artifacts. mkstemp creates 0600; the share is read by
+#: other agents on the host, so restore the umask-default readability a plain
+#: ``open(..., "wb")`` used to give these files.
+_UPLOAD_MODE = 0o644
+
+
+class _TruncatedUpload(Exception):
+    """The client sent fewer bytes than Content-Length promised."""
 
 
 def _normalize_prefix(raw: str) -> str:
@@ -201,25 +211,29 @@ class WebDAVHandler(BaseHTTPRequestHandler):
             )
             return
         target.parent.mkdir(parents=True, exist_ok=True)
-        # Write to a temp sibling then atomically rename so a concurrent
-        # reader never sees a half-written file.
-        tmp = target.with_name(".%s.partial" % target.name)
+        # Write to a UNIQUELY named temp sibling then atomically rename, so a
+        # concurrent reader never sees a half-written file AND two concurrent
+        # PUTs to the same path cannot splice. This is a ThreadingHTTPServer in
+        # front of a share many agents write: a fixed ".<name>.partial" gave
+        # every in-flight PUT for one path the same temp file, so they truncated
+        # and interleaved into it, one rename installed the mixture (answering
+        # 201 with a byte count it had counted itself, not one it had written),
+        # and the loser's rename raised FileNotFoundError -> 500.
         remaining = length
         try:
-            with tmp.open("wb") as fh:
+            with atomic_writer(target, binary=True, mode=_UPLOAD_MODE) as fh:
                 while remaining > 0:
                     chunk = self.rfile.read(min(65536, remaining))
                     if not chunk:
                         break
                     fh.write(chunk)
                     remaining -= len(chunk)
-            if remaining != 0:
-                tmp.unlink(missing_ok=True)
-                self._send_status(HTTPStatus.BAD_REQUEST, "truncated upload")
-                return
-            os.replace(tmp, target)
+                if remaining != 0:
+                    raise _TruncatedUpload()
+        except _TruncatedUpload:
+            self._send_status(HTTPStatus.BAD_REQUEST, "truncated upload")
+            return
         except OSError as exc:
-            tmp.unlink(missing_ok=True)
             self._send_status(HTTPStatus.INTERNAL_SERVER_ERROR, "write failed: %s" % exc)
             return
         self._send_status(HTTPStatus.CREATED, "stored %d bytes" % length)
@@ -249,11 +263,25 @@ class WebDAVHandler(BaseHTTPRequestHandler):
         target = self._target_path()
         if target is None:
             return
-        if target.is_file():
-            target.unlink()
-            self._send_status(HTTPStatus.NO_CONTENT)
-        else:
+        # is_file() followed by unlink() is a TOCTOU: on a share written by many
+        # agents the file can vanish (or be replaced by a PUT's rename) between
+        # the two calls, turning a benign concurrent delete into an unhandled
+        # FileNotFoundError and a 500. Attempt the unlink and interpret failure.
+        if target.is_dir():
             self._send_status(HTTPStatus.NOT_FOUND)
+            return
+        try:
+            target.unlink()
+        except FileNotFoundError:
+            self._send_status(HTTPStatus.NOT_FOUND)
+            return
+        except IsADirectoryError:
+            self._send_status(HTTPStatus.NOT_FOUND)
+            return
+        except OSError as exc:
+            self._send_status(HTTPStatus.INTERNAL_SERVER_ERROR, "delete failed: %s" % exc)
+            return
+        self._send_status(HTTPStatus.NO_CONTENT)
 
     def _propfind_response(self, href: str, target: Path) -> str:
         is_dir = target.is_dir()

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -36,6 +36,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from mac import mac_paths
+from mac.atomic_file import atomic_write_text
 from typing import Any, Callable, Dict, List, Mapping, Optional
 from urllib.parse import quote, urlencode
 
@@ -5263,11 +5264,18 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
             # Write-then-rename so a crash mid-write can never leave the executor
             # resolving a truncated policy — which, being a valid YAML prefix,
             # could silently drop the network_policies mapping entirely.
-            target.parent.mkdir(parents=True, exist_ok=True)
-            tmp = target.with_suffix(".yaml.tmp")
-            tmp.write_text(text, encoding="utf-8")
-            tmp.chmod(0o600)
-            tmp.replace(target)
+            #
+            # Closing that on both axes requires more than a rename. A fixed
+            # ``openshell-policy.yaml.tmp`` in the per-USER ~/.mac directory is
+            # shared by every worker on the host, so two syncs splice each
+            # other's bytes and rename the mixture into place; and os.replace is
+            # atomic against other processes but not against a crash, so without
+            # an fsync the rename can land ahead of the data blocks and leave a
+            # zero-length policy. A spliced or empty policy still parses, so
+            # sandbox egress restriction disappears silently instead of failing
+            # closed. atomic_write_text uses a unique temp name and fsyncs both
+            # the file and the directory.
+            atomic_write_text(target, text, mode=0o600)
         except OSError as exc:
             self._observe_log(
                 "worker.openshell_policy.install_failed",
@@ -7898,12 +7906,13 @@ _OPENSHELL_CONTAINERFILE_RELPATH = "deploy/openshell/mac-hermes.Containerfile"
 
 
 def _atomic_write_text(path: Path, text: str) -> None:
-    """Write a marker file so a crash cannot leave it half-written."""
+    """Write a marker file so a crash cannot leave it half-written.
 
-    temporary = path.with_name("%s.tmp.%d" % (path.name, os.getpid()))
-    temporary.write_text(text, encoding="utf-8")
-    temporary.chmod(0o600)
-    os.replace(temporary, path)
+    A pid-suffixed temp name is not unique (two threads in one process share
+    it), and a rename without an fsync is not crash-safe.
+    """
+
+    atomic_write_text(path, text, mode=0o600)
 
 
 _OPENSHELL_RUNTIME_REPO = "ghcr.io/jordanhubbard/mac-openshell-runtime"

--- a/src/mac/worker_runtime_deps.py
+++ b/src/mac/worker_runtime_deps.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from mac import mac_paths
+from mac.atomic_file import atomic_write_text
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -60,11 +61,16 @@ class RuntimeDepsMixin:
             return {}
 
     def _write_footprint(self, footprint: JsonDict) -> None:
+        # ``~/.mac`` is per-USER, not per-agent: every worker, CLI invocation and
+        # agent startup writes this file. A fixed ``agent-footprint.json.tmp``
+        # therefore has multiple concurrent owners that truncate and splice each
+        # other, and _load_footprint swallows the resulting parse error and
+        # returns {} — silently erasing the record of what is installed in the
+        # shared venv. atomic_write_text gives each writer a private temp name.
         path = self._footprint_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_name(path.name + ".tmp")
-        tmp.write_text(json.dumps(footprint, indent=2, sort_keys=True), encoding="utf-8")
-        tmp.replace(path)
+        atomic_write_text(
+            path, json.dumps(footprint, indent=2, sort_keys=True), mode=0o600
+        )
 
     def _report_footprint(self, footprint: JsonDict) -> None:
         try:
@@ -180,7 +186,17 @@ class RuntimeDepsMixin:
         })
         return {"ok": rc == 0, "returncode": rc, "stdout": out[-4000:], "stderr": err[-4000:], "specs": specs}
 
-    def _update_footprint(self, manager: str, specs: List[str], *, index_url: Optional[str] = None) -> None:
+    def _update_footprint(
+        self, manager: str, specs: List[str], *, index_url: Optional[str] = None
+    ) -> JsonDict:
+        """Read-modify-write the shared footprint. Caller MUST hold _install_lock.
+
+        Two agents that interleave load -> mutate -> write here lose one of the
+        two updates outright, so serialization is not optional. The hub report
+        deliberately happens outside this method: it is network I/O and must not
+        run while the host-wide install lock is held.
+        """
+
         fp = self._load_footprint()
         entries = fp.get(manager) if isinstance(fp.get(manager), list) else []
         by_name = {e.get("name"): dict(e) for e in entries if isinstance(e, dict) and e.get("name")}
@@ -194,9 +210,31 @@ class RuntimeDepsMixin:
         fp[manager] = [by_name[k] for k in sorted(by_name)]
         fp["updated_at"] = now
         self._write_footprint(fp)
-        self._report_footprint(fp)
+        return fp
+
+    def _update_footprint_serialized(
+        self, manager: str, specs: List[str], *, index_url: Optional[str] = None
+    ) -> None:
+        """Take the install lock, update the footprint, report after releasing."""
+
+        lock = self._install_lock()
+        try:
+            fp = self._update_footprint(manager, specs, index_url=index_url)
+        finally:
+            lock.close()
+        if isinstance(fp, dict):
+            self._report_footprint(fp)
 
     def _install_lock(self):
+        """Take the shared-venv install lock, or fail loudly.
+
+        Swallowing a flock error here meant running ``pip install`` into the
+        shared ``~/.mac/venv`` unserialized while believing the process was
+        holding a lock — the exact scenario that leaves a half-installed
+        distribution behind. A failed lock now raises so the caller reports the
+        install as failed instead of racing.
+        """
+
         lock_path = self._mac_home() / ".install.lock"
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         fh = open(lock_path, "w")  # noqa: SIM115 - held until caller closes
@@ -204,9 +242,29 @@ class RuntimeDepsMixin:
             import fcntl
 
             fcntl.flock(fh, fcntl.LOCK_EX)
-        except Exception:
-            pass
+        except ImportError:
+            # Platform without fcntl (Windows). There is no shared venv there;
+            # log rather than hard-fail, but never claim the lock silently.
+            self._observe_install_lock_unavailable("fcntl unavailable on this platform")
+        except OSError as exc:
+            fh.close()
+            raise RuntimeError(
+                "could not take the shared install lock at %s: %s" % (lock_path, exc)
+            ) from exc
         return fh
+
+    def _observe_install_lock_unavailable(self, reason: str) -> None:
+        observe = getattr(self, "_observe_log", None)
+        if observe is None:
+            return
+        try:
+            observe(
+                "worker.runtime_deps.install_lock_unavailable",
+                level="warning",
+                detail={"reason": reason},
+            )
+        except Exception:  # noqa: BLE001 - telemetry must not break installs
+            pass
 
     def ensure_pip(self, specs: List[str], *, reason: str = "agent self-install",
                    index_url: Optional[str] = None) -> JsonDict:
@@ -222,18 +280,24 @@ class RuntimeDepsMixin:
         # we don't churn transitive deps).
         pending = [s for s in specs if not self._pip_spec_satisfied(s, installed)]
         if not pending:
-            self._update_footprint("pip", specs, index_url=index_url)
+            # The footprint update is a read-modify-write against a file shared
+            # by every agent on the host, so it belongs inside the install lock
+            # on the fast path exactly as much as on the install path.
+            self._update_footprint_serialized("pip", specs, index_url=index_url)
             return {"ok": True, "skipped": "already satisfied", "specs": specs}
         argv = [py, "-m", "pip", "install", *pending]
         if index_url:
             argv += ["--index-url", index_url]
         lock = self._install_lock()
+        footprint: Optional[JsonDict] = None
         try:
             result = self._run_install(argv, manager="pip", reason=reason, specs=pending)
             if result.get("ok"):
-                self._update_footprint("pip", pending, index_url=index_url)
+                footprint = self._update_footprint("pip", pending, index_url=index_url)
         finally:
             lock.close()
+        if isinstance(footprint, dict):
+            self._report_footprint(footprint)
         return result
 
     def ensure_npm(self, packages: List[str], *, reason: str = "agent self-install") -> JsonDict:
@@ -244,16 +308,19 @@ class RuntimeDepsMixin:
         installed = self._npm_installed(prefix)
         pending = [p for p in packages if self._npm_base_name(p) not in installed]
         if not pending:
-            self._update_footprint("npm", packages)
+            self._update_footprint_serialized("npm", packages)
             return {"ok": True, "skipped": "already satisfied", "packages": packages}
         argv = ["npm", "install", "--prefix", prefix, *pending]
         lock = self._install_lock()
+        footprint: Optional[JsonDict] = None
         try:
             result = self._run_install(argv, manager="npm", reason=reason, specs=pending)
             if result.get("ok"):
-                self._update_footprint("npm", pending)
+                footprint = self._update_footprint("npm", pending)
         finally:
             lock.close()
+        if isinstance(footprint, dict):
+            self._report_footprint(footprint)
         return result
 
     def reconcile_runtime_deps(self, specs: Optional[List[str]] = None) -> JsonDict:

--- a/tests/test_atomic_shared_writes.py
+++ b/tests/test_atomic_shared_writes.py
@@ -1,0 +1,698 @@
+"""Temp-file safety for the writers that share a directory with other processes.
+
+Two independent defects are covered:
+
+**Splice.** ``os.replace`` is atomic; *choosing the same temporary path is not*.
+Several writers in this tree wrote a FIXED temp name (``agent-footprint.json.tmp``,
+``openshell-policy.yaml.tmp``, ``finalizer-progress.json.tmp``,
+``.<name>.partial``) into a directory that many processes share — ``~/.mac`` is
+per-USER, not per-agent, and the AgentFS WebDAV share is written by many agents
+through a ThreadingHTTPServer. Concurrent writers truncated and interleaved into
+one temp file and then renamed the mixture into place. The tests below run real
+concurrent writers against one path and assert the file is always EXACTLY one
+writer's bytes.
+
+**Durability.** ``os.replace`` is atomic with respect to other processes but not
+with respect to a crash: with delayed allocation the rename can be journalled
+ahead of the data blocks, leaving a zero-length file. Every reader in this tree
+swallows the resulting parse error and substitutes an empty default, so the
+failure is silent. The tests below count ``os.fsync`` calls and assert both the
+data descriptor and the parent *directory* descriptor are synced.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import socket
+import stat
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+
+from mac import atomic_file
+from mac.atomic_file import atomic_write_text
+from mac.webdav_server import WebDAVHandler, WebDAVServer
+
+
+# --------------------------------------------------------------------------
+# Harness
+# --------------------------------------------------------------------------
+
+
+class _FsyncSpy:
+    """Records every ``os.fsync`` and whether its descriptor was a directory."""
+
+    def __init__(self, monkeypatch):
+        self.calls = []
+        real = os.fsync
+
+        def spy(fd):
+            try:
+                is_dir = stat.S_ISDIR(os.fstat(fd).st_mode)
+            except OSError:
+                is_dir = False
+            self.calls.append(is_dir)
+            return real(fd)
+
+        monkeypatch.setattr(os, "fsync", spy)
+
+    @property
+    def files(self) -> int:
+        return sum(1 for is_dir in self.calls if not is_dir)
+
+    @property
+    def directories(self) -> int:
+        return sum(1 for is_dir in self.calls if is_dir)
+
+
+def _run_forked_writers(write_fns, *, iterations: int) -> None:
+    """Run each callable in its own process, concurrently, ``iterations`` times.
+
+    Separate processes (not threads) because the splice this guards against is
+    an interleaving of ``write(2)`` calls against one shared temp inode; the GIL
+    would otherwise hide it.
+    """
+
+    children = []
+    for write_fn in write_fns:
+        pid = os.fork()
+        if pid == 0:  # child
+            code = 0
+            try:
+                for _ in range(iterations):
+                    write_fn()
+            except BaseException:  # noqa: BLE001 - reported through the exit code
+                code = 1
+            finally:
+                os._exit(code)
+        children.append(pid)
+    return children
+
+
+def _assert_never_spliced(path: Path, expected: set, children) -> None:
+    """Poll *path* while the writers run; every observation must be intact."""
+
+    bad = []
+    seen = 0
+    remaining = list(children)
+    deadline = time.monotonic() + 120.0
+    while remaining:
+        if time.monotonic() > deadline:
+            for pid in remaining:
+                os.kill(pid, 9)
+                os.waitpid(pid, 0)
+            pytest.fail("forked writers did not finish within 120s")
+        for pid in list(remaining):
+            done, status = os.waitpid(pid, os.WNOHANG)
+            if done:
+                remaining.remove(pid)
+                assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0, (
+                    "writer process %d failed" % pid
+                )
+        try:
+            observed = path.read_text(encoding="utf-8")
+        except (FileNotFoundError, UnicodeDecodeError) as exc:
+            bad.append(repr(exc))
+            continue
+        seen += 1
+        if observed not in expected:
+            bad.append(
+                "spliced write: %d bytes, head=%r tail=%r"
+                % (len(observed), observed[:60], observed[-60:])
+            )
+    assert not bad, "concurrent writers corrupted %s:\n%s" % (path, "\n".join(bad[:5]))
+    assert seen > 0, "reader never observed the file"
+
+
+def _filler(marker: str, size: int = 400_000) -> str:
+    """A payload big enough that one write is many write(2) calls."""
+
+    return (marker * 64)[:64] * (size // 64)
+
+
+# --------------------------------------------------------------------------
+# The shared helper itself
+# --------------------------------------------------------------------------
+
+
+def test_atomic_write_text_fsyncs_data_and_directory(tmp_path, monkeypatch):
+    spy = _FsyncSpy(monkeypatch)
+    target = tmp_path / "nested" / "state.json"
+
+    atomic_write_text(target, "payload\n")
+
+    assert target.read_text(encoding="utf-8") == "payload\n"
+    assert spy.files >= 1, "the data descriptor was never fsynced before the rename"
+    assert spy.directories >= 1, "the parent directory was never fsynced after the rename"
+
+
+def test_atomic_writer_picks_a_unique_temp_name_per_call(tmp_path):
+    names = []
+    for _ in range(8):
+        with atomic_file.atomic_writer(tmp_path / "shared.json") as handle:
+            names.append(
+                sorted(p.name for p in tmp_path.iterdir() if p.name != "shared.json")
+            )
+            handle.write("{}")
+    flat = [n for batch in names for n in batch]
+    assert len(set(flat)) == len(flat), "temp names collided: %r" % flat
+
+
+def test_atomic_writer_leaves_the_target_untouched_on_failure(tmp_path):
+    target = tmp_path / "state.json"
+    target.write_text("original", encoding="utf-8")
+    with pytest.raises(ValueError):
+        with atomic_file.atomic_writer(target) as handle:
+            handle.write("half")
+            raise ValueError("boom")
+    assert target.read_text(encoding="utf-8") == "original"
+    assert list(tmp_path.iterdir()) == [target], "temp file was left behind"
+
+
+def test_fsync_directory_survives_filesystems_that_refuse_it(tmp_path, monkeypatch):
+    def refuse(fd):
+        raise OSError(errno.EINVAL, "fsync not supported")
+
+    monkeypatch.setattr(os, "fsync", refuse)
+    atomic_file.fsync_directory(tmp_path)  # must not raise
+
+
+# --------------------------------------------------------------------------
+# 1. ~/.mac/agent-footprint.json  (worker_runtime_deps)
+# --------------------------------------------------------------------------
+
+
+def _footprint_worker(home: Path):
+    from mac.worker_runtime_deps import RuntimeDepsMixin
+
+    instance = object.__new__(RuntimeDepsMixin)
+    instance._mac_home = lambda: home
+    return instance
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_concurrent_agents_never_splice_the_shared_footprint(tmp_path):
+    """``~/.mac`` is per-USER: every worker, CLI run and agent startup writes here.
+
+    With one fixed ``agent-footprint.json.tmp`` the writers truncate and
+    interleave into each other's temp file, and ``_load_footprint`` swallows the
+    resulting JSONDecodeError and returns ``{}`` — silently erasing the record of
+    what is installed in the shared venv.
+    """
+
+    home = tmp_path / "machome"
+    home.mkdir()
+    instance = _footprint_worker(home)
+    path = home / "agent-footprint.json"
+
+    payloads = [
+        {"pip": [{"name": "pkg-%s" % marker}], "filler": _filler(marker)}
+        for marker in ("a", "b", "c")
+    ]
+    expected = set()
+    for payload in payloads:
+        instance._write_footprint(payload)
+        expected.add(path.read_text(encoding="utf-8"))
+
+    children = _run_forked_writers(
+        [lambda p=p: instance._write_footprint(p) for p in payloads], iterations=25
+    )
+    _assert_never_spliced(path, expected, children)
+    assert json.loads(path.read_text(encoding="utf-8"))["pip"]
+
+
+def test_footprint_write_is_durable(tmp_path, monkeypatch):
+    home = tmp_path / "machome"
+    home.mkdir()
+    spy = _FsyncSpy(monkeypatch)
+    _footprint_worker(home)._write_footprint({"pip": []})
+    assert spy.files >= 1 and spy.directories >= 1
+
+
+# --------------------------------------------------------------------------
+# 1b. the shared-venv install lock must not fail open
+# --------------------------------------------------------------------------
+
+
+def _lockable_worker(home: Path):
+    from mac.worker_runtime_deps import RuntimeDepsMixin
+
+    instance = object.__new__(RuntimeDepsMixin)
+    instance._mac_home = lambda: home
+    instance._agent_venv_python = lambda: sys.executable
+    instance._observe_log = lambda *a, **k: None
+    return instance
+
+
+def test_install_lock_failure_raises_instead_of_running_pip_unserialized(
+    tmp_path, monkeypatch
+):
+    """A swallowed flock error meant installing into the shared venv unlocked.
+
+    ``except Exception: pass`` around ``fcntl.flock`` returned a handle that the
+    caller treated as an exclusive lock, so two agents ran ``pip install`` into
+    ``~/.mac/venv`` at the same time while each believed it was serialized.
+    """
+
+    import fcntl
+
+    home = tmp_path / "machome"
+    home.mkdir()
+    instance = _lockable_worker(home)
+
+    def refuse(handle, operation):
+        raise OSError(errno.ENOLCK, "no locks available")
+
+    monkeypatch.setattr(fcntl, "flock", refuse)
+    with pytest.raises(RuntimeError, match="install lock"):
+        instance._install_lock()
+
+
+def test_footprint_update_on_the_already_satisfied_fast_path_holds_the_lock(tmp_path):
+    """The fast path read-modify-writes the shared footprint too.
+
+    ``_update_footprint`` loads, mutates and rewrites a host-shared file, so an
+    unlocked call on the "already satisfied" path loses a concurrent agent's
+    update outright. Every call must sit inside the install lock.
+    """
+
+    home = tmp_path / "machome"
+    home.mkdir()
+    instance = _lockable_worker(home)
+    instance._pip_installed = lambda py: {"nemo-relay": "0.3.0"}
+    instance._report_footprint = lambda fp: events.append("report")
+
+    events = []
+    real_lock = instance._install_lock
+
+    class _Tracked:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def close(self):
+            events.append("unlock")
+            self._handle.close()
+
+    def tracked_lock():
+        events.append("lock")
+        return _Tracked(real_lock())
+
+    instance._install_lock = tracked_lock
+    real_write = instance._write_footprint
+    instance._write_footprint = lambda fp: (events.append("write"), real_write(fp))[1]
+
+    result = instance.ensure_pip(["nemo-relay==0.3.0"])
+
+    assert result.get("skipped") == "already satisfied"
+    assert events.index("lock") < events.index("write") < events.index("unlock")
+    # The hub report is network I/O; holding a host-wide lock across it would
+    # let an unreachable hub block every other agent's installs.
+    assert events.index("unlock") < events.index("report")
+
+
+# --------------------------------------------------------------------------
+# 2. ~/.mac/openshell-policy.yaml  (worker)
+# --------------------------------------------------------------------------
+
+
+POLICY_TEMPLATE = """version: 1
+
+network_policies:
+  mac_hub:
+    name: mac-hub-%s
+    endpoints:
+      - host: hub.example.com
+        port: 8789
+# %s
+"""
+
+
+class _PolicyClient:
+    def __init__(self, assigned):
+        self._assigned = assigned
+
+    def get(self, path):
+        return dict(self._assigned)
+
+    def post(self, path, payload):
+        return {}
+
+
+def _policy_worker(tmp_path, text):
+    from mac import worker
+    from mac.openshell_service import policy_checksum
+
+    client = _PolicyClient(
+        {
+            "schema": "mac.openshell.assigned_policy.v1",
+            "agent_id": "agent-1",
+            "policy_id": "ospol_1",
+            "policy_name": "fleet",
+            "version": 3,
+            "checksum": policy_checksum(text),
+            "policy_text": text,
+        }
+    )
+    return worker.MacWorker(
+        client,
+        "agent-1",
+        tmp_path,
+        lambda _task, _path: worker.WorkerExecution(0, "ok"),
+        self_update_repo=tmp_path,
+    )
+
+
+@pytest.fixture
+def policy_home(tmp_path, monkeypatch):
+    from mac import worker
+
+    home = tmp_path / "machome"
+    home.mkdir()
+    monkeypatch.setattr(worker.mac_paths, "mac_home", lambda: home)
+    monkeypatch.delenv("MAC_OPENSHELL_POLICY", raising=False)
+    return home
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_concurrent_policy_syncs_never_install_a_spliced_policy(policy_home, tmp_path):
+    """A spliced policy is still valid YAML, so egress restriction vanishes quietly.
+
+    The comment above this write already stated the threat model: a truncated
+    policy "being a valid YAML prefix, could silently drop the network_policies
+    mapping entirely". A fixed ``openshell-policy.yaml.tmp`` in the per-user
+    ``~/.mac`` gave every worker on the host the same temp file to write it in.
+    """
+
+    target = policy_home / "openshell-policy.yaml"
+    texts = [
+        POLICY_TEMPLATE % (marker, _filler(marker, 1_200_000))
+        for marker in ("a", "b", "c")
+    ]
+    workers = [_policy_worker(tmp_path / ("w" + m), t) for m, t in zip("abc", texts)]
+
+    expected = set()
+    for instance in workers:
+        instance._last_openshell_policy_sync = None
+        instance._maybe_sync_openshell_policy()
+        expected.add(target.read_text(encoding="utf-8"))
+    assert len(expected) == 3
+
+    def writer(instance):
+        def run():
+            instance._last_openshell_policy_sync = None
+            instance._maybe_sync_openshell_policy()
+
+        return run
+
+    children = _run_forked_writers([writer(w) for w in workers], iterations=60)
+    _assert_never_spliced(target, expected, children)
+
+    import yaml
+
+    parsed = yaml.safe_load(target.read_text(encoding="utf-8"))
+    assert parsed["network_policies"]["mac_hub"]["endpoints"]
+
+
+def test_policy_install_is_durable(policy_home, tmp_path, monkeypatch):
+    text = POLICY_TEMPLATE % ("a", "a")
+    instance = _policy_worker(tmp_path / "w", text)
+    spy = _FsyncSpy(monkeypatch)
+    instance._maybe_sync_openshell_policy()
+    target = policy_home / "openshell-policy.yaml"
+    assert target.read_text(encoding="utf-8") == text
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert spy.files >= 1, "policy data was never fsynced before the rename"
+    assert spy.directories >= 1, "the policy directory was never fsynced"
+
+
+# --------------------------------------------------------------------------
+# 3. AgentFS WebDAV share  (webdav_server)
+# --------------------------------------------------------------------------
+
+
+class _DavFixture:
+    def __init__(self, tmp_path, token="tok"):
+        self.root = tmp_path / "agentfs"
+        self.root.mkdir()
+        self.token = token
+        self.server = WebDAVServer(
+            ("127.0.0.1", 0),
+            WebDAVHandler,
+            root=self.root,
+            public_prefix="/agentfs/",
+            max_upload_bytes=8 * 1024 * 1024,
+            write_token=token,
+        )
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.port = self.server.server_address[1]
+
+    @property
+    def base(self):
+        return "http://127.0.0.1:%d" % self.port
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+@pytest.fixture
+def dav(tmp_path):
+    fixture = _DavFixture(tmp_path)
+    try:
+        yield fixture
+    finally:
+        fixture.close()
+
+
+def _trickle_put(port, token, url_path, body, *, chunks=8, delay=0.02, start_delay=0.0):
+    """PUT *body* slowly on a raw socket so concurrent uploads really overlap."""
+
+    time.sleep(start_delay)
+    conn = socket.create_connection(("127.0.0.1", port), timeout=10)
+    try:
+        header = (
+            "PUT %s HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer %s\r\n"
+            "Content-Length: %d\r\nConnection: close\r\n\r\n"
+            % (url_path, token, len(body))
+        )
+        conn.sendall(header.encode())
+        step = max(1, len(body) // chunks)
+        for offset in range(0, len(body), step):
+            conn.sendall(body[offset : offset + step])
+            time.sleep(delay)
+        conn.shutdown(socket.SHUT_WR)
+        response = b""
+        while True:
+            piece = conn.recv(4096)
+            if not piece:
+                break
+            response += piece
+        return response
+    finally:
+        conn.close()
+
+
+def test_concurrent_puts_to_one_path_never_splice(dav):
+    """Two agents PUTting one AgentFS path must not interleave into one temp file.
+
+    With a fixed ``.<name>.partial`` the two uploads shared a temp inode: the
+    first rename installed a mixture of both bodies and answered 201 with a byte
+    count it had counted itself rather than one it had written, and the second
+    rename raised FileNotFoundError -> 500.
+    """
+
+    body_a = b"A" * 200_000
+    body_b = b"B" * 200_000
+    results = {}
+
+    def run(name, body, start_delay):
+        results[name] = _trickle_put(
+            dav.port, dav.token, "/agentfs/race.bin", body, start_delay=start_delay
+        )
+
+    threads = [
+        threading.Thread(target=run, args=("a", body_a, 0.0)),
+        threading.Thread(target=run, args=("b", body_b, 0.03)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=60)
+
+    for name, response in results.items():
+        assert b"201" in response.split(b"\r\n", 1)[0], (name, response[:120])
+
+    stored = (dav.root / "race.bin").read_bytes()
+    assert stored in (body_a, body_b), (
+        "stored file is a splice: %d bytes, %d 'A' + %d 'B'"
+        % (len(stored), stored.count(b"A"), stored.count(b"B"))
+    )
+
+
+def test_truncated_upload_is_still_rejected_and_leaves_no_temp(dav):
+    conn = socket.create_connection(("127.0.0.1", dav.port), timeout=10)
+    try:
+        conn.sendall(
+            (
+                "PUT /agentfs/short.bin HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+                "Authorization: Bearer %s\r\nContent-Length: 100\r\n"
+                "Connection: close\r\n\r\n" % dav.token
+            ).encode()
+        )
+        conn.sendall(b"x" * 10)
+        conn.shutdown(socket.SHUT_WR)
+        response = b""
+        while True:
+            piece = conn.recv(4096)
+            if not piece:
+                break
+            response += piece
+    finally:
+        conn.close()
+    assert b"400" in response.split(b"\r\n", 1)[0]
+    assert not (dav.root / "short.bin").exists()
+    assert list(dav.root.iterdir()) == [], "a temp file survived the failed upload"
+
+
+def test_delete_of_a_vanished_file_is_404_not_500(dav, monkeypatch):
+    """``if target.is_file(): target.unlink()`` is a TOCTOU on a shared share.
+
+    Another agent's DELETE (or a PUT's rename) can remove the file between the
+    check and the unlink, and the resulting FileNotFoundError escaped the
+    handler as a 500 instead of the 404 the client should see.
+    """
+
+    (dav.root / "gone.txt").write_text("bye\n", encoding="utf-8")
+
+    real_unlink = Path.unlink
+
+    def vanishing(self, *args, **kwargs):
+        if self.name == "gone.txt":
+            real_unlink(self, *args, **kwargs)
+            raise FileNotFoundError(2, "No such file or directory", str(self))
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", vanishing)
+
+    request = urllib.request.Request(
+        dav.base + "/agentfs/gone.txt",
+        method="DELETE",
+        headers={"Authorization": "Bearer %s" % dav.token},
+    )
+    with pytest.raises(urllib.error.HTTPError) as excinfo:
+        urllib.request.urlopen(request, timeout=10)  # noqa: S310
+    assert excinfo.value.code == HTTPStatus.NOT_FOUND
+
+
+# --------------------------------------------------------------------------
+# 4. finalizer-progress.json  (executor_finalizer)
+# --------------------------------------------------------------------------
+
+
+def _progress_context(workspace: Path, phase: str):
+    from mac.executor_finalizer import _FinalizerPhaseContext
+
+    return _FinalizerPhaseContext(workspace, "task_1", phase)
+
+
+@pytest.mark.skipif(not hasattr(os, "fork"), reason="requires fork")
+def test_concurrent_finalizer_phases_never_splice_progress(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    path = workspace / "finalizer-progress.json"
+    contexts = [_progress_context(workspace, "phase-%s" % m) for m in ("a", "b", "c")]
+    fillers = {ctx.phase: _filler(ctx.phase[-1]) for ctx in contexts}
+
+    expected = set()
+    for ctx in contexts:
+        ctx._write_progress("running", filler=fillers[ctx.phase])
+        expected.add(path.read_text(encoding="utf-8"))
+    assert len(expected) == 3
+
+    children = _run_forked_writers(
+        [
+            lambda c=c: c._write_progress("running", filler=fillers[c.phase])
+            for c in contexts
+        ],
+        iterations=25,
+    )
+    _assert_never_spliced(path, expected, children)
+    assert json.loads(path.read_text(encoding="utf-8"))["schema"]
+
+
+def test_finalizer_progress_write_is_durable(tmp_path, monkeypatch):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    ctx = _progress_context(workspace, "phase-a")
+    spy = _FsyncSpy(monkeypatch)
+    ctx._write_progress("running")
+    assert spy.files >= 1 and spy.directories >= 1
+
+
+# --------------------------------------------------------------------------
+# 5. the "atomic" writers that renamed without ever syncing
+# --------------------------------------------------------------------------
+
+
+def test_human_interface_profile_write_is_durable(tmp_path, monkeypatch):
+    from mac import human_interface_profile
+
+    spy = _FsyncSpy(monkeypatch)
+    target = tmp_path / "profile" / "SOUL.md"
+    human_interface_profile._atomic_write(target, "soul\n")
+    assert target.read_text(encoding="utf-8") == "soul\n"
+    assert spy.files >= 1 and spy.directories >= 1
+
+
+def test_hermes_config_surface_writes_are_durable(tmp_path, monkeypatch):
+    from mac import hermes_config_surface
+
+    spy = _FsyncSpy(monkeypatch)
+    hermes_config_surface._atomic_yaml_write(tmp_path / "cfg" / "config.yaml", {"a": 1})
+    assert spy.files >= 1 and spy.directories >= 1
+
+    spy2 = _FsyncSpy(monkeypatch)
+    hermes_config_surface._atomic_text_write(tmp_path / "cfg" / ".env", "A=1\n")
+    assert spy2.files >= 1 and spy2.directories >= 1
+
+
+def test_executor_directive_queue_write_is_durable(tmp_path, monkeypatch):
+    from mac.executor_directive import ExecutorDirectiveQueue, ExecutorDirectiveRecord
+
+    queue = ExecutorDirectiveQueue(tmp_path / "queue" / "directives.json")
+    spy = _FsyncSpy(monkeypatch)
+    assert queue.enqueue(
+        ExecutorDirectiveRecord(
+            stream_id="s1",
+            task_id="task_1",
+            correlation_id="c1",
+            message="hello",
+            issued_by="operator",
+            enqueued_at="2026-08-16T00:00:00+00:00",
+        )
+    )
+    assert spy.files >= 1 and spy.directories >= 1
+    assert [r.stream_id for r in queue.all_records()] == ["s1"]
+
+
+def test_worker_atomic_write_text_is_durable_and_uniquely_named(tmp_path, monkeypatch):
+    from mac import worker
+
+    spy = _FsyncSpy(monkeypatch)
+    target = tmp_path / "marker.txt"
+    worker._atomic_write_text(target, "marker\n")
+    assert target.read_text(encoding="utf-8") == "marker\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert spy.files >= 1 and spy.directories >= 1
+    # A pid-suffixed temp name is shared by every thread in the process.
+    assert not list(tmp_path.glob("marker.txt.tmp.*"))


### PR DESCRIPTION
## The bug

`os.replace` is atomic. **Choosing the same temporary path is not.** Four writers in this tree wrote a *fixed* temp name into a directory that several processes share, so two concurrent writers truncated and interleaved into one inode and then renamed the mixture into place.

| writer | temp name | shared by |
| --- | --- | --- |
| `worker_runtime_deps._write_footprint` | `agent-footprint.json.tmp` | every worker/CLI/agent startup — `~/.mac` is per-**user**, not per-agent |
| `worker._maybe_sync_openshell_policy` | `openshell-policy.yaml.tmp` | every worker on the host |
| `webdav_server.do_PUT` | `.<name>.partial` | every agent writing the AgentFS share, via `ThreadingHTTPServer` |
| `executor_finalizer._write_progress` | `finalizer-progress.json.tmp` | overlapping finalizer phases in one workspace |

Every one of these fails **silently**. `_load_footprint` catches everything and returns `{}`. The comment above the OpenShell policy write already named the threat model exactly — a truncated policy, *"being a valid YAML prefix, could silently drop the `network_policies` mapping entirely"* — and the implementation closed it on neither axis.

**Live evidence:** with the old code, three forked policy syncs against one `~/.mac` had the reader observe a **zero-length** `openshell-policy.yaml`. `yaml.safe_load("")` is `None`, so sandbox egress restriction disappears with no error anywhere.

For WebDAV: the first rename installed a splice of both bodies and answered **201 with a byte count it had counted itself** rather than one it had written; the loser's rename raised `FileNotFoundError` → **500**.

## Two more failures on the same paths

- `_install_lock` wrapped `fcntl.flock` in `except Exception: pass`. A host that could not grant the lock ran `pip install` into the shared `~/.mac/venv` **unserialized** while every caller believed it held an exclusive lock. A failed flock now raises.
- `_update_footprint` is a read-modify-write of that host-shared file and was called **outside** the lock on both "already satisfied" fast paths, losing a concurrent agent's update outright. Every call is now serialized — and the hub report was moved *out* of the locked region, because an unreachable hub must not hold a host-wide install lock across a network timeout.
- `do_DELETE`'s `if target.is_file(): target.unlink()` is a TOCTOU on a share many agents write; the resulting `FileNotFoundError` escaped as a 500 instead of a 404.

## Durability

Six writers did temp-then-replace with **no fsync**. `os.replace` is atomic with respect to other processes but not with respect to a crash: with delayed allocation the rename can be journalled ahead of the data blocks, leaving a zero-length file — and every reader of these files swallows the parse error and substitutes an empty default. fsync of the data descriptor *and* the parent directory added to `human_interface_profile._atomic_write`, `hermes_config_surface._atomic_yaml_write` / `_atomic_text_write`, `ExecutorDirectiveQueue._write`, `executor_finalizer._write_progress`, and `worker._atomic_write_text` (whose pid-suffixed temp name was also not unique across threads in one process).

## The fix

New `src/mac/atomic_file.py` — the pattern already proven twice in this repo (`read_only_report_verifier.atomic_write_result`, `deployment_attestation._atomic_private_json`): `tempfile.mkstemp` for a name no other writer can open, `fsync(data fd)`, `os.replace`, `fsync(dir fd)`.

## What the tests prove

`tests/test_atomic_shared_writes.py` fails **14 ways** on the unfixed tree.

- **Splice**: `os.fork()`s real concurrent writers at one path (footprint, OpenShell policy, finalizer progress) while a reader polls, and asserts every observation is *exactly* one writer's bytes.
- **WebDAV**: trickles two overlapping 200 KB uploads to one path over raw sockets and asserts the stored file is all-`A` or all-`B` and that **both** requests got 201.
- **Durability**: monkeypatches `os.fsync` to a counter and asserts both a regular-file descriptor and a *directory* descriptor were synced.
- **Lock**: a refusing `flock` must raise rather than return a handle the caller mistakes for a lock; the "already satisfied" fast path must order `lock → write → unlock → report`.

## Verification

```
uv run --extra dev pytest tests/ -q -k "worker or webdav or finalizer or runtime_deps or directive or interface_profile"
867 passed, 10616 deselected
```

`scripts/run-contract-tests.sh` preflight + xdist slice: `578 passed`.

No tests were deleted or renamed, so `src/mac/data/test_impact_map.json` needs no remap. Note `test_committed_impact_map_has_no_stale_node_ids` fails identically on the unmodified base commit — pre-existing, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
