### PR TITLE
The selector must not choose the scope that verifies itself

### DIFF
--- a/test-policy.toml
+++ b/test-policy.toml
@@ -38,12 +38,31 @@ impact_map = "src/mac/data/test_impact_map.json"
 # change to any of them forces a full run regardless of the map. Kept minimal
 # on purpose: the old selector escalated on every scripts/ and pyproject edit,
 # which is exactly the over-escalation impact selection removes.
+#
+# The last four are the SELECTOR ITSELF. `test-policy.toml` was already here;
+# the code it configures was not, so a change to the selection machinery got a
+# scope chosen by the changed machinery. Observed on #408 (run 32104798882),
+# which modified two of these files:
+#
+#     sanity selection: focused (impact_hybrid_scope)
+#     collected 750 items
+#     746 passed, 4 skipped in 68.70s
+#
+# 750 of ~11,400 tests, in 1m44s. The change was correct, but
+# `tests/test_select_sanity_tests.py` -- the file whose failures prompted that
+# very fix -- was selected ZERO times, so the run could not have contradicted
+# it. A component that decides what gets verified must not be allowed to narrow
+# its own verification.
 global_full_paths = [
     "conftest.py",
     "tests/conftest.py",
     "test-policy.toml",
     "uv.lock",
     "poetry.lock",
+    "scripts/select-sanity-tests.py",
+    "scripts/resolve-impacted-tests.py",
+    "scripts/build-test-impact-map.py",
+    "src/mac/test_checkpoint.py",
 ]
 
 # Cross-cutting guards that can never be safely deselected by the dynamic layer

--- a/tests/test_selector_forces_full_run.py
+++ b/tests/test_selector_forces_full_run.py
@@ -1,0 +1,117 @@
+"""A change to the test selector must force a full run.
+
+`test-policy.toml` was already in `global_full_paths`; the CODE it configures
+was not. So a change to the selection machinery was scoped by the changed
+selection machinery. Observed on PR #408 (run 32104798882), which modified
+`scripts/select-sanity-tests.py` and `src/mac/test_checkpoint.py`:
+
+    sanity selection: focused (impact_hybrid_scope)
+      provenance: 2 from the change, 10 always_run guards
+    collected 750 items
+    746 passed, 4 skipped in 68.70s
+
+750 of ~11,400 tests, 1m44s instead of ~50min. The change happened to be
+correct. But `tests/test_select_sanity_tests.py` -- the file whose two failures
+prompted that fix -- was selected ZERO times, so that run could not have
+contradicted the fix even if it had been wrong in exactly the original way.
+
+This is the trusted-computing-base argument. Every other gate in this
+repository is only as strong as the component that decides which tests run;
+that component alone cannot be permitted to narrow its own verification. It is
+also the reason the cheaper option was rejected: adding the selector's test
+files to `always_run` closes the one hole we happened to notice, and leaves the
+general property ("you cannot shrink your own gate") unenforced.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+#: Changing any of these changes WHICH TESTS RUN.
+SELECTOR_FILES = (
+    "test-policy.toml",
+    "scripts/select-sanity-tests.py",
+    "scripts/resolve-impacted-tests.py",
+    "scripts/build-test-impact-map.py",
+    "src/mac/test_checkpoint.py",
+)
+
+
+def _policy() -> dict:
+    with (ROOT / "test-policy.toml").open("rb") as stream:
+        return tomllib.load(stream)["selection"]
+
+
+@pytest.mark.parametrize("path", SELECTOR_FILES)
+def test_each_selector_file_forces_a_full_run(path):
+    assert path in _policy()["global_full_paths"], (
+        "%s decides which tests CI runs, but changing it does not force a full "
+        "run -- so the changed selector chooses the scope that verifies itself"
+        % path
+    )
+
+
+@pytest.mark.parametrize("path", SELECTOR_FILES)
+def test_each_selector_file_exists(path):
+    """A renamed selector silently drops out of global_full_paths.
+
+    `global_full_paths` matches on exact repository-relative path, so a rename
+    turns the entry into a no-op with no error anywhere -- the same failure
+    shape as a stranded impact-map node id.
+    """
+    assert (ROOT / path).exists(), (
+        "%s is listed in global_full_paths but does not exist; the entry is "
+        "now dead and the file it was meant to guard is unguarded" % path
+    )
+
+
+def _selector():
+    name = "mac_select_sanity_tests_globalcheck"
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(
+        name, ROOT / "scripts" / "select-sanity-tests.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("path", SELECTOR_FILES)
+def test_the_resolver_actually_escalates_each_one(path):
+    """End to end, not just the config: the change must produce mode=full."""
+    result = _selector().select([path], codegraph=lambda _s, _r: ([], None))
+
+    assert result["mode"] == "full"
+    assert result["reason"] == "global_infrastructure_changed"
+    assert path in result["global_files"]
+
+
+def test_an_ordinary_source_change_is_still_focused():
+    """The point is a narrow escalation, not a return to over-escalation.
+
+    The previous selector escalated on every scripts/ and pyproject edit, which
+    is exactly what impact selection exists to remove.
+    """
+    result = _selector().select(
+        ["src/mac/services.py"],
+        codegraph=lambda _s, _r: (["tests/test_services.py"], None),
+    )
+
+    assert result["mode"] == "focused"
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["pyproject.toml", "scripts/run-contract-tests.sh", "deploy/codex-runner/build.sh"],
+)
+def test_the_old_broad_prefixes_stay_out(path):
+    assert path not in _policy()["global_full_paths"]


### PR DESCRIPTION
`test-policy.toml` was already in `global_full_paths`. **The code it configures was not.**

So a change to the selection machinery got a scope chosen by the changed selection
machinery. Observed on #408 (run 32104798882), which modified two of these files:

```
sanity selection: focused (impact_hybrid_scope)
  provenance: 2 from the change, 10 always_run guards
  changed: scripts/select-sanity-tests.py
  changed: src/mac/test_checkpoint.py
collected 750 items
746 passed, 4 skipped in 68.70s
```

**750 of ~11,400 tests, 1m44s instead of ~50min**, and green.

That change was correct — verified independently. But `tests/test_select_sanity_tests.py`,
the file whose two failures prompted the fix, was selected **zero times**. The run could
not have contradicted the fix even if it had been wrong in exactly the original way.

## The change

Four implementation files join `global_full_paths`:

```
scripts/select-sanity-tests.py
scripts/resolve-impacted-tests.py
scripts/build-test-impact-map.py
src/mac/test_checkpoint.py
```

## Why not the cheaper option

Adding the selector's own test files to `always_run` also closes this hole, and costs
nothing. It was rejected deliberately: it fixes the instance we happened to notice and
leaves the general property unenforced.

Every other gate in this repository is only as strong as the component that decides
which tests run. That component alone cannot be permitted to narrow its own
verification — it is the trusted computing base for all the others.

## Kept narrow on purpose

The previous selector escalated on every `scripts/` and `pyproject.toml` edit, which is
exactly the over-escalation impact selection exists to remove. Both directions are
asserted: an ordinary `src/mac/services.py` change is still `focused`, and
`pyproject.toml`, `scripts/run-contract-tests.sh` and `deploy/codex-runner/build.sh`
stay out.

## Verification

19 tests, **8 fail without the policy change**. Three properties:

1. each file is in `global_full_paths`
2. **each listed file exists** — `global_full_paths` matches on exact repo-relative path,
   so a rename turns an entry into a silent no-op, the same failure shape as a stranded
   impact-map node id
3. the resolver actually returns `mode=full` / `global_infrastructure_changed` for each

Selection, checkpoint and impact-map suites together: **135 passed**.

This PR touches `test-policy.toml`, so it will demonstrate itself by forcing a full
sanity run.

Closes task_78bf3c52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)