### PR TITLE
Land approved work through a pull request instead of pushing main

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -832,6 +832,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_PROJECT_CONTRACT_FILE` | str | consumer-defined | core | Core setting: project contract file. |
 | `MAC_PRUNE_KEEP_LAST` | bool | consumer-defined | core | Core setting: prune keep last. |
 | `MAC_PRUNE_LOG_DAYS` | str | consumer-defined | core | Core setting: prune log days. |
+| `MAC_PUBLICATION_STRATEGY` | str | consumer-defined | core | Core setting: publication strategy. |
 | `MAC_PUBLICATION_WORKER_INTERVAL_SECONDS` | int | consumer-defined | core | Core setting: publication worker interval seconds. |
 | `MAC_PUBLISH_DIR` | str | consumer-defined | publication | Publication setting: publish dir. |
 | `MAC_PUBLISH_METHOD` | str | consumer-defined | publication | Publication setting: publish method. |

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -619,6 +619,74 @@ individually with `review.require_different_model_family: true` and
 }
 ```
 
+### How approved work lands: pull requests, not pushes to main
+
+Publication is how an approved task reaches the canonical branch. The default
+is a **pull request**, matching the worktree-and-PR discipline the repository
+already asks of humans:
+
+1. The agent works in its own worktree on its own branch and pushes **only that
+   branch** (the executor finalizer's `guarded_push`, which pushes an explicit
+   `HEAD:refs/heads/<task-branch>` refspec and refuses if the canonical tip is
+   not already contained in the branch).
+2. On approval, the hub clones the exact canonical tip, runs the merge gate,
+   makes sure the reviewed commit is on the task branch on the remote, and
+   opens a pull request against the canonical branch.
+3. The forge squash-merges that pull request, pinned to the reviewed head SHA
+   (the pull-request equivalent of `--force-with-lease`: if the branch moved
+   underneath us, the merge is refused rather than landing something nobody
+   reviewed).
+4. The hub verifies the resulting canonical tip and records it as the
+   canonical-integration proof.
+
+The hub never pushes the canonical branch on this path.
+
+**Who gates the merge.** Both, at different moments. mac's own reviewer verdict
+plus the merge gate decide whether a pull request is opened and a merge is
+requested *at all*; the forge's required status checks decide whether that merge
+is *permitted*. When the forge reports required status checks for the canonical
+branch, the hub skips its own local re-projection of the contract suite —
+GitHub runs those checks against the merge result it will actually produce,
+which is a better question than the hub's approximation and does not cost the
+15–45 minutes that previously made approved tasks time out unpublished. When
+the forge reports **no** required checks, the hub keeps its own contract gate:
+an unprotected repository must not silently lose its gate.
+
+**Checks still running.** A merge the forge refuses because its own gates have
+not finished is not a failure. Publication defers with
+`publication_failure_kind=pull_request_checks_pending` and the existing
+publication-retry backoff re-attempts later; the pull request is reused rather
+than reopened, so retries are cheap. The task stays in `reviewing` — approved
+but not completed — until the change is genuinely on the canonical branch.
+
+**Squash and the integration proof.** A squash merge lands the reviewed
+*content* under a new SHA, so the reviewed commit is deliberately not an
+ancestor of the canonical tip afterwards. The canonical-integration proof
+records this honestly (`squash_merged: true`, `contains_reviewed_head: false`,
+plus the pull-request number and URL) instead of asserting an ancestry that
+squashing destroys, and task completion accepts that proof shape.
+
+**Opting out.** `MAC_PUBLICATION_STRATEGY` selects the strategy:
+
+| value | behaviour |
+| --- | --- |
+| `pull_request` (default) | push the branch, open a PR, let the forge squash-merge it |
+| `direct_push` | the legacy path: merge locally in a disposable clone and push the canonical branch under optimistic concurrency (`push_main_occ`) |
+
+**Repositories with no forge.** mac manages repositories that have no pull
+requests at all — a bare path, a `file://` remote, or an http(s) remote for
+which no `GH_TOKEN`/`GITEA_TOKEN` is configured. Those fall back to
+`direct_push` automatically rather than failing, because refusing to publish
+them would strand the work. The fallback is never silent: the publication
+evidence carries a `publication_strategy` entry naming the strategy and the
+reason it was chosen, so a repository that *should* be using a pull request but
+is not shows up in `mac task show`'s publication detail.
+
+**Migration.** Nothing is stranded by the change. Publication is stateless per
+attempt (a fresh clone every time) and the worker side already pushes only its
+own branch, so a task that was mid-publication under the old path simply gets a
+pull request on its next attempt against the branch it had already pushed.
+
 ### Repository credential learning and reviewer routing
 
 Every completed remote review preparation writes an authoritative

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -9819,6 +9819,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: publication strategy.",
+    "family": "core",
+    "name": "MAC_PUBLICATION_STRATEGY",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: publication worker interval seconds.",
     "family": "core",
     "name": "MAC_PUBLICATION_WORKER_INTERVAL_SECONDS",

--- a/src/mac/gitops.py
+++ b/src/mac/gitops.py
@@ -33,6 +33,22 @@ class PullRequestResult:
     state: str
 
 
+@dataclass
+class PullRequestMergeResult:
+    """Outcome of asking a forge to merge a pull request.
+
+    ``merged`` is the only success signal.  ``blocked`` distinguishes "the
+    forge refused because its own gates have not passed yet" (retry later,
+    the PR is fine) from a hard error (raised, never returned).
+    """
+
+    merged: bool
+    number: int
+    sha: str = ""
+    blocked: bool = False
+    reason: str = ""
+
+
 _GIT_REMOTE_URL_RE = re.compile(
     r"^(?:https?://|ssh://|git://|file://|git@|/)[A-Za-z0-9._\-:/@%+~?=&]*$"
 )
@@ -996,3 +1012,258 @@ def _find_existing_pr(
                 state=str(pr.get("state") or "open"),
             )
     return None
+
+
+def _scrub_secret(text: str, *secrets: Optional[str]) -> str:
+    """Remove credential material from text that may reach a log or a ledger.
+
+    Forge API errors are echoed into publication evidence and operator-facing
+    diagnoses.  A token never appears in a request URL here (it travels in the
+    ``Authorization`` header), but a misconfigured proxy, a redirect, or a
+    forge that reflects a header back into its error body would leak it, so
+    every string that escapes this module is scrubbed unconditionally.
+    """
+    scrubbed = redact_git_remote_auth_in_text(str(text or ""))
+    for secret in secrets:
+        value = str(secret or "").strip()
+        if len(value) >= 8:
+            scrubbed = scrubbed.replace(value, "***")
+    return scrubbed
+
+
+def _forge_api_context(
+    repo_url: str,
+    *,
+    github_token: Optional[str] = None,
+    gitea_token: Optional[str] = None,
+) -> Tuple[str, str, str, str, Dict[str, str], str]:
+    """Resolve (host_kind, owner, repo, api_base, headers, token) for a forge."""
+    host_kind = detect_host(repo_url)
+    owner, repo = _parse_owner_repo(repo_url)
+    api_base = _api_base_for(host_kind, repo_url)
+    if host_kind == "github":
+        token = github_token or token_for_host("github")
+        if not token:
+            raise ValueError("GH_TOKEN required to call the github API")
+        headers = {
+            "Authorization": "token " + token,
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "mac-gitops",
+        }
+    else:
+        token = gitea_token or token_for_host("gitea")
+        if not token:
+            raise ValueError("GITEA_TOKEN required to call the gitea API")
+        headers = {"Authorization": "token " + token, "User-Agent": "mac-gitops"}
+    return host_kind, owner, repo, api_base, headers, token
+
+
+def resolve_forge(repo_url: str) -> Optional[str]:
+    """Return the forge kind when ``repo_url`` is an API-reachable forge.
+
+    ``None`` means "this remote has no forge we can open a pull request on" —
+    a ``file://`` or bare-path remote, an ``ssh://`` remote with no token to
+    rewrite it, or an http(s) remote for which no credential is configured.
+    Publication uses this to decide whether the pull-request strategy is even
+    possible; a ``None`` here is what makes the direct-push fallback legitimate
+    rather than a silent downgrade of a repo that could have used a PR.
+    """
+    value = https_remote_for_token_auth(str(repo_url or "").strip())
+    if not value:
+        return None
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+    try:
+        host_kind = detect_host(value)
+        _parse_owner_repo(value)
+    except ValueError:
+        return None
+    return host_kind if token_for_host(host_kind) else None
+
+
+def required_status_check_contexts(
+    repo_url: str,
+    branch: str,
+    *,
+    github_token: Optional[str] = None,
+    gitea_token: Optional[str] = None,
+) -> Optional[Tuple[str, ...]]:
+    """Status checks the forge requires before ``branch`` may be merged into.
+
+    Returns ``None`` when the answer is unknown (unsupported forge, API error,
+    insufficient scope).  Callers must treat ``None`` and ``()`` as "the forge
+    is not gating this merge for us" and keep their own gate.
+
+    Uses GitHub's ``/rules/branches/{branch}`` endpoint rather than the branch
+    protection API because it needs no admin scope and reports rulesets, which
+    is how this repository's ``main`` is actually protected.
+    """
+    try:
+        host_kind, owner, repo, api_base, headers, token = _forge_api_context(
+            repo_url, github_token=github_token, gitea_token=gitea_token
+        )
+    except ValueError:
+        return None
+    if host_kind != "github":
+        return None
+    url = "%s/repos/%s/%s/rules/branches/%s" % (
+        api_base,
+        owner,
+        repo,
+        _quote(str(branch or ""), safe=""),
+    )
+    try:
+        rules = _http_get_json(url, headers)
+    except Exception:  # noqa: BLE001 - an unknown answer must not block publication
+        return None
+    if not isinstance(rules, list):
+        return None
+    contexts: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict) or rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters")
+        checks = params.get("required_status_checks") if isinstance(params, dict) else None
+        for check in checks or []:
+            if isinstance(check, dict) and str(check.get("context") or "").strip():
+                contexts.append(str(check["context"]).strip())
+    return tuple(dict.fromkeys(contexts))
+
+
+def _http_put_json(
+    url: str, headers: dict, body: dict, timeout: float = 30.0
+) -> Tuple[int, dict, str]:
+    """PUT JSON, returning (status, decoded_body, error_text) without raising.
+
+    The merge endpoint answers "not yet" with a 4xx that is *expected*, so the
+    status code is data here rather than an exception.
+    """
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json", **headers},
+        method="PUT",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+            decoded = json.loads(raw) if raw else {}
+            return int(resp.status or 0), (decoded if isinstance(decoded, dict) else {}), ""
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        try:
+            decoded = json.loads(raw) if raw else {}
+        except ValueError:
+            decoded = {}
+        message = ""
+        if isinstance(decoded, dict):
+            message = str(decoded.get("message") or "")
+        return int(exc.code), (decoded if isinstance(decoded, dict) else {}), (
+            message or raw[:500] or str(exc.reason)
+        )
+    except urllib.error.URLError as exc:
+        return 0, {}, str(exc.reason)
+
+
+# Forge responses that mean "the PR is fine, its gates have not passed yet".
+_MERGE_BLOCKED_MARKERS = (
+    "required status check",
+    "required status checks",
+    "checks have not",
+    "not mergeable",
+    "is not mergeable",
+    "review is required",
+    "changes requested",
+    "protected branch",
+    "branch protection",
+    "merge conflict",
+    "waiting on code owner",
+    "expected head sha",
+    "head sha",
+)
+
+
+def merge_pull_request(
+    repo_url: str,
+    number: int,
+    *,
+    method: str = "squash",
+    sha: Optional[str] = None,
+    commit_title: Optional[str] = None,
+    commit_message: Optional[str] = None,
+    github_token: Optional[str] = None,
+    gitea_token: Optional[str] = None,
+) -> PullRequestMergeResult:
+    """Ask the forge to merge PR ``number``; squash by default.
+
+    ``sha`` pins the head the caller reviewed: the forge refuses the merge if
+    the branch moved underneath us, which is the pull-request equivalent of the
+    direct-push path's ``--force-with-lease``.
+
+    A refusal that names the forge's own gates comes back as
+    ``blocked=True`` so the caller can retry cheaply once the checks finish,
+    instead of turning a normal "CI is still running" into a publication
+    failure.
+    """
+    if int(number) <= 0:
+        raise ValueError("pull request number is required to merge")
+    if method not in {"squash", "merge", "rebase"}:
+        raise ValueError("unsupported merge method: %r" % method)
+    host_kind, owner, repo, api_base, headers, token = _forge_api_context(
+        repo_url, github_token=github_token, gitea_token=gitea_token
+    )
+
+    url = "%s/repos/%s/%s/pulls/%d/merge" % (api_base, owner, repo, int(number))
+    if host_kind == "github":
+        body: Dict[str, object] = {"merge_method": method}
+        if commit_title:
+            body["commit_title"] = commit_title
+        if commit_message:
+            body["commit_message"] = commit_message
+        if sha:
+            body["sha"] = sha
+    else:
+        body = {"Do": method}
+        if commit_title:
+            body["MergeTitleField"] = commit_title
+        if commit_message:
+            body["MergeMessageField"] = commit_message
+        if sha:
+            body["head_commit_id"] = sha
+
+    status, decoded, error = _http_put_json(url, headers, body)
+    if 200 <= status < 300:
+        merged_sha = str(decoded.get("sha") or "").strip()
+        if not merged_sha and host_kind != "github":
+            merged_sha = _merged_sha_for(api_base, headers, owner, repo, int(number))
+        return PullRequestMergeResult(
+            merged=True, number=int(number), sha=merged_sha
+        )
+
+    reason = _scrub_secret(error or ("HTTP %d" % status), token)
+    lowered = reason.lower()
+    blocked = status in {405, 409, 422} and any(
+        marker in lowered for marker in _MERGE_BLOCKED_MARKERS
+    )
+    if blocked:
+        return PullRequestMergeResult(
+            merged=False, number=int(number), blocked=True, reason=reason
+        )
+    raise RuntimeError(
+        "merge of pull request #%d failed (HTTP %d): %s" % (int(number), status, reason)
+    )
+
+
+def _merged_sha_for(
+    api_base: str, headers: dict, owner: str, repo: str, number: int
+) -> str:
+    try:
+        pr = _http_get_json(
+            "%s/repos/%s/%s/pulls/%d" % (api_base, owner, repo, number), headers
+        )
+    except Exception:  # noqa: BLE001 - the merge already succeeded
+        return ""
+    if not isinstance(pr, dict):
+        return ""
+    return str(pr.get("merge_commit_sha") or pr.get("merged_commit_id") or "").strip()

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -2399,9 +2399,10 @@ class ControlPlane:
 
         The consumer is stoppable. Its work (``advance_default_review_workflow``
         -> ``_publish_git_target_attempt``) clones a repo, runs the merge gate,
-        and pushes to main before the publication row commits, so a process that
-        exits with a nudge in flight can land a push whose bookkeeping never
-        commits. :meth:`disable_event_driven_review_advance` is called from the
+        and lands the change (a squash-merged pull request by default, a direct
+        push under ``MAC_PUBLICATION_STRATEGY=direct_push``) before the
+        publication row commits, so a process that exits with a nudge in flight
+        can land a merge whose bookkeeping never commits. :meth:`disable_event_driven_review_advance` is called from the
         lifespan shutdown for exactly that reason."""
         import queue as _queue
 
@@ -12543,13 +12544,28 @@ class ControlPlane:
                 and reviewed_sha == head_sha
                 and integration.get("contains_reviewed_head") is True
             )
+            # A squash-merged pull request lands the reviewed *content* under a
+            # new canonical SHA, so neither SHA equality nor ancestry can hold.
+            # The forge reporting the merge of exactly this reviewed head IS the
+            # integration proof. Kept as tight as the ancestry branch: the proof
+            # must name this evidence's reviewed commit and carry the explicit
+            # squash marker the publication path writes.
+            proof_squash_merged = (
+                _GIT_SHA_RE.match(reviewed_sha)
+                and reviewed_sha == head_sha
+                and integration.get("squash_merged") is True
+            )
             if (
                 str(integration.get("status") or "").strip().lower() in {"pass", "passed"}
                 and integration.get("remote_verified") is True
                 and str(integration.get("canonical_ref") or "").strip() == canonical_ref
                 and _GIT_SHA_RE.match(head_sha)
                 and _GIT_SHA_RE.match(proof_sha)
-                and (head_sha == proof_sha or proof_carries_reviewed_head)
+                and (
+                    head_sha == proof_sha
+                    or proof_carries_reviewed_head
+                    or proof_squash_merged
+                )
             ):
                 return
         raise ValidationError(
@@ -22030,9 +22046,29 @@ class ControlPlane:
                 "canonical_ref": "refs/heads/%s" % canonical_branch,
                 "canonical_tip_sha": final_sha,
                 "reviewed_head_sha": reviewed_sha,
-                "contains_reviewed_head": True,
+                # A squash merge lands the reviewed *content* under a new SHA,
+                # so the reviewed commit is intentionally not an ancestor of
+                # the canonical tip. Report what the publication observed
+                # rather than asserting an ancestry squashing destroys.
+                "contains_reviewed_head": bool(
+                    publication.get("contains_reviewed_head", True)
+                ),
                 "remote_verified": True,
                 "publication_mode": str(publication.get("publication_mode") or ""),
+                **(
+                    {
+                        "squash_merged": True,
+                        "pull_request_url": str(
+                            publication.get("pull_request_url") or ""
+                        ),
+                        "pull_request_number": int(
+                            publication.get("pull_request_number") or 0
+                        ),
+                    }
+                    if str(publication.get("publication_mode") or "")
+                    == "pull_request_squash"
+                    else {}
+                ),
             },
         }
         self.add_evidence(
@@ -22218,6 +22254,253 @@ class ControlPlane:
         exhausted.publication_failure_kind = "canonical_base_moved"
         raise exhausted
 
+    # ------------------------------------------------------------------
+    # Publication strategy: land through a pull request, not a push to main.
+    # ------------------------------------------------------------------
+
+    _PUBLICATION_STRATEGIES = ("pull_request", "direct_push")
+
+    def _resolve_publication_strategy(self, clone_url: str) -> JsonDict:
+        """Decide how this publication lands, and say why.
+
+        ``pull_request`` is the default: the reviewed branch is pushed, a PR is
+        opened against the canonical branch, and the *forge* performs a squash
+        merge.  The hub never pushes the canonical branch.
+
+        ``direct_push`` (``MAC_PUBLICATION_STRATEGY=direct_push``) is the
+        documented opt-out and the automatic fallback for a canonical remote
+        with no API-reachable forge — a ``file://`` or bare-path remote, or an
+        http(s) remote for which no credential is configured.  Falling back is
+        deliberate rather than fatal: mac manages repositories that have no
+        forge at all, and refusing to publish those would strand them.  The
+        fallback reason is recorded in the publication commands so a repo that
+        *should* be using a PR but silently is not is visible in the evidence.
+        """
+
+        from mac.env_config import env_str
+
+        from . import gitops as _gitops
+
+        configured = (
+            str(env_str("MAC_PUBLICATION_STRATEGY", "pull_request") or "").strip().lower()
+            or "pull_request"
+        )
+        if configured not in self._PUBLICATION_STRATEGIES:
+            raise ValidationError(
+                "MAC_PUBLICATION_STRATEGY must be one of %s (got %r)"
+                % (", ".join(self._PUBLICATION_STRATEGIES), configured)
+            )
+        if configured == "direct_push":
+            return {
+                "strategy": "direct_push",
+                "forge": "",
+                "reason": "MAC_PUBLICATION_STRATEGY=direct_push (explicit opt-out)",
+                "api_url": "",
+            }
+        api_url = _gitops.https_remote_for_token_auth(clone_url)
+        forge = _gitops.resolve_forge(clone_url)
+        if not forge:
+            return {
+                "strategy": "direct_push",
+                "forge": "",
+                "reason": (
+                    "canonical remote has no API-reachable forge (no http(s) "
+                    "forge URL, or no GH_TOKEN/GITEA_TOKEN for its host); "
+                    "falling back to direct push"
+                ),
+                "api_url": "",
+            }
+        return {
+            "strategy": "pull_request",
+            "forge": forge,
+            "reason": "",
+            "api_url": api_url,
+        }
+
+    def _publish_via_pull_request(
+        self,
+        *,
+        task: Task,
+        target: str,
+        remote_ref: str,
+        source_branch: str,
+        head_sha: str,
+        base_sha: str,
+        canonical_branch: str,
+        api_url: str,
+        commands: List[JsonDict],
+        attempt: int,
+        git_step: Any,
+        root: Path,
+    ) -> JsonDict:
+        """Push the branch, open the PR, and let the forge squash-merge it.
+
+        The hub does not merge and does not push the canonical branch.  The
+        squash merge means the reviewed commit is deliberately *not* an
+        ancestor of the canonical tip afterwards, so the canonical-integration
+        proof records ``contains_reviewed_head`` honestly instead of asserting
+        an ancestry that squashing destroys.
+        """
+
+        from . import gitops as _gitops
+
+        branch = str(source_branch or "").strip()
+        remote_head_ref = "refs/heads/%s" % branch
+        observed = git_step(
+            "observe_pull_request_branch",
+            ["ls-remote", "origin", remote_head_ref],
+            check=False,
+        )
+        observed_sha = str(observed.get("stdout") or "").split(None, 1)
+        observed_sha = observed_sha[0] if observed_sha else ""
+        if observed_sha != head_sha:
+            # NEVER a bare push: an explicit source:destination refspec, and a
+            # lease pinned to exactly what we just observed, so a branch that
+            # moved under us fails instead of being overwritten.
+            push_args = ["push"]
+            if observed_sha:
+                push_args.append(
+                    "--force-with-lease=%s:%s" % (remote_head_ref, observed_sha)
+                )
+            push_args += ["origin", "%s:%s" % (head_sha, remote_head_ref)]
+            git_step("push_pull_request_branch", push_args, timeout=180)
+            confirm = git_step(
+                "verify_pull_request_branch", ["ls-remote", "origin", remote_head_ref]
+            )
+            confirmed = str(confirm.get("stdout") or "").split(None, 1)
+            if (confirmed[0] if confirmed else "") != head_sha:
+                raise ValidationError(
+                    "git publication could not place reviewed commit %s on branch %s"
+                    % (head_sha[:12], branch)
+                )
+
+        title = "%s (%s)" % (str(task.title or "").strip() or "mac change", task.id)
+        body = (
+            "Landed by the MAC control plane after review approval.\n\n"
+            "- task: `%s`\n- reviewed head: `%s`\n- base at publication: `%s`\n"
+            % (task.id, head_sha, base_sha)
+        )
+        try:
+            pr = _gitops.open_pull_request(
+                api_url,
+                branch,
+                base=canonical_branch,
+                title=title,
+                body=body,
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced as a publication failure
+            detail = _gitops._scrub_secret(str(exc))
+            failure = ValidationError(
+                "git publication could not open a pull request for branch %s: %s"
+                % (branch, detail[:400])
+            )
+            failure.publication_retry_after_seconds = 600
+            failure.publication_failure_kind = "pull_request_open_failed"
+            raise failure from None
+        commands.append(
+            {
+                "name": "open_pull_request",
+                "attempt": attempt,
+                "number": pr.number,
+                "url": pr.url,
+                "state": pr.state,
+                "head": branch,
+                "base": canonical_branch,
+            }
+        )
+
+        try:
+            merge = _gitops.merge_pull_request(
+                api_url,
+                pr.number,
+                method="squash",
+                sha=head_sha,
+                commit_title="%s (#%d)" % (title, pr.number),
+                commit_message=body,
+            )
+        except Exception as exc:  # noqa: BLE001
+            detail = _gitops._scrub_secret(str(exc))
+            failure = ValidationError(
+                "git publication could not merge pull request %s: %s"
+                % (pr.url or ("#%d" % pr.number), detail[:400])
+            )
+            failure.publication_retry_after_seconds = 600
+            failure.publication_failure_kind = "pull_request_merge_failed"
+            raise failure from None
+        commands.append(
+            {
+                "name": "merge_pull_request",
+                "attempt": attempt,
+                "number": pr.number,
+                "merged": merge.merged,
+                "blocked": merge.blocked,
+                "sha": merge.sha,
+                "reason": merge.reason,
+            }
+        )
+        if not merge.merged:
+            # The PR exists and is correct; the forge's own gates simply have
+            # not finished. Publication is NOT complete, so the task stays in
+            # REVIEWING and the existing publication-retry backoff re-attempts
+            # later. Retrying is cheap because the PR is reused, not reopened.
+            pending = ValidationError(
+                "git publication is waiting on the pull request's own required "
+                "checks before %s can merge into %s: %s"
+                % (pr.url or ("#%d" % pr.number), canonical_branch, merge.reason[:300])
+            )
+            pending.publication_retry_after_seconds = 600
+            pending.publication_failure_kind = "pull_request_checks_pending"
+            raise pending
+
+        final_sha = str(merge.sha or "").strip()
+        git_step(
+            "refresh_canonical_after_merge",
+            [
+                "fetch",
+                "origin",
+                "+refs/heads/%s:refs/remotes/origin/%s"
+                % (canonical_branch, canonical_branch),
+            ],
+        )
+        verify_remote = git_step(
+            "verify_remote_canonical",
+            ["ls-remote", "origin", "refs/heads/%s" % canonical_branch],
+        )
+        remote_sha = str(verify_remote.get("stdout") or "").split(None, 1)
+        remote_sha = remote_sha[0] if remote_sha else ""
+        if not _GIT_SHA_RE.match(final_sha):
+            final_sha = remote_sha
+        if not _GIT_SHA_RE.match(final_sha):
+            raise ValidationError(
+                "git publication merged pull request #%d but could not resolve the "
+                "resulting canonical SHA" % pr.number
+            )
+        contains_reviewed_head = (
+            git_step(
+                "verify_source_ancestor",
+                ["merge-base", "--is-ancestor", head_sha, remote_sha or final_sha],
+                check=False,
+            ).get("returncode")
+            == 0
+        )
+        return {
+            "status": "published",
+            "target": target,
+            "repository_path": str(root),
+            "canonical_branch": canonical_branch,
+            "source_branch": source_branch,
+            "remote_ref": remote_ref,
+            "head_sha": head_sha,
+            "base_sha": base_sha,
+            "final_sha": final_sha,
+            "publication_mode": "pull_request_squash",
+            "pull_request_number": pr.number,
+            "pull_request_url": pr.url,
+            "contains_reviewed_head": bool(contains_reviewed_head),
+            "attempt": attempt,
+            "commands": commands,
+        }
+
     def _publish_git_target_attempt(
         self,
         *,
@@ -22233,6 +22516,8 @@ class ControlPlane:
         attempt: int,
     ) -> JsonDict:
         """Build, test, and publish one exact-base candidate in a fresh clone."""
+
+        from . import gitops as _gitops
 
         commands: List[JsonDict] = []
         with tempfile.TemporaryDirectory(prefix="mac-publish-") as tmp:
@@ -22354,6 +22639,35 @@ class ControlPlane:
             # by however far main moved, so the changed-file selection is the
             # honest question to ask of it. An unresolvable diff falls back to
             # the full command, exactly as the review helper does.
+            strategy = self._resolve_publication_strategy(clone_url)
+            required_checks: tuple[str, ...] = ()
+            if strategy["strategy"] == "pull_request":
+                probed = _gitops.required_status_check_contexts(
+                    str(strategy["api_url"]), canonical_branch
+                )
+                required_checks = tuple(probed or ())
+            commands.append(
+                {
+                    "name": "publication_strategy",
+                    "strategy": strategy["strategy"],
+                    "forge": strategy["forge"],
+                    "reason": strategy["reason"],
+                    "required_status_checks": list(required_checks),
+                }
+            )
+            # WHO gates the merge. On the pull-request path the forge's own
+            # required status checks run against the merge result GitHub will
+            # actually produce, which is a strictly better question than the
+            # hub's local re-projection of it -- and the local one costs 15-45
+            # minutes under MAC_HUB_VERIFY_TIMEOUT, which is exactly why
+            # approved tasks used to sit unpublished (see the note below). So
+            # when the forge is demonstrably gating the branch, mac's reviewer
+            # verdict decides whether a PR is opened and merged at all, and the
+            # forge's checks decide whether that merge is permitted. When the
+            # forge reports no required checks, the hub keeps its own gate --
+            # a repo nobody protected must not silently lose the contract run.
+            forge_gates_merge = bool(required_checks)
+
             projected_changed: list[str] = []
             try:
                 projected_diff = self._git_output(
@@ -22385,27 +22699,53 @@ class ControlPlane:
                     "command": full_test_command[:200],
                 }
             )
-            publication_test_runner = getattr(
-                self, "_publication_merge_test_runner", None
-            )
-            if publication_test_runner is None:
-                publication_test_runner = self._hub_verify_run_contract_test
-            contract_gate = validate_projected_merge_contract(
-                str(root),
-                base_sha,
-                head_sha,
-                full_test_command,
-                test_runner=publication_test_runner,
-                merge_gate=gate,
-            )
-            commands.append(
-                {"name": "publication_contract_gate", **contract_gate.to_dict()}
-            )
-            if not contract_gate.passed:
-                diagnosis = contract_gate.error or contract_gate.output_tail
-                raise ValidationError(
-                    "git publication contract gate failed on the projected "
-                    "current-main merge: %s" % (diagnosis or "unknown failure")
+            if forge_gates_merge:
+                commands.append(
+                    {
+                        "name": "publication_contract_gate",
+                        "skipped": True,
+                        "reason": "delegated to the pull request's required checks",
+                        "required_status_checks": list(required_checks),
+                    }
+                )
+            else:
+                publication_test_runner = getattr(
+                    self, "_publication_merge_test_runner", None
+                )
+                if publication_test_runner is None:
+                    publication_test_runner = self._hub_verify_run_contract_test
+                contract_gate = validate_projected_merge_contract(
+                    str(root),
+                    base_sha,
+                    head_sha,
+                    full_test_command,
+                    test_runner=publication_test_runner,
+                    merge_gate=gate,
+                )
+                commands.append(
+                    {"name": "publication_contract_gate", **contract_gate.to_dict()}
+                )
+                if not contract_gate.passed:
+                    diagnosis = contract_gate.error or contract_gate.output_tail
+                    raise ValidationError(
+                        "git publication contract gate failed on the projected "
+                        "current-main merge: %s" % (diagnosis or "unknown failure")
+                    )
+
+            if strategy["strategy"] == "pull_request":
+                return self._publish_via_pull_request(
+                    task=task,
+                    target=target,
+                    remote_ref=remote_ref,
+                    source_branch=source_branch,
+                    head_sha=head_sha,
+                    base_sha=base_sha,
+                    canonical_branch=canonical_branch,
+                    api_url=str(strategy["api_url"]),
+                    commands=commands,
+                    attempt=attempt,
+                    git_step=git_step,
+                    root=root,
                 )
 
             publication_mode = "fast_forward"

--- a/tests/test_publication_pull_request.py
+++ b/tests/test_publication_pull_request.py
@@ -1,0 +1,469 @@
+"""Publication lands through a reviewed pull request, not a push to main.
+
+The old default had the hub merge an approved task branch locally and push the
+result straight to the canonical branch. These tests pin the new default: the
+agent's branch is pushed, a pull request is opened against the canonical
+branch, and the *forge* squash-merges it. The hub never pushes main.
+
+The forge itself is faked (no network, no credential), but everything below it
+is real: a real bare git remote, a real task branch, and a fake merge that
+performs an actual squash merge so the assertions are about real git history.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mac import gitops
+from mac.models import ReviewStatus, TaskState, ValidationError
+from mac.services import ControlPlane
+from tests.conftest import submit_review_verdict
+from tests.test_control_plane import _sign, register_agent
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+def git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def build_repo(tmp_path: Path):
+    """A bare remote with ``main`` and a pushed ``task/feature`` branch."""
+    remote = tmp_path / "remote.git"
+    source = tmp_path / "source"
+    subprocess.run(
+        ["git", "init", "--bare", str(remote)], check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "clone", str(remote), str(source)], check=True, capture_output=True
+    )
+    git(source, "config", "user.email", "mac-test@example.com")
+    git(source, "config", "user.name", "MAC Test")
+    (source / "base.txt").write_text("base\n", encoding="utf-8")
+    git(source, "add", "base.txt")
+    git(source, "commit", "-m", "base")
+    git(source, "branch", "-M", "main")
+    git(source, "push", "-u", "origin", "main")
+    main_head = git(source, "rev-parse", "HEAD")
+
+    git(source, "checkout", "-b", "task/feature")
+    (source / "feature.txt").write_text("feature\n", encoding="utf-8")
+    git(source, "add", "feature.txt")
+    git(source, "commit", "-m", "feature branch")
+    task_head = git(source, "rev-parse", "HEAD")
+    git(source, "push", "origin", "task/feature")
+    git(source, "checkout", "main")
+    return remote, source, main_head, task_head
+
+
+class FakeForge:
+    """A forge that records PR calls and really squash-merges on request."""
+
+    def __init__(self, remote: Path, workdir: Path, *, merge_blocked: str = ""):
+        self.remote = remote
+        self.workdir = workdir
+        self.merge_blocked = merge_blocked
+        self.opened: list[dict] = []
+        self.merges: list[dict] = []
+
+    def open_pull_request(self, repo_url, head, *, base=None, title=None, body=None):
+        self.opened.append(
+            {"repo_url": repo_url, "head": head, "base": base, "title": title}
+        )
+        return gitops.PullRequestResult(
+            host="github",
+            number=101,
+            url="https://github.invalid/acme/widgets/pull/101",
+            state="open",
+        )
+
+    def merge_pull_request(self, repo_url, number, *, method="squash", sha=None, **_):
+        self.merges.append({"number": number, "method": method, "sha": sha})
+        if self.merge_blocked:
+            return gitops.PullRequestMergeResult(
+                merged=False, number=number, blocked=True, reason=self.merge_blocked
+            )
+        checkout = self.workdir / ("merge-%d" % len(self.merges))
+        subprocess.run(
+            ["git", "clone", "--branch", "main", str(self.remote), str(checkout)],
+            check=True,
+            capture_output=True,
+        )
+        git(checkout, "config", "user.email", "forge@example.com")
+        git(checkout, "config", "user.name", "Fake Forge")
+        git(checkout, "fetch", "origin", "task/feature")
+        git(checkout, "merge", "--squash", sha)
+        git(checkout, "commit", "-m", "squashed (#%d)" % number)
+        merged = git(checkout, "rev-parse", "HEAD")
+        git(checkout, "push", "origin", "HEAD:refs/heads/main")
+        return gitops.PullRequestMergeResult(merged=True, number=number, sha=merged)
+
+
+def install_forge(monkeypatch, forge: FakeForge, *, checks=("sanity",)):
+    monkeypatch.setattr(gitops, "resolve_forge", lambda url: "github")
+    monkeypatch.setattr(
+        gitops, "required_status_check_contexts", lambda url, branch: tuple(checks)
+    )
+    monkeypatch.setattr(gitops, "open_pull_request", forge.open_pull_request)
+    monkeypatch.setattr(gitops, "merge_pull_request", forge.merge_pull_request)
+
+
+def drive_to_approval(cp, source: Path, task_head: str):
+    worker = register_agent(cp, "worker", ["python"])
+    reviewer = register_agent(cp, "reviewer", ["review"])
+    cp.create_project(
+        "pr-publication",
+        metadata={"repository_url": "https://github.com/acme/widgets.git"},
+        dispatch_paused=False,
+    )
+    task = cp.create_task(
+        "publish through a pull request",
+        project="pr-publication",
+        required_capabilities=["python"],
+        metadata={
+            "origin": {
+                "type": "direct_task",
+                "repository_path": str(source),
+                "repository_contract": {
+                    "schema": "mac.repository_contract.v1",
+                    "default_branch": "main",
+                    "test": {"command": "make suite"},
+                },
+            },
+            "publication_target": "git://main",
+        },
+    )
+    cp.claim_task(task.id, worker.id)
+    cp.start_task(task.id, worker.id)
+    manifest = _sign(
+        cp,
+        worker.id,
+        {
+            "schema": "mac.worker_evidence.v1",
+            "status": "complete",
+            "evidence_type": "repo_change",
+            "repo": {
+                "head_sha": task_head,
+                "pushed": True,
+                "remote_ref": "refs/heads/task/feature",
+                "dirty": False,
+                "files_changed": ["feature.txt"],
+            },
+            "tests": [{"command": "make smoke", "returncode": 0}],
+        },
+    )
+    evidence = cp.add_evidence(
+        task.id,
+        "test",
+        "artifact://feature",
+        "feature branch tested",
+        worker.id,
+        metadata={"returncode": 0, "verification": manifest},
+    )
+    cp.submit_for_review(task.id, worker.id)
+    review = cp.request_review(task.id, reviewer.id)
+    verdict_id = submit_review_verdict(cp, task.id, reviewer.id, evidence.id)
+    cp.submit_review(
+        review.id, ReviewStatus.APPROVED.value, reviewer.id, evidence_id=verdict_id
+    )
+    return task, evidence, reviewer
+
+
+def published_detail(cp, task_id):
+    events = [
+        event
+        for event in cp.list_observability(limit=100)
+        if event.name == "task.git_published" and event.subject_id == task_id
+    ]
+    assert events, "no git publication was recorded"
+    return events[0].detail
+
+
+def test_publication_opens_and_squash_merges_a_pull_request(cp, tmp_path, monkeypatch):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    # The hub must never run its own contract gate on this path -- the PR's
+    # required checks are the gate. If it did, this runner would fire.
+    cp._publication_merge_test_runner = lambda *a, **k: pytest.fail(
+        "hub contract gate ran even though the forge gates the merge"
+    )
+
+    publication = cp.publish_task(
+        task.id, "git://main", reviewer.id, evidence_id=evidence.id
+    )
+
+    assert publication.status == "published"
+    assert cp.get_task(task.id).state == TaskState.COMPLETED.value
+
+    # A pull request was opened from the agent's branch onto main.
+    assert len(forge.opened) == 1
+    assert forge.opened[0]["head"] == "task/feature"
+    assert forge.opened[0]["base"] == "main"
+    assert task.id in forge.opened[0]["title"]
+
+    # It was squash-merged, pinned to the reviewed head.
+    assert forge.merges == [{"number": 101, "method": "squash", "sha": task_head}]
+
+    detail = published_detail(cp, task.id)
+    assert detail["publication_mode"] == "pull_request_squash"
+    assert detail["pull_request_number"] == 101
+    assert detail["pull_request_url"].endswith("/pull/101")
+    assert detail["head_sha"] == task_head
+    assert detail["contains_reviewed_head"] is False
+
+    final = git(source, "ls-remote", "origin", "refs/heads/main").split()[0]
+    assert final == detail["final_sha"]
+    assert final != main_head
+    # A squash: one parent, the old main tip -- and the reviewed commit is
+    # deliberately NOT an ancestor.
+    git(source, "fetch", "origin", "main")
+    parents = git(source, "rev-list", "--parents", "-n", "1", final).split()
+    assert parents[1:] == [main_head]
+    assert (
+        subprocess.run(
+            ["git", "merge-base", "--is-ancestor", task_head, final],
+            cwd=source,
+            capture_output=True,
+        ).returncode
+        != 0
+    )
+
+    # The hub never pushed main itself.
+    commands = detail["commands"]
+    assert not any(item["name"] == "push_main_occ" for item in commands)
+    strategy = next(item for item in commands if item["name"] == "publication_strategy")
+    assert strategy["strategy"] == "pull_request"
+    assert strategy["required_status_checks"] == ["sanity"]
+    gate = next(
+        item for item in commands if item["name"] == "publication_contract_gate"
+    )
+    assert gate["skipped"] is True
+
+    # The completion proof is honest about squashing and still admits the task.
+    proofs = [
+        item.metadata["verification"]["canonical_integration"]
+        for item in cp.list_evidence(task.id)
+        if item.metadata.get("verification", {}).get("canonical_integration")
+    ]
+    assert len(proofs) == 1
+    assert proofs[0]["squash_merged"] is True
+    assert proofs[0]["contains_reviewed_head"] is False
+    assert proofs[0]["canonical_tip_sha"] == final
+    assert proofs[0]["reviewed_head_sha"] == task_head
+
+
+def test_publication_defers_while_the_pull_request_checks_are_pending(
+    cp, tmp_path, monkeypatch
+):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(
+        remote,
+        tmp_path / "forge",
+        merge_blocked="Required status check \"sanity\" is expected.",
+    )
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert "required checks" in str(excinfo.value)
+    assert (
+        getattr(excinfo.value, "publication_failure_kind", "")
+        == "pull_request_checks_pending"
+    )
+    assert getattr(excinfo.value, "publication_retry_after_seconds", 0) > 0
+    # The PR exists; main is untouched; the task is not completed.
+    assert len(forge.opened) == 1
+    assert git(source, "ls-remote", "origin", "refs/heads/main").split()[0] == main_head
+    assert cp.get_task(task.id).state != TaskState.COMPLETED.value
+
+
+def test_direct_push_opt_out_still_pushes_the_canonical_branch(
+    cp, tmp_path, monkeypatch
+):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    monkeypatch.setenv("MAC_PUBLICATION_STRATEGY", "direct_push")
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+    cp._publication_merge_test_runner = lambda *a, **k: (0, "suite passed")
+
+    publication = cp.publish_task(
+        task.id, "git://main", reviewer.id, evidence_id=evidence.id
+    )
+
+    assert publication.status == "published"
+    assert forge.opened == []
+    assert forge.merges == []
+    detail = published_detail(cp, task.id)
+    assert detail["publication_mode"] in {"fast_forward", "merge_commit"}
+    assert any(item["name"] == "push_main_occ" for item in detail["commands"])
+    strategy = next(
+        item for item in detail["commands"] if item["name"] == "publication_strategy"
+    )
+    assert strategy["strategy"] == "direct_push"
+    assert "opt-out" in strategy["reason"]
+    final = git(source, "ls-remote", "origin", "refs/heads/main").split()[0]
+    assert final != main_head
+    git(source, "fetch", "origin", "main")
+    git(source, "merge-base", "--is-ancestor", task_head, final)
+
+
+def test_repository_without_a_forge_falls_back_to_direct_push(cp, tmp_path):
+    # No monkeypatching: the canonical remote is a bare local path, so there is
+    # no API to open a pull request against. Publication must still land.
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+    cp._publication_merge_test_runner = lambda *a, **k: (0, "suite passed")
+
+    publication = cp.publish_task(
+        task.id, "git://main", reviewer.id, evidence_id=evidence.id
+    )
+
+    assert publication.status == "published"
+    detail = published_detail(cp, task.id)
+    strategy = next(
+        item for item in detail["commands"] if item["name"] == "publication_strategy"
+    )
+    assert strategy["strategy"] == "direct_push"
+    assert "no API-reachable forge" in strategy["reason"]
+    assert any(item["name"] == "push_main_occ" for item in detail["commands"])
+
+
+def test_unknown_publication_strategy_is_rejected(cp, monkeypatch):
+    monkeypatch.setenv("MAC_PUBLICATION_STRATEGY", "yolo")
+    with pytest.raises(ValidationError, match="MAC_PUBLICATION_STRATEGY"):
+        cp._resolve_publication_strategy("https://github.com/acme/widgets.git")
+
+
+def test_pull_request_is_the_default_strategy(cp, monkeypatch):
+    monkeypatch.delenv("MAC_PUBLICATION_STRATEGY", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    assert (
+        cp._resolve_publication_strategy("https://github.com/acme/widgets.git")[
+            "strategy"
+        ]
+        == "pull_request"
+    )
+
+
+# ---------------------------------------------------------------------------
+# gitops forge helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "file:///srv/git/widgets.git",
+        "/srv/git/widgets.git",
+        "git://example.invalid/widgets.git",
+        "https://github.com/acme",
+    ],
+)
+def test_resolve_forge_declines_remotes_without_a_reachable_api(url, monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    assert gitops.resolve_forge(url) is None
+
+
+def test_resolve_forge_requires_a_credential(monkeypatch):
+    for name in ("GH_TOKEN", "GITHUB_TOKEN", "MAC_TASK_GIT_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    assert gitops.resolve_forge("https://github.com/acme/widgets.git") is None
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    assert gitops.resolve_forge("https://github.com/acme/widgets.git") == "github"
+
+
+def test_merge_pull_request_reports_gate_refusals_as_blocked(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    monkeypatch.setattr(
+        gitops,
+        "_http_put_json",
+        lambda *a, **k: (405, {}, 'Required status check "sanity" is expected.'),
+    )
+    result = gitops.merge_pull_request(
+        "https://github.com/acme/widgets.git", 7, sha="a" * 40
+    )
+    assert result.blocked is True
+    assert result.merged is False
+    assert "sanity" in result.reason
+
+
+def test_merge_pull_request_raises_on_a_real_error(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    monkeypatch.setattr(
+        gitops, "_http_put_json", lambda *a, **k: (500, {}, "internal server error")
+    )
+    with pytest.raises(RuntimeError, match="internal server error"):
+        gitops.merge_pull_request("https://github.com/acme/widgets.git", 7)
+
+
+def test_merge_failures_never_echo_the_token(monkeypatch):
+    token = "ghp_" + "s" * 36
+    monkeypatch.setenv("GH_TOKEN", token)
+    # A forge that reflects the Authorization header back into its error body.
+    monkeypatch.setattr(
+        gitops,
+        "_http_put_json",
+        lambda *a, **k: (403, {}, "bad credentials for token %s" % token),
+    )
+    with pytest.raises(RuntimeError) as excinfo:
+        gitops.merge_pull_request("https://github.com/acme/widgets.git", 7)
+    assert token not in str(excinfo.value)
+    assert "***" in str(excinfo.value)
+
+    monkeypatch.setattr(
+        gitops,
+        "_http_put_json",
+        lambda *a, **k: (405, {}, "required status check pending for %s" % token),
+    )
+    blocked = gitops.merge_pull_request("https://github.com/acme/widgets.git", 7)
+    assert blocked.blocked is True
+    assert token not in blocked.reason
+
+
+def test_required_status_check_contexts_reads_rulesets(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    monkeypatch.setattr(
+        gitops,
+        "_http_get_json",
+        lambda *a, **k: [
+            {"type": "pull_request", "parameters": {}},
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [
+                        {"context": "sanity"},
+                        {"context": "compatibility"},
+                        {"context": "sanity"},
+                    ]
+                },
+            },
+        ],
+    )
+    assert gitops.required_status_check_contexts(
+        "https://github.com/acme/widgets.git", "main"
+    ) == ("sanity", "compatibility")
+
+
+def test_required_status_check_contexts_is_unknown_without_credentials(monkeypatch):
+    for name in ("GH_TOKEN", "GITHUB_TOKEN", "MAC_TASK_GIT_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    assert (
+        gitops.required_status_check_contexts(
+            "https://github.com/acme/widgets.git", "main"
+        )
+        is None
+    )


### PR DESCRIPTION
## What

Changes the default agent landing strategy from *"the hub merges locally and pushes `main`"* to *"work in a worktree, push the branch, open a PR, let the forge gate it, squash-merge the PR"*.

`ControlPlane._publish_git_target_attempt` did a local `git merge --ff-only <head_sha>` (falling back to `--no-ff`) and pushed the result straight to the canonical branch via a step named `push_main_occ`. No pull request existed anywhere in that path — and it is now blocked outright: `main` carries ruleset 20954943 requiring a PR plus six status checks, with bypass only for the admin role.

Steps 1 and 2 of the new flow were already true — the executor finalizer's `guarded_push` pushes only the task branch, with an explicit `HEAD:refs/heads/<branch>` refspec. This adds steps 3–5.

## Design decisions

**How is the PR created?** Through the existing seam, not `gh`. `gitops.open_pull_request` already spoke the GitHub/gitea REST API using `token_for_host` (`GH_TOKEN`/`GITHUB_TOKEN`/`GITEA_TOKEN`). This adds `merge_pull_request`, `required_status_check_contexts`, and `resolve_forge` beside it. The hub needs no extra binary and no new credential path.

**Who merges, and when?** Both parties, at different moments. mac's reviewer verdict plus the merge gate decide whether a PR is opened and a merge requested *at all*; the forge's required status checks decide whether that merge is *permitted*. When the forge reports required checks for the canonical branch, the hub **skips** its own local re-projection of the contract suite: GitHub runs those checks against the merge result it will actually produce, which is a better question than the hub's approximation, and it does not cost the 15–45 minutes that (per the comment already in that function) made approved tasks sit unpublished. When the forge reports **no** required checks, the hub keeps its own contract gate — an unprotected repo must not silently lose it.

**Checks still running is not a failure.** A merge the forge refuses because its gates have not finished comes back as `blocked`; publication defers with `publication_failure_kind=pull_request_checks_pending` through the *existing* retry backoff. The PR is reused rather than reopened, so retries are cheap, and the task stays approved-but-unpublished until the change is genuinely on `main`.

**No GitHub remote?** Falls back to `direct_push` automatically — a bare path, a `file://` remote, or an http(s) remote with no configured token. mac manages repositories that have no pull requests at all, and refusing to publish them would strand them. The fallback is never silent: a `publication_strategy` entry in the publication evidence names the strategy and the reason, so a repo that *should* be using a PR but is not is visible in `mac task show`.

**Flag name.** `MAC_PUBLICATION_STRATEGY` — `pull_request` (default) or `direct_push` (documented opt-out). An unknown value is rejected rather than silently defaulted.

**Migration.** A no-op. Publication is stateless per attempt (a fresh clone every time) and the worker already pushed its branch, so a task mid-flight under the old path simply gets a PR on its next attempt against the branch it already has on the remote.

**Squash honesty.** A squash merge lands the reviewed *content* under a new SHA, so the reviewed commit is deliberately not an ancestor of the canonical tip. The canonical-integration proof records `squash_merged: true` / `contains_reviewed_head: false` plus the PR number and URL, instead of asserting an ancestry squashing destroys. The completion gate accepts that proof shape, kept as tight as the ancestry branch beside it.

## Did I flip the default?

**Yes.** `pull_request` is the default. The risk that argued for gating it is absent here: the worker side is already branch-only, the PR path reuses code that exists, failures are deferrals rather than destructive actions, and the old path is *already* failing on protected repositories.

## Secrets

Every string escaping the forge helpers goes through `_scrub_secret`. `test_merge_failures_never_echo_the_token` feeds back a forge error that reflects the token into its body and asserts the token never reaches either the raised message or the `blocked` reason.

## Tests

New `tests/test_publication_pull_request.py` (16 tests). The forge is faked — no network, no credential — but everything under it is real: a real bare remote, a real task branch, and a fake merge that performs an actual `git merge --squash` so assertions are about real git history.

- publication opens a PR from the task branch onto `main` and squash-merges it; `push_main_occ` never runs; the hub contract gate does not run; the resulting tip is a single-parent squash whose parent is the old `main` and which does not contain the reviewed commit
- pending required checks defer publication, leave `main` untouched, leave the PR open, and do not complete the task
- `MAC_PUBLICATION_STRATEGY=direct_push` still pushes `main` and opens no PR
- a repo with no forge falls back to direct push and records the reason
- `resolve_forge` declines `file://`, bare paths, `git://`, malformed owner/repo, and any remote with no credential
- `merge_pull_request` classifies gate refusals as `blocked` and real errors as raised

```
tests/test_publication_pull_request.py .................. 16 passed
tests/ -k "publish or publication or git or review or finaliz" -n 8 .... 1166 passed, 2 failed
tests/test_control_plane.py test_work_package_telemetry.py test_gitops.py
  test_gitops_publication_target.py test_task_executor.py -n 8 ......... 739 passed
```

The two failures are `test_worker_control_edges.py::test_managed_image_*`, pre-existing on `origin/main` (verified in a clean worktree at `origin/main`; this branch does not touch `worker.py`).

Gates: contract preflight green (`test-docs.py --static-only`, `generate-env-config-registry.py --check`, `generate-docs-reference.py --check`, `test_control_plane_public_contract.py` 580 passed); `dead-code-check.sh` clean; `run-lint.sh` reports only the 6 pre-existing F821/F823 errors, none in changed files; `test_build_test_impact_map.py` 12 passed (no tests deleted or renamed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)