### PR TITLE
Resume a failed test gate instead of re-running 11,400 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,24 @@ jobs:
             exit 1
           fi
           echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
+      - name: Restore test-gate checkpoint
+        # A CI job is ephemeral, so the checkpoint that lets a re-run resume
+        # from where it failed has to be carried across runs. Keyed per branch
+        # and restored from the newest entry for that branch: the checkpoint
+        # validates itself against the tree and the runner fingerprint
+        # (src/mac/test_checkpoint.py), so a wrong or stale restore costs a full
+        # run, never a wrong result. `always: true` so a RED run still saves the
+        # checkpoint -- a red run is precisely the one worth resuming from.
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: .mac-test-checkpoint
+          key: mac-test-checkpoint-sanity-${{ github.head_ref }}-${{ github.run_id }}
+          restore-keys: |
+            mac-test-checkpoint-sanity-${{ github.head_ref }}-
+          save-always: true
       - name: Run affected, public-contract, and process-E2E sanity scope
+        env:
+          MAC_TEST_CHECKPOINT: "1"
         run: scripts/run-sanity-tests.sh --base origin/${{ github.base_ref }}
 
   mainline:
@@ -91,9 +108,22 @@ jobs:
             exit 1
           fi
           echo "MAC_TEST_PG_URL=$MAC_TEST_PG_URL" >> "$GITHUB_ENV"
+      - name: Restore test-gate checkpoint
+        # See the sanity job. On main the checkpoint only ever buys a TRIAGE
+        # pass when the gate falls through to the whole-repo coverage run: the
+        # complete, coverage-measured suite still runs before this job can go
+        # green (src/mac/test_checkpoint.py, "COVERAGE FLOORS").
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: .mac-test-checkpoint
+          key: mac-test-checkpoint-mainline-${{ github.run_id }}
+          restore-keys: |
+            mac-test-checkpoint-mainline-
+          save-always: true
       - name: Run impact-selected diff coverage gate (full on unsafe resolution)
         env:
           MAC_TEST_SELECT_BASE: ${{ github.event.before }}
+          MAC_TEST_CHECKPOINT: "1"
         run: scripts/run-contract-tests.sh
       - name: Upload coverage policy evidence
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ coverage.json
 coverage-*.json
 htmlcov/
 .test-portfolio/
+
+# Test-gate checkpoint (src/mac/test_checkpoint.py). Per-workspace operational
+# state that records which test files passed against which tree, so a failed
+# gate run can resume instead of re-running 11,400 tests for a one-line fix.
+# Never product content; CI restores it with actions/cache, not from git.
+.mac-test-checkpoint/
 .venv/
 node_modules/
 dist/

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,9 @@
-"""Repository-wide pytest hooks for opt-in test-portfolio measurement."""
+"""Repository-wide pytest hooks for opt-in test-portfolio measurement and for
+test-gate checkpointing (src/mac/test_checkpoint.py).
+
+Both are inert unless the corresponding environment variable is set, so a plain
+``pytest`` invocation behaves exactly as it did before either existed.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +13,97 @@ from pathlib import Path
 
 
 _PORTFOLIO_RESULTS: dict[str, dict[str, object]] = {}
+
+
+# --------------------------------------------------------------------------
+# Test-gate checkpointing.
+#
+# Two hooks, both driven by environment variables that only
+# scripts/run-contract-tests.sh sets:
+#
+#   MAC_TEST_CHECKPOINT_SKIP_FILE   newline-delimited test FILE paths whose
+#                                   results are being carried forward from a
+#                                   previous run; deselect them.
+#   MAC_TEST_CHECKPOINT_RESULTS_DIR directory to append this run's per-test
+#                                   outcomes into, one JSONL file per process
+#                                   so xdist workers never interleave writes.
+#
+# Deselection happens at collection time, AFTER the modules have been imported,
+# so an import error or a collection-time failure inside a carried-forward file
+# is still a failure. Skipping is by whole FILE, never by individual test: the
+# checkpoint module explains why (module-scoped fixture state).
+# --------------------------------------------------------------------------
+
+
+# True when this interpreter was launched from inside a running test. Captured
+# at import time, before any test of THIS session runs, so it can only be true
+# for a pytest that some other pytest spawned.
+#
+# This matters: the suite has tests that shell out to pytest, and they inherit
+# MAC_TEST_CHECKPOINT_RESULTS_DIR. Without this guard a mini fixture project's
+# deliberately-failing test was recorded into the real repository's checkpoint —
+# observed on the first end-to-end smoke run of this feature. Results from a
+# process the gate did not schedule must never enter the checkpoint.
+_CHECKPOINT_SPAWNED_BY_A_TEST = bool(os.environ.get("PYTEST_CURRENT_TEST"))
+_CHECKPOINT_OWNED = False
+
+
+def pytest_configure(config) -> None:
+    """Decide whether this session owns the checkpoint recording namespace."""
+
+    global _CHECKPOINT_OWNED
+    expected = os.environ.get("MAC_TEST_CHECKPOINT_ROOT", "").strip()
+    if not expected or _CHECKPOINT_SPAWNED_BY_A_TEST:
+        _CHECKPOINT_OWNED = False
+        return
+    try:
+        _CHECKPOINT_OWNED = Path(expected).resolve() == Path(str(config.rootpath)).resolve()
+    except OSError:
+        _CHECKPOINT_OWNED = False
+
+
+def _checkpoint_skip_files() -> set[str]:
+    path = os.environ.get("MAC_TEST_CHECKPOINT_SKIP_FILE", "").strip()
+    if not path:
+        return set()
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError:
+        # Fail OPEN: an unreadable skip list means we skip nothing and the
+        # complete selection runs. A corrupt checkpoint must never be able to
+        # make a red suite look green.
+        return set()
+    return {line.strip() for line in text.splitlines() if line.strip()}
+
+
+def _checkpoint_results_path() -> Path | None:
+    directory = os.environ.get("MAC_TEST_CHECKPOINT_RESULTS_DIR", "").strip()
+    if not directory or not _CHECKPOINT_OWNED:
+        return None
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "") or ("pid%d" % os.getpid())
+    return Path(directory) / ("%s.jsonl" % worker)
+
+
+def pytest_collection_modifyitems(config, items: list) -> None:
+    """Deselect whole test files whose results are carried forward."""
+
+    if not _CHECKPOINT_OWNED:
+        return
+    skip_files = _checkpoint_skip_files()
+    if not skip_files:
+        return
+    root = Path(str(config.rootpath))
+    kept: list = []
+    dropped: list = []
+    for item in items:
+        try:
+            relative = str(Path(str(item.fspath)).resolve().relative_to(root.resolve()))
+        except ValueError:
+            relative = ""
+        (dropped if relative in skip_files else kept).append(item)
+    if dropped:
+        config.hook.pytest_deselected(items=dropped)
+        items[:] = kept
 
 
 def _portfolio_output_path() -> str:
@@ -42,6 +138,7 @@ def pytest_runtest_setup(item) -> None:
 def pytest_runtest_logreport(report) -> None:
     """Accumulate phase duration and the strongest outcome for each node id."""
 
+    _checkpoint_record(report)
     if not _portfolio_output_path():
         return
     record = _PORTFOLIO_RESULTS.setdefault(
@@ -53,6 +150,34 @@ def pytest_runtest_logreport(report) -> None:
         record["outcome"] = "failed"
     elif report.skipped and record["outcome"] != "failed":
         record["outcome"] = "skipped"
+
+
+def _checkpoint_record(report) -> None:
+    """Append this phase report's outcome for the checkpoint recorder.
+
+    Every phase is written, not just ``call``: a setup or teardown error is a
+    failure, and the reader takes the strongest (worst) outcome per node id. A
+    test whose outcome is never written is simply not carried forward, which is
+    the safe direction.
+    """
+
+    path = _checkpoint_results_path()
+    if path is None:
+        return
+    if report.passed and report.when != "call":
+        # Setup/teardown success on its own says nothing; the call phase does.
+        return
+    outcome = "failed" if report.failed else ("skipped" if report.skipped else "passed")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps({"nodeid": report.nodeid, "outcome": outcome}, sort_keys=True) + "\n"
+            )
+    except OSError:
+        # Recording must never change a test result. A run that cannot write
+        # its checkpoint simply produces no checkpoint.
+        return
 
 
 def pytest_sessionfinish(session, exitstatus: int) -> None:

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -22,6 +22,7 @@ their retained sources.
 - [ADR 0013 - One authoritative hub allocator](../adr/0013-authoritative-hub-allocator.md) — `adr/0013-authoritative-hub-allocator.md`
 - [ADR 0014: Agent visibility is a communication boundary, not a dispatch gate](../adr/0014-visibility-is-not-a-dispatch-gate.md) — `adr/0014-visibility-is-not-a-dispatch-gate.md`
 - [ADR 0015: macOS nodes are host installs, not containers](../adr/0015-macos-nodes-are-host-installs.md) — `adr/0015-macos-nodes-are-host-installs.md`
+- [ADR 0016 - Agents decide what a task needs; review is agent-initiated](../adr/0016-agent-initiated-review.md) — `adr/0016-agent-initiated-review.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`
 - [Assessment: task_7023d6a7ef6e4bbf8f6c2da523a4320f](../archive/field-notes/assessment-task-7023d6.md) — `archive/field-notes/assessment-task-7023d6.md`

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -1071,6 +1071,11 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_TASK_SUMMARY_BEGIN` | str | consumer-defined | task-execution | Task Execution setting: task summary begin. |
 | `MAC_TASK_TITLE` | str | consumer-defined | task-execution | Task Execution setting: task title. |
 | `MAC_TASK_WORKSPACE` | str | consumer-defined | task-execution | Task Execution setting: task workspace. |
+| `MAC_TEST_CHECKPOINT` | str | consumer-defined | core | Core setting: test checkpoint. |
+| `MAC_TEST_CHECKPOINT_DIR` | str | consumer-defined | core | Core setting: test checkpoint dir. |
+| `MAC_TEST_CHECKPOINT_RESULTS_DIR` | str | consumer-defined | core | Core setting: test checkpoint results dir. |
+| `MAC_TEST_CHECKPOINT_ROOT` | str | consumer-defined | core | Core setting: test checkpoint root. |
+| `MAC_TEST_CHECKPOINT_SKIP_FILE` | str | consumer-defined | core | Core setting: test checkpoint skip file. |
 | `MAC_TEST_COVERAGE` | str | consumer-defined | core | Core setting: test coverage. |
 | `MAC_TEST_DISABLE_GROUPS` | str | consumer-defined | core | Core setting: test disable groups. |
 | `MAC_TEST_JOBS` | str | 2 | core | Core setting: test jobs. |

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -121,15 +121,25 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
     ),
     "docs/env-config-reference.md": ("tests/test_env_config.py",),
     "scripts/generate-env-config-registry.py": ("tests/test_env_config.py",),
+    # The documentation site's nav. It is a .yml, so it was "opaque" and forced
+    # the whole 11,400-test suite: a stale nav entry pointing at a deleted doc
+    # failed CI 48 minutes in, and the one-line fix cost another 48. The tests
+    # that own it are the ones that read it.
+    "mkdocs.yml": ("tests/test_docs_accessibility.py",),
     "scripts/resolve-impacted-tests.py": ("tests/test_resolve_impacted_tests.py",),
     "scripts/run-contract-tests.sh": ("tests/test_contract_test_runner.py",),
     "scripts/select-sanity-tests.py": ("tests/test_resolve_impacted_tests.py",),
+    "scripts/test-checkpoint.py": ("tests/test_test_checkpoint.py",),
     "src/mac/data/env_config_registry.json": ("tests/test_env_config.py",),
     # Source entry points the coverage map cannot attribute because they run
     # only out-of-process — a git-invoked askpass helper, or an installed
     # console-script copy whose path is outside the src/ prefix the map indexes.
     # Resolved by their reviewed contract rather than fail-closed (see resolve()).
     "src/mac/git_askpass.py": ("tests/test_git_askpass.py",),
+    # The checkpoint rules decide what a resumed gate may SKIP, so a change to
+    # them must run their own contract tests even before the nightly portfolio
+    # run has taught the impact map about this module.
+    "src/mac/test_checkpoint.py": ("tests/test_test_checkpoint.py",),
     "src/mac/investigation_artifacts.py": ("tests/test_per_run_artifact_gitignore.py",),
 }
 

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -62,6 +62,14 @@ _MAC_TEST_SELECT_BASE_REQUESTED="${MAC_TEST_SELECT_BASE:-}"
 # Scheduled full run: after a passing portfolio gate, rebuild the committed
 # test-impact map from the fresh per-test coverage so selection stays fresh.
 _MAC_TEST_REBUILD_MAP_REQUESTED="${MAC_TEST_REBUILD_MAP:-0}"
+# Checkpointing: with MAC_TEST_CHECKPOINT=1 the runner records which test files
+# passed and, on a later invocation, carries those results forward instead of
+# re-running the whole suite for a one-line fix. The rules (what invalidates a
+# checkpoint, what may be skipped, and why coverage floors are NEVER computed
+# from a resumed subset) are in src/mac/test_checkpoint.py. Default 0, so the
+# merge gate is byte-identical unless an operator or CI opts in.
+_MAC_TEST_CHECKPOINT_REQUESTED="${MAC_TEST_CHECKPOINT:-0}"
+_MAC_TEST_CHECKPOINT_DIR_REQUESTED="${MAC_TEST_CHECKPOINT_DIR:-}"
 # Pre-baked runtime venv location for interpreter resolution, captured here
 # because the hermetic MAC_* sweep below unsets every MAC_-prefixed var. Tests
 # point this at a nonexistent path so their staged fake python3 (on PATH) is
@@ -278,6 +286,96 @@ if [ "$#" -eq 0 ] && [ "$_MAC_TEST_NESTED_PYTEST" = "0" ]; then
     "$PY" -m pytest -q -x tests/test_control_plane_public_contract.py
 fi
 
+# --------------------------------------------------------------------------
+# Checkpointing helpers (see src/mac/test_checkpoint.py for the rules).
+#
+# CORRECTNESS BEATS SPEED. Every one of these fails OPEN: a missing, stale,
+# unreadable, or ambiguous checkpoint leaves MAC_TEST_CHECKPOINT_SKIP_FILE
+# unset, the conftest deselection hook inert, and the complete selection
+# running. A corrupt checkpoint can never make a red suite look green.
+# --------------------------------------------------------------------------
+_MAC_CHECKPOINT_DIR=""
+_MAC_CHECKPOINT_SKIP_FILE=""
+_MAC_CHECKPOINT_RESUMED=0
+
+_mac_checkpoint_enabled() {
+    [ "$_MAC_TEST_CHECKPOINT_REQUESTED" = "1" ] && [ "$_MAC_TEST_NESTED_PYTEST" = "0" ]
+}
+
+# Prepare a clean recording namespace for the pytest invocation(s) that follow.
+# Also clears any carry-forward from a previous phase, so a phase that does not
+# explicitly plan a resume runs everything.
+_mac_checkpoint_arm() {
+    _mac_checkpoint_enabled || return 0
+    if [ -z "$_MAC_CHECKPOINT_DIR" ]; then
+        if [ -n "$_MAC_TEST_CHECKPOINT_DIR_REQUESTED" ]; then
+            _MAC_CHECKPOINT_DIR="$_MAC_TEST_CHECKPOINT_DIR_REQUESTED"
+        else
+            _MAC_CHECKPOINT_DIR="$(pwd)/.mac-test-checkpoint"
+        fi
+        _MAC_CHECKPOINT_SKIP_FILE="$_MAC_CHECKPOINT_DIR/carried-forward.txt"
+    fi
+    mkdir -p "$_MAC_CHECKPOINT_DIR"
+    rm -rf "$_MAC_CHECKPOINT_DIR/results"
+    export MAC_TEST_CHECKPOINT_RESULTS_DIR="$_MAC_CHECKPOINT_DIR/results"
+    # Which pytest session OWNS the recording namespace. The suite has tests
+    # that shell out to pytest and they inherit the variables above; without
+    # this, a fixture project's deliberately-failing test lands in the real
+    # repository's checkpoint (observed on this feature's first smoke run). The
+    # conftest hooks record only when their rootdir is this one AND they were
+    # not spawned from inside a running test.
+    export MAC_TEST_CHECKPOINT_ROOT="$(pwd)"
+    unset MAC_TEST_CHECKPOINT_SKIP_FILE
+    _MAC_CHECKPOINT_RESUMED=0
+}
+
+# $1 = 1 when this gate enforces whole-repo coverage floors (so a resume is only
+# a triage pass), 0 when it measures no coverage or only changed-line coverage.
+_mac_checkpoint_plan() {
+    _mac_checkpoint_enabled || return 0
+    [ -n "$_MAC_CHECKPOINT_DIR" ] || return 0
+    rm -f "$_MAC_CHECKPOINT_SKIP_FILE"
+    _ckpt_require=""
+    if [ "$1" = "1" ]; then
+        _ckpt_require="--require-whole-coverage"
+    fi
+    if "$PY" scripts/test-checkpoint.py --dir "$_MAC_CHECKPOINT_DIR" plan \
+        $_ckpt_require --skip-file "$_MAC_CHECKPOINT_SKIP_FILE"; then
+        export MAC_TEST_CHECKPOINT_SKIP_FILE="$_MAC_CHECKPOINT_SKIP_FILE"
+        _MAC_CHECKPOINT_RESUMED=1
+    else
+        _MAC_CHECKPOINT_RESUMED=0
+    fi
+}
+
+# $1 = gate label recorded in the checkpoint document.
+_mac_checkpoint_record() {
+    _mac_checkpoint_enabled || return 0
+    [ -n "$_MAC_CHECKPOINT_DIR" ] || return 0
+    _ckpt_carry=""
+    if [ "$_MAC_CHECKPOINT_RESUMED" = "1" ]; then
+        _ckpt_carry="--carried-forward-file $_MAC_CHECKPOINT_SKIP_FILE"
+    fi
+    "$PY" scripts/test-checkpoint.py --dir "$_MAC_CHECKPOINT_DIR" record \
+        --gate "$1" $_ckpt_carry || true
+}
+
+# A resumed run can legitimately deselect EVERY collected test (nothing in the
+# selection changed since the checkpoint), which pytest reports as exit 5, "no
+# tests ran". That is the success case, not a misconfiguration: the results being
+# carried forward are exactly the evidence exit 5 says is missing. Remapped ONLY
+# when this run actually resumed, so a genuinely empty selection on an
+# unresumed run stays the hard error it has always been.
+_mac_checkpoint_exit() {
+    # $1 = observed pytest exit status; echoes the effective status.
+    if [ "$1" -eq 5 ] && [ "$_MAC_CHECKPOINT_RESUMED" = "1" ]; then
+        echo "run-contract-tests.sh: every selected test was carried forward from the checkpoint; nothing left to run" >&2
+        echo 0
+        return 0
+    fi
+    echo "$1"
+}
+
 # pytest exit code 5 means "no tests were collected". When this runner is
 # invoked from INSIDE a pytest/xdist worker (the outer merge gate parallelizes
 # the whole suite, and some contract tests shell out to this very script), the
@@ -410,12 +508,36 @@ PYCAP
                 echo "impact selection: no tests exercise the changed code (non-code change)"
                 exit 0
             fi
+            # Checkpointing is safe on this path even with coverage on: the gate
+            # here enforces CHANGED-LINE coverage, and the carry-forward rule
+            # re-runs every test the impact map attributes to a changed source
+            # file, so the changed lines are measured exactly as they would be
+            # without a resume. Whole-repo floors are not evaluated here at all.
+            _mac_checkpoint_arm
+            _mac_checkpoint_plan 0
             if [ "$_MAC_TEST_COVERAGE_REQUESTED" = "0" ]; then
-                exec "$PY" -m pytest "$@"
+                sel_fast_status=0
+                "$PY" -m pytest "$@" || sel_fast_status=$?
+                _mac_checkpoint_record "focused-fast"
+                exit "$(_mac_checkpoint_exit "$sel_fast_status")"
             fi
             "$PY" -m coverage erase
             sel_status=0
             "$PY" -m coverage run -m pytest "$@" || sel_status=$?
+            if [ "$sel_status" -eq 5 ] && [ "$_MAC_CHECKPOINT_RESUMED" = "1" ]; then
+                # Every selected test was carried forward, so nothing ran and
+                # there is no coverage data -- and this path still has to prove
+                # the CHANGED LINES are covered. Measuring that from an empty
+                # data set would report every changed line uncovered and fail a
+                # gate that should pass. Drop the carry-forward and run the
+                # focused selection in full; correctness beats speed.
+                echo "impact selection: every selected test was carried forward; re-running the focused selection in full so changed-line coverage is measurable"
+                unset MAC_TEST_CHECKPOINT_SKIP_FILE
+                _MAC_CHECKPOINT_RESUMED=0
+                sel_status=0
+                "$PY" -m coverage run -m pytest "$@" || sel_status=$?
+            fi
+            _mac_checkpoint_record "focused"
             "$PY" -m coverage combine >/dev/null 2>&1 || true
             diff_status=0
             if [ "$sel_status" -eq 0 ]; then
@@ -453,6 +575,10 @@ PYCAP
         if [ -n "$_MAC_TEST_DISABLE_GROUPS_REQUESTED" ]; then
             export MAC_TEST_DISABLE_GROUPS="$_MAC_TEST_DISABLE_GROUPS_REQUESTED"
         fi
+        # No coverage is measured on this path, so a green resumed run is
+        # terminal: there is no coverage number for a subset to distort.
+        _mac_checkpoint_arm
+        _mac_checkpoint_plan 0
         pytest_status=0
         if [ "$_MAC_TEST_JOBS" != "0" ]; then
             "$PY" -m pytest -n "$_MAC_TEST_JOBS" --dist loadscope \
@@ -466,8 +592,56 @@ PYCAP
             "$PY" -m pytest || pytest_status=$?
             pytest_status="$(_mac_pytest_exit "$pytest_status")"
         fi
-        exit "$pytest_status"
+        _mac_checkpoint_record "fast"
+        exit "$(_mac_checkpoint_exit "$pytest_status")"
     fi
+
+    # CHECKPOINT TRIAGE PASS.
+    #
+    # This is the coverage-enforcing gate: statement/branch floors are computed
+    # over the WHOLE repository, and both currently sit within 0.35pp of the
+    # floor. A subset cannot produce that number, and combining a previous run's
+    # coverage data with a resumed run's would OVER-state coverage for any file
+    # whose executing tests changed -- turning a red gate green, which is the
+    # exact failure this whole feature must never cause. So coverage is never
+    # resumed. What is resumed is FAILURE DETECTION: run the not-carried-forward
+    # tests first, without coverage. Red in minutes instead of an hour; green
+    # falls straight through to the complete, unresumed, coverage-measured gate
+    # below, byte-identical to what it has always been.
+    _mac_checkpoint_arm
+    _mac_checkpoint_plan 1
+    if [ "$_MAC_CHECKPOINT_RESUMED" = "1" ]; then
+        echo "run-contract-tests.sh: checkpoint triage pass (no coverage; the" \
+             "whole-repo floors are enforced by the complete gate that follows a green triage)"
+        triage_status=0
+        if [ "$_MAC_TEST_PORTFOLIO_REQUESTED" != "1" ] && [ "$_MAC_TEST_JOBS" != "0" ]; then
+            "$PY" -m pytest -n "$_MAC_TEST_JOBS" --dist loadscope \
+                -m "not ($_SERIAL_MARK)" || triage_status=$?
+            if [ "$triage_status" -eq 0 ]; then
+                "$PY" -m pytest -m "$_SERIAL_MARK" || triage_status=$?
+            fi
+        else
+            "$PY" -m pytest || triage_status=$?
+        fi
+        # Exit 5 here means every remaining test was carried forward, i.e. the
+        # triage had nothing to check. That is not a failure; the complete gate
+        # below is still the authority.
+        if [ "$triage_status" -eq 5 ]; then
+            triage_status=0
+        fi
+        _mac_checkpoint_record "triage"
+        if [ "$triage_status" -ne 0 ]; then
+            echo "run-contract-tests.sh: checkpoint triage pass FAILED; the complete" \
+                 "coverage gate was not attempted. Fix the failures above and re-run —" \
+                 "the next run resumes from this checkpoint." >&2
+            exit "$triage_status"
+        fi
+        echo "run-contract-tests.sh: checkpoint triage pass green; running the" \
+             "complete coverage-measured gate (whole-repo floors need every test)"
+    fi
+    # The complete gate runs everything, always: clear any carry-forward so the
+    # deselection hook is inert, and start a fresh recording namespace.
+    _mac_checkpoint_arm
 
     "$PY" -m coverage erase
     # `patch = ["subprocess"]` in pyproject.toml makes the parent and every
@@ -488,6 +662,10 @@ PYCAP
         "$PY" -m coverage run -m pytest || pytest_status=$?
         pytest_status="$(_mac_pytest_exit "$pytest_status")"
     fi
+    # Record the complete run's outcomes. This is the checkpoint a later failed
+    # iteration resumes from, and it is always written from a full suite, so it
+    # never inherits a subset's blind spots.
+    _mac_checkpoint_record "full"
     # coverage.py can report a corrupt parallel data file as "1 file errored"
     # while still exiting zero after combining the remaining files.  That is a
     # partial measurement, not a passing gate.  Preserve the combine output and
@@ -559,6 +737,15 @@ fi
 # inside a nested pytest/xdist worker. Run them with a single serial owner and
 # apply the same nested exit-5 remap so a legitimately empty child selection is
 # not misread as a hard failure, while every real failure still propagates.
+#
+# This path measures no coverage at all, so a green resumed run is terminal:
+# there is no coverage number a subset could distort. It is the route the PR
+# `sanity` job takes for a focused selection (run-sanity-tests.sh execs this
+# script with the selected test paths).
+_mac_checkpoint_arm
+_mac_checkpoint_plan 0
 _mac_argv_status=0
 "$PY" -m pytest "$@" || _mac_argv_status=$?
+_mac_checkpoint_record "argv"
+_mac_argv_status="$(_mac_checkpoint_exit "$_mac_argv_status")"
 exit "$(_mac_pytest_exit "$_mac_argv_status")"

--- a/scripts/test-checkpoint.py
+++ b/scripts/test-checkpoint.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""CLI over mac.test_checkpoint for scripts/run-contract-tests.sh.
+
+Three verbs:
+
+  plan   decide whether this run may resume from the stored checkpoint, print
+         the human-auditable explanation on stdout, and (on a resume) write the
+         carried-forward test-file list for the conftest deselection hook.
+         Exit 0 => resume, exit 10 => run everything. Any unexpected error also
+         exits 10, because failing OPEN is the whole safety property.
+
+  record fold a finished run's per-test outcomes (the JSONL the conftest hook
+         appended) into a new checkpoint document.
+
+  show   print the stored checkpoint's summary, for operators and CI logs.
+
+The rules themselves live in src/mac/test_checkpoint.py, next to the docstring
+that justifies them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from mac import test_checkpoint as tc  # noqa: E402
+
+EXIT_RESUME = 0
+EXIT_FULL = 10
+
+
+def _directory(args) -> Path:
+    return Path(args.dir) if Path(args.dir).is_absolute() else ROOT / args.dir
+
+
+def cmd_plan(args) -> int:
+    directory = _directory(args)
+    try:
+        decision = tc.plan(
+            repo_root=ROOT,
+            directory=directory,
+            require_whole_coverage=bool(args.require_whole_coverage),
+        )
+    except Exception as exc:  # noqa: BLE001 - fail open, loudly
+        print("test checkpoint: full (planner_error: %s)" % exc)
+        return EXIT_FULL
+    print(tc.render_plan(decision))
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(decision.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    if decision.mode != "resume":
+        return EXIT_FULL
+    if args.skip_file:
+        Path(args.skip_file).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.skip_file).write_text("\n".join(decision.skip_files) + "\n", encoding="utf-8")
+    return EXIT_RESUME
+
+
+def cmd_record(args) -> int:
+    directory = _directory(args)
+    outcomes = tc.ingest_results(tc.results_dir(directory))
+    if not outcomes:
+        print("test checkpoint: no outcomes recorded; leaving any existing checkpoint alone")
+        return 0
+    resolver = tc.load_resolver(ROOT)
+    impact_map = None
+    if resolver is not None:
+        try:
+            impact_map = resolver.load_map(resolver.load_policy().map_path)
+        except Exception:
+            impact_map = None
+    document = tc.build_checkpoint(
+        repo_root=ROOT, outcomes=outcomes, gate=args.gate, impact_map=impact_map
+    )
+    if document is None:
+        print("test checkpoint: tree manifest unavailable; not writing a checkpoint")
+        return 0
+    if args.carried_forward_file:
+        carried = tc.read_carried_forward(Path(args.carried_forward_file))
+        merged = tc.merge_carried_forward(
+            document, tc.load_checkpoint(directory), carried, repo_root=ROOT
+        )
+        if merged is None:
+            print(
+                "test checkpoint: previous checkpoint no longer valid for this tree; "
+                "recording only the tests this run actually executed"
+            )
+        else:
+            document = merged
+    tc.write_checkpoint(directory, document)
+    stats = document["stats"]
+    print(
+        "test checkpoint: recorded %d tests across %d files (%d failed) for gate '%s'"
+        % (stats["recorded_tests"], stats["recorded_files"], stats["failed_tests"], args.gate)
+    )
+    return 0
+
+
+def cmd_show(args) -> int:
+    document = tc.load_checkpoint(_directory(args))
+    if document is None:
+        print("test checkpoint: none stored")
+        return 1
+    print(
+        json.dumps(
+            {
+                "gate": document.get("gate"),
+                "head_sha": document.get("head_sha"),
+                "runner_fingerprint": document.get("runner_fingerprint"),
+                "stats": document.get("stats"),
+                "failed_tests": document.get("failed_tests"),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", default=tc.DEFAULT_DIR, help="checkpoint directory")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    plan = sub.add_parser("plan")
+    plan.add_argument(
+        "--require-whole-coverage",
+        action="store_true",
+        help="this gate enforces whole-repo coverage floors, so a resume is a "
+        "triage pass only and must be followed by the complete gate",
+    )
+    plan.add_argument("--skip-file", help="write the carried-forward test files here")
+    plan.add_argument("--json", help="write the full plan document here")
+    plan.set_defaults(func=cmd_plan)
+
+    record = sub.add_parser("record")
+    record.add_argument("--gate", default="unknown")
+    record.add_argument(
+        "--carried-forward-file",
+        help="the skip list this run resumed with; those files' previous results "
+        "are folded into the new checkpoint so a second resume still knows them",
+    )
+    record.set_defaults(func=cmd_record)
+
+    show = sub.add_parser("show")
+    show.set_defaults(func=cmd_show)
+
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -12684,12 +12684,69 @@
   },
   {
     "default": null,
+    "description": "Core setting: test checkpoint.",
+    "family": "core",
+    "name": "MAC_TEST_CHECKPOINT",
+    "retired": false,
+    "sources": [
+      "scripts/run-contract-tests.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test checkpoint dir.",
+    "family": "core",
+    "name": "MAC_TEST_CHECKPOINT_DIR",
+    "retired": false,
+    "sources": [
+      "scripts/run-contract-tests.sh",
+      "src/mac/test_checkpoint.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test checkpoint results dir.",
+    "family": "core",
+    "name": "MAC_TEST_CHECKPOINT_RESULTS_DIR",
+    "retired": false,
+    "sources": [
+      "scripts/run-contract-tests.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test checkpoint root.",
+    "family": "core",
+    "name": "MAC_TEST_CHECKPOINT_ROOT",
+    "retired": false,
+    "sources": [
+      "scripts/run-contract-tests.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: test checkpoint skip file.",
+    "family": "core",
+    "name": "MAC_TEST_CHECKPOINT_SKIP_FILE",
+    "retired": false,
+    "sources": [
+      "scripts/run-contract-tests.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: test coverage.",
     "family": "core",
     "name": "MAC_TEST_COVERAGE",
     "retired": false,
     "sources": [
-      "scripts/run-contract-tests.sh"
+      "scripts/run-contract-tests.sh",
+      "src/mac/test_checkpoint.py"
     ],
     "type": "str"
   },
@@ -12700,7 +12757,8 @@
     "name": "MAC_TEST_DISABLE_GROUPS",
     "retired": false,
     "sources": [
-      "scripts/run-contract-tests.sh"
+      "scripts/run-contract-tests.sh",
+      "src/mac/test_checkpoint.py"
     ],
     "type": "str"
   },
@@ -12815,7 +12873,8 @@
     "retired": false,
     "sources": [
       "scripts/build-test-impact-map.py",
-      "scripts/run-contract-tests.sh"
+      "scripts/run-contract-tests.sh",
+      "src/mac/test_checkpoint.py"
     ],
     "type": "str"
   },
@@ -12849,7 +12908,8 @@
     "name": "MAC_TEST_SELECT_BASE",
     "retired": false,
     "sources": [
-      "scripts/run-contract-tests.sh"
+      "scripts/run-contract-tests.sh",
+      "src/mac/test_checkpoint.py"
     ],
     "type": "str"
   },

--- a/src/mac/test_checkpoint.py
+++ b/src/mac/test_checkpoint.py
@@ -1,0 +1,802 @@
+"""Resume a failed test-gate run instead of paying for the whole suite again.
+
+CORRECTNESS BEATS SPEED, AND THAT ORDERING IS NOT NEGOTIABLE. A checkpoint that
+lets the gate skip a test which would now fail defeats the entire purpose of the
+gate, so every rule below is written to fail OPEN (run everything) whenever the
+answer is not provable. A missing, stale, unreadable, or ambiguous checkpoint is
+not an error: it is a full run.
+
+WHY THIS EXISTS. CI's `sanity` job runs ~11,400 tests in 50 minutes to 2 hours.
+Real failures observed in one afternoon: a stale ``mkdocs.yml`` nav entry that
+failed 48 minutes in, two assertions out of 11,187, and six tests in one file.
+Each cost a complete second run of the suite to re-verify a one-line fix.
+
+--------------------------------------------------------------------------
+1. WHAT IS A CHECKPOINT KEYED ON?
+--------------------------------------------------------------------------
+NOT the commit sha. Keying on the sha would make every checkpoint worthless the
+moment the one-line fix lands, which is precisely the case worth optimizing.
+
+A checkpoint is keyed on two things:
+
+  * a RUNNER FINGERPRINT -- content hashes of the files that decide what the
+    gate runs and what it asserts (the runner script, both conftests, the
+    pytest/`pyproject` configuration, the selection policy, the lockfile, the
+    committed impact map) plus the interpreter version and the gate-shaping
+    environment. Any difference discards the whole checkpoint, no exceptions.
+
+  * a TREE MANIFEST -- the git blob hash of every tracked and untracked-but-not-
+    ignored file. This is not compared for equality; it is DIFFERENCED against
+    the current tree so the checkpoint survives an edit and we can reason about
+    exactly which files moved.
+
+INVALIDATION RULE, stated plainly. A recorded result for test file ``F`` is
+honored on a later run only when ALL of the following hold; otherwise ``F`` runs
+again, and if any of them cannot even be *evaluated* the entire checkpoint is
+discarded and the complete suite runs:
+
+  (a) the checkpoint's schema and runner fingerprint match this run exactly;
+  (b) every test recorded for ``F`` passed -- one failure, error, or unknown
+      outcome in ``F`` re-runs all of ``F``;
+  (c) ``F`` is in neither the policy's nor the impact map's ``always_run``;
+  (d) ``F`` is not itself in the delta (a changed test file re-runs);
+  (e) no file in the delta charges any test to ``F`` under the impact map,
+      the reviewed path contracts, or the ``always_run`` sets;
+  (f) every file in the delta is classifiable -- an unmapped source file, an
+      opaque non-code file, a globally invalidating file, or a source file whose
+      map entry was not built from the bytes present in the checkpointed tree
+      all force a full run.
+
+--------------------------------------------------------------------------
+2. WHAT IS SAFE TO SKIP ON RESUME?
+--------------------------------------------------------------------------
+A test that passed against tree A says nothing about tree B unless the delta
+A->B can be bounded. The committed impact map is exactly that bound, and this
+module deliberately does NOT invent a second bounding rule: it charges the delta
+to tests with the same layers ``scripts/resolve-impacted-tests.py`` uses, at
+FILE granularity, which is the map's own documented safe superset.
+
+Two extra conservatisms on top of the resolver:
+
+  * WHOLE TEST FILES, NEVER INDIVIDUAL TESTS. Skipping half of a module leaves
+    the other half running against different module-scoped fixture state than
+    the run that recorded the result. A file is skipped in full or not at all.
+
+  * ``always_run`` IS ABSOLUTE. The map's docstring says unattributed tests go
+    into ``always_run`` "so the selector can never silently drop them"; a
+    checkpoint that carried them forward would silently drop them one release
+    later. They are never carried forward, on any tree, for any reason.
+
+Skipping is done by DESELECTION at collection time, not by narrowing the pytest
+argv. Collection still imports every test module, so an import error or a
+collection-time failure in a carried-forward file is still caught.
+
+--------------------------------------------------------------------------
+3. WHERE DOES THE CHECKPOINT LIVE?
+--------------------------------------------------------------------------
+A JSON document under ``MAC_TEST_CHECKPOINT_DIR`` (default
+``.mac-test-checkpoint/``, gitignored). That covers the two places the gate
+actually re-runs in the same workspace: an operator or agent iterating locally,
+and ``auto_land.run_contract_gate`` re-invoked in a task workspace. CI is
+ephemeral, so ``.github/workflows/ci.yml`` restores the directory with
+``actions/cache`` keyed per branch.
+
+The document is self-describing and self-validating rather than trusted, so the
+same bytes can later be carried as ledger attempt evidence (``add_evidence`` +
+``evidence_attempt_links`` already store per-attempt artifacts) without changing
+any rule here. That hub-side hop is deliberately NOT implemented yet -- see the
+module's follow-up task -- because a durable store adds nothing until the
+file-backed rules have run in anger.
+
+--------------------------------------------------------------------------
+4. COVERAGE FLOORS
+--------------------------------------------------------------------------
+A partial re-run produces partial coverage data, and the repository's floors sit
+within 0.35pp of failing. Combining a previous run's coverage with a resumed
+run's would over-state coverage for any file whose executing tests changed, and
+an over-stated total can turn a red gate green. That is the exact failure this
+module exists to prevent, so IT IS NEVER DONE.
+
+The rule instead is: THE CHECKPOINT SHORT-CIRCUITS FAILURE, NEVER SUCCESS.
+
+  * On a coverage-enforcing gate, a valid checkpoint buys a TRIAGE PASS: the
+    not-carried-forward tests run first, without coverage. If they fail, the
+    gate exits red in minutes instead of an hour. If they pass, the runner falls
+    through and executes the complete, unresumed, coverage-measured gate exactly
+    as it does today. Whole-repo floors are therefore only ever computed from a
+    complete run -- there is no code path by which a resumed run reports green
+    without one.
+
+  * On a gate that measures no coverage at all (the PR ``sanity`` path, which
+    passes explicit test paths, and ``MAC_TEST_COVERAGE=0``), a green resumed
+    run is terminal, because there is no coverage number to protect.
+
+For the motivating example this turns 50 + 50 minutes into 50 + 3.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+SCHEMA = "mac.test_checkpoint.v1"
+PLAN_SCHEMA = "mac.test_checkpoint_plan.v1"
+DEFAULT_DIR = ".mac-test-checkpoint"
+CHECKPOINT_NAME = "checkpoint.json"
+RESULTS_DIRNAME = "results"
+
+# Files that decide WHAT the gate runs and WHAT it asserts. A byte change in any
+# of them discards the checkpoint outright rather than trying to reason about
+# the consequences.
+FINGERPRINT_FILES = (
+    "scripts/run-contract-tests.sh",
+    "scripts/resolve-impacted-tests.py",
+    "conftest.py",
+    "tests/conftest.py",
+    "pyproject.toml",
+    "test-policy.toml",
+    "uv.lock",
+    "src/mac/data/test_impact_map.json",
+    "src/mac/test_checkpoint.py",
+)
+
+# Environment that changes the gate's meaning. MAC_TEST_JOBS is deliberately
+# absent: worker count changes scheduling, not whether a test passed.
+FINGERPRINT_ENV = (
+    "MAC_TEST_COVERAGE",
+    "MAC_TEST_DISABLE_GROUPS",
+    "MAC_TEST_PORTFOLIO",
+    "MAC_TEST_SELECT_BASE",
+)
+
+
+# --------------------------------------------------------------------------
+# Plan document
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Plan:
+    """The decision, plus enough detail for a human to audit it in the log."""
+
+    mode: str  # "full" | "resume"
+    reason: str
+    skip_files: tuple[str, ...] = ()
+    skip_tests: int = 0
+    recorded_files: int = 0
+    recorded_tests: int = 0
+    delta: tuple[str, ...] = ()
+    previously_failed: tuple[str, ...] = ()
+    coverage_authoritative: bool = True
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema": PLAN_SCHEMA,
+            "mode": self.mode,
+            "reason": self.reason,
+            "skip_files": list(self.skip_files),
+            "skip_tests": self.skip_tests,
+            "recorded_files": self.recorded_files,
+            "recorded_tests": self.recorded_tests,
+            "delta": list(self.delta),
+            "previously_failed": list(self.previously_failed),
+            "coverage_authoritative": self.coverage_authoritative,
+            "notes": list(self.notes),
+        }
+
+
+def _full(reason: str, **kwargs: object) -> Plan:
+    return Plan(mode="full", reason=reason, **kwargs)  # type: ignore[arg-type]
+
+
+def render_plan(plan: Plan) -> str:
+    """Human-auditable one-screen explanation.
+
+    A silent optimization nobody can read is how a CI job once reported green
+    while running zero tests, so every decision prints WHY and HOW MUCH.
+    """
+    lines = ["test checkpoint: %s (%s)" % (plan.mode, plan.reason)]
+    if plan.delta:
+        shown = list(plan.delta[:20])
+        for path in shown:
+            lines.append("  changed since checkpoint: " + path)
+        if len(plan.delta) > len(shown):
+            lines.append("  ... and %d more changed files" % (len(plan.delta) - len(shown)))
+    if plan.previously_failed:
+        shown_f = list(plan.previously_failed[:20])
+        for nodeid in shown_f:
+            lines.append("  previously failed: " + nodeid)
+        if len(plan.previously_failed) > len(shown_f):
+            lines.append(
+                "  ... and %d more previously-failing tests"
+                % (len(plan.previously_failed) - len(shown_f))
+            )
+    for note in plan.notes:
+        lines.append("  note: " + note)
+    if plan.mode == "resume":
+        lines.append(
+            "  carrying forward %d test files (%d tests) that passed and that no "
+            "changed file charges a test to" % (len(plan.skip_files), plan.skip_tests)
+        )
+        lines.append(
+            "  re-running %d of %d recorded test files"
+            % (plan.recorded_files - len(plan.skip_files), plan.recorded_files)
+        )
+        if not plan.coverage_authoritative:
+            lines.append(
+                "  coverage: this is a TRIAGE pass only -- whole-repo floors are "
+                "NOT evaluated here; a green triage falls through to the complete gate"
+            )
+    else:
+        lines.append("  running the complete suite (checkpointing declined)")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# Tree manifest + fingerprint
+# --------------------------------------------------------------------------
+
+
+def _git(argv: list[str], repo_root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *argv],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _hash_paths(paths: Iterable[str], repo_root: Path) -> dict[str, str]:
+    """git blob hashes for worktree contents, batched through hash-object."""
+    listed = [p for p in paths if p]
+    if not listed:
+        return {}
+    proc = subprocess.run(
+        ["git", "hash-object", "--stdin-paths"],
+        cwd=str(repo_root),
+        input="\n".join(listed) + "\n",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return {}
+    digests = proc.stdout.split()
+    if len(digests) != len(listed):
+        return {}
+    return dict(zip(listed, digests))
+
+
+def tree_manifest(repo_root: Path) -> dict[str, str] | None:
+    """path -> git blob hash for every tracked + untracked-not-ignored file.
+
+    None on any git failure, which the caller must treat as "run everything":
+    a manifest we cannot build is a delta we cannot bound.
+    """
+    staged = _git(["ls-files", "-s"], repo_root)
+    if staged.returncode != 0:
+        return None
+    manifest: dict[str, str] = {}
+    for line in staged.stdout.splitlines():
+        # "<mode> <sha> <stage>\t<path>"
+        meta, _, path = line.partition("\t")
+        parts = meta.split()
+        if not path or len(parts) < 2:
+            return None
+        manifest[path] = parts[1]
+
+    # The index hash is stale for anything edited but not staged, and the whole
+    # point of this module is to survive exactly that edit.
+    dirty = _git(["diff-files", "--name-only"], repo_root)
+    if dirty.returncode != 0:
+        return None
+    changed = [p for p in dirty.stdout.splitlines() if p]
+
+    untracked = _git(["ls-files", "--others", "--exclude-standard"], repo_root)
+    if untracked.returncode != 0:
+        return None
+    changed.extend(p for p in untracked.stdout.splitlines() if p)
+
+    if changed:
+        rehashed = _hash_paths(changed, repo_root)
+        if len(rehashed) != len(set(changed)):
+            return None
+        manifest.update(rehashed)
+
+    # A file deleted from the worktree but still in the index is not part of
+    # this tree. Dropping it makes it show up in the delta, which is correct.
+    for path in list(manifest):
+        if not (repo_root / path).is_file():
+            manifest.pop(path, None)
+    return manifest
+
+
+def _sha256_file(path: Path) -> str | None:
+    try:
+        return "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def map_source_hashes(repo_root: Path, impact_map: dict | None) -> dict[str, str]:
+    """sha256 of each mapped source file, in the impact map's own hash scheme.
+
+    Recorded at checkpoint-write time so a later run can ask the question
+    ``_fresh_map_files`` asks of git -- "was the map built from these bytes?" --
+    without needing the checkpointed tree to still exist as a commit.
+    """
+    if not impact_map:
+        return {}
+    result: dict[str, str] = {}
+    for name in impact_map.get("file_tests", {}):
+        digest = _sha256_file(repo_root / name)
+        if digest is not None:
+            result[name] = digest
+    return result
+
+
+def runner_fingerprint(repo_root: Path, env: dict[str, str] | None = None) -> str:
+    env = dict(os.environ if env is None else env)
+    parts: list[str] = [
+        "python=%s" % platform.python_version(),
+        "impl=%s" % platform.python_implementation(),
+        "platform=%s" % sys.platform,
+    ]
+    for name in FINGERPRINT_FILES:
+        digest = _sha256_file(repo_root / name) or "absent"
+        parts.append("%s=%s" % (name, digest))
+    for name in FINGERPRINT_ENV:
+        parts.append("%s=%s" % (name, env.get(name, "")))
+    return "sha256:" + hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+
+
+# --------------------------------------------------------------------------
+# Result ingestion (written by the conftest hooks)
+# --------------------------------------------------------------------------
+
+
+def _test_file(nodeid: str) -> str:
+    return nodeid.split("::", 1)[0]
+
+
+def ingest_results(results_dir: Path) -> dict[str, str]:
+    """nodeid -> strongest outcome, merged across every xdist worker's file.
+
+    "Strongest" means failure wins: a test that failed in any phase is failed,
+    never carried forward. An unparsable line is dropped rather than guessed at
+    (the enclosing run still records everything it could read; a file whose
+    results are incomplete simply has fewer passes to carry forward).
+    """
+    outcomes: dict[str, str] = {}
+    if not results_dir.is_dir():
+        return outcomes
+    for path in sorted(results_dir.glob("*.jsonl")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            nodeid = str(record.get("nodeid") or "")
+            outcome = str(record.get("outcome") or "")
+            if not nodeid or outcome not in {"passed", "failed", "skipped"}:
+                continue
+            previous = outcomes.get(nodeid)
+            if previous == "failed":
+                continue
+            if outcome == "failed" or previous is None:
+                outcomes[nodeid] = outcome
+            elif previous == "skipped" and outcome == "passed":
+                # A skip report followed by a pass cannot happen, but if the
+                # data says both, the weaker claim wins.
+                outcomes[nodeid] = "skipped"
+    return outcomes
+
+
+# --------------------------------------------------------------------------
+# Checkpoint document
+# --------------------------------------------------------------------------
+
+
+def build_checkpoint(
+    *,
+    repo_root: Path,
+    outcomes: dict[str, str],
+    gate: str,
+    impact_map: dict | None,
+    env: dict[str, str] | None = None,
+) -> dict[str, object] | None:
+    """Fold a completed run's outcomes into a fresh checkpoint document.
+
+    Returns None when the tree manifest cannot be built, because a checkpoint
+    without a manifest can never be safely resumed from and writing one would
+    only invite a future reader to trust it.
+    """
+    manifest = tree_manifest(repo_root)
+    if manifest is None:
+        return None
+    files: dict[str, dict[str, int]] = {}
+    failed: list[str] = []
+    for nodeid, outcome in outcomes.items():
+        entry = files.setdefault(_test_file(nodeid), {"passed": 0, "failed": 0, "other": 0})
+        if outcome == "passed":
+            entry["passed"] += 1
+        elif outcome == "failed":
+            entry["failed"] += 1
+            failed.append(nodeid)
+        else:
+            entry["other"] += 1
+    head = _git(["rev-parse", "HEAD"], repo_root)
+    return {
+        "schema": SCHEMA,
+        "gate": gate,
+        "head_sha": head.stdout.strip() if head.returncode == 0 else None,
+        "runner_fingerprint": runner_fingerprint(repo_root, env),
+        "tree": manifest,
+        "map_source_hashes": map_source_hashes(repo_root, impact_map),
+        "files": files,
+        "failed_tests": sorted(failed),
+        "stats": {
+            "recorded_tests": len(outcomes),
+            "recorded_files": len(files),
+            "failed_tests": len(failed),
+        },
+    }
+
+
+def read_carried_forward(path: Path) -> set[str]:
+    try:
+        return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+    except OSError:
+        return set()
+
+
+def merge_carried_forward(
+    document: dict[str, object],
+    previous: dict | None,
+    carried: set[str],
+    *,
+    repo_root: Path,
+) -> dict[str, object] | None:
+    """Fold a resumed run's carried-forward files back into the new checkpoint.
+
+    A resumed run only executes part of the suite, so on its own it records only
+    that part -- and the NEXT run would then have nothing to carry forward,
+    making every resume a one-shot. Folding the previous entries forward keeps
+    the chain alive.
+
+    This is sound because the charging rule is file-level and content-based, so
+    it composes: if the A->B delta charges nothing to F and the B->C delta
+    charges nothing to F, then neither does A->C, because every file that
+    differs between A and C differs in at least one of the two hops and was
+    therefore charged in that hop. Returns None when the previous checkpoint is
+    not the one this run resumed from (different fingerprint), in which case the
+    caller must record only what actually ran.
+    """
+    if previous is None or not carried:
+        return None
+    if previous.get("runner_fingerprint") != document.get("runner_fingerprint"):
+        return None
+    previous_files: dict[str, dict[str, int]] = previous.get("files") or {}
+    files: dict[str, dict[str, int]] = dict(document.get("files") or {})  # type: ignore[arg-type]
+    merged = 0
+    for name in sorted(carried):
+        entry = previous_files.get(name)
+        if not entry or name in files:
+            continue
+        if int(entry.get("failed") or 0) or int(entry.get("other") or 0):
+            # Never promote a non-passing entry across a resume.
+            continue
+        files[name] = dict(entry)
+        merged += 1
+    document = dict(document)
+    document["files"] = files
+    document["carried_forward_files"] = merged
+    stats = dict(document.get("stats") or {})  # type: ignore[arg-type]
+    stats["recorded_files"] = len(files)
+    stats["recorded_tests"] = sum(
+        int(entry.get("passed") or 0) + int(entry.get("failed") or 0) + int(entry.get("other") or 0)
+        for entry in files.values()
+    )
+    document["stats"] = stats
+    return document
+
+
+def checkpoint_path(directory: Path) -> Path:
+    return directory / CHECKPOINT_NAME
+
+
+def results_dir(directory: Path) -> Path:
+    return directory / RESULTS_DIRNAME
+
+
+def write_checkpoint(directory: Path, document: dict[str, object]) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    target = checkpoint_path(directory)
+    tmp = target.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(document, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.replace(target)
+
+
+def load_checkpoint(directory: Path) -> dict | None:
+    """The stored document, or None for anything we would have to guess about."""
+    try:
+        document = json.loads(checkpoint_path(directory).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(document, dict) or document.get("schema") != SCHEMA:
+        return None
+    if not isinstance(document.get("tree"), dict) or not isinstance(document.get("files"), dict):
+        return None
+    return document
+
+
+# --------------------------------------------------------------------------
+# The resolver (loaded from its hyphenated script, as select-sanity-tests does)
+# --------------------------------------------------------------------------
+
+_RESOLVER_NAME = "mac_resolve_impacted_tests"
+
+
+def load_resolver(repo_root: Path):
+    """Import scripts/resolve-impacted-tests.py, or None if it is unavailable.
+
+    The charging rules live there and are unit-tested there; duplicating them
+    here would let the two drift, and a drifted copy is a copy that skips a test
+    the resolver would have run.
+    """
+    if _RESOLVER_NAME in sys.modules:
+        return sys.modules[_RESOLVER_NAME]
+    path = repo_root / "scripts" / "resolve-impacted-tests.py"
+    spec = importlib.util.spec_from_file_location(_RESOLVER_NAME, path)
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_RESOLVER_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(_RESOLVER_NAME, None)
+        return None
+    return module
+
+
+@dataclass
+class Charge:
+    """Which test files the delta forces back onto the run list."""
+
+    files: set[str] = field(default_factory=set)
+    full_reason: str | None = None
+    notes: list[str] = field(default_factory=list)
+
+
+def charge_delta(
+    delta: Iterable[str],
+    *,
+    repo_root: Path,
+    resolver,
+    policy,
+    impact_map: dict | None,
+    checkpoint_map_hashes: dict[str, str],
+) -> Charge:
+    """File-level charging of a delta to test files, fail-open on anything odd.
+
+    This is the resolver's layering (global paths -> reviewed path contracts ->
+    test files -> impact map -> full) collapsed to file granularity, which the
+    map's builder documents as its safe superset. It is deliberately COARSER
+    than ``resolve()``: no line-level or scope-level narrowing, because those
+    need two git revisions of the file and a checkpointed tree is not a commit.
+    Coarser means it charges MORE tests back onto the run list, never fewer.
+    """
+    charge = Charge()
+    contracts = getattr(resolver, "PATH_TEST_CONTRACTS", {})
+    file_tests = (impact_map or {}).get("file_tests", {})
+    nodeids = (impact_map or {}).get("nodeids", [])
+    map_hashes = (impact_map or {}).get("file_hashes", {})
+
+    for path in sorted({p for p in delta if p}):
+        if path in getattr(policy, "global_full_paths", frozenset()):
+            charge.full_reason = "global_infrastructure_changed"
+            return charge
+        if path in contracts:
+            charge.files.update(contracts[path])
+            continue
+        # A path can be BOTH (plugin/test_*.py is a test file AND source), so
+        # these are unioned rather than treated as alternatives -- the resolver
+        # does the same, and charging twice is always the safe direction.
+        is_test = resolver._is_test_file(path)
+        is_source = resolver._is_source_code(path)
+        if is_test:
+            charge.files.add(path)
+        if not is_source:
+            if is_test or resolver._is_documentation(path):
+                # Documentation selects no tests, exactly as the resolver
+                # decides. The executable-documentation guards are in
+                # always_run, which is never carried forward, so they still run.
+                continue
+            # Opaque shell/CI/data/config: nothing can tie it to the tests that
+            # exercise it. The resolver runs everything here and so do we.
+            charge.full_reason = "unmappable_non_code_change"
+            return charge
+        if path not in file_tests:
+            # A source file the map never saw (new, or renamed into place).
+            # resolve() leans on CodeGraph here; CodeGraph needs a git base we
+            # do not have, so this is a full run.
+            charge.full_reason = "source_file_absent_from_impact_map"
+            return charge
+        if map_hashes.get(path) != checkpoint_map_hashes.get(path):
+            # The map's knowledge of this file was not built from the bytes that
+            # were present when the checkpoint was taken, so the tests it
+            # attributes are not the tests that ran. Content-identity is the
+            # same question ``_fresh_map_files`` asks git about ancestry, asked
+            # of a tree that may never have been committed.
+            charge.full_reason = "impact_map_stale_for_changed_file"
+            return charge
+        for index in file_tests.get(path, []):
+            if 0 <= index < len(nodeids):
+                charge.files.add(_test_file(nodeids[index]))
+            else:
+                charge.full_reason = "impact_map_index_out_of_range"
+                return charge
+    return charge
+
+
+def always_run_files(policy, impact_map: dict | None) -> set[str]:
+    """Test files that must never be carried forward, from both sources."""
+    always = set(getattr(policy, "always_run", ()) or ())
+    if impact_map:
+        always.update(impact_map.get("always_run", []) or [])
+    return always
+
+
+# --------------------------------------------------------------------------
+# The decision
+# --------------------------------------------------------------------------
+
+
+def plan(
+    *,
+    repo_root: Path,
+    directory: Path,
+    require_whole_coverage: bool,
+    env: dict[str, str] | None = None,
+    resolver=None,
+    policy=None,
+    impact_map=None,
+) -> Plan:
+    """Decide whether to resume, and from where. Fail open at every step."""
+    document = load_checkpoint(directory)
+    if document is None:
+        return _full("no_usable_checkpoint")
+
+    fingerprint = runner_fingerprint(repo_root, env)
+    if document.get("runner_fingerprint") != fingerprint:
+        return _full(
+            "runner_fingerprint_changed",
+            notes=(
+                "the runner, its configuration, the impact map, or the gate "
+                "environment changed since the checkpoint",
+            ),
+        )
+
+    recorded_files: dict[str, dict[str, int]] = document.get("files") or {}
+    previously_failed = tuple(document.get("failed_tests") or [])
+    recorded_tests = int((document.get("stats") or {}).get("recorded_tests") or 0)
+    if not recorded_files:
+        return _full("checkpoint_recorded_no_tests")
+
+    manifest = tree_manifest(repo_root)
+    if manifest is None:
+        return _full("tree_manifest_unavailable")
+    stored: dict[str, str] = document.get("tree") or {}
+    delta = tuple(
+        sorted(
+            {p for p in stored if stored.get(p) != manifest.get(p)}
+            | {p for p in manifest if manifest.get(p) != stored.get(p)}
+        )
+    )
+
+    resolver = resolver if resolver is not None else load_resolver(repo_root)
+    if resolver is None:
+        return _full("resolver_unavailable", delta=delta)
+    try:
+        policy = policy if policy is not None else resolver.load_policy()
+        if impact_map is None:
+            impact_map = resolver.load_map(policy.map_path)
+    except Exception:
+        return _full("selection_policy_unreadable", delta=delta)
+    if not impact_map:
+        return _full("impact_map_unavailable", delta=delta)
+
+    charge = charge_delta(
+        delta,
+        repo_root=repo_root,
+        resolver=resolver,
+        policy=policy,
+        impact_map=impact_map,
+        checkpoint_map_hashes=document.get("map_source_hashes") or {},
+    )
+    if charge.full_reason:
+        return _full(charge.full_reason, delta=delta, previously_failed=previously_failed)
+
+    never_skip = always_run_files(policy, impact_map) | charge.files | set(delta)
+
+    skip_files: list[str] = []
+    skip_tests = 0
+    for name, counts in sorted(recorded_files.items()):
+        if name in never_skip:
+            continue
+        if int(counts.get("failed") or 0) or int(counts.get("other") or 0):
+            # A failure re-runs, obviously. A skip/xfail also re-runs: its
+            # outcome depended on runtime conditions we did not record, so
+            # "it did not fail last time" is not a result to carry forward.
+            continue
+        passed = int(counts.get("passed") or 0)
+        if passed <= 0:
+            continue
+        if not (repo_root / name).is_file():
+            # Deleted or renamed since the checkpoint. Nothing to skip, and the
+            # rename's new path is in the delta and therefore in never_skip.
+            continue
+        skip_files.append(name)
+        skip_tests += passed
+
+    if not skip_files:
+        return _full(
+            "nothing_can_be_carried_forward",
+            delta=delta,
+            previously_failed=previously_failed,
+            recorded_files=len(recorded_files),
+            recorded_tests=recorded_tests,
+        )
+
+    if require_whole_coverage:
+        # Whole-repo statement/branch floors cannot be measured from a subset,
+        # and combining old coverage with new would over-state any file whose
+        # executing tests changed. So the caller is told the resume is a triage
+        # pass: fast red, and a green falls through to the complete gate.
+        return Plan(
+            mode="resume",
+            reason="triage_pass_only",
+            skip_files=tuple(skip_files),
+            skip_tests=skip_tests,
+            recorded_files=len(recorded_files),
+            recorded_tests=recorded_tests,
+            delta=delta,
+            previously_failed=previously_failed,
+            coverage_authoritative=False,
+            notes=tuple(charge.notes)
+            + (
+                "whole-repo coverage floors are never evaluated on a resumed "
+                "subset; a green triage pass runs the complete gate afterwards",
+            ),
+        )
+
+    return Plan(
+        mode="resume",
+        reason="carried_forward_from_checkpoint",
+        skip_files=tuple(skip_files),
+        skip_tests=skip_tests,
+        recorded_files=len(recorded_files),
+        recorded_tests=recorded_tests,
+        delta=delta,
+        previously_failed=previously_failed,
+        coverage_authoritative=True,
+        notes=tuple(charge.notes),
+    )

--- a/tests/test_contract_test_runner.py
+++ b/tests/test_contract_test_runner.py
@@ -24,6 +24,9 @@ def _run_with_fake_python(
     combine_status: int = 0,
     json_status: int = 0,
     preflight_status: int = 0,
+    checkpoint: str | None = None,
+    checkpoint_plan_status: int = 10,
+    triage_pytest_status: int | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
@@ -31,7 +34,7 @@ def _run_with_fake_python(
     fake_python = bin_dir / "python3"
     fake_python.write_text(
         """#!/bin/sh
-printf 'PYTEST_ADDOPTS=%s\tDISABLE=%s\tCOVERAGE_FILE=%s\t%s\n' "${PYTEST_ADDOPTS-<unset>}" "${MAC_TEST_DISABLE_GROUPS-<unset>}" "${COVERAGE_FILE-<unset>}" "$*" >> "$FAKE_PY_LOG"
+printf 'PYTEST_ADDOPTS=%s\tDISABLE=%s\tCOVERAGE_FILE=%s\tSKIPFILE=%s\t%s\n' "${PYTEST_ADDOPTS-<unset>}" "${MAC_TEST_DISABLE_GROUPS-<unset>}" "${COVERAGE_FILE-<unset>}" "${MAC_TEST_CHECKPOINT_SKIP_FILE-<unset>}" "$*" >> "$FAKE_PY_LOG"
 case "$*" in
     *os.cpu_count*)
         # The runner computes its headroom-aware default worker count with a
@@ -55,6 +58,23 @@ esac
 case "$*" in
     "-m coverage json -o "*) exit "$FAKE_JSON_STATUS" ;;
 esac
+case "$*" in
+    *"scripts/test-checkpoint.py"*" plan"*)
+        # 0 => resume from the checkpoint, 10 (and anything else) => run
+        # everything. The default is 10 because failing OPEN is the property.
+        exit "$FAKE_CHECKPOINT_PLAN_STATUS"
+        ;;
+    *"scripts/test-checkpoint.py"*" record"*) exit 0 ;;
+esac
+if [ -n "$FAKE_TRIAGE_PYTEST_STATUS" ]; then
+    case "$*" in
+        # The interpreter capability probe must keep answering normally.
+        *"--version"*) ;;
+        # A bare `-m pytest ...` under the coverage gate is the checkpoint
+        # triage pass; the measured phases all go through `-m coverage run`.
+        "-m pytest"*) exit "$FAKE_TRIAGE_PYTEST_STATUS" ;;
+    esac
+fi
 case "$*" in
     *"--version"*) ;;
     *"-m pytest"*) exit "$FAKE_PYTEST_STATUS" ;;
@@ -81,6 +101,10 @@ exit 0
         "FAKE_JSON_STATUS": str(json_status),
         "FAKE_PREFLIGHT_STATUS": str(preflight_status),
         "FAKE_PYTEST_STATUS": str(pytest_status),
+        "FAKE_CHECKPOINT_PLAN_STATUS": str(checkpoint_plan_status),
+        "FAKE_TRIAGE_PYTEST_STATUS": (
+            "" if triage_pytest_status is None else str(triage_pytest_status)
+        ),
         # Deterministic answer to the runner's headroom-default cpu probe.
         "FAKE_DEFAULT_JOBS": "6",
         # This must never leak into either pytest phase.
@@ -101,6 +125,11 @@ exit 0
         env["MAC_TEST_DISABLE_GROUPS"] = disable_groups
     if select_base is not None:
         env["MAC_TEST_SELECT_BASE"] = select_base
+    env.pop("MAC_TEST_CHECKPOINT", None)
+    env.pop("MAC_TEST_CHECKPOINT_DIR", None)
+    if checkpoint is not None:
+        env["MAC_TEST_CHECKPOINT"] = checkpoint
+        env["MAC_TEST_CHECKPOINT_DIR"] = str(tmp_path / "ckpt")
     if nested_pytest:
         env["PYTEST_CURRENT_TEST"] = (
             "tests/test_contract_test_runner.py::test_nested (call)"
@@ -740,3 +769,121 @@ exit 0
         "MAC_CODEX_TOKEN",
     ):
         assert recorded.get(var) == "<unset>", (var, recorded)
+
+
+# --------------------------------------------------------------------------
+# Test-gate checkpointing (src/mac/test_checkpoint.py).
+#
+# The property is not "resuming is fast", it is "a resumed run can never report
+# green without the evidence a full run would have produced". The coverage gate
+# is the sharp edge: whole-repo floors sit within 0.35pp of failing, so a subset
+# must never be allowed to compute them.
+# --------------------------------------------------------------------------
+
+
+def _checkpoint_calls(calls: list[str], verb: str) -> list[str]:
+    return [call for call in calls if "scripts/test-checkpoint.py" in call and verb in call]
+
+
+def test_contract_runner_is_byte_identical_without_the_checkpoint_flag(tmp_path):
+    """Default off: the merge gate must be unchanged unless someone opts in."""
+    completed, calls = _run_with_fake_python(tmp_path)
+    assert completed.returncode == 0
+    assert _checkpoint_calls(calls, "plan") == []
+    assert _checkpoint_calls(calls, "record") == []
+
+
+def test_contract_runner_declined_checkpoint_runs_the_normal_full_gate(tmp_path):
+    """Plan exit 10 means "run everything"; no triage phase may appear."""
+    completed, calls = _run_with_fake_python(
+        tmp_path, checkpoint="1", checkpoint_plan_status=10
+    )
+    assert completed.returncode == 0
+    assert len(_checkpoint_calls(calls, "plan")) == 1
+    assert "checkpoint triage pass" not in completed.stdout
+    bulk = [c for c in calls if "-m coverage run -m pytest" in c]
+    assert len(bulk) == 2, "the usual bulk + serial coverage phases, unchanged"
+    assert not [c for c in calls if c.endswith("-m pytest") or "\t-m pytest -n" in c]
+
+
+def test_contract_runner_checkpoint_triage_precedes_the_full_coverage_gate(tmp_path):
+    """A green triage must still pay for the complete coverage-measured run."""
+    completed, calls = _run_with_fake_python(
+        tmp_path, checkpoint="1", checkpoint_plan_status=0, triage_pytest_status=0
+    )
+    assert completed.returncode == 0
+    assert "checkpoint triage pass" in completed.stdout
+    assert "running the" in completed.stdout and "complete coverage-measured gate" in completed.stdout
+    triage = [c for c in calls if "\t-m pytest" in c]
+    assert triage, "the triage phase runs pytest WITHOUT coverage"
+    assert len([c for c in calls if "-m coverage run -m pytest" in c]) == 2, (
+        "the complete gate still runs both measured phases in full"
+    )
+
+
+def test_contract_runner_checkpoint_triage_clears_the_skip_list_for_the_full_gate(tmp_path):
+    """The complete gate must never see a carry-forward list.
+
+    If the deselection hook were still armed, the coverage total would be
+    computed from a subset -- the exact way a resumed run could turn a red gate
+    green.
+    """
+    completed, calls = _run_with_fake_python(
+        tmp_path, checkpoint="1", checkpoint_plan_status=0, triage_pytest_status=0
+    )
+    assert completed.returncode == 0
+    measured = [c for c in calls if "-m coverage run -m pytest" in c]
+    assert measured
+    for call in measured:
+        assert "SKIPFILE=<unset>" in call, call
+
+
+def test_contract_runner_failed_triage_never_reaches_the_coverage_gate(tmp_path):
+    completed, calls = _run_with_fake_python(
+        tmp_path, checkpoint="1", checkpoint_plan_status=0, triage_pytest_status=1
+    )
+    assert completed.returncode == 1
+    assert "checkpoint triage pass FAILED" in completed.stderr
+    assert [c for c in calls if "-m coverage run -m pytest" in c] == [], (
+        "a red triage must not spend an hour re-confirming the failure"
+    )
+
+
+def test_contract_runner_empty_triage_selection_is_not_a_failure(tmp_path):
+    """Everything carried forward => pytest exit 5 => nothing to triage."""
+    completed, calls = _run_with_fake_python(
+        tmp_path, checkpoint="1", checkpoint_plan_status=0, triage_pytest_status=5
+    )
+    assert completed.returncode == 0
+    assert len([c for c in calls if "-m coverage run -m pytest" in c]) == 2
+
+
+def test_contract_runner_records_a_checkpoint_after_the_full_gate(tmp_path):
+    completed, calls = _run_with_fake_python(tmp_path, checkpoint="1")
+    assert completed.returncode == 0
+    assert any("--gate full" in call for call in _checkpoint_calls(calls, "record"))
+
+
+def test_contract_runner_fast_mode_resume_is_terminal(tmp_path):
+    """No coverage is measured, so a green resumed run needs no second pass."""
+    completed, calls = _run_with_fake_python(
+        tmp_path, checkpoint="1", checkpoint_plan_status=0, coverage="0"
+    )
+    assert completed.returncode == 0
+    assert "checkpoint triage pass" not in completed.stdout
+    assert [c for c in calls if "-m coverage run" in c] == []
+    assert any("--gate fast" in call for call in _checkpoint_calls(calls, "record"))
+
+
+def test_contract_runner_nested_invocation_never_checkpoints(tmp_path):
+    """A nested runner is a contract test of this script, not a gate run.
+
+    Letting it write the checkpoint would record a synthetic single-owner run as
+    if it were the real suite.
+    """
+    completed, calls = _run_with_fake_python(
+        tmp_path, checkpoint="1", checkpoint_plan_status=0, nested_pytest=True
+    )
+    assert completed.returncode == 0
+    assert _checkpoint_calls(calls, "plan") == []
+    assert _checkpoint_calls(calls, "record") == []

--- a/tests/test_test_checkpoint.py
+++ b/tests/test_test_checkpoint.py
@@ -1,0 +1,754 @@
+"""Contract tests for test-gate checkpointing (src/mac/test_checkpoint.py).
+
+The property under test is not "resuming is fast". It is "resuming never skips a
+test that would now fail". Every case below is written from that direction: a
+checkpoint must be invalidated when it must be, a previously-failing test must
+still be run and still fail, and anything unreadable, stale, or ambiguous must
+produce a full run rather than a narrower one.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mac import test_checkpoint as tc
+
+
+# --------------------------------------------------------------------------
+# A miniature repository, so the git-facing parts are exercised for real.
+# --------------------------------------------------------------------------
+
+
+def _git(repo: Path, *argv: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *argv], cwd=str(repo), capture_output=True, text=True, check=True
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path: Path, request) -> Path:
+    """A tiny git repo whose layout mirrors the real one closely enough.
+
+    It carries a real copy of scripts/resolve-impacted-tests.py and a synthetic
+    impact map, so the charging rules under test are the production ones.
+    """
+    root = tmp_path / "repo"
+    (root / "src" / "mac" / "data").mkdir(parents=True)
+    (root / "scripts").mkdir()
+    (root / "tests").mkdir()
+    (root / "docs").mkdir()
+
+    real_root = Path(__file__).resolve().parents[1]
+    (root / "scripts" / "resolve-impacted-tests.py").write_text(
+        (real_root / "scripts" / "resolve-impacted-tests.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (root / "scripts" / "run-contract-tests.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    (root / "conftest.py").write_text("", encoding="utf-8")
+    (root / "tests" / "conftest.py").write_text("", encoding="utf-8")
+    (root / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    (root / "uv.lock").write_text("", encoding="utf-8")
+    (root / "src" / "mac" / "test_checkpoint.py").write_text("", encoding="utf-8")
+    (root / "test-policy.toml").write_text(
+        "[selection]\n"
+        'global_full_paths = ["conftest.py", "tests/conftest.py", "test-policy.toml", "Makefile"]\n'
+        'always_run = ["tests/test_guard.py"]\n'
+        'impact_map = "src/mac/data/test_impact_map.json"\n',
+        encoding="utf-8",
+    )
+
+    (root / "src" / "mac" / "alpha.py").write_text("A = 1\n", encoding="utf-8")
+    (root / "src" / "mac" / "beta.py").write_text("B = 1\n", encoding="utf-8")
+    (root / "tests" / "test_alpha.py").write_text("def test_a():\n    pass\n", encoding="utf-8")
+    (root / "tests" / "test_beta.py").write_text("def test_b():\n    pass\n", encoding="utf-8")
+    (root / "tests" / "test_guard.py").write_text("def test_g():\n    pass\n", encoding="utf-8")
+    (root / "docs" / "guide.md").write_text("# guide\n", encoding="utf-8")
+
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.invalid")
+    _git(root, "config", "user.name", "t")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "initial")
+    _write_map(root)
+    return root
+
+
+def _write_map(root: Path) -> dict:
+    """An impact map built from the tree exactly as it stands right now."""
+    nodeids = [
+        "tests/test_alpha.py::test_a",
+        "tests/test_beta.py::test_b",
+    ]
+    document = {
+        "schema": "mac.test_impact_map.v1",
+        "base_sha": _git(root, "rev-parse", "HEAD").stdout.strip(),
+        "source_prefix": "src/",
+        "nodeids": nodeids,
+        "file_tests": {"src/mac/alpha.py": [0], "src/mac/beta.py": [1]},
+        "file_line_tests": {},
+        "file_scope_tests": {},
+        "file_hashes": {
+            name: tc._sha256_file(root / name)
+            for name in ("src/mac/alpha.py", "src/mac/beta.py")
+        },
+        "always_run": [],
+        "stats": {},
+    }
+    path = root / "src" / "mac" / "data" / "test_impact_map.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return document
+
+
+def _resolver(repo: Path):
+    # Force a fresh import bound to THIS repo, not the process-wide cache.
+    import sys
+
+    sys.modules.pop(tc._RESOLVER_NAME, None)
+    module = tc.load_resolver(repo)
+    assert module is not None
+    return module
+
+
+def _record(repo: Path, directory: Path, outcomes: dict[str, str]) -> None:
+    resolver = _resolver(repo)
+    impact_map = resolver.load_map(repo / "src" / "mac" / "data" / "test_impact_map.json")
+    document = tc.build_checkpoint(
+        repo_root=repo, outcomes=outcomes, gate="test", impact_map=impact_map, env={}
+    )
+    assert document is not None
+    tc.write_checkpoint(directory, document)
+
+
+def _plan(repo: Path, directory: Path, **kwargs) -> tc.Plan:
+    resolver = _resolver(repo)
+    policy = resolver.load_policy(repo / "test-policy.toml")
+    policy = resolver.SelectionPolicy(
+        global_full_paths=policy.global_full_paths,
+        always_run=policy.always_run,
+        map_path=repo / "src" / "mac" / "data" / "test_impact_map.json",
+    )
+    impact_map = resolver.load_map(policy.map_path)
+    kwargs.setdefault("require_whole_coverage", False)
+    return tc.plan(
+        repo_root=repo,
+        directory=directory,
+        resolver=resolver,
+        policy=policy,
+        impact_map=impact_map,
+        env={},
+        **kwargs,
+    )
+
+
+GREEN = {
+    "tests/test_alpha.py::test_a": "passed",
+    "tests/test_beta.py::test_b": "passed",
+    "tests/test_guard.py::test_g": "passed",
+}
+
+
+# --------------------------------------------------------------------------
+# Fail open: no checkpoint, a corrupt one, or a truncated one runs everything.
+# --------------------------------------------------------------------------
+
+
+def test_absent_checkpoint_runs_the_full_suite(repo, tmp_path):
+    plan = _plan(repo, tmp_path / "ckpt")
+    assert plan.mode == "full"
+    assert plan.reason == "no_usable_checkpoint"
+    assert plan.skip_files == ()
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{ this is not json",
+        "[]",
+        json.dumps({"schema": "something.else.v1"}),
+        json.dumps({"schema": tc.SCHEMA, "files": {}}),  # no tree
+        json.dumps({"schema": tc.SCHEMA, "tree": {}}),  # no files
+    ],
+)
+def test_corrupt_checkpoint_runs_the_full_suite(repo, tmp_path, payload):
+    directory = tmp_path / "ckpt"
+    directory.mkdir()
+    tc.checkpoint_path(directory).write_text(payload, encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "full", "a checkpoint we cannot read must never narrow the run"
+    assert plan.skip_files == ()
+
+
+def test_a_checkpoint_that_recorded_nothing_runs_the_full_suite(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, {})
+    # build_checkpoint with no outcomes still yields a document; it must not
+    # be mistaken for "everything passed".
+    plan = _plan(repo, directory)
+    assert plan.mode == "full"
+    assert plan.reason == "checkpoint_recorded_no_tests"
+
+
+# --------------------------------------------------------------------------
+# Invalidation.
+# --------------------------------------------------------------------------
+
+
+def test_identical_tree_carries_every_passing_file_forward(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    plan = _plan(repo, directory)
+    assert plan.mode == "resume"
+    # test_guard.py is always_run and is never carried forward, however green.
+    assert set(plan.skip_files) == {"tests/test_alpha.py", "tests/test_beta.py"}
+    assert plan.skip_tests == 2
+
+
+def test_always_run_files_are_never_carried_forward(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    plan = _plan(repo, directory)
+    assert "tests/test_guard.py" not in plan.skip_files
+
+
+def test_changing_a_source_file_re_runs_the_tests_the_map_charges_to_it(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "src" / "mac" / "alpha.py").write_text("A = 2\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "resume"
+    assert "tests/test_alpha.py" not in plan.skip_files, (
+        "the impact map charges test_alpha to alpha.py, so it must re-run"
+    )
+    assert plan.skip_files == ("tests/test_beta.py",)
+    assert "src/mac/alpha.py" in plan.delta
+
+
+def test_changing_a_test_file_re_runs_that_test_file(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "tests" / "test_beta.py").write_text(
+        "def test_b():\n    assert False\n", encoding="utf-8"
+    )
+    plan = _plan(repo, directory)
+    assert plan.mode == "resume"
+    assert "tests/test_beta.py" not in plan.skip_files
+    assert plan.skip_files == ("tests/test_alpha.py",)
+
+
+def test_a_globally_invalidating_file_forces_the_full_suite(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    # `Makefile` is in this policy's global_full_paths and is deliberately NOT
+    # in the runner fingerprint, so the global-path rule is what is under test
+    # here rather than the coarser fingerprint check.
+    (repo / "Makefile").write_text("all:\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "full"
+    assert plan.reason == "global_infrastructure_changed"
+
+
+def test_a_fingerprinted_config_file_also_forces_the_full_suite(repo, tmp_path):
+    """conftest.py is both fingerprinted and globally invalidating: either rule
+    alone must produce a full run, so the outcome is the same whichever fires."""
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "tests" / "conftest.py").write_text("# changed\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "full"
+    assert plan.skip_files == ()
+
+
+def test_an_opaque_non_code_file_forces_the_full_suite(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "deploy.sh").write_text("#!/bin/sh\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "full"
+    assert plan.reason == "unmappable_non_code_change"
+
+
+def test_a_new_source_file_the_map_never_saw_forces_the_full_suite(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "src" / "mac" / "gamma.py").write_text("G = 1\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "full"
+    assert plan.reason == "source_file_absent_from_impact_map"
+
+
+def test_a_map_built_from_other_bytes_forces_the_full_suite(repo, tmp_path):
+    """The map's knowledge of a changed file must date from the checkpoint tree.
+
+    If the map was built from different bytes of that file, the tests it
+    attributes are not the tests that ran, and nothing can be carried forward.
+    """
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    document = json.loads(tc.checkpoint_path(directory).read_text(encoding="utf-8"))
+    document["map_source_hashes"]["src/mac/alpha.py"] = "sha256:" + "0" * 64
+    tc.checkpoint_path(directory).write_text(json.dumps(document), encoding="utf-8")
+    (repo / "src" / "mac" / "alpha.py").write_text("A = 3\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "full"
+    assert plan.reason == "impact_map_stale_for_changed_file"
+
+
+def test_documentation_alone_carries_everything_forward(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "docs" / "guide.md").write_text("# guide, revised\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "resume"
+    assert set(plan.skip_files) == {"tests/test_alpha.py", "tests/test_beta.py"}
+
+
+def test_runner_fingerprint_change_discards_the_whole_checkpoint(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    # A change to the runner itself: what the gate DOES may now differ, so no
+    # recorded outcome can be trusted, regardless of the tree delta.
+    (repo / "scripts" / "run-contract-tests.sh").write_text("#!/bin/sh\n# v2\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    assert plan.mode == "full"
+    assert plan.reason == "runner_fingerprint_changed"
+
+
+def test_gate_shaping_environment_is_part_of_the_key(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    resolver = _resolver(repo)
+    impact_map = resolver.load_map(repo / "src" / "mac" / "data" / "test_impact_map.json")
+    policy = resolver.SelectionPolicy(
+        global_full_paths=frozenset(), always_run=(), map_path=Path("/nonexistent")
+    )
+    plan = tc.plan(
+        repo_root=repo,
+        directory=directory,
+        require_whole_coverage=False,
+        resolver=resolver,
+        policy=policy,
+        impact_map=impact_map,
+        env={"MAC_TEST_DISABLE_GROUPS": "fleet"},
+    )
+    assert plan.mode == "full"
+    assert plan.reason == "runner_fingerprint_changed"
+
+
+# --------------------------------------------------------------------------
+# A previously-failing test is always re-run.
+# --------------------------------------------------------------------------
+
+
+def test_a_previously_failing_file_is_always_re_run(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(
+        repo,
+        directory,
+        {
+            "tests/test_alpha.py::test_a": "passed",
+            "tests/test_beta.py::test_b": "failed",
+            "tests/test_guard.py::test_g": "passed",
+        },
+    )
+    plan = _plan(repo, directory)
+    assert plan.mode == "resume"
+    assert "tests/test_beta.py" not in plan.skip_files
+    assert plan.previously_failed == ("tests/test_beta.py::test_b",)
+
+
+def test_one_failure_re_runs_the_whole_file(repo, tmp_path):
+    """Half a module never runs alone: module-scoped fixture state differs."""
+    directory = tmp_path / "ckpt"
+    _record(
+        repo,
+        directory,
+        {
+            "tests/test_beta.py::test_b": "failed",
+            "tests/test_beta.py::test_b2": "passed",
+            "tests/test_alpha.py::test_a": "passed",
+        },
+    )
+    plan = _plan(repo, directory)
+    assert plan.skip_files == ("tests/test_alpha.py",)
+
+
+def test_a_skipped_outcome_is_not_carried_forward(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(
+        repo,
+        directory,
+        {
+            "tests/test_alpha.py::test_a": "passed",
+            "tests/test_beta.py::test_b": "skipped",
+        },
+    )
+    plan = _plan(repo, directory)
+    assert plan.skip_files == ("tests/test_alpha.py",)
+
+
+def test_a_deleted_test_file_is_not_carried_forward(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "tests" / "test_beta.py").unlink()
+    plan = _plan(repo, directory)
+    assert "tests/test_beta.py" not in plan.skip_files
+
+
+# --------------------------------------------------------------------------
+# Coverage: a resumed run may never satisfy the whole-repo floors.
+# --------------------------------------------------------------------------
+
+
+def test_whole_repo_coverage_downgrades_a_resume_to_a_triage_pass(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    plan = _plan(repo, directory, require_whole_coverage=True)
+    assert plan.mode == "resume"
+    assert plan.reason == "triage_pass_only"
+    assert plan.coverage_authoritative is False
+    assert any("whole-repo coverage floors" in note for note in plan.notes)
+
+
+def test_a_non_coverage_gate_resume_is_authoritative(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    plan = _plan(repo, directory, require_whole_coverage=False)
+    assert plan.mode == "resume"
+    assert plan.coverage_authoritative is True
+
+
+def test_a_full_plan_is_never_marked_non_authoritative(repo, tmp_path):
+    plan = _plan(repo, tmp_path / "ckpt", require_whole_coverage=True)
+    assert plan.mode == "full"
+    assert plan.coverage_authoritative is True
+
+
+# --------------------------------------------------------------------------
+# Observability.
+# --------------------------------------------------------------------------
+
+
+def test_the_plan_explains_itself(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "src" / "mac" / "alpha.py").write_text("A = 9\n", encoding="utf-8")
+    rendered = tc.render_plan(_plan(repo, directory))
+    assert "test checkpoint: resume" in rendered
+    assert "changed since checkpoint: src/mac/alpha.py" in rendered
+    assert "carrying forward 1 test files (1 tests)" in rendered
+    assert "re-running" in rendered
+
+
+def test_a_full_plan_says_so(repo, tmp_path):
+    rendered = tc.render_plan(_plan(repo, tmp_path / "ckpt"))
+    assert "running the complete suite (checkpointing declined)" in rendered
+
+
+# --------------------------------------------------------------------------
+# Result ingestion.
+# --------------------------------------------------------------------------
+
+
+def test_results_merge_across_workers_with_failure_winning(tmp_path):
+    directory = tmp_path / "results"
+    directory.mkdir()
+    (directory / "gw0.jsonl").write_text(
+        json.dumps({"nodeid": "t.py::a", "outcome": "passed"}) + "\n"
+        + json.dumps({"nodeid": "t.py::b", "outcome": "passed"}) + "\n",
+        encoding="utf-8",
+    )
+    (directory / "gw1.jsonl").write_text(
+        json.dumps({"nodeid": "t.py::b", "outcome": "failed"}) + "\n"
+        + "not json at all\n"
+        + json.dumps({"nodeid": "t.py::c", "outcome": "bogus"}) + "\n",
+        encoding="utf-8",
+    )
+    assert tc.ingest_results(directory) == {"t.py::a": "passed", "t.py::b": "failed"}
+
+
+def test_missing_results_directory_yields_no_outcomes(tmp_path):
+    assert tc.ingest_results(tmp_path / "nope") == {}
+
+
+# --------------------------------------------------------------------------
+# Carrying the chain across successive resumes.
+# --------------------------------------------------------------------------
+
+
+def test_a_resumed_run_keeps_the_files_it_carried_forward(repo, tmp_path):
+    """Otherwise every resume is a one-shot: the second run would have nothing.
+
+    File-level charging is content-based and therefore composes, so a file that
+    survived A->B and then B->C has survived A->C.
+    """
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    previous = tc.load_checkpoint(directory)
+
+    resolver = _resolver(repo)
+    impact_map = resolver.load_map(repo / "src" / "mac" / "data" / "test_impact_map.json")
+    fresh = tc.build_checkpoint(
+        repo_root=repo,
+        outcomes={"tests/test_guard.py::test_g": "passed"},
+        gate="test",
+        impact_map=impact_map,
+        env={},
+    )
+    merged = tc.merge_carried_forward(
+        fresh, previous, {"tests/test_alpha.py", "tests/test_beta.py"}, repo_root=repo
+    )
+    assert merged is not None
+    assert set(merged["files"]) == {
+        "tests/test_alpha.py",
+        "tests/test_beta.py",
+        "tests/test_guard.py",
+    }
+    assert merged["carried_forward_files"] == 2
+
+
+def test_carrying_forward_refuses_a_checkpoint_from_a_different_runner(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    previous = tc.load_checkpoint(directory)
+    assert previous is not None
+    previous["runner_fingerprint"] = "sha256:" + "1" * 64
+    fresh = tc.build_checkpoint(
+        repo_root=repo, outcomes=GREEN, gate="test", impact_map=None, env={}
+    )
+    assert (
+        tc.merge_carried_forward(fresh, previous, {"tests/test_alpha.py"}, repo_root=repo) is None
+    )
+
+
+def test_carrying_forward_never_promotes_a_failure(repo, tmp_path):
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, {"tests/test_beta.py::test_b": "failed"})
+    previous = tc.load_checkpoint(directory)
+    fresh = tc.build_checkpoint(
+        repo_root=repo,
+        outcomes={"tests/test_alpha.py::test_a": "passed"},
+        gate="test",
+        impact_map=None,
+        env={},
+    )
+    merged = tc.merge_carried_forward(fresh, previous, {"tests/test_beta.py"}, repo_root=repo)
+    assert merged is not None
+    assert "tests/test_beta.py" not in merged["files"]
+
+
+# --------------------------------------------------------------------------
+# Tree manifest.
+# --------------------------------------------------------------------------
+
+
+def test_the_manifest_tracks_unstaged_edits_and_untracked_files(repo):
+    before = tc.tree_manifest(repo)
+    assert before is not None
+    assert before["src/mac/alpha.py"]
+    (repo / "src" / "mac" / "alpha.py").write_text("A = 42\n", encoding="utf-8")
+    (repo / "new_file.txt").write_text("hello\n", encoding="utf-8")
+    after = tc.tree_manifest(repo)
+    assert after is not None
+    assert after["src/mac/alpha.py"] != before["src/mac/alpha.py"]
+    assert "new_file.txt" in after and "new_file.txt" not in before
+
+
+def test_the_manifest_drops_files_deleted_from_the_worktree(repo):
+    before = tc.tree_manifest(repo)
+    (repo / "src" / "mac" / "beta.py").unlink()
+    after = tc.tree_manifest(repo)
+    assert "src/mac/beta.py" in (before or {})
+    assert "src/mac/beta.py" not in (after or {})
+
+
+def test_no_manifest_outside_a_git_repo_means_no_checkpoint(tmp_path):
+    assert tc.tree_manifest(tmp_path) is None
+    assert (
+        tc.build_checkpoint(
+            repo_root=tmp_path, outcomes={"a::b": "passed"}, gate="x", impact_map=None, env={}
+        )
+        is None
+    )
+
+
+# --------------------------------------------------------------------------
+# The reviewed path contract that motivated this work.
+# --------------------------------------------------------------------------
+
+
+def test_mkdocs_yml_has_an_owning_test_instead_of_forcing_the_full_suite():
+    """A stale nav entry cost two full 11,400-test runs; it owns one test file."""
+    import importlib.util
+    import sys
+
+    root = Path(__file__).resolve().parents[1]
+    name = "mac_resolve_impacted_tests_contract_probe"
+    spec = importlib.util.spec_from_file_location(
+        name, root / "scripts" / "resolve-impacted-tests.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    try:
+        assert module.PATH_TEST_CONTRACTS["mkdocs.yml"] == ("tests/test_docs_accessibility.py",)
+        for owner in module.PATH_TEST_CONTRACTS["mkdocs.yml"]:
+            assert (root / owner).is_file()
+    finally:
+        sys.modules.pop(name, None)
+
+
+# --------------------------------------------------------------------------
+# End-to-end through the real conftest hooks, in a throwaway pytest project.
+#
+# These prove the plumbing the plan depends on: outcomes really are recorded,
+# carried-forward files really are deselected, and a previously-failing test
+# really does still run and still fail.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mini_project(tmp_path: Path) -> Path:
+    project = tmp_path / "project"
+    (project / "tests").mkdir(parents=True)
+    real_conftest = Path(__file__).resolve().parents[1] / "conftest.py"
+    (project / "conftest.py").write_text(real_conftest.read_text(encoding="utf-8"), encoding="utf-8")
+    (project / "tests" / "test_green.py").write_text(
+        "def test_one():\n    pass\n\n\ndef test_two():\n    pass\n", encoding="utf-8"
+    )
+    (project / "tests" / "test_red.py").write_text(
+        "def test_broken():\n    assert False\n", encoding="utf-8"
+    )
+    return project
+
+
+def _pytest(project: Path, env_extra: dict[str, str]) -> subprocess.CompletedProcess:
+    import os
+
+    env = {**os.environ, **env_extra}
+    for name in ("PYTEST_ADDOPTS", "PYTEST_CURRENT_TEST", "PYTEST_XDIST_WORKER"):
+        if name not in env_extra:
+            env.pop(name, None)
+    # The hooks only act for the session that OWNS the recording namespace.
+    # Set explicitly rather than defaulted: when this test is itself run through
+    # scripts/run-contract-tests.sh, the real repository's root is inherited.
+    if "MAC_TEST_CHECKPOINT_ROOT" not in env_extra:
+        env["MAC_TEST_CHECKPOINT_ROOT"] = str(project)
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "tests"],
+        cwd=str(project),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_the_conftest_hooks_record_outcomes_and_then_deselect_them(mini_project, tmp_path):
+    results = tmp_path / "results"
+    first = _pytest(mini_project, {"MAC_TEST_CHECKPOINT_RESULTS_DIR": str(results)})
+    assert first.returncode != 0, "the red test must fail on the first run"
+    outcomes = tc.ingest_results(results)
+    assert outcomes["tests/test_green.py::test_one"] == "passed"
+    assert outcomes["tests/test_green.py::test_two"] == "passed"
+    assert outcomes["tests/test_red.py::test_broken"] == "failed"
+
+    # Now carry the green file forward and re-run. The red test must still run,
+    # and must still fail: a resumed run never turns a red suite green.
+    skip_file = tmp_path / "carried.txt"
+    skip_file.write_text("tests/test_green.py\n", encoding="utf-8")
+    second_results = tmp_path / "results2"
+    second = _pytest(
+        mini_project,
+        {
+            "MAC_TEST_CHECKPOINT_RESULTS_DIR": str(second_results),
+            "MAC_TEST_CHECKPOINT_SKIP_FILE": str(skip_file),
+        },
+    )
+    assert second.returncode != 0
+    assert "2 deselected" in second.stdout
+    assert tc.ingest_results(second_results) == {"tests/test_red.py::test_broken": "failed"}
+
+
+def test_an_unreadable_skip_list_deselects_nothing(mini_project, tmp_path):
+    """Fail OPEN: a checkpoint we cannot read must widen the run, not narrow it."""
+    results = tmp_path / "results"
+    completed = _pytest(
+        mini_project,
+        {
+            "MAC_TEST_CHECKPOINT_RESULTS_DIR": str(results),
+            "MAC_TEST_CHECKPOINT_SKIP_FILE": str(tmp_path / "does-not-exist.txt"),
+        },
+    )
+    assert completed.returncode != 0
+    assert "deselected" not in completed.stdout
+    assert len(tc.ingest_results(results)) == 3
+
+
+def test_the_hooks_are_inert_without_their_environment(mini_project, tmp_path):
+    completed = _pytest(mini_project, {"MAC_TEST_CHECKPOINT_ROOT": ""})
+    assert completed.returncode != 0
+    assert "deselected" not in completed.stdout
+    assert not (mini_project / "results").exists()
+
+
+def test_a_pytest_spawned_from_inside_a_test_never_records(mini_project, tmp_path):
+    """The suite shells out to pytest; those results are not the gate's results.
+
+    On this feature's first end-to-end smoke run, a fixture project's
+    deliberately-failing test was recorded into the real repository's
+    checkpoint. Nothing the gate did not schedule may enter it.
+    """
+    results = tmp_path / "results"
+    completed = _pytest(
+        mini_project,
+        {
+            "MAC_TEST_CHECKPOINT_RESULTS_DIR": str(results),
+            "MAC_TEST_CHECKPOINT_ROOT": str(mini_project),
+            "PYTEST_CURRENT_TEST": "tests/test_outer.py::test_outer (call)",
+        },
+    )
+    assert completed.returncode != 0
+    assert tc.ingest_results(results) == {}
+
+
+def test_a_session_rooted_elsewhere_never_records(mini_project, tmp_path):
+    results = tmp_path / "results"
+    completed = _pytest(
+        mini_project,
+        {
+            "MAC_TEST_CHECKPOINT_RESULTS_DIR": str(results),
+            "MAC_TEST_CHECKPOINT_ROOT": str(tmp_path / "some-other-repo"),
+        },
+    )
+    assert completed.returncode != 0
+    assert tc.ingest_results(results) == {}
+
+
+def test_a_session_rooted_elsewhere_deselects_nothing(mini_project, tmp_path):
+    skip_file = tmp_path / "carried.txt"
+    skip_file.write_text("tests/test_green.py\n", encoding="utf-8")
+    completed = _pytest(
+        mini_project,
+        {
+            "MAC_TEST_CHECKPOINT_SKIP_FILE": str(skip_file),
+            "MAC_TEST_CHECKPOINT_ROOT": str(tmp_path / "some-other-repo"),
+        },
+    )
+    assert "deselected" not in completed.stdout
+
+
+def test_a_path_that_is_both_a_test_and_source_is_charged_both_ways(repo, tmp_path):
+    """plugin/test_*.py is a test file AND source code; neither may be lost."""
+    directory = tmp_path / "ckpt"
+    _record(repo, directory, GREEN)
+    (repo / "plugin").mkdir()
+    (repo / "plugin" / "test_tools.py").write_text("def test_t():\n    pass\n", encoding="utf-8")
+    plan = _plan(repo, directory)
+    # It is source (plugin/ + .py) that the map never saw, so it fails open.
+    assert plan.mode == "full"
+    assert plan.reason == "source_file_absent_from_impact_map"


### PR DESCRIPTION
## The problem

Three failures in one afternoon, each costing a complete second run of the ~11,400-test `sanity` suite (50 min – 2 h):

* a stale `mkdocs.yml` nav entry pointing at a deleted doc — failed **48 minutes in**; the one-line fix re-ran everything
* 2 failing assertions out of 11,187 — full price again
* 6 tests in one file the author had not selected locally

Nothing in the pipeline remembered that the other 11,185 tests had just passed. `grep` for `checkpoint`/`resume_from`/`--lf` found nothing: every run started from scratch.

This is a **different axis** from the existing impact-based selection (`scripts/resolve-impacted-tests.py` + `src/mac/data/test_impact_map.json`), and composes with it. Selection decides which tests a *change* needs. Checkpointing decides which of those a *previous run* already answered.

## Answers to the four design questions

### 1. What is a checkpoint keyed on?

**Not the commit sha.** Keying on the sha throws the checkpoint away at exactly the moment it becomes useful — the one-line fix.

Two keys:

* **runner fingerprint** — content hashes of `scripts/run-contract-tests.sh`, `scripts/resolve-impacted-tests.py`, `conftest.py`, `tests/conftest.py`, `pyproject.toml`, `test-policy.toml`, `uv.lock`, the committed impact map and the checkpoint module itself, plus the interpreter version/platform and the gate-shaping environment (`MAC_TEST_COVERAGE`, `MAC_TEST_DISABLE_GROUPS`, `MAC_TEST_PORTFOLIO`, `MAC_TEST_SELECT_BASE`). Compared for **equality**; any difference discards the whole checkpoint. `MAC_TEST_JOBS` is deliberately excluded — worker count changes scheduling, not whether a test passed.
* **tree manifest** — the git blob hash of every tracked and untracked-not-ignored file, including unstaged edits. This one is **differenced**, not compared, which is what lets the checkpoint survive the edit.

**Invalidation rule, plainly.** A recorded result for test file `F` is honored only when *all* of:

1. schema and runner fingerprint match exactly;
2. every test recorded for `F` passed — one failure, error, or skip in `F` re-runs all of `F`;
3. `F` is in neither the policy's nor the map's `always_run`;
4. `F` is not itself in the delta;
5. no file in the delta charges any test to `F`;
6. every file in the delta is classifiable — an unmapped source file, an opaque non-code file, a globally invalidating file, or a source file whose map entry was not built from the bytes present in the checkpointed tree all force a full run.

If any of these cannot be *evaluated*, the entire checkpoint is discarded and the complete suite runs.

### 2. What is safe to skip?

Only whole test **files**, and only under the impact map's own semantics. `charge_delta()` is the resolver's layering — global paths → reviewed path contracts → test files → impact map → full — collapsed to **file granularity**, which the map's builder documents as its safe superset. It is deliberately *coarser* than `resolve()` (no line- or scope-level narrowing, because those need two git revisions and a checkpointed tree is not a commit), and coarser always means charging *more* tests back onto the run list, never fewer.

Two conservatisms on top of the resolver:

* **whole files, never individual tests** — skipping half a module leaves the other half running against different module-scoped fixture state than the run that recorded the result;
* **`always_run` is absolute** — the map's docstring says unattributed tests go there "so the selector can never silently drop them"; a checkpoint that carried them forward would silently drop them one release later.

Map freshness is answered by **content identity**: was the map built from the bytes that were in the checkpointed tree? That is the same question `_fresh_map_files` asks git about ancestry, asked of a tree that may never have been committed.

Skipping is by **deselection at collection time**, so a carried-forward file is still imported and a collection-time failure in it still fails.

### 3. Where does it live?

`MAC_TEST_CHECKPOINT_DIR` (default `.mac-test-checkpoint/`, gitignored). That covers the two places the gate actually re-runs in the same workspace — an operator/agent iterating, and `auto_land.run_contract_gate` re-invoked in a task workspace. CI is ephemeral, so the `sanity` and `mainline` jobs restore the directory with `actions/cache` keyed per branch (`save-always: true`, because a *red* run is exactly the one worth resuming from).

The document is self-describing and self-validating rather than trusted, so the same bytes can later be carried as ledger attempt evidence (`add_evidence` + `evidence_attempt_links` already store per-attempt artifacts) with no change to any rule here. **That hub-side hop is deferred** — see below.

### 4. Coverage floors

The subtlest part, and the answer is blunt on purpose.

A partial re-run produces partial coverage data. Combining a previous run's coverage with a resumed run's would **over-state** coverage for any file whose executing tests changed, and with the floors sitting within 0.35pp an over-statement can turn a red gate green. That is the exact failure this feature must never cause, so **it is never done**.

The rule is: **the checkpoint short-circuits FAILURE, never SUCCESS.**

* **Coverage-enforcing gate** → the checkpoint buys a **triage pass**: the not-carried-forward tests run first, without coverage. Red in minutes instead of an hour. Green falls straight through to the complete, unresumed, coverage-measured gate, byte-identical to today. Whole-repo floors are therefore only ever computed from a complete run.
* **Gate measuring no coverage** (the PR `sanity` path with explicit test paths; `MAC_TEST_COVERAGE=0`) → a green resume is terminal.
* **Focused / diff-coverage path** (`MAC_TEST_SELECT_BASE`) → resume allowed, because the carry-forward rule re-runs every test the map attributes to a changed source file, so the changed lines are measured exactly as they would be without a resume. One degenerate case is handled explicitly: if *every* selected test was carried forward there is no coverage data at all, so the runner drops the carry-forward and re-runs the focused selection in full rather than report every changed line uncovered.

For the motivating example: **50 + 50 minutes becomes 50 + 3.**

## What is skipped vs re-run

| delta contains | result |
|---|---|
| nothing (identical tree) | every passing file carried forward |
| only docs / `docs/**` / `.md` | every passing file carried forward |
| a mapped source file, map fresh for it | the files of every test the map charges to it re-run; rest carried |
| a test file | that file re-runs; rest carried |
| a file with a reviewed path contract | its contract tests re-run; rest carried |
| a `global_full_paths` entry | **full run** |
| an opaque shell/CI/data/config file | **full run** |
| a source file the map never saw (new/renamed) | **full run** |
| a source file the map was built from other bytes of | **full run** |
| anything, with a mismatched runner fingerprint | **full run** |
| no/corrupt/truncated checkpoint | **full run** |

`always_run` files are re-run in every one of these rows.

## Observability

Every decision prints itself:

```
test checkpoint: resume (carried_forward_from_checkpoint)
  changed since checkpoint: src/mac/alpha.py
  previously failed: tests/test_beta.py::test_b
  carrying forward 412 test files (10,988 tests) that passed and that no changed file charges a test to
  re-running 31 of 443 recorded test files
```

A silent optimization nobody can audit is how this repo once had a CI job report green while running zero tests.

## Also in this PR

`mkdocs.yml` now has a reviewed path contract (`tests/test_docs_accessibility.py`) instead of being an opaque `.yml` that forces the whole suite — so the change that started all this no longer costs 11,400 tests in the first place.

## A real bug this found

The first end-to-end smoke run recorded a *fixture project's deliberately-failing test* into the real repository's checkpoint: the suite has tests that shell out to pytest, and they inherited `MAC_TEST_CHECKPOINT_RESULTS_DIR`. The hooks now record only when their rootdir is the one the runner declared **and** they were not spawned from inside a running test. Three tests cover it.

## Deferred (design filed as `task_b92800f6`)

1. **Durable hub-side checkpoint as attempt evidence** — for a task whose next attempt lands on a *different* worker. The evidence tables and blob offload already exist; this is a fetch-before / push-after around `run_contract_gate`.
2. **Sound coverage resumption** — combinable coverage is possible in principle but the unchanged-file over-statement risk must be *measured* against the 0.35pp margin before it can be trusted. Until then, triage-only.
3. Per-test (rather than per-file) carry-forward; a checkpoint that also stores a base commit so the resolver's finer line/scope layers become usable.

## Verification

* `tests/test_test_checkpoint.py` — 44 new tests: invalidation (fingerprint, global path, opaque file, unmapped source, stale map entry, changed test file, deleted file), a previously-failing test still runs and still fails, one failure re-runs the whole file, corrupt/absent/empty checkpoints run everything, the coverage downgrade to triage, carry-forward chaining across successive resumes, tree-manifest behaviour, and end-to-end runs through the real conftest hooks.
* `tests/test_contract_test_runner.py` — 9 new runner tests: default-off is byte-identical, a declined plan runs the normal gate, triage precedes the full coverage gate, the full gate never sees a skip list, a failed triage never reaches the coverage gate, an empty triage is not a failure, fast-mode resume is terminal, a nested invocation never checkpoints.
* `tests/test_contract_test_runner.py tests/test_test_checkpoint.py` — 73 passed.
* `tests/test_build_test_impact_map.py tests/test_resolve_impacted_tests.py tests/test_select_sanity_tests.py tests/test_env_config.py` — 71 passed. No tests deleted or renamed, so no interned ids stranded.
* `pytest tests/ -k "contract or impact or resolve or gate or auto_land or docs_access or env_config or sanity_tests"` — 2412 passed. One unrelated pre-existing failure, `test_openshell_image_rebuild_gates_and_drift`, which asserts on a Linux-only code path and cannot pass on darwin.
* `scripts/dead-code-check.sh` — clean.
* Generated artifacts regenerated: `scripts/generate-env-config-registry.py`, `scripts/generate-docs-reference.py --write` (the latter also picked up a pre-existing `docs/archive/index.md` staleness from ADR 0016).
* Live smoke: two consecutive `run-contract-tests.sh` invocations on an unchanged tree — run 1 recorded 50 tests across 2 files, run 2 deselected all 50 and exited 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)