### PR TITLE
Key the resolver module cache by repo root, not one shared name

### DIFF
--- a/scripts/select-sanity-tests.py
+++ b/scripts/select-sanity-tests.py
@@ -31,16 +31,34 @@ SCHEMA = "mac.sanity_selection.v1"
 _RESOLVER_NAME = "mac_resolve_impacted_tests"
 
 
+def _resolver_module_name() -> str:
+    """`sys.modules` key for the resolver bound to THIS repository root.
+
+    See `mac.test_checkpoint.resolver_module_name`. Sharing one fixed key with
+    every other loader let a resolver imported against a temp repository answer
+    for this one, which made `Makefile` global infrastructure and replaced the
+    real `always_run` canaries with a synthetic `tests/test_guard.py`.
+    """
+    import hashlib
+
+    return "%s__%s" % (
+        _RESOLVER_NAME,
+        hashlib.sha256(str(ROOT.resolve()).encode("utf-8")).hexdigest()[:16],
+    )
+
+
 def _resolver():
     """Import the sibling resolver module (hyphenated file name)."""
-    if _RESOLVER_NAME in sys.modules:
-        return sys.modules[_RESOLVER_NAME]
+    name = _resolver_module_name()
+    cached = sys.modules.get(name)
+    if cached is not None:
+        return cached
     path = ROOT / "scripts" / "resolve-impacted-tests.py"
-    spec = importlib.util.spec_from_file_location(_RESOLVER_NAME, path)
+    spec = importlib.util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
         raise RuntimeError("cannot load resolve-impacted-tests.py")
     module = importlib.util.module_from_spec(spec)
-    sys.modules[_RESOLVER_NAME] = module  # register so dataclasses resolve
+    sys.modules[name] = module  # register so dataclasses resolve
     spec.loader.exec_module(module)
     return module
 

--- a/src/mac/test_checkpoint.py
+++ b/src/mac/test_checkpoint.py
@@ -554,6 +554,38 @@ def load_checkpoint(directory: Path) -> dict | None:
 _RESOLVER_NAME = "mac_resolve_impacted_tests"
 
 
+def resolver_module_name(repo_root: Path) -> str:
+    """The `sys.modules` key for the resolver loaded from ``repo_root``.
+
+    KEYED BY ROOT, deliberately. The resolver reads `test-policy.toml` and the
+    impact map relative to a root captured at import, so a module loaded from
+    one repository answers questions about THAT repository forever. Caching it
+    under a single fixed name -- which is what this did -- makes the first
+    caller in the process decide the answers for every later one.
+
+    That is not hypothetical. `tests/test_test_checkpoint.py` builds a synthetic
+    repository whose policy declares `Makefile` global and
+    `always_run = ["tests/test_guard.py"]`, loads the resolver against it, and
+    leaves it in `sys.modules`. Any later caller in the same pytest worker then
+    resolved against a temp directory that had already been deleted:
+
+        tests/test_select_sanity_tests.py::test_opaque_non_code_forces_full
+            assert 'global_infrastructure_changed' == 'unmappable_non_code_change'
+        tests/test_select_sanity_tests.py::test_source_change_uses_codegraph_and_canaries
+            assert 'tests/.../public_contract.py' in ['tests/test_guard.py', ...]
+
+    Both files pass in isolation, so this only appears when `-n 8` happens to
+    put them in one worker -- and it surfaced as two red tests only by luck.
+    The same contaminated module is what CHOOSES WHICH TESTS CI RUNS, and a
+    wrong policy there under-selects silently: fewer tests run, the gate is
+    green, and nothing reports it.
+    """
+    return "%s__%s" % (
+        _RESOLVER_NAME,
+        hashlib.sha256(str(Path(repo_root).resolve()).encode("utf-8")).hexdigest()[:16],
+    )
+
+
 def load_resolver(repo_root: Path):
     """Import scripts/resolve-impacted-tests.py, or None if it is unavailable.
 
@@ -561,18 +593,20 @@ def load_resolver(repo_root: Path):
     here would let the two drift, and a drifted copy is a copy that skips a test
     the resolver would have run.
     """
-    if _RESOLVER_NAME in sys.modules:
-        return sys.modules[_RESOLVER_NAME]
+    name = resolver_module_name(repo_root)
+    cached = sys.modules.get(name)
+    if cached is not None:
+        return cached
     path = repo_root / "scripts" / "resolve-impacted-tests.py"
-    spec = importlib.util.spec_from_file_location(_RESOLVER_NAME, path)
+    spec = importlib.util.spec_from_file_location(name, path)
     if spec is None or spec.loader is None:
         return None
     module = importlib.util.module_from_spec(spec)
-    sys.modules[_RESOLVER_NAME] = module
+    sys.modules[name] = module
     try:
         spec.loader.exec_module(module)
     except Exception:
-        sys.modules.pop(_RESOLVER_NAME, None)
+        sys.modules.pop(name, None)
         return None
     return module
 

--- a/tests/test_resolver_module_isolation.py
+++ b/tests/test_resolver_module_isolation.py
@@ -1,0 +1,143 @@
+"""The test selector must not inherit another repository's policy.
+
+`scripts/resolve-impacted-tests.py` captures its repository root at import and
+reads `test-policy.toml` and the impact map relative to it. Both loaders cached
+that module under ONE fixed `sys.modules` key, `mac_resolve_impacted_tests`, so
+the first caller in a process decided the answers for every later one.
+
+`tests/test_test_checkpoint.py` builds a synthetic repo whose policy declares
+`Makefile` global and `always_run = ["tests/test_guard.py"]`, loads the resolver
+against it, and left it installed. Every later caller in that pytest worker then
+resolved against a temp directory that had already been deleted:
+
+    tests/test_select_sanity_tests.py::test_opaque_non_code_forces_full
+        assert 'global_infrastructure_changed' == 'unmappable_non_code_change'
+    tests/test_select_sanity_tests.py::test_source_change_uses_codegraph_and_canaries
+        assert '...public_contract.py' in ['tests/test_guard.py', 'tests/test_mapped.py']
+
+Each file passes alone. It only fails when `-n 8` puts them in one worker, which
+is why it sat until an unrelated new test file shifted xdist's distribution.
+
+THE REASON THIS IS NOT MERELY TWO RED TESTS. The contaminated module is the one
+that CHOOSES WHICH TESTS CI RUNS. Here a wrong policy made assertions fail, which
+is the lucky outcome. The same wrong policy during a real selection UNDER-SELECTS:
+fewer tests run, the gate reports success, and nothing anywhere says so.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from mac import test_checkpoint as tc
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture()
+def foreign_repo(tmp_path: Path) -> Path:
+    """A checkout whose policy disagrees with the real one on every point."""
+    root = tmp_path / "other-repo"
+    (root / "scripts").mkdir(parents=True)
+    (root / "tests").mkdir()
+    (root / "scripts" / "resolve-impacted-tests.py").write_text(
+        (ROOT / "scripts" / "resolve-impacted-tests.py").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    (root / "test-policy.toml").write_text(
+        "[selection]\n"
+        'global_full_paths = ["Makefile"]\n'
+        'always_run = ["tests/test_guard.py"]\n',
+        encoding="utf-8",
+    )
+    _git(root, "init", "-q", "-b", "main")
+    return root
+
+
+def _load_selector():
+    """A fresh copy of scripts/select-sanity-tests.py, as CI invokes it."""
+    name = "mac_select_sanity_tests_isolation"
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(
+        name, ROOT / "scripts" / "select-sanity-tests.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_a_foreign_repo_does_not_capture_the_shared_module_key(foreign_repo):
+    """The exact sequence that broke CI, reduced to two calls."""
+    foreign = tc.load_resolver(foreign_repo)
+    assert foreign is not None
+
+    ours = tc.load_resolver(ROOT)
+    assert ours is not None
+
+    assert ours is not foreign, (
+        "loading the resolver against a temp repo returned that same module "
+        "for the real checkout; every policy question is now answered by a "
+        "directory that pytest is about to delete"
+    )
+    assert "Makefile" not in ours.load_policy().global_full_paths
+    assert "Makefile" in foreign.load_policy(foreign_repo / "test-policy.toml").global_full_paths
+
+
+def test_the_selector_reads_its_own_policy_after_a_foreign_load(foreign_repo):
+    """End to end: the failure CI actually reported."""
+    tc.load_resolver(foreign_repo)
+
+    selector = _load_selector()
+    result = selector.select(["Makefile"], codegraph=lambda _s, _r: ([], None))
+
+    assert result["reason"] == "unmappable_non_code_change", (
+        "Makefile is global infrastructure ONLY in the synthetic policy; the "
+        "selector is reading a foreign repository's test-policy.toml"
+    )
+
+
+def test_canaries_come_from_the_real_policy_after_a_foreign_load(foreign_repo):
+    tc.load_resolver(foreign_repo)
+
+    selector = _load_selector()
+    resolver = selector._resolver()
+    always_run = resolver.load_policy().always_run
+
+    assert "tests/test_guard.py" not in always_run, (
+        "the canary list is the synthetic one; a real selection would run the "
+        "wrong guards and skip the public-contract canary"
+    )
+    assert "tests/test_control_plane_public_contract.py" in always_run
+
+
+def test_the_module_key_distinguishes_roots(tmp_path):
+    a = tc.resolver_module_name(tmp_path / "a")
+    b = tc.resolver_module_name(tmp_path / "b")
+
+    assert a != b
+    assert tc.resolver_module_name(tmp_path / "a") == a, "must be deterministic"
+
+
+def test_the_same_root_is_still_cached(foreign_repo):
+    """Keying by root must not turn every call into a fresh exec_module."""
+    first = tc.load_resolver(foreign_repo)
+
+    assert tc.load_resolver(foreign_repo) is first
+
+
+def test_an_unreadable_root_still_returns_none(tmp_path):
+    assert tc.load_resolver(tmp_path / "nonexistent") is None
+    assert not [
+        name for name in sys.modules if name.startswith(tc._RESOLVER_NAME)
+        and sys.modules[name] is None
+    ], "a failed load must not leave a placeholder behind"

--- a/tests/test_test_checkpoint.py
+++ b/tests/test_test_checkpoint.py
@@ -105,10 +105,11 @@ def _write_map(root: Path) -> dict:
 
 
 def _resolver(repo: Path):
-    # Force a fresh import bound to THIS repo, not the process-wide cache.
-    import sys
-
-    sys.modules.pop(tc._RESOLVER_NAME, None)
+    # No cache-popping needed: load_resolver keys sys.modules by repo root, so
+    # this repo's module cannot displace the one bound to the real checkout.
+    # Popping a shared key was the old workaround, and it was the bug -- it
+    # left THIS synthetic repo's resolver installed for every later caller in
+    # the worker. See mac.test_checkpoint.resolver_module_name.
     module = tc.load_resolver(repo)
     assert module is not None
     return module


### PR DESCRIPTION
## The failure

PR #407's `sanity` gate went red on two tests it could not have affected:

```
FAILED tests/test_select_sanity_tests.py::test_opaque_non_code_forces_full
  AssertionError: assert 'global_infrastructure_changed' == 'unmappable_non_code_change'
FAILED tests/test_select_sanity_tests.py::test_source_change_uses_codegraph_and_canaries
  AssertionError: assert 'tests/test_control_plane_public_contract.py'
                      in ['tests/test_guard.py', 'tests/test_mapped.py']
```

Reproduced exactly, with no reference to #407:

```console
$ pytest -p no:randomly tests/test_test_checkpoint.py tests/test_select_sanity_tests.py
2 failed, 53 passed
$ pytest tests/test_select_sanity_tests.py
11 passed
```

## The mechanism

`scripts/select-sanity-tests.py:31` and `src/mac/test_checkpoint.py:554` both cache
`scripts/resolve-impacted-tests.py` under one process-global key:

```python
_RESOLVER_NAME = "mac_resolve_impacted_tests"
```

The resolver captures its repository root at import and reads `test-policy.toml`
and the impact map relative to it. `tests/test_test_checkpoint.py` builds a
synthetic repository whose policy is

```toml
global_full_paths = ["conftest.py", "tests/conftest.py", "test-policy.toml", "Makefile"]
always_run = ["tests/test_guard.py"]
```

loads the resolver against it, and leaves it in `sys.modules`. Every later caller
in that worker resolves against a temp directory pytest has already deleted —
which is why `Makefile` reads as global infrastructure and the canary set becomes
`tests/test_guard.py`, a file that exists nowhere in this repository.

Each file passes alone, so it only fires when `-n 8` happens to co-locate them.
Adding an unrelated test file in #407 shifted xdist's distribution enough to do that.

## Why this is worth more than two red tests

The contaminated module is the one that **chooses which tests CI runs**. Here a
wrong policy made assertions fail, which is the lucky outcome. The same wrong
policy during a real selection **under-selects**: fewer tests run, the gate reports
success, and nothing anywhere says so. Same shape as the retention bug — every
failure mode looked identical to "nothing to do".

## The fix

Key the `sys.modules` entry by resolved repo root, so a resolver loaded against a
temp repository cannot answer for the real checkout. This also retires the
`sys.modules.pop` workaround in the checkpoint tests — popping a shared key is
precisely what left the synthetic resolver installed for everyone else.

## Verification

- `tests/test_resolver_module_isolation.py` — 6 new tests; **5 fail without the fix**.
  The 6th (`test_the_same_root_is_still_cached`) is a guard that must hold both ways,
  so keying by root does not turn every call into a fresh `exec_module`.
- The original reproduction now passes in **both orders**: 61 passed.
- Selection/checkpoint/impact-map suites together: **116 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)