### PR TITLE
The agent owns its pull request; the merge queue serializes it; and the requester verifies the checks actually ran

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -22,6 +22,7 @@ their retained sources.
 - [ADR 0013 - One authoritative hub allocator](../adr/0013-authoritative-hub-allocator.md) — `adr/0013-authoritative-hub-allocator.md`
 - [ADR 0014: Agent visibility is a communication boundary, not a dispatch gate](../adr/0014-visibility-is-not-a-dispatch-gate.md) — `adr/0014-visibility-is-not-a-dispatch-gate.md`
 - [ADR 0015: macOS nodes are host installs, not containers](../adr/0015-macos-nodes-are-host-installs.md) — `adr/0015-macos-nodes-are-host-installs.md`
+- [ADR 0016 - Agents decide what a task needs; review is agent-initiated](../adr/0016-agent-initiated-review.md) — `adr/0016-agent-initiated-review.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`
 - [Assessment: task_7023d6a7ef6e4bbf8f6c2da523a4320f](../archive/field-notes/assessment-task-7023d6.md) — `archive/field-notes/assessment-task-7023d6.md`

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -629,17 +629,64 @@ already asks of humans:
    branch** (the executor finalizer's `guarded_push`, which pushes an explicit
    `HEAD:refs/heads/<task-branch>` refspec and refuses if the canonical tip is
    not already contained in the branch).
-2. On approval, the hub clones the exact canonical tip, runs the merge gate,
+2. **The agent opens its own pull request**, onto the task's canonical branch
+   (from the repository contract — never assumed to be `main`), and records it
+   in the worker evidence manifest as `repo.pull_request`.
+3. On approval, the hub clones the exact canonical tip, runs the merge gate,
    makes sure the reviewed commit is on the task branch on the remote, and
-   opens a pull request against the canonical branch.
-3. The forge squash-merges that pull request, pinned to the reviewed head SHA
-   (the pull-request equivalent of `--force-with-lease`: if the branch moved
+   **reuses the agent's pull request**. It opens one itself only when the
+   evidence carries none — an older worker, or a forge the agent could not
+   reach — and that fallback is recorded (`opened_by: hub_fallback`) rather
+   than being indistinguishable from the normal path.
+4. The forge lands that pull request, pinned to the reviewed head SHA (the
+   pull-request equivalent of `--force-with-lease`: if the branch moved
    underneath us, the merge is refused rather than landing something nobody
-   reviewed).
-4. The hub verifies the resulting canonical tip and records it as the
+   reviewed) — through the branch's **merge queue** when it has one, and
+   otherwise through a plain squash merge, see below.
+5. The hub verifies the resulting canonical tip and records it as the
    canonical-integration proof.
 
-The hub never pushes the canonical branch on this path.
+The hub never pushes the canonical branch on this path, and it does not author
+pull requests: opening one is the agent's decision about how its own work
+lands, and the hub's job is to record that it happened and to gate completion.
+
+**The agent's forge credential.** The agent uses the credential already in its
+own process environment (`GH_TOKEN`/`GITHUB_TOKEN`/`GITEA_TOKEN` — the same
+variable `guarded_push` authenticates with, written into `~/.mac/mac.env` at
+deploy time and mounted as an optional `secretKeyRef` on K8s workers). When it
+has none, it resolves `github.token` from the **hub's secret store** by name,
+at the moment of use — audited, never cached, never written to evidence, never
+carried in a bus message or task metadata. A resolved secret that does not
+claim the forge's capability is refused rather than sent to the API.
+
+**How the merge is serialized.** `merge_queue.py` validates against the
+*projected post-merge* state — the "Not Rocket Science Rule": test the tree
+that will actually land, serialize the merges, and post-merge testing is then
+redundant. A plain forge squash merge does **not** preserve that: if the
+canonical branch advances between the required checks completing and the merge
+executing, the tree that lands was never tested as such. Required status checks
+alone do not close this; a **merge queue** does, and unlike
+`strict_required_status_checks_policy` it serializes the *merges* without
+serializing the *test runs* (which here take ~2 hours, so strict rebasing never
+converges with several open pull requests).
+
+| branch has | what mac does | the guarantee |
+| --- | --- | --- |
+| a merge queue | enqueues the PR pinned to the reviewed head; the queue tests the projected merge and lands it in order | what was tested is what lands |
+| no merge queue (or gitea, or an unreadable ruleset) | re-validates that the canonical tip is still the base this candidate was gated against, then squash-merges | weaker: not serialized against concurrent merges, so the re-validation is what stands in for it |
+
+Both branches are recorded in the publication evidence as a
+`merge_serialization` entry naming the mode and its guarantee, and on the
+canonical-integration proof as `merge_serialization`. A repository whose queue
+has not been enabled yet is therefore visible as such rather than silently
+assumed to have one.
+
+**Queued, not merged yet.** A pull request accepted into the merge queue has
+not landed. Publication defers with
+`publication_failure_kind=pull_request_queued` through the same retry backoff
+pending checks use, and a later attempt observes the merge the queue performed
+(it asks the forge for the pull request's state before doing anything, so a PR
+the queue already landed is never merged twice).
 
 **Who gates the merge.** Both, at different moments. mac's own reviewer verdict
 plus the merge gate decide whether a pull request is opened and a merge is

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -659,6 +659,29 @@ at the moment of use — audited, never cached, never written to evidence, never
 carried in a bus message or task metadata. A resolved secret that does not
 claim the forge's capability is refused rather than sent to the API.
 
+**Verify, do not assume.** The party requesting the merge confirms the required
+contexts actually passed *for the reviewed head SHA* before asking, rather than
+trusting the forge to refuse if they have not. This is not belt-and-braces
+pedantry: the fleet authenticates as the repository owner, and the ruleset
+carries a `RepositoryRole` bypass with mode `always` (deliberate operator
+break-glass), so the merge request inherits that bypass and can land straight
+past required checks — the first publication under this flow merged two seconds
+after the pull request was opened, with every required context reported
+`SKIPPED`. Nothing gated it: not the forge (bypassed) and not the hub (which
+skips its own contract re-projection precisely *because* the forge reports
+required checks).
+
+A context that has not reported, is still running, or reported `skipped` is
+**not** a pass; publication defers with
+`publication_failure_kind=pull_request_checks_pending`. A context that reported
+a real failure raises `pull_request_checks_failed`. An empty required-contexts
+list is a *different case* from a required list that is still pending, and the
+two are recorded separately in the publication evidence
+(`required_check_verification.case`: `none_configured`, `pending`, `failed`,
+`unverifiable`, or `verified`) — an unprotected repository is gated by the
+hub's own contract run instead, and a repository whose checks simply have not
+started is not mistaken for one.
+
 **How the merge is serialized.** `merge_queue.py` validates against the
 *projected post-merge* state — the "Not Rocket Science Rule": test the tree
 that will actually land, serialize the merges, and post-merge testing is then

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -583,6 +583,7 @@
       "src/mac/fleet_creds.py",
       "src/mac/fleet_env.py",
       "src/mac/fleet_setup.py",
+      "src/mac/gitops.py",
       "src/mac/hermes_adapter.py",
       "src/mac/ide_launcher.py",
       "src/mac/k8s/bootstrap.py",
@@ -635,6 +636,7 @@
       "deploy/openclaw/install-openclaw-gateway.sh",
       "src/mac/cli.py",
       "src/mac/dispatch.py",
+      "src/mac/gitops.py",
       "src/mac/ide_launcher.py"
     ],
     "type": "str"
@@ -6284,6 +6286,7 @@
       "src/mac/executor_hub_io.py",
       "src/mac/executor_sandbox.py",
       "src/mac/executor_scope.py",
+      "src/mac/gitops.py",
       "src/mac/hermes_adapter.py",
       "src/mac/hermes_runtime.py",
       "src/mac/hermes_startup.py",
@@ -13022,6 +13025,7 @@
       "src/mac/executor_hub_io.py",
       "src/mac/executor_sandbox.py",
       "src/mac/executor_scope.py",
+      "src/mac/gitops.py",
       "src/mac/hermes_adapter.py",
       "src/mac/hermes_runtime.py",
       "src/mac/hermes_startup.py",

--- a/src/mac/executor_finalizer.py
+++ b/src/mac/executor_finalizer.py
@@ -90,6 +90,7 @@ from mac.fleet_learning import (
 )
 from mac.gitops import (
     CanonicalFreshnessResult,
+    agent_pull_request,
     check_canonical_freshness,
     guarded_push,
     resolve_canonical_publication_target,
@@ -1442,6 +1443,7 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
     clean = not bool(final_status)
     freshness_ok = freshness_error is None
     pushed = False
+    pull_request: Optional[dict] = None
     publication: Optional[CanonicalFreshnessResult] = None
     push_remote_display = (
         freshness.target.remote_display if freshness.target is not None else ""
@@ -1474,6 +1476,20 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
             "status": "pass" if pushed else "fail",
             "stderr": clip_process_text(publication.push_stderr or publication.error),
         }
+        if pushed:
+            # THE AGENT OPENS ITS OWN PULL REQUEST. The branch is on the
+            # remote; the request to land it onto the task's canonical branch
+            # (from the repository contract -- not assumed to be "main") is
+            # this agent's to make. The hub records it and gates completion;
+            # it no longer opens PRs. Never fatal: a repo with no forge is a
+            # legitimate configuration, and the work is already pushed.
+            pull_request = agent_pull_request(
+                publication.target or publication_target,
+                task_id=str(task_id),
+                task_title=str(task.get("title") or ""),
+                head_sha=head_sha,
+                base_sha=base_sha,
+            )
     elif not clean:
         push_evidence = {
             "remote": push_remote_display,
@@ -1545,6 +1561,7 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
             "files_changed": files_changed,
             "freshness": (publication or freshness).evidence(),
             "canonical_sync": canonical_sync,
+            **({"pull_request": pull_request} if pull_request else {}),
         },
         "canonical_integration": canonical_integration,
         "codegraph": codegraph,

--- a/src/mac/gitops.py
+++ b/src/mac/gitops.py
@@ -40,6 +40,25 @@ class PullRequestMergeResult:
     ``merged`` is the only success signal.  ``blocked`` distinguishes "the
     forge refused because its own gates have not passed yet" (retry later,
     the PR is fine) from a hard error (raised, never returned).
+
+    ``serialization`` names WHICH landing mechanism produced this outcome, so
+    the guarantee behind a merge is recorded rather than assumed:
+
+    ``merge_queue``
+        The forge's merge queue owns the landing.  It builds a speculative
+        merge candidate, tests the projected post-merge tree, and merges in
+        order — the property :mod:`mac.merge_queue` models (bors' "Not Rocket
+        Science Rule").  The tree that was tested IS the tree that lands.
+    ``direct_squash``
+        A plain squash merge.  Required status checks ran against a merge
+        candidate built from *some* canonical tip; nothing stops the canonical
+        branch from advancing between the checks finishing and the merge
+        executing, so the landed tree may never have been tested as such.
+        Callers must re-validate the canonical tip immediately before asking
+        for this merge; ``queued`` is False and the evidence says so.
+
+    ``queued`` is True when the PR was accepted into the merge queue but has
+    not landed yet: not a failure, and not yet a success.
     """
 
     merged: bool
@@ -47,6 +66,8 @@ class PullRequestMergeResult:
     sha: str = ""
     blocked: bool = False
     reason: str = ""
+    serialization: str = ""
+    queued: bool = False
 
 
 _GIT_REMOTE_URL_RE = re.compile(
@@ -1267,3 +1288,537 @@ def _merged_sha_for(
     if not isinstance(pr, dict):
         return ""
     return str(pr.get("merge_commit_sha") or pr.get("merged_commit_id") or "").strip()
+
+
+# ----------------------------------------------------------------------
+# Merge queue: serialize the merges without serializing the test runs.
+# ----------------------------------------------------------------------
+
+
+def merge_queue_enabled(
+    repo_url: str,
+    branch: str,
+    *,
+    github_token: Optional[str] = None,
+    gitea_token: Optional[str] = None,
+) -> Optional[bool]:
+    """Whether ``branch`` is landed through the forge's merge queue.
+
+    ``True``/``False`` are answers; ``None`` means "unknown" (a forge with no
+    merge queue at all, an API error, or insufficient scope).  Callers must
+    treat ``None`` exactly like ``False`` *and say so in their evidence*: a
+    repository without a queue gets a plain squash merge, which does not carry
+    the queue's guarantee, and silently assuming otherwise just relocates the
+    hole.
+
+    Reuses the same ``/rules/branches/{branch}`` endpoint as
+    :func:`required_status_check_contexts` — no admin scope, and it reports
+    rulesets, which is how protection is actually configured here.
+    """
+    try:
+        host_kind, owner, repo, api_base, headers, _token = _forge_api_context(
+            repo_url, github_token=github_token, gitea_token=gitea_token
+        )
+    except ValueError:
+        return None
+    if host_kind != "github":
+        # gitea has no merge-queue equivalent. "Unknown" rather than False so
+        # the caller records "this forge cannot serialize merges for us".
+        return None
+    url = "%s/repos/%s/%s/rules/branches/%s" % (
+        api_base,
+        owner,
+        repo,
+        _quote(str(branch or ""), safe=""),
+    )
+    try:
+        rules = _http_get_json(url, headers)
+    except Exception:  # noqa: BLE001 - an unknown answer must not block publication
+        return None
+    if not isinstance(rules, list):
+        return None
+    for rule in rules:
+        if isinstance(rule, dict) and rule.get("type") == "merge_queue":
+            return True
+    return False
+
+
+def _graphql_url(host_kind: str, repo_url: str) -> str:
+    parsed = urlparse(repo_url if "://" in repo_url else "https://" + repo_url)
+    if host_kind == "github" and (parsed.hostname or "").lower() in {
+        "github.com",
+        "api.github.com",
+        "www.github.com",
+    }:
+        return "https://api.github.com/graphql"
+    scheme = parsed.scheme or "https"
+    port = (":" + str(parsed.port)) if parsed.port else ""
+    return "%s://%s%s/api/graphql" % (scheme, parsed.hostname or "", port)
+
+
+def _graphql(
+    url: str, headers: dict, query: str, variables: dict, token: str
+) -> Tuple[dict, str]:
+    """POST a GraphQL document; return ``(data, error_text)`` without raising.
+
+    GitHub answers a rejected mutation with HTTP 200 and an ``errors`` array,
+    so errors are data here in exactly the way the merge endpoint's 4xx is.
+    """
+    body = {"query": query, "variables": variables}
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json", **headers},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30.0) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        return {}, _scrub_secret(
+            "HTTP %d %s: %s" % (exc.code, exc.reason, raw[:500]), token
+        )
+    except urllib.error.URLError as exc:
+        return {}, _scrub_secret(str(exc.reason), token)
+    try:
+        decoded = json.loads(raw) if raw else {}
+    except ValueError:
+        return {}, _scrub_secret("unparseable GraphQL response", token)
+    if not isinstance(decoded, dict):
+        return {}, _scrub_secret("unexpected GraphQL response", token)
+    errors = decoded.get("errors")
+    if errors:
+        messages = [
+            str(err.get("message") or "")
+            for err in errors
+            if isinstance(err, dict)
+        ]
+        return _ensure_mapping(decoded.get("data")), _scrub_secret(
+            "; ".join(m for m in messages if m)[:500] or "GraphQL error", token
+        )
+    return _ensure_mapping(decoded.get("data")), ""
+
+
+def _ensure_mapping(value: object) -> dict:
+    """Return ``value`` when it is a dict, otherwise an empty dict."""
+    return value if isinstance(value, dict) else {}
+
+
+_PULL_REQUEST_NODE_QUERY = """
+query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$number){
+      id state merged headRefOid
+      mergeCommit{ oid }
+    }
+  }
+}
+"""
+
+_ENQUEUE_MUTATION = """
+mutation($pullRequestId:ID!,$expectedHeadOid:GitObjectID!){
+  enqueuePullRequest(input:{pullRequestId:$pullRequestId,expectedHeadOid:$expectedHeadOid}){
+    mergeQueueEntry{ id position state }
+  }
+}
+"""
+
+# GraphQL refusals that mean "the PR is fine, it is simply not landable yet".
+_ENQUEUE_BLOCKED_MARKERS = (
+    "not mergeable",
+    "is not in a mergeable state",
+    "required status check",
+    "checks have not",
+    "review is required",
+    "changes requested",
+    "already queued",
+    "already in the merge queue",
+    "pull request is in an unstable",
+    "merge queue is not enabled",
+    "base branch modified",
+    "head sha",
+    "expected head",
+    "waiting on code owner",
+    "protected branch",
+)
+
+
+def pull_request_state(
+    repo_url: str,
+    number: int,
+    *,
+    github_token: Optional[str] = None,
+    gitea_token: Optional[str] = None,
+) -> Dict[str, object]:
+    """Current forge state of PR ``number``: merged, its SHA, and its head.
+
+    Publication is retried, and between attempts a queued PR may have landed
+    on its own.  Asking the forge first is what makes "the merge queue merged
+    it while we were backing off" a success rather than a second merge
+    attempt.
+    """
+    host_kind, owner, repo, api_base, headers, token = _forge_api_context(
+        repo_url, github_token=github_token, gitea_token=gitea_token
+    )
+    try:
+        pr = _http_get_json(
+            "%s/repos/%s/%s/pulls/%d" % (api_base, owner, repo, int(number)), headers
+        )
+    except Exception as exc:  # noqa: BLE001 - unknown state is not fatal
+        return {
+            "known": False,
+            "merged": False,
+            "sha": "",
+            "state": "",
+            "head_sha": "",
+            "error": _scrub_secret(str(exc), token)[:300],
+        }
+    if not isinstance(pr, dict):
+        return {"known": False, "merged": False, "sha": "", "state": "", "head_sha": ""}
+    head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
+    return {
+        "known": True,
+        "merged": bool(pr.get("merged") or pr.get("merged_at")),
+        "sha": str(
+            pr.get("merge_commit_sha") or pr.get("merged_commit_id") or ""
+        ).strip(),
+        "state": str(pr.get("state") or ""),
+        "head_sha": str((head or {}).get("sha") or "").strip(),
+        "host": host_kind,
+    }
+
+
+def enqueue_pull_request(
+    repo_url: str,
+    number: int,
+    *,
+    sha: str,
+    github_token: Optional[str] = None,
+    gitea_token: Optional[str] = None,
+) -> PullRequestMergeResult:
+    """Add PR ``number`` to the forge's merge queue, pinned to ``sha``.
+
+    ``sha`` is the reviewed head, passed as ``expectedHeadOid``: the forge
+    refuses the enqueue if the branch moved underneath us.  That is the same
+    safety property the direct merge gets from its ``sha`` parameter and the
+    direct-push path gets from ``--force-with-lease``.
+
+    The queue lands the PR asynchronously, so a *successful* enqueue returns
+    ``merged=False, queued=True``: the caller defers through its existing
+    retry backoff and observes the merge on a later attempt.  A refusal that
+    names the forge's own gates comes back ``blocked=True``; anything else
+    raises.
+    """
+    if int(number) <= 0:
+        raise ValueError("pull request number is required to enqueue")
+    if not str(sha or "").strip():
+        raise ValueError("a reviewed head sha is required to enqueue")
+    host_kind, owner, repo, _api_base, headers, token = _forge_api_context(
+        repo_url, github_token=github_token, gitea_token=gitea_token
+    )
+    if host_kind != "github":
+        raise ValueError("merge queue enqueue is only supported on github")
+    url = _graphql_url(host_kind, repo_url)
+    data, error = _graphql(
+        url,
+        headers,
+        _PULL_REQUEST_NODE_QUERY,
+        {"owner": owner, "name": repo, "number": int(number)},
+        token,
+    )
+    pull = _ensure_mapping(
+        _ensure_mapping(_ensure_mapping(data).get("repository")).get("pullRequest")
+    )
+    if error or not pull.get("id"):
+        raise RuntimeError(
+            "could not resolve pull request #%d for the merge queue: %s"
+            % (int(number), error or "no pull request node")
+        )
+    if bool(pull.get("merged")):
+        return PullRequestMergeResult(
+            merged=True,
+            number=int(number),
+            sha=str(_ensure_mapping(pull.get("mergeCommit")).get("oid") or "").strip(),
+            serialization="merge_queue",
+        )
+
+    _data, error = _graphql(
+        url,
+        headers,
+        _ENQUEUE_MUTATION,
+        {"pullRequestId": str(pull["id"]), "expectedHeadOid": str(sha).strip()},
+        token,
+    )
+    if not error:
+        return PullRequestMergeResult(
+            merged=False,
+            number=int(number),
+            queued=True,
+            serialization="merge_queue",
+            reason="enqueued into the merge queue",
+        )
+    lowered = error.lower()
+    if any(marker in lowered for marker in _ENQUEUE_BLOCKED_MARKERS):
+        return PullRequestMergeResult(
+            merged=False,
+            number=int(number),
+            blocked=True,
+            serialization="merge_queue",
+            reason=error,
+        )
+    raise RuntimeError(
+        "enqueue of pull request #%d failed: %s" % (int(number), error)
+    )
+
+
+def request_pull_request_merge(
+    repo_url: str,
+    number: int,
+    *,
+    sha: str,
+    branch: str,
+    method: str = "squash",
+    commit_title: Optional[str] = None,
+    commit_message: Optional[str] = None,
+    queue_enabled: Optional[bool] = None,
+    github_token: Optional[str] = None,
+    gitea_token: Optional[str] = None,
+) -> PullRequestMergeResult:
+    """Ask the forge to land PR ``number``, through its merge queue if there is one.
+
+    THE GUARANTEE, written down rather than assumed:
+
+    * **With a merge queue** (``queue_enabled`` True): the queue builds a
+      speculative merge candidate, runs the required checks against the
+      *projected post-merge* tree, and merges in order.  What was tested is
+      what lands — the property :mod:`mac.merge_queue` relies on, restored
+      without the serial-rebase cost of ``strict`` required status checks
+      (the queue serializes the merges, not the test runs).
+    * **Without one** (``None`` or False — a repo with no queue configured,
+      gitea, or an unreadable ruleset): a plain squash merge.  Required
+      checks alone do NOT guarantee the landed tree was tested, because the
+      canonical branch can advance between the checks finishing and the merge
+      executing.  The caller must re-validate the canonical tip immediately
+      before calling this, and the returned ``serialization`` says
+      ``direct_squash`` so the weaker guarantee is visible in the evidence.
+
+    Already-merged PRs (the queue landed it between attempts) return
+    ``merged=True`` rather than being merged twice.
+    """
+    if queue_enabled:
+        observed = pull_request_state(
+            repo_url, number, github_token=github_token, gitea_token=gitea_token
+        )
+        if observed.get("known") and observed.get("merged"):
+            return PullRequestMergeResult(
+                merged=True,
+                number=int(number),
+                sha=str(observed.get("sha") or ""),
+                serialization="merge_queue",
+            )
+        return enqueue_pull_request(
+            repo_url,
+            number,
+            sha=sha,
+            github_token=github_token,
+            gitea_token=gitea_token,
+        )
+    result = merge_pull_request(
+        repo_url,
+        number,
+        method=method,
+        sha=sha,
+        commit_title=commit_title,
+        commit_message=commit_message,
+        github_token=github_token,
+        gitea_token=gitea_token,
+    )
+    result.serialization = "direct_squash"
+    return result
+
+
+def open_pull_request_for_target(
+    target: "CanonicalPublicationTarget",
+    *,
+    title: str,
+    body: str,
+) -> Dict[str, object]:
+    """Open the task's pull request FROM THE AGENT, onto the canonical branch.
+
+    This runs in the worker/finalizer process, right after ``guarded_push``
+    placed the task branch on the remote — the agent publishes its own work
+    rather than asking the hub to do it.  The base is
+    ``target.canonical_branch``, which comes from the task's repository
+    contract; it is not assumed to be ``main``.
+
+    Never raises: a repository with no API-reachable forge (``file://``, a
+    bare path, no token) is a legitimate configuration, and a forge hiccup
+    must not fail a finalizer whose work is already pushed.  The outcome —
+    including *why* no PR exists — is returned for the evidence manifest.
+    """
+    remote_url = str(getattr(target, "canonical_remote_url", "") or "").strip()
+    base = str(getattr(target, "canonical_branch", "") or "").strip()
+    head = str(getattr(target, "destination_branch", "") or "").strip()
+    if not (remote_url and base and head):
+        return {
+            "opened": False,
+            "reason": "publication target has no canonical remote/branch",
+        }
+    if head == base:
+        return {
+            "opened": False,
+            "reason": "task publishes directly to the canonical branch; no pull request",
+        }
+    forge = resolve_forge(remote_url)
+    token = ""
+    if not forge:
+        # No env-backed token is not the end of the question: the hub is the
+        # fleet's credential store, so ask it by name before giving up.
+        try:
+            host_kind = detect_host(remote_url)
+        except ValueError:
+            host_kind = ""
+        if host_kind and str(remote_url).startswith(("http://", "https://")):
+            try:
+                token = forge_token_from_hub(host_kind)
+            except ValueError as exc:
+                return {"opened": False, "reason": str(exc)}
+            if token:
+                forge = host_kind
+    if not forge:
+        return {
+            "opened": False,
+            "reason": (
+                "canonical remote has no API-reachable forge (no http(s) forge "
+                "URL, and no credential from the environment or the hub secret "
+                "store for its host)"
+            ),
+        }
+    api_url = https_remote_for_token_auth(remote_url)
+    try:
+        pr = open_pull_request(
+            api_url,
+            head,
+            base=base,
+            title=title,
+            body=body,
+            **({"github_token": token} if token and forge == "github" else {}),
+            **({"gitea_token": token} if token and forge == "gitea" else {}),
+        )
+    except Exception as exc:  # noqa: BLE001 - reported, never fatal
+        # The token never reaches the evidence manifest, which is read by
+        # operators and stored in the ledger.
+        return {
+            "opened": False,
+            "forge": forge,
+            "base": base,
+            "head": head,
+            "reason": _scrub_secret(str(exc), token or token_for_host(forge))[:400],
+        }
+    return {
+        "opened": True,
+        "forge": forge,
+        "number": int(pr.number),
+        "url": str(pr.url),
+        "state": str(pr.state),
+        "base": base,
+        "head": head,
+        "opened_by": "agent",
+    }
+
+
+# The hub is the fleet's credential store. An agent that has no forge token in
+# its own environment asks the hub for one BY NAME, at the moment of use.
+_FORGE_SECRET_NAMES = {"github": "github.token", "gitea": "gitea.token"}
+
+
+def forge_token_from_hub(host_kind: str) -> str:
+    """Resolve the forge credential from the hub's audited secret store.
+
+    Resolution is BY NAME (``github.token``), never by id, so a rotation does
+    not break publication.  The value is fetched at the moment of use and
+    returned to the caller; it is never cached, never written to evidence,
+    never put in a bus message or task metadata, and never logged.  Failures
+    return an empty string rather than an error carrying a partial credential.
+
+    The secret's ``capabilities`` are the authorization signal: a credential
+    that does not claim this host's capability is refused loudly instead of
+    being sent to the API to come back as a confusing 401.
+    """
+    name = _FORGE_SECRET_NAMES.get(host_kind, "")
+    if not name:
+        return ""
+    base_url = (
+        os.environ.get("MAC_API_URL", "").strip()
+        or os.environ.get("MAC_URL", "").strip()
+        or os.environ.get("MAC_HUB_URL", "").strip()
+    )
+    api_token = os.environ.get("MAC_API_TOKEN", "").strip()
+    if not base_url:
+        return ""
+
+    from mac.http_client import HubClient, HubClientError
+
+    client = HubClient(base_url, token=api_token or None)
+    try:
+        resolved = client.request("POST", "/secrets/%s/resolve" % _quote(name, safe=""))
+    except HubClientError:
+        return ""
+    except Exception:  # noqa: BLE001 - an unreachable hub is not a crash
+        return ""
+    if not isinstance(resolved, dict):
+        return ""
+    capabilities = resolved.get("capabilities")
+    if isinstance(capabilities, (list, tuple)) and capabilities:
+        if host_kind not in {str(item).strip() for item in capabilities}:
+            raise ValueError(
+                "hub secret %s does not carry the %s capability; refusing to use it"
+                % (name, host_kind)
+            )
+    return str(resolved.get("value") or "").strip()
+
+
+def forge_token(host_kind: str) -> str:
+    """The forge credential for ``host_kind``, environment first, hub second.
+
+    Deployed workers already carry ``GH_TOKEN`` in their process environment
+    (``deploy_env.build_mac_env`` writes it into ``~/.mac/mac.env``, which the
+    service wrapper sources with ``set -a``; k8s workers get it as an optional
+    ``secretKeyRef``), and that is the same variable ``token_for_host`` reads
+    for ``guarded_push``.  When it is absent -- a worker deployed without the
+    GitHub credential, or a lane that scrubbed it -- the hub's audited secret
+    store answers instead.  Either way the agent, not the hub, is the party
+    that calls the forge.
+    """
+    return token_for_host(host_kind) or forge_token_from_hub(host_kind)
+
+
+def agent_pull_request(
+    target: "CanonicalPublicationTarget",
+    *,
+    task_id: str,
+    task_title: str = "",
+    head_sha: str = "",
+    base_sha: str = "",
+) -> Dict[str, object]:
+    """The agent's own pull request for the work it just pushed.
+
+    Opening the PR is the agent's job, not the hub's: the hub is a resource
+    orchestrator that records what happened and gates completion, and deciding
+    how a task's own work lands belongs to the agent doing the task.  The
+    result goes into the worker evidence manifest, so the hub reads the PR
+    from the ledger instead of opening one itself.
+    """
+    title = "%s (%s)" % (
+        str(task_title or "").strip() or "mac change",
+        str(task_id or "").strip(),
+    )
+    body = (
+        "Opened by the MAC agent that produced this change.\n\n"
+        "- task: `%s`\n- head: `%s`\n- base at push: `%s`\n"
+        % (task_id, head_sha or getattr(target, "task_head_sha", ""), base_sha)
+    )
+    outcome = open_pull_request_for_target(target, title=title, body=body)
+    outcome.setdefault("task_id", str(task_id or ""))
+    return outcome

--- a/src/mac/gitops.py
+++ b/src/mac/gitops.py
@@ -1291,6 +1291,121 @@ def _merged_sha_for(
 
 
 # ----------------------------------------------------------------------
+# Verify, do not assume: the requester checks that the gates actually ran.
+# ----------------------------------------------------------------------
+
+# A required context that reported one of these has genuinely failed; retrying
+# will not change it.
+_CHECK_FAILED_CONCLUSIONS = {
+    "failure",
+    "timed_out",
+    "cancelled",
+    "action_required",
+    "stale",
+    "startup_failure",
+}
+# Everything else that is not "success" -- queued, in_progress, neutral,
+# SKIPPED, or no report at all -- means the gate has not passed. Skipped is
+# deliberately NOT success: a required check that did not run is exactly the
+# "green gate enforcing nothing" shape this verification exists to catch.
+
+
+def required_check_verdicts(
+    repo_url: str,
+    sha: str,
+    contexts: Tuple[str, ...],
+    *,
+    github_token: Optional[str] = None,
+    gitea_token: Optional[str] = None,
+) -> Dict[str, object]:
+    """Did each required context actually pass for ``sha``?
+
+    DO NOT RELY ON THE FORGE REFUSING. An identity that holds a ruleset bypass
+    -- the repository owner, which is what the fleet authenticates as -- can
+    merge straight past required status checks, and did: the first publication
+    under the pull-request flow merged two seconds after the PR was created,
+    with every required context reported SKIPPED. Nothing gated it: not the
+    forge (bypassed) and not the hub (which skips its own contract
+    re-projection precisely *because* the forge reports required checks).
+
+    So the party requesting the merge verifies first, instead of assuming a
+    refusal will arrive if the checks have not passed. This holds whether or
+    not the identity has a bypass, and it composes with a merge queue rather
+    than duplicating it: the queue serializes and tests the candidate, this
+    makes sure nobody asks for a merge that was never validated.
+
+    Returns ``passed``/``pending``/``failed`` lists plus ``known``.  ``known``
+    is False when the forge could not be asked, which callers must treat as
+    "not verified" -- never as "fine".
+    """
+    verdict: Dict[str, object] = {
+        "known": False,
+        "contexts": list(contexts),
+        "passed": [],
+        "pending": list(contexts),
+        "failed": [],
+    }
+    if not contexts:
+        verdict["known"] = True
+        verdict["pending"] = []
+        return verdict
+    try:
+        host_kind, owner, repo, api_base, headers, _token = _forge_api_context(
+            repo_url, github_token=github_token, gitea_token=gitea_token
+        )
+    except ValueError:
+        return verdict
+    if host_kind != "github":
+        return verdict
+
+    latest: Dict[str, str] = {}
+    try:
+        combined = _http_get_json(
+            "%s/repos/%s/%s/commits/%s/status" % (api_base, owner, repo, _quote(sha, safe="")),
+            headers,
+        )
+    except Exception:  # noqa: BLE001 - an unknown answer is "not verified"
+        return verdict
+    for status in (combined or {}).get("statuses") or []:
+        if isinstance(status, dict) and str(status.get("context") or ""):
+            latest.setdefault(str(status["context"]), str(status.get("state") or ""))
+    try:
+        runs = _http_get_json(
+            "%s/repos/%s/%s/commits/%s/check-runs?per_page=100"
+            % (api_base, owner, repo, _quote(sha, safe="")),
+            headers,
+        )
+    except Exception:  # noqa: BLE001
+        runs = {}
+    for run in (runs or {}).get("check_runs") or []:
+        if not isinstance(run, dict):
+            continue
+        name = str(run.get("name") or "")
+        if not name:
+            continue
+        if str(run.get("status") or "") != "completed":
+            latest[name] = "pending"
+            continue
+        latest[name] = str(run.get("conclusion") or "")
+
+    passed: list[str] = []
+    pending: list[str] = []
+    failed: list[str] = []
+    for context in contexts:
+        outcome = latest.get(context, "")
+        if outcome == "success":
+            passed.append(context)
+        elif outcome in _CHECK_FAILED_CONCLUSIONS or outcome == "failure":
+            failed.append(context)
+        else:
+            pending.append(context)
+    verdict.update(
+        {"known": True, "passed": passed, "pending": pending, "failed": failed}
+    )
+    return verdict
+
+
+# ----------------------------------------------------------------------
 # Merge queue: serialize the merges without serializing the test runs.
 # ----------------------------------------------------------------------
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -22058,6 +22058,12 @@ class ControlPlane:
                 **(
                     {
                         "squash_merged": True,
+                        "merge_serialization": str(
+                            publication.get("merge_serialization") or ""
+                        ),
+                        "pull_request_opened_by": str(
+                            publication.get("pull_request_opened_by") or ""
+                        ),
                         "pull_request_url": str(
                             publication.get("pull_request_url") or ""
                         ),
@@ -22141,6 +22147,9 @@ class ControlPlane:
         head_sha = str(repo.get("head_sha") or "").strip()
         if not _GIT_SHA_RE.match(head_sha):
             raise ValidationError("git publication requires evidence repo.head_sha")
+        # The agent opens its own pull request when it pushes the branch; the
+        # hub reads that fact from the evidence rather than opening one.
+        agent_pull_request = ensure_json_object(repo.get("pull_request"))
         remote_ref = str(repo.get("remote_ref") or "").strip()
         source_branch = _remote_branch_from_ref(remote_ref)
         if not source_branch:
@@ -22240,6 +22249,7 @@ class ControlPlane:
                     auth_env=auth_env,
                     canonical_branch=canonical_branch,
                     attempt=attempt + 1,
+                    agent_pull_request=agent_pull_request,
                 )
             except _PublicationBaseMovedError as exc:
                 last_base_move = exc
@@ -22332,14 +22342,30 @@ class ControlPlane:
         attempt: int,
         git_step: Any,
         root: Path,
+        agent_pull_request: Optional[JsonDict] = None,
     ) -> JsonDict:
-        """Push the branch, open the PR, and let the forge squash-merge it.
+        """Land the agent's pull request; the hub records, it does not author.
 
-        The hub does not merge and does not push the canonical branch.  The
-        squash merge means the reviewed commit is deliberately *not* an
-        ancestor of the canonical tip afterwards, so the canonical-integration
-        proof records ``contains_reviewed_head`` honestly instead of asserting
-        an ancestry that squashing destroys.
+        The AGENT opens the pull request when it pushes its branch
+        (``gitops.agent_pull_request``), and the hub reads it from the worker
+        evidence.  The hub opens one itself only when the evidence carries
+        none -- an older worker, or a forge the agent could not reach -- and
+        that fallback is recorded in the publication commands rather than
+        being indistinguishable from the normal path.
+
+        The hub does not merge either: it asks the forge's MERGE QUEUE to
+        land the PR when the canonical branch has one, and the queue performs
+        the merge after testing the projected post-merge tree.  Without a
+        queue the request degrades to a plain squash merge, which does *not*
+        carry that guarantee -- so the canonical tip is re-validated against
+        the tested base immediately beforehand, and the weaker serialization
+        is named in the evidence.
+
+        The hub never pushes the canonical branch.  A squash merge means the
+        reviewed commit is deliberately *not* an ancestor of the canonical tip
+        afterwards, so the canonical-integration proof records
+        ``contains_reviewed_head`` honestly instead of asserting an ancestry
+        that squashing destroys.
         """
 
         from . import gitops as _gitops
@@ -22380,23 +22406,44 @@ class ControlPlane:
             "- task: `%s`\n- reviewed head: `%s`\n- base at publication: `%s`\n"
             % (task.id, head_sha, base_sha)
         )
-        try:
-            pr = _gitops.open_pull_request(
-                api_url,
-                branch,
-                base=canonical_branch,
-                title=title,
-                body=body,
+        # The agent's own pull request, opened when it pushed the branch.
+        # Opening a PR is not the hub's job -- storing the fact that one was
+        # opened is.
+        agent_pr = ensure_json_object(agent_pull_request)
+        agent_pr_number = int(agent_pr.get("number") or 0)
+        agent_pr_base = str(agent_pr.get("base") or "").strip()
+        reuse_agent_pr = bool(
+            agent_pr.get("opened")
+            and agent_pr_number > 0
+            and (not agent_pr_base or agent_pr_base == canonical_branch)
+        )
+        if reuse_agent_pr:
+            pr = _gitops.PullRequestResult(
+                host=str(agent_pr.get("forge") or ""),
+                number=agent_pr_number,
+                url=str(agent_pr.get("url") or ""),
+                state=str(agent_pr.get("state") or "open"),
             )
-        except Exception as exc:  # noqa: BLE001 - surfaced as a publication failure
-            detail = _gitops._scrub_secret(str(exc))
-            failure = ValidationError(
-                "git publication could not open a pull request for branch %s: %s"
-                % (branch, detail[:400])
-            )
-            failure.publication_retry_after_seconds = 600
-            failure.publication_failure_kind = "pull_request_open_failed"
-            raise failure from None
+            opened_by = "agent"
+        else:
+            try:
+                pr = _gitops.open_pull_request(
+                    api_url,
+                    branch,
+                    base=canonical_branch,
+                    title=title,
+                    body=body,
+                )
+            except Exception as exc:  # noqa: BLE001 - surfaced as a publication failure
+                detail = _gitops._scrub_secret(str(exc))
+                failure = ValidationError(
+                    "git publication could not open a pull request for branch %s: %s"
+                    % (branch, detail[:400])
+                )
+                failure.publication_retry_after_seconds = 600
+                failure.publication_failure_kind = "pull_request_open_failed"
+                raise failure from None
+            opened_by = "hub_fallback"
         commands.append(
             {
                 "name": "open_pull_request",
@@ -22406,17 +22453,71 @@ class ControlPlane:
                 "state": pr.state,
                 "head": branch,
                 "base": canonical_branch,
+                "opened_by": opened_by,
+                "agent_reason": ""
+                if reuse_agent_pr
+                else str(agent_pr.get("reason") or "worker evidence carried no pull request"),
             }
         )
 
+        # HOW THE MERGE IS SERIALIZED -- the guarantee, written down.
+        #
+        # merge_queue.py validates against the PROJECTED post-merge state (the
+        # "Not Rocket Science Rule"): test the tree that will actually land,
+        # serialize the merges, and post-merge testing is redundant because
+        # what was tested IS what landed. A plain forge squash-merge does not
+        # preserve that -- if the canonical branch advances between the status
+        # checks finishing and the merge executing, the landed tree was never
+        # tested. Required status checks alone do not close that; a MERGE
+        # QUEUE does, and unlike `strict` required checks it serializes the
+        # merges without serializing the (here ~2 hour) test runs.
+        #
+        # So: use the queue when the canonical branch has one. When it does
+        # not -- no queue configured yet, gitea, or an unreadable ruleset --
+        # degrade EXPLICITLY: re-validate that the canonical tip is still the
+        # base this candidate was projected and gated against, and name the
+        # weaker serialization in the evidence. Silently squash-merging while
+        # the code still assumes the queue's guarantee is the same hole in a
+        # harder-to-see place.
+        queue_enabled = _gitops.merge_queue_enabled(api_url, canonical_branch)
+        if not queue_enabled:
+            observed_canonical = git_step(
+                "revalidate_canonical_tip",
+                ["ls-remote", "origin", "refs/heads/%s" % canonical_branch],
+            )
+            observed_tip = str(observed_canonical.get("stdout") or "").split(None, 1)
+            observed_tip = observed_tip[0] if observed_tip else ""
+            if observed_tip and observed_tip != base_sha:
+                # OCC validation phase: the tested projection is stale, so a
+                # merge now would land a tree nobody tested. Re-project.
+                raise _PublicationBaseMovedError(base_sha, observed_tip)
+        commands.append(
+            {
+                "name": "merge_serialization",
+                "attempt": attempt,
+                "merge_queue": bool(queue_enabled),
+                "mode": "merge_queue" if queue_enabled else "direct_squash",
+                "guarantee": (
+                    "the forge merge queue tests the projected post-merge tree "
+                    "and merges in order: what was tested is what lands"
+                    if queue_enabled
+                    else "no merge queue on this branch; a plain squash merge "
+                    "is not serialized against concurrent merges, so the "
+                    "canonical tip was re-validated against the tested base "
+                    "immediately before requesting it"
+                ),
+            }
+        )
         try:
-            merge = _gitops.merge_pull_request(
+            merge = _gitops.request_pull_request_merge(
                 api_url,
                 pr.number,
-                method="squash",
                 sha=head_sha,
+                branch=canonical_branch,
+                method="squash",
                 commit_title="%s (#%d)" % (title, pr.number),
                 commit_message=body,
+                queue_enabled=queue_enabled,
             )
         except Exception as exc:  # noqa: BLE001
             detail = _gitops._scrub_secret(str(exc))
@@ -22434,10 +22535,25 @@ class ControlPlane:
                 "number": pr.number,
                 "merged": merge.merged,
                 "blocked": merge.blocked,
+                "queued": merge.queued,
+                "serialization": merge.serialization,
                 "sha": merge.sha,
                 "reason": merge.reason,
             }
         )
+        if merge.queued and not merge.merged:
+            # Accepted into the merge queue. The queue tests the projected
+            # post-merge tree and lands it in order, so publication is not
+            # complete yet: defer through the SAME retry backoff pending
+            # checks use, and observe the merge on a later attempt.
+            queued = ValidationError(
+                "git publication placed %s in the %s merge queue; it lands once "
+                "the queue's checks pass"
+                % (pr.url or ("#%d" % pr.number), canonical_branch)
+            )
+            queued.publication_retry_after_seconds = 600
+            queued.publication_failure_kind = "pull_request_queued"
+            raise queued
         if not merge.merged:
             # The PR exists and is correct; the forge's own gates simply have
             # not finished. Publication is NOT complete, so the task stays in
@@ -22494,6 +22610,10 @@ class ControlPlane:
             "base_sha": base_sha,
             "final_sha": final_sha,
             "publication_mode": "pull_request_squash",
+            "merge_serialization": merge.serialization or (
+                "merge_queue" if queue_enabled else "direct_squash"
+            ),
+            "pull_request_opened_by": opened_by,
             "pull_request_number": pr.number,
             "pull_request_url": pr.url,
             "contains_reviewed_head": bool(contains_reviewed_head),
@@ -22514,6 +22634,7 @@ class ControlPlane:
         auth_env: Mapping[str, str],
         canonical_branch: str,
         attempt: int,
+        agent_pull_request: Optional[JsonDict] = None,
     ) -> JsonDict:
         """Build, test, and publish one exact-base candidate in a fresh clone."""
 
@@ -22746,6 +22867,7 @@ class ControlPlane:
                     attempt=attempt,
                     git_step=git_step,
                     root=root,
+                    agent_pull_request=agent_pull_request,
                 )
 
             publication_mode = "fast_forward"

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -22343,6 +22343,7 @@ class ControlPlane:
         git_step: Any,
         root: Path,
         agent_pull_request: Optional[JsonDict] = None,
+        required_checks: Tuple[str, ...] = (),
     ) -> JsonDict:
         """Land the agent's pull request; the hub records, it does not author.
 
@@ -22459,6 +22460,88 @@ class ControlPlane:
                 else str(agent_pr.get("reason") or "worker evidence carried no pull request"),
             }
         )
+
+        # VERIFY, DO NOT ASSUME. The party requesting the merge confirms the
+        # required contexts actually passed for this head SHA, instead of
+        # trusting the forge to refuse. The fleet authenticates as the
+        # repository owner, and this repository's ruleset carries a
+        # RepositoryRole bypass with mode `always` (deliberate operator
+        # break-glass) -- so the requester inherits it and CAN merge straight
+        # past required checks. It did: the first publication under this flow
+        # merged two seconds after the PR was opened, with every required
+        # context reported SKIPPED. Nothing gated it, because this path also
+        # skips its own contract re-projection precisely BECAUSE the forge
+        # reports required checks.
+        #
+        # "No required contexts" and "required contexts that have not reported
+        # yet" are NOT the same thing, and are recorded separately: the first
+        # is an unprotected repository, where the local contract gate above
+        # ran instead; the second is a gate that has not run, which defers.
+        if required_checks:
+            verdicts = _gitops.required_check_verdicts(
+                api_url, head_sha, tuple(required_checks)
+            )
+            if verdicts.get("failed"):
+                case = "failed"
+            elif not verdicts.get("known"):
+                case = "unverifiable"
+            elif verdicts.get("pending"):
+                case = "pending"
+            else:
+                case = "verified"
+        else:
+            verdicts = {
+                "known": True,
+                "contexts": [],
+                "passed": [],
+                "pending": [],
+                "failed": [],
+            }
+            case = "none_configured"
+        commands.append(
+            {
+                "name": "required_check_verification",
+                "attempt": attempt,
+                "case": case,
+                "head_sha": head_sha,
+                "contexts": list(verdicts.get("contexts") or []),
+                "passed": list(verdicts.get("passed") or []),
+                "pending": list(verdicts.get("pending") or []),
+                "failed": list(verdicts.get("failed") or []),
+            }
+        )
+        if case == "failed":
+            failure = ValidationError(
+                "git publication will not merge %s: required checks failed for "
+                "reviewed head %s: %s"
+                % (
+                    pr.url or ("#%d" % pr.number),
+                    head_sha[:12],
+                    ", ".join(str(item) for item in verdicts.get("failed") or []),
+                )
+            )
+            failure.publication_retry_after_seconds = 600
+            failure.publication_failure_kind = "pull_request_checks_failed"
+            raise failure
+        if case in {"pending", "unverifiable"}:
+            pending = ValidationError(
+                "git publication is waiting on the pull request's own required "
+                "checks before %s can merge into %s: %s"
+                % (
+                    pr.url or ("#%d" % pr.number),
+                    canonical_branch,
+                    "could not read check results for %s" % head_sha[:12]
+                    if case == "unverifiable"
+                    else "not yet reported for %s: %s"
+                    % (
+                        head_sha[:12],
+                        ", ".join(str(item) for item in verdicts.get("pending") or []),
+                    ),
+                )
+            )
+            pending.publication_retry_after_seconds = 600
+            pending.publication_failure_kind = "pull_request_checks_pending"
+            raise pending
 
         # HOW THE MERGE IS SERIALIZED -- the guarantee, written down.
         #
@@ -22868,6 +22951,7 @@ class ControlPlane:
                     git_step=git_step,
                     root=root,
                     agent_pull_request=agent_pull_request,
+                    required_checks=required_checks,
                 )
 
             publication_mode = "fast_forward"

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -112,6 +112,7 @@ from mac.models import (
     utcnow,
 )
 from mac.gitops import (
+    agent_pull_request,
     guarded_push,
     resolve_canonical_publication_target,
     strip_git_remote_auth,
@@ -4604,6 +4605,17 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
             problems.append("repository contract test failed; refusing to push")
 
         repo["pushed"] = pushed
+        # THE AGENT OPENS ITS OWN PULL REQUEST onto the task's canonical
+        # branch (from the repository contract -- never assumed to be "main").
+        # The hub records it and gates completion; it does not open PRs.
+        if pushed and not package_mode and publication_target is not None:
+            repo["pull_request"] = agent_pull_request(
+                publication_target,
+                task_id=str(task_id),
+                task_title=str(task.get("title") or ""),
+                head_sha=str(repo.get("head_sha") or ""),
+                base_sha=str(repo.get("base_sha") or ""),
+            )
         # Broadcast the two git facts peers cannot otherwise learn in time:
         # a branch landed on the shared remote, or this worktree hit a
         # conflict against the canonical tip someone else advanced. Emitted

--- a/tests/test_publication_pull_request.py
+++ b/tests/test_publication_pull_request.py
@@ -83,6 +83,21 @@ class FakeForge:
         self.merges: list[dict] = []
         self.enqueued: list[dict] = []
         self.queue_merged_sha = ""
+        self.verified: list[dict] = []
+        self.checks_pending = False
+        self.checks_failed: tuple = ()
+        self.checks_known = True
+
+    # -- required checks --------------------------------------------------
+    def required_check_verdicts(self, repo_url, sha, contexts, **_):
+        self.verified.append({"sha": sha, "contexts": list(contexts)})
+        return {
+            "known": self.checks_known,
+            "contexts": list(contexts),
+            "passed": [] if self.checks_pending else list(contexts),
+            "pending": list(contexts) if self.checks_pending else [],
+            "failed": list(self.checks_failed),
+        }
 
     # -- merge queue -----------------------------------------------------
     def merge_queue_enabled(self, repo_url, branch, **_):
@@ -158,6 +173,7 @@ def install_forge(monkeypatch, forge: FakeForge, *, checks=("sanity",)):
     monkeypatch.setattr(gitops, "open_pull_request", forge.open_pull_request)
     monkeypatch.setattr(gitops, "merge_pull_request", forge.merge_pull_request)
     monkeypatch.setattr(gitops, "merge_queue_enabled", forge.merge_queue_enabled)
+    monkeypatch.setattr(gitops, "required_check_verdicts", forge.required_check_verdicts)
     monkeypatch.setattr(gitops, "enqueue_pull_request", forge.enqueue_pull_request)
     monkeypatch.setattr(gitops, "pull_request_state", forge.pull_request_state)
 
@@ -1045,3 +1061,177 @@ def test_forge_token_from_hub_is_empty_without_a_hub(monkeypatch):
     for name in ("MAC_API_URL", "MAC_URL", "MAC_HUB_URL"):
         monkeypatch.delenv(name, raising=False)
     assert gitops.forge_token_from_hub("github") == ""
+
+
+# ---------------------------------------------------------------------------
+# Verify, do not assume: an identity with a ruleset bypass can merge past the
+# forge's own gates, so the requester checks the gates actually passed.
+# ---------------------------------------------------------------------------
+
+
+def test_merge_is_not_requested_until_required_checks_actually_passed(
+    cp, tmp_path, monkeypatch
+):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    # The forge would happily merge -- the caller holds a ruleset bypass, which
+    # is exactly the situation this must not depend on.
+    forge.checks_pending = True
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert (
+        getattr(excinfo.value, "publication_failure_kind", "")
+        == "pull_request_checks_pending"
+    )
+    # It asked about the reviewed head, and asked for nothing else.
+    assert forge.verified == [{"sha": task_head, "contexts": ["sanity"]}]
+    assert forge.merges == []
+    assert forge.enqueued == []
+    assert git(source, "ls-remote", "origin", "refs/heads/main").split()[0] == main_head
+    assert cp.get_task(task.id).state != TaskState.COMPLETED.value
+
+
+def test_failed_required_checks_are_not_a_deferral(cp, tmp_path, monkeypatch):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    forge.checks_failed = ("sanity",)
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert (
+        getattr(excinfo.value, "publication_failure_kind", "")
+        == "pull_request_checks_failed"
+    )
+    assert forge.merges == []
+    assert git(source, "ls-remote", "origin", "refs/heads/main").split()[0] == main_head
+
+
+def test_unreadable_check_results_are_not_treated_as_passing(
+    cp, tmp_path, monkeypatch
+):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    forge.checks_known = False
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert (
+        getattr(excinfo.value, "publication_failure_kind", "")
+        == "pull_request_checks_pending"
+    )
+    assert forge.merges == []
+
+
+def test_verified_checks_are_recorded_and_allow_the_merge(cp, tmp_path, monkeypatch):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    detail = published_detail(cp, task.id)
+    verification = next(
+        item
+        for item in detail["commands"]
+        if item["name"] == "required_check_verification"
+    )
+    assert verification["case"] == "verified"
+    assert verification["passed"] == ["sanity"]
+    assert verification["pending"] == []
+    assert verification["head_sha"] == task_head
+
+
+def test_no_required_contexts_is_recorded_distinctly_from_pending(
+    cp, tmp_path, monkeypatch
+):
+    """An unprotected repo is not a repo whose checks have not started."""
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge, checks=())
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+    ran: list[str] = []
+    cp._publication_merge_test_runner = lambda *a, **k: (
+        ran.append("gate") or (0, "suite passed")
+    )
+
+    cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    detail = published_detail(cp, task.id)
+    verification = next(
+        item
+        for item in detail["commands"]
+        if item["name"] == "required_check_verification"
+    )
+    assert verification["case"] == "none_configured"
+    assert verification["contexts"] == []
+    # The local contract gate is what protected this one, and it really ran.
+    gate = next(
+        item for item in detail["commands"] if item["name"] == "publication_contract_gate"
+    )
+    assert gate.get("skipped") is not True
+    assert ran == ["gate"]
+
+
+def test_required_check_verdicts_classifies_each_context(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    responses = {
+        "status": {"statuses": [{"context": "legacy", "state": "success"}]},
+        "check-runs": {
+            "check_runs": [
+                {"name": "sanity", "status": "completed", "conclusion": "success"},
+                {"name": "compat", "status": "in_progress", "conclusion": None},
+                {"name": "lint", "status": "completed", "conclusion": "failure"},
+                # A required check that did not run is NOT a pass.
+                {"name": "docs", "status": "completed", "conclusion": "skipped"},
+            ]
+        },
+    }
+
+    def fake_get(url, headers, *a, **k):
+        return responses["check-runs" if "check-runs" in url else "status"]
+
+    monkeypatch.setattr(gitops, "_http_get_json", fake_get)
+    verdict = gitops.required_check_verdicts(
+        "https://github.com/acme/widgets.git",
+        "a" * 40,
+        ("sanity", "compat", "lint", "docs", "legacy", "never-reported"),
+    )
+    assert verdict["known"] is True
+    assert verdict["passed"] == ["sanity", "legacy"]
+    assert verdict["failed"] == ["lint"]
+    assert verdict["pending"] == ["compat", "docs", "never-reported"]
+
+
+def test_required_check_verdicts_is_unknown_when_the_forge_cannot_be_asked(
+    monkeypatch,
+):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+
+    def boom(*a, **k):
+        raise RuntimeError("no network")
+
+    monkeypatch.setattr(gitops, "_http_get_json", boom)
+    verdict = gitops.required_check_verdicts(
+        "https://github.com/acme/widgets.git", "a" * 40, ("sanity",)
+    )
+    assert verdict["known"] is False
+    assert verdict["pending"] == ["sanity"]
+
+
+def test_required_check_verdicts_with_no_contexts_is_known_and_empty():
+    verdict = gitops.required_check_verdicts(
+        "https://github.com/acme/widgets.git", "a" * 40, ()
+    )
+    assert verdict["known"] is True
+    assert verdict["pending"] == []

--- a/tests/test_publication_pull_request.py
+++ b/tests/test_publication_pull_request.py
@@ -67,12 +67,50 @@ def build_repo(tmp_path: Path):
 class FakeForge:
     """A forge that records PR calls and really squash-merges on request."""
 
-    def __init__(self, remote: Path, workdir: Path, *, merge_blocked: str = ""):
+    def __init__(
+        self,
+        remote: Path,
+        workdir: Path,
+        *,
+        merge_blocked: str = "",
+        queue: bool = False,
+    ):
         self.remote = remote
         self.workdir = workdir
         self.merge_blocked = merge_blocked
+        self.queue = queue
         self.opened: list[dict] = []
         self.merges: list[dict] = []
+        self.enqueued: list[dict] = []
+        self.queue_merged_sha = ""
+
+    # -- merge queue -----------------------------------------------------
+    def merge_queue_enabled(self, repo_url, branch, **_):
+        return self.queue
+
+    def enqueue_pull_request(self, repo_url, number, *, sha, **_):
+        self.enqueued.append({"number": number, "sha": sha})
+        return gitops.PullRequestMergeResult(
+            merged=False,
+            number=number,
+            queued=True,
+            serialization="merge_queue",
+            reason="enqueued into the merge queue",
+        )
+
+    def pull_request_state(self, repo_url, number, **_):
+        return {
+            "known": True,
+            "merged": bool(self.queue_merged_sha),
+            "sha": self.queue_merged_sha,
+            "state": "closed" if self.queue_merged_sha else "open",
+            "head_sha": "",
+        }
+
+    def land_from_queue(self, sha: str, number: int = 101) -> str:
+        """What the queue does asynchronously: squash the PR onto main."""
+        self.queue_merged_sha = self._squash(sha, number)
+        return self.queue_merged_sha
 
     def open_pull_request(self, repo_url, head, *, base=None, title=None, body=None):
         self.opened.append(
@@ -91,7 +129,12 @@ class FakeForge:
             return gitops.PullRequestMergeResult(
                 merged=False, number=number, blocked=True, reason=self.merge_blocked
             )
-        checkout = self.workdir / ("merge-%d" % len(self.merges))
+        return gitops.PullRequestMergeResult(
+            merged=True, number=number, sha=self._squash(sha, number)
+        )
+
+    def _squash(self, sha, number) -> str:
+        checkout = self.workdir / ("merge-%d" % (len(self.merges) + len(self.enqueued) + 1))
         subprocess.run(
             ["git", "clone", "--branch", "main", str(self.remote), str(checkout)],
             check=True,
@@ -104,7 +147,7 @@ class FakeForge:
         git(checkout, "commit", "-m", "squashed (#%d)" % number)
         merged = git(checkout, "rev-parse", "HEAD")
         git(checkout, "push", "origin", "HEAD:refs/heads/main")
-        return gitops.PullRequestMergeResult(merged=True, number=number, sha=merged)
+        return merged
 
 
 def install_forge(monkeypatch, forge: FakeForge, *, checks=("sanity",)):
@@ -114,9 +157,12 @@ def install_forge(monkeypatch, forge: FakeForge, *, checks=("sanity",)):
     )
     monkeypatch.setattr(gitops, "open_pull_request", forge.open_pull_request)
     monkeypatch.setattr(gitops, "merge_pull_request", forge.merge_pull_request)
+    monkeypatch.setattr(gitops, "merge_queue_enabled", forge.merge_queue_enabled)
+    monkeypatch.setattr(gitops, "enqueue_pull_request", forge.enqueue_pull_request)
+    monkeypatch.setattr(gitops, "pull_request_state", forge.pull_request_state)
 
 
-def drive_to_approval(cp, source: Path, task_head: str):
+def drive_to_approval(cp, source: Path, task_head: str, *, pull_request=None):
     worker = register_agent(cp, "worker", ["python"])
     reviewer = register_agent(cp, "reviewer", ["review"])
     cp.create_project(
@@ -156,6 +202,7 @@ def drive_to_approval(cp, source: Path, task_head: str):
                 "remote_ref": "refs/heads/task/feature",
                 "dirty": False,
                 "files_changed": ["feature.txt"],
+                **({"pull_request": pull_request} if pull_request else {}),
             },
             "tests": [{"command": "make smoke", "returncode": 0}],
         },
@@ -467,3 +514,534 @@ def test_required_status_check_contexts_is_unknown_without_credentials(monkeypat
         )
         is None
     )
+
+
+# ---------------------------------------------------------------------------
+# The AGENT owns the pull request; the hub records it and gates completion.
+# ---------------------------------------------------------------------------
+
+
+def test_hub_reuses_the_pull_request_the_agent_opened(cp, tmp_path, monkeypatch):
+    """Opening a PR is the agent's job. The hub must not open a second one."""
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(
+        cp,
+        source,
+        task_head,
+        pull_request={
+            "opened": True,
+            "forge": "github",
+            "number": 77,
+            "url": "https://github.invalid/acme/widgets/pull/77",
+            "state": "open",
+            "base": "main",
+            "head": "task/feature",
+            "opened_by": "agent",
+        },
+    )
+
+    publication = cp.publish_task(
+        task.id, "git://main", reviewer.id, evidence_id=evidence.id
+    )
+
+    assert publication.status == "published"
+    # The hub opened nothing; it merged the agent's PR, pinned to the head the
+    # reviewer approved.
+    assert forge.opened == []
+    assert forge.merges == [{"number": 77, "method": "squash", "sha": task_head}]
+
+    detail = published_detail(cp, task.id)
+    assert detail["pull_request_number"] == 77
+    assert detail["pull_request_opened_by"] == "agent"
+    opened = next(
+        item for item in detail["commands"] if item["name"] == "open_pull_request"
+    )
+    assert opened["opened_by"] == "agent"
+
+    proof = [
+        item.metadata["verification"]["canonical_integration"]
+        for item in cp.list_evidence(task.id)
+        if item.metadata.get("verification", {}).get("canonical_integration")
+    ][0]
+    assert proof["squash_merged"] is True
+    assert proof["contains_reviewed_head"] is False
+    assert proof["pull_request_opened_by"] == "agent"
+
+
+def test_hub_fallback_pull_request_is_recorded_as_a_fallback(
+    cp, tmp_path, monkeypatch
+):
+    """A worker that opened no PR still publishes -- visibly, not silently."""
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    detail = published_detail(cp, task.id)
+    opened = next(
+        item for item in detail["commands"] if item["name"] == "open_pull_request"
+    )
+    assert opened["opened_by"] == "hub_fallback"
+    assert opened["agent_reason"]
+    assert detail["pull_request_opened_by"] == "hub_fallback"
+
+
+def test_agent_opens_the_pull_request_onto_the_contract_canonical_branch(
+    tmp_path, monkeypatch
+):
+    """canonical_branch comes from the contract; it is never assumed to be main."""
+    calls: list[dict] = []
+
+    def fake_open(repo_url, head, *, base=None, title=None, body=None):
+        calls.append({"repo_url": repo_url, "head": head, "base": base, "title": title})
+        return gitops.PullRequestResult(
+            host="github", number=5, url="https://github.invalid/pull/5", state="open"
+        )
+
+    monkeypatch.setattr(gitops, "resolve_forge", lambda url: "github")
+    monkeypatch.setattr(gitops, "open_pull_request", fake_open)
+    target = gitops.CanonicalPublicationTarget(
+        worktree=tmp_path,
+        canonical_remote_url="https://github.com/acme/widgets.git",
+        remote="https://github.com/acme/widgets.git",
+        remote_display="https://github.com/acme/widgets.git",
+        canonical_branch="release/v2",
+        destination_branch="task/feature",
+        prepared_base_sha="b" * 40,
+        task_head_sha="a" * 40,
+        isolated_ref="refs/mac/task",
+        git_common_dir=tmp_path,
+        lock_path=tmp_path / "lock",
+    )
+
+    outcome = gitops.agent_pull_request(
+        target, task_id="task_1", task_title="widen the widget", head_sha="a" * 40
+    )
+
+    assert outcome["opened"] is True
+    assert outcome["opened_by"] == "agent"
+    assert outcome["number"] == 5
+    assert calls == [
+        {
+            "repo_url": "https://github.com/acme/widgets.git",
+            "head": "task/feature",
+            "base": "release/v2",
+            "title": "widen the widget (task_1)",
+        }
+    ]
+
+
+def test_agent_pull_request_declines_without_a_forge_and_never_raises(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(gitops, "resolve_forge", lambda url: None)
+    target = gitops.CanonicalPublicationTarget(
+        worktree=tmp_path,
+        canonical_remote_url="file:///srv/git/widgets.git",
+        remote="file:///srv/git/widgets.git",
+        remote_display="file:///srv/git/widgets.git",
+        canonical_branch="main",
+        destination_branch="task/feature",
+        prepared_base_sha="b" * 40,
+        task_head_sha="a" * 40,
+        isolated_ref="refs/mac/task",
+        git_common_dir=tmp_path,
+        lock_path=tmp_path / "lock",
+    )
+    outcome = gitops.agent_pull_request(target, task_id="task_1")
+    assert outcome["opened"] is False
+    assert "no API-reachable forge" in outcome["reason"]
+
+
+def test_agent_pull_request_reports_forge_errors_without_the_token(
+    tmp_path, monkeypatch
+):
+    token = "ghp_" + "z" * 36
+    monkeypatch.setenv("GH_TOKEN", token)
+    monkeypatch.setattr(gitops, "resolve_forge", lambda url: "github")
+
+    def boom(*a, **k):
+        raise RuntimeError("bad credentials for token %s" % token)
+
+    monkeypatch.setattr(gitops, "open_pull_request", boom)
+    target = gitops.CanonicalPublicationTarget(
+        worktree=tmp_path,
+        canonical_remote_url="https://github.com/acme/widgets.git",
+        remote="https://github.com/acme/widgets.git",
+        remote_display="https://github.com/acme/widgets.git",
+        canonical_branch="main",
+        destination_branch="task/feature",
+        prepared_base_sha="b" * 40,
+        task_head_sha="a" * 40,
+        isolated_ref="refs/mac/task",
+        git_common_dir=tmp_path,
+        lock_path=tmp_path / "lock",
+    )
+    outcome = gitops.agent_pull_request(target, task_id="task_1")
+    assert outcome["opened"] is False
+    assert token not in outcome["reason"]
+    assert "***" in outcome["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Merge safety: the queue serializes the merges, and the fallback says so.
+# ---------------------------------------------------------------------------
+
+
+def test_merge_queue_enqueues_instead_of_merging_directly(cp, tmp_path, monkeypatch):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge", queue=True)
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert "merge queue" in str(excinfo.value)
+    assert getattr(excinfo.value, "publication_failure_kind", "") == (
+        "pull_request_queued"
+    )
+    assert getattr(excinfo.value, "publication_retry_after_seconds", 0) > 0
+    # Enqueued, pinned to the reviewed head -- and never merged directly.
+    assert forge.enqueued == [{"number": 101, "sha": task_head}]
+    assert forge.merges == []
+    # main is untouched and the task is not complete until the queue lands it.
+    assert git(source, "ls-remote", "origin", "refs/heads/main").split()[0] == main_head
+    assert cp.get_task(task.id).state != TaskState.COMPLETED.value
+
+
+def test_publication_completes_once_the_merge_queue_lands_the_pull_request(
+    cp, tmp_path, monkeypatch
+):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge", queue=True)
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    with pytest.raises(ValidationError):
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    # The queue tests the projected merge and lands it, asynchronously.
+    landed = forge.land_from_queue(task_head)
+
+    publication = cp.publish_task(
+        task.id, "git://main", reviewer.id, evidence_id=evidence.id
+    )
+
+    assert publication.status == "published"
+    assert cp.get_task(task.id).state == TaskState.COMPLETED.value
+    # Observed, not merged a second time.
+    assert forge.merges == []
+    assert len(forge.enqueued) == 1
+    detail = published_detail(cp, task.id)
+    assert detail["final_sha"] == landed
+    assert detail["merge_serialization"] == "merge_queue"
+    serialization = next(
+        item for item in detail["commands"] if item["name"] == "merge_serialization"
+    )
+    assert serialization["merge_queue"] is True
+    assert "what was tested is what lands" in serialization["guarantee"]
+
+
+def test_without_a_merge_queue_the_canonical_tip_is_revalidated_before_merging(
+    cp, tmp_path, monkeypatch
+):
+    """No queue means no serialization, so the tested base must still be the tip.
+
+    The checks ran against a merge candidate built from one canonical tip. If
+    the branch advances before the merge executes, the landed tree was never
+    tested. Without a queue that is caught here: the stale projection is
+    rejected and re-projected instead of merged blind.
+    """
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    # Someone else lands on main between the gate and the merge -- exactly once,
+    # so the second attempt projects onto the tip that is really there.
+    moved: list[str] = []
+
+    def advance_main_once(url, branch):
+        if not moved:
+            other = tmp_path / "other"
+            subprocess.run(
+                ["git", "clone", "--branch", "main", str(remote), str(other)],
+                check=True,
+                capture_output=True,
+            )
+            git(other, "config", "user.email", "other@example.com")
+            git(other, "config", "user.name", "Other Agent")
+            (other / "other.txt").write_text("other\n", encoding="utf-8")
+            git(other, "add", "other.txt")
+            git(other, "commit", "-m", "someone else landed first")
+            git(other, "push", "origin", "HEAD:refs/heads/main")
+            moved.append(git(other, "rev-parse", "HEAD"))
+        return ("sanity",)
+
+    monkeypatch.setattr(
+        gitops, "required_status_check_contexts", advance_main_once
+    )
+
+    publication = cp.publish_task(
+        task.id, "git://main", reviewer.id, evidence_id=evidence.id
+    )
+
+    assert publication.status == "published"
+    detail = published_detail(cp, task.id)
+    # The first attempt refused to merge a projection that was already stale.
+    assert detail["attempt"] == 2
+    assert [item["sha"] for item in forge.merges] == [task_head]
+    # ``commands`` is per-attempt, so this is the second attempt's own
+    # re-validation -- the first attempt's raised before it could merge.
+    revalidations = [
+        item
+        for item in detail["commands"]
+        if item["name"] == "revalidate_canonical_tip"
+    ]
+    assert len(revalidations) == 1
+    serialization = next(
+        item for item in detail["commands"] if item["name"] == "merge_serialization"
+    )
+    assert serialization["merge_queue"] is False
+    assert serialization["mode"] == "direct_squash"
+    assert "not serialized" in serialization["guarantee"]
+    # What landed is a squash of the reviewed head onto the tip that really was
+    # main when the merge was requested.
+    final = git(source, "ls-remote", "origin", "refs/heads/main").split()[0]
+    git(source, "fetch", "origin", "main")
+    parents = git(source, "rev-list", "--parents", "-n", "1", final).split()
+    assert parents[1:] == [moved[0]]
+
+
+def test_merge_queue_enabled_reads_the_branch_ruleset(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    monkeypatch.setattr(
+        gitops,
+        "_http_get_json",
+        lambda *a, **k: [
+            {"type": "pull_request", "parameters": {}},
+            {"type": "merge_queue", "parameters": {"merge_method": "SQUASH"}},
+        ],
+    )
+    assert (
+        gitops.merge_queue_enabled("https://github.com/acme/widgets.git", "main") is True
+    )
+    monkeypatch.setattr(
+        gitops, "_http_get_json", lambda *a, **k: [{"type": "pull_request"}]
+    )
+    assert (
+        gitops.merge_queue_enabled("https://github.com/acme/widgets.git", "main")
+        is False
+    )
+
+
+def test_merge_queue_enabled_is_unknown_without_credentials_or_on_gitea(monkeypatch):
+    for name in ("GH_TOKEN", "GITHUB_TOKEN", "MAC_TASK_GIT_TOKEN", "GITEA_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    assert (
+        gitops.merge_queue_enabled("https://github.com/acme/widgets.git", "main") is None
+    )
+    monkeypatch.setenv("GITEA_TOKEN", "gt_" + "x" * 36)
+    # gitea has no merge queue: unknown, so the caller records the weaker
+    # guarantee rather than assuming serialization it will not get.
+    assert (
+        gitops.merge_queue_enabled("https://gitea.invalid/acme/widgets.git", "main")
+        is None
+    )
+
+
+def test_enqueue_pins_the_reviewed_head_and_classifies_refusals(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    sent: list[dict] = []
+
+    def fake_graphql(url, headers, query, variables, token):
+        sent.append(dict(variables))
+        if "enqueuePullRequest" in query:
+            return {}, ""
+        return (
+            {"repository": {"pullRequest": {"id": "PR_1", "merged": False}}},
+            "",
+        )
+
+    monkeypatch.setattr(gitops, "_graphql", fake_graphql)
+    result = gitops.enqueue_pull_request(
+        "https://github.com/acme/widgets.git", 7, sha="a" * 40
+    )
+    assert result.queued is True
+    assert result.merged is False
+    assert result.serialization == "merge_queue"
+    assert sent[-1]["expectedHeadOid"] == "a" * 40
+
+    def refuse(url, headers, query, variables, token):
+        if "enqueuePullRequest" in query:
+            return {}, "Pull request is not mergeable: required status check pending"
+        return {"repository": {"pullRequest": {"id": "PR_1", "merged": False}}}, ""
+
+    monkeypatch.setattr(gitops, "_graphql", refuse)
+    blocked = gitops.enqueue_pull_request(
+        "https://github.com/acme/widgets.git", 7, sha="a" * 40
+    )
+    assert blocked.blocked is True
+    assert blocked.queued is False
+
+    def explode(url, headers, query, variables, token):
+        if "enqueuePullRequest" in query:
+            return {}, "internal server error"
+        return {"repository": {"pullRequest": {"id": "PR_1", "merged": False}}}, ""
+
+    monkeypatch.setattr(gitops, "_graphql", explode)
+    with pytest.raises(RuntimeError, match="internal server error"):
+        gitops.enqueue_pull_request(
+            "https://github.com/acme/widgets.git", 7, sha="a" * 40
+        )
+
+
+def test_enqueue_failures_never_echo_the_token(monkeypatch):
+    token = "ghp_" + "q" * 36
+    monkeypatch.setenv("GH_TOKEN", token)
+    captured: list[str] = []
+
+    def reflecting_http(url, headers, query, variables, token_arg):
+        captured.append(token_arg)
+        return {}, gitops._scrub_secret(
+            "bad credentials for token %s" % token, token_arg
+        )
+
+    monkeypatch.setattr(gitops, "_graphql", reflecting_http)
+    with pytest.raises(RuntimeError) as excinfo:
+        gitops.enqueue_pull_request(
+            "https://github.com/acme/widgets.git", 7, sha="a" * 40
+        )
+    assert token not in str(excinfo.value)
+    assert captured == [token]
+
+
+# ---------------------------------------------------------------------------
+# The credential: the agent's environment first, the hub's secret store second.
+# ---------------------------------------------------------------------------
+
+
+def _pr_target(tmp_path, remote="https://github.com/acme/widgets.git"):
+    return gitops.CanonicalPublicationTarget(
+        worktree=tmp_path,
+        canonical_remote_url=remote,
+        remote=remote,
+        remote_display=remote,
+        canonical_branch="main",
+        destination_branch="task/feature",
+        prepared_base_sha="b" * 40,
+        task_head_sha="a" * 40,
+        isolated_ref="refs/mac/task",
+        git_common_dir=tmp_path,
+        lock_path=tmp_path / "lock",
+    )
+
+
+class _FakeHubClient:
+    def __init__(self, base_url, *, token=None, transport=None):
+        self.base_url = base_url
+        self.token = token
+        _FakeHubClient.calls.append(base_url)
+
+    calls: list[str] = []
+    payload: dict = {}
+
+    def request(self, method, path, body=None):
+        _FakeHubClient.calls.append((method, path))
+        return dict(_FakeHubClient.payload)
+
+
+def _install_fake_hub(monkeypatch, payload):
+    import mac.http_client as http_client
+
+    _FakeHubClient.calls = []
+    _FakeHubClient.payload = payload
+    monkeypatch.setattr(http_client, "HubClient", _FakeHubClient)
+    monkeypatch.setenv("MAC_API_URL", "https://hub.invalid")
+    monkeypatch.setenv("MAC_API_TOKEN", "hub-token")
+    return _FakeHubClient
+
+
+def test_agent_asks_the_hub_for_the_forge_credential_when_its_env_has_none(
+    tmp_path, monkeypatch
+):
+    for name in ("GH_TOKEN", "GITHUB_TOKEN", "MAC_TASK_GIT_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    hub_token = "ghp_" + "h" * 36
+    client = _install_fake_hub(
+        monkeypatch, {"name": "github.token", "value": hub_token}
+    )
+    seen: list[dict] = []
+
+    def fake_open(repo_url, head, *, base=None, title=None, body=None, **kwargs):
+        seen.append(kwargs)
+        return gitops.PullRequestResult(
+            host="github", number=9, url="https://github.invalid/pull/9", state="open"
+        )
+
+    monkeypatch.setattr(gitops, "open_pull_request", fake_open)
+
+    outcome = gitops.agent_pull_request(_pr_target(tmp_path), task_id="task_1")
+
+    assert outcome["opened"] is True
+    # Resolved BY NAME at the moment of use, not by id and not cached.
+    assert ("POST", "/secrets/github.token/resolve") in client.calls
+    assert seen == [{"github_token": hub_token}]
+
+
+def test_hub_resolved_credential_never_reaches_the_evidence(tmp_path, monkeypatch):
+    for name in ("GH_TOKEN", "GITHUB_TOKEN", "MAC_TASK_GIT_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    hub_token = "ghp_" + "k" * 36
+    _install_fake_hub(monkeypatch, {"name": "github.token", "value": hub_token})
+
+    def boom(*a, **k):
+        raise RuntimeError("forge rejected token %s" % hub_token)
+
+    monkeypatch.setattr(gitops, "open_pull_request", boom)
+
+    outcome = gitops.agent_pull_request(_pr_target(tmp_path), task_id="task_1")
+
+    assert outcome["opened"] is False
+    assert hub_token not in outcome["reason"]
+    assert "***" in outcome["reason"]
+
+
+def test_hub_secret_without_the_forge_capability_is_refused(tmp_path, monkeypatch):
+    for name in ("GH_TOKEN", "GITHUB_TOKEN", "MAC_TASK_GIT_TOKEN"):
+        monkeypatch.delenv(name, raising=False)
+    _install_fake_hub(
+        monkeypatch,
+        {"name": "github.token", "value": "x" * 40, "capabilities": ["slack"]},
+    )
+    monkeypatch.setattr(
+        gitops,
+        "open_pull_request",
+        lambda *a, **k: pytest.fail("called the forge with an unauthorised secret"),
+    )
+
+    outcome = gitops.agent_pull_request(_pr_target(tmp_path), task_id="task_1")
+
+    assert outcome["opened"] is False
+    assert "capability" in outcome["reason"]
+
+
+def test_forge_token_prefers_the_agents_own_environment(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "e" * 36)
+    monkeypatch.setattr(
+        gitops,
+        "forge_token_from_hub",
+        lambda host: pytest.fail("asked the hub for a token it already had"),
+    )
+    assert gitops.forge_token("github") == "ghp_" + "e" * 36
+
+
+def test_forge_token_from_hub_is_empty_without_a_hub(monkeypatch):
+    for name in ("MAC_API_URL", "MAC_URL", "MAC_HUB_URL"):
+        monkeypatch.delenv(name, raising=False)
+    assert gitops.forge_token_from_hub("github") == ""


### PR DESCRIPTION
## What

Three linked changes, one principle: **the hub is a resource orchestrator, not a ringmaster.** Deciding and executing how a task's own work lands belongs to the agent doing the task. Recording that it happened, and gating completion on it, belongs to the hub.

## 1. The agent opens its own pull request

`gitops.agent_pull_request` runs in the worker, right after `guarded_push` puts the task branch on the remote. It opens the PR onto `target.canonical_branch` — from the repository contract, **never assumed to be `main`** — and records the outcome in the worker evidence manifest as `repo.pull_request`. Both agent finalizers use it (`executor_finalizer`, `worker._repository_finalizer`).

It never raises. A repository with no forge is a legitimate configuration and the work is already pushed, so the reason no PR exists is returned for the evidence instead of failing a finalizer.

The hub stops authoring PRs. `_publish_via_pull_request` reuses the agent's, and opens one itself only when the evidence carries none — an older worker, or a forge the agent could not reach. That fallback is recorded (`opened_by: hub_fallback`, plus the agent's reason) rather than being indistinguishable from the normal path.

### The credential answer: **yes, the agent already has one**

- `GH_TOKEN` is written into `~/.mac/mac.env` by `deploy_env.build_mac_env`, and the service wrapper sources it with `set -a` before `exec`ing `mac-agent` (`deploy/fleet-node-install.sh`). K8s workers get it as an optional `secretKeyRef` (`k8s/runner.py`). Executor children inherit `os.environ.copy()`; the sandbox forwards `GH_TOKEN,GITHUB_TOKEN,GITEA_TOKEN` explicitly.
- It is the **same variable** `token_for_host` reads for `guarded_push` and `_forge_api_context` reads for the REST API — not a git-only mechanism. Deploy validates it with `gh auth status`, and `worker.github_credentials_required` defaults true for pure workers, so a worker that deployed successfully has an API-capable credential.
- When it is absent, `forge_token_from_hub` resolves `github.token` from the **hub's Fernet secret store** by name (so rotation does not break publication), at the moment of use — never cached, never written to evidence, never carried in a bus message or task metadata. A secret whose `capabilities` do not include the forge is refused rather than sent to the API to come back as a confusing 401.

No new credential distribution scheme was invented.

## 2. Merge safety — option (b), the merge queue

`merge_queue.py` validates against the projected post-merge state (the "Not Rocket Science Rule"): test the tree that will land, serialize the merges, and post-merge testing is redundant. A plain forge squash-merge does not preserve that — if the canonical branch advances between the checks completing and the merge executing, the landed tree was never tested. Required status checks alone do not close it, and `strict_required_status_checks_policy` is deliberately false here because serial rebasing a ~2 hour `sanity` never converges.

The merge queue closes it: speculative candidates tested in parallel, merged in order. It serializes the **merges** without serializing the **test runs**.

- `merge_queue_enabled` detects it from the same `/rules/branches/{branch}` endpoint the required-checks probe already uses (no admin scope).
- `enqueue_pull_request` enqueues over GraphQL with `expectedHeadOid` pinned to the reviewed head — the same safety `sha` gives the direct merge and `--force-with-lease` gives the push path.
- A successful enqueue is **not** a merge: publication defers with `publication_failure_kind=pull_request_queued` through the existing retry backoff, and a later attempt asks the forge for the PR's state first, so a PR the queue already landed is observed rather than merged twice.

**The not-configured case is handled explicitly, not silently.** A merge queue is a per-repo forge setting and gitea has no equivalent. When there is none, the request degrades to a plain squash merge — but before requesting it, the canonical tip is re-validated against the base this candidate was projected and gated against. A tip that moved raises `_PublicationBaseMovedError` and the existing two-attempt loop re-projects instead of merging blind. Both paths write a `merge_serialization` entry naming the mode **and its guarantee** into the publication evidence and onto the canonical-integration proof.

| branch has | what mac does | guarantee |
| --- | --- | --- |
| a merge queue | enqueue pinned to the reviewed head | what was tested is what lands |
| no queue / gitea / unreadable ruleset | re-validate the canonical tip, then squash | weaker: not serialized; the re-validation stands in for it |

No repository settings were touched. This works whether or not the queue is enabled yet.

## 3. Verify, do not assume — the bypass makes the forge gate vacuous

The fleet authenticates as the repository owner, and ruleset 20954943 carries a `RepositoryRole` bypass with mode `always` (deliberate operator break-glass). The publication identity inherits it.

Measured: task_88443a13 → PR #399, created `01:05:54Z`, merged `01:05:56Z`. **Two seconds.** Every required context reported SKIPPED. Nothing gated it — not the forge (bypassed), and not the local contract gate, which #396 deliberately skips *because* the forge reports required checks. A gate reporting healthy while enforcing nothing.

So the requester verifies. `required_check_verdicts` asks the forge, for the exact head SHA being merged, whether each required context has a SUCCESS conclusion — reading both the combined status API and check-runs. Only then is the merge requested.

- not-reported / queued / in-progress / **`skipped`** → pending → defers via the existing `pull_request_checks_pending` kind and backoff. `skipped` is called out deliberately: that is what #399's contexts reported, and treating it as a pass is the bug.
- a real failure → `pull_request_checks_failed`, raised rather than looped.
- a forge that cannot be asked → `unverifiable`, which defers. Never "fine".
- **empty required list ≠ checks not started.** The first is an unprotected repository, gated by the hub's own contract run; the second is a gate that has not run. Recorded separately as `required_check_verification.case` (`none_configured` / `verified` / `pending` / `failed` / `unverifiable`).

This composes with the queue rather than duplicating it, and neither depends on an ACL staying configured a particular way.

## Preserved from #396

Reviewed head pinned on merge, `blocked` vs raised classification, `pull_request_checks_pending` deferring through the existing backoff, PR reuse on retry, the `direct_push` fallback for repos with no forge, `MAC_PUBLICATION_STRATEGY`, and the squash-honesty proof (`squash_merged: true` / `contains_reviewed_head: false`) that the completion gate accepts. All 16 original tests in `tests/test_publication_pull_request.py` are unchanged in what they assert.

## Secrets

Every string escaping the new helpers goes through `_scrub_secret` — the agent-side PR failure reason (with the env *or* hub-resolved token as the secret) and the GraphQL error path included. Three tests extend `test_merge_failures_never_echo_the_token`'s standard to the agent path and the hub-resolved credential.

## Tests

`tests/test_publication_pull_request.py`: **16 → 41**. New coverage, each failing without the change:

- the hub reuses the agent's PR and opens none; the hub fallback is recorded *as* a fallback
- the agent's PR targets the contract's canonical branch (`release/v2`, not `main`)
- the queue enqueues instead of merging, and the task does not complete until the queue lands it; the second attempt observes the landing instead of merging twice
- without a queue, a canonical tip that moved forces a re-projection instead of a blind merge (attempt 2 squashes onto the tip that really was main)
- pending / failed / unreadable check verdicts each block the merge and leave the canonical branch untouched; `none_configured` is distinct from pending *and* runs the local gate
- ruleset parsing, enqueue pinning and refusal classification, skipped-is-not-success
- the credential path: environment first, hub second, capability refusal, and no token in any message

```
tests/test_publication_pull_request.py ........................ 41 passed
tests/ -k "publish or publication or merge or gitops or finaliz or auto_land" -n 8
                                                          572 passed, 2 failed
tests/test_control_plane.py + public_contract + finalizers -n 8 .. 1077 passed
tests/test_build_test_impact_map.py .. 12 passed (no tests deleted or renamed)
tests/test_docs_accessibility.py ....... 5 passed
```

The two failures are `test_worker_control_edges.py::test_managed_image_*`, pre-existing on `origin/main` and unrelated (this branch does not touch that code path) — the same two #396 recorded.

Gates: contract preflight green (documentation execution, env registry, docs reference, public contract). `dead-code-check.sh` clean. `run-lint.sh` reports only the 6 pre-existing F821/F823 errors, none in changed files. `docs/archive/index.md` was already stale on `main` (ADR 0016 unindexed); regenerating it is what unblocks the docs gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
