### PR TITLE
Attribute transcripts to the coding agent and model that actually ran

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -5426,6 +5426,14 @@ def _agent_argv(
         # the provider refuses mid-task.
         chosen["agent"] = choice.agent
         chosen["fingerprint"] = choice.route_fingerprint()
+        # ...and to ATTRIBUTE the transcript. `task_agent_transcripts` has
+        # `coding_agent` and `model` columns that were empty on all 275 live
+        # rows, because the only place either value existed was here, and it
+        # never left this function. The task's own metadata is not a substitute:
+        # on the live hub, 0 of 8,154 tasks carry `coding_agent` and 11 carry
+        # `model`. The route that actually ran is the only truthful source.
+        if choice.model:
+            chosen["model"] = choice.model
     rationale = list(choice.rationale)
     if not choice.available:
         reason = (
@@ -5659,6 +5667,37 @@ def _route_failover_class(result: Any) -> str:
     return failure_class if failure_class in _ROUTE_FAILOVER_CLASSES else ""
 
 
+def _opts_with_route(opts: dict, route: Dict[str, str]) -> dict:
+    """Carry the resolved coding-agent route into the runner's audit metadata.
+
+    `run_audited_command` writes `coding_agent` and `model` onto every
+    `task_agent_transcripts` row, reading them from the metadata it is handed.
+    Nothing put them there, so both columns were empty on ALL 275 rows on the
+    live hub -- every transcript recorded WHAT was said and by nobody in
+    particular. That makes the one question a transcript exists to answer --
+    which CLI and which model produced this -- unanswerable, and it silently
+    defeats any comparison between agents or models.
+
+    The task's own metadata is not the source: 0 of 8,154 live tasks carry
+    `coding_agent`, and 11 carry `model`. `route` is populated by `_agent_argv`
+    with the agent that ACTUALLY ran, including after a mid-task failover to a
+    different provider -- so it stays truthful precisely when attribution
+    matters most.
+
+    Existing keys win: an explicit value already in `opts` is not overwritten.
+    """
+    agent = str(route.get("agent") or "").strip()
+    model = str(route.get("model") or "").strip()
+    if not agent and not model:
+        return opts
+    merged = dict(opts)
+    if agent and not merged.get("coding_agent"):
+        merged["coding_agent"] = agent
+    if model and not merged.get("model"):
+        merged["model"] = model
+    return merged
+
+
 def _invoke_agent(
     runner: Callable[..., Any], prompt: str, workspace: Path, audit_id: Any, opts: dict
 ) -> Any:
@@ -5728,7 +5767,7 @@ def _invoke_agent(
                 bundle.argv(sandbox_workspace=sandbox_workspace),
                 workspace,
                 audit_id,
-                opts,
+                _opts_with_route(opts, route),
             )
             # Failover. A subscription that ran dry, or a provider that is
             # down, refuses the run after the route passed its preflight --
@@ -5774,7 +5813,14 @@ def _invoke_agent(
                         bundle.argv(sandbox_workspace=sandbox_workspace),
                         workspace,
                         audit_id,
-                        opts,
+                        # fallback_route, not route: after a failover the
+                        # transcript must be attributed to the agent that
+                        # ACTUALLY produced it. Attributing a successful
+                        # fallback run to the provider that already refused is
+                        # worse than no attribution -- it is wrong data that
+                        # looks right, and it would silently corrupt any
+                        # comparison between agents.
+                        _opts_with_route(opts, fallback_route),
                     )
             return result
         return runner(
@@ -5785,7 +5831,7 @@ def _invoke_agent(
             workspace,
             audit_id,
             {
-                **opts,
+                **_opts_with_route(opts, route),
                 "execution_boundary": (
                     "host" if break_glass_authorization is not None else "unsandboxed"
                 ),

--- a/tests/test_transcript_attribution.py
+++ b/tests/test_transcript_attribution.py
@@ -1,0 +1,125 @@
+"""A transcript must say WHICH coding agent and model produced it.
+
+`task_agent_transcripts` has `coding_agent` and `model` columns. On the live hub
+they were empty on **all 275 rows**, across 188 distinct tasks:
+
+    SELECT count(*) FILTER (WHERE coalesce(coding_agent,'')<>'') -> 0
+
+So every transcript recorded what was said, by nobody in particular. That makes
+the one question a transcript exists to answer -- which CLI and which model
+produced this -- unanswerable from the ledger, and it silently defeats any
+comparison between agents or between models.
+
+The obvious diagnosis was wrong, and the numbers say so. It was reported as
+"`run_audited_command` reads `opts` instead of `opts['task']['metadata']`", but
+neither location holds the value: on the live hub **0 of 8,154 tasks** carry
+`coding_agent` in their metadata, and 11 carry `model`. Nothing ever put it
+there. Reading a different key would have changed nothing.
+
+The only truthful source is the route that actually ran. `_agent_argv` populates
+its `chosen` dict with the selected agent (`route["agent"]`), and
+`CodingAgentChoice` also knows the model -- but neither ever left that function.
+`_opts_with_route` carries both into the metadata the runner writes.
+
+The failover case is the one that matters most: when a provider refuses mid-task
+and execution moves to a different CLI, attribution must follow the agent that
+actually produced the output. Attributing a successful fallback to the provider
+that already refused is worse than no attribution -- it is wrong data that looks
+right.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac import executor_sandbox
+
+
+def test_the_resolved_route_reaches_the_runner_metadata():
+    opts = {"task": {"id": "task_1", "metadata": {}}}
+    route = {"agent": "claude", "model": "claude-opus-4-8"}
+
+    merged = executor_sandbox._opts_with_route(opts, route)
+
+    assert merged["coding_agent"] == "claude", (
+        "the transcript would be written with no coding_agent, which is the "
+        "state all 275 live rows are in"
+    )
+    assert merged["model"] == "claude-opus-4-8"
+    assert merged["task"] == opts["task"], "unrelated opts must survive"
+
+
+def test_an_empty_route_changes_nothing():
+    """No route resolved yet is not the same as 'attributed to nothing'."""
+    opts = {"task": {"id": "task_1"}}
+
+    assert executor_sandbox._opts_with_route(opts, {}) is opts
+    assert executor_sandbox._opts_with_route(opts, {"agent": "", "model": ""}) is opts
+
+
+def test_an_explicit_value_already_present_wins():
+    """A caller that already knows better is not overwritten."""
+    opts = {"coding_agent": "codex", "model": "gpt-5"}
+    route = {"agent": "claude", "model": "claude-opus-4-8"}
+
+    merged = executor_sandbox._opts_with_route(opts, route)
+
+    assert merged["coding_agent"] == "codex"
+    assert merged["model"] == "gpt-5"
+
+
+def test_a_partial_route_fills_only_what_it_knows():
+    """Some routes resolve an agent without a model. Half an attribution is
+    still better than none, and must not invent the other half."""
+    merged = executor_sandbox._opts_with_route({}, {"agent": "cursor"})
+
+    assert merged["coding_agent"] == "cursor"
+    assert "model" not in merged, "a model must never be fabricated"
+
+
+def test_the_original_opts_are_not_mutated():
+    """The caller reuses opts across a failover; mutating it would attribute the
+    fallback run to the agent that already refused."""
+    opts = {"task": {"id": "task_1"}}
+
+    executor_sandbox._opts_with_route(opts, {"agent": "claude"})
+
+    assert "coding_agent" not in opts, (
+        "opts was mutated in place; after a failover the same dict is reused "
+        "and would carry the FAILED provider's name into the successful run"
+    )
+
+
+def test_every_invocation_path_attributes(monkeypatch):
+    """Source-level: all three runner call sites must go through the helper.
+
+    There are three ways the coding agent is invoked -- sandboxed, sandboxed
+    after a mid-task failover, and unsandboxed/break-glass. A path that skips
+    attribution produces exactly the silent hole this fixes.
+    """
+    import inspect
+
+    source = inspect.getsource(executor_sandbox._invoke_agent)
+
+    assert source.count("_opts_with_route") == 3, (
+        "expected all three runner call sites (sandboxed, failover, "
+        "unsandboxed) to attribute; found %d"
+        % source.count("_opts_with_route")
+    )
+    assert "_opts_with_route(opts, fallback_route)" in source, (
+        "the failover path must attribute to the FALLBACK route. Using the "
+        "original route here would credit the provider that refused."
+    )
+
+
+def test_the_route_carries_the_model_not_just_the_agent():
+    """`chosen` used to record only agent + fingerprint, so `model` had no
+    source at all."""
+    import inspect
+
+    source = inspect.getsource(executor_sandbox._agent_argv)
+
+    assert 'chosen["model"]' in source, (
+        "the resolved route does not carry the model, so the transcript's "
+        "`model` column can never be populated"
+    )


### PR DESCRIPTION
`task_agent_transcripts` has `coding_agent` and `model` columns. On the live hub they are empty on **all 275 rows**, across 188 distinct tasks:

```sql
SELECT count(*) FILTER (WHERE coalesce(coding_agent,'')<>'') FROM task_agent_transcripts;  -- 0
```

Every transcript records *what was said, by nobody in particular*. The one question a transcript exists to answer — which CLI and which model produced this — is unanswerable, and any comparison between agents or models is silently impossible.

## The reported diagnosis was wrong

It was filed as *"`run_audited_command` reads `opts` instead of `opts['task']['metadata']`"*. **Neither location holds the value:**

| | |
|---|---:|
| tasks with `coding_agent` in metadata | **0** of 8,154 |
| tasks with `model` in metadata | 11 of 8,154 |

Nothing ever *put* it there. Reading a different key would have changed nothing.

## The only truthful source is the route that actually ran

`_agent_argv` already populates its `chosen` dict with the selected agent — `_record_runner_choice` uses `route.get("agent")` a few hundred lines away — but it never left that function. And `chosen` recorded only `agent` + `fingerprint`, so `model` had **no source at all**, despite `CodingAgentChoice.model` knowing it.

- `chosen["model"]` is now populated from the resolved choice
- `_opts_with_route()` carries agent + model into the metadata the runner writes. Existing explicit values win; an empty route is a no-op returning the original object, so *"no route resolved"* stays distinct from *"attributed to nothing"*
- **All three** invocation paths use it: sandboxed, unsandboxed/break-glass, failover

## The failover path is the one that matters

When a provider refuses mid-task and execution moves to a different CLI, attribution must follow the agent that **actually produced the output**. Crediting a successful fallback to the provider that already refused is *worse than no attribution* — wrong data that looks right, corrupting exactly the comparison the column exists for.

It uses `fallback_route`, and a test pins that. `_opts_with_route` also copies rather than mutating, because the same `opts` dict is reused across the failover — mutation would carry the failed provider's name into the successful run.

## Verification

**7 new tests, all seven fail without the change.** 1,386 pass across sandbox/executor/transcript/route; 597 across public-contract, impact-map and docs-accessibility.

## Not fixed here

- The **275 existing rows stay unattributed forever** — this fixes transcripts written from now on
- Transcript coverage is ~2% of tasks (188 of ~8,000)
- `command_audit` still records only the harness's own spawns, not what the coding CLI ran inside the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)