### PR TITLE
Give the publication contract gate its own worker (task_3f139555)

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -832,6 +832,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_PROJECT_CONTRACT_FILE` | str | consumer-defined | core | Core setting: project contract file. |
 | `MAC_PRUNE_KEEP_LAST` | bool | consumer-defined | core | Core setting: prune keep last. |
 | `MAC_PRUNE_LOG_DAYS` | str | consumer-defined | core | Core setting: prune log days. |
+| `MAC_PUBLICATION_WORKER_INTERVAL_SECONDS` | int | consumer-defined | core | Core setting: publication worker interval seconds. |
 | `MAC_PUBLISH_DIR` | str | consumer-defined | publication | Publication setting: publish dir. |
 | `MAC_PUBLISH_METHOD` | str | consumer-defined | publication | Publication setting: publish method. |
 | `MAC_PUBLISH_PUBLIC_URL` | str | consumer-defined | publication | Publication setting: publish public url. |
@@ -1086,6 +1087,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_TEST_SELECT_BASE` | str | consumer-defined | core | Core setting: test select base. |
 | `MAC_TEST_STALL_TIMEOUT` | int | consumer-defined | core | Core setting: test stall timeout. |
 | `MAC_TICK_BLOCKING_HUB_VERIFY` | str | consumer-defined | core | Core setting: tick blocking hub verify. |
+| `MAC_TICK_RUNS_REVIEW_SWEEP` | str | consumer-defined | core | Core setting: tick runs review sweep. |
 | `MAC_TOKEN` | str | consumer-defined | core | Core setting: token. |
 | `MAC_TOKENHUB_ALLOW_DEGRADED` | bool | consumer-defined | tokenhub-legacy | Tokenhub Legacy setting: tokenhub allow degraded. |
 | `MAC_TOKENHUB_CHECK_TIMEOUT_SECONDS` | int | consumer-defined | tokenhub-legacy | Tokenhub Legacy setting: tokenhub check timeout seconds. |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -4296,6 +4296,97 @@ def _start_hub_tick_loop(app: FastAPI, cp: ControlPlane) -> None:
     app.state.hub_tick_thread = thread
 
 
+def _start_publication_worker(app: FastAPI, cp: ControlPlane) -> None:
+    """Run the default-review sweep on a dedicated worker, off every other thread.
+
+    The sweep clones a repository and runs a sandboxed contract gate inline. It
+    used to run in two places, and both were the wrong place:
+
+      * ``ControlPlane.tick()``, which made the hub's tick period equal to a git
+        clone plus a test run instead of MAC_HUB_TICK_INTERVAL_SECONDS. A manual
+        POST /dispatch/tick on the live hub did not return within 120 seconds,
+        and every stage ordered after it was starved. Retention is the one that
+        got measured -- ZERO retention events in 48 minutes (#392), then only
+        one burst per tick after being reordered (#393) -- but nothing about
+        retention was special. Each later stage had the same problem, silently.
+
+      * ``_maybe_advance_reviews_on_heartbeat``, which ran it on a WORKER'S
+        HEARTBEAT REQUEST THREAD, so the cost landed on the worker rather than
+        the hub: heartbeats of 250-315 seconds and 33-second lease renewals.
+
+    A single dedicated worker is strictly SAFER than what it replaces.
+    ``_advance_default_review_sweep_page`` already serialises through
+    ``reconciliation.claim("default-review-sweep")``; previously the tick thread
+    and any number of heartbeat threads could all enter it and contend for that
+    claim. Now one thread drives it.
+
+    Gated by ``MAC_PUBLICATION_WORKER_INTERVAL_SECONDS`` (>0 enables; defaults to
+    30 on a hub that runs the dispatch tick, and off otherwise) so the CLI, the
+    test suite and stateless replicas do not each spawn a competing sweeper.
+    """
+    try:
+        tick_interval = float((os.environ.get("MAC_HUB_TICK_INTERVAL_SECONDS") or "0").strip())
+    except ValueError:
+        tick_interval = 0.0
+    default = "30" if tick_interval > 0 else "0"
+    try:
+        interval = float(
+            (os.environ.get("MAC_PUBLICATION_WORKER_INTERVAL_SECONDS") or default).strip()
+        )
+    except ValueError:
+        interval = 0.0
+    if interval <= 0:
+        return
+    existing = getattr(app.state, "publication_worker_thread", None)
+    if existing is not None and existing.is_alive():
+        return
+
+    try:
+        limit = int((os.environ.get("MAC_REVIEW_TICK_LIMIT") or "25").strip())
+    except ValueError:
+        limit = 25
+    limit = max(1, limit)
+
+    stop_event = threading.Event()
+
+    def _loop() -> None:
+        # Sleep-first, so app construction returns immediately.
+        while not stop_event.wait(interval):
+            try:
+                cp._advance_default_review_sweep_page(
+                    limit=limit,
+                    actor="publication-worker",
+                    tenant_id=None,
+                    allow_blocking_hub_verify=True,
+                )
+            except Exception:  # noqa: BLE001 - the worker must never crash the hub
+                logging.getLogger("mac.publication_worker").warning(
+                    "publication sweep failed", exc_info=True
+                )
+
+    thread = threading.Thread(target=_loop, name="mac-publication", daemon=True)
+    thread.start()
+    app.state.publication_worker_stop_event = stop_event
+    app.state.publication_worker_thread = thread
+
+
+def _stop_publication_worker(app: FastAPI) -> None:
+    """Stop the lifespan-owned publication worker with a bounded join.
+
+    The sweep pushes to main. A sweeper that outlives the lifespan would keep
+    merging against a control plane the app has already torn down, which is the
+    hazard #381 established for every other background thread here.
+    """
+    stop_event = getattr(app.state, "publication_worker_stop_event", None)
+    thread = getattr(app.state, "publication_worker_thread", None)
+    if stop_event is not None:
+        stop_event.set()
+    if thread is not None and thread is not threading.current_thread():
+        thread.join(timeout=10.0)
+    app.state.publication_worker_stop_event = None
+    app.state.publication_worker_thread = None
+
+
 def _start_retention_loop(app: FastAPI, cp: ControlPlane) -> None:
     """Run retention on its OWN timer, independent of the dispatch tick.
 
@@ -4622,6 +4713,7 @@ def create_app(
         services: List[Tuple[str, Callable[[], Any], Callable[[], Any]]] = [
             ("hub_tick", lambda: _start_hub_tick_loop(_app, cp), lambda: _stop_hub_tick_loop(_app)),
             ("retention", lambda: _start_retention_loop(_app, cp), lambda: _stop_retention_loop(_app)),
+            ("publication_worker", lambda: _start_publication_worker(_app, cp), lambda: _stop_publication_worker(_app)),
             ("repository_ref_reconciler", repository_ref_reconciler.start, repository_ref_reconciler.stop),
             ("github_ingestor", github_ingestor.start, github_ingestor.stop),
             ("cicd_monitor", cicd_monitor.start, cicd_monitor.stop),

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -9819,6 +9819,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: publication worker interval seconds.",
+    "family": "core",
+    "name": "MAC_PUBLICATION_WORKER_INTERVAL_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/api.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Publication setting: publish dir.",
     "family": "publication",
     "name": "MAC_PUBLISH_DIR",
@@ -10702,6 +10713,7 @@
     "name": "MAC_REVIEW_TICK_LIMIT",
     "retired": false,
     "sources": [
+      "src/mac/api.py",
       "src/mac/k8s/orchestrator.py",
       "src/mac/services.py"
     ],
@@ -12846,6 +12858,17 @@
     "description": "Core setting: tick blocking hub verify.",
     "family": "core",
     "name": "MAC_TICK_BLOCKING_HUB_VERIFY",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: tick runs review sweep.",
+    "family": "core",
+    "name": "MAC_TICK_RUNS_REVIEW_SWEEP",
     "retired": false,
     "sources": [
       "src/mac/services.py"

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -18999,7 +18999,16 @@ class ControlPlane:
             pass
 
     def _maybe_advance_reviews_on_heartbeat(self, agent: Agent) -> None:
-        if not _truthy_env("MAC_REVIEW_TICK_ON_HEARTBEAT", "1"):
+        # DEFAULT OFF. This ran the review sweep -- a repository clone plus a
+        # sandboxed contract gate -- on a WORKER'S HEARTBEAT REQUEST THREAD.
+        # The cost was paid by the worker, not the hub: heartbeats of 250-315
+        # seconds and lease renewals of 33 seconds were observed live, which is
+        # a worker unable to finish a request while it waits on someone else's
+        # test run.
+        #
+        # The sweep now has a dedicated worker (api._start_publication_worker).
+        # Set MAC_REVIEW_TICK_ON_HEARTBEAT=1 to restore the old behaviour.
+        if not _truthy_env("MAC_REVIEW_TICK_ON_HEARTBEAT", "0"):
             return
         hub_agent = resolve_hub_agent("MAC_REVIEW_TICK_HUB_AGENT")
         if not hub_agent:
@@ -20540,12 +20549,39 @@ class ControlPlane:
         # This is the narrow version of task_fad95a2b. The full fix is a bounded
         # publication worker so neither the tick nor a request waits on a
         # sandboxed test run.
-        review_workflows = self._advance_default_review_sweep_page(
-            limit=limit_value,
-            actor="default-review-workflow",
-            tenant_id=None,
-            allow_blocking_hub_verify=_truthy_env("MAC_TICK_BLOCKING_HUB_VERIFY", "1"),
-        )
+        # The review sweep is NOT run here any more. It clones a repository and
+        # runs a contract gate inline, so it used to make this thread's period
+        # equal to a git clone plus a test run rather than
+        # MAC_HUB_TICK_INTERVAL_SECONDS. Measured on the live hub: a manual
+        # POST /dispatch/tick did not return within 120 seconds.
+        #
+        # Everything ordered after it inherited that period. Retention was the
+        # stage that got measured -- it emitted ZERO events in 48 minutes while
+        # sitting behind this call (#392), and even after being moved ahead of
+        # it ran only once per tick (#393), which is why it ended up on its own
+        # timer. Retention was not special; every later stage had the same
+        # problem, silently.
+        #
+        # It now runs on a dedicated worker (api._start_publication_worker) on
+        # its own interval. `_advance_default_review_sweep_page` already
+        # serialises through `reconciliation.claim("default-review-sweep")`, so
+        # a single worker is strictly safer than the previous arrangement,
+        # where the tick thread AND any worker's heartbeat thread could both
+        # enter the sweep and contend for that claim.
+        #
+        # Set MAC_TICK_RUNS_REVIEW_SWEEP=1 to restore the inline behaviour for
+        # an operator who would rather the tick own it.
+        if _truthy_env("MAC_TICK_RUNS_REVIEW_SWEEP", "0"):
+            review_workflows = self._advance_default_review_sweep_page(
+                limit=limit_value,
+                actor="default-review-workflow",
+                tenant_id=None,
+                allow_blocking_hub_verify=_truthy_env(
+                    "MAC_TICK_BLOCKING_HUB_VERIFY", "1"
+                ),
+            )
+        else:
+            review_workflows = {"skipped": "runs_on_publication_worker"}
         # Stranding episodes were only ever created inside task_flow.report(),
         # whose callers are the CLI, the HTTP route and two facades -- no
         # scheduler. docs/task-throughput-observability.md describes an episode

--- a/tests/api/test_publication_worker.py
+++ b/tests/api/test_publication_worker.py
@@ -1,0 +1,160 @@
+"""The review sweep runs on its own worker, not on the tick or a heartbeat.
+
+`_advance_default_review_sweep_page` clones a repository and runs a sandboxed
+contract gate inline. It used to run in two places, both wrong:
+
+  * `ControlPlane.tick()` -- making the tick's period a git clone plus a test
+    run instead of MAC_HUB_TICK_INTERVAL_SECONDS. A manual POST /dispatch/tick
+    on the live hub did not return within 120 seconds, and every stage ordered
+    after it was starved. Retention is the one that got measured: ZERO events in
+    48 minutes (#392), then one burst per tick after being reordered (#393).
+    Nothing about retention was special -- each later stage had the same
+    problem, silently.
+
+  * `_maybe_advance_reviews_on_heartbeat` -- running it on a WORKER'S HEARTBEAT
+    REQUEST THREAD, so the cost landed on the worker: heartbeats of 250-315
+    seconds and 33-second lease renewals, observed live.
+
+A single dedicated worker is strictly SAFER than what it replaces. The sweep
+already serialises through `reconciliation.claim("default-review-sweep")`;
+previously the tick thread and any number of heartbeat threads could all enter
+it and contend for that claim. Now one thread drives it.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from fastapi import FastAPI
+
+from mac.api import _start_publication_worker, _stop_publication_worker
+from mac.services import ControlPlane
+
+
+def _named() -> set[str]:
+    return {t.name for t in threading.enumerate()}
+
+
+@pytest.fixture()
+def app_and_cp():
+    app = FastAPI()
+    cp = ControlPlane.in_memory()
+    yield app, cp
+    _stop_publication_worker(app)
+
+
+def test_the_tick_no_longer_runs_the_sweep_inline(monkeypatch):
+    """The tick must not block on a repository clone."""
+    cp = ControlPlane.in_memory()
+    called = []
+    monkeypatch.setattr(
+        cp,
+        "_advance_default_review_sweep_page",
+        lambda **kw: called.append(kw) or {},
+    )
+    monkeypatch.delenv("MAC_TICK_RUNS_REVIEW_SWEEP", raising=False)
+
+    cp.tick()
+
+    assert not called, (
+        "tick() still runs the review sweep inline; its period becomes a git "
+        "clone plus a contract-gate run, and every stage after it starves"
+    )
+
+
+def test_the_inline_behaviour_is_still_available_as_an_escape_hatch(monkeypatch):
+    cp = ControlPlane.in_memory()
+    called = []
+    monkeypatch.setattr(
+        cp,
+        "_advance_default_review_sweep_page",
+        lambda **kw: called.append(kw) or {},
+    )
+    monkeypatch.setenv("MAC_TICK_RUNS_REVIEW_SWEEP", "1")
+
+    cp.tick()
+
+    assert called, (
+        "MAC_TICK_RUNS_REVIEW_SWEEP=1 must restore the inline sweep for an "
+        "operator who wants the tick to own it"
+    )
+
+
+def test_a_heartbeat_does_not_run_the_sweep_by_default(monkeypatch):
+    """A worker's request thread must never pay for someone else's test run."""
+    cp = ControlPlane.in_memory()
+    called = []
+    monkeypatch.setattr(
+        cp,
+        "_advance_default_review_sweep_page",
+        lambda **kw: called.append(kw) or {},
+    )
+    monkeypatch.delenv("MAC_REVIEW_TICK_ON_HEARTBEAT", raising=False)
+
+    cp._maybe_advance_reviews_on_heartbeat(
+        type("A", (), {"id": "agent_x", "name": "x"})()
+    )
+
+    assert not called, (
+        "the heartbeat path still runs the sweep by default; this is what "
+        "produced 250-315 second heartbeats and 33-second lease renewals"
+    )
+
+
+def test_the_worker_starts_when_a_hub_tick_is_configured(app_and_cp, monkeypatch):
+    """Opt-out, not opt-in: the sweep must still run on a real hub."""
+    app, cp = app_and_cp
+    monkeypatch.delenv("MAC_PUBLICATION_WORKER_INTERVAL_SECONDS", raising=False)
+    monkeypatch.setenv("MAC_HUB_TICK_INTERVAL_SECONDS", "30")
+
+    before = _named()
+    _start_publication_worker(app, cp)
+
+    assert "mac-publication" in (_named() - before), (
+        "a hub running the dispatch tick got no publication worker; with the "
+        "tick and heartbeat paths both off by default, nothing would advance "
+        "reviews at all"
+    )
+
+
+def test_it_is_off_without_a_hub_tick(app_and_cp, monkeypatch):
+    app, cp = app_and_cp
+    monkeypatch.delenv("MAC_PUBLICATION_WORKER_INTERVAL_SECONDS", raising=False)
+    monkeypatch.delenv("MAC_HUB_TICK_INTERVAL_SECONDS", raising=False)
+
+    before = _named()
+    _start_publication_worker(app, cp)
+
+    assert "mac-publication" not in (_named() - before), (
+        "the worker started with no hub tick configured; every CLI invocation "
+        "and test process would spawn a competing sweeper that pushes to main"
+    )
+
+
+def test_the_lifespan_can_stop_it(app_and_cp, monkeypatch):
+    app, cp = app_and_cp
+    monkeypatch.setenv("MAC_PUBLICATION_WORKER_INTERVAL_SECONDS", "30")
+    _start_publication_worker(app, cp)
+    thread = app.state.publication_worker_thread
+
+    _stop_publication_worker(app)
+
+    assert not thread.is_alive(), (
+        "the publication worker outlived the lifespan. This one pushes to "
+        "main, so a sweeper that cannot be joined keeps merging against a "
+        "control plane the app has already torn down."
+    )
+    assert app.state.publication_worker_thread is None
+
+
+def test_starting_twice_does_not_spawn_a_second_sweeper(app_and_cp, monkeypatch):
+    app, cp = app_and_cp
+    monkeypatch.setenv("MAC_PUBLICATION_WORKER_INTERVAL_SECONDS", "30")
+
+    _start_publication_worker(app, cp)
+    first = app.state.publication_worker_thread
+    _start_publication_worker(app, cp)
+
+    assert app.state.publication_worker_thread is first
+    assert len([t for t in threading.enumerate() if t.name == "mac-publication"]) == 1

--- a/tests/test_retention_not_starved_by_tick.py
+++ b/tests/test_retention_not_starved_by_tick.py
@@ -58,21 +58,30 @@ def _order_of_calls(cp, monkeypatch):
     return seen
 
 
-def test_retention_runs_before_the_review_sweep(cp, monkeypatch):
+def test_the_tick_no_longer_runs_the_review_sweep_at_all(cp, monkeypatch):
+    """Superseded, in the right direction.
+
+    This test used to assert retention ran BEFORE the review sweep inside
+    tick(). That ordering was the #392 fix, and it was only half a solution:
+    retention still ran once per tick, and the tick's period was the sweep's
+    duration, so retention pruned once and then not again for 27 minutes
+    (measured live).
+
+    The sweep has since moved to its own worker
+    (api._start_publication_worker), so the ordering question is gone: the tick
+    does not run it at all. What matters now is that retention still runs on
+    the tick path AND that the sweep no longer blocks it.
+    """
     seen = _order_of_calls(cp, monkeypatch)
+    monkeypatch.delenv("MAC_TICK_RUNS_REVIEW_SWEEP", raising=False)
 
     cp.tick()
 
     assert "retention" in seen, "the tick never reached retention at all"
-    assert "review_sweep" in seen, (
-        "the review sweep did not run; this test would pass vacuously"
-    )
-    assert seen.index("retention") < seen.index("review_sweep"), (
-        "retention ran AFTER the review sweep (%s). The sweep clones a "
-        "repository and runs a contract gate inline, so anything ordered after "
-        "it can be starved for minutes -- which is exactly what happened on "
-        "2026-08-17, when the hub emitted no retention events for 48 minutes "
-        "while 235k rows sat past the cutoff." % seen
+    assert "review_sweep" not in seen, (
+        "tick() still runs the review sweep inline (%s); it clones a "
+        "repository and runs a contract gate, so every stage after it is "
+        "starved -- which is what this whole chain of fixes was about" % seen
     )
 
 

--- a/tests/test_tick_runs_publication.py
+++ b/tests/test_tick_runs_publication.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 
 import inspect
 
+from mac import api
+
 from mac import services
 
 
@@ -52,10 +54,40 @@ def test_the_tick_is_allowed_to_run_the_publication_gate():
 def test_the_operator_switch_defaults_to_publishing():
     """A default that cannot publish is how this went unnoticed: reviews kept
     advancing, nothing ever landed, and the state that resulted -- approved and
-    unpublished -- looks like work in progress rather than a stall."""
+    unpublished -- looks like work in progress rather than a stall.
+
+    The invariant is unchanged; only its location moved. This module's own
+    docstring called the tick "the narrow version of task_fad95a2b" and named
+    the real fix: "a bounded publication worker so neither the tick nor a
+    request waits on a sandboxed run". That worker now exists
+    (api._start_publication_worker), so the tick no longer runs the sweep
+    inline and the blocking-verify default lives on the worker instead.
+
+    What must NOT change is that publication happens BY DEFAULT somewhere. If
+    every path is off by default, reviews accumulate silently -- the exact
+    failure this test was written to prevent.
+    """
     source = _tick_source()
 
-    assert '_truthy_env("MAC_TICK_BLOCKING_HUB_VERIFY", "1")' in source
+    # The tick keeps its escape hatch, still defaulting to blocking-verify when
+    # an operator opts back in.
+    assert "MAC_TICK_BLOCKING_HUB_VERIFY" in source
+    assert '"MAC_TICK_BLOCKING_HUB_VERIFY", "1"' in source, (
+        "the tick's opt-in path must still default to actually publishing"
+    )
+
+    worker = inspect.getsource(api._start_publication_worker)
+    assert "allow_blocking_hub_verify=True" in worker, (
+        "the publication worker must run the contract gate, not merely advance "
+        "reviews; a path that advances without publishing is what left three "
+        "approved canaries unpublished for hours"
+    )
+    assert '"30" if tick_interval > 0 else "0"' in worker, (
+        "the worker must default ON for a hub that runs the dispatch tick. "
+        "With the tick and heartbeat paths both off by default, a worker that "
+        "is also off by default means NOTHING publishes -- reviews would "
+        "accumulate with no error anywhere."
+    )
 
 
 def test_the_heartbeat_is_not_the_only_publisher():


### PR DESCRIPTION
The default-review sweep clones a repository and runs a sandboxed contract gate **inline**. It ran in two places, and both were the wrong place.

| where | cost |
|---|---|
| `ControlPlane.tick()` | made the hub's tick period a git clone + test run instead of `MAC_HUB_TICK_INTERVAL_SECONDS`. A manual `POST /dispatch/tick` on the live hub **did not return within 120 seconds**. |
| `_maybe_advance_reviews_on_heartbeat()` | ran it on a **worker's heartbeat request thread**. Measured on the fleet hub: heartbeats of **249.7s, 276.5s, 315.5s**, and 33-second lease renewals. The agent's client gives up at 30s and retries, so each attempt started another overlapping publication that could never converge. |

## Everything after the sweep inherited that period

Retention is the stage that happened to get measured, and fixing it took **three PRs** because the tick kept finding new ways not to run it:

- **#392** — zero retention events in **48 minutes** while ordered behind the sweep
- **#393** — exactly **7 prune events in 27 minutes** once reordered ahead of it, because it still ran once per tick
- It became reliable only when moved off the thread entirely

Nothing about retention was special. Every later stage had the same problem, silently.

## This is safer than what it replaces

The sweep already serialises through `reconciliation.claim("default-review-sweep")`. Previously the tick thread **and any number of heartbeat threads** could all enter it and contend for that claim. Now one thread drives it.

Both old paths are off by default with escape hatches: `MAC_TICK_RUNS_REVIEW_SWEEP=1`, `MAC_REVIEW_TICK_ON_HEARTBEAT=1`.

## The risk this creates, and how it's guarded

With both old paths off, if the worker fails to start then **nothing advances reviews** — and the symptom is tasks accumulating in `reviewing` with no error anywhere, the same invisible-failure shape as the retention chain.

So: the worker defaults **ON** whenever `MAC_HUB_TICK_INTERVAL_SECONDS` is set (off otherwise, so the CLI, tests and stateless replicas don't each spawn a sweeper **that pushes to main**), and a test asserts exactly that. Lifespan-owned with a 10s bounded join, because this one pushes to main and must not outlive the app.

## The existing test was strengthened, not relaxed

`test_tick_runs_publication.py`'s intent — *"a default that cannot publish is how this went unnoticed"* — is precisely the risk above. It now asserts the worker runs with `allow_blocking_hub_verify=True` **and** that it defaults on for a hub.

That file's own docstring already named this fix: *"the full fix is a bounded publication worker so neither the tick nor a request waits on a sandboxed run."*

## Verification

- **7 new tests**, all failing without the change
- **1,020 pass** across review/publication/tick/lifespan/heartbeat/retention
- **597 pass** across public-contract, docs-accessibility, impact-map
- Both artifact generators re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)