### PR TITLE
Define the AgentBus lifecycle vocabulary humans and agents share

### DIFF
--- a/src/mac/agentbus_control.py
+++ b/src/mac/agentbus_control.py
@@ -58,9 +58,160 @@ PEER_REPLY_TOPIC = "peer.reply.v1"
 PEER_REPLY_SCHEMA = "mac.agent.peer_reply.v1"
 PEER_REPLY_CONTENT_TYPE = "application/vnd.mac.agent-peer-reply+json"
 
+# ---------------------------------------------------------------------------
+# Lifecycle vocabulary (v2): the verbs every agent understands, and that a
+# human speaks too.
+#
+# WHY A SHARED VOCABULARY. The console carries a few controls -- stand down,
+# resume -- for when agents go off the rails. The retired dashboard did that by
+# calling POST /agents/bulk: a privileged control-plane mutation that bypassed
+# the agents entirely. These are REQUESTS on a channel every participant can
+# see, which each agent observes and honours. That is what lets the console
+# keep an honest invariant: it never mutates the control plane directly, it
+# speaks on the bus like any other participant.
+#
+# WHY v2 AND NOT v1. There are no v1 agents; this fleet is the only deployment
+# of mac. Rather than add a lifecycle namespace alongside the existing v1
+# control events and carry two shapes forever, the lifecycle verbs start at v2
+# and the version is stated so a later reader can see where the break was.
+#
+# STAND-DOWN IS NOT ABORT, and collapsing them is the mistake this vocabulary
+# exists to prevent. A single button labelled "stop" that means ABORT destroys
+# work in flight; one that means PAUSE does not stop a runaway. Most
+# off-the-rails moments want stand-down. Both verbs ship, named honestly.
+LIFECYCLE_VERSION = "v2"
+
+#: Stop claiming new work; finish whatever is already held.
+LIFECYCLE_STAND_DOWN = "stand_down"
+#: Drop current work now. DESTRUCTIVE: in-flight work is lost.
+LIFECYCLE_ABORT = "abort"
+#: Stop claiming new work (same as stand_down for a worker, but scoped and
+#: reversible by ``resume``; stand_down is the urgent form and may be honoured
+#: mid-step).
+LIFECYCLE_PAUSE = "pause"
+#: Resume claiming work after a pause or stand-down.
+LIFECYCLE_RESUME = "resume"
+#: Report what you are doing, now. The liveness question a heartbeat cannot
+#: answer: a wedged agent still heartbeats.
+LIFECYCLE_STATUS = "status"
+
+LIFECYCLE_VERBS = (
+    LIFECYCLE_STAND_DOWN,
+    LIFECYCLE_ABORT,
+    LIFECYCLE_PAUSE,
+    LIFECYCLE_RESUME,
+    LIFECYCLE_STATUS,
+)
+
+#: The verbs that destroy work in flight. A caller that offers these must say
+#: so; a UI must not put them behind the same control as the reversible ones.
+LIFECYCLE_DESTRUCTIVE_VERBS = frozenset({LIFECYCLE_ABORT})
+
+#: Who a directive is aimed at. ``fleet`` is everyone on the bus, ``project``
+#: everyone working a named project, ``agent`` one named agent.
+LIFECYCLE_SCOPES = ("fleet", "project", "agent")
+
+LIFECYCLE_SCHEMA = "mac.agentbus.lifecycle.v2"
+LIFECYCLE_TOPIC = "mac.lifecycle.directive.v2"
+LIFECYCLE_CONTENT_TYPE = "application/vnd.mac.lifecycle+json"
+
+LIFECYCLE_ACK_SCHEMA = "mac.agentbus.lifecycle_ack.v2"
+LIFECYCLE_ACK_TOPIC = "mac.lifecycle.ack.v2"
+LIFECYCLE_ACK_CONTENT_TYPE = "application/vnd.mac.lifecycle-ack+json"
+
+
+class LifecycleVerbError(ValueError):
+    """An unknown lifecycle verb or scope.
+
+    Raised rather than ignored. A directive nobody understands must fail where
+    it is built, not travel the bus and be silently dropped by every receiver --
+    that is indistinguishable from a fleet that heard it and did nothing.
+    """
+
+
+def lifecycle_payload(
+    *,
+    verb: str,
+    scope: str = "fleet",
+    target: Optional[str] = None,
+    reason: str = "",
+    issued_by: str = "human",
+    correlation_id: Optional[str] = None,
+) -> JsonDict:
+    """Build a lifecycle directive.
+
+    ``correlation_id`` is what makes the acknowledgement loop possible: every
+    ack names the directive it answers, so a caller can tell WHO HEARD IT from
+    who did not. That distinction is the whole point -- see
+    :func:`lifecycle_ack_payload`.
+    """
+    verb = str(verb or "").strip()
+    if verb not in LIFECYCLE_VERBS:
+        raise LifecycleVerbError(
+            "unknown lifecycle verb %r; known verbs are %s"
+            % (verb, ", ".join(LIFECYCLE_VERBS))
+        )
+    scope = str(scope or "").strip()
+    if scope not in LIFECYCLE_SCOPES:
+        raise LifecycleVerbError(
+            "unknown lifecycle scope %r; known scopes are %s"
+            % (scope, ", ".join(LIFECYCLE_SCOPES))
+        )
+    if scope in ("project", "agent") and not str(target or "").strip():
+        raise LifecycleVerbError(
+            "scope %r requires a target; without one this would address the "
+            "whole fleet, which is the opposite of what was asked" % scope
+        )
+    payload: JsonDict = {
+        "schema": LIFECYCLE_SCHEMA,
+        "verb": verb,
+        "scope": scope,
+        "issued_by": str(issued_by or "human"),
+        "destructive": verb in LIFECYCLE_DESTRUCTIVE_VERBS,
+    }
+    if scope != "fleet":
+        payload["target"] = str(target).strip()
+    if reason:
+        payload["reason"] = str(reason)
+    if correlation_id:
+        payload["correlation_id"] = str(correlation_id)
+    return payload
+
+
+def lifecycle_ack_payload(
+    *,
+    correlation_id: str,
+    agent_id: str,
+    verb: str,
+    honoured: bool,
+    detail: str = "",
+) -> JsonDict:
+    """Build an agent's answer to a lifecycle directive.
+
+    ACKNOWLEDGEMENT IS NOT OPTIONAL DECORATION. A bus directive is best-effort:
+    a wedged agent -- one that is not draining its subscription -- never hears
+    "stand down", and that is precisely the agent the directive exists for. So
+    a caller must be able to distinguish HEARD from NOT HEARD, and a UI must
+    never report "stopped" when the truth is "asked". Without acks there is no
+    denominator and the control reports success while enforcing nothing.
+
+    ``honoured=False`` is a real answer, not a failure: an agent may decline
+    (mid-commit, holding a lease) and saying so is more useful than silence.
+    """
+    return {
+        "schema": LIFECYCLE_ACK_SCHEMA,
+        "correlation_id": str(correlation_id),
+        "agent_id": str(agent_id),
+        "verb": str(verb),
+        "honoured": bool(honoured),
+        "detail": str(detail or ""),
+    }
+
+
 CONTROL_STREAM_TYPES = {
     (REPO_UPDATE_TOPIC, REPO_UPDATE_CONTENT_TYPE),
     (REFLECT_REQUEST_TOPIC, REFLECT_REQUEST_CONTENT_TYPE),
+    (LIFECYCLE_TOPIC, LIFECYCLE_CONTENT_TYPE),
 }
 
 

--- a/tests/test_agentbus_lifecycle_vocabulary.py
+++ b/tests/test_agentbus_lifecycle_vocabulary.py
@@ -1,0 +1,199 @@
+"""The lifecycle verbs humans and agents share.
+
+The console is getting controls -- stand down, resume -- for when agents go off
+the rails. The retired dashboard did that with POST /agents/bulk: a privileged
+control-plane mutation that bypassed the agents entirely. These are REQUESTS on
+a channel every participant can see, which each agent observes and honours.
+
+Two properties are load-bearing and both are tested here:
+
+1. STAND-DOWN IS NOT ABORT. One button labelled "stop" that means abort
+   destroys work in flight; one that means pause does not stop a runaway. The
+   vocabulary keeps them distinct and marks which one destroys.
+
+2. ASKED IS NOT STOPPED. A bus directive is best-effort. A wedged agent -- one
+   not draining its subscription -- never hears "stand down", and that is
+   exactly the agent the directive exists for. The ack carries a correlation
+   id so a caller can tell who heard it from who did not. Without that there is
+   no denominator, and the control reports success while enforcing nothing --
+   the failure this repository has now produced four separate times.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.agentbus_control import (
+    CONTROL_STREAM_TYPES,
+    LIFECYCLE_ABORT,
+    LIFECYCLE_ACK_SCHEMA,
+    LIFECYCLE_CONTENT_TYPE,
+    LIFECYCLE_DESTRUCTIVE_VERBS,
+    LIFECYCLE_PAUSE,
+    LIFECYCLE_RESUME,
+    LIFECYCLE_SCHEMA,
+    LIFECYCLE_SCOPES,
+    LIFECYCLE_STAND_DOWN,
+    LIFECYCLE_STATUS,
+    LIFECYCLE_TOPIC,
+    LIFECYCLE_VERBS,
+    LifecycleVerbError,
+    is_control_stream,
+    lifecycle_ack_payload,
+    lifecycle_payload,
+)
+
+
+# --------------------------------------------------------------------------
+# stand-down is not abort
+# --------------------------------------------------------------------------
+
+
+def test_stand_down_and_abort_are_different_verbs():
+    assert LIFECYCLE_STAND_DOWN != LIFECYCLE_ABORT
+    assert {LIFECYCLE_STAND_DOWN, LIFECYCLE_ABORT} <= set(LIFECYCLE_VERBS)
+
+
+def test_only_abort_is_marked_destructive():
+    """A UI must be able to ask which verbs lose work, rather than knowing.
+
+    If stand_down ever became destructive, or abort stopped being so, a caller
+    that renders them behind the same control would silently start destroying
+    work in flight.
+    """
+    assert LIFECYCLE_DESTRUCTIVE_VERBS == {LIFECYCLE_ABORT}
+    assert lifecycle_payload(verb=LIFECYCLE_ABORT)["destructive"] is True
+    for verb in (LIFECYCLE_STAND_DOWN, LIFECYCLE_PAUSE, LIFECYCLE_RESUME, LIFECYCLE_STATUS):
+        assert lifecycle_payload(verb=verb)["destructive"] is False
+
+
+# --------------------------------------------------------------------------
+# a directive nobody understands must fail where it is built
+# --------------------------------------------------------------------------
+
+
+def test_an_unknown_verb_is_refused_not_sent():
+    """Travelling the bus and being dropped by every receiver is
+    indistinguishable from a fleet that heard it and did nothing."""
+    with pytest.raises(LifecycleVerbError) as exc:
+        lifecycle_payload(verb="halt")
+
+    assert "halt" in str(exc.value)
+    assert LIFECYCLE_STAND_DOWN in str(exc.value), "the error must name the real verbs"
+
+
+def test_an_unknown_scope_is_refused():
+    with pytest.raises(LifecycleVerbError):
+        lifecycle_payload(verb=LIFECYCLE_PAUSE, scope="everyone")
+
+
+@pytest.mark.parametrize("scope", ["project", "agent"])
+def test_a_targeted_scope_without_a_target_is_refused(scope):
+    """Defaulting a missing target to the whole fleet is the opposite of what
+    was asked, and it is the direction that does the damage."""
+    with pytest.raises(LifecycleVerbError) as exc:
+        lifecycle_payload(verb=LIFECYCLE_STAND_DOWN, scope=scope)
+
+    assert "whole fleet" in str(exc.value)
+
+
+def test_a_fleet_directive_carries_no_target():
+    payload = lifecycle_payload(verb=LIFECYCLE_PAUSE, scope="fleet")
+
+    assert "target" not in payload
+
+
+def test_a_targeted_directive_carries_its_target():
+    payload = lifecycle_payload(
+        verb=LIFECYCLE_PAUSE, scope="agent", target="agent_rocky"
+    )
+
+    assert payload["target"] == "agent_rocky"
+    assert payload["scope"] == "agent"
+
+
+# --------------------------------------------------------------------------
+# asked is not stopped
+# --------------------------------------------------------------------------
+
+
+def test_a_directive_can_carry_a_correlation_id():
+    payload = lifecycle_payload(verb=LIFECYCLE_STAND_DOWN, correlation_id="abc123")
+
+    assert payload["correlation_id"] == "abc123"
+
+
+def test_an_ack_names_the_directive_it_answers():
+    """Without this there is no denominator: a caller cannot tell an agent that
+    heard and complied from one that never heard at all."""
+    ack = lifecycle_ack_payload(
+        correlation_id="abc123",
+        agent_id="agent_rocky",
+        verb=LIFECYCLE_STAND_DOWN,
+        honoured=True,
+    )
+
+    assert ack["schema"] == LIFECYCLE_ACK_SCHEMA
+    assert ack["correlation_id"] == "abc123"
+    assert ack["agent_id"] == "agent_rocky"
+    assert ack["honoured"] is True
+
+
+def test_declining_is_a_real_answer_not_a_failure():
+    """An agent mid-commit or holding a lease may decline. Saying so is more
+    useful than silence, and must be distinguishable from silence."""
+    ack = lifecycle_ack_payload(
+        correlation_id="abc123",
+        agent_id="agent_natasha",
+        verb=LIFECYCLE_ABORT,
+        honoured=False,
+        detail="holding a publication lease",
+    )
+
+    assert ack["honoured"] is False
+    assert ack["detail"] == "holding a publication lease"
+
+
+# --------------------------------------------------------------------------
+# wiring
+# --------------------------------------------------------------------------
+
+
+def test_the_lifecycle_topic_is_a_control_stream():
+    assert is_control_stream(LIFECYCLE_TOPIC, LIFECYCLE_CONTENT_TYPE)
+    assert (LIFECYCLE_TOPIC, LIFECYCLE_CONTENT_TYPE) in CONTROL_STREAM_TYPES
+
+
+def test_the_content_type_survives_a_charset_parameter():
+    assert is_control_stream(LIFECYCLE_TOPIC, LIFECYCLE_CONTENT_TYPE + "; charset=utf-8")
+
+
+def test_the_vocabulary_is_v2_and_says_so():
+    """There are no v1 agents and this fleet is the only deployment, so the
+    lifecycle namespace starts at v2 rather than carrying two shapes. The
+    version is stated so a later reader can see where the break was."""
+    assert LIFECYCLE_SCHEMA.endswith(".v2")
+    assert LIFECYCLE_TOPIC.endswith(".v2")
+    assert LIFECYCLE_ACK_SCHEMA.endswith(".v2")
+
+
+def test_every_verb_and_scope_builds():
+    """No verb in the published tuple may be unbuildable -- a vocabulary that
+    advertises a verb it cannot express is worse than a shorter one."""
+    for verb in LIFECYCLE_VERBS:
+        assert lifecycle_payload(verb=verb)["verb"] == verb
+    for scope in LIFECYCLE_SCOPES:
+        target = None if scope == "fleet" else "x"
+        assert lifecycle_payload(
+            verb=LIFECYCLE_STATUS, scope=scope, target=target
+        )["scope"] == scope
+
+
+def test_the_issuer_is_recorded():
+    """A human speaks the same verbs on the same bus as an agent, so the
+    payload has to say which one spoke."""
+    assert lifecycle_payload(verb=LIFECYCLE_PAUSE)["issued_by"] == "human"
+    assert (
+        lifecycle_payload(verb=LIFECYCLE_PAUSE, issued_by="agent_rocky")["issued_by"]
+        == "agent_rocky"
+    )


### PR DESCRIPTION
Schema layer only — the verbs, scopes, and directive/ack payload builders. **Nothing
publishes or honours them yet.** This is the dependency under the "talk to the agents"
view (`task_a649529a`) and its controls (`task_803c8e4e`).

## Why this is not a return to command-and-control

The retired dashboard called `POST /agents/bulk` — a privileged control-plane mutation
that **bypassed the agents entirely**. These are *requests* on a channel every
participant can see, which each agent observes and honours. That is what lets the
console keep an honest invariant:

> it never mutates the control plane directly; it speaks on the bus like any other participant

## Stand-down is not abort

| verb | meaning | destructive |
|---|---|---|
| `stand_down` | stop claiming new work, finish what you hold | no |
| `abort` | drop current work now | **yes** |
| `pause` / `resume` | scoped, reversible | no |
| `status` | report what you are doing | no |

A single button labelled "stop" that means abort destroys work in flight; one that
means pause does not stop a runaway. Most off-the-rails moments want stand-down.
`destructive` is a **field rather than folklore**, so a UI can *ask* which verbs lose
work instead of knowing.

## Asked is not stopped

This is why the ack exists at all. A bus directive is best-effort: **a wedged agent —
one not draining its subscription — never hears "stand down", and that is exactly the
agent the directive exists for.**

The correlation id lets a caller tell who heard it from who did not. Without a
denominator the control reports success while enforcing nothing — the failure this
repository has now produced four separate times.

`honoured=False` is a real answer, not a failure: an agent holding a publication lease
may decline, and saying so is more useful than silence.

## Failing where it is built

An unknown verb or scope **raises**. A directive nobody understands must fail at
construction, not travel the bus and be dropped by every receiver — that is
indistinguishable from a fleet that heard it and did nothing. A `project`- or
`agent`-scoped directive with no target is refused for the same reason: defaulting a
missing target to the whole fleet is the direction that does the damage.

## v2, not v1

There are no v1 agents and this fleet is the only deployment of mac, so the lifecycle
namespace starts at v2 rather than carrying two shapes forever. The version is stated
so a later reader can see where the break was.

## Still to come

- agents declaring which verbs they understand in `/agents/{id}/agentbus/roll-call`,
  so a UI can gray out what an agent cannot honour rather than sending into the void
- the publish path and the agent-side honouring
- the escalation when the bus goes unanswered: bus request → timeout → control-plane
  hold, surfaced **as** an escalation, never silently substituted

## Verification

16 tests. `dead-code-check.sh` clean. Public contract **598 passed**. Env registry current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)