### PR TITLE
Stop the review sweep from starving retention, and make dormancy visible

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -10696,6 +10696,12 @@ class ControlPlane:
     # is deliberately left preserve-by-default.
     _RETENTION_TICK_CLASSES = ("action_events", "observability_events")
 
+    #: How often the retention liveness heartbeat is emitted, in seconds. The
+    #: tick itself runs far more often (every MAC_HUB_TICK_INTERVAL_SECONDS),
+    #: so this throttles the heartbeat to something an operator can read
+    #: without it becoming the telemetry it exists to bound.
+    RETENTION_HEARTBEAT_SECONDS = 300.0
+
     def _configure_default_retention_policies(self) -> None:
         if os.environ.get("MAC_RETENTION_TICK_ENABLED", "1").strip() not in {"1", "true", "yes", "on"}:
             return
@@ -10754,6 +10760,38 @@ class ControlPlane:
             if deleted:
                 summary["deleted"][record_class] = deleted
                 summary["batches"][record_class] = batches
+        # Liveness heartbeat. `prune()` is deliberately silent when it has no
+        # work, so without this a retention tick that NEVER RUNS is
+        # indistinguishable from one that ran and found nothing -- and the
+        # silent case is the dangerous one: it is how the store reached 16GB
+        # while retention was believed to be wired, and how retention sat
+        # starved behind the review sweep for 48 minutes on 2026-08-17 with no
+        # signal at all.
+        #
+        # Emitted at most once per interval so the heartbeat cannot itself
+        # become the firehose it exists to bound. `enabled_classes` is the
+        # datum that distinguishes "policies are off" from "policies are on and
+        # the backlog is empty" -- two states that previously looked the same.
+        now = utcnow()
+        last = getattr(self, "_retention_heartbeat_at", None)
+        if last is None or (now - last).total_seconds() >= self.RETENTION_HEARTBEAT_SECONDS:
+            self._retention_heartbeat_at = now
+            enabled_classes = [
+                rc
+                for rc in self._RETENTION_TICK_CLASSES
+                if self.retention.get_policy(rc).enabled
+            ]
+            self.record_log(
+                "retention.tick_ran",
+                layer="control_plane",
+                source="dispatcher.tick",
+                detail={
+                    "schema": "mac.retention_tick_heartbeat.v1",
+                    "enabled_classes": enabled_classes,
+                    "deleted": dict(summary["deleted"]),
+                    "max_batches": max_batches,
+                },
+            )
         return summary
 
     # OpenShell policies / action events --------------------------------
@@ -20444,6 +20482,34 @@ class ControlPlane:
         auto_retry_page = self._auto_retry_blocked_attempts_sweep_page(
             limit=limit_value
         )
+        # Retention runs HERE -- before the review sweep -- and not further down,
+        # because the sweep below can block this thread for minutes while it
+        # clones a repository and runs a contract gate. Retention used to sit
+        # after it and was therefore starved: observed live on 2026-08-17, the
+        # hub emitted ZERO retention events in the 48 minutes after a restart
+        # while 235,615 observability_events and 5,576 action_events sat past
+        # the 7-day cutoff.
+        #
+        # That failure is invisible by construction. `prune()` deliberately
+        # stays silent when there is nothing to do (so the audit row never
+        # becomes the retained data), so "retention is alive with no work" and
+        # "retention is never reached" look identical from outside -- which is
+        # how the store previously grew to 16GB / 10.4M rows while retention was
+        # believed to be wired. See the `retention.tick_ran` heartbeat below.
+        #
+        # Retention is cheap and bounded (max_batches x batch_size rows), so
+        # running it first costs the sweep nothing.
+        try:
+            retention_pruned = self.retention_prune_tick()
+        except Exception as exc:  # noqa: BLE001 - retention must never stop dispatch.
+            retention_pruned = {"errors": [{"error": str(exc)[:500]}]}
+            self.record_log(
+                "retention.prune_tick_failed",
+                layer="control_plane",
+                source="dispatcher.tick",
+                level="error",
+                detail={"error": str(exc)[:500]},
+            )
         # The tick is the RIGHT place to run a publication's contract gate, and
         # for a long time it was the only place that refused to.
         #
@@ -20516,17 +20582,6 @@ class ControlPlane:
             }
             self.record_log(
                 "agent.crash.repair_tick_failed",
-                layer="control_plane",
-                source="dispatcher.tick",
-                level="error",
-                detail={"error": str(exc)[:500]},
-            )
-        try:
-            retention_pruned = self.retention_prune_tick()
-        except Exception as exc:  # noqa: BLE001 - retention must never stop dispatch.
-            retention_pruned = {"errors": [{"error": str(exc)[:500]}]}
-            self.record_log(
-                "retention.prune_tick_failed",
                 layer="control_plane",
                 source="dispatcher.tick",
                 level="error",

--- a/tests/test_retention_not_starved_by_tick.py
+++ b/tests/test_retention_not_starved_by_tick.py
@@ -1,0 +1,144 @@
+"""Retention must not be starved by slow work later in the same tick.
+
+`ControlPlane.tick()` runs its stages sequentially on one background thread.
+`_advance_default_review_sweep_page` sits in that sequence and can block for
+minutes: it clones a repository and runs a contract gate inline (the tick's own
+comment says "Blocking here delays the next tick"). Retention used to be called
+*after* it, so a hub whose review sweep was busy simply never pruned.
+
+Observed live on 2026-08-17: in the 48 minutes after a hub restart the control
+plane emitted ZERO retention events of any kind, while 235,615
+observability_events and 5,576 action_events sat past the 7-day cutoff. The
+retention code itself was correct -- verified against real PostgreSQL -- it was
+never reached.
+
+The failure is invisible by construction, which is what makes it expensive.
+`RetentionService.prune()` deliberately emits nothing when there is no work, so
+the audit row never becomes the retained data. That means "alive, nothing to do"
+and "never ran" produce identical silence. This is the same blind spot that let
+the store grow to 16GB / 10.4M rows while retention was believed to be wired.
+
+Two guarantees are pinned here:
+
+1. Retention is called BEFORE the review sweep, so slow publication work cannot
+   starve it.
+2. A `retention.tick_ran` heartbeat is emitted, so dormancy is observable
+   without waiting for a deletion to happen.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+def _order_of_calls(cp, monkeypatch):
+    """Record the order in which the tick reaches its stages."""
+    seen: list[str] = []
+
+    real_retention = cp.retention_prune_tick
+    real_sweep = cp._advance_default_review_sweep_page
+
+    def spy_retention(*a, **k):
+        seen.append("retention")
+        return real_retention(*a, **k)
+
+    def spy_sweep(*a, **k):
+        seen.append("review_sweep")
+        return real_sweep(*a, **k)
+
+    monkeypatch.setattr(cp, "retention_prune_tick", spy_retention)
+    monkeypatch.setattr(cp, "_advance_default_review_sweep_page", spy_sweep)
+    return seen
+
+
+def test_retention_runs_before_the_review_sweep(cp, monkeypatch):
+    seen = _order_of_calls(cp, monkeypatch)
+
+    cp.tick()
+
+    assert "retention" in seen, "the tick never reached retention at all"
+    assert "review_sweep" in seen, (
+        "the review sweep did not run; this test would pass vacuously"
+    )
+    assert seen.index("retention") < seen.index("review_sweep"), (
+        "retention ran AFTER the review sweep (%s). The sweep clones a "
+        "repository and runs a contract gate inline, so anything ordered after "
+        "it can be starved for minutes -- which is exactly what happened on "
+        "2026-08-17, when the hub emitted no retention events for 48 minutes "
+        "while 235k rows sat past the cutoff." % seen
+    )
+
+
+def test_a_blocking_review_sweep_cannot_starve_retention(cp, monkeypatch):
+    """The real-world shape: the sweep is slow, retention must still have run."""
+    seen = _order_of_calls(cp, monkeypatch)
+
+    real_sweep = cp._advance_default_review_sweep_page
+
+    def slow_sweep(*a, **k):
+        seen.append("review_sweep")
+        # Stand in for "clone a repo and run the contract suite". We do not
+        # actually sleep -- ordering is the property under test, and a sleeping
+        # test is a slow test that proves the same thing.
+        raise RuntimeError("sweep is busy cloning a repository")
+
+    monkeypatch.setattr(cp, "_advance_default_review_sweep_page", slow_sweep)
+
+    try:
+        cp.tick()
+    except RuntimeError:
+        # The tick may or may not swallow the sweep's failure; either way the
+        # question is whether retention already ran by that point.
+        pass
+
+    assert "retention" in seen, (
+        "retention never ran because the review sweep blocked first -- the "
+        "starvation this ordering exists to prevent"
+    )
+
+
+def test_the_tick_emits_a_retention_heartbeat(cp):
+    """Dormancy must be observable without waiting for a deletion."""
+    cp.tick()
+
+    logs = cp.observability.list_observability(
+        name="retention.tick_ran", limit=500
+    )
+    assert logs, (
+        "no retention.tick_ran heartbeat. Without it, a retention tick that "
+        "never runs is indistinguishable from one that ran and found nothing, "
+        "because prune() is deliberately silent when idle."
+    )
+
+    detail = logs[0].detail or {}
+    assert "enabled_classes" in detail, (
+        "the heartbeat must report which policies are enabled -- that is the "
+        "datum distinguishing 'retention is off' from 'retention is on and the "
+        "backlog is empty'"
+    )
+    assert detail["enabled_classes"], (
+        "no retention policy is enabled; the default policies should cover "
+        "action_events and observability_events"
+    )
+
+
+def test_the_heartbeat_is_throttled(cp):
+    """The heartbeat must not become the firehose it exists to bound."""
+    cp.tick()
+    cp.tick()
+    cp.tick()
+
+    logs = cp.observability.list_observability(
+        name="retention.tick_ran", limit=500
+    )
+    assert len(logs) == 1, (
+        "expected the heartbeat to be throttled to one emission per "
+        "RETENTION_HEARTBEAT_SECONDS, got %d across three ticks" % len(logs)
+    )


### PR DESCRIPTION
**Observed live on the hub, 2026-08-17:** in the 48 minutes after a restart the control plane emitted **zero retention events of any kind**, while **235,615 `observability_events` and 5,576 `action_events`** sat past the 7-day cutoff.

## The retention code was not at fault

I initially suspected #387 (my own follow-up, which rewrote the candidate query) and verified it against **real PostgreSQL** rather than a fake store:

- `_translate_placeholders("... LIMIT ?")` → `"... LIMIT %s"` ✓
- `SELECT COUNT(*) ... WHERE created_at < ?` → 30 ✓
- `SELECT ... ORDER BY created_at ASC LIMIT ?` (5) → 5 rows ✓
- `dry_run()` → eligible=10 · `prune()` → deleted=10, emitted `retention.prune` ✓

Policies default to `enabled=True`; the live hub had no `MAC_RETENTION_*` overrides; no `retention.policy_config_failed`; no tick exception in the log. **#387 is exonerated.** Retention was never *reached*.

## Why

`ControlPlane.tick()` runs its stages sequentially on one background thread, and `_advance_default_review_sweep_page` sits **ahead of** retention. That sweep clones a repository and runs a contract gate inline — the tick's own comment already says *"Blocking here delays the next tick"* — and a manual `POST /dispatch/tick` against the live hub **did not return within 120 seconds**.

Retention is cheap and bounded (`max_batches × batch_size`), so it now runs **before** the sweep. The sweep loses nothing.

## The heartbeat is the more important half

`prune()` deliberately emits nothing when idle, so the audit row never becomes the retained data. The consequence: **"alive with an empty backlog" and "never ran" produce identical silence.**

That's not hypothetical — it's how this store reached 16GB / 10.4M rows while retention was believed to be wired, and it's why this starvation went unnoticed until rows were counted by hand.

`retention.tick_ran` now reports `enabled_classes` on a 300s throttle: the one datum separating *"policies are off"* from *"policies are on with nothing to do"*. Throttled so it can't become the firehose it exists to bound.

## Verification

**4 new tests, all four fail on the unfixed tree** (confirmed by stashing only the `src` change) and pass with it — ordering, starvation-under-a-blocking-sweep, heartbeat presence, and heartbeat throttling.

- 279 pass across `retention or prune or tick`
- 585 pass across docs-accessibility + public-contract
- Both artifact generators re-run, no drift

## Not fixed here

The tick shouldn't be doing repository work at all — already filed as `task_fad95a2b` and in the pull/terminal-push audit. This change stops *retention* paying for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)