### PR TITLE
Bound the retention candidate scan in SQL, not in Python (#379 follow-up)

### DIFF
--- a/src/mac/retention_service.py
+++ b/src/mac/retention_service.py
@@ -485,6 +485,22 @@ class RetentionService:
     # Core prune logic
     # ------------------------------------------------------------------
 
+    def _count(self, sql: str, params: tuple = ()) -> int:
+        """Run a ``SELECT COUNT(*) AS n`` and return the scalar.
+
+        Used instead of ``len()`` of a materialized candidate list so that the
+        backlog figure behind ``batch_capped`` costs O(1) memory.
+        """
+        rows = self.store.query_all(sql, params)
+        if not rows:
+            return 0
+        row = rows[0]
+        try:
+            value = row["n"]
+        except (KeyError, IndexError, TypeError):
+            value = list(dict(row).values())[0]
+        return int(value or 0)
+
     def _execute_prune(
         self,
         record_class: str,
@@ -544,8 +560,12 @@ class RetentionService:
         # ---------------------------------------------------------------
         # Build the candidate set
         # ---------------------------------------------------------------
-        # Step 1: collect IDs that exceed the age or count limit.
+        # Step 1: collect at most ONE WINDOW of IDs that exceed the age or
+        # count limit, oldest first.  The window size is bounded here, in SQL,
+        # so the database never has to hand the whole backlog to Python.
         candidate_ids: List[str] = []
+        window_size = min(policy.batch_size, MAX_BIND_PARAMETERS)
+        total_candidates = 0
 
         if policy.max_age_seconds is not None:
             from datetime import datetime, timedelta, timezone as _tz
@@ -556,25 +576,33 @@ class RetentionService:
             cutoff = (dt_now - timedelta(seconds=policy.max_age_seconds)).isoformat(
                 timespec="microseconds"
             )
-            rows = self.store.query_all(
-                "SELECT %s AS pk_val, %s AS ts_val, %s AS sz"
-                " FROM %s WHERE %s < ?"
-                " ORDER BY %s ASC" % (pk, ts_col, size_sql, table, ts_col, ts_col),
+            total_candidates = self._count(
+                "SELECT COUNT(*) AS n FROM %s WHERE %s < ?" % (table, ts_col),
                 (cutoff,),
             )
-            candidate_ids = [str(r["pk_val"]) for r in rows]
+            if total_candidates:
+                rows = self.store.query_all(
+                    "SELECT %s AS pk_val FROM %s WHERE %s < ?"
+                    " ORDER BY %s ASC LIMIT ?" % (pk, table, ts_col, ts_col),
+                    (cutoff, window_size),
+                )
+                candidate_ids = [str(r["pk_val"]) for r in rows]
 
         elif policy.max_rows is not None:
             # Keep the newest max_rows; candidates are the excess older ones.
-            rows = self.store.query_all(
-                "SELECT %s AS pk_val, %s AS ts_val, %s AS sz"
-                " FROM %s ORDER BY %s ASC" % (pk, ts_col, size_sql, table, ts_col),
-            )
-            total = len(rows)
+            # Counting first means the excess is computed without reading the
+            # table: only the oldest min(excess, window) ids are fetched.
+            total = self._count("SELECT COUNT(*) AS n FROM %s" % table)
             keep = max(0, policy.max_rows)
-            excess = max(0, total - keep)
-            rows = rows[:excess]
-            candidate_ids = [str(r["pk_val"]) for r in rows]
+            total_candidates = max(0, total - keep)
+            take = min(total_candidates, window_size)
+            if take:
+                rows = self.store.query_all(
+                    "SELECT %s AS pk_val FROM %s ORDER BY %s ASC LIMIT ?"
+                    % (pk, table, ts_col),
+                    (take,),
+                )
+                candidate_ids = [str(r["pk_val"]) for r in rows]
 
         if not candidate_ids:
             return PruneReport(
@@ -595,13 +623,12 @@ class RetentionService:
             )
 
         # ---------------------------------------------------------------
-        # Step 2: cap the candidate window BEFORE excluding
+        # Step 2: the window is already capped; exclude within it
         # ---------------------------------------------------------------
-        # Step 1 is deliberately unbounded -- it selects every row past the
-        # cutoff so `batch_capped` can report an honest backlog. The exclusion
-        # queries below bind one parameter per candidate, and PostgreSQL caps a
-        # statement at 65535 of them, so passing the raw candidate list made
-        # prune fail outright once a table had ~65k prunable rows:
+        # The exclusion queries below bind one parameter per candidate, and
+        # PostgreSQL caps a statement at 65535 of them, so passing an uncapped
+        # candidate list made prune fail outright once a table had ~65k
+        # prunable rows:
         #
         #   retention.prune_tick_failed
         #     "sending query and params failed: number of parameters must be
@@ -612,11 +639,18 @@ class RetentionService:
         # prune fails harder. That is the mechanism behind the 16GB / 10.4M-row
         # action_events incident, where retention was wired but never pruned.
         #
-        # Candidates are ordered oldest-first, so taking the head keeps prune
-        # working on the oldest rows and the backlog still drains across ticks
-        # via retention_prune_tick's max_batches loop.
-        total_candidates = len(candidate_ids)
-        window_size = min(policy.batch_size, MAX_BIND_PARAMETERS)
+        # The cap used to be applied in Python, AFTER step 1 had materialized
+        # the entire prunable backlog into a list. That stopped the crash but
+        # left `retention_prune_tick` doing MAC_RETENTION_MAX_BATCHES_PER_TICK
+        # full scans of the whole backlog per record class, inline in the
+        # dispatcher tick, to delete one batch each. The cap now lives in SQL
+        # (LIMIT), and the honest backlog figure `batch_capped` needs comes
+        # from a COUNT(*) instead of len() of a materialized list -- same
+        # honesty, O(1) memory.
+        #
+        # Candidates are ordered oldest-first, so the window is the oldest rows
+        # and the backlog still drains across ticks via retention_prune_tick's
+        # max_batches loop.
         window = candidate_ids[:window_size]
 
         excluded_ids, exclusion_reasons = self._apply_exclusions(
@@ -628,8 +662,9 @@ class RetentionService:
         # ---------------------------------------------------------------
         # Step 3: report whether more remains beyond this batch
         # ---------------------------------------------------------------
-        # Reported against the FULL candidate count, not the window, so the
-        # tick loop keeps draining while a real backlog exists.
+        # Reported against the FULL candidate count from the COUNT(*) above,
+        # not the window, so the tick loop keeps draining while a real backlog
+        # exists.
         batch_capped = total_candidates > window_size
 
         # ---------------------------------------------------------------

--- a/tests/test_retention_service.py
+++ b/tests/test_retention_service.py
@@ -696,13 +696,53 @@ class TestControlPlaneFacade:
         )
 
 
+class _BacklogStore:
+    """A fake store that behaves like a database rather than a Python list.
+
+    ``COUNT(*)`` returns a scalar, ``LIMIT ?`` actually limits, and the
+    candidate select is asserted to carry a LIMIT at all -- which is the whole
+    point: the bound must live in SQL, so the backlog is never materialized in
+    Python.  Rows come back oldest-first, ``row0000000`` being the oldest.
+    """
+
+    def __init__(self, backlog: int, total_rows: Optional[int] = None):
+        self.backlog = backlog
+        self.total_rows = backlog if total_rows is None else total_rows
+        self.step1_fetched: List[int] = []  # rows RETURNED by the candidate select
+        self.in_clause_binds: List[tuple] = []
+        self.counts: List[str] = []
+
+    def query_all(self, sql: str, params: tuple = ()) -> List[Dict[str, Any]]:
+        if "COUNT(*)" in sql:
+            self.counts.append(sql)
+            return [{"n": self.backlog if " WHERE " in sql else self.total_rows}]
+        if " IN (" in sql:
+            self.in_clause_binds.append(tuple(params))
+            return []
+        # The step-1 candidate select.
+        assert "LIMIT ?" in sql, (
+            "the candidate window must be bounded in SQL, not sliced in Python "
+            "after the whole backlog has been read: %s" % sql
+        )
+        assert "ORDER BY" in sql and " ASC" in sql, (
+            "the window must still take the OLDEST rows: %s" % sql
+        )
+        limit = int(params[-1])
+        available = self.backlog if " WHERE " in sql else self.total_rows
+        n = min(limit, available)
+        self.step1_fetched.append(n)
+        return [{"pk_val": "row%07d" % i} for i in range(n)]
+
+    def transaction(self):  # pragma: no cover - these tests are all dry runs
+        raise AssertionError("dry run must not delete")
+
+
 class TestBindParameterCeiling:
     """Prune must survive a backlog larger than PostgreSQL's parameter limit.
 
-    Step 1 of prune() is deliberately unbounded so `batch_capped` can report an
-    honest backlog. The exclusion queries bind ONE PARAMETER PER CANDIDATE, and
-    PostgreSQL caps a statement at 65535, so passing the raw candidate list made
-    prune fail outright once a table held ~65k prunable rows:
+    The exclusion queries bind ONE PARAMETER PER CANDIDATE, and PostgreSQL caps
+    a statement at 65535, so passing an uncapped candidate list made prune fail
+    outright once a table held ~65k prunable rows:
 
         retention.prune_tick_failed
           "sending query and params failed: number of parameters must be
@@ -723,23 +763,9 @@ class TestBindParameterCeiling:
             RetentionService,
         )
 
-        seen: List[int] = []
-
-        class _Store:
-            def query_all(self, sql: str, params: tuple = ()) -> List[Dict[str, Any]]:
-                if " IN (" in sql:
-                    seen.append(len(params))
-                    return []
-                # Step 1: a backlog far larger than the bind ceiling.
-                return [
-                    {"pk_val": "row%d" % i, "ts_val": "2020-01-01T00:00:00+00:00", "sz": 1}
-                    for i in range(MAX_BIND_PARAMETERS * 3)
-                ]
-
-            def transaction(self):  # pragma: no cover - dry_run never executes
-                raise AssertionError("dry run must not delete")
-
-        service = RetentionService(_Store())
+        # A backlog far larger than the bind ceiling.
+        store = _BacklogStore(MAX_BIND_PARAMETERS * 3)
+        service = RetentionService(store)
         service.set_policy(
             RetentionPolicy(
                 "observability_events",
@@ -751,6 +777,7 @@ class TestBindParameterCeiling:
         )
         report = service.dry_run("observability_events", actor="test")
 
+        seen = [len(p) for p in store.in_clause_binds]
         assert seen, "no exclusion query ran"
         assert max(seen) <= MAX_BIND_PARAMETERS, (
             "bound %d parameters; PostgreSQL rejects anything over 65535 and the "
@@ -770,22 +797,8 @@ class TestBindParameterCeiling:
             RetentionService,
         )
 
-        captured: List[tuple] = []
-
-        class _Store:
-            def query_all(self, sql: str, params: tuple = ()) -> List[Dict[str, Any]]:
-                if " IN (" in sql:
-                    captured.append(params)
-                    return []
-                return [
-                    {"pk_val": "row%05d" % i, "ts_val": "2020-01-01T00:00:00+00:00", "sz": 1}
-                    for i in range(MAX_BIND_PARAMETERS + 500)
-                ]
-
-            def transaction(self):  # pragma: no cover
-                raise AssertionError("dry run must not delete")
-
-        service = RetentionService(_Store())
+        store = _BacklogStore(MAX_BIND_PARAMETERS + 500)
+        service = RetentionService(store)
         service.set_policy(
             RetentionPolicy(
                 "observability_events",
@@ -796,7 +809,164 @@ class TestBindParameterCeiling:
         )
         service.dry_run("observability_events", actor="test")
 
+        captured = store.in_clause_binds
         assert captured, "no exclusion query ran"
         first_batch = captured[0]
-        assert first_batch[0] == "row00000", "the oldest row must be in the window"
+        assert first_batch[0] == "row0000000", "the oldest row must be in the window"
         assert len(first_batch) <= MAX_BIND_PARAMETERS
+
+
+class TestCandidateWindowIsBoundedInSql:
+    """The window must be bounded by the DATABASE, not sliced in Python.
+
+    #379 capped the window before the exclusion query bound it, which stopped
+    the crash. But step 1 still ran
+
+        SELECT <pk>, <ts>, LENGTH(...) FROM <table> WHERE <ts> < ?  ORDER BY <ts> ASC
+
+    with no LIMIT -- and on the max_rows branch, with no WHERE either, i.e. the
+    whole table. `StorePostgres.query_all` is `execute(...).fetchall()`, so the
+    entire prunable backlog was materialized into a Python list on every call.
+    `retention_prune_tick` calls prune() up to MAC_RETENTION_MAX_BATCHES_PER_TICK
+    (25) times per record class, inline in the dispatcher tick and before
+    `_dispatch_batch_impl` -- so a large-backlog recovery meant 25 full scans of
+    the backlog per class per tick to delete 2000 rows.
+
+    Deletion did still make monotonic progress (each batch commits in its own
+    transaction), so this is not "the table never drains"; the harm is the
+    repeated full-backlog materialization stalling dispatch, plus the memory it
+    takes to hold it.
+
+    These assert on rows FETCHED, not rows deleted -- the old code deleted the
+    right number while reading everything.
+    """
+
+    def test_max_age_branch_fetches_at_most_one_window(self):
+        store = _BacklogStore(backlog=50_000)
+        service = RetentionService(store)
+        service.set_policy(
+            RetentionPolicy(
+                "observability_events",
+                enabled=True,
+                max_age_seconds=1,
+                batch_size=2_000,
+            )
+        )
+        report = service.dry_run("observability_events", actor="test")
+
+        assert store.step1_fetched == [2_000], (
+            "step 1 fetched %r rows; a 50k backlog must yield exactly one "
+            "2000-row window" % store.step1_fetched
+        )
+        assert report.batch_capped is True, (
+            "the backlog beyond the window must still be reported, or the tick "
+            "loop stops draining"
+        )
+        assert store.counts, "batch_capped must come from a COUNT(*), not from len()"
+
+    def test_max_age_window_is_the_oldest_rows(self):
+        store = _BacklogStore(backlog=10_000)
+        service = RetentionService(store)
+        service.set_policy(
+            RetentionPolicy(
+                "observability_events",
+                enabled=True,
+                max_age_seconds=1,
+                batch_size=100,
+            )
+        )
+        service.dry_run("observability_events", actor="test")
+
+        window = store.in_clause_binds[0]
+        assert window[0] == "row0000000", "the window must start at the oldest row"
+        assert window[-1] == "row0000099", "the window must be a contiguous oldest run"
+
+    def test_max_rows_branch_never_reads_the_whole_table(self):
+        """The worse branch: it had no WHERE clause at all."""
+        store = _BacklogStore(backlog=0, total_rows=1_000_000)
+        service = RetentionService(store)
+        service.set_policy(
+            RetentionPolicy(
+                "observability_events",
+                enabled=True,
+                max_rows=1_000,
+                batch_size=2_000,
+            )
+        )
+        report = service.dry_run("observability_events", actor="test")
+
+        assert store.step1_fetched == [2_000], (
+            "step 1 fetched %r rows; the max_rows branch must fetch only the "
+            "oldest window of the excess, never the table" % store.step1_fetched
+        )
+        # 1,000,000 rows - keep 1,000 = 999,000 excess, far beyond one window.
+        assert report.batch_capped is True
+        assert report.eligible_rows == 2_000
+
+    def test_max_rows_excess_smaller_than_window_is_not_capped(self):
+        store = _BacklogStore(backlog=0, total_rows=1_050)
+        service = RetentionService(store)
+        service.set_policy(
+            RetentionPolicy(
+                "observability_events",
+                enabled=True,
+                max_rows=1_000,
+                batch_size=2_000,
+            )
+        )
+        report = service.dry_run("observability_events", actor="test")
+
+        assert store.step1_fetched == [50], (
+            "only the 50 excess rows may be fetched, not a full window and not "
+            "the table: %r" % store.step1_fetched
+        )
+        assert report.batch_capped is False
+        assert report.eligible_rows == 50
+
+    def test_max_rows_below_limit_fetches_nothing(self):
+        store = _BacklogStore(backlog=0, total_rows=10)
+        service = RetentionService(store)
+        service.set_policy(
+            RetentionPolicy("observability_events", enabled=True, max_rows=1_000)
+        )
+        report = service.dry_run("observability_events", actor="test")
+
+        assert store.step1_fetched == [], "nothing is over the limit; read nothing"
+        assert report.eligible_rows == 0
+        assert "no_candidates" in report.exclusion_reasons
+
+    def test_max_rows_prunes_oldest_excess_in_batches_against_a_real_store(
+        self, store, retention
+    ):
+        """End-to-end on PostgreSQL: keep the newest, drain the oldest."""
+        ids = []
+        for i in range(10):
+            obs_id = new_id("obs")
+            ts = "2025-01-%02dT12:00:00+00:00" % (i + 1)
+            store.execute(
+                "INSERT INTO observability_events"
+                " (id, kind, layer, source, level, name, value, unit, detail, created_at)"
+                " VALUES (?, 'log', 'control_plane', 'test', 'info', 'cnt.evt',"
+                " NULL, '', '{}', ?)",
+                (obs_id, ts),
+            )
+            ids.append(obs_id)
+
+        pol = RetentionPolicy(
+            "observability_events", enabled=True, max_rows=3, batch_size=4
+        )
+        first = retention.prune("observability_events", override_policy=pol)
+        assert first.deleted_rows == 4
+        assert first.batch_capped is True, "7 excess > 4 window: more remains"
+
+        second = retention.prune("observability_events", override_policy=pol)
+        assert second.deleted_rows == 3
+        assert second.batch_capped is False, "3 excess <= 4 window: drained"
+
+        remaining = [
+            r["id"]
+            for r in store.query_all(
+                "SELECT id FROM observability_events ORDER BY created_at ASC"
+            )
+        ]
+        assert remaining == ids[7:], "the 3 newest survive, the 7 oldest went"


### PR DESCRIPTION
Follow-up to #379, which was an **incomplete fix**.

#379 capped the candidate window before the exclusion query bound it, which
stopped `retention.prune_tick_failed` ("number of parameters must be between 0
and 65535"). That part was correct and is unchanged here. What it missed is that
**step 1 was still unbounded** — the query that finds candidates selected the
entire prunable backlog, and the cap was applied afterwards, in Python.

```sql
-- max_age branch: no LIMIT
SELECT <pk>, <ts>, LENGTH(...) FROM <table> WHERE <ts> < ? ORDER BY <ts> ASC
-- max_rows branch: no LIMIT *and no WHERE at all* — the whole table
SELECT <pk>, <ts>, LENGTH(...) FROM <table> ORDER BY <ts> ASC
```

`StorePostgres.query_all` is `execute(...).fetchall()` — client-side, no
server-side cursor, and no `statement_timeout` is configured in the backend. So
each call materialized the whole backlog into a Python list.

## Why it matters

`retention_prune_tick` calls `prune()` up to `MAC_RETENTION_MAX_BATCHES_PER_TICK`
(25) times per record class, **inline in the dispatcher tick and before
`_dispatch_batch_impl`**. During a large-backlog recovery — the exact scenario
this module was rewritten for after the 16GB / 10.4M-row `action_events`
incident — that is 25 full index+heap scans of the backlog per class per tick,
each building a multi-million-element list, to delete 2000 rows.

## Severity, stated honestly

Deletion **did** make monotonic progress. Each batch commits in its own
transaction, so 25 × 2000 = 50k rows/tick is durable and a 10.4M backlog drains
in ~208 ticks. It is **not** true that the table never drains, and **not** true
that a crash loses everything — only the in-flight batch is lost. Steady state
was fine too: once drained, only rows newly crossing the cutoff match.

The real harm is the repeated full-backlog materialization blocking the
dispatcher tick, plus plausible (not certain) memory pressure.

## The fix

- Both branches now select only the candidate pk, `ORDER BY <ts> ASC` (still
  load-bearing — the window must be the **oldest** rows) with `LIMIT ?` bound to
  the window size. At most one window ever crosses the wire.
- **`batch_capped` stays honest** via a new `_count()` helper running
  `SELECT COUNT(*)` instead of `len()` of a materialized list — the same honesty
  at O(1) memory. The old comment said the unbounded scan existed *only* so
  `batch_capped` could be honest; a COUNT gives that for free. Comment and tests
  updated to describe the new mechanism.
- The `max_rows` branch counts the table first, computes `excess = total - keep`,
  and fetches only the oldest `min(excess, window)` ids — still keeping the
  newest `max_rows`, without reading the table.
- `MAX_BIND_PARAMETERS` and #379's exclusion logic are **untouched**.

## Tests

5 new tests in `TestCandidateWindowIsBoundedInSql`, **all failing before this
change**, asserting on rows **fetched** rather than rows deleted (the old code
deleted the right number while reading everything):

- one-window fetch on the `max_age` branch, with `batch_capped` still true
- the window is still the oldest contiguous run
- the `max_rows` branch — the worse of the two, with no `WHERE` today — never
  reads the whole table
- excess below the window is not reported as capped
- nothing over the limit reads nothing

Plus an end-to-end `max_rows` drain across two batches against PostgreSQL.

#379's two `TestBindParameterCeiling` regression tests keep every assertion; only
their fake store was upgraded to behave like a database (COUNT returns a scalar,
LIMIT actually limits, and the candidate select is asserted to *carry* a LIMIT)
instead of returning a full Python list for every query.

119 retention/prune tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)