### PR TITLE
Stop asking for the hermes-gateway extra that #377 removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ COPY --from=uv /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock README.md ./
 COPY src ./src
 RUN uv sync --frozen --no-dev --no-editable \
-      --extra postgres --extra k8s --extra hermes-gateway \
+      --extra postgres --extra k8s \
     && /opt/mac-venv/bin/python -c \
       "import cryptography, fastapi, kubernetes, psycopg, uvicorn, yaml"
 
@@ -46,8 +46,8 @@ RUN printf '%s\n' 'mac:x:10001:' >> /etc/group && \
 COPY --from=builder /opt/mac-venv /opt/mac-venv
 COPY --chmod=0755 deploy/mac-crash-observer.py /usr/local/bin/mac-crash-observer
 # The copied environment is resolved exclusively from uv.lock, including the
-# postgres, k8s, and hermes-gateway extras needed by the shared deployment
-# image. Runtime backend selection still comes from environment configuration.
+# postgres and k8s extras needed by the shared deployment image. Runtime
+# backend selection still comes from environment configuration.
 
 USER mac
 WORKDIR /var/lib/mac

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -10826,7 +10826,7 @@ log "installing mac Python package (with gateway, relay, and PostgreSQL runtime 
 # The relay extra ships nemo-relay so the gateway has the observability seam at
 # deploy time (the worker also reconciles REQUIRED_RUNTIME_PIP at lifecycle
 # start, so a stale node self-upgrades on demand — see mac/worker.py).
-"$VENV/bin/python" -m pip install -e "${SRC_DIR}[hermes-gateway,relay,postgres]" >/dev/null
+"$VENV/bin/python" -m pip install -e "${SRC_DIR}[relay,postgres]" >/dev/null
 if [ "$NODE_ACTION" = legacy-one-shot ]; then
   mkdir -p "$HOME/.local/bin"
   ln -sf "$VENV/bin/mac" "$HOME/.local/bin/mac"

--- a/deploy/fleet-node-machine-onboard.py
+++ b/deploy/fleet-node-machine-onboard.py
@@ -764,7 +764,7 @@ def commit(
                     "--python",
                     str(staged_venv / "bin" / "python"),
                     "--no-config",
-                    f"{staged_source}[hermes-gateway,relay,postgres]",
+                    f"{staged_source}[relay,postgres]",
                 ),
                 env=python_env,
             )

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -65,6 +65,7 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
     ),
     "deploy/fleet-node-install.sh": (
         "tests/test_codegraph_runtime_baseline.py",
+        "tests/test_declared_extras_exist.py",
         "tests/test_container_runtime_declaration.py",
         "tests/test_crash_observer.py",
         "tests/test_deploy_agent_configs.py",

--- a/tests/test_declared_extras_exist.py
+++ b/tests/test_declared_extras_exist.py
@@ -1,0 +1,124 @@
+"""Every extra the build and deploy surface asks for must exist in pyproject.
+
+Removing an optional-dependency group is a two-sided change: the group goes out
+of ``pyproject.toml``, and every place that installs it has to stop asking. Miss
+the second half and nothing complains until a build runs, because ``uv``/``pip``
+only learn the extra is gone at install time.
+
+That is not hypothetical. PR #377 removed the vendored Hermes runtime and with it
+the ``hermes-gateway`` extra (slack_bolt, discord.py, python-telegram-bot,
+aiohttp -- none of which ``src/mac`` imports). Two callers kept asking for it:
+
+    Dockerfile:29                            uv sync ... --extra hermes-gateway
+    deploy/fleet-node-machine-onboard.py:767 {source}[hermes-gateway,relay,postgres]
+
+The container build broke immediately and stayed broken on main:
+
+    error: Extra `hermes-gateway` is not defined in the project's
+           optional-dependencies table
+
+The Python test suite was fully green throughout, because no test builds the
+image or onboards a node. The onboarding break was worse than the build break --
+it is not exercised by CI at all, so it would have surfaced on a real node.
+
+So this is a gate, not a generator: it reads the extras actually declared and
+fails if anything references one that is not there. It is deliberately cheap and
+dependency-free so it runs in every suite.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def declared_extras() -> set[str]:
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    return set(data.get("project", {}).get("optional-dependencies", {}))
+
+
+#: ``--extra NAME`` as uv spells it.
+_UV_EXTRA = re.compile(r"--extra[=\s]+([A-Za-z0-9._-]+)")
+
+#: ``something[a,b,c]`` as pip/uv spell it in a requirement string. The prefix
+#: guard keeps this from matching list indexing in Python sources.
+_BRACKET_EXTRAS = re.compile(r"[\w}\"'/.\]]\[([A-Za-z0-9._,-]+)\]")
+
+#: Files that install this project. Kept explicit rather than globbed: a glob
+#: would silently stop covering a file that got renamed.
+_INSTALL_SITES = (
+    "Dockerfile",
+    "deploy/fleet-node-machine-onboard.py",
+    "deploy/deploy-mac-fleet.sh",
+    "deploy/fleet-node-install.sh",
+)
+
+
+def _referenced_extras(text: str) -> set[str]:
+    found = set(_UV_EXTRA.findall(text))
+    for group in _BRACKET_EXTRAS.findall(text):
+        for name in group.split(","):
+            name = name.strip()
+            # Bracket syntax is also PEP 508 for third-party requirements
+            # (``psycopg[binary]``). Only names we declare are our business;
+            # an unknown name here is far more likely to be someone else's
+            # extra than a typo of ours, and this gate must not cry wolf.
+            if name:
+                found.add(name)
+    return found
+
+
+def test_pyproject_declares_the_extras_we_expect():
+    """Pin the set, so removing one is a deliberate edit to this list."""
+    assert declared_extras() == {"dev", "docs", "postgres", "k8s", "relay"}
+
+
+@pytest.mark.parametrize("relpath", _INSTALL_SITES)
+def test_install_sites_only_request_extras_that_exist(relpath):
+    path = REPO_ROOT / relpath
+    if not path.exists():  # pragma: no cover - covered by the existence test
+        pytest.skip("%s is not present in this checkout" % relpath)
+
+    declared = declared_extras()
+    # Third-party extras legitimately appear in these files; we can only judge
+    # the ones that look like ours, i.e. that appear alongside the project path
+    # or a `uv sync` for this project. `--extra` is unambiguous, so it is
+    # checked strictly; bracket groups are checked only for names that were
+    # once ours, which is what actually regresses.
+    once_ours = {"hermes-gateway"}
+    text = path.read_text()
+
+    strict = set(_UV_EXTRA.findall(text))
+    unknown = sorted(strict - declared)
+    assert not unknown, (
+        "%s runs `--extra %s`, but pyproject.toml declares only %s. "
+        "Removing an optional-dependency group means removing every request "
+        "for it; otherwise the build fails with "
+        "'Extra `%s` is not defined in the project's optional-dependencies "
+        "table' while the Python suite stays green."
+        % (relpath, ", ".join(unknown), sorted(declared), unknown[0])
+    )
+
+    resurrected = sorted(
+        name for name in _referenced_extras(text) if name in once_ours
+    )
+    assert not resurrected, (
+        "%s references the removed extra(s) %s. These were dropped with the "
+        "vendored Hermes runtime in #377; src/mac imports none of "
+        "slack_bolt, discord, telegram or aiohttp."
+        % (relpath, ", ".join(resurrected))
+    )
+
+
+def test_every_install_site_still_exists():
+    """If one of these is renamed, this gate stops covering it -- say so."""
+    missing = [p for p in _INSTALL_SITES if not (REPO_ROOT / p).exists()]
+    assert not missing, (
+        "install sites %s no longer exist; update _INSTALL_SITES so this gate "
+        "keeps covering the files that install this project" % missing
+    )

--- a/tests/test_deployment_image_artifact.py
+++ b/tests/test_deployment_image_artifact.py
@@ -24,8 +24,15 @@ def test_deployment_image_uses_immutable_bases_and_frozen_lock() -> None:
     )
     assert "COPY pyproject.toml uv.lock README.md ./" in dockerfile
     assert "uv sync --frozen --no-dev --no-editable" in dockerfile
-    for extra in ("postgres", "k8s", "hermes-gateway"):
+    # `hermes-gateway` was dropped from pyproject with the vendored Hermes
+    # runtime in #377. This assertion outlived it and pinned the broken state:
+    # it demanded the Dockerfile request an extra that no longer exists, while
+    # the actual image build failed with "Extra `hermes-gateway` is not defined
+    # in the project's optional-dependencies table". Two gates asserting
+    # opposite things is why main stayed red.
+    for extra in ("postgres", "k8s"):
         assert f"--extra {extra}" in dockerfile
+    assert "--extra hermes-gateway" not in dockerfile
     assert "pip install" not in dockerfile
     assert "COPY --from=builder /opt/mac-venv /opt/mac-venv" in dockerfile
     assert "mac:x:10001:10001:" in dockerfile

--- a/tests/test_fleet_node_machine_onboard.py
+++ b/tests/test_fleet_node_machine_onboard.py
@@ -429,9 +429,15 @@ def test_deployment_runtime_includes_postgres_extra():
     onboard = HELPER.read_text(encoding="utf-8")
     installer = (ROOT / "deploy" / "fleet-node-install.sh").read_text(encoding="utf-8")
 
-    expected = "[hermes-gateway,relay,postgres]"
+    # The `hermes-gateway` extra went away with the vendored Hermes runtime in
+    # #377; asking for it makes `pip install` fail outright. This assertion
+    # pinned the pre-#377 spelling, so it actively required node provisioning to
+    # request a nonexistent extra -- and unlike the Dockerfile, CI never builds
+    # a node, so nothing else would have caught it.
+    expected = "[relay,postgres]"
     assert expected in onboard
     assert expected in installer
+    assert "hermes-gateway" not in expected
 
 
 def test_node_installer_prefers_phase_zero_managed_python(tmp_path):


### PR DESCRIPTION
`main`'s container build has been **red since #377** (de-vendoring):

```
error: Extra `hermes-gateway` is not defined in the project's optional-dependencies table
```

The extra was removed with the vendored Hermes runtime, but **three** callers kept installing it:

| site | how |
|---|---|
| `Dockerfile:29` | `uv sync ... --extra hermes-gateway` |
| `deploy/fleet-node-machine-onboard.py:767` | `{source}[hermes-gateway,relay,postgres]` |
| `deploy/fleet-node-install.sh:10829` | `pip install -e "${SRC_DIR}[hermes-gateway,relay,postgres]"` |

Only the first is visible in CI. **The other two are node provisioning, which CI never exercises** — they would have surfaced on a real host mid-install. I found the third only because the new test flagged it, not because I grepped well.

Dropping it loses nothing: `src/mac` imports none of `slack_bolt`, `discord`, `telegram`, or `aiohttp`. mac's Slack support goes over HTTP, not the SDKs.

## The gate

`tests/test_declared_extras_exist.py` reads the extras actually declared in `pyproject.toml` and fails if an install site asks for one that isn't there.

This class of break is invisible to the existing suite — **the entire Python test suite was green the whole time**, because no test builds the image or onboards a node. A content check on the build/deploy surface is the only thing that catches it. The test also pins the declared set (so removing a group is a deliberate edit) and asserts the install-site list still points at real files (so a rename can't silently drop coverage).

**Verified:** 6 pass fixed, 3 fail unfixed — one per site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)