### PR TITLE
`mac --version` should answer the question, not demand a subcommand

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,7 @@ The book uses executable `bash` blocks; reference usage is rendered as output.
 
 ```console
 $ mac --help
-usage: mac [-h] [--db DB] [--local-authority] [--hub-url HUB_URL]
+usage: mac [-h] [--version] [--db DB] [--local-authority] [--hub-url HUB_URL]
            [--token TOKEN] [--fleet FLEET] [--profile PROFILE] [--json]
            SUBCOMMAND ...
 
@@ -18,6 +18,7 @@ positional arguments:
 
 options:
   -h, --help         show this help message and exit
+  --version          print the mac version and exit
   --db DB            direct PostgreSQL control-plane authority (a postgres://
                      DSN) for hub maintenance, standalone development, tests,
                      and migration. It is not a repository ticket store or

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -24,6 +24,7 @@ from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Seque
 from mac import mac_paths
 from mac.migration import import_jsonl
 from mac.task_batch import OPERATIONS as BATCH_OPERATIONS
+from mac import __version__
 from mac.models import (
     ACTIVE_TASK_STATES,
     EVIDENCE_KIND_CHOICES,
@@ -7414,6 +7415,20 @@ def _set(func: Callable[[argparse.Namespace], None], parser: argparse.ArgumentPa
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="mac", description="Multi-agent coordinator control plane")
+    # `mac --version` prints and exits BEFORE the required SUBCOMMAND is
+    # enforced -- argparse runs a `version` action the moment it consumes the
+    # flag, so the missing positional is never reached. Without this, asking
+    # mac what version it is produced a usage error naming SUBCOMMAND, which
+    # says nothing about the version and does not exit 0. The string comes from
+    # `mac.__version__`, the same attribute pyproject's dynamic version and the
+    # FastAPI app read, so the CLI cannot report a number the wheel disagrees
+    # with.
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="mac %s" % __version__,
+        help="print the mac version and exit",
+    )
     # Transport selection (see mac.dispatch.resolve_dispatch for resolution).
     # --db is no longer auto-defaulted: the CLI either targets a hub (default
     # when MAC_API_URL or fleets.yaml is configured) or an explicit PostgreSQL

--- a/tests/cli/test_cli_version_flag.py
+++ b/tests/cli/test_cli_version_flag.py
@@ -1,0 +1,90 @@
+"""`mac --version` prints the version and exits cleanly.
+
+It used to print a usage error instead:
+
+    usage: mac [-h] [--db DB] [--local-authority] [--hub-url HUB_URL] ...
+    mac: error: the following arguments are required: SUBCOMMAND
+
+The flag did not exist at all, so argparse fell through to enforcing the
+required positional. That is the wrong answer twice over -- it says nothing
+about the version, and the first thing anyone does when a CLI misbehaves is ask
+it what version it is.
+
+The number comes from `mac.__version__`, the same attribute `pyproject.toml`
+reads for its dynamic version and `mac.api` gives FastAPI. A CLI that printed
+its own copy could disagree with the wheel it shipped in, which is exactly the
+four-way hand-copied drift that attribute was created to end.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from mac import __version__, cli
+
+
+def _mac(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "mac.cli", *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_it_prints_the_version_and_exits_zero():
+    result = _mac("--version")
+
+    assert result.returncode == 0, (
+        "`mac --version` exited %d; it used to fail with 'the following "
+        "arguments are required: SUBCOMMAND'" % result.returncode
+    )
+    assert result.stdout.strip() == "mac %s" % __version__
+
+
+def test_it_does_not_demand_a_subcommand():
+    """The whole defect: a required positional swallowed the question."""
+    result = _mac("--version")
+
+    assert "SUBCOMMAND" not in (result.stdout + result.stderr)
+    assert "usage:" not in (result.stdout + result.stderr)
+
+
+def test_the_version_is_the_package_version():
+    """Not a second copy. `pyproject.toml` has dynamic = ["version"] pointing at
+    src/mac/__init__.py, and mac.api hands the same attribute to FastAPI."""
+    import mac
+
+    assert _mac("--version").stdout.strip() == "mac %s" % mac.__version__
+
+
+def test_it_works_alongside_the_other_global_flags():
+    """--json is accepted in any position, so it can precede --version."""
+    assert _mac("--json", "--version").returncode == 0
+
+
+def test_the_flag_is_on_the_root_parser_not_a_subcommand():
+    parser = cli.build_parser()
+
+    assert "--version" in {
+        option for action in parser._actions for option in action.option_strings
+    }
+
+
+def test_a_real_subcommand_still_requires_its_arguments():
+    """Adding a short-circuiting flag must not relax the parser elsewhere."""
+    result = _mac("task", "show")
+
+    assert result.returncode != 0
+    assert "usage:" in result.stderr
+
+
+def test_no_subcommand_at_all_is_still_an_error():
+    """`mac` alone must keep reporting the missing SUBCOMMAND."""
+    result = _mac()
+
+    assert result.returncode != 0
+    assert "SUBCOMMAND" in result.stderr


### PR DESCRIPTION
`mac --version` printed a usage error:

```
usage: mac [-h] [--db DB] [--local-authority] [--hub-url HUB_URL] ...
mac: error: the following arguments are required: SUBCOMMAND
```

The flag did not exist, so argparse fell through to enforcing the required positional. Wrong twice over: it says nothing about the version, and it does not exit 0 — so a script asking mac what it is got a failure.

Now:

```console
$ mac --version
mac 1.1.0
```

A `version` action short-circuits the moment argparse consumes the flag, so the missing SUBCOMMAND is never reached.

The string comes from `mac.__version__` — the same attribute `pyproject.toml` reads for its dynamic version and `mac.api` hands to FastAPI. A CLI printing its own copy could disagree with the wheel it shipped in, which is the four-way hand-copied drift that attribute was created to end.

## Verification

7 tests, **5 fail without the change**. The other two are guards in the opposite direction, because a short-circuiting flag must not relax the parser elsewhere: `mac task show` with no id still errors, and bare `mac` still reports the missing SUBCOMMAND.

119 passed across the version, skill, CLI and first-class-surface suites. `docs/reference/cli.md` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)