### PR TITLE
Teach the CLI skill that lists are scoped, and gate the flags it names

### DIFF
--- a/skills/mac-cli/SKILL.md
+++ b/skills/mac-cli/SKILL.md
@@ -45,6 +45,44 @@ compensation ran`. Wait until no agent reports `current_task_id`.
 destroying tasks. `mac work-package delete` is `cancel`. Read the help before
 assuming a delete is destructive — or that it is not.
 
+## Lists are scoped by default
+
+`list` shows what you can still act on, not the whole table. Both defaults exist
+because the unscoped view was unreadable on a real hub.
+
+    mac task list                  active work only (17 rows on the live hub)
+    mac task list --all-states     every task, terminal included (507)
+    mac task list --state=cancelled   one state, unchanged
+
+    mac project list               projects with live work OR a registration (10)
+    mac project list --all         every project, including derived ghosts (19)
+
+**When to pass the flag.** `--all-states` / `--all` are for auditing and
+archaeology — counting what a project ever held, finding a task you cancelled
+last week, verifying a prune. For anything about what the fleet is doing now,
+the default is the answer, and a flag that adds 490 cancelled rows is actively
+misleading.
+
+**What `project list --all` reveals.** A project with no `project_id` is
+DERIVED: it exists only because some task carries that string. `mac project
+show`, `pause`, `activate` and `unregister` all return `Not Found` for one, and
+nothing can be dispatched to it. It is a label, not an object. That is why it is
+hidden unless it holds live work.
+
+## How the project is inferred
+
+`mac task create` with no `--project` infers one from the working directory: the
+name of the repository, resolved through `git rev-parse --git-common-dir`, which
+every linked worktree shares.
+
+This matters because CLAUDE.md mandates a worktree per agent. Inferring from
+`--show-toplevel` instead — which is what this used to do — takes the basename
+of the WORKTREE, so filing from `/tmp/mac-dev` created a project called
+`mac-dev`. Six such ghosts were live on the hub, each holding one or two
+cancelled tasks. If you see a project named after a branch, that is what it is.
+
+Pass `--project ''` for none, or `--project NAME` to override.
+
 ## Finding things
 
     mac help                      the object list
@@ -77,10 +115,11 @@ created and never claimed.
     WRONG   --capabilities linux
     RIGHT   --hardware '{"os": ["linux"], "cpu_arch": ["x86_64"]}'
 
-A preflight that answers whether the fleet could ever claim a task -- and
-names this mapping error specifically -- is in review, not yet on main. Until
-it lands, compare the task's requirements against `mac agent list --json` and
-the `resources.hardware` of each agent.
+`mac task preflight` answers whether the fleet could ever claim a task, and
+names this mapping error specifically. Run it before filing anything with
+requirements; a task that cannot be satisfied is accepted and queued, and then
+waits forever rather than failing. Use `mac task why-unclaimed <id>` for one
+that is already filed and sitting.
 
 ## Where mac is talking to
 

--- a/tests/test_mac_cli_skill.py
+++ b/tests/test_mac_cli_skill.py
@@ -99,6 +99,69 @@ def test_every_command_the_skill_names_exists(tree):
     )
 
 
+def _mentioned_flags(text: str) -> set[tuple[tuple[str, ...], str]]:
+    """(command path, --flag) pairs the skill tells you to RUN.
+
+    Commands were already checked against the parser; FLAGS were not, and a
+    flag is what the reader actually types to change behaviour. The skill can
+    document `mac task list --all-states` while no such option exists, send the
+    reader to a usage error, and stay green.
+    """
+    pairs: set[tuple[tuple[str, ...], str]] = set()
+    for line in text.splitlines():
+        if not line.startswith("    "):
+            continue
+        for chunk in re.split(r"\s{2,}", line.strip()):
+            tokens = chunk.strip().split()
+            if not tokens or tokens[0] != "mac":
+                continue
+            path: list[str] = []
+            flags: list[str] = []
+            for token in tokens[1:]:
+                if token.startswith("--"):
+                    flags.append(token.split("=", 1)[0])
+                elif re.fullmatch(r"[a-z][a-z0-9-]*", token) and not flags:
+                    path.append(token)
+                elif not flags:
+                    break
+            for flag in flags:
+                if path:
+                    pairs.add((tuple(path), flag))
+    return pairs
+
+
+def _options_for(path: tuple[str, ...]) -> set[str]:
+    sys.argv = ["mac"]
+    from mac import cli as C
+
+    node = C.build_parser()
+    for name in path:
+        for action in node._actions:
+            mapping = getattr(action, "_name_parser_map", None)
+            if mapping and name in mapping:
+                node = mapping[name]
+                break
+        else:
+            return set()
+    options = {o for action in node._actions for o in action.option_strings}
+    # Global flags are declared on the root parser and accepted anywhere.
+    root = C.build_parser()
+    options |= {o for action in root._actions for o in action.option_strings}
+    return options
+
+
+def test_every_flag_the_skill_names_exists():
+    """A documented flag that does not exist is a usage error on a live fleet."""
+    text = SKILL.read_text(encoding="utf-8")
+    missing = []
+    for path, flag in sorted(_mentioned_flags(text)):
+        if flag not in _options_for(path):
+            missing.append("mac %s %s" % (" ".join(path), flag))
+    assert not missing, (
+        "the skill names flags that do not exist: %s" % ", ".join(missing)
+    )
+
+
 def test_the_traps_it_documents_are_real(tree):
     """Each of these cost a wrong command against a live fleet, so each is
     pinned: if the CLI changes to match the guess, the skill must stop warning


### PR DESCRIPTION
> **Merge last.** Depends on #407 and #409. The failing check below is the dependency, not a defect — see the gate section.

## What the skill now says

`mac task list` and `mac project list` show what you can act on rather than the
whole table, so the skill has to say which view you get and when to ask for the other:

```
mac task list                  active work only (17 rows on the live hub)
mac task list --all-states     every task, terminal included (507)

mac project list               projects with live work OR a registration (10)
mac project list --all         every project, including derived ghosts (19)
```

With the judgement attached: `--all` is for auditing and archaeology. For anything
about what the fleet is doing now, a flag that adds 490 cancelled rows is actively
misleading.

It also explains what `project list --all` reveals — a project with no `project_id`
is **derived**: `show`, `pause`, `activate` and `unregister` all return `Not Found`,
and nothing can be dispatched to it. It is a label, not an object.

## How the project is inferred

Documented because it interacts directly with the worktree-per-agent rule in
CLAUDE.md. Inference resolves `git rev-parse --git-common-dir`, which every linked
worktree shares. Inferring from `--show-toplevel` — what it used to do — takes the
basename of the *worktree*, so filing from `/tmp/mac-dev` created a project called
`mac-dev`. **If you see a project named after a branch, that is what it is.**

## A stale claim corrected

The skill said the "would this task ever be claimed?" preflight was "in review, not
yet on main", and told the reader to hand-compare requirements against
`mac agent list --json`. It shipped in #337 as `mac task preflight`.

## The gate

`test_mac_cli_skill.py` already checks every command the skill names against the real
parser. It did **not** check flags — and a flag is what the reader types to change
behaviour. The skill could document `mac task list --all-states` against a CLI with no
such option, send the reader to a usage error, and stay green.

`test_every_flag_the_skill_names_exists` closes that, and proves itself by failing on
this very commit:

```
AssertionError: the skill names flags that do not exist:
    mac project list --all, mac task list --all-states
```

Both flags are correct as documentation and both are still in review. This PR goes
green when #407 and #409 land, and I will rebase it then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)