### PR TITLE
Make `make install` work on a clean machine, and provision CodeGraph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ DESKTOP_NODE_MODULES_STAMP := desktop/node_modules/.package-lock.json
 # Console scripts declared in pyproject.toml [project.scripts]; keep in sync.
 CONSOLE_SCRIPTS = mac mac-hermes mac-agent mac-firecrawl-gateway mac-k8s-orchestrator mac-k8s-bootstrap mac-task-runner mac-webdav-server mac-evidence mac-hermes-gateway
 
-.PHONY: help require-python require-npm require-uv codegraph-sync \
+.PHONY: help require-python require-npm require-uv codegraph-sync install-codegraph \
 	install install-cli install-gui uninstall uninstall-cli \
 	build build-cli build-gui package package-cli package-gui publish \
 	clean clean-cli clean-gui distclean run-gui \
@@ -77,11 +77,14 @@ require-uv:
 codegraph-sync: ## Initialize or incrementally refresh the CodeGraph index.
 	@MAC_CODEGRAPH_BIN="$(CODEGRAPH)" scripts/sync-codegraph.sh
 
+install-codegraph: ## Install CodeGraph if absent (litai init and the skills need it).
+	@MAC_CODEGRAPH_BIN="$(CODEGRAPH)" scripts/install-codegraph.sh
+
 # ---------------------------------------------------------------------------
 # Common lifecycle: these are the targets a new contributor/client should use.
 # ---------------------------------------------------------------------------
 
-install: install-cli install-gui ## Install the CLI and canonical Fleet IDE from this checkout.
+install: install-codegraph install-cli install-gui ## Install the CLI and canonical Fleet IDE from this checkout.
 	@printf '%s\n' \
 		'Installed MAC CLI + Fleet IDE.' \
 		'  CLI:  mac --help' \

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -91,6 +91,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_CLIENT_PRINCIPALS_FILE` | str | consumer-defined | client-auth | Client Auth setting: client principals file. |
 | `MAC_CLIENT_PROFILES_DIR` | str | consumer-defined | core | Core setting: client profiles dir. |
 | `MAC_CODEGRAPH_BIN` | str | consumer-defined | core | Core setting: codegraph bin. |
+| `MAC_CODEGRAPH_INSTALLER_URL` | str | consumer-defined | core | Core setting: codegraph installer url. |
 | `MAC_CODEX_BASE_URL` | str | consumer-defined | core | Core setting: codex base url. |
 | `MAC_CODEX_MODEL` | str | consumer-defined | core | Core setting: codex model. |
 | `MAC_CODEX_PROVIDER` | str | consumer-defined | core | Core setting: codex provider. |
@@ -879,6 +880,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_REPO_UPDATE_DISPATCH_BLOCKER_FILE` | str | consumer-defined | core | Core setting: repo update dispatch blocker file. |
 | `MAC_REPO_UPDATE_SELF_TEST` | str | consumer-defined | core | Core setting: repo update self test. |
 | `MAC_REPO_UPDATE_SELF_TEST_PYTHON` | str | consumer-defined | core | Core setting: repo update self test python. |
+| `MAC_REQUIRE_CODEGRAPH` | bool | consumer-defined | core | Core setting: require codegraph. |
 | `MAC_REQUIRE_FIRECRAWL` | bool | consumer-defined | core | Core setting: require firecrawl. |
 | `MAC_REQUIRE_HERMES_STARTUP_READY` | bool | consumer-defined | core | Core setting: require hermes startup ready. |
 | `MAC_REQUIRE_QDRANT_MEMORY` | bool | consumer-defined | core | Core setting: require qdrant memory. |
@@ -1019,6 +1021,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_SERVICE_NOFILE_LIMIT` | int | consumer-defined | core | Core setting: service nofile limit. |
 | `MAC_SERVICE_ROLE_OPS` | str | consumer-defined | core | Core setting: service role ops. |
 | `MAC_SHARED_SERVICES_MANAGER_AGENT` | str | consumer-defined | core | Core setting: shared services manager agent. |
+| `MAC_SKIP_CODEGRAPH_INSTALL` | bool | consumer-defined | core | Core setting: skip codegraph install. |
 | `MAC_SKIP_SLACK_VERIFY` | str | consumer-defined | core | Core setting: skip slack verify. |
 | `MAC_SKIP_TELEGRAM_VERIFY` | str | consumer-defined | core | Core setting: skip telegram verify. |
 | `MAC_SLOW_REQUEST_SECONDS` | int | consumer-defined | core | Core setting: slow request seconds. |

--- a/scripts/bootstrap-project.py
+++ b/scripts/bootstrap-project.py
@@ -50,6 +50,53 @@ def report_missing_commands(missing: list[str]) -> None:
             print("  - %s: %s" % (command, hint), file=sys.stderr)
 
 
+def has_pip() -> bool:
+    return (
+        subprocess.run(
+            [str(VENV_PYTHON), "-m", "pip", "--version"],
+            cwd=str(ROOT),
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def ensure_pip() -> None:
+    """Make sure the venv has pip, even when something else created it.
+
+    An existing venv is REUSED -- the check above only builds one when the
+    interpreter is missing -- and a venv built by `uv venv` has no pip at all.
+    That is the likely state in this repository, which runs `uv run --extra dev`
+    everywhere, and it produced a bare failure on puck.local:
+
+        /Users/jkh/Src/mac/.venv/bin/python: No module named pip
+        make: *** [.venv/bin/mac] Error 1
+
+    `ensurepip` is tried first because it preserves the existing environment.
+    Some distributions ship Python without it, so recreating the venv is the
+    fallback -- noisy, but it leaves a working install rather than a message
+    about a module the user never chose to omit.
+    """
+    if has_pip():
+        return
+    print("venv has no pip (created by uv?); bootstrapping it", flush=True)
+    result = subprocess.run(
+        [str(VENV_PYTHON), "-m", "ensurepip", "--upgrade"],
+        cwd=str(ROOT),
+        capture_output=True,
+    )
+    if result.returncode == 0 and has_pip():
+        return
+    print("ensurepip unavailable; recreating the venv with python -m venv", flush=True)
+    shutil.rmtree(VENV)
+    run([sys.executable, "-m", "venv", str(VENV)])
+    if not has_pip():
+        raise SystemExit(
+            "could not provision pip in %s; create it with `python3 -m venv` "
+            "and re-run `make install`" % VENV
+        )
+
+
 def main() -> int:
     # --venv-only: build just the .venv (pip install -e .[dev]) without the
     # dev-workflow tool checks. git/gh serve the human dev loop; verification
@@ -92,6 +139,7 @@ def main() -> int:
         shutil.rmtree(VENV)
     if not VENV_PYTHON.exists():
         run([sys.executable, "-m", "venv", str(VENV)])
+    ensure_pip()
     run([str(VENV_PYTHON), "-m", "pip", "install", "--upgrade", "pip"])
     run([str(VENV_PYTHON), "-m", "pip", "install", "-e", ".[dev]"])
     return 0

--- a/scripts/install-codegraph.sh
+++ b/scripts/install-codegraph.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+set -eu
+
+# Install CodeGraph if it is not already present.
+#
+# WHY THIS IS PART OF `make install` RATHER THAN A HARD REQUIREMENT.
+# CodeGraph is not needed to BUILD mac -- no index is committed, indexes are
+# generated per-directory, and scripts/resolve-impacted-tests.py fails closed
+# to a full test run without one. So `codegraph-sync` degrading is correct.
+#
+# But skipping it silently strands the user later: `litai init`, the skills, and
+# the coding-CLI paths all expect CodeGraph, and the failure surfaces far from
+# the install that omitted it. Provisioning it here is the cheap fix -- the user
+# asked for mac to be installed, and this is part of a working install.
+#
+# Set MAC_SKIP_CODEGRAPH_INSTALL=1 to decline (air-gapped machines, or an
+# operator who wants to choose their own installation method).
+
+CODEGRAPH_BIN=${MAC_CODEGRAPH_BIN:-codegraph}
+INSTALLER_URL=${MAC_CODEGRAPH_INSTALLER_URL:-https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh}
+
+if command -v "$CODEGRAPH_BIN" >/dev/null 2>&1; then
+    echo "codegraph: already installed ($(command -v "$CODEGRAPH_BIN"))"
+    exit 0
+fi
+
+if [ "${MAC_SKIP_CODEGRAPH_INSTALL:-0}" = "1" ]; then
+    echo "codegraph: not installed, and MAC_SKIP_CODEGRAPH_INSTALL=1; skipping." >&2
+    echo "  mac will build and run without it. \`litai init\`, the skills and the" >&2
+    echo "  coding-CLI paths expect it, so install it before using those:" >&2
+    echo "    curl -fsSL $INSTALLER_URL | sh" >&2
+    exit 0
+fi
+
+# Stated plainly rather than run quietly: this fetches and executes a script
+# from the network, and the operator should be able to see that happening.
+echo "codegraph: not found; installing from $INSTALLER_URL"
+echo "  (set MAC_SKIP_CODEGRAPH_INSTALL=1 to decline)"
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "codegraph: curl is not available; cannot install automatically." >&2
+    echo "  Install CodeGraph manually: $INSTALLER_URL" >&2
+    exit 0
+fi
+
+if curl -fsSL "$INSTALLER_URL" | sh; then
+    # The installer commonly lands in ~/.local/bin, which may not be on PATH
+    # for this shell yet. Report the truth rather than assuming success.
+    if command -v "$CODEGRAPH_BIN" >/dev/null 2>&1; then
+        echo "codegraph: installed ($(command -v "$CODEGRAPH_BIN"))"
+    elif [ -x "$HOME/.local/bin/codegraph" ]; then
+        echo "codegraph: installed at $HOME/.local/bin/codegraph"
+        echo "  It is not on this shell's PATH; add ~/.local/bin to PATH."
+    else
+        echo "codegraph: installer finished but the binary was not found on PATH." >&2
+        echo "  mac is still usable; install it manually before \`litai init\`." >&2
+    fi
+    exit 0
+fi
+
+# A failed install must not block the CLI the user asked for.
+echo "codegraph: installation failed; continuing without it." >&2
+echo "  mac will build and run. Install it before \`litai init\` or the skills:" >&2
+echo "    curl -fsSL $INSTALLER_URL | sh" >&2
+exit 0

--- a/scripts/sync-codegraph.sh
+++ b/scripts/sync-codegraph.sh
@@ -4,10 +4,34 @@ set -eu
 ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 CODEGRAPH_BIN=${MAC_CODEGRAPH_BIN:-codegraph}
 
+# CodeGraph is a developer/agent code-intelligence index. It is NOT required to
+# build, install, test or deploy mac, and this script used to exit 127 when it
+# was missing -- which made `make install` fail on any machine without it, since
+# codegraph-sync is a prerequisite of install, build, test, coverage, setup and
+# deploy alike. Observed on puck.local:
+#
+#     CodeGraph is required but 'codegraph' was not found on PATH
+#     make: *** [codegraph-sync] Error 127
+#
+# Everything downstream already tolerates its absence. scripts/resolve-impacted-
+# tests.py treats an unavailable CodeGraph as a reason to FAIL CLOSED to a full
+# test run -- CI has done exactly that ("sanity selection: full
+# (codegraph_unavailable)") -- and the repository ships no committed index, so a
+# fresh clone never has one.
+#
+# Set MAC_REQUIRE_CODEGRAPH=1 to restore the hard failure, for a machine where
+# the index is meant to exist and its absence should stop the build.
 if ! command -v "$CODEGRAPH_BIN" >/dev/null 2>&1; then
-    echo "CodeGraph is required but '$CODEGRAPH_BIN' was not found on PATH" >&2
-    echo "Install it with: curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh" >&2
-    exit 127
+    if [ "${MAC_REQUIRE_CODEGRAPH:-0}" = "1" ]; then
+        echo "CodeGraph is required (MAC_REQUIRE_CODEGRAPH=1) but '$CODEGRAPH_BIN' was not found on PATH" >&2
+        echo "Install it with: curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh" >&2
+        exit 127
+    fi
+    echo "codegraph-sync: '$CODEGRAPH_BIN' not on PATH; skipping the index." >&2
+    echo "  mac does not need it to build, install, test or deploy. Test" >&2
+    echo "  selection falls back to a full run without it." >&2
+    echo "  To index anyway: curl -fsSL https://raw.githubusercontent.com/colbymchenry/codegraph/main/install.sh | sh" >&2
+    exit 0
 fi
 
 cd "$ROOT"

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -1071,8 +1071,20 @@
     "name": "MAC_CODEGRAPH_BIN",
     "retired": false,
     "sources": [
+      "scripts/install-codegraph.sh",
       "scripts/sync-codegraph.sh",
       "src/mac/codegraph_audit.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: codegraph installer url.",
+    "family": "core",
+    "name": "MAC_CODEGRAPH_INSTALLER_URL",
+    "retired": false,
+    "sources": [
+      "scripts/install-codegraph.sh"
     ],
     "type": "str"
   },
@@ -10381,6 +10393,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: require codegraph.",
+    "family": "core",
+    "name": "MAC_REQUIRE_CODEGRAPH",
+    "retired": false,
+    "sources": [
+      "scripts/sync-codegraph.sh"
+    ],
+    "type": "bool"
+  },
+  {
+    "default": null,
     "description": "Core setting: require firecrawl.",
     "family": "core",
     "name": "MAC_REQUIRE_FIRECRAWL",
@@ -12018,6 +12041,17 @@
       "src/mac/worker.py"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: skip codegraph install.",
+    "family": "core",
+    "name": "MAC_SKIP_CODEGRAPH_INSTALL",
+    "retired": false,
+    "sources": [
+      "scripts/install-codegraph.sh"
+    ],
+    "type": "bool"
   },
   {
     "default": null,

--- a/tests/test_codegraph_sync_is_optional.py
+++ b/tests/test_codegraph_sync_is_optional.py
@@ -1,0 +1,191 @@
+"""CodeGraph: `make install` provisions it; the build never requires it.
+
+Two separate properties, and they are not in tension:
+
+  * `make install` INSTALLS CodeGraph when it is absent, because skipping it
+    silently strands the user later -- `litai init`, the skills and the
+    coding-CLI paths all expect it, and that failure surfaces far from the
+    install that omitted it.
+  * every other target DEGRADES without it, because nothing in the build,
+    the test run or the deploy needs an index.
+
+REPORTED FROM A REAL MACHINE. `make install` on puck.local:
+
+    CodeGraph is required but 'codegraph' was not found on PATH
+    make: *** [codegraph-sync] Error 127
+
+Before this, `codegraph-sync` was a prerequisite of install, install-cli, install-gui,
+build-cli, build-gui, test, coverage, setup and deploy, so exiting 127 when the
+binary is absent made every one of those targets fail on a machine that had
+never installed an optional developer tool.
+
+WHY IT IS OPTIONAL, on the evidence rather than by assertion:
+
+  * no index is committed -- `.codegraph/` is generated locally, so a fresh
+    clone has never had one
+  * `scripts/resolve-impacted-tests.py` treats an unavailable CodeGraph as a
+    reason to FAIL CLOSED to a full test run, and CI has done exactly that:
+    "sanity selection: full (codegraph_unavailable)"
+  * nothing in the wheel build or the CLI link reads the index
+
+So the absence of CodeGraph is a supported, already-tested condition
+everywhere except the one script that refused to proceed without it.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "sync-codegraph.sh"
+
+
+def _run(env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    # A PATH with no codegraph on it, whatever the developer has installed.
+    env["PATH"] = "/usr/bin:/bin"
+    env["MAC_CODEGRAPH_BIN"] = "definitely-not-a-real-codegraph-binary"
+    env.pop("MAC_REQUIRE_CODEGRAPH", None)
+    env.update(env_extra or {})
+    return subprocess.run(
+        ["sh", str(SCRIPT)], capture_output=True, text=True, timeout=60, env=env
+    )
+
+
+def test_a_missing_codegraph_does_not_fail_the_build():
+    """The reported bug. Exit 0, so `make install` proceeds."""
+    result = _run()
+
+    assert result.returncode == 0, (
+        "sync-codegraph.sh exited %d; every make target that depends on it "
+        "(install, build, test, deploy) fails on a machine without CodeGraph"
+        % result.returncode
+    )
+
+
+def test_it_says_what_it_skipped_rather_than_passing_silently():
+    """Degrading quietly is its own failure: a developer who wanted the index
+    must be able to tell that they did not get one."""
+    result = _run()
+
+    assert "not on PATH" in result.stderr
+    assert "skipping" in result.stderr.lower()
+
+
+def test_it_says_the_build_does_not_need_it():
+    """Without this the warning reads like a problem to fix before continuing."""
+    result = _run()
+
+    assert "does not need it" in result.stderr
+
+
+def test_it_still_says_how_to_install_it():
+    result = _run()
+
+    assert "install.sh" in result.stderr
+
+
+def test_strict_mode_restores_the_hard_failure():
+    """A machine where the index is meant to exist can still demand it."""
+    result = _run({"MAC_REQUIRE_CODEGRAPH": "1"})
+
+    assert result.returncode == 127
+    assert "MAC_REQUIRE_CODEGRAPH=1" in result.stderr
+
+
+def test_strict_mode_is_off_by_default():
+    """Opt-in, not opt-out: the default must be the one that installs."""
+    assert _run().returncode == 0
+
+
+@pytest.mark.parametrize(
+    "target", ["install", "install-cli", "install-gui", "build-cli", "test"]
+)
+def test_the_affected_targets_still_depend_on_the_sync(target):
+    """The fix is to the script, NOT to the wiring. These targets should still
+    refresh the index when CodeGraph IS present -- degrading is about the
+    machine that lacks it, not about dropping the step."""
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    line = next(
+        line for line in makefile.splitlines() if line.startswith(target + ":")
+    )
+    assert "codegraph-sync" in line or target == "install"
+
+
+# --------------------------------------------------------------------------
+# `make install` provisions it
+# --------------------------------------------------------------------------
+
+INSTALLER = ROOT / "scripts" / "install-codegraph.sh"
+
+
+def _install(env_extra: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PATH"] = "/usr/bin:/bin"
+    env.pop("MAC_SKIP_CODEGRAPH_INSTALL", None)
+    env.update(env_extra or {})
+    return subprocess.run(
+        ["sh", str(INSTALLER)], capture_output=True, text=True, timeout=60, env=env
+    )
+
+
+def test_install_depends_on_provisioning_codegraph():
+    """The reason this exists: an install without CodeGraph is an install that
+    fails later, at `litai init`, far from the cause."""
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    line = next(l for l in makefile.splitlines() if l.startswith("install:"))
+
+    assert "install-codegraph" in line
+    assert "install-codegraph:" in makefile
+
+
+def test_an_already_installed_codegraph_is_left_alone():
+    """No reinstall, no network call, on the common path."""
+    result = _install({"MAC_CODEGRAPH_BIN": "sh"})
+
+    assert result.returncode == 0
+    assert "already installed" in result.stdout
+
+
+def test_it_can_be_declined():
+    """Air-gapped machines, or an operator choosing their own method."""
+    result = _install({
+        "MAC_CODEGRAPH_BIN": "definitely-not-real-codegraph",
+        "MAC_SKIP_CODEGRAPH_INSTALL": "1",
+    })
+
+    assert result.returncode == 0
+    assert "skipping" in result.stderr
+    # Declining must still say what it will cost, and when.
+    assert "litai init" in result.stderr
+
+
+def test_declining_still_leaves_a_working_build():
+    """The CLI the user asked for must install either way."""
+    result = _install({
+        "MAC_CODEGRAPH_BIN": "definitely-not-real-codegraph",
+        "MAC_SKIP_CODEGRAPH_INSTALL": "1",
+    })
+
+    assert result.returncode == 0
+    assert "without it" in result.stderr
+
+
+def test_the_installer_url_is_overridable():
+    """A mirror, or a pinned revision, without editing the script."""
+    text = INSTALLER.read_text(encoding="utf-8")
+
+    assert "MAC_CODEGRAPH_INSTALLER_URL" in text
+
+
+def test_it_announces_the_network_fetch_rather_than_doing_it_quietly():
+    """`curl | sh` is a supply-chain action. An operator must be able to see it
+    happen, and to decline."""
+    text = INSTALLER.read_text(encoding="utf-8")
+
+    assert 'echo "codegraph: not found; installing from' in text
+    assert "MAC_SKIP_CODEGRAPH_INSTALL=1 to decline" in text

--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -32,7 +32,9 @@ def test_makefile_defaults_to_help_and_keeps_fleet_setup_distinct() -> None:
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
 
     assert ".DEFAULT_GOAL := help" in makefile
-    assert "install: install-cli install-gui" in makefile
+    # install-codegraph leads: an install that omits CodeGraph is one that
+    # fails later at `litai init`, far from the cause.
+    assert "install: install-codegraph install-cli install-gui" in makefile
     assert "build: build-cli build-gui" in makefile
     assert "clean: clean-cli clean-gui" in makefile
     assert "setup: require-python codegraph-sync" in makefile


### PR DESCRIPTION
`make install` failed on puck.local. Two separate causes — one of which I had to be corrected on.

## The reported failure was pip, not CodeGraph

```
/Users/jkh/Src/mac/.venv/bin/python: No module named pip
make: *** [.venv/bin/mac] Error 1
```

The `.venv` there was built by **uv** (`uv = 0.9.15` in `pyvenv.cfg`), and uv doesn't
install pip. `bootstrap-project.py` only *creates* a venv when the interpreter is
missing — so it reused that one and then ran `python -m pip`. This repo runs
`uv run --extra dev` everywhere, which makes a uv-built venv the **expected** state and
this failure reachable from the normal workflow.

`ensure_pip()` tries `ensurepip --upgrade` first (preserves the environment), falls back
to recreating the venv, and fails with an actionable message rather than a bare
`No module named pip`.

## My first reproduction was an artifact of how I ran it

`ssh host 'cmd'` gets a non-interactive shell with `PATH=/usr/bin:/bin:/usr/sbin:/sbin`
— no Homebrew, no `~/.local/bin`. So I hit a CodeGraph error the reporter never saw.
**Both `gh` and `codegraph` were installed on that machine the whole time.**

## CodeGraph is now installed by `make install`

This is the better answer than the one I first reached for.

Indexes are generated per-directory and never committed, and nothing in the build, test
or deploy needs one — so `codegraph-sync` now **degrades** instead of exiting 127, and
no longer takes `install`, `build`, `test`, `coverage`, `setup` and `deploy` down with
it.

But degrading *silently* strands the user later: `litai init`, the skills and the
coding-CLI paths all expect CodeGraph, and that failure surfaces far from the install
that omitted it. So `install` provisions it.

The provisioning fetches and runs a script from the network, so it:

- **says so before doing it** — `curl | sh` is a supply-chain action and shouldn't be quiet
- takes `MAC_SKIP_CODEGRAPH_INSTALL=1` to decline
- takes `MAC_CODEGRAPH_INSTALLER_URL` for a mirror or pinned revision
- **never blocks the CLI the user asked for** on failure or decline — it warns, names
  `litai init` as the thing that will want it, and continues

`MAC_REQUIRE_CODEGRAPH=1` restores the old hard failure for a machine where the index is
meant to exist.

## Verified on the reporting machine

- `make install` completes through the CLI and Fleet IDE build
- `MAC_SKIP_CODEGRAPH_INSTALL=1 make install` also completes
- an already-installed CodeGraph is left alone, with no network call

**546 passed** across the Makefile contract, codegraph audit and public contract suites;
dead-code clean; docs gate green. CI never invokes `make`, so the network step doesn't
touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)