### PR TITLE
Make /ui the observability console; move the command-and-control shell aside

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -599,7 +599,18 @@ function uiFileForRequest(reqUrl) {
   if (!root) return "";
   const parsed = new URL(reqUrl || "/", "http://desktop.local");
   let name = "";
-  if (parsed.pathname === "/ui" || parsed.pathname === "/ui/" || parsed.pathname === "/ui/index.html") {
+  if (
+    parsed.pathname === "/ui" ||
+    parsed.pathname === "/ui/" ||
+    parsed.pathname === "/ui/index.html" ||
+    parsed.pathname === "/ui/console" ||
+    parsed.pathname === "/ui/console/"
+  ) {
+    // /ui is the read-only observability console, matching the hub. The
+    // offline shell must open the same screen the hub serves, or the desktop
+    // app shows a command-and-control dashboard the browser no longer does.
+    name = path.join("console", "index.html");
+  } else if (parsed.pathname === "/ui/legacy" || parsed.pathname === "/ui/legacy/") {
     name = "index.html";
   } else if (parsed.pathname.startsWith(UI_ASSET_PREFIX)) {
     const decoded = decodeURIComponent(parsed.pathname.slice(UI_ASSET_PREFIX.length));

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -5163,22 +5163,40 @@ def create_app(
 
     @app.get("/ui", include_in_schema=False)
     @app.get("/ui/", include_in_schema=False)
-    def dashboard() -> FileResponse:
-        return FileResponse(ui_dir / "index.html")
-
     @app.get("/ui/console", include_in_schema=False)
     @app.get("/ui/console/", include_in_schema=False)
     def observability_console_shell() -> FileResponse:
-        """The read-only observability console (built from ``observe/``).
+        """The hub UI: the read-only observability console, built from ``observe/``.
 
-        Served beside the legacy dashboard rather than on top of it: taking over
-        ``/ui/`` means rewriting ~50 structural assertions in
-        ``tests/ui/test_ui_shell.py`` and ``tests/api/test_api.py`` that freeze
-        the legacy shell's markup, which is a cut-over, not an addition. Its
-        bundle lives under ``src/mac/ui/console/`` so the existing
+        ``/ui`` serves THIS, not the legacy dashboard. The two cannot both be
+        the front door and mean opposite things: ``observe`` is asserted
+        read-only by ``observe/tests/readonly.test.ts``, while the legacy shell
+        calls ``/dispatch/tick``, ``/agents/bulk``, ``/roles/seed``,
+        ``/notifier/deliver`` and ``/secrets`` -- it pokes dispatch, mutates
+        agents in bulk, seeds roles, sends notifications and reads secrets.
+        A hub UI whose job is to observe cannot be the one that also commands.
+
+        ``/ui/console`` stays as an alias so links already handed out keep
+        working. The legacy shell is still reachable and still tested, at
+        ``/ui/legacy`` -- moved rather than deleted, because deleting it also
+        deletes the only caller of several routes and that is a separate,
+        irreversible decision (task_b69ddb42).
+
+        Its bundle lives under ``src/mac/ui/console/`` so the existing
         ``/ui/assets`` StaticFiles mount serves it unchanged.
         """
         return FileResponse(ui_dir / "console" / "index.html")
+
+    @app.get("/ui/legacy", include_in_schema=False)
+    @app.get("/ui/legacy/", include_in_schema=False)
+    def dashboard() -> FileResponse:
+        """The legacy command-and-control dashboard, no longer the front door.
+
+        Kept reachable so that retiring it stays a separate change with its own
+        review: this route move is reversible, deleting 14k lines of shell and
+        the routes only it calls is not.
+        """
+        return FileResponse(ui_dir / "index.html")
 
     @app.get("/dashboard/observe")
     def dashboard_observe(

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -3153,7 +3153,7 @@ class ControlPlane:
             else {}
         )
         dashboard_operation_ready = (
-            dashboard_operation_contract.get("entrypoint") == "/ui"
+            dashboard_operation_contract.get("entrypoint") == "/ui/legacy"
             and {
                 "work",
                 "projects",
@@ -3593,7 +3593,12 @@ class ControlPlane:
         fleet_id = str(fleets[0].get("id")) if fleets else "{fleet_id}"
         contract = {
             "schema": "mac.hermes.dashboard_url_contract.v1",
-            "entrypoint": "/ui",
+            # /ui now serves the read-only observability console. This
+            # contract requires views the console deliberately does not have
+            # (`secrets`, `ops`, `runtime`), so it describes the legacy shell
+            # and must name where that shell actually is. Pointing it at /ui
+            # would make it assert a screen that no longer exists there.
+            "entrypoint": "/ui/legacy",
             "required_views": [
                 "work",
                 "projects",
@@ -4331,7 +4336,12 @@ class ControlPlane:
             ],
             "dashboard": {
                 "schema": "mac.hermes.dashboard_operation_contract.v1",
-                "entrypoint": "/ui",
+                # /ui now serves the read-only observability console. This
+            # contract requires views the console deliberately does not have
+            # (`secrets`, `ops`, `runtime`), so it describes the legacy shell
+            # and must name where that shell actually is. Pointing it at /ui
+            # would make it assert a screen that no longer exists there.
+            "entrypoint": "/ui/legacy",
                 "views": [
                     "work",
                     "projects",

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1060,7 +1060,7 @@ def test_fastapi_exposes_hermes_identity_boundary(monkeypatch, tmp_path):
     # The legacy `hgmac` binary is gone; agent/fleet/project/task CRUD is the
     # mac-hermes CLI + the REST API. There is no hgmac_cli operation surface.
     assert "hgmac_cli" not in work_context["operations"]
-    assert work_context["operations"]["dashboard"]["entrypoint"] == "/ui"
+    assert work_context["operations"]["dashboard"]["entrypoint"] == "/ui/legacy"
     assert {"work", "projects", "map", "fleets", "agents", "tasks", "hermes", "observability"} <= set(
         work_context["operations"]["dashboard"]["views"]
     )
@@ -1087,7 +1087,7 @@ def test_fastapi_exposes_hermes_identity_boundary(monkeypatch, tmp_path):
     dashboard_url_contract = runtime_proof["evidence"]["ui"]["dashboard_url_contract"]
     assert dashboard_url_contract["schema"] == "mac.hermes.dashboard_url_contract.v1"
     assert dashboard_url_contract["ready"] is True
-    assert dashboard_url_contract["entrypoint"] == "/ui"
+    assert dashboard_url_contract["entrypoint"] == "/ui/legacy"
     assert any(
         url.startswith("/ui?view=fleets&selected=")
         for url in dashboard_url_contract["object_deep_links"]["fleets"]["samples"]
@@ -1102,7 +1102,7 @@ def test_fastapi_exposes_hermes_identity_boundary(monkeypatch, tmp_path):
         url.startswith("/ui?view=work&selected=")
         for url in dashboard_url_contract["object_deep_links"]["tasks"]["samples"]
     )
-    assert runtime_proof["evidence"]["ui"]["dashboard_operation_contract"]["entrypoint"] == "/ui"
+    assert runtime_proof["evidence"]["ui"]["dashboard_operation_contract"]["entrypoint"] == "/ui/legacy"
     live_alignment = runtime_proof["evidence"]["live_alignment"]
     assert live_alignment["schema"] == "mac.hermes.live_object_alignment.v1"
     assert live_alignment["ready"] is True
@@ -2426,7 +2426,8 @@ def test_fastapi_serves_dashboard_shell_without_api_token():
         )
     )
 
-    ui_response = client.get("/ui")
+    # The legacy shell moved; /ui is the console now (asserted separately).
+    ui_response = client.get("/ui/legacy")
     assert ui_response.status_code == 200
     assert "MAC Control Plane" in ui_response.text
     assert "/ui/assets/app.js?v=" in ui_response.text

--- a/tests/ui/test_observability_console.py
+++ b/tests/ui/test_observability_console.py
@@ -281,9 +281,15 @@ def test_console_bundle_is_served_from_the_existing_ui_assets_mount(cp: ControlP
     assert "javascript" in resp.headers["content-type"]
 
 
-def test_legacy_dashboard_shell_is_untouched(cp: ControlPlane):
-    """The console is additive. /ui/ must still serve the legacy shell."""
-    html = _client(cp).get("/ui").text
+def test_legacy_dashboard_shell_still_works_where_it_now_lives(cp: ControlPlane):
+    """The legacy shell MOVED to /ui/legacy; it was not changed or deleted.
+
+    This used to assert it at /ui. That was correct while the console was
+    additive; /ui is now the console. The property being pinned is the same one
+    -- the legacy shell still renders -- because retiring it is a separate,
+    irreversible change (task_b69ddb42).
+    """
+    html = _client(cp).get("/ui/legacy").text
     assert 'id="loginScreen"' in html
     assert "/ui/assets/app.js?v=" in html
 
@@ -642,3 +648,57 @@ def test_the_section_degrades_honestly(cp: ControlPlane, monkeypatch):
 
     assert "merge_queue" not in payload, "a failed section must be ABSENT, not zero"
     assert any(d["section"] == "merge_queue" for d in payload["degraded"])
+
+
+# ---------------------------------------------------------------------------
+# The console IS the hub UI
+# ---------------------------------------------------------------------------
+
+
+def test_ui_serves_the_console_not_the_legacy_dashboard(cp: ControlPlane):
+    """`/ui` is the front door, and the front door observes rather than commands.
+
+    The two shells mean opposite things and cannot both be it. `observe/` is
+    asserted read-only by `observe/tests/readonly.test.ts`. The legacy shell
+    calls `/dispatch/tick`, `/agents/bulk`, `/roles/seed`, `/notifier/deliver`
+    and `/secrets` -- it pokes dispatch, mutates agents in bulk, seeds roles,
+    sends notifications and reads secrets.
+    """
+    body = _client(cp).get("/ui").text
+
+    assert "console.js" in body, "/ui is still serving the legacy dashboard shell"
+    assert "/ui/assets/app.js" not in body
+
+
+def test_the_console_alias_still_works(cp: ControlPlane):
+    """Links already handed out must not break on the move."""
+    client = _client(cp)
+
+    assert client.get("/ui/console").text == client.get("/ui").text
+
+
+def test_the_legacy_dashboard_is_moved_not_deleted(cp: ControlPlane):
+    """Retiring it deletes the only caller of several routes, which is a
+    separate and irreversible decision (task_b69ddb42). Until then it must keep
+    working where it now lives."""
+    resp = _client(cp).get("/ui/legacy")
+
+    assert resp.status_code == 200
+    assert "/ui/assets/app.js" in resp.text
+
+
+def test_the_dashboard_contract_names_where_the_shell_actually_is():
+    """The contract requires views the console deliberately lacks -- `secrets`,
+    `ops`, `runtime`. Left pointing at /ui it would assert a screen that is no
+    longer there, which is a contract that passes while describing nothing."""
+    cp = ControlPlane.in_memory()
+
+    contract = cp._hermes_dashboard_url_contract(
+        "hermes_x", tasks=[], projects=[], agents=[], fleets=[]
+    )
+
+    assert contract["entrypoint"] == "/ui/legacy"
+    assert "secrets" in contract["required_views"], (
+        "if this view ever leaves the contract, re-point the entrypoint at /ui "
+        "instead of leaving it on a path that is about to be deleted"
+    )

--- a/tests/ui/test_ui_shell.py
+++ b/tests/ui/test_ui_shell.py
@@ -3,6 +3,10 @@
 These tests verify what the browser receives, not the API logic behind it.
 They focus on the login screen, service-link sidebar, and token bootstrap
 features added to the dashboard UI.
+
+These fetch ``/ui/legacy``. ``/ui`` now serves the read-only observability
+console; the legacy command-and-control shell MOVED rather than changed, so
+every assertion below is unchanged and still runs against it.
 """
 
 from __future__ import annotations
@@ -28,13 +32,13 @@ def _client(**kwargs) -> TestClient:
 
 
 def test_ui_route_serves_html():
-    resp = _client().get("/ui")
+    resp = _client().get("/ui/legacy")
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/html")
 
 
 def test_ui_html_contains_login_screen():
-    html = _client().get("/ui").text
+    html = _client().get("/ui/legacy").text
     assert 'id="loginScreen"' in html
     assert 'class="login-screen"' in html
     assert 'id="loginForm"' in html
@@ -43,7 +47,7 @@ def test_ui_html_contains_login_screen():
 
 def test_ui_html_login_screen_starts_hidden():
     """Login screen must have the `hidden` attribute so it doesn't flash on load."""
-    html = _client().get("/ui").text
+    html = _client().get("/ui/legacy").text
     # The loginScreen div must carry the hidden attribute
     import re
     match = re.search(r'id="loginScreen"[^>]*>', html)
@@ -52,13 +56,13 @@ def test_ui_html_login_screen_starts_hidden():
 
 
 def test_ui_html_contains_service_links_sidebar():
-    html = _client().get("/ui").text
+    html = _client().get("/ui/legacy").text
     assert 'id="serviceLinks"' in html
     assert 'class="service-links"' in html
 
 
 def test_ui_html_contains_all_nav_views():
-    html = _client().get("/ui").text
+    html = _client().get("/ui/legacy").text
     for view in ("overview", "work", "projects", "map", "fleets", "agents",
                  "tasks", "workflows", "hermes", "ops", "integrations",
                  "runtime", "observability", "secrets"):
@@ -66,7 +70,7 @@ def test_ui_html_contains_all_nav_views():
 
 
 def test_ui_html_groups_nav_views_for_discoverability():
-    html = _client().get("/ui").text
+    html = _client().get("/ui/legacy").text
     assert 'class="nav-section"' in html
     for label in ("Home", "Work", "Fleet", "Operations", "Security"):
         assert 'class="nav-section-label">%s</span>' % label in html
@@ -74,12 +78,12 @@ def test_ui_html_groups_nav_views_for_discoverability():
 
 
 def test_ui_html_loads_app_js_with_cache_bust():
-    html = _client().get("/ui").text
+    html = _client().get("/ui/legacy").text
     assert '/ui/assets/app.js?v=' in html
 
 
 def test_ui_html_loads_vendored_xterm_assets():
-    html = _client().get("/ui").text
+    html = _client().get("/ui/legacy").text
     assert "/ui/assets/vendor/xterm/xterm.css?v=5.5.0" in html
     assert "/ui/assets/vendor/xterm/xterm.js?v=5.5.0" in html
     assert "/ui/assets/vendor/xterm/addon-fit.js?v=0.10.0" in html
@@ -122,7 +126,7 @@ def test_ui_assets_vendored_xterm_serves():
 def test_ui_served_without_api_token_auth():
     """The UI shell must be publicly accessible regardless of auth config."""
     client = _client(auth_tokens={"reader": ["read"]})
-    assert client.get("/ui").status_code == 200
+    assert client.get("/ui/legacy").status_code == 200
     assert client.get("/ui/assets/app.js").status_code == 200
     assert client.get("/ui/assets/styles.css").status_code == 200
 


### PR DESCRIPTION
Two shells were served side by side, and they mean opposite things.

`observe/` is asserted read-only by `observe/tests/readonly.test.ts`. The legacy
shell calls `/dispatch/tick`, `/agents/bulk`, `/roles/seed`, `/notifier/deliver`
and `/secrets` — it pokes dispatch, mutates agents in bulk, seeds roles, sends
notifications and reads secrets. **A hub UI whose job is to observe cannot also be
the one that commands**, and the one at the front door was the one that commands.

```
/ui, /ui/          -> observability console   (was: legacy dashboard)
/ui/console        -> alias, unchanged
/ui/legacy         -> legacy dashboard        (new home, still fully tested)
```

## Moved, not retired — deliberately

Deleting the legacy shell also deletes the only caller of several routes, and each
needs its own check first. The `/dashboard/terminal-sessions` routes *look* like
dashboard routes but belong to the **Fleet IDE** (`ide/src/api/mac.ts` plus four
`ide/tests` specs). Sweeping those up would break a different app.

That retirement is filed as `task_b69ddb42` with the sequence and the trap written
down. **This PR is a route move: revert it by editing two decorators.**

## The contract follows the shell, not the path

`dashboard_operation_contract` requires views the console deliberately does not have
— `secrets`, `ops`, `runtime`. Left pointing at `/ui` it would have become a contract
that **passes while describing a screen that is no longer there**: the same failure
shape as a gate reporting healthy while enforcing nothing. It now names `/ui/legacy`,
and a test pins the reason so the next person moves it deliberately.

The Electron shell's offline file server follows too, so the desktop app opens the
same screen the hub serves rather than a dashboard the browser no longer shows.

## No assertion was weakened

The 9 fetches in `test_ui_shell.py` and 4 in `test_api.py` are **re-pointed**, not
rewritten — every property they pin about the legacy shell still runs, against where
that shell now lives. `test_legacy_dashboard_shell_is_untouched` asserted the old
front door specifically, so it is renamed and re-pointed rather than deleted; the
property is unchanged.

4 new tests: `/ui` serves the console, the alias matches it byte for byte, the legacy
shell still renders at its new path, and the contract names where that shell is.

**211 passed** across `tests/ui` and `tests/api/test_api.py`; public contract **582**;
docs gate green.

## One observation, not fixed here

`desktop/main.js`'s traversal guard — `path.resolve(root, name) !== path.join(root, name)`
— does not actually catch `../`; both normalize identically. It is currently
unreachable because the asset branch checks `decoded !== path.basename(decoded)` first,
and my added paths are string literals. Flagging rather than widening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)