### PR TITLE
Make `mac project list` readable, and stop inventing a project per worktree

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -157,7 +157,7 @@ project -- a unit of work ownership: repositories, policy, dispatch state
 
 CRUD:
   create  create a project and its dispatch policy
-  list    list every project
+  list    list projects with live work or a registration
   show    show one project: policy, repositories, dispatch state
   update  update project fields or its branch-qualified repository registration
   delete  remove a project; --force detaches historical tasks and disables linked checkout registrations (same as `unregister`)

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -582,6 +582,23 @@ def _one_liner(value: Any) -> str:
             _agent_hw_summary(d),
             activity,
         )
+    # A project summary record. Without this branch it fell through to the
+    # generic key=value dump below, which printed all 18 scalar fields on one
+    # unreadable line per project -- including two truncated copies of the same
+    # repository URL -- while tasks and agents each got a real column layout.
+    if "task_count" in d and "project" in d:
+        repo = str(d.get("repository_url") or "")
+        branch = str(d.get("default_branch") or "")
+        where = "%s#%s" % (repo, branch) if repo and branch else (repo or "-")
+        return "%-26s %-8s %6d act %5d rdy %5d blk %5d rev  %s" % (
+            _trunc(str(d.get("project") or ident or "-"), 26),
+            str(d.get("status") or "?"),
+            int(d.get("active_count") or 0),
+            int(d.get("ready_count") or 0),
+            int(d.get("blocked_count") or 0),
+            int(d.get("review_count") or 0),
+            _trunc(where, 52),
+        )
     scal = [
         "%s=%s" % (k, _trunc(v, 40))
         for k, v in d.items()
@@ -2012,6 +2029,29 @@ def _default_project_from_cwd() -> Optional[str]:
     """
     import subprocess
 
+    # --git-common-dir, NOT --show-toplevel. In a linked worktree the toplevel
+    # is the worktree directory, so filing from /tmp/mac-dev invented a project
+    # called "mac-dev". CLAUDE.md *mandates* a worktree per agent, so the
+    # convention that keeps agents from colliding was manufacturing a junk
+    # project per branch: mac-bom, mac-dead1, mac-deadtests, mac-dev,
+    # mac-dispatch-fix and mac-sandbox-loop were all live on the hub, each
+    # holding one or two cancelled tasks and nothing else. The common dir is
+    # shared by every worktree of a repository, so its parent is the canonical
+    # checkout and every worktree of mac resolves to "mac".
+    try:
+        common = subprocess.run(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        git_dir = common.stdout.strip()
+        if common.returncode == 0 and git_dir:
+            root = os.path.dirname(git_dir.rstrip("/"))
+            if root:
+                return os.path.basename(root) or None
+    except Exception:
+        pass
     try:
         top = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
@@ -3199,9 +3239,45 @@ def cmd_task_audit(args: argparse.Namespace) -> None:
             )
 
 
+def _project_is_reachable(record: Any) -> bool:
+    """Is this project something an operator can still act on?
+
+    `list_projects` returns registered projects UNIONED with projects derived
+    from the `project` string on tasks, and a derived project has no
+    `project_id` -- there is no record to show, update, pause or unregister.
+    Most were manufactured by the worktree-basename default this commit also
+    fixes, and they are unreachable in the strict sense: `mac project show
+    mac-dev` cannot resolve them, and no task can be dispatched to them.
+
+    A derived project still earns its row while it holds live work, because
+    that work has to go somewhere and hiding it would hide the tasks too.
+    Registration alone is enough for a registered project: an operator asked
+    for it, so an empty backlog is a fact about the project, not a reason to
+    conceal it.
+    """
+    d = _unwrap(record)
+    if not isinstance(d, dict):
+        return True
+    if d.get("project_id"):
+        return True
+    counts = d.get("state_counts") or {}
+    if not isinstance(counts, dict):
+        return True
+    from mac.models import TERMINAL_TASK_STATES
+
+    return any(
+        int(value or 0) > 0
+        for state, value in counts.items()
+        if str(state) not in TERMINAL_TASK_STATES
+    )
+
+
 def cmd_project_list(args: argparse.Namespace) -> None:
-    """List registered projects."""
-    _print(_apply_selector(list(_plane(args).list_projects()), args, "project"))
+    """List projects an operator can still act on (--all for every one)."""
+    records = list(_plane(args).list_projects())
+    if not getattr(args, "all", False):
+        records = [record for record in records if _project_is_reachable(record)]
+    _print(_apply_selector(records, args, "project"))
 
 
 def cmd_project_create(args: argparse.Namespace) -> None:
@@ -8773,7 +8849,17 @@ def build_parser() -> argparse.ArgumentParser:
     sandbox_rollout_cmd.add_argument("--project", default=None)
     sandbox_rollout_cmd.add_argument("--actor", default="human")
     _set(cmd_sandbox_rollout, sandbox_rollout_cmd)
-    project_list = project.add_parser("list", help="list every project")
+    project_list = project.add_parser(
+        "list", help="list projects with live work or a registration"
+    )
+    project_list.add_argument(
+        "--all",
+        action="store_true",
+        help=(
+            "include unregistered projects whose tasks are all terminal "
+            "(derived from a task's project string, with nothing to act on)"
+        ),
+    )
     _set(cmd_project_list, project_list)
     project_show = project.add_parser(
         "show", help="show one project: policy, repositories, dispatch state"

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -365,10 +365,60 @@ class _FakeProc:
         self.stdout = stdout
 
 
-def test_default_project_from_cwd_uses_git_toplevel(monkeypatch):
+def _fake_git(common_dir=None, toplevel=None):
+    """Answer per git subcommand, the way real git does.
+
+    The previous fake returned ONE string for every `git rev-parse ...`, which
+    made it impossible to tell `--git-common-dir` from `--show-toplevel` -- and
+    that difference is the whole point: in a linked worktree they disagree, and
+    only the common dir names the repository.
+    """
+
+    def run(argv, *a, **k):
+        args = list(argv)
+        if "--git-common-dir" in args:
+            return _FakeProc(0, (common_dir or "") + "\n") if common_dir else _FakeProc(128, "")
+        if "--show-toplevel" in args:
+            return _FakeProc(0, (toplevel or "") + "\n") if toplevel else _FakeProc(128, "")
+        return _FakeProc(128, "")
+
+    return run
+
+
+def test_default_project_from_cwd_uses_the_repository_not_the_worktree(monkeypatch):
+    """A linked worktree must resolve to the repository it belongs to.
+
+    CLAUDE.md mandates `git worktree add /tmp/mac-<task>` per agent, so
+    inferring from `--show-toplevel` filed work under a project named after the
+    branch directory. `mac-bom`, `mac-dead1`, `mac-deadtests`, `mac-dev`,
+    `mac-dispatch-fix` and `mac-sandbox-loop` all became live projects on the
+    hub that way, each holding one or two cancelled tasks and nothing else.
+    """
     from mac.cli import _default_project_from_cwd
 
-    monkeypatch.setattr("subprocess.run", lambda *a, **k: _FakeProc(0, "/home/u/Src/myrepo\n"))
+    monkeypatch.setattr(
+        "subprocess.run",
+        _fake_git(common_dir="/home/u/Src/myrepo/.git", toplevel="/tmp/mac-dev"),
+    )
+    assert _default_project_from_cwd() == "myrepo"
+
+
+def test_default_project_from_cwd_uses_git_toplevel(monkeypatch):
+    """The ordinary checkout case: both answers agree."""
+    from mac.cli import _default_project_from_cwd
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        _fake_git(common_dir="/home/u/Src/myrepo/.git", toplevel="/home/u/Src/myrepo"),
+    )
+    assert _default_project_from_cwd() == "myrepo"
+
+
+def test_default_project_from_cwd_falls_back_to_toplevel(monkeypatch):
+    """Older git without --path-format still resolves via --show-toplevel."""
+    from mac.cli import _default_project_from_cwd
+
+    monkeypatch.setattr("subprocess.run", _fake_git(toplevel="/home/u/Src/myrepo"))
     assert _default_project_from_cwd() == "myrepo"
 
 

--- a/tests/test_project_list_scope_and_format.py
+++ b/tests/test_project_list_scope_and_format.py
@@ -1,0 +1,245 @@
+"""`mac project list` must be readable, and must not list ghosts.
+
+Three defects, all visible in one live run against the hub:
+
+1. **Every project printed as an 18-field key=value dump.** `_one_liner` has a
+   real column layout for tasks and for agents; a project summary fell through
+   to the generic scalar dump, so one project was one ~340-character line
+   carrying `repository_url` and `repository_registration` -- the same URL
+   twice, both truncated with an ellipsis mid-hostname.
+
+2. **9 of 19 projects were junk manufactured by our own worktree rule.**
+   CLAUDE.md mandates `git worktree add /tmp/mac-<task>` per agent. Filing from
+   there inferred the project from `git rev-parse --show-toplevel`, whose
+   basename in a linked worktree is the WORKTREE directory. So `mac-bom`,
+   `mac-dead1`, `mac-deadtests`, `mac-dev`, `mac-dispatch-fix` and
+   `mac-sandbox-loop` were all live projects on the hub, alongside `tmp`,
+   `tasks` and `jkh`. The convention that stops agents colliding was quietly
+   shredding the project namespace.
+
+3. **Derived projects are unreachable.** They have no `project_id`, so
+   `mac project show mac-dev` cannot resolve one, and nothing can be
+   dispatched to it. Listing them by default offers an operator rows that no
+   other verb accepts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+
+import pytest
+
+from mac import cli
+
+
+def _rec(**over):
+    base = {
+        "project": "mac",
+        "project_id": "project_72e4",
+        "status": "active",
+        "task_count": 6788,
+        "active_count": 446,
+        "ready_count": 5,
+        "blocked_count": 357,
+        "review_count": 10,
+        "repository_url": "git@github.com:jordanhubbard/mac.git",
+        "default_branch": "main",
+        "state_counts": {"open": 54, "cancelled": 3524},
+    }
+    base.update(over)
+    return base
+
+
+# --------------------------------------------------------------------------
+# 1. formatting
+# --------------------------------------------------------------------------
+
+
+def test_a_project_is_not_rendered_as_a_key_value_dump():
+    line = cli._one_liner(_rec())
+
+    assert "task_count=" not in line, (
+        "the generic scalar dump is still being used for projects; every one "
+        "of the 18 fields lands on a single unreadable line"
+    )
+    assert line.startswith("mac "), "the project name must lead the line"
+    assert "active" in line and "446" in line
+
+
+def test_the_repository_is_named_once_not_twice():
+    """`repository_url` and `repository_registration` are the same URL; the
+    dump printed both, each truncated mid-hostname."""
+    line = cli._one_liner(
+        _rec(repository_registration="git@github.com:jordanhubbard/mac.git#main")
+    )
+
+    assert line.count("jordanhubbard/mac.git") == 1
+
+
+def test_the_counts_that_describe_live_work_are_all_present():
+    line = cli._one_liner(
+        _rec(active_count=98, ready_count=0, blocked_count=84, review_count=7)
+    )
+
+    for value in ("98", "84", "7"):
+        assert value in line, "count %s is missing from the rendered line" % value
+
+
+def test_a_project_without_a_repository_still_renders():
+    line = cli._one_liner(
+        _rec(project="fleet-maintenance", repository_url="", default_branch="")
+    )
+
+    assert line.startswith("fleet-maintenance")
+    assert "#" not in line, "an empty repo must not render as a bare '#branch'"
+
+
+def test_a_task_is_still_rendered_as_a_task():
+    """The project branch keys off `task_count`; a task record must not match
+    it. Tasks carry `project` too."""
+    line = cli._one_liner(
+        {"id": "task_d95bcaee", "state": "open", "project": "mac", "title": "x"}
+    )
+
+    assert "open" in line and "x" in line
+    assert "act" not in line
+
+
+# --------------------------------------------------------------------------
+# 2. the worktree-basename project factory
+# --------------------------------------------------------------------------
+
+
+def _git(cwd, *args):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.fixture()
+def repo_with_worktree(tmp_path):
+    repo = tmp_path / "mac"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    (repo / "f.txt").write_text("x")
+    _git(repo, "add", "f.txt")
+    _git(repo, "commit", "-qm", "init")
+    tree = tmp_path / "mac-dev"
+    _git(repo, "worktree", "add", "-q", str(tree), "-b", "wt")
+    return repo, tree
+
+
+def test_filing_from_a_worktree_uses_the_repository_not_the_directory(
+    repo_with_worktree, monkeypatch
+):
+    """This is the bug that put mac-dev, mac-bom and mac-deadtests on the hub."""
+    _repo, tree = repo_with_worktree
+    monkeypatch.chdir(tree)
+
+    assert cli._default_project_from_cwd() == "mac", (
+        "a task filed from the CLAUDE.md-mandated worktree was assigned to a "
+        "project named after the worktree directory"
+    )
+
+
+def test_the_main_checkout_is_unchanged(repo_with_worktree, monkeypatch):
+    repo, _tree = repo_with_worktree
+    monkeypatch.chdir(repo)
+
+    assert cli._default_project_from_cwd() == "mac"
+
+
+def test_a_subdirectory_of_a_worktree_also_resolves(repo_with_worktree, monkeypatch):
+    _repo, tree = repo_with_worktree
+    nested = tree / "src" / "mac"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
+
+    assert cli._default_project_from_cwd() == "mac"
+
+
+def test_outside_a_repository_it_still_falls_back_to_the_directory(
+    tmp_path, monkeypatch
+):
+    """Non-git directories keep bd parity; only the worktree case changes."""
+    plain = tmp_path / "somewhere"
+    plain.mkdir()
+    monkeypatch.chdir(plain)
+
+    assert cli._default_project_from_cwd() == "somewhere"
+
+
+# --------------------------------------------------------------------------
+# 3. default scope
+# --------------------------------------------------------------------------
+
+
+def test_a_derived_project_holding_only_terminal_tasks_is_hidden():
+    ghost = _rec(
+        project="mac-dev",
+        project_id=None,
+        status="derived",
+        state_counts={"cancelled": 2},
+    )
+
+    assert not cli._project_is_reachable(ghost), (
+        "`mac project show mac-dev` cannot resolve this and nothing can be "
+        "dispatched to it, yet it occupied a row"
+    )
+
+
+def test_a_derived_project_with_live_work_is_kept():
+    """Hiding it would hide the tasks, which still have to go somewhere."""
+    live = _rec(
+        project="unassigned",
+        project_id=None,
+        status="derived",
+        state_counts={"open": 11, "blocked": 16, "cancelled": 473},
+    )
+
+    assert cli._project_is_reachable(live)
+
+
+def test_a_registered_project_survives_an_entirely_terminal_backlog():
+    """An operator asked for it; an empty backlog is a fact, not a reason to
+    conceal the project."""
+    quiet = _rec(
+        project="fleet-maintenance",
+        project_id="proj_af53",
+        state_counts={"cancelled": 14},
+    )
+
+    assert cli._project_is_reachable(quiet)
+
+
+def test_a_registered_project_with_no_tasks_at_all_survives():
+    assert cli._project_is_reachable(_rec(project="c26", state_counts={}))
+
+
+def test_all_shows_everything(monkeypatch, capsys):
+    records = [
+        _rec(),
+        _rec(project="mac-dev", project_id=None, state_counts={"cancelled": 2}),
+    ]
+
+    class _Plane:
+        def list_projects(self):
+            return records
+
+    monkeypatch.setattr(cli, "_plane", lambda args: _Plane())
+
+    cli.cmd_project_list(argparse.Namespace(all=True, selector=None))
+    assert "mac-dev" in capsys.readouterr().out
+
+    cli.cmd_project_list(argparse.Namespace(all=False, selector=None))
+    assert "mac-dev" not in capsys.readouterr().out
+
+
+def test_the_flag_is_declared_on_the_parser():
+    parser = cli.build_parser()
+    args = parser.parse_args(["project", "list", "--all"])
+
+    assert args.all is True
+    assert parser.parse_args(["project", "list"]).all is False


### PR DESCRIPTION
Three defects, all visible in one run against the live hub.

## 1. Every project printed as an 18-field key=value dump

`_one_liner` has a real column layout for tasks and for agents; a project summary
fell through to the generic scalar dump. One project was one ~340-character line
carrying `repository_url` **and** `repository_registration` — the same URL twice,
both truncated with an ellipsis mid-hostname.

Before:

```
project=mac  task_count=6788  active_count=446  ready_count=5  held_count=49  waiting_count=18  blocked_count=357  review_count=10  completed_count=723  dependency_edge_count=7054  cross_project_dependency_count=1  bridge_item_count=0  repository_count=1  repository_url=git@github.com:jordanhubbard/mac.git  default_branch=main  repository_registration=git@github.com:jordanhubbard/mac.git#ma…  description=  status=active  project_id=project_72e44675ee154038a8b7bcf2f28b6433
```

After:

```
mac                        active      448 act     5 rdy   357 blk    11 rev  git@github.com:jordanhubbard/mac.git#main
isaacsim7-poc@feat/ros-sim active       98 act     0 rdy    84 blk     0 rev  https://github.com/jordanhubbard/isaacsim7-…
unassigned                 derived      29 act     0 rdy    16 blk     0 rev  -
```

## 2. Nine of nineteen projects were manufactured by our own worktree rule

CLAUDE.md **mandates** `git worktree add /tmp/mac-<task>` per agent. The project
was inferred from `git rev-parse --show-toplevel`, whose basename in a linked
worktree is the *worktree directory*. So the hub carried `mac-bom`, `mac-dead1`,
`mac-deadtests`, `mac-dev`, `mac-dispatch-fix` and `mac-sandbox-loop` as live
projects, alongside `tmp`, `tasks` and `jkh`. The convention that keeps agents
from colliding was quietly shredding the project namespace.

Fixed by resolving `--git-common-dir`, which every worktree of a repository
shares, so its parent is the canonical checkout and all of them resolve to `mac`.

## 3. Derived projects are unreachable

A derived project has no `project_id`: `mac project show mac-dev` cannot resolve
one, and nothing can be dispatched to it. Eight of the nine held nothing but
cancelled tasks.

`list` now shows projects with live work **or** a registration; `--all` restores
every row. Two deliberate carve-outs:

- a derived project **with live work** is kept — hiding it would hide the tasks,
  which still have to go somewhere
- a **registered** project with an entirely terminal backlog is kept — an operator
  asked for it, so an empty backlog is a fact about the project, not a reason to
  conceal it

Live result: **19 rows → 10**.

## Verification

- `tests/test_project_list_scope_and_format.py` — 15 new tests, **11 fail without
  the change**. The 4 that pass either way are guards: a task record must still
  render as a task, and the non-git fallback must keep bd parity.
- `tests/cli` — 636 tests, all pass.
- `docs/reference/cli.md` regenerated for the new flag.

`test_default_project_from_cwd_uses_git_toplevel` was pinning the old behaviour
with a fake that returned one string for *every* `git rev-parse`, so it could not
distinguish `--git-common-dir` from `--show-toplevel` — the one difference that
matters here. Rewritten to answer per subcommand, split into worktree, ordinary
checkout, and older-git fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)