### PR TITLE
Let go of the lease when a worker is shut down; make lifespan a closed loop

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -1160,6 +1160,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_WORKER_RESOURCES` | str | consumer-defined | worker | Worker setting: worker resources. |
 | `MAC_WORKER_RESOURCES_FILE` | str | consumer-defined | worker | Worker setting: worker resources file. |
 | `MAC_WORKER_RUNNING_DIGEST` | str | consumer-defined | worker | Worker setting: worker running digest. |
+| `MAC_WORKER_SHUTDOWN_EXIT` | str | consumer-defined | worker | Worker setting: worker shutdown exit. |
+| `MAC_WORKER_SHUTDOWN_GRACE_SECONDS` | int | consumer-defined | worker | Worker setting: worker shutdown grace seconds. |
 | `MAC_WORKER_TOKEN` | str | consumer-defined | worker | Worker setting: worker token. |
 | `MAC_WORKER_WORKSPACE` | str | consumer-defined | worker | Worker setting: worker workspace. |
 | `MAC_WORKER_WORKSPACE_GC_ENABLED` | bool | consumer-defined | worker | Worker setting: worker workspace gc enabled. |

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -101,6 +101,11 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         "tests/test_selftest_transient_timeout_crash.py",
         "tests/test_task_sandbox_reaping_policy.py",
         "tests/test_worker_control_edges.py",
+        # The worker's shutdown grace must stay inside this installer's
+        # TimeoutStopSec, or the lease is never released before SIGKILL.
+        # The test asserts on that relationship, so lowering the unit's
+        # timeout here has to run it.
+        "tests/test_worker_shutdown_abandon.py",
         # Added with the container-runtime declaration (#291) and the
         # Covers the worker side of the runtime-marker contract this installer
         # a change to it must select them.

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -23,7 +23,18 @@ from collections import Counter
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Literal, Mapping, Optional, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Literal,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from fastapi import BackgroundTasks, Depends, FastAPI, Query, Request, WebSocket
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, StreamingResponse
@@ -4283,7 +4294,14 @@ def _start_hub_tick_loop(app: FastAPI, cp: ControlPlane) -> None:
 
 
 def _stop_hub_tick_loop(app: FastAPI) -> None:
-    """Stop the lifespan-owned hub ticker without leaking it across restarts."""
+    """Stop the lifespan-owned hub ticker without leaking it across restarts.
+
+    Also stops the event-driven review-advance consumer that ``_start_hub_tick_loop``
+    enables on the same gate. It used to be an unstoppable ``while True`` daemon
+    whose Thread object was never retained, so nothing could join it — and its
+    work pushes to main, which must not still be running after the lifespan has
+    torn the rest of the hub down.
+    """
     stop_event = getattr(app.state, "hub_tick_stop_event", None)
     thread = getattr(app.state, "hub_tick_thread", None)
     if stop_event is not None:
@@ -4292,6 +4310,14 @@ def _stop_hub_tick_loop(app: FastAPI) -> None:
         thread.join(timeout=5.0)
     app.state.hub_tick_stop_event = None
     app.state.hub_tick_thread = None
+    control_plane = getattr(app.state, "control_plane", None)
+    if control_plane is not None:
+        try:
+            control_plane.disable_event_driven_review_advance()
+        except Exception:  # noqa: BLE001 - shutdown is a boundary
+            logging.getLogger("mac.hub_tick").warning(
+                "review-advance consumer shutdown failed", exc_info=True
+            )
 
 
 #: How long one follow connection may be held. A follower reconnects with the
@@ -4515,35 +4541,54 @@ def create_app(
         # ticker during construction made a legacy module-level app plus the
         # factory app run competing tick/review threads against one SQLite
         # authority, convoying its process-wide lock and stalling /health.
-        _start_hub_tick_loop(_app, cp)
-        repository_ref_reconciler.start()
-        github_ingestor.start()
-        cicd_monitor.start()
-        backlog_groomer.start()
-        model_selection_service.start()
-        scientific_optimizer.start()
-        nap_ticker.start()
-        curiosity_reviewer.start()
-        self_healing_sentinel.start()
-        hgx_autoscaler.start()
-        pg_backup_scheduler.start()
-        work_package_pipeline.start()
+        #
+        # Every start() is paired with its stop() here, and the sequence is
+        # unwound in reverse if any start() raises. They used to run outside
+        # the try, so one failing service skipped the finally entirely and left
+        # every service started before it running as an orphaned daemon thread
+        # against a control plane the app then abandoned.
+        services: List[Tuple[str, Callable[[], Any], Callable[[], Any]]] = [
+            ("hub_tick", lambda: _start_hub_tick_loop(_app, cp), lambda: _stop_hub_tick_loop(_app)),
+            ("repository_ref_reconciler", repository_ref_reconciler.start, repository_ref_reconciler.stop),
+            ("github_ingestor", github_ingestor.start, github_ingestor.stop),
+            ("cicd_monitor", cicd_monitor.start, cicd_monitor.stop),
+            ("backlog_groomer", backlog_groomer.start, backlog_groomer.stop),
+            ("model_selection_service", model_selection_service.start, model_selection_service.stop),
+            ("scientific_optimizer", scientific_optimizer.start, scientific_optimizer.stop),
+            ("nap_ticker", nap_ticker.start, nap_ticker.stop),
+            ("curiosity_reviewer", curiosity_reviewer.start, curiosity_reviewer.stop),
+            ("self_healing_sentinel", self_healing_sentinel.start, self_healing_sentinel.stop),
+            ("hgx_autoscaler", hgx_autoscaler.start, hgx_autoscaler.stop),
+            ("pg_backup_scheduler", pg_backup_scheduler.start, pg_backup_scheduler.stop),
+            ("work_package_pipeline", work_package_pipeline.start, work_package_pipeline.stop),
+        ]
+        started: List[Tuple[str, Callable[[], Any]]] = []
+
+        def _stop_started() -> None:
+            # One service's failure to stop must not strand the rest.
+            for name, stop in reversed(started):
+                try:
+                    stop()
+                except Exception:  # noqa: BLE001 - shutdown is a boundary
+                    logging.getLogger("mac.lifespan").warning(
+                        "service %s failed to stop", name, exc_info=True
+                    )
+            started.clear()
+
+        for name, start, stop in services:
+            try:
+                start()
+            except Exception:
+                logging.getLogger("mac.lifespan").error(
+                    "service %s failed to start; unwinding", name, exc_info=True
+                )
+                _stop_started()
+                raise
+            started.append((name, stop))
         try:
             yield
         finally:
-            _stop_hub_tick_loop(_app)
-            work_package_pipeline.stop()
-            pg_backup_scheduler.stop()
-            hgx_autoscaler.stop()
-            self_healing_sentinel.stop()
-            curiosity_reviewer.stop()
-            nap_ticker.stop()
-            scientific_optimizer.stop()
-            repository_ref_reconciler.stop()
-            github_ingestor.stop()
-            cicd_monitor.stop()
-            backlog_groomer.stop()
-            model_selection_service.stop()
+            _stop_started()
 
     app = FastAPI(title="MAC Control Plane", version=__version__, lifespan=lifespan)
     # The Fleet IDE state is list-oriented JSON and compresses by roughly an

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -13806,6 +13806,28 @@
   },
   {
     "default": null,
+    "description": "Worker setting: worker shutdown exit.",
+    "family": "worker",
+    "name": "MAC_WORKER_SHUTDOWN_EXIT",
+    "retired": false,
+    "sources": [
+      "src/mac/worker.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Worker setting: worker shutdown grace seconds.",
+    "family": "worker",
+    "name": "MAC_WORKER_SHUTDOWN_GRACE_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/worker.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Worker setting: worker token.",
     "family": "worker",
     "name": "MAC_WORKER_TOKEN",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -2222,6 +2222,11 @@ class ControlPlane:
         self._advance_queue: Optional[Any] = None
         self._advance_queued: set = set()
         self._advance_state_lock = threading.Lock()
+        # The review-advance consumer is a lifecycle-managed service like every
+        # other background worker: the thread and its stop signal are retained
+        # so the ASGI lifespan can shut it down instead of leaving it mid-push.
+        self._advance_thread: Optional[threading.Thread] = None
+        self._advance_stop: Optional[threading.Event] = None
         self._reconcile_legacy_task_state_semantics()
 
     def _reconcile_legacy_task_state_semantics(self) -> None:
@@ -2380,20 +2385,37 @@ class ControlPlane:
 
         Called from the hub's self-drive wiring only — the same gate that owns
         the periodic tick — so stateless replicas, the CLI, and the test suite
-        never spawn a competing advancer."""
+        never spawn a competing advancer.
+
+        The consumer is stoppable. Its work (``advance_default_review_workflow``
+        -> ``_publish_git_target_attempt``) clones a repo, runs the merge gate,
+        and pushes to main before the publication row commits, so a process that
+        exits with a nudge in flight can land a push whose bookkeeping never
+        commits. :meth:`disable_event_driven_review_advance` is called from the
+        lifespan shutdown for exactly that reason."""
         import queue as _queue
 
         with self._advance_state_lock:
             if self._advance_queue is not None:
                 return
-            q: "_queue.Queue[str]" = _queue.Queue()
+            q: "_queue.Queue[Optional[str]]" = _queue.Queue()
+            stop = threading.Event()
             self._advance_queue = q
+            self._advance_stop = stop
 
         def _consume() -> None:
-            while True:
-                task_id = q.get()
+            while not stop.is_set():
+                try:
+                    task_id = q.get(timeout=self.REVIEW_ADVANCE_POLL_SECONDS)
+                except _queue.Empty:
+                    continue
+                # ``None`` is the shutdown sentinel pushed by disable().
+                if task_id is None:
+                    break
                 with self._advance_state_lock:
                     self._advance_queued.discard(task_id)
+                if stop.is_set():
+                    break
                 try:
                     self.advance_default_review_workflow(
                         task_id, actor="event-driven-review"
@@ -2403,9 +2425,47 @@ class ControlPlane:
                         "event-driven review advance failed for %s", task_id, exc_info=True
                     )
 
-        threading.Thread(
+        thread = threading.Thread(
             target=_consume, name="mac-review-advance", daemon=True
-        ).start()
+        )
+        with self._advance_state_lock:
+            self._advance_thread = thread
+        thread.start()
+
+    #: How long the review-advance consumer blocks on its queue before
+    #: re-checking the stop event. Short enough that shutdown is prompt, long
+    #: enough that an idle hub is not spinning.
+    REVIEW_ADVANCE_POLL_SECONDS = 0.5
+
+    def disable_event_driven_review_advance(self, timeout: float = 10.0) -> None:
+        """Stop the review-advance consumer and wait for it (bounded).
+
+        Idempotent. New nudges become no-ops the moment the queue reference is
+        cleared, so nothing can start a fresh clone/push after this returns.
+        An advance already running is given ``timeout`` seconds to finish; the
+        join is bounded so a wedged git operation cannot hang hub shutdown.
+        """
+        with self._advance_state_lock:
+            thread = self._advance_thread
+            stop = self._advance_stop
+            q = self._advance_queue
+            self._advance_thread = None
+            self._advance_stop = None
+            self._advance_queue = None
+            self._advance_queued.clear()
+        if stop is not None:
+            stop.set()
+        if q is not None:
+            try:
+                q.put_nowait(None)
+            except Exception:  # noqa: BLE001 - a full queue still stops on the event
+                pass
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=max(0.0, float(timeout)))
+            if thread.is_alive():
+                logging.getLogger("mac.review_advance").warning(
+                    "review-advance consumer did not stop within %ss", timeout
+                )
 
     def _nudge_review_workflow(self, task_id: str) -> None:
         """Queue an immediate workflow advance for ``task_id``.

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -215,6 +215,18 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+#: How long after the first SIGTERM/SIGINT the worker keeps letting the current
+#: task run before it actively abandons the assignment (releases the lease and
+#: goes offline). Tuned to the unit that runs it: ``mac-agent-service`` sets
+#: ``KillMode=mixed`` / ``TimeoutStopSec=600``, so at 600s systemd SIGKILLs the
+#: whole cgroup — the lease would then stay ACTIVE for the rest of
+#: ``lease_seconds`` (900s) with nobody left to release it. 540s preserves the
+#: existing "let the task finish" drain for anything shorter while guaranteeing
+#: the release happens with a minute of headroom before the kill. A second
+#: signal abandons immediately; ``MAC_WORKER_SHUTDOWN_GRACE_SECONDS`` overrides.
+DEFAULT_SHUTDOWN_GRACE_SECONDS = 540.0
+
+
 def _deployment_barrier_state() -> tuple[str, bool]:
     """Return the configured rollout generation and whether its barrier is live."""
 
@@ -925,6 +937,31 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         self._delivery_drain_lock = threading.Lock()
         self._delivery_drain_stop: Optional[threading.Event] = None
         self._delivery_drain_thread: Optional[threading.Thread] = None
+        # Shutdown abandonment (task: worker SIGTERM never releases its lease).
+        # Executor children are spawned with ``start_new_session=True`` so they
+        # deliberately do NOT see the unit's SIGTERM. That is correct for a
+        # graceful drain and catastrophic past it: when the unit's
+        # ``TimeoutStopSec`` fires, SIGKILL takes the process down with the
+        # lease still ACTIVE, the renewal thread dies with it, ``_shutdown()``
+        # never posts "offline", and the task sits leased and undispatchable
+        # for the remainder of ``lease_seconds`` (900s by default) — the exact
+        # mechanism behind the ledger's recurring "Agent went offline mid-task
+        # (lease expired / heartbeat lost)" diagnosis. On a SECOND signal, or
+        # once the bounded grace below elapses, actively abandon instead:
+        # release the lease, post the offline heartbeat, and publish an
+        # observation so the hub can tell "worker restarted" from
+        # "worker crashed". See DEFAULT_SHUTDOWN_GRACE_SECONDS for why the
+        # deadline is where it is.
+        self._shutdown_lock = threading.Lock()
+        self._shutdown_signal_seen = threading.Event()
+        self._shutdown_now = threading.Event()
+        self._shutdown_watchdog: Optional[threading.Thread] = None
+        self._shutdown_abandoned = False
+        self._active_assignment: Optional[JsonDict] = None
+        self._daemon_run = False
+        self.shutdown_grace_seconds = _env_float(
+            "MAC_WORKER_SHUTDOWN_GRACE_SECONDS", DEFAULT_SHUTDOWN_GRACE_SECONDS
+        )
         # Directable peer/directive turns (task_c6f02f06, MAC_WORKER_DIRECTABLE):
         # run off the poll thread so a 120s turn cannot starve heartbeats. The
         # in-flight set stops a second thread being spawned for the same stream
@@ -971,6 +1008,7 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         duration of this call are restored before return — the process-wide
         SIGTERM/SIGINT state is not mutated past the worker's lifetime.
         """
+        self._daemon_run = max_iterations is None
         prior_handlers = self._install_signal_handlers()
         results: List[WorkerRunResult] = []
         iterations = 0
@@ -1022,7 +1060,10 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         prior: Dict[int, Any] = {}
         for signum in (signal.SIGTERM, signal.SIGINT):
             try:
-                prior[signum] = signal.signal(signum, lambda *_: self.stop())
+                prior[signum] = signal.signal(
+                    signum,
+                    lambda received, _frame: self._handle_shutdown_signal(received),
+                )
             except (ValueError, AttributeError, OSError):
                 # signal.signal raises if not in main thread or on platforms
                 # without the signal. Tests bound execution via max_iterations.
@@ -1035,6 +1076,156 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                 signal.signal(signum, handler)
             except (ValueError, AttributeError, OSError):
                 pass
+
+    def _handle_shutdown_signal(self, signum: int) -> None:
+        """Request a graceful stop, and arm the bounded abandonment deadline.
+
+        Runs inside a signal handler, so it does no I/O: it flips flags and
+        hands the work to a watchdog thread. The first signal asks the run loop
+        to finish the current task; a second signal (or the grace deadline)
+        means "we are about to be killed" and triggers active abandonment.
+        """
+        self.stop()
+        if self._shutdown_signal_seen.is_set():
+            self._shutdown_now.set()
+            return
+        self._shutdown_signal_seen.set()
+        self._arm_shutdown_watchdog(signum)
+
+    def _arm_shutdown_watchdog(self, signum: int) -> None:
+        with self._shutdown_lock:
+            if self._shutdown_watchdog is not None:
+                return
+            thread = threading.Thread(
+                target=self._shutdown_watchdog_loop,
+                args=(signum,),
+                name="worker-shutdown-watchdog",
+                daemon=True,
+            )
+            self._shutdown_watchdog = thread
+        thread.start()
+
+    def _shutdown_watchdog_loop(self, signum: int) -> None:
+        grace = float(self.shutdown_grace_seconds or 0.0)
+        forced = False
+        if grace > 0:
+            forced = self._shutdown_now.wait(grace)
+        else:
+            forced = self._shutdown_now.is_set()
+        # The process normally exits before this point (run_forever returns and
+        # the daemon watchdog dies with it), so reaching here means the worker
+        # is still holding work past its shutdown budget.
+        reason = (
+            "second shutdown signal received"
+            if forced
+            else "shutdown grace of %.1fs elapsed with work still in flight" % grace
+        )
+        self._abandon_active_assignment(
+            reason,
+            signum=signum,
+            exit_process=self._daemon_run and _env_bool("MAC_WORKER_SHUTDOWN_EXIT", True),
+        )
+
+    def _set_active_assignment(self, task_id: str, lease_id: str) -> None:
+        with self._shutdown_lock:
+            self._active_assignment = {"task_id": task_id, "lease_id": lease_id}
+
+    def _clear_active_assignment(self, task_id: str, lease_id: str) -> None:
+        with self._shutdown_lock:
+            active = self._active_assignment or {}
+            if active.get("task_id") == task_id and active.get("lease_id") == lease_id:
+                self._active_assignment = None
+
+    def _abandon_active_assignment(
+        self,
+        reason: str,
+        *,
+        signum: Optional[int] = None,
+        exit_process: bool = False,
+    ) -> JsonDict:
+        """Release the held lease and go offline before the process dies.
+
+        Idempotent and boundary-safe: every step is best-effort because the
+        alternative is the status quo, where a SIGKILL leaves the task leased
+        and undispatchable until ``lease_seconds`` expires. The transition is
+        lease-fenced, so if the run loop already finished the task this call
+        fails harmlessly and records why.
+        """
+        with self._shutdown_lock:
+            if self._shutdown_abandoned:
+                return {}
+            self._shutdown_abandoned = True
+            assignment = dict(self._active_assignment or {})
+        task_id = str(assignment.get("task_id") or "")
+        lease_id = str(assignment.get("lease_id") or "")
+        detail: JsonDict = {
+            "schema": "mac.worker_shutdown_abandonment.v1",
+            "agent_id": self.agent_id,
+            "task_id": task_id or None,
+            "lease_id": lease_id or None,
+            "reason": reason,
+            "signal": int(signum) if signum is not None else None,
+            "grace_seconds": float(self.shutdown_grace_seconds or 0.0),
+            "held_assignment": bool(task_id and lease_id),
+        }
+        if task_id and lease_id:
+            # The executor child is in its own session and would otherwise
+            # outlive us, still writing into a worktree whose task another
+            # agent is now free to claim. Stop it before letting go.
+            try:
+                if isinstance(self.executor, SubprocessExecutor):
+                    detail["executor_cancelled"] = bool(
+                        self.executor.cancel_current(reason)
+                    )
+            except Exception as exc:  # noqa: BLE001 — shutdown is a boundary
+                detail["executor_cancel_error"] = str(exc)
+            try:
+                self.client.post(
+                    "/tasks/%s/transition" % quote(task_id, safe=""),
+                    {
+                        "target_state": "open",
+                        "actor": self.agent_id,
+                        "lease_id": lease_id,
+                        "detail": {
+                            "reason": "worker_shutdown_abandoned",
+                            "manual_repair_required": False,
+                            "abandonment": dict(detail),
+                        },
+                    },
+                )
+                detail["lease_released"] = True
+            except Exception as exc:  # noqa: BLE001 — shutdown is a boundary
+                detail["lease_released"] = False
+                detail["release_error"] = str(exc)
+        try:
+            self._observe_log(
+                "worker.shutdown.abandoned",
+                level="warning",
+                subject_type="task" if task_id else "agent",
+                subject_id=task_id or self.agent_id,
+                detail=detail,
+            )
+        except Exception:  # noqa: BLE001 — shutdown is a boundary
+            pass
+        try:
+            self.client.post(
+                "/agents/%s/heartbeat" % quote(self.agent_id, safe=""),
+                {"status": "offline"},
+            )
+            detail["heartbeat_offline"] = True
+        except Exception as exc:  # noqa: BLE001 — shutdown is a boundary
+            detail["heartbeat_offline"] = False
+            detail["heartbeat_error"] = str(exc)
+        if exit_process:
+            # Deliberate: the run loop is blocked in an executor that will not
+            # see our SIGTERM, and the unit is counting down to SIGKILL. We
+            # have already released everything the hub cares about.
+            sys.stderr.write(
+                "mac-worker: abandoning active assignment and exiting (%s)\n" % reason
+            )
+            sys.stderr.flush()
+            os._exit(0)
+        return detail
 
     def _shutdown(self) -> None:
         self._close_all_debug_terminal_sessions()
@@ -1244,6 +1435,9 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         lease_id = str(lease["id"])
         task_dir: Optional[Path] = None
         attempt_state: JsonDict = {"recovery_count": 0, "recovery_log": []}
+        # Published for the shutdown watchdog: this is the lease that must be
+        # released if the process is torn down mid-execution.
+        self._set_active_assignment(task_id, lease_id)
         self._observe_log(
             "worker.task_claimed",
             subject_type="task",
@@ -1610,6 +1804,8 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
             except Exception:
                 pass
             raise
+        finally:
+            self._clear_active_assignment(task_id, lease_id)
 
     def _assignment_is_current(self, task_id: str, lease_id: str) -> bool:
         try:
@@ -2122,9 +2318,32 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         self._delivery_drain_thread = thread
         thread.start()
 
-    def _stop_delivery_drain_thread(self) -> None:
-        if self._delivery_drain_stop is not None:
-            self._delivery_drain_stop.set()
+    def _stop_delivery_drain_thread(self, timeout: float = 10.0) -> None:
+        """Stop the drain thread and WAIT for it (bounded).
+
+        Dropping the reference without joining let a drain that was already
+        inside ``_process_human_delivery_outbox`` — an HTTP round trip plus a
+        local openclaw-message delivery — keep running while ``_shutdown()``
+        posted "offline" and the process exited. A message delivered locally
+        but never acked to the hub is redelivered on the next start, so the
+        human sees it twice. Bounded so a wedged HTTP call cannot hang exit.
+        """
+        stop = self._delivery_drain_stop
+        thread = self._delivery_drain_thread
+        if stop is not None:
+            stop.set()
+        if (
+            thread is not None
+            and thread.is_alive()
+            and thread is not threading.current_thread()
+        ):
+            thread.join(timeout=max(0.0, float(timeout)))
+            if thread.is_alive():
+                self._observe_log(
+                    "worker.communication.outbox_drain_thread_join_timeout",
+                    level="warning",
+                    detail={"agent_id": self.agent_id, "timeout_seconds": timeout},
+                )
         self._delivery_drain_thread = None
         self._delivery_drain_stop = None
 

--- a/tests/api/test_lifespan_shutdown.py
+++ b/tests/api/test_lifespan_shutdown.py
@@ -10,12 +10,20 @@ Two defects motivated these tests (audit 2026-08-17):
 * Every ``start()`` in the lifespan ran OUTSIDE the ``try``, so one raising
   service skipped the ``finally`` entirely and left already-started daemon
   tickers running against a control plane the app had abandoned.
+
+Every assertion here is scoped to the threads the individual test started.
+pytest-xdist gives each worker ONE process shared by many test modules, so
+"no thread named X exists anywhere" is not a claim a test in this suite can
+make -- another module's leak would fail it for reasons that have nothing to
+do with the lifespan. The contract is "the threads THIS lifespan started are
+gone when it exits", and that is what these check.
 """
 
 from __future__ import annotations
 
 import threading
 import time
+from typing import Set
 
 import pytest
 from fastapi.testclient import TestClient
@@ -24,32 +32,36 @@ from mac.api import create_app
 from mac.services import ControlPlane
 
 
-def _threads_named(name: str) -> list[threading.Thread]:
-    return [t for t in threading.enumerate() if t.name == name and t.is_alive()]
+def _threads_named(name: str) -> Set[threading.Thread]:
+    return {t for t in threading.enumerate() if t.name == name and t.is_alive()}
 
 
-def _wait_gone(name: str, timeout: float = 5.0) -> list[threading.Thread]:
+def _wait_all_stopped(
+    threads: Set[threading.Thread], timeout: float = 10.0
+) -> Set[threading.Thread]:
+    """Return whichever of ``threads`` are still alive after ``timeout``."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        alive = _threads_named(name)
+        alive = {t for t in threads if t.is_alive()}
         if not alive:
-            return []
+            return set()
         time.sleep(0.05)
-    return _threads_named(name)
+    return {t for t in threads if t.is_alive()}
 
 
 def test_review_advance_consumer_does_not_outlive_the_lifespan(monkeypatch):
     monkeypatch.setenv("MAC_HUB_TICK_INTERVAL_SECONDS", "999")
     app = create_app(control_plane=ControlPlane.in_memory())
-    assert not _threads_named("mac-review-advance")
+    before = _threads_named("mac-review-advance")
 
     with TestClient(app) as client:
         assert client.get("/health").status_code == 200
-        assert _threads_named("mac-review-advance"), (
+        started = _threads_named("mac-review-advance") - before
+        assert started, (
             "the hub tick gate should have enabled the review-advance consumer"
         )
 
-    assert _wait_gone("mac-review-advance") == [], (
+    assert _wait_all_stopped(started) == set(), (
         "the review-advance consumer is still alive after the lifespan exited; "
         "it pushes to main, so it must not outlive the app"
     )
@@ -57,14 +69,17 @@ def test_review_advance_consumer_does_not_outlive_the_lifespan(monkeypatch):
 
 def test_review_advance_disable_is_idempotent_and_stops_nudges():
     cp = ControlPlane.in_memory()
+    before = _threads_named("mac-review-advance")
     cp.enable_event_driven_review_advance()
-    assert _threads_named("mac-review-advance")
+    started = _threads_named("mac-review-advance") - before
+    assert started
 
     cp.disable_event_driven_review_advance()
-    assert _wait_gone("mac-review-advance") == []
+    assert _wait_all_stopped(started) == set()
     # A nudge after shutdown must not start a fresh clone/push.
     cp._nudge_review_workflow("task_never_advanced")
     assert cp._advance_queue is None
+    assert _threads_named("mac-review-advance") - before == set()
     # Idempotent: a second stop is a no-op, not an error.
     cp.disable_event_driven_review_advance()
 
@@ -72,6 +87,8 @@ def test_review_advance_disable_is_idempotent_and_stops_nudges():
 def test_failed_service_start_unwinds_the_services_already_started(monkeypatch):
     monkeypatch.setenv("MAC_HUB_TICK_INTERVAL_SECONDS", "999")
     app = create_app(control_plane=ControlPlane.in_memory())
+    before_tick = _threads_named("mac-hub-tick")
+    before_advance = _threads_named("mac-review-advance")
 
     # The autoscaler starts late in the sequence, so a failure there proves the
     # earlier services (hub tick + review advance among them) are unwound.
@@ -86,10 +103,10 @@ def test_failed_service_start_unwinds_the_services_already_started(monkeypatch):
         with TestClient(app):
             pass  # pragma: no cover - startup must fail before the body runs
 
-    assert _wait_gone("mac-hub-tick") == [], (
+    assert _wait_all_stopped(_threads_named("mac-hub-tick") - before_tick) == set(), (
         "hub ticker survived a failed lifespan startup"
     )
-    assert _wait_gone("mac-review-advance") == [], (
-        "review-advance consumer survived a failed lifespan startup"
-    )
+    assert _wait_all_stopped(
+        _threads_named("mac-review-advance") - before_advance
+    ) == set(), "review-advance consumer survived a failed lifespan startup"
     assert getattr(app.state, "hub_tick_thread", None) is None

--- a/tests/api/test_lifespan_shutdown.py
+++ b/tests/api/test_lifespan_shutdown.py
@@ -1,0 +1,95 @@
+"""Lifespan start/stop is a closed loop: nothing survives the context manager.
+
+Two defects motivated these tests (audit 2026-08-17):
+
+* ``ControlPlane.enable_event_driven_review_advance`` started an unstoppable
+  ``while True`` daemon whose Thread object was never retained. Its work clones
+  a repo, runs the merge gate, and ``git push``es to main before the publication
+  row commits, so a hub torn down with a nudge in flight can land a push whose
+  bookkeeping never lands.
+* Every ``start()`` in the lifespan ran OUTSIDE the ``try``, so one raising
+  service skipped the ``finally`` entirely and left already-started daemon
+  tickers running against a control plane the app had abandoned.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+def _threads_named(name: str) -> list[threading.Thread]:
+    return [t for t in threading.enumerate() if t.name == name and t.is_alive()]
+
+
+def _wait_gone(name: str, timeout: float = 5.0) -> list[threading.Thread]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        alive = _threads_named(name)
+        if not alive:
+            return []
+        time.sleep(0.05)
+    return _threads_named(name)
+
+
+def test_review_advance_consumer_does_not_outlive_the_lifespan(monkeypatch):
+    monkeypatch.setenv("MAC_HUB_TICK_INTERVAL_SECONDS", "999")
+    app = create_app(control_plane=ControlPlane.in_memory())
+    assert not _threads_named("mac-review-advance")
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        assert _threads_named("mac-review-advance"), (
+            "the hub tick gate should have enabled the review-advance consumer"
+        )
+
+    assert _wait_gone("mac-review-advance") == [], (
+        "the review-advance consumer is still alive after the lifespan exited; "
+        "it pushes to main, so it must not outlive the app"
+    )
+
+
+def test_review_advance_disable_is_idempotent_and_stops_nudges():
+    cp = ControlPlane.in_memory()
+    cp.enable_event_driven_review_advance()
+    assert _threads_named("mac-review-advance")
+
+    cp.disable_event_driven_review_advance()
+    assert _wait_gone("mac-review-advance") == []
+    # A nudge after shutdown must not start a fresh clone/push.
+    cp._nudge_review_workflow("task_never_advanced")
+    assert cp._advance_queue is None
+    # Idempotent: a second stop is a no-op, not an error.
+    cp.disable_event_driven_review_advance()
+
+
+def test_failed_service_start_unwinds_the_services_already_started(monkeypatch):
+    monkeypatch.setenv("MAC_HUB_TICK_INTERVAL_SECONDS", "999")
+    app = create_app(control_plane=ControlPlane.in_memory())
+
+    # The autoscaler starts late in the sequence, so a failure there proves the
+    # earlier services (hub tick + review advance among them) are unwound.
+    autoscaler = app.state.hgx_autoscaler
+
+    def _explode() -> None:
+        raise RuntimeError("simulated service start failure")
+
+    monkeypatch.setattr(autoscaler, "start", _explode)
+
+    with pytest.raises(RuntimeError, match="simulated service start failure"):
+        with TestClient(app):
+            pass  # pragma: no cover - startup must fail before the body runs
+
+    assert _wait_gone("mac-hub-tick") == [], (
+        "hub ticker survived a failed lifespan startup"
+    )
+    assert _wait_gone("mac-review-advance") == [], (
+        "review-advance consumer survived a failed lifespan startup"
+    )
+    assert getattr(app.state, "hub_tick_thread", None) is None

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -14859,18 +14859,23 @@ def test_event_driven_advance_reviews_without_tick(cp, monkeypatch):
     # _setup_hubverify_task already called submit_for_review BEFORE the
     # advancer existed; enable it and nudge as submit_for_review now does.
     cp.enable_event_driven_review_advance()
-    cp._nudge_review_workflow(task.id)
+    try:
+        cp._nudge_review_workflow(task.id)
 
-    deadline = _time.monotonic() + 10.0
-    while _time.monotonic() < deadline:
-        if cp.get_task(task.id).state == TaskState.COMPLETED.value:
-            break
-        _time.sleep(0.05)
-    # verdict recording re-nudges, so review AND publication complete without
-    # any cp.tick()/advance call from a sweep.
-    assert cp.get_task(task.id).state == TaskState.COMPLETED.value
-    reviews = cp.list_reviews(task.id)
-    assert reviews and reviews[0].status == ReviewStatus.APPROVED.value
+        deadline = _time.monotonic() + 10.0
+        while _time.monotonic() < deadline:
+            if cp.get_task(task.id).state == TaskState.COMPLETED.value:
+                break
+            _time.sleep(0.05)
+        # verdict recording re-nudges, so review AND publication complete
+        # without any cp.tick()/advance call from a sweep.
+        assert cp.get_task(task.id).state == TaskState.COMPLETED.value
+        reviews = cp.list_reviews(task.id)
+        assert reviews and reviews[0].status == ReviewStatus.APPROVED.value
+    finally:
+        # The advancer clones and pushes; it must not outlive the test that
+        # started it and go on running against a torn-down fixture.
+        cp.disable_event_driven_review_advance()
 
 
 def test_nudge_is_noop_when_advancer_disabled(cp):

--- a/tests/test_worker_contract_edges.py
+++ b/tests/test_worker_contract_edges.py
@@ -158,6 +158,14 @@ def test_execute_assignment_routes_plan_to_durable_children(tmp_path) -> None:
         def _observe_metric(self, *args, **kwargs):
             return None
 
+        # execute_assignment publishes the in-flight lease for the shutdown
+        # watchdog to release if the process is torn down mid-task.
+        def _set_active_assignment(self, task_id, lease_id):
+            return None
+
+        def _clear_active_assignment(self, task_id, lease_id):
+            return None
+
         def _prepare_task_workspace(self, task, lease):
             (tmp_path / "task.json").write_text(
                 json.dumps({"task": task, "lease": lease})

--- a/tests/test_worker_shutdown_abandon.py
+++ b/tests/test_worker_shutdown_abandon.py
@@ -1,0 +1,472 @@
+"""A worker that is being shut down must let go of its lease.
+
+Audit 2026-08-17. The worker installed SIGTERM/SIGINT handlers that only set
+``self._stop``, which is read at the TOP of ``run_forever``'s loop. Executor
+children are spawned with ``start_new_session=True`` so they deliberately never
+see the signal — correct, until the unit's ``TimeoutStopSec`` expires and
+SIGKILL arrives. Then ``_shutdown()`` never runs (no "offline" heartbeat), the
+lease-renewal thread dies with the process, and the task stays LEASED and
+undispatchable for the rest of ``lease_seconds`` (900s by default) with no
+evidence published — while the attempt still burns. The hub's recurring
+"Agent went offline mid-task (lease expired / heartbeat lost)" diagnosis is
+this, seen from the other end.
+
+These tests pin the fix: a second signal, or a bounded grace after the first,
+actively abandons — release the lease, post the offline heartbeat, and publish
+a ``worker.shutdown.abandoned`` observation so the hub can distinguish
+"worker restarted" from "worker crashed".
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.hermes_adapter import MacApiClient, MacApiError
+from mac.models import TaskState
+from mac.services import ControlPlane
+from mac.worker import (
+    DEFAULT_SHUTDOWN_GRACE_SECONDS,
+    MacWorker,
+    WorkerExecution,
+)
+
+
+def _api_transport(client: TestClient):
+    def transport(method: str, path: str, payload: Optional[Dict[str, Any]]) -> Any:
+        request = getattr(client, method.lower())
+        kwargs: Dict[str, Any] = {}
+        if payload is not None:
+            kwargs["json"] = payload
+        response = request(path, **kwargs)
+        if response.status_code >= 400:
+            raise MacApiError(response.text)
+        return response.json() if response.content else None
+
+    return transport
+
+
+def _register_worker(cp: ControlPlane):
+    machine = cp.register_machine("shutdown-host")
+    return cp.register_agent(machine.id, "shutdown-worker", capabilities=["python"])
+
+
+def _wait_for(predicate, timeout: float = 10.0, interval: float = 0.05) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_shutdown_grace_expiry_releases_the_lease_and_marks_agent_offline(tmp_path: Path):
+    cp = ControlPlane.in_memory()
+    agent = _register_worker(cp)
+    task = cp.create_task("Long task", required_capabilities=["python"])
+    client = TestClient(create_app(control_plane=cp))
+
+    executor_entered = threading.Event()
+    release_executor = threading.Event()
+
+    def blocking_executor(task_payload: Dict[str, Any], task_dir: Path) -> WorkerExecution:
+        executor_entered.set()
+        # Stands in for the detached executor child that never sees SIGTERM.
+        release_executor.wait(timeout=30)
+        return WorkerExecution(0, "done")
+
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=_api_transport(client)),
+        agent.id,
+        tmp_path,
+        blocking_executor,
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+    worker.shutdown_grace_seconds = 0.2
+
+    loop = threading.Thread(target=worker.run_forever, kwargs={"max_iterations": 1})
+    loop.start()
+    try:
+        assert executor_entered.wait(timeout=20), "executor never started"
+        assert cp.get_task(task.id).state == TaskState.RUNNING.value
+        assert cp.get_task(task.id).lease_id is not None
+
+        # Exactly what the OS-installed handler does on SIGTERM.
+        worker._handle_shutdown_signal(signal.SIGTERM)
+
+        # Without the fix this never happens: the flag is only read between
+        # iterations, so the lease lives until it expires 900s later.
+        assert _wait_for(
+            lambda: cp.get_task(task.id).state == TaskState.OPEN.value
+        ), "shutdown did not release the lease within the grace deadline"
+        released = cp.get_task(task.id)
+        assert released.lease_id is None
+        assert released.owner_agent_id is None
+        # The offline heartbeat follows the release; the hub needs both to tell
+        # a departing worker from one that simply stopped answering.
+        assert _wait_for(
+            lambda: cp.get_agent(agent.id).status == "offline"
+        ), "the worker never marked itself offline on the way out"
+    finally:
+        release_executor.set()
+        loop.join(timeout=30)
+
+
+def test_second_signal_abandons_immediately_without_waiting_for_the_grace(tmp_path: Path):
+    cp = ControlPlane.in_memory()
+    agent = _register_worker(cp)
+    task = cp.create_task("Long task", required_capabilities=["python"])
+    client = TestClient(create_app(control_plane=cp))
+
+    executor_entered = threading.Event()
+    release_executor = threading.Event()
+
+    def blocking_executor(task_payload: Dict[str, Any], task_dir: Path) -> WorkerExecution:
+        executor_entered.set()
+        release_executor.wait(timeout=30)
+        return WorkerExecution(0, "done")
+
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=_api_transport(client)),
+        agent.id,
+        tmp_path,
+        blocking_executor,
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+    # A grace long enough that only the SECOND signal can explain a release.
+    worker.shutdown_grace_seconds = 600.0
+
+    loop = threading.Thread(target=worker.run_forever, kwargs={"max_iterations": 1})
+    loop.start()
+    try:
+        assert executor_entered.wait(timeout=20), "executor never started"
+        worker._handle_shutdown_signal(signal.SIGTERM)
+        assert cp.get_task(task.id).state == TaskState.RUNNING.value
+        worker._handle_shutdown_signal(signal.SIGTERM)
+        assert _wait_for(
+            lambda: cp.get_task(task.id).state == TaskState.OPEN.value
+        ), "a second SIGTERM did not abandon the assignment"
+    finally:
+        release_executor.set()
+        loop.join(timeout=30)
+
+
+def test_abandonment_publishes_a_shutdown_observation(tmp_path: Path):
+    # "Worker restarted" and "worker crashed" must be distinguishable in the
+    # ledger; the only way to tell is an observation the worker publishes on
+    # its way out.
+    cp = ControlPlane.in_memory()
+    agent = _register_worker(cp)
+    task = cp.create_task("Long task", required_capabilities=["python"])
+    client = TestClient(create_app(control_plane=cp))
+
+    executor_entered = threading.Event()
+    release_executor = threading.Event()
+
+    def blocking_executor(task_payload: Dict[str, Any], task_dir: Path) -> WorkerExecution:
+        executor_entered.set()
+        release_executor.wait(timeout=30)
+        return WorkerExecution(0, "done")
+
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=_api_transport(client)),
+        agent.id,
+        tmp_path,
+        blocking_executor,
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+    worker.shutdown_grace_seconds = 0.2
+
+    loop = threading.Thread(target=worker.run_forever, kwargs={"max_iterations": 1})
+    loop.start()
+    try:
+        assert executor_entered.wait(timeout=20)
+        worker._handle_shutdown_signal(signal.SIGTERM)
+        assert _wait_for(lambda: cp.get_task(task.id).state == TaskState.OPEN.value)
+        assert _wait_for(
+            lambda: bool(
+                cp.list_observability(name="worker.shutdown.abandoned", limit=5)
+            )
+        ), "no worker.shutdown.abandoned observation was published"
+    finally:
+        release_executor.set()
+        loop.join(timeout=30)
+
+
+def test_abandonment_is_a_no_op_when_no_assignment_is_held(tmp_path: Path):
+    cp = ControlPlane.in_memory()
+    agent = _register_worker(cp)
+    client = TestClient(create_app(control_plane=cp))
+    worker = MacWorker(
+        MacApiClient("http://mac.test", transport=_api_transport(client)),
+        agent.id,
+        tmp_path,
+        lambda _task, _dir: WorkerExecution(0, "unused"),
+        attestation_key=cp._agent_attestation_key(agent.id),
+    )
+    detail = worker._abandon_active_assignment("test")
+    assert detail["held_assignment"] is False
+    assert detail["heartbeat_offline"] is True
+    # Idempotent: a second call does nothing at all.
+    assert worker._abandon_active_assignment("test") == {}
+
+
+def test_default_grace_fits_inside_the_units_stop_timeout(tmp_path: Path):
+    # The whole point of the deadline is to release BEFORE systemd's SIGKILL.
+    # mac-agent-service ships TimeoutStopSec=600 with KillMode=mixed, so a
+    # default at or above that would abandon nothing.
+    unit = Path(__file__).resolve().parents[1] / "deploy" / "fleet-node-install.sh"
+    text = unit.read_text(encoding="utf-8")
+    assert "TimeoutStopSec=600" in text
+    assert 0 < DEFAULT_SHUTDOWN_GRACE_SECONDS < 600
+
+    worker = MacWorker(
+        object(),  # type: ignore[arg-type]
+        "agent_default",
+        tmp_path,
+        lambda _task, _dir: WorkerExecution(0, "unused"),
+    )
+    assert worker.shutdown_grace_seconds == DEFAULT_SHUTDOWN_GRACE_SECONDS
+
+
+def test_delivery_drain_thread_is_joined_before_shutdown_completes(tmp_path: Path):
+    # A drain already inside _process_human_delivery_outbox (an HTTP round trip
+    # plus a local openclaw-message delivery) must not still be running when
+    # _shutdown() posts offline and the process exits: a message delivered
+    # locally but never acked is redelivered on the next start.
+    worker = MacWorker(
+        object(),  # type: ignore[arg-type] - no HTTP in this test
+        "agent_drain",
+        tmp_path,
+        lambda _task, _dir: WorkerExecution(0, "unused"),
+    )
+    worker.delivery_drain_interval_seconds = 0.01
+
+    entered = threading.Event()
+    finished = threading.Event()
+
+    def slow_drain() -> None:
+        entered.set()
+        time.sleep(0.5)
+        finished.set()
+
+    worker._process_human_delivery_outbox = slow_drain  # type: ignore[assignment]
+    worker._start_delivery_drain_thread()
+    thread = worker._delivery_drain_thread
+    assert thread is not None
+    assert entered.wait(timeout=5), "drain never ran"
+
+    worker._stop_delivery_drain_thread()
+
+    assert finished.is_set(), (
+        "the drain was still in flight when shutdown returned; it was stopped "
+        "without a join"
+    )
+    assert not thread.is_alive()
+
+
+# --------------------------------------------------------------------------
+# Process-level proof: a real SIGTERM followed by a real SIGKILL, against a
+# fake hub that records what it was told.
+# --------------------------------------------------------------------------
+
+
+class _FakeHub:
+    """Records every request; answers the handful of paths the worker needs."""
+
+    def __init__(self) -> None:
+        self.requests: List[Dict[str, Any]] = []
+        self._lock = threading.Lock()
+        self._claimed = False
+        hub = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *_args: Any) -> None:  # noqa: A003
+                pass
+
+            def _respond(self, payload: Any) -> None:
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _record(self, method: str) -> Dict[str, Any]:
+                length = int(self.headers.get("Content-Length") or 0)
+                raw = self.rfile.read(length) if length else b""
+                try:
+                    payload = json.loads(raw.decode("utf-8")) if raw else None
+                except ValueError:
+                    payload = None
+                entry = {"method": method, "path": self.path, "payload": payload}
+                with hub._lock:
+                    hub.requests.append(entry)
+                return entry
+
+            def do_GET(self) -> None:  # noqa: N802
+                self._record("GET")
+                if self.path.startswith("/agents/"):
+                    self._respond({"id": "agent_fake", "dispatch_hold": False})
+                    return
+                self._respond({})
+
+            def do_POST(self) -> None:  # noqa: N802
+                entry = self._record("POST")
+                path = entry["path"]
+                if path.endswith("/claim-next"):
+                    with hub._lock:
+                        first = not hub._claimed
+                        hub._claimed = True
+                    if first:
+                        self._respond(
+                            {
+                                "task": {
+                                    "id": "task_fake",
+                                    "title": "blocking task",
+                                    "metadata": {},
+                                },
+                                "lease": {"id": "lease_fake"},
+                            }
+                        )
+                        return
+                    self._respond(None)
+                    return
+                self._respond({})
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+
+    @property
+    def url(self) -> str:
+        host, port = self._server.server_address[:2]
+        return "http://%s:%d" % (host, port)
+
+    def __enter__(self) -> "_FakeHub":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+    def snapshot(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return list(self.requests)
+
+
+_CHILD_SCRIPT = '''
+import sys, time
+from pathlib import Path
+from mac.hermes_adapter import MacApiClient
+from mac.worker import MacWorker, WorkerExecution
+
+hub_url, workspace = sys.argv[1], sys.argv[2]
+
+
+def executor(task, task_dir):
+    # The detached executor child: it does not see SIGTERM.
+    time.sleep(300)
+    return WorkerExecution(0, "never")
+
+
+class _Worker(MacWorker):
+    def _reconcile_runtime_deps_best_effort(self):
+        return None
+
+    def _prepare_task_workspace(self, task, lease):
+        directory = Path(workspace) / "task"
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory
+
+
+worker = _Worker(
+    MacApiClient(hub_url, token="test-token"),
+    "agent_fake",
+    Path(workspace),
+    executor,
+    poll_interval_seconds=0.2,
+    lease_renew_interval_seconds=0.5,
+)
+worker.shutdown_grace_seconds = 1.0
+worker.delivery_drain_interval_seconds = 0
+worker.run_forever()
+'''
+
+
+def test_real_sigterm_then_sigkill_still_releases_the_lease(tmp_path: Path):
+    script = tmp_path / "run_worker.py"
+    script.write_text(_CHILD_SCRIPT, encoding="utf-8")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    env = dict(os.environ)
+    env["MAC_WORKER_SHUTDOWN_GRACE_SECONDS"] = "1"
+    env["PYTHONUNBUFFERED"] = "1"
+
+    with _FakeHub() as hub:
+        child = subprocess.Popen(
+            [sys.executable, str(script), hub.url, str(workspace)],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            def started() -> bool:
+                return any(
+                    "/tasks/task_fake/start" in entry["path"]
+                    for entry in hub.snapshot()
+                )
+
+            assert _wait_for(started, timeout=60), (
+                "worker never began executing the fake task; hub saw %r"
+                % [entry["path"] for entry in hub.snapshot()][:40]
+            )
+
+            child.send_signal(signal.SIGTERM)
+            # Past the grace, then the hard kill the unit's TimeoutStopSec
+            # eventually delivers. Whatever the hub learned, it learned before
+            # this point.
+            time.sleep(4)
+            child.send_signal(signal.SIGKILL)
+            child.wait(timeout=30)
+
+            observed = hub.snapshot()
+            released = [
+                entry
+                for entry in observed
+                if "/tasks/task_fake/transition" in entry["path"]
+                and (entry["payload"] or {}).get("target_state") == "open"
+            ]
+            offline = [
+                entry
+                for entry in observed
+                if "/heartbeat" in entry["path"]
+                and (entry["payload"] or {}).get("status") == "offline"
+            ]
+            assert released or offline, (
+                "SIGTERM+SIGKILL left the lease held: the hub was told nothing. "
+                "Paths seen: %r" % [entry["path"] for entry in observed][-40:]
+            )
+            assert released, (
+                "the held lease was never released; the task stays "
+                "undispatchable until it expires"
+            )
+        finally:
+            if child.poll() is None:
+                child.kill()
+                child.wait(timeout=10)


### PR DESCRIPTION
Four shutdown/lifecycle defects found by audit on 2026-08-17. Each one loses work silently — nothing errors, the tests pass, and the damage only shows up later in the ledger or in `git log`.

## 1. A worker's SIGTERM never released its lease

`_install_signal_handlers` installed handlers that called `self.stop()`, which only sets `self._stop` — read at the **top** of `run_forever`'s loop. Executor children are spawned with `start_new_session=True` so they deliberately never see the SIGTERM. That is correct for a graceful drain and catastrophic past it: `mac-agent-service` ships `KillMode=mixed` / `TimeoutStopSec=600`, so at 600s systemd SIGKILLs the whole cgroup. `_shutdown()` never runs (no "offline" heartbeat), `_renew_lease_until_stopped` dies with the process, and the task stays **leased and undispatchable for the rest of `lease_seconds` (900s)** with no evidence published — while the attempt still burns.

The ledger's recurring dispatcher diagnosis *"Agent went offline mid-task (lease expired / heartbeat lost)"* is this mechanism seen from the hub's end.

The new process-level test reproduces it exactly. Against a recording fake hub, on `main`:

```
'/leases/lease_fake/renew', '/agents/agent_fake/heartbeat',
'/leases/lease_fake/renew', '/agents/agent_fake/heartbeat', ...
AssertionError: SIGTERM+SIGKILL left the lease held: the hub was told nothing.
```

**Fix.** A second signal — or a bounded grace after the first — actively abandons: cancel the detached executor (another agent is about to be free to claim that task), release the lease with the lease-fenced transition to OPEN, post the offline heartbeat, and publish a `worker.shutdown.abandoned` observation so the hub can distinguish "worker restarted" from "worker crashed".

The default grace is **540s**, chosen against the unit that runs the worker: inside `TimeoutStopSec=600` with a minute of headroom, so today's "let the task finish" drain is preserved for anything shorter while the release is guaranteed to happen before the kill. `MAC_WORKER_SHUTDOWN_GRACE_SECONDS` overrides it; a test pins the relationship to the unit file so the two cannot drift apart silently.

The signal handler itself does no I/O — it flips flags and hands the work to a watchdog thread.

## 2. The delivery drain thread was stopped without a join

`_stop_delivery_drain_thread` set the stop event and dropped the thread reference, so a drain already inside `_process_human_delivery_outbox()` (an HTTP round trip plus a local openclaw-message delivery) could still be running when `_shutdown()` posted offline and the process exited. Worst case: a message delivered locally but never acked to the hub, redelivered on the next start. Bounded join added, with a warning observation if it times out.

## 3. An unstoppable daemon thread pushed to `main`

`ControlPlane.enable_event_driven_review_advance` started

```python
threading.Thread(target=_consume, name="mac-review-advance", daemon=True)
```

with `while True: q.get()` — no stop sentinel, no stop Event, and the Thread object was never retained, so nothing could join it. The lifespan's `finally` stopped the ticker and twelve services; this consumer was not among them. Its work (`advance_default_review_workflow` -> `_publish_git_target_attempt`) clones a repo, runs merge-gate validation, and `git push`es to `main`, then writes publication rows and evidence — side effects outside Postgres, non-transactional with respect to them.

It is now a lifecycle-managed service like every other: retained thread, stop Event, `q.get(timeout=)` plus a `None` sentinel for immediate wake-up, and `disable_event_driven_review_advance()` called from `_stop_hub_tick_loop` with a bounded join. Nudges become no-ops the moment the queue reference is cleared, so nothing can start a fresh clone/push after shutdown begins.

## 4. Partial lifespan initialization left threads running

All twelve `start()` calls were **outside** the `try`, so if any raised, the `finally` never ran and every already-started daemon ticker kept running against a control plane the app then abandoned. The sequence is now a table of `(start, stop)` pairs, unwound in reverse both on startup failure and on normal shutdown, with each `stop()` isolated so one service's failure to stop cannot strand the rest.

## Tests

All nine new tests fail on `main`:

- `tests/test_worker_shutdown_abandon.py` (6) — grace-deadline release, second-signal release, the published observation, idempotence, the bounded drain join, the unit-timeout relationship, and a real `SIGTERM`-then-`SIGKILL` subprocess against a fake hub that records what it was told.
- `tests/api/test_lifespan_shutdown.py` (3) — no `mac-review-advance` thread survives the lifespan; `disable` is idempotent and silences nudges; a failing service `start()` leaves no earlier service's thread alive.

`uv run --extra dev pytest tests/ -q -n 8 -k "worker or lifespan or api or review_advance or shutdown"` → **1032 passed**.

`tests/test_worker_contract_edges.py` gains two no-op stubs on its duck-typed `Harness`, which borrows `MacWorker.execute_assignment` unbound and so must model its new collaborators. No test was deleted or renamed, so `test_impact_map.json` needs no remap. The generated env registry was regenerated for the two new variables.

## Deliberately not fixed here

- The review-advance publication is still non-transactional across the `git push`, and its `mac-publish-*` `TemporaryDirectory` is still never cleaned. Making the push and the publication row atomic is a design change, not a lifecycle fix.
- An attempt abandoned at shutdown still consumes the task's retry budget. Releasing the lease returns the task to OPEN but does not decrement `attempt_count`, so a rolling deploy can spend a task's budget without any real failure.

Both are filed as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
