### PR TITLE
Release v1.1.0

### DIFF
--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 #: import it, so the number lives in exactly one place. It used to be copied by
 #: hand into four (pyproject, this package, the FastAPI app, the A2A card) with
 #: a comment on each asking the next person to keep them in sync.
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 __all__ = [
     "ControlPlane",


### PR DESCRIPTION
Single-source version bump, 1.0.0 -> 1.1.0. pyproject.toml declares dynamic version pointing at mac.__version__, so this one line is the whole change. Verified: tests/test_a2a.py 14 passed (it compares the agent card version against mac.__version__ rather than hardcoding). Full notes go on the tag.