### PR TITLE
Give retention its own timer, so it stops queueing behind repository work

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -890,6 +890,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_REQUIRE_TOKENHUB` | bool | consumer-defined | core | Core setting: require tokenhub. |
 | `MAC_RESOURCE_HEALTH_INTERVAL_SECONDS` | int | consumer-defined | core | Core setting: resource health interval seconds. |
 | `MAC_RETENTION_BATCH_SIZE` | int | consumer-defined | core | Core setting: retention batch size. |
+| `MAC_RETENTION_INTERVAL_SECONDS` | int | consumer-defined | core | Core setting: retention interval seconds. |
 | `MAC_RETENTION_MAX_BATCHES_PER_TICK` | str | consumer-defined | core | Core setting: retention max batches per tick. |
 | `MAC_RETENTION_TELEMETRY_DAYS` | str | consumer-defined | core | Core setting: retention telemetry days. |
 | `MAC_RETENTION_TICK_ENABLED` | bool | consumer-defined | core | Core setting: retention tick enabled. |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -4296,6 +4296,75 @@ def _start_hub_tick_loop(app: FastAPI, cp: ControlPlane) -> None:
     app.state.hub_tick_thread = thread
 
 
+def _start_retention_loop(app: FastAPI, cp: ControlPlane) -> None:
+    """Run retention on its OWN timer, independent of the dispatch tick.
+
+    Retention used to be a stage inside ``ControlPlane.tick()``. That thread also
+    runs the default-review sweep, which clones a repository and runs a contract
+    gate inline, so a tick can take tens of minutes. #392 moved retention ahead
+    of the sweep, which fixed the case where it never ran at all -- but it still
+    only ran ONCE PER TICK, and the tick interval is the sweep's duration, not
+    ``MAC_HUB_TICK_INTERVAL_SECONDS``.
+
+    Measured on the hub 2026-08-17 after #392 shipped: retention pruned once at
+    startup (action_events 5,576 -> 902) and then emitted nothing for nine
+    minutes while both backlogs GREW (observability_events 238,918 -> 239,188).
+    Alive, and still losing ground.
+
+    Retention is bounded (``max_batches x batch_size`` rows) and touches only the
+    two disposable telemetry classes, so it needs none of the tick's ordering
+    guarantees and has no reason to queue behind repository work.
+
+    Gated by ``MAC_RETENTION_INTERVAL_SECONDS`` (>0 enables; defaults to 60 on a
+    hub that runs the dispatch tick, and off otherwise) so the CLI, the test
+    suite and stateless replicas do not each spawn a competing pruner.
+    """
+    try:
+        tick_interval = float((os.environ.get("MAC_HUB_TICK_INTERVAL_SECONDS") or "0").strip())
+    except ValueError:
+        tick_interval = 0.0
+    default = "60" if tick_interval > 0 else "0"
+    try:
+        interval = float((os.environ.get("MAC_RETENTION_INTERVAL_SECONDS") or default).strip())
+    except ValueError:
+        interval = 0.0
+    if interval <= 0:
+        return
+    existing = getattr(app.state, "retention_thread", None)
+    if existing is not None and existing.is_alive():
+        return
+
+    stop_event = threading.Event()
+
+    def _loop() -> None:
+        # Sleep-first, so app construction returns immediately and a process that
+        # never lives a full interval does no retention work.
+        while not stop_event.wait(interval):
+            try:
+                cp.retention_prune_tick()
+            except Exception:  # noqa: BLE001 - retention must never crash the hub
+                logging.getLogger("mac.retention").warning(
+                    "retention tick failed", exc_info=True
+                )
+
+    thread = threading.Thread(target=_loop, name="mac-retention", daemon=True)
+    thread.start()
+    app.state.retention_stop_event = stop_event
+    app.state.retention_thread = thread
+
+
+def _stop_retention_loop(app: FastAPI) -> None:
+    """Stop the lifespan-owned retention timer with a bounded join."""
+    stop_event = getattr(app.state, "retention_stop_event", None)
+    thread = getattr(app.state, "retention_thread", None)
+    if stop_event is not None:
+        stop_event.set()
+    if thread is not None and thread is not threading.current_thread():
+        thread.join(timeout=5.0)
+    app.state.retention_stop_event = None
+    app.state.retention_thread = None
+
+
 def _stop_hub_tick_loop(app: FastAPI) -> None:
     """Stop the lifespan-owned hub ticker without leaking it across restarts.
 
@@ -4552,6 +4621,7 @@ def create_app(
         # against a control plane the app then abandoned.
         services: List[Tuple[str, Callable[[], Any], Callable[[], Any]]] = [
             ("hub_tick", lambda: _start_hub_tick_loop(_app, cp), lambda: _stop_hub_tick_loop(_app)),
+            ("retention", lambda: _start_retention_loop(_app, cp), lambda: _stop_retention_loop(_app)),
             ("repository_ref_reconciler", repository_ref_reconciler.start, repository_ref_reconciler.stop),
             ("github_ingestor", github_ingestor.start, github_ingestor.stop),
             ("cicd_monitor", cicd_monitor.start, cicd_monitor.stop),

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -10519,6 +10519,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: retention interval seconds.",
+    "family": "core",
+    "name": "MAC_RETENTION_INTERVAL_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/api.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Core setting: retention max batches per tick.",
     "family": "core",
     "name": "MAC_RETENTION_MAX_BATCHES_PER_TICK",

--- a/tests/api/test_retention_loop_lifespan.py
+++ b/tests/api/test_retention_loop_lifespan.py
@@ -1,0 +1,126 @@
+"""Retention runs on its own timer, not behind the dispatch tick.
+
+#392 moved retention ahead of the default-review sweep inside
+``ControlPlane.tick()``, which fixed the case where it never ran at all. But it
+still ran only ONCE PER TICK, and the tick's real period is the sweep's
+duration -- the sweep clones a repository and runs a contract gate inline, so a
+tick can take tens of minutes.
+
+Measured on the hub 2026-08-17 after #392 shipped:
+
+    t+0    obs_backlog=238,918  act_backlog=902   prunes=7
+    t+3min obs_backlog=238,937  act_backlog=909   prunes=7
+    t+6min obs_backlog=239,063  act_backlog=975   prunes=7
+    t+9min obs_backlog=239,188  act_backlog=1045  prunes=7
+
+One prune burst at startup, then nothing for nine minutes while both backlogs
+grew. Alive, and still losing ground.
+
+Retention is bounded and touches only the two disposable telemetry classes, so
+it needs none of the tick's ordering guarantees. These tests pin that it has its
+own thread, that the thread is gated, and that the lifespan can stop it -- an
+unstoppable pruning daemon is its own hazard.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from fastapi import FastAPI
+
+from mac.api import _start_retention_loop, _stop_retention_loop
+from mac.services import ControlPlane
+
+
+def _named_threads() -> set[str]:
+    return {t.name for t in threading.enumerate()}
+
+
+@pytest.fixture()
+def app_and_cp():
+    app = FastAPI()
+    cp = ControlPlane.in_memory()
+    yield app, cp
+    _stop_retention_loop(app)
+
+
+def test_the_retention_thread_starts_when_enabled(app_and_cp, monkeypatch):
+    app, cp = app_and_cp
+    monkeypatch.setenv("MAC_RETENTION_INTERVAL_SECONDS", "30")
+
+    before = _named_threads()
+    _start_retention_loop(app, cp)
+    started = _named_threads() - before
+
+    assert "mac-retention" in started, (
+        "no dedicated retention thread; retention would still be queued behind "
+        "the dispatch tick, which is as slow as the review sweep"
+    )
+    assert app.state.retention_thread.is_alive()
+
+
+def test_it_is_off_by_default_without_a_hub_tick(app_and_cp, monkeypatch):
+    """The CLI, the test suite and stateless replicas must not each prune."""
+    app, cp = app_and_cp
+    monkeypatch.delenv("MAC_RETENTION_INTERVAL_SECONDS", raising=False)
+    monkeypatch.delenv("MAC_HUB_TICK_INTERVAL_SECONDS", raising=False)
+
+    before = _named_threads()
+    _start_retention_loop(app, cp)
+
+    assert "mac-retention" not in (_named_threads() - before), (
+        "retention started with no hub tick configured; every CLI invocation "
+        "and test process would spawn a competing pruner"
+    )
+
+
+def test_a_hub_that_ticks_gets_retention_by_default(app_and_cp, monkeypatch):
+    """On a real hub the default must be ON -- opt-out, not opt-in.
+
+    The failure this whole change addresses was retention silently not running.
+    Requiring an operator to set one more variable to get it back would
+    reproduce exactly that.
+    """
+    app, cp = app_and_cp
+    monkeypatch.delenv("MAC_RETENTION_INTERVAL_SECONDS", raising=False)
+    monkeypatch.setenv("MAC_HUB_TICK_INTERVAL_SECONDS", "30")
+
+    before = _named_threads()
+    _start_retention_loop(app, cp)
+
+    assert "mac-retention" in (_named_threads() - before), (
+        "a hub running the dispatch tick did not get a retention timer by "
+        "default; retention must be opt-out on a hub, never opt-in"
+    )
+
+
+def test_the_lifespan_can_stop_it(app_and_cp, monkeypatch):
+    app, cp = app_and_cp
+    monkeypatch.setenv("MAC_RETENTION_INTERVAL_SECONDS", "30")
+    _start_retention_loop(app, cp)
+    thread = app.state.retention_thread
+
+    _stop_retention_loop(app)
+
+    assert not thread.is_alive(), (
+        "the retention thread outlived the lifespan; a pruning daemon that "
+        "cannot be joined keeps deleting against a control plane the app has "
+        "already torn down"
+    )
+    assert app.state.retention_thread is None
+
+
+def test_starting_twice_does_not_spawn_a_second_pruner(app_and_cp, monkeypatch):
+    app, cp = app_and_cp
+    monkeypatch.setenv("MAC_RETENTION_INTERVAL_SECONDS", "30")
+
+    _start_retention_loop(app, cp)
+    first = app.state.retention_thread
+    _start_retention_loop(app, cp)
+
+    assert app.state.retention_thread is first, (
+        "a second retention thread was started; two pruners racing on the same "
+        "tables is how a bounded batch stops being bounded"
+    )
+    assert len([t for t in threading.enumerate() if t.name == "mac-retention"]) == 1


### PR DESCRIPTION
#392 moved retention ahead of the default-review sweep inside `ControlPlane.tick()`. That fixed the case where it never ran at all — and it was worth shipping — but it was only half the problem, and **production said so within ten minutes.**

## Measured on the hub after #392 deployed (`a9a855c7`)

| | obs_backlog | act_backlog | prunes |
|---|---|---|---|
| t+0 | 238,918 | 902 | 7 |
| t+3min | 238,937 | 909 | 7 |
| t+6min | 239,063 | 975 | 7 |
| t+9min | 239,188 | 1,045 | 7 |
| t+12min | 239,328 | 1,120 | 7 |

One prune burst at startup — which did real work, `action_events` fell **5,576 → 902** — then **nothing for twelve minutes** while both backlogs grew. Alive, and still losing ground.

## Why

Retention ran **once per tick**, and the tick's real period is not `MAC_HUB_TICK_INTERVAL_SECONDS=30`. It's however long the review sweep takes, because that sweep clones a repository and runs a contract gate on the same thread — a manual `POST /dispatch/tick` **did not return within 120 seconds**. Ordering retention first only guarantees it runs at the *start* of each of those long intervals.

Retention is bounded (`max_batches × batch_size`) and touches only the two disposable telemetry classes. It needs none of the tick's ordering guarantees and has no reason to wait behind a git clone.

## Default is ON for a hub, deliberately

`MAC_RETENTION_INTERVAL_SECONDS` defaults to **60 when `MAC_HUB_TICK_INTERVAL_SECONDS` is set**, and **0 otherwise** — so the CLI, the test suite and stateless replicas don't each spawn a competing pruner.

The failure being fixed here is *retention silently not running*. Requiring an operator to set one more variable to get it back would reproduce exactly that.

The thread is lifespan-owned with a bounded join, following the pattern #381 established — an unstoppable pruning daemon that outlives the app keeps deleting against a control plane that's been torn down.

## Verification

5 new tests: thread starts when enabled · **off** by default without a hub tick · **on** by default with one · the lifespan can stop it · starting twice doesn't race two pruners.

8 pass alongside the existing lifespan-shutdown suite; 585 across public-contract + docs-accessibility. Env registry and docs reference regenerated.

## Not closed by this

`task_fad95a2b` — the tick doing repository work at all is the root cause, and **every stage ordered after that sweep is starved by the same mechanism.** Retention is just the one that got measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)