### PR TITLE
Build the merge queue in mac, because GitHub only gives one to organizations

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -613,6 +613,11 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_MEMORY_EMBED_INPUT_TYPE` | str | consumer-defined | memory | Memory setting: memory embed input type. |
 | `MAC_MEMORY_EMBED_MODEL` | str | consumer-defined | memory | Memory setting: memory embed model. |
 | `MAC_MEMORY_TOPOLOGY_FILE` | str | consumer-defined | memory | Memory setting: memory topology file. |
+| `MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS` | int | consumer-defined | merge-queue | Merge Queue setting: merge queue capability ttl seconds. |
+| `MAC_MERGE_QUEUE_LEASE_SECONDS` | int | consumer-defined | merge-queue | Merge Queue setting: merge queue lease seconds. |
+| `MAC_MERGE_QUEUE_WINDOW_CEILING` | str | consumer-defined | merge-queue | Merge Queue setting: merge queue window ceiling. |
+| `MAC_MERGE_QUEUE_WINDOW_FLOOR` | int | consumer-defined | merge-queue | Merge Queue setting: merge queue window floor. |
+| `MAC_MERGE_QUEUE_WINDOW_INCREMENT` | str | consumer-defined | merge-queue | Merge Queue setting: merge queue window increment. |
 | `MAC_MIGRATION_DATABASE_URL` | str | consumer-defined | core | Core setting: migration database url. |
 | `MAC_MODELS_DEV_CACHE_FILE` | str | consumer-defined | core | Core setting: models dev cache file. |
 | `MAC_MODEL_SELECTION_FILE` | str | consumer-defined | core | Core setting: model selection file. |

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -695,14 +695,95 @@ converges with several open pull requests).
 
 | branch has | what mac does | the guarantee |
 | --- | --- | --- |
-| a merge queue | enqueues the PR pinned to the reviewed head; the queue tests the projected merge and lands it in order | what was tested is what lands |
-| no merge queue (or gitea, or an unreadable ruleset) | re-validates that the canonical tip is still the base this candidate was gated against, then squash-merges | weaker: not serialized against concurrent merges, so the re-validation is what stands in for it |
+| a forge merge queue (`merge_queue`) | enqueues the PR pinned to the reviewed head; the queue tests the projected merge and lands it in order | what was tested is what lands |
+| no forge merge queue (`mac_native_queue`) | orders the change in **mac's own merge queue**, tests it against the tree it will land on, and refuses the merge unless the canonical tip's tree is still that exact tree | what was tested is what lands |
 
 Both branches are recorded in the publication evidence as a
 `merge_serialization` entry naming the mode and its guarantee, and on the
-canonical-integration proof as `merge_serialization`. A repository whose queue
-has not been enabled yet is therefore visible as such rather than silently
-assumed to have one.
+canonical-integration proof as `merge_serialization`.
+
+### mac's own merge queue
+
+**Why it exists.** GitHub merge queues are available only on
+**organization-owned** repositories, and GitHub has said it does not plan to
+open them to personal accounts. Adding a `merge_queue` rule to a User-owned
+repository's ruleset returns HTTP 422 `Invalid rule 'merge_queue'` even with no
+parameters. So on every personal repository mac manages there is no forge queue
+to borrow serialization from, and `mac_native_queue` is not a rare fallback —
+it is the only path. `src/mac/native_merge_queue.py` provides the queue itself.
+
+**What it does.** Approved changes awaiting land are ordered per (repository,
+canonical branch) in the `merge_queue_entries` table. Entry *N* is projected on
+top of entries *1..N-1* (Zuul's speculative merge train) so several entries can
+be tested in parallel, and they land in order. If entry *K* fails it is
+**evicted**, and every speculative result behind it is **discarded** — those
+entries were green against a state that will never exist — and the survivors are
+re-planned in a new speculation epoch without *K*.
+
+**The invariant.** *Never land an untested tree.* Each entry records the tree it
+was tested against; the land gate refuses the merge unless the canonical tip's
+tree is byte-identical to it. Comparing trees rather than commit SHAs is what
+makes speculation safe and what survives squash merges, which change the commit
+but not the tree. Every ambiguous state — an unreadable tip, a lost lease, a PR
+whose state the forge will not report — defers through the existing publication
+retry backoff. None of them can reach "merge anyway".
+
+**Never double-land.** Before merging, the queue reads the pull request's state.
+A PR already merged (by the forge, a human, or an attempt of ours that died
+after the merge) is *observed* and recorded as landed, not merged again. Landing
+is idempotent in the ledger, so a hub restart mid-flight cannot credit one land
+twice.
+
+**Bounded.** An AIMD window — the same control law as TCP congestion control,
+which is where Zuul got it — caps how many entries may speculate at once. It
+starts at the floor (so a fresh queue is strictly serial), grows by
+`MAC_MERGE_QUEUE_WINDOW_INCREMENT` on each successful land up to
+`MAC_MERGE_QUEUE_WINDOW_CEILING`, and **halves** on any failure down to
+`MAC_MERGE_QUEUE_WINDOW_FLOOR`. Entries outside the window defer; they keep
+their place in line.
+
+| knob | default | what it bounds |
+| --- | --- | --- |
+| `MAC_MERGE_QUEUE_WINDOW_FLOOR` | `1` | the narrowest window; `1` is a strictly serial queue |
+| `MAC_MERGE_QUEUE_WINDOW_CEILING` | `4` | the most entries that may speculate at once, and therefore the most workers speculation can occupy. Set to `1` to disable speculation without disabling the queue |
+| `MAC_MERGE_QUEUE_WINDOW_INCREMENT` | `1` | how fast the window recovers after a failure |
+| `MAC_MERGE_QUEUE_LEASE_SECONDS` | `5400` | how long a slot may be held before a dead hub's slot is reclaimable. Deliberately longer than a full contract run (~45 min) |
+| `MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS` | `86400` | how long a resolved forge capability is trusted before it is re-probed |
+
+**What is observable.** Every publication records a `merge_serialization`
+command carrying a queue snapshot: `queue_depth`, `window_size`,
+`window_floor`/`window_ceiling`, `entries_testing`/`entries_tested`,
+`landed_count`, `failure_count`, `speculation_discarded`, and the last ten
+evictions with their reasons. The same numbers are emitted as metrics under
+`merge_queue.*` (`GET /observability/metrics?name=merge_queue.evicted`), and the
+per-attempt commands name each decision: `merge_serialization_capability`,
+`merge_queue_slot`, `merge_queue_speculative_base`, `merge_queue_tested`,
+`merge_queue_observe_pull_request`, `merge_queue_land_gate`,
+`merge_queue_landed`, `merge_queue_eviction`.
+
+**Which mechanism applies is a stored project attribute, not a per-merge probe.**
+`mac.merge_capability` resolves the forge's capability once and stores it on the
+project's repository record in `project_repositories.metadata` under
+`merge_serialization_capability`. It records *supported* and *enabled*
+separately (they differ: an org repo can have a queue and may not have turned it
+on), the forge kind, whether a credential resolved, and when and by what it was
+determined — so an operator can see that an answer is six weeks old rather than
+trusting it silently. The existing GitHub ingest poller refreshes it on its
+normal pass, behind `MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS`, and reports the
+outcome in its run report under `merge_queue_capability`. To force a refresh
+now, run the poller: `mac fleet github-ingest run` (`POST /github-ingest/run`).
+A missing or expired answer is re-resolved at publication time. **Unknown is
+never permission to do an unserialized squash** — it routes to mac's queue,
+which serializes correctly regardless of what the forge does.
+
+> **Live-hub note.** `schema.sql` is `CREATE TABLE IF NOT EXISTS` with no
+> migration framework, and `PostgresStore.initialize()` only creates missing
+> tables. `merge_queue_entries` and `merge_queue_windows` therefore appear on a
+> hub the next time the schema is applied; on an already-running hub, apply the
+> DDL from `src/mac/data/postgres/schema.sql` (the block headed *"mac's own
+> merge queue"*) once by hand. Until they exist, publication on a repository
+> without a forge queue will fail rather than fall back to an unserialized
+> squash — which is the correct direction to fail.
 
 **Queued, not merged yet.** A pull request accepted into the merge queue has
 not landed. Publication defers with

--- a/scripts/generate-env-config-registry.py
+++ b/scripts/generate-env-config-registry.py
@@ -56,6 +56,7 @@ FAMILIES = (
     ("MAC_QDRANT_", "qdrant-memory"),
     ("MAC_TOKENHUB_", "tokenhub-legacy"),
     ("MAC_WEBDAV_", "webdav-publish"),
+    ("MAC_MERGE_QUEUE_", "merge-queue"),
     ("MAC_PUBLISH_", "publication"),
     ("MAC_MEMORY_", "memory"),
     ("MAC_RUNNER_", "kubernetes-runner"),

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -7258,6 +7258,61 @@
   },
   {
     "default": null,
+    "description": "Merge Queue setting: merge queue capability ttl seconds.",
+    "family": "merge-queue",
+    "name": "MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/merge_capability.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Merge Queue setting: merge queue lease seconds.",
+    "family": "merge-queue",
+    "name": "MAC_MERGE_QUEUE_LEASE_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/native_merge_queue.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Merge Queue setting: merge queue window ceiling.",
+    "family": "merge-queue",
+    "name": "MAC_MERGE_QUEUE_WINDOW_CEILING",
+    "retired": false,
+    "sources": [
+      "src/mac/native_merge_queue.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Merge Queue setting: merge queue window floor.",
+    "family": "merge-queue",
+    "name": "MAC_MERGE_QUEUE_WINDOW_FLOOR",
+    "retired": false,
+    "sources": [
+      "src/mac/native_merge_queue.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Merge Queue setting: merge queue window increment.",
+    "family": "merge-queue",
+    "name": "MAC_MERGE_QUEUE_WINDOW_INCREMENT",
+    "retired": false,
+    "sources": [
+      "src/mac/native_merge_queue.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: migration database url.",
     "family": "core",
     "name": "MAC_MIGRATION_DATABASE_URL",

--- a/src/mac/data/postgres/schema.sql
+++ b/src/mac/data/postgres/schema.sql
@@ -6246,3 +6246,74 @@ CREATE INDEX IF NOT EXISTS idx_fleet_release_admission_barrier
     ON fleet_release_admission_episodes (barrier_resource_digest, created_at);
 CREATE INDEX IF NOT EXISTS idx_fleet_release_admission_owner
     ON fleet_release_admission_episodes (owner_kind, owner_id, created_at);
+
+-- ---------------------------------------------------------------------------
+-- mac's own merge queue (mac.native_merge_queue).
+--
+-- GitHub merge queues are an organization-only feature, so every User-owned
+-- repository mac manages has no forge-provided serialization at all.  These two
+-- tables are the durable state that lets mac provide it itself: an ORDERED set
+-- of approved changes per (repository, canonical branch), and the AIMD
+-- speculation window for that same key.
+--
+-- Crash safety lives in `lease_owner` / `lease_expires_at`: a hub that dies
+-- mid-flight leaves a leased row that the next hub reclaims once the lease
+-- expires, WITHOUT losing the entry's position.  Double-landing is prevented by
+-- the terminal states plus `landing_is_safe`, which refuses to merge unless the
+-- canonical tip's TREE is still the tree the entry was tested on top of.
+-- ---------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS merge_queue_entries (
+    id TEXT PRIMARY KEY,
+    repository TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    pull_request_number INTEGER NOT NULL DEFAULT 0,
+    head_sha TEXT NOT NULL,
+    state TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    speculation_epoch INTEGER NOT NULL DEFAULT 0,
+    tested_base_sha TEXT NOT NULL DEFAULT '',
+    tested_base_tree TEXT NOT NULL DEFAULT '',
+    tested_merge_tree TEXT NOT NULL DEFAULT '',
+    predecessors TEXT NOT NULL DEFAULT '[]',
+    lease_owner TEXT,
+    lease_expires_at TEXT,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    eviction_reason TEXT NOT NULL DEFAULT '',
+    landed_sha TEXT NOT NULL DEFAULT '',
+    detail TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK (state IN (
+        'queued', 'testing', 'tested', 'landed', 'evicted', 'superseded'
+    )),
+    CHECK (position >= 0),
+    CHECK (speculation_epoch >= 0),
+    CHECK (attempts >= 0)
+);
+-- One LIVE entry per task per queue.  Terminal rows are excluded so a task
+-- evicted from the queue can be re-admitted after it is fixed.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_merge_queue_live_task
+    ON merge_queue_entries (repository, branch, task_id)
+    WHERE state IN ('queued', 'testing', 'tested');
+CREATE INDEX IF NOT EXISTS idx_merge_queue_entries_order
+    ON merge_queue_entries (repository, branch, state, position, id);
+CREATE INDEX IF NOT EXISTS idx_merge_queue_entries_lease
+    ON merge_queue_entries (lease_expires_at, state);
+
+CREATE TABLE IF NOT EXISTS merge_queue_windows (
+    repository TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    window_size INTEGER NOT NULL DEFAULT 1,
+    landed_count INTEGER NOT NULL DEFAULT 0,
+    failure_count INTEGER NOT NULL DEFAULT 0,
+    speculation_discarded INTEGER NOT NULL DEFAULT 0,
+    last_event TEXT NOT NULL DEFAULT '',
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (repository, branch),
+    CHECK (window_size >= 1),
+    CHECK (landed_count >= 0),
+    CHECK (failure_count >= 0),
+    CHECK (speculation_discarded >= 0)
+);

--- a/src/mac/github_ingest.py
+++ b/src/mac/github_ingest.py
@@ -63,6 +63,8 @@ GITHUB_API_ROOT = "https://api.github.com"
 
 _log = logging.getLogger("mac.github_ingest")
 
+MERGE_CAPABILITY_REPORT_SCHEMA = "mac.merge_capability_refresh.v1"
+
 # A fetcher returns the raw GitHub issue objects (list of dicts). Injectable so
 # tests never touch the network.
 IssueFetcher = Callable[..., List[Dict[str, Any]]]
@@ -387,6 +389,15 @@ class GitHubIssueIngestor:
         started_at = _utcnow()
         run_id = "ghingest_%s" % uuid.uuid4().hex
         results: List[Dict[str, Any]] = []
+        capability: Dict[str, Any] = {
+            "schema": MERGE_CAPABILITY_REPORT_SCHEMA,
+            "checked": 0,
+            "refreshed": 0,
+            "skipped_fresh": 0,
+            "failed": 0,
+            "error": "",
+            "repositories": [],
+        }
         try:
             token = ""
             try:
@@ -406,6 +417,26 @@ class GitHubIssueIngestor:
                         open_task_counts=open_task_counts,
                     )
                 )
+            # Ride along on the pass that is already visiting every
+            # repository, behind a TTL.  FAILURE-ISOLATED in both directions:
+            # a capability probe that blows up must not stop issue ingest, and
+            # ingest results must not hide an unresolved capability -- so this
+            # is its own try/except and its own report section.
+            try:
+                capability = self._refresh_merge_capabilities(actor=actor)
+            except Exception as exc:  # noqa: BLE001 - never break ingest.
+                _log.warning(
+                    "merge-queue capability refresh failed: %s", _safe_error(exc)
+                )
+                capability = {
+                    "schema": MERGE_CAPABILITY_REPORT_SCHEMA,
+                    "checked": 0,
+                    "refreshed": 0,
+                    "skipped_fresh": 0,
+                    "failed": 0,
+                    "error": _safe_error(exc),
+                    "repositories": [],
+                }
         finally:
             self._run_lock.release()
 
@@ -420,11 +451,108 @@ class GitHubIssueIngestor:
             "created_count": sum(int(r.get("created", 0)) for r in results),
             "cancelled_count": sum(int(r.get("cancelled", 0)) for r in results),
             "repositories": results,
+            "merge_queue_capability": capability,
         }
         with self._state_lock:
             self._last_report = report
         level = "warning" if any(r.get("error") for r in results) else "info"
         self._observe("github.ingest.run", level, report)
+        return report
+
+    def _refresh_merge_capabilities(self, *, actor: str) -> Dict[str, Any]:
+        """Re-resolve each registered repository's merge-serialization capability.
+
+        Only when the stored answer has expired.  Merge-queue configuration
+        changes maybe twice a year while this poller runs every 60 seconds, so
+        an unconditional probe would spend ~1,440 API calls a day per
+        repository re-learning the same boolean.
+
+        This visits ``project_repositories``, not the ingest opt-in list: a
+        repository does not have to want its GitHub issues imported in order to
+        need its merges serialized.
+        """
+
+        from mac.merge_capability import (
+            MergeCapability,
+            capability_ttl_seconds,
+            repository_remote_and_branch,
+            resolve_merge_capability,
+            stored_capability,
+        )
+
+        report: Dict[str, Any] = {
+            "schema": MERGE_CAPABILITY_REPORT_SCHEMA,
+            "checked": 0,
+            "refreshed": 0,
+            "skipped_fresh": 0,
+            "failed": 0,
+            "error": "",
+            "repositories": [],
+        }
+        try:
+            repositories = list(
+                self.control_plane.list_project_repositories(enabled=True)
+            )
+        except Exception as exc:  # noqa: BLE001
+            report["error"] = _safe_error(exc)
+            return report
+
+        ttl = capability_ttl_seconds()
+        for repo in repositories:
+            report["checked"] += 1
+            coordinates = repository_remote_and_branch(repo)
+            remote, branch = coordinates["remote"], coordinates["branch"]
+            existing: Optional[MergeCapability] = stored_capability(
+                getattr(repo, "metadata", None)
+            )
+            if existing is not None and not existing.is_stale(
+                branch=branch, ttl_seconds=ttl
+            ):
+                report["skipped_fresh"] += 1
+                report["repositories"].append(
+                    {
+                        "repository": getattr(repo, "name", ""),
+                        "status": "fresh",
+                        "resolved_at": existing.resolved_at,
+                        "mode": "merge_queue"
+                        if existing.use_forge_queue
+                        else "mac_native_queue",
+                    }
+                )
+                continue
+            try:
+                resolved = resolve_merge_capability(
+                    remote, branch, resolver="github-ingest"
+                )
+                self.control_plane.record_repository_merge_capability(
+                    getattr(repo, "id", ""), resolved.to_dict()
+                )
+            except Exception as exc:  # noqa: BLE001 - one repo must not stop the rest
+                report["failed"] += 1
+                report["repositories"].append(
+                    {
+                        "repository": getattr(repo, "name", ""),
+                        "status": "error",
+                        "error": _safe_error(exc),
+                    }
+                )
+                continue
+            report["refreshed"] += 1
+            report["repositories"].append(
+                {
+                    "repository": getattr(repo, "name", ""),
+                    "status": "resolved",
+                    "forge": resolved.forge,
+                    "supported": resolved.supported,
+                    "enabled": resolved.enabled,
+                    "branch": resolved.branch,
+                    "resolved_at": resolved.resolved_at,
+                    "error": resolved.error,
+                    "mode": "merge_queue"
+                    if resolved.use_forge_queue
+                    else "mac_native_queue",
+                }
+            )
         return report
 
     def _candidate_projects(self) -> List[Any]:

--- a/src/mac/merge_capability.py
+++ b/src/mac/merge_capability.py
@@ -105,10 +105,6 @@ class MergeCapability:
 
         return self.supported is True and self.enabled is True
 
-    @property
-    def resolved(self) -> bool:
-        return bool(self.resolved_at) and self.enabled is not None
-
     def to_dict(self) -> JsonDict:
         return {
             "schema": CAPABILITY_SCHEMA,

--- a/src/mac/merge_capability.py
+++ b/src/mac/merge_capability.py
@@ -1,0 +1,385 @@
+"""Which merge-serialization mechanism a repository actually has.
+
+## Why this is a stored project attribute and not a per-merge probe
+
+#400 asked the forge on every publication whether the canonical branch had a
+merge queue (``gitops.merge_queue_enabled`` -> ``GET /repos/{o}/{r}/rules/
+branches/{b}``).  That is one API call per land against a rate limit, to answer
+a question whose answer changes maybe twice a year -- and it answers it at the
+worst possible moment, inside the merge window, where a rate-limited or flaky
+response has to be turned into a landing decision.
+
+So the answer is resolved once and stored on the project's repository record,
+in ``project_repositories.metadata`` under
+``merge_serialization_capability``.  ``metadata`` is used rather than a new
+column deliberately: ``schema.sql`` is ``CREATE TABLE IF NOT EXISTS`` with no
+migration framework, so a new column would never appear on the live hub.
+
+## Why it is refreshed by the poller and not by a new timer
+
+``GitHubIssueIngestor`` already visits every registered repository on a timer,
+already parses owner/repo out of the remote, and already holds a forge
+credential.  Capability resolution rides along on that pass, behind a TTL:
+issue ingest wants to run every 60 seconds and merge-queue configuration
+essentially never changes, so re-probing the ruleset on every poll would spend
+1,440 API calls a day per repository to re-learn the same boolean.  The TTL
+(``MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS``, default 24h) makes that one call.
+
+Forcing a refresh now needs no new endpoint: ``POST /github-ingest/run`` (CLI:
+``mac fleet github-ingest run``) already exists and runs the pass on demand, and
+its report carries the capability section, so "not refreshed yet" and
+"refreshing and failing every time" are distinguishable from outside -- which is
+the whole point, because they look identical when the only signal is a boolean.
+
+## What is recorded, and why each field is separate
+
+``supported`` and ``enabled`` are NOT the same question and are stored
+separately.  GitHub merge queues are an organization-only feature: a
+User-owned repository CANNOT have one (adding the rule returns HTTP 422
+``Invalid rule 'merge_queue'``), while an org-owned repository can have one and
+may simply not have turned it on.  Collapsing those into one boolean loses the
+difference between "mac must serialize this itself, forever" and "an operator
+could switch the forge queue on".  ``forge`` and ``credential`` record whether
+the question could be asked at all, and ``resolved_at`` / ``resolver`` record
+when and by what -- so an operator can see that an answer is six weeks old
+rather than trusting it silently.
+
+## The decision rule
+
+* forge queue supported AND enabled -> the forge queue (#400's path).
+* anything else, INCLUDING unknown -> mac's native queue.
+
+"Unknown" is never permission to do an unserialized squash.  The native queue
+serializes correctly regardless of what the forge does, so it is the safe branch
+and it is where every ambiguous answer lands.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Optional
+
+from mac.models import JsonDict, ensure_json_object, parse_time, utcnow
+
+CAPABILITY_KEY = "merge_serialization_capability"
+CAPABILITY_SCHEMA = "mac.merge_serialization_capability.v1"
+
+DEFAULT_TTL_SECONDS = 86400
+
+
+def capability_ttl_seconds(environ: Optional[Mapping[str, str]] = None) -> int:
+    """How long a resolved capability is trusted before it is re-probed.
+
+    ``MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS``, default 86400 (24 hours).
+    """
+
+    env = os.environ if environ is None else environ
+    try:
+        value = int(
+            str(env.get("MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS", "")).strip()
+            or DEFAULT_TTL_SECONDS
+        )
+    except (TypeError, ValueError):
+        value = DEFAULT_TTL_SECONDS
+    return max(60, value)
+
+
+@dataclass(frozen=True)
+class MergeCapability:
+    """What mac knows about how a repository's branch can be serialized."""
+
+    forge: str = ""
+    credential: bool = False
+    supported: Optional[bool] = None
+    enabled: Optional[bool] = None
+    branch: str = ""
+    remote: str = ""
+    resolved_at: str = ""
+    resolver: str = ""
+    error: str = ""
+
+    @property
+    def use_forge_queue(self) -> bool:
+        """Only an unambiguous yes-and-yes routes to the forge."""
+
+        return self.supported is True and self.enabled is True
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.resolved_at) and self.enabled is not None
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "schema": CAPABILITY_SCHEMA,
+            "forge": self.forge,
+            "credential": self.credential,
+            "supported": self.supported,
+            "enabled": self.enabled,
+            "branch": self.branch,
+            "remote": self.remote,
+            "resolved_at": self.resolved_at,
+            "resolver": self.resolver,
+            "error": self.error,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> Optional["MergeCapability"]:
+        record = ensure_json_object(value if isinstance(value, Mapping) else None)
+        if not record or record.get("schema") != CAPABILITY_SCHEMA:
+            return None
+
+        def _tri(name: str) -> Optional[bool]:
+            raw = record.get(name)
+            return None if raw is None else bool(raw)
+
+        return cls(
+            forge=str(record.get("forge") or ""),
+            credential=bool(record.get("credential")),
+            supported=_tri("supported"),
+            enabled=_tri("enabled"),
+            branch=str(record.get("branch") or ""),
+            remote=str(record.get("remote") or ""),
+            resolved_at=str(record.get("resolved_at") or ""),
+            resolver=str(record.get("resolver") or ""),
+            error=str(record.get("error") or ""),
+        )
+
+    def is_stale(
+        self,
+        *,
+        branch: str = "",
+        ttl_seconds: Optional[int] = None,
+        now: Optional[str] = None,
+    ) -> bool:
+        """A missing, unparseable, wrong-branch, or expired answer is stale.
+
+        Erring toward stale is deliberate: re-probing costs one API call, and
+        trusting a stale capability is exactly the "reports healthy while
+        enforcing nothing" shape this repository keeps producing.
+        """
+
+        if not self.resolved_at or self.enabled is None:
+            return True
+        if branch and self.branch and branch != self.branch:
+            return True
+        ttl = capability_ttl_seconds() if ttl_seconds is None else int(ttl_seconds)
+        try:
+            age = (parse_time(now or utcnow()) - parse_time(self.resolved_at)).total_seconds()
+        except Exception:  # noqa: BLE001 - an unparseable stamp is stale
+            return True
+        return age >= ttl or age < 0
+
+
+def stored_capability(metadata: Any) -> Optional[MergeCapability]:
+    """Read the capability out of a ``project_repositories.metadata`` blob."""
+
+    record = ensure_json_object(metadata if isinstance(metadata, Mapping) else None)
+    return MergeCapability.from_dict(record.get(CAPABILITY_KEY))
+
+
+def merge_serialization_mode(capability: Optional[MergeCapability]) -> str:
+    """Map a capability (possibly missing) onto a ``merge_serialization`` mode.
+
+    Imported lazily by callers to avoid a cycle; the string values are the same
+    contract #400 established.
+    """
+
+    from mac.native_merge_queue import MODE_FORGE_QUEUE, MODE_NATIVE_QUEUE
+
+    if capability is not None and capability.use_forge_queue:
+        return MODE_FORGE_QUEUE
+    return MODE_NATIVE_QUEUE
+
+
+def resolve_merge_capability(
+    remote_url: str,
+    branch: str,
+    *,
+    resolver: str = "github-ingest",
+    now: Callable[[], str] = utcnow,
+    resolve_forge: Optional[Callable[[str], Optional[str]]] = None,
+    queue_enabled: Optional[Callable[..., Optional[bool]]] = None,
+    owner_is_organization: Optional[Callable[[str], Optional[bool]]] = None,
+) -> MergeCapability:
+    """Ask the forge once.  Never raises; an unanswerable question is recorded.
+
+    The injected callables exist so this is testable without a forge and so the
+    ingest pass can hand in a token-scoped client.
+    """
+
+    from mac import gitops as _gitops
+
+    _resolve_forge = resolve_forge or _gitops.resolve_forge
+    _queue_enabled = queue_enabled or _gitops.merge_queue_enabled
+    _is_org = owner_is_organization or forge_owner_is_organization
+
+    remote = str(remote_url or "").strip()
+    target = str(branch or "").strip()
+    stamp = now()
+    if not remote or not target:
+        return MergeCapability(
+            branch=target,
+            remote=remote,
+            resolved_at=stamp,
+            resolver=resolver,
+            error="repository has no canonical remote/branch to probe",
+        )
+    try:
+        forge = str(_resolve_forge(remote) or "")
+    except Exception as exc:  # noqa: BLE001 - probing must not raise
+        return MergeCapability(
+            branch=target,
+            remote=remote,
+            resolved_at=stamp,
+            resolver=resolver,
+            error=_safe(exc),
+        )
+    if not forge:
+        # No API-reachable forge, or no credential for its host.  There is
+        # nothing that could serialize this for us, which is a definite answer
+        # rather than an unknown: mac's own queue is the only mechanism.
+        return MergeCapability(
+            forge="",
+            credential=False,
+            supported=False,
+            enabled=False,
+            branch=target,
+            remote=remote,
+            resolved_at=stamp,
+            resolver=resolver,
+            error="",
+        )
+    if forge != "github":
+        # gitea has no merge-queue equivalent at all.
+        return MergeCapability(
+            forge=forge,
+            credential=True,
+            supported=False,
+            enabled=False,
+            branch=target,
+            remote=remote,
+            resolved_at=stamp,
+            resolver=resolver,
+        )
+    try:
+        enabled = _queue_enabled(remote, target)
+    except Exception as exc:  # noqa: BLE001
+        return MergeCapability(
+            forge=forge,
+            credential=True,
+            branch=target,
+            remote=remote,
+            resolved_at=stamp,
+            resolver=resolver,
+            error=_safe(exc),
+        )
+    if enabled is None:
+        return MergeCapability(
+            forge=forge,
+            credential=True,
+            branch=target,
+            remote=remote,
+            resolved_at=stamp,
+            resolver=resolver,
+            error="forge could not be asked whether %s has a merge queue" % target,
+        )
+    if enabled:
+        # A queue that is on is a queue that is supported.
+        return MergeCapability(
+            forge=forge,
+            credential=True,
+            supported=True,
+            enabled=True,
+            branch=target,
+            remote=remote,
+            resolved_at=stamp,
+            resolver=resolver,
+        )
+    try:
+        organization = _is_org(remote)
+    except Exception:  # noqa: BLE001
+        organization = None
+    return MergeCapability(
+        forge=forge,
+        credential=True,
+        # Support tracks repository ownership: GitHub merge queues are an
+        # organization-only feature, so a User-owned repo can never enable one
+        # however the operator configures it.  Unknown ownership leaves
+        # ``supported`` unknown, which is honest -- and irrelevant to routing,
+        # because ``enabled`` is already a definite False.
+        supported=None if organization is None else bool(organization),
+        enabled=False,
+        branch=target,
+        remote=remote,
+        resolved_at=stamp,
+        resolver=resolver,
+    )
+
+
+def forge_owner_is_organization(remote_url: str) -> Optional[bool]:
+    """Whether the remote's owner is an Organization (so a queue is possible).
+
+    ``None`` when it cannot be determined.  Reuses ``gitops``' own API context
+    so the credential path and the URL parsing stay in one place.
+    """
+
+    from mac import gitops as _gitops
+
+    try:
+        _host, owner, repo, api_base, headers, _token = _gitops._forge_api_context(
+            remote_url
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        payload = _gitops._http_get_json(
+            "%s/repos/%s/%s" % (api_base, owner, repo), headers
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    if not isinstance(payload, dict):
+        return None
+    owner_record = payload.get("owner")
+    if not isinstance(owner_record, dict):
+        return None
+    kind = str(owner_record.get("type") or "").strip().lower()
+    if not kind:
+        return None
+    return kind == "organization"
+
+
+def _safe(exc: BaseException) -> str:
+    from mac import gitops as _gitops
+
+    return _gitops._scrub_secret(str(exc))[:300]
+
+
+def repository_remote_and_branch(repository: Any) -> Dict[str, str]:
+    """Pull the canonical remote/branch out of a registered repository record.
+
+    The runtime contract stored in ``metadata['repository_contract']`` is the
+    authority for both, exactly as publication treats it -- the canonical
+    branch is never assumed to be ``main``.
+    """
+
+    metadata = ensure_json_object(getattr(repository, "metadata", None))
+    contract = ensure_json_object(metadata.get("repository_contract"))
+    remote = str(contract.get("canonical_remote_url") or "").strip()
+    branch = str(
+        contract.get("canonical_branch") or contract.get("default_branch") or ""
+    ).strip()
+    return {"remote": remote, "branch": branch}
+
+
+__all__ = [
+    "CAPABILITY_KEY",
+    "CAPABILITY_SCHEMA",
+    "MergeCapability",
+    "capability_ttl_seconds",
+    "forge_owner_is_organization",
+    "merge_serialization_mode",
+    "repository_remote_and_branch",
+    "resolve_merge_capability",
+    "stored_capability",
+]

--- a/src/mac/native_merge_queue.py
+++ b/src/mac/native_merge_queue.py
@@ -1,0 +1,1145 @@
+"""A merge queue that mac owns, for repositories the forge will not serialize.
+
+## Why this exists
+
+:mod:`mac.merge_queue` implements the OCC *validation phase* for one landing:
+serialize per repository, project the merge against the CURRENT tip with ``git
+merge-tree``, and run the contract suite against that projected tree.  What it
+does not do is order *several* approved changes against each other.  Until now
+that ordering was borrowed from the forge: ``gitops.merge_queue_enabled`` asks
+GitHub whether the canonical branch has a merge queue, and when it does the
+landing is enqueued with ``expectedHeadOid`` and GitHub serializes it.
+
+GitHub merge queues are an **organization-only** feature.  On a User-owned
+repository the API refuses the rule outright -- adding a ``merge_queue`` rule to
+a personal repo's ruleset returns HTTP 422 ``Invalid rule 'merge_queue'`` even
+with no parameters -- and GitHub has said it does not plan to open the feature
+to personal accounts.  So for every personal repository mac manages, the
+serialization guarantee simply is not available from the forge, and #400's
+"no forge queue" path degraded to a plain squash merge whose weaker guarantee it
+recorded honestly but could not fix.
+
+This module is the fix: the queue itself, inside mac, durable in the ledger.
+
+## The algorithm (well-trodden; nothing here is invented)
+
+* **Ordering.**  Entries are approved changes awaiting land, ordered by
+  admission, keyed by (repository, canonical branch).
+* **Speculative batching** (Zuul's model).  Assume every queued entry will pass.
+  Entry *N* is projected and tested on top of entries *1..N-1* rather than on
+  the bare tip, so the entries can be tested in parallel instead of serially.
+  If they all pass they land in order.  If entry *K* fails, everything behind it
+  was tested against a state that will never exist: those speculative results
+  are **discarded**, *K* is **evicted**, and the survivors are re-planned in a
+  new speculation epoch without it.
+* **Window sizing** (Zuul again, explicitly modelled on TCP congestion
+  control).  An active window bounds how many entries may be speculating at
+  once.  It grows **additively** on each successful land up to a ceiling and is
+  **halved** on failure down to a floor.  That is what stops a flaky or
+  conflict-heavy period from burning the whole fleet on speculation that will be
+  thrown away.  The window starts at the floor, so a fresh queue behaves exactly
+  like a serial queue and only speculates once it has evidence that landing is
+  working.
+
+## The invariant that outranks all of the above
+
+**Never land an untested tree.**  Every other property here is negotiable and
+this one is not.  It is enforced structurally rather than by bookkeeping: an
+entry records the *tree* it was tested against (``tested_base_tree``) and the
+*tree* the test produced (``tested_merge_tree``), and :func:`landing_is_safe`
+refuses the land unless the canonical tip's tree is byte-identical to the tree
+the entry was tested on top of.  Comparing trees rather than commit SHAs is what
+makes speculation safe *and* survives squash merges, which change the commit but
+not the tree.
+
+Ambiguity resolves to NOT landing: an unreadable tip, a missing entry, a lease
+we no longer hold, or a queue state we cannot parse all defer through the
+publication retry backoff.  None of them can reach "merge anyway".
+
+References: Hoare, "The Not Rocket Science Rule"; bors-ng; GitHub Merge Queue;
+Zuul project gating (speculative merge trains, windowed on TCP congestion
+control); Kung & Robinson, "On Optimistic Methods for Concurrency Control"
+(ACM TODS 1981).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from mac.models import (
+    JsonDict,
+    ensure_json_object,
+    json_dumps,
+    json_loads,
+    new_id,
+    parse_time,
+    utcnow,
+)
+
+# States an entry can be in.  The first three are live; the last three are
+# terminal and are what the partial unique index excludes, so a task may be
+# re-admitted after an eviction without colliding with its own history.
+STATE_QUEUED = "queued"
+STATE_TESTING = "testing"
+STATE_TESTED = "tested"
+STATE_LANDED = "landed"
+STATE_EVICTED = "evicted"
+STATE_SUPERSEDED = "superseded"
+
+LIVE_STATES = (STATE_QUEUED, STATE_TESTING, STATE_TESTED)
+TERMINAL_STATES = (STATE_LANDED, STATE_EVICTED, STATE_SUPERSEDED)
+
+QUEUE_SCHEMA = "mac.native_merge_queue.v1"
+
+# Serialization modes, recorded in publication evidence as `merge_serialization`
+# exactly the way #400 records the forge's.  These strings are a contract: they
+# show up in `mac task show` and in the integration proof.
+MODE_FORGE_QUEUE = "merge_queue"
+MODE_NATIVE_QUEUE = "mac_native_queue"
+MODE_DIRECT_SQUASH = "direct_squash"
+
+
+# ----------------------------------------------------------------------------
+# Window sizing: additive increase, multiplicative decrease.
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WindowBounds:
+    """Bounds and step size for the AIMD speculation window.
+
+    ``floor`` of 1 means the degenerate case is a *serial* queue: one entry
+    tested against the real tip, landed, then the next.  That is the safe
+    behaviour, and it is where every queue starts and where a failing queue is
+    driven back to.  ``ceiling`` is the cap the brief asks to be stated: it is
+    the maximum number of entries that may hold a speculative slot at once, and
+    therefore the maximum number of workers speculation can occupy.
+    """
+
+    floor: int = 1
+    ceiling: int = 4
+    increment: int = 1
+
+    def __post_init__(self) -> None:
+        if self.floor < 1:
+            raise ValueError("merge queue window floor must be >= 1")
+        if self.ceiling < self.floor:
+            raise ValueError("merge queue window ceiling must be >= floor")
+        if self.increment < 1:
+            raise ValueError("merge queue window increment must be >= 1")
+
+    def clamp(self, value: int) -> int:
+        return max(self.floor, min(self.ceiling, int(value)))
+
+
+def next_window(current: int, *, outcome: str, bounds: WindowBounds) -> int:
+    """The AIMD step.  ``landed`` grows additively; anything else halves.
+
+    Halving on *any* non-land outcome is deliberate.  A conflict, a failing
+    test, and a forge that could not be read all mean the same thing to the
+    controller: speculation built on this queue is currently being thrown away,
+    so buy less of it.
+    """
+
+    size = bounds.clamp(current)
+    if outcome == "landed":
+        return bounds.clamp(size + bounds.increment)
+    return bounds.clamp(size // 2 if size > bounds.floor else size)
+
+
+def bounds_from_env(environ: Optional[Dict[str, str]] = None) -> WindowBounds:
+    """Read the window knobs.
+
+    ``MAC_MERGE_QUEUE_WINDOW_FLOOR`` (default 1), ``..._WINDOW_CEILING``
+    (default 4) and ``..._WINDOW_INCREMENT`` (default 1).  A ceiling of 1
+    disables speculation entirely and leaves a strictly serial queue, which is
+    the documented way to turn speculation off without turning the queue off.
+    """
+
+    env = os.environ if environ is None else environ
+
+    def _int(name: str, default: int) -> int:
+        try:
+            return int(str(env.get(name, "")).strip() or default)
+        except (TypeError, ValueError):
+            return default
+
+    floor = max(1, _int("MAC_MERGE_QUEUE_WINDOW_FLOOR", 1))
+    ceiling = max(floor, _int("MAC_MERGE_QUEUE_WINDOW_CEILING", 4))
+    increment = max(1, _int("MAC_MERGE_QUEUE_WINDOW_INCREMENT", 1))
+    return WindowBounds(floor=floor, ceiling=ceiling, increment=increment)
+
+
+def lease_seconds_from_env(environ: Optional[Dict[str, str]] = None) -> int:
+    """How long a speculative slot may be held before it is reclaimable.
+
+    ``MAC_MERGE_QUEUE_LEASE_SECONDS``, default 5400 (90 minutes).  The full
+    contract suite here runs ~45 minutes and the scoped one ~15, so the default
+    is deliberately longer than a slow test run: reclaiming a slot from a worker
+    that is still testing wastes the test, while reclaiming one from a hub that
+    died is the entire point of the lease.
+    """
+
+    env = os.environ if environ is None else environ
+    try:
+        value = int(str(env.get("MAC_MERGE_QUEUE_LEASE_SECONDS", "")).strip() or 5400)
+    except (TypeError, ValueError):
+        value = 5400
+    return max(60, value)
+
+
+# ----------------------------------------------------------------------------
+# Entries and pure planning.
+# ----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class QueueEntry:
+    """One approved change awaiting land."""
+
+    id: str
+    repository: str
+    branch: str
+    task_id: str
+    pull_request_number: int
+    head_sha: str
+    state: str
+    position: int
+    speculation_epoch: int
+    tested_base_sha: str = ""
+    tested_base_tree: str = ""
+    tested_merge_tree: str = ""
+    predecessors: Tuple[str, ...] = ()
+    lease_owner: str = ""
+    lease_expires_at: str = ""
+    attempts: int = 0
+    eviction_reason: str = ""
+    landed_sha: str = ""
+    detail: JsonDict = field(default_factory=dict)
+    created_at: str = ""
+    updated_at: str = ""
+
+    @property
+    def live(self) -> bool:
+        return self.state in LIVE_STATES
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "schema": QUEUE_SCHEMA,
+            "id": self.id,
+            "repository": self.repository,
+            "branch": self.branch,
+            "task_id": self.task_id,
+            "pull_request_number": self.pull_request_number,
+            "head_sha": self.head_sha,
+            "state": self.state,
+            "position": self.position,
+            "speculation_epoch": self.speculation_epoch,
+            "tested_base_sha": self.tested_base_sha,
+            "tested_base_tree": self.tested_base_tree,
+            "tested_merge_tree": self.tested_merge_tree,
+            "predecessors": list(self.predecessors),
+            "lease_owner": self.lease_owner,
+            "attempts": self.attempts,
+            "eviction_reason": self.eviction_reason,
+            "landed_sha": self.landed_sha,
+        }
+
+
+@dataclass(frozen=True)
+class BatchSlot:
+    """One entry's place in the speculative batch."""
+
+    entry_id: str
+    task_id: str
+    head_sha: str
+    depth: int
+    predecessors: Tuple[str, ...]
+
+
+def speculation_plan(
+    entries: Sequence[QueueEntry], window: int
+) -> List[BatchSlot]:
+    """Assign each live entry, in order, the heads it must speculate on top of.
+
+    The frontmost entry speculates on nothing (it is tested against the real
+    tip); entry *N* speculates on the heads of entries *1..N-1*.  Only the first
+    ``window`` live entries get a slot -- that is the bound, and it is what
+    keeps speculation from consuming every worker.
+    """
+
+    live = [entry for entry in entries if entry.live]
+    live.sort(key=lambda item: (item.position, item.id))
+    slots: List[BatchSlot] = []
+    heads: List[str] = []
+    for depth, entry in enumerate(live[: max(1, int(window))]):
+        slots.append(
+            BatchSlot(
+                entry_id=entry.id,
+                task_id=entry.task_id,
+                head_sha=entry.head_sha,
+                depth=depth,
+                predecessors=tuple(heads),
+            )
+        )
+        heads.append(entry.head_sha)
+    return slots
+
+
+@dataclass(frozen=True)
+class EvictionPlan:
+    """What an eviction does to the rest of the batch.
+
+    ``discarded`` is the part that matters and the part that is easy to forget:
+    every entry BEHIND the failure was tested against a projected state that
+    now will never exist, so its result is worthless even though its tests were
+    green.  Keeping those results is precisely how a speculative queue lands an
+    untested tree.
+    """
+
+    evicted_id: str
+    reason: str
+    discarded: Tuple[str, ...]
+    survivors: Tuple[str, ...]
+
+
+def plan_eviction(
+    entries: Sequence[QueueEntry], failed_entry_id: str, reason: str
+) -> EvictionPlan:
+    live = [entry for entry in entries if entry.live]
+    live.sort(key=lambda item: (item.position, item.id))
+    ids = [entry.id for entry in live]
+    if failed_entry_id not in ids:
+        return EvictionPlan(failed_entry_id, reason, (), tuple(ids))
+    index = ids.index(failed_entry_id)
+    behind = live[index + 1 :]
+    # Only entries that actually carry a speculative result are "discarded";
+    # an entry that never got as far as testing has nothing to throw away.
+    discarded = tuple(
+        entry.id
+        for entry in behind
+        if entry.state in (STATE_TESTING, STATE_TESTED) or entry.predecessors
+    )
+    survivors = tuple(entry.id for entry in live if entry.id != failed_entry_id)
+    return EvictionPlan(failed_entry_id, reason, discarded, survivors)
+
+
+def landing_is_safe(
+    entry: QueueEntry,
+    *,
+    canonical_tip_tree: str,
+    front_entry_id: str,
+) -> Tuple[bool, str]:
+    """The one gate that may never be wrong: is it safe to land ``entry`` now?
+
+    Three conditions, all of which fail toward NOT landing:
+
+    1. the entry is the FRONT of its queue -- landing out of order would put a
+       tree on the trunk that nothing was tested against;
+    2. it actually carries a test result (``tested_base_tree`` /
+       ``tested_merge_tree``);
+    3. the canonical tip's tree is byte-identical to the tree the entry was
+       tested on top of.  A tip that moved -- whether by a concurrent land, a
+       human push, or a predecessor landing something other than what we
+       speculated -- means the tested projection is stale.
+
+    Anything unreadable (an empty tip tree) is a refusal, not a pass.
+    """
+
+    if entry.id != front_entry_id:
+        return False, "entry is not at the front of the queue"
+    if entry.state not in (STATE_TESTED, STATE_TESTING):
+        return False, "entry has no recorded test result (state=%s)" % entry.state
+    if not entry.tested_base_tree or not entry.tested_merge_tree:
+        return False, "entry carries no tested trees"
+    tip = str(canonical_tip_tree or "").strip()
+    if not tip:
+        return False, "canonical tip tree could not be read"
+    if tip != entry.tested_base_tree:
+        return False, (
+            "canonical tip tree %s is not the tree this entry was tested on top "
+            "of (%s); the tested projection is stale"
+            % (tip[:12], entry.tested_base_tree[:12])
+        )
+    return True, ""
+
+
+@dataclass(frozen=True)
+class SlotDecision:
+    """Whether this publication attempt may proceed, and on what base."""
+
+    admitted: bool
+    entry: Optional[QueueEntry] = None
+    predecessors: Tuple[str, ...] = ()
+    depth: int = 0
+    window: int = 1
+    depth_in_queue: int = 0
+    reason: str = ""
+    defer_seconds: int = 0
+
+    def to_dict(self) -> JsonDict:
+        return {
+            "schema": "mac.native_merge_queue.slot.v1",
+            "admitted": self.admitted,
+            "entry_id": self.entry.id if self.entry else "",
+            "position": self.entry.position if self.entry else 0,
+            "speculation_epoch": self.entry.speculation_epoch if self.entry else 0,
+            "predecessors": list(self.predecessors),
+            "speculation_depth": self.depth,
+            "window": self.window,
+            "queue_depth": self.depth_in_queue,
+            "reason": self.reason,
+            "defer_seconds": self.defer_seconds,
+        }
+
+
+# ----------------------------------------------------------------------------
+# The durable queue.
+# ----------------------------------------------------------------------------
+
+
+class NativeMergeQueue:
+    """Ledger-backed ordered queue, one per (repository, canonical branch).
+
+    Every mutation is a single conditional UPDATE whose row count is the
+    compare-and-swap result, so two hubs racing on the same entry cannot both
+    win, and a hub that dies mid-flight leaves a leased row that the next hub
+    reclaims once the lease expires.  Nothing is held in process memory: a
+    restart re-reads the queue and continues.
+    """
+
+    def __init__(
+        self,
+        store: Any,
+        *,
+        bounds: Optional[WindowBounds] = None,
+        lease_seconds: Optional[int] = None,
+        now: Callable[[], str] = utcnow,
+        observe: Optional[Callable[..., Any]] = None,
+    ) -> None:
+        self._store = store
+        self._bounds = bounds or bounds_from_env()
+        self._lease_seconds = (
+            int(lease_seconds) if lease_seconds is not None else lease_seconds_from_env()
+        )
+        self._now = now
+        self._observe_hook = observe
+
+    # -- reading ---------------------------------------------------------
+
+    @property
+    def bounds(self) -> WindowBounds:
+        return self._bounds
+
+    def entries(self, repository: str, branch: str) -> List[QueueEntry]:
+        rows = self._store.query_all(
+            """
+            SELECT * FROM merge_queue_entries
+            WHERE repository = ? AND branch = ?
+            ORDER BY position, id
+            """,
+            (repository, branch),
+        )
+        return [self._from_row(row) for row in rows]
+
+    def live_entries(self, repository: str, branch: str) -> List[QueueEntry]:
+        return [entry for entry in self.entries(repository, branch) if entry.live]
+
+    def entry(self, entry_id: str) -> Optional[QueueEntry]:
+        row = self._store.query_one(
+            "SELECT * FROM merge_queue_entries WHERE id = ?", (entry_id,)
+        )
+        return self._from_row(row) if row is not None else None
+
+    def window(self, repository: str, branch: str) -> int:
+        row = self._store.query_one(
+            "SELECT window_size FROM merge_queue_windows WHERE repository = ? AND branch = ?",
+            (repository, branch),
+        )
+        if row is None:
+            return self._bounds.floor
+        return self._bounds.clamp(int(row["window_size"]))
+
+    def snapshot(self, repository: str, branch: str) -> JsonDict:
+        """Everything an operator needs to watch this queue.
+
+        The brief is explicit about why this exists: this repository has
+        produced four separate gates that reported healthy while enforcing
+        nothing.  A queue nobody can watch is the next one, so depth, window,
+        what is testing, what was evicted and why, and how much speculation has
+        been discarded are all first-class here rather than inferred from logs.
+        """
+
+        entries = self.entries(repository, branch)
+        live = [entry for entry in entries if entry.live]
+        row = self._store.query_one(
+            """
+            SELECT window_size, landed_count, failure_count, speculation_discarded,
+                   last_event, updated_at
+            FROM merge_queue_windows WHERE repository = ? AND branch = ?
+            """,
+            (repository, branch),
+        )
+        evicted = [
+            entry for entry in entries if entry.state == STATE_EVICTED
+        ][-10:]
+        return {
+            "schema": "mac.native_merge_queue.snapshot.v1",
+            "repository": repository,
+            "branch": branch,
+            "queue_depth": len(live),
+            "window_size": self._bounds.clamp(
+                int(row["window_size"]) if row is not None else self._bounds.floor
+            ),
+            "window_floor": self._bounds.floor,
+            "window_ceiling": self._bounds.ceiling,
+            "entries_testing": sum(
+                1 for entry in live if entry.state == STATE_TESTING
+            ),
+            "entries_tested": sum(1 for entry in live if entry.state == STATE_TESTED),
+            "entries_queued": sum(1 for entry in live if entry.state == STATE_QUEUED),
+            "landed_count": int(row["landed_count"]) if row is not None else 0,
+            "failure_count": int(row["failure_count"]) if row is not None else 0,
+            "speculation_discarded": (
+                int(row["speculation_discarded"]) if row is not None else 0
+            ),
+            "last_event": str(row["last_event"]) if row is not None else "",
+            "front": live[0].to_dict() if live else None,
+            "live": [entry.to_dict() for entry in live],
+            "recent_evictions": [
+                {
+                    "entry_id": entry.id,
+                    "task_id": entry.task_id,
+                    "reason": entry.eviction_reason,
+                    "at": entry.updated_at,
+                }
+                for entry in evicted
+            ],
+        }
+
+    # -- admission -------------------------------------------------------
+
+    def admit(
+        self,
+        *,
+        repository: str,
+        branch: str,
+        task_id: str,
+        head_sha: str,
+        pull_request_number: int = 0,
+        detail: Optional[JsonDict] = None,
+    ) -> QueueEntry:
+        """Place ``task_id`` in the queue, or return the entry it already has.
+
+        Idempotent by construction: publication is retried, and a retry must
+        rejoin the queue where it already stands rather than queue a second
+        time.  A retry whose reviewed head CHANGED supersedes the old entry --
+        the previous entry's test result was for a different commit and must
+        not be reused.
+        """
+
+        now = self._now()
+        existing = self._live_entry_for_task(repository, branch, task_id)
+        if existing is not None:
+            if existing.head_sha == head_sha:
+                return existing
+            self._terminate(
+                existing.id,
+                STATE_SUPERSEDED,
+                reason="reviewed head moved from %s to %s"
+                % (existing.head_sha[:12], str(head_sha)[:12]),
+            )
+        position = self._next_position(repository, branch)
+        entry_id = new_id("mergeq")
+        self._store.execute(
+            """
+            INSERT INTO merge_queue_entries (
+                id, repository, branch, task_id, pull_request_number, head_sha,
+                state, position, speculation_epoch, tested_base_sha,
+                tested_base_tree, tested_merge_tree, predecessors, lease_owner,
+                lease_expires_at, attempts, eviction_reason, landed_sha, detail,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '', '', '', '[]', NULL, NULL,
+                      0, '', '', ?, ?, ?)
+            """,
+            (
+                entry_id,
+                repository,
+                branch,
+                task_id,
+                int(pull_request_number or 0),
+                str(head_sha),
+                STATE_QUEUED,
+                position,
+                self._current_epoch(repository, branch),
+                json_dumps(ensure_json_object(detail)),
+                now,
+                now,
+            ),
+        )
+        self._ensure_window_row(repository, branch)
+        self._emit(
+            "merge_queue.admitted",
+            repository,
+            branch,
+            {
+                "entry_id": entry_id,
+                "task_id": task_id,
+                "position": position,
+                "value": position,
+            },
+        )
+        admitted = self.entry(entry_id)
+        assert admitted is not None
+        return admitted
+
+    def claim_slot(
+        self,
+        *,
+        repository: str,
+        branch: str,
+        task_id: str,
+        head_sha: str,
+        owner: str,
+        pull_request_number: int = 0,
+        detail: Optional[JsonDict] = None,
+    ) -> SlotDecision:
+        """Admit, then hand out a speculative slot if the window has room.
+
+        Returns ``admitted=False`` with a ``defer_seconds`` when the window is
+        full.  Deferring is the correct answer, not a failure: the publication
+        retry backoff already exists, the PR is already open, and the entry
+        keeps its place in line.
+        """
+
+        entry = self.admit(
+            repository=repository,
+            branch=branch,
+            task_id=task_id,
+            head_sha=head_sha,
+            pull_request_number=pull_request_number,
+            detail=detail,
+        )
+        self._reclaim_expired(repository, branch)
+        live = self.live_entries(repository, branch)
+        window = self.window(repository, branch)
+        plan = speculation_plan(live, window)
+        slot = next((item for item in plan if item.entry_id == entry.id), None)
+        if slot is None:
+            position_in_line = next(
+                (index for index, item in enumerate(live) if item.id == entry.id),
+                len(live),
+            )
+            return SlotDecision(
+                admitted=False,
+                entry=entry,
+                window=window,
+                depth_in_queue=len(live),
+                reason=(
+                    "merge queue window is %d and this entry is #%d in line"
+                    % (window, position_in_line + 1)
+                ),
+                defer_seconds=300,
+            )
+        # CAS the slot. A row already leased by a live owner is not ours.
+        now = self._now()
+        expires = (
+            parse_time(now) + timedelta(seconds=self._lease_seconds)
+        ).isoformat(timespec="microseconds")
+        result = self._store.execute(
+            """
+            UPDATE merge_queue_entries
+               SET state = ?, lease_owner = ?, lease_expires_at = ?,
+                   predecessors = ?, attempts = attempts + 1, updated_at = ?
+             WHERE id = ?
+               AND state IN (?, ?, ?)
+               AND (lease_owner IS NULL OR lease_owner = '' OR lease_owner = ?
+                    OR lease_expires_at IS NULL OR lease_expires_at < ?)
+            """,
+            (
+                STATE_TESTING,
+                owner,
+                expires,
+                json_dumps(list(slot.predecessors)),
+                now,
+                entry.id,
+                STATE_QUEUED,
+                STATE_TESTING,
+                STATE_TESTED,
+                owner,
+                now,
+            ),
+        )
+        if int(getattr(result, "rowcount", 0) or 0) < 1:
+            return SlotDecision(
+                admitted=False,
+                entry=entry,
+                window=window,
+                depth_in_queue=len(live),
+                reason="merge queue slot is leased by another worker",
+                defer_seconds=300,
+            )
+        claimed = self.entry(entry.id)
+        assert claimed is not None
+        self._emit(
+            "merge_queue.slot_claimed",
+            repository,
+            branch,
+            {
+                "entry_id": claimed.id,
+                "task_id": task_id,
+                "speculation_depth": slot.depth,
+                "predecessors": list(slot.predecessors),
+                "window": window,
+                "value": slot.depth,
+            },
+        )
+        return SlotDecision(
+            admitted=True,
+            entry=claimed,
+            predecessors=slot.predecessors,
+            depth=slot.depth,
+            window=window,
+            depth_in_queue=len(live),
+        )
+
+    # -- test results ----------------------------------------------------
+
+    def record_tested(
+        self,
+        entry_id: str,
+        *,
+        owner: str,
+        base_sha: str,
+        base_tree: str,
+        merge_tree: str,
+    ) -> bool:
+        """Attach the projected-merge result to the entry, under our lease."""
+
+        now = self._now()
+        result = self._store.execute(
+            """
+            UPDATE merge_queue_entries
+               SET state = ?, tested_base_sha = ?, tested_base_tree = ?,
+                   tested_merge_tree = ?, updated_at = ?
+             WHERE id = ? AND lease_owner = ? AND state IN (?, ?)
+            """,
+            (
+                STATE_TESTED,
+                str(base_sha),
+                str(base_tree),
+                str(merge_tree),
+                now,
+                entry_id,
+                owner,
+                STATE_TESTING,
+                STATE_TESTED,
+            ),
+        )
+        return int(getattr(result, "rowcount", 0) or 0) >= 1
+
+    def front(self, repository: str, branch: str) -> Optional[QueueEntry]:
+        live = self.live_entries(repository, branch)
+        return live[0] if live else None
+
+    def may_land(
+        self, entry_id: str, *, canonical_tip_tree: str
+    ) -> Tuple[bool, str, Optional[QueueEntry]]:
+        """Re-read the entry from the ledger and apply :func:`landing_is_safe`.
+
+        Re-reading is the point: the caller may have spent 45 minutes testing
+        since it claimed the slot, and the decision must be made on the state
+        that exists now, not on a snapshot from before the test run.
+        """
+
+        entry = self.entry(entry_id)
+        if entry is None:
+            return False, "merge queue entry disappeared", None
+        if entry.state in TERMINAL_STATES:
+            return False, "merge queue entry is %s" % entry.state, entry
+        front = self.front(entry.repository, entry.branch)
+        ok, reason = landing_is_safe(
+            entry,
+            canonical_tip_tree=canonical_tip_tree,
+            front_entry_id=front.id if front else "",
+        )
+        return ok, reason, entry
+
+    # -- terminal transitions -------------------------------------------
+
+    def record_landed(self, entry_id: str, *, landed_sha: str) -> JsonDict:
+        """Mark the entry landed and grow the window.
+
+        Idempotent: an entry already recorded as landed returns the same
+        outcome rather than bumping the window twice.  That matters because the
+        forge may have landed the PR between attempts, and observing that is a
+        success, not a second land.
+        """
+
+        entry = self.entry(entry_id)
+        if entry is None:
+            return {"changed": False, "reason": "entry not found"}
+        if entry.state == STATE_LANDED:
+            return {
+                "changed": False,
+                "reason": "already landed",
+                "window_size": self.window(entry.repository, entry.branch),
+            }
+        now = self._now()
+        result = self._store.execute(
+            """
+            UPDATE merge_queue_entries
+               SET state = ?, landed_sha = ?, lease_owner = NULL,
+                   lease_expires_at = NULL, updated_at = ?
+             WHERE id = ? AND state <> ?
+            """,
+            (STATE_LANDED, str(landed_sha or ""), now, entry_id, STATE_LANDED),
+        )
+        if int(getattr(result, "rowcount", 0) or 0) < 1:
+            return {"changed": False, "reason": "entry already terminal"}
+        window = self._step_window(
+            entry.repository,
+            entry.branch,
+            outcome="landed",
+            event="landed %s" % entry.task_id,
+        )
+        self._emit(
+            "merge_queue.landed",
+            entry.repository,
+            entry.branch,
+            {
+                "entry_id": entry_id,
+                "task_id": entry.task_id,
+                "landed_sha": str(landed_sha or "")[:40],
+                "window_size": window,
+                "value": window,
+            },
+        )
+        return {"changed": True, "window_size": window}
+
+    def evict(self, entry_id: str, *, reason: str) -> JsonDict:
+        """Evict a failed entry and discard every speculative result behind it.
+
+        This is the half of speculation that keeps it honest.  Entries behind
+        the failure were green -- against a tree that will never exist.  They go
+        back to ``queued`` in a NEW speculation epoch with their test results
+        cleared, so nothing downstream can present a stale result as a pass.
+        """
+
+        entry = self.entry(entry_id)
+        if entry is None:
+            return {"changed": False, "reason": "entry not found"}
+        repository, branch = entry.repository, entry.branch
+        plan = plan_eviction(self.entries(repository, branch), entry_id, reason)
+        now = self._now()
+        self._store.execute(
+            """
+            UPDATE merge_queue_entries
+               SET state = ?, eviction_reason = ?, lease_owner = NULL,
+                   lease_expires_at = NULL, updated_at = ?
+             WHERE id = ? AND state IN (?, ?, ?)
+            """,
+            (
+                STATE_EVICTED,
+                str(reason)[:500],
+                now,
+                entry_id,
+                STATE_QUEUED,
+                STATE_TESTING,
+                STATE_TESTED,
+            ),
+        )
+        epoch = self._bump_epoch(repository, branch)
+        discarded = 0
+        for other_id in plan.survivors:
+            other = self.entry(other_id)
+            if other is None or not other.live:
+                continue
+            had_result = bool(other.tested_base_tree) or bool(other.predecessors)
+            self._store.execute(
+                """
+                UPDATE merge_queue_entries
+                   SET state = ?, tested_base_sha = '', tested_base_tree = '',
+                       tested_merge_tree = '', predecessors = '[]',
+                       speculation_epoch = ?, lease_owner = NULL,
+                       lease_expires_at = NULL, updated_at = ?
+                 WHERE id = ? AND state IN (?, ?, ?)
+                """,
+                (
+                    STATE_QUEUED,
+                    epoch,
+                    now,
+                    other_id,
+                    STATE_QUEUED,
+                    STATE_TESTING,
+                    STATE_TESTED,
+                ),
+            )
+            if had_result:
+                discarded += 1
+        window = self._step_window(
+            repository,
+            branch,
+            outcome="failed",
+            event="evicted %s: %s" % (entry.task_id, str(reason)[:120]),
+            discarded=discarded,
+        )
+        self._emit(
+            "merge_queue.evicted",
+            repository,
+            branch,
+            {
+                "entry_id": entry_id,
+                "task_id": entry.task_id,
+                "reason": str(reason)[:300],
+                "speculation_discarded": discarded,
+                "discarded_entries": list(plan.discarded),
+                "survivors": list(plan.survivors),
+                "window_size": window,
+                "speculation_epoch": epoch,
+                "value": discarded,
+            },
+            level="warning",
+        )
+        return {
+            "changed": True,
+            "window_size": window,
+            "speculation_discarded": discarded,
+            "discarded_entries": list(plan.discarded),
+            "survivors": list(plan.survivors),
+            "speculation_epoch": epoch,
+        }
+
+    def release(self, entry_id: str, *, owner: str) -> bool:
+        """Give the slot back without a verdict (a deferral, not a failure)."""
+
+        result = self._store.execute(
+            """
+            UPDATE merge_queue_entries
+               SET lease_owner = NULL, lease_expires_at = NULL, updated_at = ?
+             WHERE id = ? AND lease_owner = ? AND state IN (?, ?, ?)
+            """,
+            (
+                self._now(),
+                entry_id,
+                owner,
+                STATE_QUEUED,
+                STATE_TESTING,
+                STATE_TESTED,
+            ),
+        )
+        return int(getattr(result, "rowcount", 0) or 0) >= 1
+
+    # -- internals -------------------------------------------------------
+
+    def _live_entry_for_task(
+        self, repository: str, branch: str, task_id: str
+    ) -> Optional[QueueEntry]:
+        row = self._store.query_one(
+            """
+            SELECT * FROM merge_queue_entries
+             WHERE repository = ? AND branch = ? AND task_id = ?
+               AND state IN (?, ?, ?)
+             ORDER BY position DESC LIMIT 1
+            """,
+            (repository, branch, task_id, *LIVE_STATES),
+        )
+        return self._from_row(row) if row is not None else None
+
+    def _next_position(self, repository: str, branch: str) -> int:
+        row = self._store.query_one(
+            "SELECT MAX(position) AS top FROM merge_queue_entries WHERE repository = ? AND branch = ?",
+            (repository, branch),
+        )
+        top = row["top"] if row is not None else None
+        return int(top or 0) + 1
+
+    def _current_epoch(self, repository: str, branch: str) -> int:
+        row = self._store.query_one(
+            "SELECT MAX(speculation_epoch) AS epoch FROM merge_queue_entries WHERE repository = ? AND branch = ?",
+            (repository, branch),
+        )
+        epoch = row["epoch"] if row is not None else None
+        return int(epoch or 0)
+
+    def _bump_epoch(self, repository: str, branch: str) -> int:
+        return self._current_epoch(repository, branch) + 1
+
+    def _reclaim_expired(self, repository: str, branch: str) -> int:
+        """Return slots whose holder died.  This is the crash-safety hinge.
+
+        A hub that dies between claiming a slot and landing leaves the row in
+        ``testing`` with a lease that stops being renewed.  Once it expires the
+        slot is reclaimable; the entry keeps its POSITION, so recovery resumes
+        the queue rather than reordering it.
+        """
+
+        result = self._store.execute(
+            """
+            UPDATE merge_queue_entries
+               SET lease_owner = NULL, lease_expires_at = NULL,
+                   state = ?, tested_base_sha = '', tested_base_tree = '',
+                   tested_merge_tree = '', updated_at = ?
+             WHERE repository = ? AND branch = ? AND state IN (?, ?)
+               AND lease_expires_at IS NOT NULL AND lease_expires_at < ?
+            """,
+            (
+                STATE_QUEUED,
+                self._now(),
+                repository,
+                branch,
+                STATE_TESTING,
+                STATE_TESTED,
+                self._now(),
+            ),
+        )
+        reclaimed = int(getattr(result, "rowcount", 0) or 0)
+        if reclaimed:
+            self._emit(
+                "merge_queue.lease_reclaimed",
+                repository,
+                branch,
+                {"reclaimed": reclaimed, "value": reclaimed},
+                level="warning",
+            )
+        return reclaimed
+
+    def _ensure_window_row(self, repository: str, branch: str) -> None:
+        now = self._now()
+        self._store.execute(
+            """
+            INSERT INTO merge_queue_windows (
+                repository, branch, window_size, landed_count, failure_count,
+                speculation_discarded, last_event, updated_at
+            ) VALUES (?, ?, ?, 0, 0, 0, '', ?)
+            ON CONFLICT(repository, branch) DO NOTHING
+            """,
+            (repository, branch, self._bounds.floor, now),
+        )
+
+    def _step_window(
+        self,
+        repository: str,
+        branch: str,
+        *,
+        outcome: str,
+        event: str,
+        discarded: int = 0,
+    ) -> int:
+        self._ensure_window_row(repository, branch)
+        current = self.window(repository, branch)
+        size = next_window(current, outcome=outcome, bounds=self._bounds)
+        landed = 1 if outcome == "landed" else 0
+        failed = 0 if outcome == "landed" else 1
+        self._store.execute(
+            """
+            UPDATE merge_queue_windows
+               SET window_size = ?, landed_count = landed_count + ?,
+                   failure_count = failure_count + ?,
+                   speculation_discarded = speculation_discarded + ?,
+                   last_event = ?, updated_at = ?
+             WHERE repository = ? AND branch = ?
+            """,
+            (
+                size,
+                landed,
+                failed,
+                int(discarded),
+                str(event)[:300],
+                self._now(),
+                repository,
+                branch,
+            ),
+        )
+        return size
+
+    def _terminate(self, entry_id: str, state: str, *, reason: str) -> None:
+        self._store.execute(
+            """
+            UPDATE merge_queue_entries
+               SET state = ?, eviction_reason = ?, lease_owner = NULL,
+                   lease_expires_at = NULL, updated_at = ?
+             WHERE id = ?
+            """,
+            (state, str(reason)[:500], self._now(), entry_id),
+        )
+
+    def _emit(
+        self,
+        name: str,
+        repository: str,
+        branch: str,
+        detail: JsonDict,
+        *,
+        level: str = "info",
+    ) -> None:
+        if self._observe_hook is None:
+            return
+        payload = dict(detail)
+        payload.update({"repository": repository, "branch": branch})
+        try:
+            # ``observe`` is ControlPlane.record_metric: (name, value, ...).
+            # The value carries the number that matters for that event so a
+            # `GET /observability/metrics?name=merge_queue.depth` is a real
+            # time series and not a bag of JSON blobs.
+            self._observe_hook(
+                name,
+                float(payload.get("value", 1) or 0),
+                unit="count",
+                layer="control_plane",
+                source="native-merge-queue",
+                level=level,
+                subject_type="repository",
+                subject_id="%s#%s" % (repository, branch),
+                detail=payload,
+            )
+        except Exception:  # noqa: BLE001 - telemetry must never break a land.
+            pass
+
+    @staticmethod
+    def _from_row(row: Any) -> QueueEntry:
+        return QueueEntry(
+            id=row["id"],
+            repository=row["repository"],
+            branch=row["branch"],
+            task_id=row["task_id"],
+            pull_request_number=int(row["pull_request_number"] or 0),
+            head_sha=row["head_sha"] or "",
+            state=row["state"],
+            position=int(row["position"] or 0),
+            speculation_epoch=int(row["speculation_epoch"] or 0),
+            tested_base_sha=row["tested_base_sha"] or "",
+            tested_base_tree=row["tested_base_tree"] or "",
+            tested_merge_tree=row["tested_merge_tree"] or "",
+            predecessors=tuple(json_loads(row["predecessors"], []) or []),
+            lease_owner=row["lease_owner"] or "",
+            lease_expires_at=row["lease_expires_at"] or "",
+            attempts=int(row["attempts"] or 0),
+            eviction_reason=row["eviction_reason"] or "",
+            landed_sha=row["landed_sha"] or "",
+            detail=ensure_json_object(json_loads(row["detail"], {})),
+            created_at=row["created_at"] or "",
+            updated_at=row["updated_at"] or "",
+        )
+
+
+__all__ = [
+    "MODE_DIRECT_SQUASH",
+    "MODE_FORGE_QUEUE",
+    "MODE_NATIVE_QUEUE",
+    "BatchSlot",
+    "EvictionPlan",
+    "NativeMergeQueue",
+    "QueueEntry",
+    "SlotDecision",
+    "WindowBounds",
+    "bounds_from_env",
+    "landing_is_safe",
+    "lease_seconds_from_env",
+    "next_window",
+    "plan_eviction",
+    "speculation_plan",
+]

--- a/src/mac/native_merge_queue.py
+++ b/src/mac/native_merge_queue.py
@@ -430,10 +430,6 @@ class NativeMergeQueue:
 
     # -- reading ---------------------------------------------------------
 
-    @property
-    def bounds(self) -> WindowBounds:
-        return self._bounds
-
     def entries(self, repository: str, branch: str) -> List[QueueEntry]:
         rows = self._store.query_all(
             """
@@ -914,15 +910,27 @@ class NativeMergeQueue:
         }
 
     def release(self, entry_id: str, *, owner: str) -> bool:
-        """Give the slot back without a verdict (a deferral, not a failure)."""
+        """Give the slot back without a verdict (a deferral, not a failure).
+
+        The entry returns to ``queued``, not merely un-leased.  Leaving it in
+        ``testing`` with no owner made ``snapshot()['entries_testing']`` count
+        an entry nobody was testing -- a queue that reports work in flight that
+        is not in flight is the same lie as a gate that reports healthy while
+        enforcing nothing.  Any partial result is dropped with it, for the same
+        reason :meth:`_reclaim_expired` drops one: it was produced for a
+        position this entry may not re-take.
+        """
 
         result = self._store.execute(
             """
             UPDATE merge_queue_entries
-               SET lease_owner = NULL, lease_expires_at = NULL, updated_at = ?
+               SET lease_owner = NULL, lease_expires_at = NULL, state = ?,
+                   tested_base_sha = '', tested_base_tree = '',
+                   tested_merge_tree = '', updated_at = ?
              WHERE id = ? AND lease_owner = ? AND state IN (?, ?, ?)
             """,
             (
+                STATE_QUEUED,
                 self._now(),
                 entry_id,
                 owner,

--- a/src/mac/project_repository_service.py
+++ b/src/mac/project_repository_service.py
@@ -188,6 +188,31 @@ class ProjectRepositoryService:
             )
         return [self.from_row(row) for row in rows]
 
+    def record_merge_capability(
+        self, repo_id_or_name: str, capability: Dict[str, Any]
+    ) -> ProjectRepository:
+        """Store a resolved merge-serialization capability on the repo record.
+
+        Written into ``metadata`` rather than a new column because
+        ``schema.sql`` is ``CREATE TABLE IF NOT EXISTS`` with no migration
+        framework -- a new column simply would not appear on the live hub.
+
+        The capability's own ``error`` field carries a failed probe rather than
+        ``last_error``: ``last_error`` belongs to issue ingest, and letting a
+        capability probe overwrite it would make an ingest failure and a
+        capability failure indistinguishable, which is the exact confusion this
+        record exists to remove.
+        """
+
+        repo = self.get(repo_id_or_name)
+        metadata = ensure_json_object(repo.metadata)
+        metadata["merge_serialization_capability"] = ensure_json_object(capability)
+        self._store.execute(
+            "UPDATE project_repositories SET metadata = ?, updated_at = ? WHERE id = ?",
+            (json_dumps(metadata), utcnow(), repo.id),
+        )
+        return self.get(repo.id)
+
     def contract_for(self, repo: ProjectRepository) -> JsonDict:
         contract = self._load_contract(Path(repo.path).expanduser())
         if contract["project"] != repo.project:

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -17,6 +17,7 @@ import os
 import re
 import shlex
 import shutil
+import socket
 import subprocess
 import tempfile
 import threading
@@ -1014,6 +1015,21 @@ VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
 PUBLICATION_BLOCK_SCHEMA = "mac.publication_block.v1"
 _GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
 _FULL_GIT_OBJECT_ID_RE = re.compile(r"^(?:[0-9a-f]{40}|[0-9a-f]{64})$")
+
+
+def _git_step_returncode(result: Mapping[str, Any]) -> int:
+    """Read a git step's exit code without turning success into failure.
+
+    ``int(result.get("returncode") or 1)`` reads as "1 when it is missing", but
+    ``0 or 1`` is ``1`` -- so it reported EVERY successful git command as a
+    failure. That silently disabled the merge queue's speculative base: the
+    first `cat-file -e` on a commit we already had looked like a miss, the
+    fetch that followed had no branch to fetch, and speculation fell back to
+    deferring forever.
+    """
+
+    value = result.get("returncode", 1)
+    return 1 if value is None else int(value)
 
 
 class _PublicationBaseMovedError(ValidationError):
@@ -22327,6 +22343,211 @@ class ControlPlane:
             "api_url": api_url,
         }
 
+    # ------------------------------------------------------------------
+    # mac's own merge queue (see mac.native_merge_queue).
+    # ------------------------------------------------------------------
+
+    def _native_merge_queue(self) -> Any:
+        """The durable native queue, bound to this hub's store.
+
+        Constructed lazily and cached: the queue holds no state of its own --
+        everything lives in ``merge_queue_entries`` / ``merge_queue_windows`` --
+        so a restart rebuilds this object and continues from the ledger.
+        """
+
+        from mac.native_merge_queue import NativeMergeQueue
+
+        queue = getattr(self, "_native_merge_queue_instance", None)
+        if queue is None:
+            queue = NativeMergeQueue(self.store, observe=self.record_metric)
+            self._native_merge_queue_instance = queue
+        return queue
+
+    def _merge_queue_snapshot(self, queue: Any, entry_id: str) -> Optional[JsonDict]:
+        """Depth, window, and eviction history for the queue this entry is in.
+
+        Recorded into the publication evidence beside `merge_serialization` so
+        the guarantee is not a claim: an operator reading `mac task show` can
+        see how deep the queue was, how wide the speculation window was, and
+        what was evicted and why. This repository has shipped four gates today
+        that reported healthy while enforcing nothing; a queue nobody can watch
+        is the next one.
+        """
+
+        try:
+            entry = queue.entry(entry_id)
+            if entry is None:
+                return None
+            return queue.snapshot(entry.repository, entry.branch)
+        except Exception:  # noqa: BLE001 - observability never blocks a land
+            return None
+
+    def _merge_queue_owner(self) -> str:
+        """Who holds a queue slot.  Stable per hub process, unique per hub."""
+
+        owner = getattr(self, "_merge_queue_owner_id", "")
+        if not owner:
+            owner = "hub-%s-%d" % (socket.gethostname(), os.getpid())
+            self._merge_queue_owner_id = owner
+        return owner
+
+    def _resolve_merge_serialization(
+        self, clone_url: str, canonical_branch: str
+    ) -> JsonDict:
+        """Decide WHICH mechanism serializes this landing, from stored state.
+
+        The capability is a project attribute refreshed by the existing GitHub
+        ingest poller (see :mod:`mac.merge_capability`), not a per-merge probe.
+        A missing or expired answer is resolved right here and written back, so
+        a repository registered five minutes ago does not have to wait for a
+        poll before it can publish.
+
+        If it still cannot be determined, the answer is mac's own queue.
+        "Unknown" is never permission to do an unserialized squash.
+        """
+
+        from mac.merge_capability import (
+            MergeCapability,
+            capability_ttl_seconds,
+            repository_remote_and_branch,
+            resolve_merge_capability,
+            stored_capability,
+        )
+        from mac.native_merge_queue import MODE_FORGE_QUEUE, MODE_NATIVE_QUEUE
+
+        wanted = _canonicalize_git_url(clone_url)
+        record = None
+        capability: Optional[MergeCapability] = None
+        try:
+            for repo in self.list_project_repositories(enabled=True):
+                coordinates = repository_remote_and_branch(repo)
+                if not coordinates["remote"]:
+                    continue
+                if _canonicalize_git_url(coordinates["remote"]) == wanted:
+                    record = repo
+                    break
+        except Exception:  # noqa: BLE001 - an unreadable registry is not fatal
+            record = None
+        if record is not None:
+            capability = stored_capability(getattr(record, "metadata", None))
+        source = "stored"
+        if capability is None or capability.is_stale(
+            branch=canonical_branch, ttl_seconds=capability_ttl_seconds()
+        ):
+            source = "resolved_now"
+            capability = resolve_merge_capability(
+                clone_url, canonical_branch, resolver="publication"
+            )
+            if record is not None:
+                try:
+                    self.record_repository_merge_capability(
+                        record.id, capability.to_dict()
+                    )
+                except Exception:  # noqa: BLE001 - caching is best effort
+                    pass
+        mode = MODE_FORGE_QUEUE if capability.use_forge_queue else MODE_NATIVE_QUEUE
+        return {
+            "mode": mode,
+            "source": source,
+            "repository_id": getattr(record, "id", "") if record is not None else "",
+            "capability": capability.to_dict(),
+        }
+
+    def _build_speculative_base(
+        self,
+        root: Path,
+        git_step: Any,
+        base_sha: str,
+        predecessors: Sequence[JsonDict],
+    ) -> str:
+        """Project the queue entries ahead of us on top of the canonical tip.
+
+        This is the speculative half of the queue: entry N is tested against
+        ``tip + entries 1..N-1`` rather than the bare tip, so N does not have to
+        wait for N-1 to land before it can be tested.  Each predecessor is
+        merged with ``git merge-tree`` (no working tree is touched) and the
+        result committed with ``commit-tree`` to give the next step a parent.
+
+        Returns "" when the projection cannot be built -- an unfetchable
+        predecessor branch, or a conflict between two queued changes.  The
+        caller defers; it never falls back to testing against the bare tip,
+        because that result would be attributed to a queue position it was not
+        tested at.
+        """
+
+        current = str(base_sha or "").strip()
+        for predecessor in predecessors:
+            sha = str(predecessor.get("head_sha") or "").strip()
+            branch = str(predecessor.get("source_branch") or "").strip()
+            if not sha:
+                return ""
+            have = git_step(
+                "speculative_have", ["cat-file", "-e", "%s^{commit}" % sha], check=False
+            )
+            if _git_step_returncode(have) != 0:
+                if not branch:
+                    return ""
+                fetched = git_step(
+                    "speculative_fetch",
+                    [
+                        "fetch",
+                        "origin",
+                        "+refs/heads/%s:refs/remotes/origin/%s" % (branch, branch),
+                    ],
+                    timeout=180,
+                    check=False,
+                )
+                if _git_step_returncode(fetched) != 0:
+                    return ""
+                have = git_step(
+                    "speculative_have_after_fetch",
+                    ["cat-file", "-e", "%s^{commit}" % sha],
+                    check=False,
+                )
+                if _git_step_returncode(have) != 0:
+                    return ""
+            merged = git_step(
+                "speculative_merge_tree",
+                ["merge-tree", "--write-tree", "--name-only", current, sha],
+                check=False,
+            )
+            if _git_step_returncode(merged) != 0:
+                # Two queued changes conflict with each other. Speculation on
+                # top of this predecessor is worthless; defer rather than
+                # pretend the bare tip is our base.
+                return ""
+            lines = [
+                line
+                for line in str(merged.get("stdout") or "").splitlines()
+                if line.strip()
+            ]
+            if not lines:
+                return ""
+            committed = git_step(
+                "speculative_commit_tree",
+                [
+                    "-c",
+                    "user.name=MAC Merge Queue",
+                    "-c",
+                    "user.email=merge-queue@mac.invalid",
+                    "commit-tree",
+                    lines[0],
+                    "-p",
+                    current,
+                    "-p",
+                    sha,
+                    "-m",
+                    "MAC merge queue speculative base",
+                ],
+                check=False,
+            )
+            if _git_step_returncode(committed) != 0:
+                return ""
+            current = str(committed.get("stdout") or "").strip()
+            if not current:
+                return ""
+        return current
+
     def _publish_via_pull_request(
         self,
         *,
@@ -22344,6 +22565,9 @@ class ControlPlane:
         root: Path,
         agent_pull_request: Optional[JsonDict] = None,
         required_checks: Tuple[str, ...] = (),
+        serialization: Optional[JsonDict] = None,
+        queue: Any = None,
+        queue_entry_id: str = "",
     ) -> JsonDict:
         """Land the agent's pull request; the hub records, it does not author.
 
@@ -22562,8 +22786,118 @@ class ControlPlane:
         # weaker serialization in the evidence. Silently squash-merging while
         # the code still assumes the queue's guarantee is the same hole in a
         # harder-to-see place.
-        queue_enabled = _gitops.merge_queue_enabled(api_url, canonical_branch)
-        if not queue_enabled:
+        from mac.native_merge_queue import (
+            MODE_DIRECT_SQUASH,
+            MODE_FORGE_QUEUE,
+            MODE_NATIVE_QUEUE,
+        )
+
+        mode = str(ensure_json_object(serialization).get("mode") or "")
+        if not mode:
+            # No capability was resolved for us (a direct caller, or a test
+            # exercising this method alone). Ask, and fail toward the mechanism
+            # that serializes: an unknown answer is never a licence to squash.
+            probed = _gitops.merge_queue_enabled(api_url, canonical_branch)
+            mode = MODE_FORGE_QUEUE if probed else MODE_DIRECT_SQUASH
+        queue_enabled = mode == MODE_FORGE_QUEUE
+        native = bool(queue is not None and queue_entry_id and mode == MODE_NATIVE_QUEUE)
+
+        pre_merged: Optional[Any] = None
+        if native:
+            # NEVER DOUBLE-LAND. Between attempts the PR may have been merged by
+            # a human, by the forge, or by a previous attempt of ours that died
+            # after the merge and before recording it. #400 established the
+            # pattern -- read PR state before acting -- and this path needs it
+            # more, because mac is the one doing the merging.
+            observed_pr = _gitops.pull_request_state(api_url, pr.number)
+            commands.append(
+                {
+                    "name": "merge_queue_observe_pull_request",
+                    "attempt": attempt,
+                    "number": pr.number,
+                    "known": bool(observed_pr.get("known")),
+                    "merged": bool(observed_pr.get("merged")),
+                    "state": str(observed_pr.get("state") or ""),
+                    "sha": str(observed_pr.get("sha") or ""),
+                }
+            )
+            if not observed_pr.get("known"):
+                unreadable = ValidationError(
+                    "mac merge queue could not read the state of %s before "
+                    "merging; deferring rather than merging blind"
+                    % (pr.url or ("#%d" % pr.number))
+                )
+                unreadable.publication_retry_after_seconds = 600
+                unreadable.publication_failure_kind = "merge_queue_unreadable_state"
+                raise unreadable
+            if observed_pr.get("merged"):
+                pre_merged = _gitops.PullRequestMergeResult(
+                    merged=True,
+                    number=pr.number,
+                    sha=str(observed_pr.get("sha") or ""),
+                    serialization=MODE_NATIVE_QUEUE,
+                    reason="already merged on the forge; observed, not re-merged",
+                )
+            else:
+                git_step(
+                    "merge_queue_refresh_tip",
+                    [
+                        "fetch",
+                        "origin",
+                        "+refs/heads/%s:refs/remotes/origin/%s"
+                        % (canonical_branch, canonical_branch),
+                    ],
+                    check=False,
+                )
+                tip_tree = str(
+                    git_step(
+                        "merge_queue_tip_tree",
+                        [
+                            "rev-parse",
+                            "refs/remotes/origin/%s^{tree}" % canonical_branch,
+                        ],
+                        check=False,
+                    ).get("stdout")
+                    or ""
+                ).strip()
+                allowed, why, _entry = queue.may_land(
+                    queue_entry_id, canonical_tip_tree=tip_tree
+                )
+                commands.append(
+                    {
+                        "name": "merge_queue_land_gate",
+                        "attempt": attempt,
+                        "entry_id": queue_entry_id,
+                        "allowed": bool(allowed),
+                        "reason": why,
+                        "canonical_tip_tree": tip_tree,
+                    }
+                )
+                if not allowed:
+                    if "front of the queue" in why:
+                        waiting = ValidationError(
+                            "mac merge queue is landing an earlier change first: "
+                            "%s" % why
+                        )
+                        waiting.publication_retry_after_seconds = 300
+                        waiting.publication_failure_kind = "merge_queue_waiting"
+                        raise waiting
+                    observed_canonical = git_step(
+                        "revalidate_canonical_tip",
+                        [
+                            "ls-remote",
+                            "origin",
+                            "refs/heads/%s" % canonical_branch,
+                        ],
+                        check=False,
+                    )
+                    observed_tip = str(
+                        observed_canonical.get("stdout") or ""
+                    ).split(None, 1)
+                    observed_tip = observed_tip[0] if observed_tip else ""
+                    # The tested projection is stale. Re-project; do NOT merge.
+                    raise _PublicationBaseMovedError(base_sha, observed_tip or why)
+        elif not queue_enabled:
             observed_canonical = git_step(
                 "revalidate_canonical_tip",
                 ["ls-remote", "origin", "refs/heads/%s" % canonical_branch],
@@ -22578,12 +22912,21 @@ class ControlPlane:
             {
                 "name": "merge_serialization",
                 "attempt": attempt,
-                "merge_queue": bool(queue_enabled),
-                "mode": "merge_queue" if queue_enabled else "direct_squash",
+                "merge_queue": bool(queue_enabled or native),
+                "mode": mode,
+                "queue_entry_id": queue_entry_id if native else "",
+                "queue": self._merge_queue_snapshot(queue, queue_entry_id)
+                if native
+                else None,
                 "guarantee": (
                     "the forge merge queue tests the projected post-merge tree "
                     "and merges in order: what was tested is what lands"
                     if queue_enabled
+                    else "mac's own merge queue ordered this change, tested it "
+                    "against the tree it will land on, and refused the merge "
+                    "unless the canonical tip's tree is still that exact tree: "
+                    "what was tested is what lands"
+                    if native
                     else "no merge queue on this branch; a plain squash merge "
                     "is not serialized against concurrent merges, so the "
                     "canonical tip was re-validated against the tested base "
@@ -22592,7 +22935,7 @@ class ControlPlane:
             }
         )
         try:
-            merge = _gitops.request_pull_request_merge(
+            merge = pre_merged or _gitops.request_pull_request_merge(
                 api_url,
                 pr.number,
                 sha=head_sha,
@@ -22651,6 +22994,20 @@ class ControlPlane:
             pending.publication_failure_kind = "pull_request_checks_pending"
             raise pending
 
+        if native:
+            landed = queue.record_landed(
+                queue_entry_id, landed_sha=str(merge.sha or "")
+            )
+            commands.append(
+                {
+                    "name": "merge_queue_landed",
+                    "attempt": attempt,
+                    "entry_id": queue_entry_id,
+                    "observed_only": bool(pre_merged),
+                    **landed,
+                }
+            )
+
         final_sha = str(merge.sha or "").strip()
         git_step(
             "refresh_canonical_after_merge",
@@ -22693,8 +23050,10 @@ class ControlPlane:
             "base_sha": base_sha,
             "final_sha": final_sha,
             "publication_mode": "pull_request_squash",
-            "merge_serialization": merge.serialization or (
-                "merge_queue" if queue_enabled else "direct_squash"
+            "merge_serialization": (
+                MODE_NATIVE_QUEUE
+                if native
+                else (merge.serialization or mode or MODE_DIRECT_SQUASH)
             ),
             "pull_request_opened_by": opened_by,
             "pull_request_number": pr.number,
@@ -22800,10 +23159,134 @@ class ControlPlane:
                 validate_projected_merge,
                 validate_projected_merge_contract,
             )
+            from mac.native_merge_queue import MODE_NATIVE_QUEUE
 
-            gate = validate_projected_merge(str(root), base_sha, head_sha)
+            # WHICH MECHANISM SERIALIZES THIS LANDING.
+            #
+            # Read from the project's stored repository attribute rather than
+            # probed here (mac.merge_capability): the answer changes maybe twice
+            # a year and this is the worst possible moment to depend on a forge
+            # API call. GitHub merge queues are organization-only, so for every
+            # User-owned repository the operator has, `mac_native_queue` is not
+            # a fallback -- it is the only path.
+            strategy = self._resolve_publication_strategy(clone_url)
+            serialization = self._resolve_merge_serialization(
+                clone_url, canonical_branch
+            )
+            commands.append(
+                {
+                    "name": "merge_serialization_capability",
+                    "attempt": attempt,
+                    "mode": serialization["mode"],
+                    "source": serialization["source"],
+                    **serialization["capability"],
+                }
+            )
+            use_native_queue = (
+                serialization["mode"] == MODE_NATIVE_QUEUE
+                and strategy["strategy"] == "pull_request"
+            )
+
+            queue = None
+            queue_entry_id = ""
+            queue_owner = ""
+            projected_base_sha = base_sha
+            if use_native_queue:
+                queue = self._native_merge_queue()
+                queue_owner = self._merge_queue_owner()
+                queue_repository = _canonicalize_git_url(clone_url) or clone_url
+                decision = queue.claim_slot(
+                    repository=queue_repository,
+                    branch=canonical_branch,
+                    task_id=str(task.id),
+                    head_sha=head_sha,
+                    owner=queue_owner,
+                    detail={"source_branch": source_branch},
+                )
+                commands.append(
+                    {
+                        "name": "merge_queue_slot",
+                        "attempt": attempt,
+                        **decision.to_dict(),
+                    }
+                )
+                if not decision.admitted:
+                    # The window is full, or another worker holds this slot.
+                    # Deferring is the correct answer: the entry keeps its place
+                    # in line and the existing publication backoff re-attempts.
+                    deferred = ValidationError(
+                        "mac merge queue deferred publication of %s: %s"
+                        % (task.id, decision.reason)
+                    )
+                    deferred.publication_retry_after_seconds = max(
+                        60, int(decision.defer_seconds or 300)
+                    )
+                    deferred.publication_failure_kind = "merge_queue_deferred"
+                    raise deferred
+                queue_entry_id = decision.entry.id if decision.entry else ""
+                if decision.predecessors:
+                    predecessor_entries = [
+                        {
+                            "head_sha": entry.head_sha,
+                            "source_branch": str(
+                                (entry.detail or {}).get("source_branch") or ""
+                            ),
+                        }
+                        for entry in queue.live_entries(
+                            queue_repository, canonical_branch
+                        )
+                        if entry.head_sha in set(decision.predecessors)
+                    ]
+                    projected_base_sha = self._build_speculative_base(
+                        root, git_step, base_sha, predecessor_entries
+                    )
+                    commands.append(
+                        {
+                            "name": "merge_queue_speculative_base",
+                            "attempt": attempt,
+                            "tip": base_sha,
+                            "speculative_base": projected_base_sha,
+                            "predecessors": list(decision.predecessors),
+                            "built": bool(projected_base_sha),
+                        }
+                    )
+                    if not projected_base_sha:
+                        # A predecessor we cannot fetch, or two queued changes
+                        # that conflict. Never test against the bare tip
+                        # instead: that result would be attributed to a queue
+                        # position it was not tested at.
+                        queue.release(queue_entry_id, owner=queue_owner)
+                        stalled = ValidationError(
+                            "mac merge queue could not project %s on top of the "
+                            "%d change(s) ahead of it; deferring rather than "
+                            "testing against a base this entry will not land on"
+                            % (task.id, len(decision.predecessors))
+                        )
+                        stalled.publication_retry_after_seconds = 300
+                        stalled.publication_failure_kind = (
+                            "merge_queue_speculation_unavailable"
+                        )
+                        raise stalled
+
+            gate = validate_projected_merge(str(root), projected_base_sha, head_sha)
             commands.append({"name": "merge_gate", **gate.to_dict()})
             if not gate.clean:
+                if queue is not None and queue_entry_id:
+                    # A conflict is this entry's fault, not the queue's: evict
+                    # it, halve the window, and discard every speculative
+                    # result that was built on top of it.
+                    eviction = queue.evict(
+                        queue_entry_id,
+                        reason="projected merge conflicts with the queue base",
+                    )
+                    commands.append(
+                        {
+                            "name": "merge_queue_eviction",
+                            "attempt": attempt,
+                            "entry_id": queue_entry_id,
+                            **eviction,
+                        }
+                    )
                 merge_gate_error = ValidationError(
                     "git publication merge gate: task branch does not integrate onto "
                     "the current main tip (%s); conflicts: %s — route to integration "
@@ -22843,7 +23326,6 @@ class ControlPlane:
             # by however far main moved, so the changed-file selection is the
             # honest question to ask of it. An unresolvable diff falls back to
             # the full command, exactly as the review helper does.
-            strategy = self._resolve_publication_strategy(clone_url)
             required_checks: tuple[str, ...] = ()
             if strategy["strategy"] == "pull_request":
                 probed = _gitops.required_status_check_contexts(
@@ -22876,7 +23358,7 @@ class ControlPlane:
             try:
                 projected_diff = self._git_output(
                     root,
-                    ["diff", "--name-only", "%s...%s" % (base_sha, head_sha)],
+                    ["diff", "--name-only", "%s...%s" % (projected_base_sha, head_sha)],
                     timeout=60,
                 )
                 if int(projected_diff.get("returncode") or 1) == 0:
@@ -22920,7 +23402,7 @@ class ControlPlane:
                     publication_test_runner = self._hub_verify_run_contract_test
                 contract_gate = validate_projected_merge_contract(
                     str(root),
-                    base_sha,
+                    projected_base_sha,
                     head_sha,
                     full_test_command,
                     test_runner=publication_test_runner,
@@ -22931,10 +23413,67 @@ class ControlPlane:
                 )
                 if not contract_gate.passed:
                     diagnosis = contract_gate.error or contract_gate.output_tail
+                    if queue is not None and queue_entry_id:
+                        eviction = queue.evict(
+                            queue_entry_id,
+                            reason="projected contract gate failed: %s"
+                            % (diagnosis or "unknown failure")[:200],
+                        )
+                        commands.append(
+                            {
+                                "name": "merge_queue_eviction",
+                                "attempt": attempt,
+                                "entry_id": queue_entry_id,
+                                **eviction,
+                            }
+                        )
                     raise ValidationError(
                         "git publication contract gate failed on the projected "
                         "current-main merge: %s" % (diagnosis or "unknown failure")
                     )
+
+            if queue is not None and queue_entry_id:
+                # THE TREES ARE THE RECEIPT. What lands is checked against
+                # `tested_base_tree` at merge time, so recording it here is what
+                # makes "never land an untested tree" enforceable rather than
+                # asserted.
+                base_tree = str(
+                    git_step(
+                        "merge_queue_tested_base_tree",
+                        ["rev-parse", "%s^{tree}" % projected_base_sha],
+                        check=False,
+                    ).get("stdout")
+                    or ""
+                ).strip()
+                recorded = queue.record_tested(
+                    queue_entry_id,
+                    owner=queue_owner,
+                    base_sha=projected_base_sha,
+                    base_tree=base_tree,
+                    merge_tree=gate.merged_tree_sha,
+                )
+                commands.append(
+                    {
+                        "name": "merge_queue_tested",
+                        "attempt": attempt,
+                        "entry_id": queue_entry_id,
+                        "recorded": bool(recorded),
+                        "tested_base_sha": projected_base_sha,
+                        "tested_base_tree": base_tree,
+                        "tested_merge_tree": gate.merged_tree_sha,
+                    }
+                )
+                if not recorded or not base_tree:
+                    # We no longer hold the slot (a restart reclaimed it) or the
+                    # tree is unreadable. Either way this result cannot be
+                    # trusted to authorize a merge.
+                    lost = ValidationError(
+                        "mac merge queue could not record the tested trees for "
+                        "%s; the slot is no longer held. Deferring." % task.id
+                    )
+                    lost.publication_retry_after_seconds = 300
+                    lost.publication_failure_kind = "merge_queue_slot_lost"
+                    raise lost
 
             if strategy["strategy"] == "pull_request":
                 return self._publish_via_pull_request(
@@ -22943,7 +23482,7 @@ class ControlPlane:
                     remote_ref=remote_ref,
                     source_branch=source_branch,
                     head_sha=head_sha,
-                    base_sha=base_sha,
+                    base_sha=projected_base_sha,
                     canonical_branch=canonical_branch,
                     api_url=str(strategy["api_url"]),
                     commands=commands,
@@ -22952,6 +23491,9 @@ class ControlPlane:
                     root=root,
                     agent_pull_request=agent_pull_request,
                     required_checks=required_checks,
+                    serialization=serialization,
+                    queue=queue,
+                    queue_entry_id=queue_entry_id,
                 )
 
             publication_mode = "fast_forward"
@@ -25046,6 +25588,13 @@ class ControlPlane:
 
     def list_project_repositories(self, enabled: Optional[bool] = None) -> List[ProjectRepository]:
         return self.project_repositories.list(enabled)
+
+    def record_repository_merge_capability(
+        self, repo_id_or_name: str, capability: JsonDict
+    ) -> ProjectRepository:
+        return self.project_repositories.record_merge_capability(
+            repo_id_or_name, capability
+        )
 
     def _repository_contract_for_repo(self, repo: ProjectRepository) -> JsonDict:
         return self.project_repositories.contract_for(repo)

--- a/tests/test_native_merge_queue.py
+++ b/tests/test_native_merge_queue.py
@@ -943,3 +943,404 @@ def test_a_change_behind_another_is_tested_on_top_of_it_and_will_not_jump_it(
     assert ours.state == STATE_TESTED
     assert ours.tested_base_sha not in {"", main_head, other_head}
     assert ours.tested_base_tree and ours.tested_merge_tree
+
+
+# ---------------------------------------------------------------------------
+# The organization probe: the one part of capability resolution that talks to
+# the forge for real, and therefore the one part every other test fakes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload,expected",
+    [
+        # The whole reason this probe exists: organization-owned repositories
+        # CAN have a GitHub merge queue, User-owned ones can never.
+        ({"owner": {"type": "Organization"}}, True),
+        ({"owner": {"type": "organization"}}, True),  # case is not a contract
+        ({"owner": {"type": "User"}}, False),
+        # Anything we cannot read is unknown -- never guessed as either.
+        ({"owner": {"type": ""}}, None),
+        ({"owner": {}}, None),
+        ({"owner": "acme"}, None),
+        ({}, None),
+        (["not", "a", "repository"], None),
+    ],
+)
+def test_the_organization_probe_reads_the_repository_owner_type(
+    monkeypatch, payload, expected
+):
+    from mac.merge_capability import forge_owner_is_organization
+
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    monkeypatch.setattr(gitops, "_http_get_json", lambda url, headers, *a, **k: payload)
+    assert forge_owner_is_organization("https://github.com/acme/widgets.git") is expected
+
+
+def test_the_organization_probe_asks_the_repository_endpoint_with_credentials(
+    monkeypatch,
+):
+    from mac.merge_capability import forge_owner_is_organization
+
+    seen: dict = {}
+
+    def capture(url, headers, *a, **k):
+        seen["url"] = url
+        seen["headers"] = headers
+        return {"owner": {"type": "Organization"}}
+
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    monkeypatch.setattr(gitops, "_http_get_json", capture)
+    forge_owner_is_organization("https://github.com/acme/widgets.git")
+
+    assert seen["url"] == "https://api.github.com/repos/acme/widgets"
+    assert "Authorization" in seen["headers"]
+
+
+def test_the_organization_probe_is_unknown_without_a_credential(monkeypatch):
+    """No token means no answer -- not a guess, and not an exception."""
+
+    from mac.merge_capability import forge_owner_is_organization
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("MAC_TASK_GIT_TOKEN", raising=False)
+    monkeypatch.setattr(
+        gitops,
+        "_http_get_json",
+        lambda *a, **k: pytest.fail("the API was called without a credential"),
+    )
+    assert forge_owner_is_organization("https://github.com/acme/widgets.git") is None
+
+
+def test_the_organization_probe_is_unknown_when_the_forge_errors(monkeypatch):
+    from mac.merge_capability import forge_owner_is_organization
+
+    def boom(*a, **k):
+        raise RuntimeError("403 API rate limit exceeded")
+
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+    monkeypatch.setattr(gitops, "_http_get_json", boom)
+    assert forge_owner_is_organization("https://github.com/acme/widgets.git") is None
+
+
+def test_a_rate_limited_organization_probe_leaves_supported_unknown(monkeypatch):
+    """A probe failure must not become "this repo cannot have a queue"."""
+
+    def boom(url):
+        raise RuntimeError("403 API rate limit exceeded")
+
+    capability = resolve_merge_capability(
+        REPO,
+        BRANCH,
+        resolve_forge=lambda url: "github",
+        queue_enabled=lambda url, branch: False,
+        owner_is_organization=boom,
+    )
+    assert capability.supported is None
+    # `enabled` is still a definite False, so routing is unaffected.
+    assert capability.enabled is False
+    assert merge_serialization_mode(capability) == MODE_NATIVE_QUEUE
+
+
+def test_a_forge_resolver_that_raises_is_recorded_not_propagated():
+    def boom(url):
+        raise RuntimeError("could not parse remote")
+
+    capability = resolve_merge_capability(REPO, BRANCH, resolve_forge=boom)
+    assert capability.enabled is None
+    assert "could not parse remote" in capability.error
+    assert merge_serialization_mode(capability) == MODE_NATIVE_QUEUE
+
+
+def test_a_repository_with_no_canonical_remote_is_unresolvable_not_a_crash():
+    """The common case, not an edge one.
+
+    `canonical_remote_url` is optional in the repository runtime contract, so a
+    registered repository can legitimately have nothing to probe. The poller
+    visits every repository, so this must produce a recorded non-answer rather
+    than an exception -- and it must still route to mac's own queue.
+    """
+
+    for remote, branch in ((REPO, ""), ("", BRANCH), ("", "")):
+        capability = resolve_merge_capability(
+            remote,
+            branch,
+            resolve_forge=lambda url: pytest.fail("nothing should be probed"),
+        )
+        assert capability.enabled is None
+        assert "no canonical remote/branch" in capability.error
+        assert merge_serialization_mode(capability) == MODE_NATIVE_QUEUE
+
+
+def test_a_garbage_capability_ttl_falls_back_to_the_default():
+    """A misconfigured env var must not take publication down with it."""
+
+    from mac.merge_capability import DEFAULT_TTL_SECONDS, capability_ttl_seconds
+
+    assert capability_ttl_seconds({"MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS": "banana"}) == (
+        DEFAULT_TTL_SECONDS
+    )
+    assert capability_ttl_seconds({"MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS": ""}) == (
+        DEFAULT_TTL_SECONDS
+    )
+    assert capability_ttl_seconds({"MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS": "600"}) == 600
+    # Floored, so a zero cannot turn the TTL into a probe-every-poll loop.
+    assert capability_ttl_seconds({"MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS": "0"}) == 60
+
+
+def test_a_corrupt_resolved_at_is_stale_rather_than_trusted():
+    """An unparseable stamp costs one API call; trusting it costs correctness."""
+
+    corrupt = MergeCapability(
+        forge="github",
+        supported=True,
+        enabled=True,
+        branch="main",
+        resolved_at="not-a-timestamp",
+    )
+    assert corrupt.is_stale(branch="main", ttl_seconds=86400) is True
+    # A stamp from the future is not fresh either.
+    future = MergeCapability(
+        forge="github",
+        supported=True,
+        enabled=True,
+        branch="main",
+        resolved_at="2099-01-01T00:00:00.000000+00:00",
+    )
+    assert future.is_stale(
+        branch="main", ttl_seconds=3600, now="2026-08-18T00:00:00.000000+00:00"
+    ) is True
+
+
+def test_recording_a_capability_keeps_the_rest_of_the_repository_metadata(
+    cp, tmp_path
+):
+    """The contract and codegraph status must survive a capability write.
+
+    `record_merge_capability` reads-modifies-writes the whole `metadata` blob.
+    If it replaced it instead, a repository would lose its runtime contract the
+    first time the poller resolved its capability -- silently, and only visible
+    the next time something needed the contract.
+    """
+
+    from tests.test_control_plane import _write_repository_contract
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_repository_contract(repo, project="repo-capability")
+    registered = cp.register_project_repository(
+        "capability-repo", str(repo), source="repo-capability"
+    )
+    assert registered.metadata["repository_contract"]["project"] == "repo-capability"
+
+    capability = MergeCapability(
+        forge="github",
+        credential=True,
+        supported=False,
+        enabled=False,
+        branch="main",
+        remote=REPO,
+        resolved_at="2026-08-18T00:00:00.000000+00:00",
+        resolver="github-ingest",
+    )
+    updated = cp.record_repository_merge_capability(registered.id, capability.to_dict())
+
+    assert stored_capability(updated.metadata) == capability
+    # Everything else is still there.
+    assert updated.metadata["repository_contract"] == (
+        registered.metadata["repository_contract"]
+    )
+    assert updated.metadata["codegraph"] == registered.metadata["codegraph"]
+    # And it is durable, not just returned.
+    assert stored_capability(cp.get_project_repository(registered.id).metadata) == (
+        capability
+    )
+
+
+def test_the_poller_records_an_unresolvable_repository_instead_of_skipping_it(
+    cp, tmp_path, monkeypatch
+):
+    """End to end: a registered repo with no remote gets a recorded non-answer."""
+
+    from mac.github_ingest import GitHubIngestConfig, GitHubIssueIngestor
+    from tests.test_control_plane import _write_repository_contract
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _write_repository_contract(repo, project="repo-noremote")
+    registered = cp.register_project_repository(
+        "noremote-repo", str(repo), source="repo-noremote"
+    )
+
+    ingestor = GitHubIssueIngestor(cp, GitHubIngestConfig.from_env())
+    report = ingestor._refresh_merge_capabilities(actor="test")
+
+    assert report["checked"] >= 1
+    assert report["failed"] == 0
+    entry = next(
+        item for item in report["repositories"] if item["repository"] == "noremote-repo"
+    )
+    assert entry["status"] == "resolved"
+    assert entry["mode"] == MODE_NATIVE_QUEUE
+    assert "no canonical remote/branch" in entry["error"]
+    # Recorded on the repository, and the contract survived the write.
+    stored = stored_capability(cp.get_project_repository(registered.id).metadata)
+    assert stored is not None and stored.enabled is None
+    assert cp.get_project_repository(registered.id).metadata["repository_contract"]
+
+
+# ---------------------------------------------------------------------------
+# Misconfiguration, concurrency, and the paths that only fire when something
+# has already gone wrong.
+# ---------------------------------------------------------------------------
+
+
+def test_garbage_window_and_lease_knobs_fall_back_to_their_defaults():
+    """A typo in an env var must not wedge the queue or uncap speculation."""
+
+    from mac.native_merge_queue import bounds_from_env, lease_seconds_from_env
+
+    bounds = bounds_from_env(
+        {
+            "MAC_MERGE_QUEUE_WINDOW_FLOOR": "banana",
+            "MAC_MERGE_QUEUE_WINDOW_CEILING": "",
+            "MAC_MERGE_QUEUE_WINDOW_INCREMENT": "3.5",
+        }
+    )
+    assert (bounds.floor, bounds.ceiling, bounds.increment) == (1, 4, 1)
+    assert lease_seconds_from_env({"MAC_MERGE_QUEUE_LEASE_SECONDS": "banana"}) == 5400
+    assert lease_seconds_from_env({"MAC_MERGE_QUEUE_LEASE_SECONDS": "900"}) == 900
+    # Floored: a lease shorter than a git fetch would reclaim live slots.
+    assert lease_seconds_from_env({"MAC_MERGE_QUEUE_LEASE_SECONDS": "1"}) == 60
+    # A configured floor above the default ceiling raises the ceiling with it,
+    # rather than producing floor > ceiling and a ValueError at import time.
+    raised = bounds_from_env({"MAC_MERGE_QUEUE_WINDOW_FLOOR": "6"})
+    assert (raised.floor, raised.ceiling) == (6, 6)
+
+
+def test_a_fresh_queue_reports_its_floor_before_anything_has_landed(queue):
+    """No window row yet is the floor, not a crash and not an unbounded window."""
+
+    assert queue.window(REPO, BRANCH) == 1
+    snapshot = queue.snapshot("https://github.invalid/never/seen.git", "release")
+    assert snapshot["window_size"] == 1
+    assert snapshot["queue_depth"] == 0
+    assert snapshot["front"] is None
+    assert snapshot["landed_count"] == 0
+
+
+def test_evicting_an_entry_that_is_not_in_the_queue_changes_nothing():
+    entries = [_entry("a", 1), _entry("b", 2)]
+    plan = plan_eviction(entries, "not-in-this-queue", "whatever")
+    assert plan.discarded == ()
+    assert plan.survivors == ("a", "b")
+
+
+def test_an_entry_marked_tested_with_no_trees_still_cannot_land():
+    """`state == tested` is not the receipt; the trees are."""
+
+    hollow = QueueEntry(
+        id="a",
+        repository=REPO,
+        branch=BRANCH,
+        task_id="t",
+        pull_request_number=1,
+        head_sha="A" * 40,
+        state=STATE_TESTED,
+        position=1,
+        speculation_epoch=0,
+        tested_base_tree="",
+        tested_merge_tree="",
+    )
+    ok, why = landing_is_safe(hollow, canonical_tip_tree="anything", front_entry_id="a")
+    assert (ok, why) == (False, "entry carries no tested trees")
+
+
+def test_two_workers_cannot_hold_the_same_slot(queue):
+    """The exclusivity guarantee: a CAS loser is told to wait, not let through."""
+
+    first = _claim(queue, "task_a", "A" * 40, owner="hub-one")
+    assert first.admitted is True
+
+    second = queue.claim_slot(
+        repository=REPO,
+        branch=BRANCH,
+        task_id="task_a",
+        head_sha="A" * 40,
+        owner="hub-two",
+    )
+    assert second.admitted is False
+    assert "leased by another worker" in second.reason
+    assert second.defer_seconds > 0
+    # The original holder still owns it, and the loser cannot record a result.
+    assert queue.entry(first.entry.id).lease_owner == "hub-one"
+    assert (
+        queue.record_tested(
+            first.entry.id,
+            owner="hub-two",
+            base_sha="T" * 40,
+            base_tree="tree",
+            merge_tree="merged",
+        )
+        is False
+    )
+
+
+def test_releasing_a_slot_returns_it_without_a_verdict(queue):
+    """A deferral gives the slot back; it does not evict or land."""
+
+    decision = _claim(queue, "task_a", "A" * 40, owner="hub-one")
+    assert queue.release(decision.entry.id, owner="hub-one") is True
+
+    released = queue.entry(decision.entry.id)
+    assert released.lease_owner == ""
+    # Back to `queued`, not left in `testing` with nobody testing it -- a queue
+    # that reports work in flight that is not in flight is a broken instrument.
+    assert released.state == STATE_QUEUED
+    assert released.tested_base_tree == ""
+    assert queue.snapshot(REPO, BRANCH)["entries_testing"] == 0
+    # No verdict was recorded: the window did not move either way.
+    assert queue.window(REPO, BRANCH) == 1
+    assert queue.snapshot(REPO, BRANCH)["failure_count"] == 0
+    # Somebody else may now take it.
+    assert queue.claim_slot(
+        repository=REPO,
+        branch=BRANCH,
+        task_id="task_a",
+        head_sha="A" * 40,
+        owner="hub-two",
+    ).admitted is True
+    # And a worker that no longer holds the slot cannot release it.
+    assert queue.release(decision.entry.id, owner="hub-one") is False
+
+
+def test_landing_or_evicting_an_entry_that_does_not_exist_is_reported_not_raised(queue):
+    assert queue.record_landed("mergeq_ghost", landed_sha="f" * 40) == {
+        "changed": False,
+        "reason": "entry not found",
+    }
+    assert queue.evict("mergeq_ghost", reason="whatever") == {
+        "changed": False,
+        "reason": "entry not found",
+    }
+
+
+def test_broken_telemetry_never_breaks_a_land(cp):
+    """The queue reports on itself; it does not depend on the report succeeding."""
+
+    calls: list = []
+
+    def exploding_metric(*args, **kwargs):
+        calls.append(args[0] if args else "")
+        raise RuntimeError("observability backend is down")
+
+    noisy = NativeMergeQueue(
+        cp.store, bounds=WindowBounds(floor=1, ceiling=4), observe=exploding_metric
+    )
+    entry = noisy.admit(
+        repository=REPO, branch=BRANCH, task_id="task_a", head_sha="A" * 40
+    )
+    assert noisy.record_landed(entry.id, landed_sha="L" * 40)["changed"] is True
+    # It really did try to report, and really did swallow the failure.
+    assert "merge_queue.admitted" in calls
+    assert "merge_queue.landed" in calls

--- a/tests/test_native_merge_queue.py
+++ b/tests/test_native_merge_queue.py
@@ -1,0 +1,945 @@
+"""mac's own merge queue: ordering, speculation, the window, and the land gate.
+
+GitHub merge queues are organization-only, so on every User-owned repository the
+operator has, there is no forge queue to borrow serialization from. These tests
+pin the queue mac provides instead.
+
+The invariant every test here exists to protect is *never land an untested
+tree*. The queue may be slow, may defer, may throw away speculation -- all of
+that is negotiable. Landing a tree nobody tested is not.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mac import gitops
+from mac.merge_capability import (
+    MergeCapability,
+    merge_serialization_mode,
+    resolve_merge_capability,
+    stored_capability,
+)
+from mac.models import TaskState, ValidationError
+from mac.native_merge_queue import (
+    MODE_FORGE_QUEUE,
+    MODE_NATIVE_QUEUE,
+    STATE_EVICTED,
+    STATE_QUEUED,
+    STATE_TESTED,
+    NativeMergeQueue,
+    QueueEntry,
+    WindowBounds,
+    landing_is_safe,
+    next_window,
+    plan_eviction,
+    speculation_plan,
+)
+from mac.services import ControlPlane
+from tests.test_publication_pull_request import (
+    FakeForge,
+    build_repo,
+    drive_to_approval,
+    git,
+    install_forge,
+    published_detail,
+)
+
+REPO = "https://github.invalid/acme/widgets.git"
+BRANCH = "main"
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+@pytest.fixture()
+def queue(cp):
+    return NativeMergeQueue(cp.store, bounds=WindowBounds(floor=1, ceiling=4))
+
+
+def _admit(queue, task_id: str, head: str, **kwargs):
+    return queue.admit(
+        repository=REPO, branch=BRANCH, task_id=task_id, head_sha=head, **kwargs
+    )
+
+
+def _claim(queue, task_id: str, head: str, owner: str = "hub-a"):
+    return queue.claim_slot(
+        repository=REPO, branch=BRANCH, task_id=task_id, head_sha=head, owner=owner
+    )
+
+
+def _entry(entry_id: str, position: int, *, state=STATE_QUEUED, head="", preds=()):
+    return QueueEntry(
+        id=entry_id,
+        repository=REPO,
+        branch=BRANCH,
+        task_id="task_" + entry_id,
+        pull_request_number=0,
+        head_sha=head or ("sha" + entry_id),
+        state=state,
+        position=position,
+        speculation_epoch=0,
+        predecessors=tuple(preds),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The window controller: additive increase, multiplicative decrease.
+# ---------------------------------------------------------------------------
+
+
+def test_window_grows_additively_on_success_and_halves_on_failure():
+    bounds = WindowBounds(floor=1, ceiling=8, increment=1)
+    size = 1
+    for expected in (2, 3, 4, 5):
+        size = next_window(size, outcome="landed", bounds=bounds)
+        assert size == expected
+    # Multiplicative decrease.
+    assert next_window(8, outcome="failed", bounds=bounds) == 4
+    assert next_window(5, outcome="failed", bounds=bounds) == 2
+
+
+def test_window_respects_its_floor_and_ceiling():
+    bounds = WindowBounds(floor=2, ceiling=3, increment=1)
+    # Ceiling: success cannot grow past it.
+    assert next_window(3, outcome="landed", bounds=bounds) == 3
+    assert next_window(99, outcome="landed", bounds=bounds) == 3
+    # Floor: failure cannot shrink below it, and a queue already at the floor
+    # stays there rather than going to zero (which would wedge the queue).
+    assert next_window(2, outcome="failed", bounds=bounds) == 2
+    assert next_window(3, outcome="failed", bounds=bounds) == 2
+
+
+def test_window_bounds_reject_nonsense():
+    with pytest.raises(ValueError):
+        WindowBounds(floor=0)
+    with pytest.raises(ValueError):
+        WindowBounds(floor=3, ceiling=2)
+    with pytest.raises(ValueError):
+        WindowBounds(increment=0)
+
+
+def test_the_durable_window_moves_with_real_landings_and_evictions(queue):
+    first = _admit(queue, "task_a", "a" * 40)
+    assert queue.window(REPO, BRANCH) == 1
+
+    queue.record_landed(first.id, landed_sha="f" * 40)
+    assert queue.window(REPO, BRANCH) == 2
+
+    second = _admit(queue, "task_b", "b" * 40)
+    queue.record_landed(second.id, landed_sha="e" * 40)
+    assert queue.window(REPO, BRANCH) == 3
+
+    third = _admit(queue, "task_c", "c" * 40)
+    queue.evict(third.id, reason="contract gate failed")
+    # Halved, not decremented.
+    assert queue.window(REPO, BRANCH) == 1
+
+    snapshot = queue.snapshot(REPO, BRANCH)
+    assert snapshot["landed_count"] == 2
+    assert snapshot["failure_count"] == 1
+    assert snapshot["window_floor"] == 1
+    assert snapshot["window_ceiling"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Speculation: plan, evict, discard.
+# ---------------------------------------------------------------------------
+
+
+def test_speculation_plans_each_entry_on_top_of_the_ones_ahead_of_it():
+    entries = [
+        _entry("a", 1, head="A" * 40),
+        _entry("b", 2, head="B" * 40),
+        _entry("c", 3, head="C" * 40),
+    ]
+    plan = speculation_plan(entries, window=3)
+    assert [slot.entry_id for slot in plan] == ["a", "b", "c"]
+    assert plan[0].predecessors == ()
+    assert plan[1].predecessors == ("A" * 40,)
+    assert plan[2].predecessors == ("A" * 40, "B" * 40)
+
+
+def test_the_window_bounds_how_many_entries_may_speculate():
+    entries = [_entry(name, index + 1) for index, name in enumerate("abcde")]
+    assert [slot.entry_id for slot in speculation_plan(entries, window=2)] == ["a", "b"]
+    assert len(speculation_plan(entries, window=5)) == 5
+
+
+def test_evicting_entry_k_discards_every_speculative_result_behind_it():
+    entries = [
+        _entry("a", 1, state=STATE_TESTED),
+        _entry("b", 2, state=STATE_TESTED, preds=("A" * 40,)),
+        _entry("c", 3, state=STATE_TESTED, preds=("A" * 40, "B" * 40)),
+    ]
+    plan = plan_eviction(entries, "a", "gate failed")
+    assert plan.evicted_id == "a"
+    assert plan.survivors == ("b", "c")
+    # b and c were green -- against a tree that will never exist.
+    assert plan.discarded == ("b", "c")
+
+
+def test_a_failed_entry_is_evicted_and_the_survivors_are_retested_without_it(queue):
+    """The core speculative-batching property, end to end on the ledger.
+
+    Three entries speculate on each other. Entry A fails. B and C were tested
+    against `tip + A`, a state that will now never exist, so their results are
+    discarded, they return to `queued` in a NEW speculation epoch, and nothing
+    behind A can present its old result as a pass.
+    """
+
+    first = _claim(queue, "task_a", "A" * 40)
+    assert first.admitted and first.predecessors == ()
+    queue.record_tested(
+        first.entry.id,
+        owner="hub-a",
+        base_sha="T" * 40,
+        base_tree="tip-tree",
+        merge_tree="tree-a",
+    )
+    # Landing A widens the window, which is what lets B speculate at all.
+    queue.record_landed(first.entry.id, landed_sha="L" * 40)
+    assert queue.window(REPO, BRANCH) == 2
+
+    second = _claim(queue, "task_b", "B" * 40)
+    third = _claim(queue, "task_c", "C" * 40)
+    assert second.admitted and third.admitted
+    assert third.predecessors == ("B" * 40,)
+    for decision, tree in ((second, "tree-b"), (third, "tree-c")):
+        assert queue.record_tested(
+            decision.entry.id,
+            owner="hub-a",
+            base_sha="S" * 40,
+            base_tree="spec-tree-%s" % tree,
+            merge_tree=tree,
+        )
+
+    outcome = queue.evict(second.entry.id, reason="contract gate failed")
+
+    assert queue.entry(second.entry.id).state == STATE_EVICTED
+    # C survives, but its speculative result is gone.
+    survivor = queue.entry(third.entry.id)
+    assert survivor.state == STATE_QUEUED
+    assert survivor.tested_base_tree == ""
+    assert survivor.tested_merge_tree == ""
+    assert survivor.predecessors == ()
+    assert survivor.speculation_epoch > third.entry.speculation_epoch
+    assert outcome["speculation_discarded"] == 1
+    assert list(outcome["discarded_entries"]) == [third.entry.id]
+
+    # And nothing behind K can land on the discarded result: even presented
+    # with the exact tree it was tested against, the land gate refuses.
+    allowed, why, _ = queue.may_land(
+        third.entry.id, canonical_tip_tree="spec-tree-tree-c"
+    )
+    assert allowed is False
+    assert "no recorded test result" in why
+
+    # Re-testing without the evicted entry puts C at the front, on the real tip.
+    replanned = _claim(queue, "task_c", "C" * 40)
+    assert replanned.admitted
+    assert replanned.predecessors == ()
+
+    snapshot = queue.snapshot(REPO, BRANCH)
+    assert snapshot["speculation_discarded"] == 1
+    assert snapshot["recent_evictions"][-1]["task_id"] == "task_b"
+    assert "contract gate failed" in snapshot["recent_evictions"][-1]["reason"]
+
+
+def test_an_entry_outside_the_window_is_deferred_not_dropped(queue):
+    _claim(queue, "task_a", "A" * 40)
+    blocked = _claim(queue, "task_b", "B" * 40)
+    assert blocked.admitted is False
+    assert blocked.defer_seconds > 0
+    assert "#2 in line" in blocked.reason
+    # It kept its place; it is still queued.
+    assert queue.entry(blocked.entry.id).state == STATE_QUEUED
+    assert queue.snapshot(REPO, BRANCH)["queue_depth"] == 2
+
+
+# ---------------------------------------------------------------------------
+# The land gate: never land an untested tree.
+# ---------------------------------------------------------------------------
+
+
+def test_landing_requires_the_front_position_a_result_and_a_matching_tree():
+    tested = QueueEntry(
+        id="a",
+        repository=REPO,
+        branch=BRANCH,
+        task_id="t",
+        pull_request_number=1,
+        head_sha="A" * 40,
+        state=STATE_TESTED,
+        position=1,
+        speculation_epoch=0,
+        tested_base_tree="base-tree",
+        tested_merge_tree="merged-tree",
+    )
+    assert landing_is_safe(tested, canonical_tip_tree="base-tree", front_entry_id="a") == (
+        True,
+        "",
+    )
+    # Not at the front.
+    ok, why = landing_is_safe(
+        tested, canonical_tip_tree="base-tree", front_entry_id="b"
+    )
+    assert (ok, "front of the queue" in why) == (False, True)
+    # The tip moved: the tested projection is stale.
+    ok, why = landing_is_safe(
+        tested, canonical_tip_tree="other-tree", front_entry_id="a"
+    )
+    assert (ok, "stale" in why) == (False, True)
+    # An unreadable tip is a refusal, never a pass.
+    ok, why = landing_is_safe(tested, canonical_tip_tree="", front_entry_id="a")
+    assert (ok, "could not be read" in why) == (False, True)
+
+
+def test_a_missing_entry_defers_rather_than_landing(queue):
+    allowed, why, entry = queue.may_land("mergeq_nope", canonical_tip_tree="t")
+    assert allowed is False
+    assert entry is None
+    assert "disappeared" in why
+
+
+# ---------------------------------------------------------------------------
+# Crash safety.
+# ---------------------------------------------------------------------------
+
+
+def test_a_crash_between_validate_and_land_does_not_double_land(cp, queue):
+    """A hub that dies after merging must not merge again on restart."""
+
+    decision = _claim(queue, "task_a", "A" * 40)
+    queue.record_tested(
+        decision.entry.id,
+        owner="hub-a",
+        base_sha="T" * 40,
+        base_tree="tip-tree",
+        merge_tree="merged",
+    )
+    first = queue.record_landed(decision.entry.id, landed_sha="L" * 40)
+    assert first["changed"] is True
+    window_after_first = queue.window(REPO, BRANCH)
+
+    # The hub dies here. A new process rebuilds the queue from the ledger.
+    restarted = NativeMergeQueue(cp.store, bounds=WindowBounds(floor=1, ceiling=4))
+    again = restarted.record_landed(decision.entry.id, landed_sha="L" * 40)
+    assert again["changed"] is False
+    assert again["reason"] == "already landed"
+    # And the window did not get credited twice for one land.
+    assert restarted.window(REPO, BRANCH) == window_after_first
+    # A landed entry can never re-enter the land gate.
+    allowed, why, _ = restarted.may_land(decision.entry.id, canonical_tip_tree="tip-tree")
+    assert allowed is False
+    assert "landed" in why
+
+
+def test_an_expired_lease_is_reclaimed_and_its_stale_result_is_dropped(cp):
+    """A dead hub's slot must come back -- WITHOUT its unverifiable result."""
+
+    queue = NativeMergeQueue(
+        cp.store, bounds=WindowBounds(floor=1, ceiling=4), lease_seconds=60
+    )
+    decision = queue.claim_slot(
+        repository=REPO,
+        branch=BRANCH,
+        task_id="task_a",
+        head_sha="A" * 40,
+        owner="hub-dead",
+    )
+    queue.record_tested(
+        decision.entry.id,
+        owner="hub-dead",
+        base_sha="T" * 40,
+        base_tree="tip-tree",
+        merge_tree="merged",
+    )
+    # Expire the lease the way wall-clock time would.
+    cp.store.execute(
+        "UPDATE merge_queue_entries SET lease_expires_at = ? WHERE id = ?",
+        ("2000-01-01T00:00:00.000000+00:00", decision.entry.id),
+    )
+    successor = queue.claim_slot(
+        repository=REPO,
+        branch=BRANCH,
+        task_id="task_a",
+        head_sha="A" * 40,
+        owner="hub-fresh",
+    )
+    assert successor.admitted is True
+    reclaimed = queue.entry(decision.entry.id)
+    assert reclaimed.lease_owner == "hub-fresh"
+    assert reclaimed.position == decision.entry.position  # order is preserved
+    assert reclaimed.tested_base_tree == ""  # the dead hub's result is not reused
+
+
+def test_a_reviewed_head_that_moved_supersedes_the_old_entry(queue):
+    first = _admit(queue, "task_a", "A" * 40)
+    second = _admit(queue, "task_a", "Z" * 40)
+    assert second.id != first.id
+    assert queue.entry(first.id).state == "superseded"
+    assert queue.snapshot(REPO, BRANCH)["queue_depth"] == 1
+
+
+def test_admission_is_idempotent_across_publication_retries(queue):
+    first = _admit(queue, "task_a", "A" * 40)
+    again = _admit(queue, "task_a", "A" * 40)
+    assert again.id == first.id
+    assert queue.snapshot(REPO, BRANCH)["queue_depth"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Capability: which mechanism serializes, resolved once and stored.
+# ---------------------------------------------------------------------------
+
+
+def test_a_repository_with_a_forge_queue_routes_to_the_forge():
+    capability = resolve_merge_capability(
+        REPO,
+        BRANCH,
+        resolve_forge=lambda url: "github",
+        queue_enabled=lambda url, branch: True,
+    )
+    assert capability.supported is True
+    assert capability.enabled is True
+    assert capability.use_forge_queue is True
+    assert merge_serialization_mode(capability) == MODE_FORGE_QUEUE
+
+
+def test_supported_and_enabled_are_recorded_separately():
+    """An org repo that has not turned the queue on is not a personal repo.
+
+    Both route to mac's queue today, but only one of them could ever stop.
+    """
+
+    org = resolve_merge_capability(
+        REPO,
+        BRANCH,
+        resolve_forge=lambda url: "github",
+        queue_enabled=lambda url, branch: False,
+        owner_is_organization=lambda url: True,
+    )
+    personal = resolve_merge_capability(
+        REPO,
+        BRANCH,
+        resolve_forge=lambda url: "github",
+        queue_enabled=lambda url, branch: False,
+        owner_is_organization=lambda url: False,
+    )
+    assert (org.supported, org.enabled) == (True, False)
+    assert (personal.supported, personal.enabled) == (False, False)
+    assert merge_serialization_mode(org) == MODE_NATIVE_QUEUE
+    assert merge_serialization_mode(personal) == MODE_NATIVE_QUEUE
+
+
+def test_an_unknown_capability_takes_the_safe_branch_never_a_bare_squash():
+    unknown = resolve_merge_capability(
+        REPO,
+        BRANCH,
+        resolve_forge=lambda url: "github",
+        queue_enabled=lambda url, branch: None,
+    )
+    assert unknown.enabled is None
+    assert unknown.error
+    assert unknown.use_forge_queue is False
+    assert merge_serialization_mode(unknown) == MODE_NATIVE_QUEUE
+    # A repository with no capability record at all is the same answer.
+    assert merge_serialization_mode(None) == MODE_NATIVE_QUEUE
+
+
+def test_a_forge_that_cannot_be_reached_is_a_definite_native_answer():
+    capability = resolve_merge_capability(
+        REPO, BRANCH, resolve_forge=lambda url: ""
+    )
+    assert (capability.forge, capability.credential) == ("", False)
+    assert (capability.supported, capability.enabled) == (False, False)
+    assert merge_serialization_mode(capability) == MODE_NATIVE_QUEUE
+
+
+def test_gitea_has_no_merge_queue_equivalent():
+    capability = resolve_merge_capability(
+        REPO, BRANCH, resolve_forge=lambda url: "gitea"
+    )
+    assert capability.forge == "gitea"
+    assert capability.enabled is False
+    assert merge_serialization_mode(capability) == MODE_NATIVE_QUEUE
+
+
+def test_a_probe_that_raises_is_recorded_not_propagated():
+    def boom(url, branch):
+        raise RuntimeError("rate limited")
+
+    capability = resolve_merge_capability(
+        REPO, BRANCH, resolve_forge=lambda url: "github", queue_enabled=boom
+    )
+    assert capability.enabled is None
+    assert "rate limited" in capability.error
+    assert merge_serialization_mode(capability) == MODE_NATIVE_QUEUE
+
+
+def test_a_capability_is_stale_when_it_expires_or_changes_branch():
+    fresh = MergeCapability(
+        forge="github",
+        enabled=False,
+        supported=False,
+        branch="main",
+        resolved_at="2026-08-18T00:00:00.000000+00:00",
+    )
+    assert fresh.is_stale(branch="main", ttl_seconds=3600, now="2026-08-18T00:10:00.000000+00:00") is False
+    assert fresh.is_stale(branch="main", ttl_seconds=3600, now="2026-08-18T02:00:00.000000+00:00") is True
+    # A different canonical branch is a different question.
+    assert fresh.is_stale(branch="release", ttl_seconds=3600, now="2026-08-18T00:10:00.000000+00:00") is True
+    # Never resolved at all.
+    assert MergeCapability().is_stale() is True
+
+
+def test_the_capability_round_trips_through_repository_metadata(cp, tmp_path):
+    capability = MergeCapability(
+        forge="github",
+        credential=True,
+        supported=False,
+        enabled=False,
+        branch="main",
+        remote=REPO,
+        resolved_at="2026-08-18T00:00:00.000000+00:00",
+        resolver="github-ingest",
+    )
+    assert stored_capability(
+        {"merge_serialization_capability": capability.to_dict()}
+    ) == capability
+    # A blob with the wrong schema is not trusted.
+    assert stored_capability({"merge_serialization_capability": {"enabled": True}}) is None
+
+
+# ---------------------------------------------------------------------------
+# Publication: the queue in the seam #400 built.
+# ---------------------------------------------------------------------------
+
+
+def test_publication_without_a_forge_queue_records_the_native_guarantee(
+    cp, tmp_path, monkeypatch
+):
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    publication = cp.publish_task(
+        task.id, "git://main", reviewer.id, evidence_id=evidence.id
+    )
+
+    assert publication.status == "published"
+    detail = published_detail(cp, task.id)
+    assert detail["merge_serialization"] == MODE_NATIVE_QUEUE
+
+    capability = next(
+        item
+        for item in detail["commands"]
+        if item["name"] == "merge_serialization_capability"
+    )
+    assert capability["mode"] == MODE_NATIVE_QUEUE
+    # supported/enabled are separate facts, both recorded.
+    assert "supported" in capability and "enabled" in capability
+
+    # The queue is observable: depth, window, and what it did.
+    serialization = next(
+        item for item in detail["commands"] if item["name"] == "merge_serialization"
+    )
+    snapshot = serialization["queue"]
+    assert snapshot["window_size"] >= 1
+    assert snapshot["window_ceiling"] >= snapshot["window_floor"]
+    assert "queue_depth" in snapshot
+
+    landed = next(
+        item for item in detail["commands"] if item["name"] == "merge_queue_landed"
+    )
+    assert landed["changed"] is True
+    assert landed["observed_only"] is False
+
+
+def test_a_queued_pull_request_that_landed_on_the_forge_is_observed_not_remerged(
+    cp, tmp_path, monkeypatch
+):
+    """Never double-land. If it is already merged, that is a success to record."""
+
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    # Somebody (a human, or a previous attempt of ours that died after the
+    # merge) lands the PR while this attempt is still preparing.
+    landed: list[str] = []
+
+    def land_it_first(url, branch):
+        if not landed:
+            landed.append(forge.land_from_queue(task_head))
+        return ("sanity",)
+
+    monkeypatch.setattr(gitops, "required_status_check_contexts", land_it_first)
+
+    publication = cp.publish_task(
+        task.id, "git://main", reviewer.id, evidence_id=evidence.id
+    )
+
+    assert publication.status == "published"
+    # The decisive assertion: mac did NOT ask the forge to merge a second time.
+    assert forge.merges == []
+
+    detail = published_detail(cp, task.id)
+    observed = next(
+        item
+        for item in detail["commands"]
+        if item["name"] == "merge_queue_observe_pull_request"
+    )
+    assert observed["merged"] is True
+    recorded = next(
+        item for item in detail["commands"] if item["name"] == "merge_queue_landed"
+    )
+    assert recorded["observed_only"] is True
+    assert detail["final_sha"] == landed[0]
+
+
+def test_an_unreadable_pull_request_state_defers_instead_of_merging(
+    cp, tmp_path, monkeypatch
+):
+    """Ambiguity resolves to NOT landing. It may never resolve to 'merge anyway'."""
+
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    monkeypatch.setattr(
+        gitops,
+        "pull_request_state",
+        lambda url, number, **_: {
+            "known": False,
+            "merged": False,
+            "sha": "",
+            "state": "",
+            "head_sha": "",
+            "error": "502 Bad Gateway",
+        },
+    )
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert (
+        getattr(excinfo.value, "publication_failure_kind", "")
+        == "merge_queue_unreadable_state"
+    )
+    assert getattr(excinfo.value, "publication_retry_after_seconds", 0) > 0
+    # Nothing was merged and main is untouched.
+    assert forge.merges == []
+    assert git(source, "ls-remote", "origin", "refs/heads/main").split()[0] == main_head
+    assert cp.get_task(task.id).state != TaskState.COMPLETED.value
+
+
+def test_a_forge_queue_still_wins_when_the_repository_actually_has_one(
+    cp, tmp_path, monkeypatch
+):
+    """The native queue is the fallback, not a third parallel mechanism."""
+
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge", queue=True)
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert (
+        getattr(excinfo.value, "publication_failure_kind", "") == "pull_request_queued"
+    )
+    # It went to the FORGE queue, and mac's queue never enrolled it.
+    assert forge.enqueued == [{"number": 101, "sha": task_head}]
+    assert (
+        cp.store.query_all("SELECT id FROM merge_queue_entries", ()) == []
+    )
+
+
+# ---------------------------------------------------------------------------
+# Capability refresh rides on the existing poller.
+# ---------------------------------------------------------------------------
+
+
+def test_the_ingest_pass_resolves_capability_once_and_then_skips_it(monkeypatch):
+    from mac.github_ingest import GitHubIngestConfig, GitHubIssueIngestor
+
+    class FakeRepo:
+        id = "projectrepo_1"
+        name = "widgets"
+        metadata = {
+            "repository_contract": {
+                "canonical_remote_url": REPO,
+                "canonical_branch": BRANCH,
+            }
+        }
+
+    class FakeControlPlane:
+        def __init__(self):
+            self.repo = FakeRepo()
+            self.recorded: list = []
+
+        def list_project_repositories(self, enabled=None):
+            return [self.repo]
+
+        def record_repository_merge_capability(self, repo_id, capability):
+            self.recorded.append((repo_id, capability))
+            self.repo.metadata = dict(self.repo.metadata)
+            self.repo.metadata["merge_serialization_capability"] = capability
+            return self.repo
+
+    control_plane = FakeControlPlane()
+    ingestor = GitHubIssueIngestor(control_plane, GitHubIngestConfig.from_env())
+
+    probes: list = []
+
+    def probe(url, branch):
+        probes.append((url, branch))
+        return False
+
+    monkeypatch.setattr(gitops, "resolve_forge", lambda url: "github")
+    monkeypatch.setattr(gitops, "merge_queue_enabled", probe)
+
+    first = ingestor._refresh_merge_capabilities(actor="test")
+    assert first["refreshed"] == 1
+    assert first["repositories"][0]["mode"] == MODE_NATIVE_QUEUE
+    assert len(probes) == 1
+
+    # The TTL is the point: merge-queue configuration changes maybe twice a
+    # year, and this poller runs every 60 seconds.
+    second = ingestor._refresh_merge_capabilities(actor="test")
+    assert second["skipped_fresh"] == 1
+    assert second["refreshed"] == 0
+    assert len(probes) == 1
+
+
+def test_a_capability_probe_failure_does_not_break_issue_ingest(monkeypatch):
+    from mac.github_ingest import GitHubIngestConfig, GitHubIssueIngestor
+
+    class ExplodingControlPlane:
+        def list_project_repositories(self, enabled=None):
+            raise RuntimeError("registry unavailable")
+
+    ingestor = GitHubIssueIngestor(
+        ExplodingControlPlane(), GitHubIngestConfig.from_env()
+    )
+    report = ingestor._refresh_merge_capabilities(actor="test")
+    assert report["checked"] == 0
+    assert "registry unavailable" in report["error"]
+
+
+# ---------------------------------------------------------------------------
+# Building the speculative base out of real git objects.
+# ---------------------------------------------------------------------------
+
+
+def _git_step_for(repo: Path):
+    """A `git_step` shaped like publication's, over a real repository."""
+
+    def step(name, args, timeout=120, *, check=True):
+        proc = subprocess.run(
+            ["git", "-C", str(repo), *args], capture_output=True, text=True
+        )
+        result = {
+            "returncode": proc.returncode,
+            "stdout": proc.stdout.strip(),
+            "stderr": proc.stderr.strip(),
+        }
+        if check and proc.returncode != 0:
+            raise AssertionError("%s failed: %s" % (name, proc.stderr))
+        return result
+
+    return step
+
+
+def _repo_with_two_branches(tmp_path: Path):
+    repo = tmp_path / "spec"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "a@example.com")
+    git(repo, "config", "user.name", "A")
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    git(repo, "add", "base.txt")
+    git(repo, "commit", "-q", "-m", "base")
+    tip = git(repo, "rev-parse", "HEAD")
+    heads = []
+    for name in ("one", "two"):
+        git(repo, "checkout", "-q", "-B", name, tip)
+        (repo / ("%s.txt" % name)).write_text(name + "\n", encoding="utf-8")
+        git(repo, "add", ".")
+        git(repo, "commit", "-q", "-m", name)
+        heads.append(git(repo, "rev-parse", "HEAD"))
+    git(repo, "checkout", "-q", "main")
+    return repo, tip, heads
+
+
+def test_the_speculative_base_stacks_every_predecessor_on_the_tip(cp, tmp_path):
+    """Entry N is tested on `tip + 1..N-1`, which is the whole point of a train."""
+
+    repo, tip, heads = _repo_with_two_branches(tmp_path)
+    projected = cp._build_speculative_base(
+        repo,
+        _git_step_for(repo),
+        tip,
+        [{"head_sha": sha, "source_branch": ""} for sha in heads],
+    )
+    assert projected and projected != tip
+    files = git(repo, "ls-tree", "--name-only", "-r", projected).split()
+    # Both predecessors are present in the tree this entry will be tested on.
+    assert sorted(files) == ["base.txt", "one.txt", "two.txt"]
+
+
+def test_two_queued_changes_that_conflict_yield_no_speculative_base(cp, tmp_path):
+    """Speculation is refused, not silently retargeted at the bare tip."""
+
+    repo = tmp_path / "conflict"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "main")
+    git(repo, "config", "user.email", "a@example.com")
+    git(repo, "config", "user.name", "A")
+    (repo / "f.txt").write_text("base\n", encoding="utf-8")
+    git(repo, "add", "f.txt")
+    git(repo, "commit", "-q", "-m", "base")
+    tip = git(repo, "rev-parse", "HEAD")
+    git(repo, "checkout", "-q", "-B", "one", tip)
+    (repo / "f.txt").write_text("one\n", encoding="utf-8")
+    git(repo, "commit", "-q", "-am", "one")
+    one = git(repo, "rev-parse", "HEAD")
+    git(repo, "checkout", "-q", "-B", "two", tip)
+    (repo / "f.txt").write_text("two\n", encoding="utf-8")
+    git(repo, "commit", "-q", "-am", "two")
+    git(repo, "checkout", "-q", "main")
+    # `two` is being tested on top of `one`, and they touch the same line.
+    (repo / "f.txt").write_text("two\n", encoding="utf-8")
+    projected = cp._build_speculative_base(
+        repo,
+        _git_step_for(repo),
+        one,
+        [{"head_sha": tip, "source_branch": ""}, {"head_sha": "", "source_branch": ""}],
+    )
+    assert projected == ""
+
+
+def test_a_predecessor_that_cannot_be_fetched_yields_no_speculative_base(
+    cp, tmp_path
+):
+    repo, tip, _heads = _repo_with_two_branches(tmp_path)
+    projected = cp._build_speculative_base(
+        repo,
+        _git_step_for(repo),
+        tip,
+        [{"head_sha": "0" * 40, "source_branch": "nonexistent"}],
+    )
+    assert projected == ""
+
+
+def test_publication_defers_when_the_queue_window_is_full(
+    cp, tmp_path, monkeypatch
+):
+    """A change behind the window waits its turn instead of jumping it."""
+
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    # Somebody else is already at the front of this queue, and the window
+    # starts at its floor of 1.
+    queue = cp._native_merge_queue()
+    repository = str(remote)
+    from mac.services import _canonicalize_git_url
+
+    queue.admit(
+        repository=_canonicalize_git_url(repository) or repository,
+        branch="main",
+        task_id="task_someone_else",
+        head_sha="9" * 40,
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert (
+        getattr(excinfo.value, "publication_failure_kind", "")
+        == "merge_queue_deferred"
+    )
+    assert getattr(excinfo.value, "publication_retry_after_seconds", 0) > 0
+    assert forge.merges == []
+    assert git(source, "ls-remote", "origin", "refs/heads/main").split()[0] == main_head
+
+
+def test_a_change_behind_another_is_tested_on_top_of_it_and_will_not_jump_it(
+    cp, tmp_path, monkeypatch
+):
+    """Speculation and ordering, end to end through publication.
+
+    Another approved change is already at the front of the queue and the window
+    is 2, so this publication is admitted as #2 -- and it is projected and
+    tested on top of the change ahead of it (`tip + entry 1`), not on the bare
+    tip. It then refuses to land, because landing out of order would put a tree
+    on the trunk that nothing was tested against.
+    """
+
+    from mac.services import _canonicalize_git_url
+
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    # A second approved change, really pushed, that is ahead of us in line.
+    git(source, "checkout", "-q", "-B", "task/other", main_head)
+    (source / "other.txt").write_text("other\n", encoding="utf-8")
+    git(source, "add", "other.txt")
+    git(source, "commit", "-q", "-m", "the change ahead of us")
+    other_head = git(source, "rev-parse", "HEAD")
+    git(source, "push", "-q", "origin", "task/other")
+    git(source, "checkout", "-q", "main")
+
+    forge = FakeForge(remote, tmp_path / "forge")
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+
+    repository = _canonicalize_git_url(str(remote)) or str(remote)
+    queue = cp._native_merge_queue()
+    ahead = queue.admit(
+        repository=repository,
+        branch="main",
+        task_id="task_ahead",
+        head_sha=other_head,
+        detail={"source_branch": "task/other"},
+    )
+    # Widen the window so a second entry may speculate at all.
+    cp.store.execute(
+        "UPDATE merge_queue_windows SET window_size = 2 WHERE repository = ? AND branch = ?",
+        (repository, "main"),
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert (
+        getattr(excinfo.value, "publication_failure_kind", "") == "merge_queue_waiting"
+    )
+    # Nothing landed, and main is exactly where it was.
+    assert forge.merges == []
+    assert git(source, "ls-remote", "origin", "refs/heads/main").split()[0] == main_head
+
+    ours = next(
+        entry
+        for entry in queue.live_entries(repository, "main")
+        if entry.task_id == task.id
+    )
+    assert ours.position > ahead.position
+    assert ours.predecessors == (other_head,)
+    # THE POINT: it was tested against `tip + the change ahead of it`, which is
+    # neither the bare tip nor that change's own commit.
+    assert ours.state == STATE_TESTED
+    assert ours.tested_base_sha not in {"", main_head, other_head}
+    assert ours.tested_base_tree and ours.tested_merge_tree

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -178,6 +178,8 @@ EXPECTED_TABLES = [
     "machines",
     "managed_task_publication_rollout",
     "memory_records",
+    "merge_queue_entries",
+    "merge_queue_windows",
     "messages",
     "mood_overlays",
     "nap_runs",

--- a/tests/test_publication_pull_request.py
+++ b/tests/test_publication_pull_request.py
@@ -763,15 +763,18 @@ def test_publication_completes_once_the_merge_queue_lands_the_pull_request(
     assert "what was tested is what lands" in serialization["guarantee"]
 
 
-def test_without_a_merge_queue_the_canonical_tip_is_revalidated_before_merging(
+def test_without_a_forge_queue_macs_own_queue_revalidates_before_merging(
     cp, tmp_path, monkeypatch
 ):
-    """No queue means no serialization, so the tested base must still be the tip.
+    """No FORGE queue means mac's own queue serializes, and it still refuses.
 
     The checks ran against a merge candidate built from one canonical tip. If
     the branch advances before the merge executes, the landed tree was never
-    tested. Without a queue that is caught here: the stale projection is
-    rejected and re-projected instead of merged blind.
+    tested. This repository has no forge merge queue (GitHub's is
+    organization-only), so `mac_native_queue` owns the landing -- and its land
+    gate compares the canonical tip's TREE with the tree the entry was tested on
+    top of, which is strictly stronger than the SHA comparison it replaced.
+    The stale projection is rejected and re-projected instead of merged blind.
     """
     remote, source, main_head, task_head = build_repo(tmp_path)
     forge = FakeForge(remote, tmp_path / "forge")
@@ -812,20 +815,20 @@ def test_without_a_merge_queue_the_canonical_tip_is_revalidated_before_merging(
     # The first attempt refused to merge a projection that was already stale.
     assert detail["attempt"] == 2
     assert [item["sha"] for item in forge.merges] == [task_head]
-    # ``commands`` is per-attempt, so this is the second attempt's own
-    # re-validation -- the first attempt's raised before it could merge.
-    revalidations = [
-        item
-        for item in detail["commands"]
-        if item["name"] == "revalidate_canonical_tip"
+    # ``commands`` is per-attempt, so this is the second attempt's own land
+    # gate -- the first attempt's raised before it could merge.
+    land_gates = [
+        item for item in detail["commands"] if item["name"] == "merge_queue_land_gate"
     ]
-    assert len(revalidations) == 1
+    assert len(land_gates) == 1
+    assert land_gates[0]["allowed"] is True
     serialization = next(
         item for item in detail["commands"] if item["name"] == "merge_serialization"
     )
-    assert serialization["merge_queue"] is False
-    assert serialization["mode"] == "direct_squash"
-    assert "not serialized" in serialization["guarantee"]
+    assert serialization["merge_queue"] is True
+    assert serialization["mode"] == "mac_native_queue"
+    assert "what was tested is what lands" in serialization["guarantee"]
+    assert detail["merge_serialization"] == "mac_native_queue"
     # What landed is a squash of the reviewed head onto the tip that really was
     # main when the merge was requested.
     final = git(source, "ls-remote", "origin", "refs/heads/main").split()[0]


### PR DESCRIPTION
GitHub merge queues are an **organization-only** feature, and GitHub has said it is not planning to open them to personal accounts. Verified against this repo: adding a `merge_queue` rule to ruleset 20954943 returns HTTP 422 `Invalid rule 'merge_queue'` even with zero parameters, on a public User-owned repository.

So #400's "no forge queue" branch is not a rare fallback. For every personal repository the operator has, it is the **only** path — and what it did there was a plain squash merge whose weaker guarantee it recorded honestly but could not fix. This builds the queue in mac.

## What landed

`src/mac/native_merge_queue.py` — a durable ordered queue per (repository, canonical branch) in `merge_queue_entries`, with the AIMD speculation window in `merge_queue_windows`.

- **Ordering + speculation (Zuul's merge train).** Entry *N* is projected on top of entries *1..N-1*, so several entries test in parallel instead of serially. If entry *K* fails it is **evicted** and every speculative result behind it is **discarded** — those entries were green against a state that will never exist — and the survivors are re-planned in a new speculation epoch without *K*.
- **Window = TCP congestion control**, which is where Zuul got it. Starts at the floor (a fresh queue is strictly serial), grows additively on each land up to the ceiling, **halves** on any failure. Entries outside the window defer and keep their place.
- **Never land an untested tree**, enforced structurally. Each entry records the *tree* it was tested against; the land gate refuses unless the canonical tip's tree is byte-identical to it. Trees rather than SHAs is what makes speculation safe and what survives a squash merge, which changes the commit but not the tree.
- **Never double-land.** The queue reads PR state before merging; one already merged (human, forge, or an attempt of ours that died after the merge) is *observed* and recorded, not merged again. `record_landed` is idempotent in the ledger.
- **Fail toward not landing.** Unreadable PR state, unreadable tip, lost lease, unbuildable speculative base, and a full window are five distinct `publication_failure_kind`s that all defer through the existing retry backoff.
- **Crash-safe.** Slots are leased with CAS; a dead hub's slot is reclaimed after expiry **without** its unverifiable test result, and keeps its position.

## Window parameters

| knob | default |
| --- | --- |
| `MAC_MERGE_QUEUE_WINDOW_FLOOR` | `1` (a strictly serial queue) |
| `MAC_MERGE_QUEUE_WINDOW_CEILING` | `4` — the cap on concurrent speculation, i.e. at most four workers |
| `MAC_MERGE_QUEUE_WINDOW_INCREMENT` | `1` |
| `MAC_MERGE_QUEUE_LEASE_SECONDS` | `5400` (longer than a full ~45 min contract run) |
| `MAC_MERGE_QUEUE_CAPABILITY_TTL_SECONDS` | `86400` |

## How it slots into #400

The same seam, not a third mechanism. `merge_serialization` now reports `merge_queue` (the forge's) or `mac_native_queue` (this one), on the publication evidence and the integration proof, each with its guarantee written out. When the forge has a queue, #400's path is untouched and mac's queue never enrolls the change (asserted by a test). `tests/test_publication_pull_request.py` still passes, 41/41.

## Capability is a stored project attribute, not a per-merge probe

`src/mac/merge_capability.py` resolves the forge capability once and stores it on `project_repositories.metadata` — metadata rather than a new column, because `schema.sql` is `CREATE TABLE IF NOT EXISTS` with no migration framework. It records `supported` and `enabled` **separately** (they differ: an org repo can have a queue and may not have turned it on), plus forge kind, whether a credential resolved, and when/by what it was determined.

Refresh rides on the poller that already visits every repository (`GitHubIssueIngestor`), behind a TTL, failure-isolated in both directions and reported in its own section of the run report. Forcing it needs no new endpoint: `mac fleet github-ingest run` already exists. **Unknown never authorises an unserialized squash** — it routes to the native queue, which serializes regardless.

## Observable

This repo shipped four gates in one day that reported healthy while enforcing nothing. Every publication records a queue snapshot beside `merge_serialization` — depth, window size, floor/ceiling, testing/tested counts, landed, failures, speculation discarded, and the last ten evictions with reasons — the same numbers go out as `merge_queue.*` metrics, and eight named commands say what each decision was (`merge_serialization_capability`, `merge_queue_slot`, `merge_queue_speculative_base`, `merge_queue_tested`, `merge_queue_observe_pull_request`, `merge_queue_land_gate`, `merge_queue_landed`, `merge_queue_eviction`).

## A bug this found in itself

`int(result.get("returncode") or 1)` reads as "1 when missing", but `0 or 1` is `1` — so every **successful** git step was read as a failure and the speculative base could never be built. Caught by the test that builds one out of real git objects; fixed with `_git_step_returncode`.

## Live-hub note (read before merging)

`merge_queue_entries` and `merge_queue_windows` will **not** appear on the running hub: `PostgresStore.initialize()` only creates missing tables at startup. Apply the DDL block headed *"mac's own merge queue"* from `src/mac/data/postgres/schema.sql` by hand. Until it exists, publication on a repo without a forge queue **fails** rather than falling back to an unserialized squash — the correct direction to fail.

## Tests

34 new in `tests/test_native_merge_queue.py`, including full-stack ones through `publish_task`: a change behind another is tested on `tip + the change ahead of it` and refuses to jump it; a PR that landed on the forge is observed, not re-merged; an unreadable state defers.

Every required property was verified to fail without its implementation by mutation — halve→decrement, keep-the-discarded-results, drop-the-already-landed guard, skip-the-PR-observation, and treat-unreadable-as-fine each turn a test red.

Local: `-k "merge or publication or publish or queue or gitops or landing or ingest or repositor"` → **874 passed**, 2 pre-existing failures (`test_worker_control_edges.py` managed-image adoption, red on `origin/main` too). Preflight green: `test-docs.py --static-only`, `generate-env-config-registry.py --check`, `generate-docs-reference.py --check`, `test_control_plane_public_contract.py` (582). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)