### PR TITLE
Cap the DEPENDENCIES column so one task's blockers stop starving every title

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -236,6 +236,35 @@ def _task_state_group(state: str) -> int:
     return 3
 
 
+#: Widest the DEPENDENCIES column may grow. Chosen to hold one short id plus an
+#: overflow marker -- "[task_d1b000e1,+5]" -- because the common case is zero or
+#: one blocker and the pathological case must not price out the title.
+MAX_DEPENDENCIES_WIDTH = 20
+
+
+def _elide_dependencies(cell: str, width: int) -> str:
+    """Fit a dependency cell into ``width``, saying how many were dropped.
+
+    "[a,b,c,d,e,f]" -> "[a,+5]". The COUNT is the point: a bare truncation
+    ("[a,b,c…") tells the reader neither how many blockers there are nor that
+    any are missing, and the number of things holding a task is exactly what a
+    listing is being scanned for.
+    """
+    if len(cell) <= width:
+        return cell
+    inner = cell[1:-1] if cell.startswith("[") and cell.endswith("]") else cell
+    if not inner:
+        return cell
+    parts = inner.split(",")
+    for keep in range(len(parts) - 1, 0, -1):
+        candidate = "[%s,+%d]" % (",".join(parts[:keep]), len(parts) - keep)
+        if len(candidate) <= width:
+            return candidate
+    # Even one id does not fit: report the count alone rather than a fragment
+    # of an id, which would look like a real id and resolve to nothing.
+    return "[+%d]" % len(parts)
+
+
 def _render_task_table(
     tasks: Iterable[Any],
     *,
@@ -284,10 +313,20 @@ def _render_task_table(
             )
             + "]"
         )
+    # CAPPED, like every other column. This one was sized to the longest
+    # dependency cell in the whole table, so ONE task with six blockers took 49
+    # columns and squeezed every title in the listing down to 23 characters --
+    # on a real blocked backlog the DEPENDENCIES field grew past 70 and the
+    # titles were effectively gone. Titles are what the reader is scanning for;
+    # the full dependency list is one `mac task show` away, and the overflow
+    # marker below says how many were elided rather than hiding them.
     dependencies_width = max(
         len("DEPENDENCIES"),
-        max(len(cell) for cell in dependency_cells),
+        min(MAX_DEPENDENCIES_WIDTH, max(len(cell) for cell in dependency_cells)),
     )
+    dependency_cells = [
+        _elide_dependencies(cell, dependencies_width) for cell in dependency_cells
+    ]
     fixed_width = (
         id_width
         + 2

--- a/tests/cli/test_cli_text_output.py
+++ b/tests/cli/test_cli_text_output.py
@@ -89,7 +89,13 @@ def test_task_table_shows_dependency_arrays_for_roots_and_children():
     root_line = next(line for line in out.splitlines() if line.startswith("task_root"))
     child_line = next(line for line in out.splitlines() if line.startswith("task_child"))
     assert "[]" in root_line
-    assert "[task_root,task_peer]" in child_line
+    # The DEPENDENCIES column is capped so one task's blocker list cannot
+    # starve every title (see tests/cli/test_task_table_column_widths.py). A
+    # real short id is 13 characters, so the cap holds one plus an overflow
+    # marker; these synthetic 9-character ids are two-thirds of a real pair.
+    # What must survive is the first blocker AND the count of the rest.
+    assert "task_root" in child_line
+    assert "+1" in child_line
 
 
 def test_task_table_prioritizes_active_and_attention_states():

--- a/tests/cli/test_task_table_column_widths.py
+++ b/tests/cli/test_task_table_column_widths.py
@@ -1,0 +1,126 @@
+"""The DEPENDENCIES column must not price out the title.
+
+REPORTED: "mac task list is severely truncated and I don't see project names or
+titles now at all."
+
+Every column in the task table was capped except one. `project_width` is
+`min(18, ...)`, ids are a fixed 13, the state cell is bounded -- but
+`dependencies_width` was sized to the longest dependency cell in the WHOLE
+table. So a single task with six blockers took 49 columns and squeezed every
+title in the listing to 23 characters. On a real blocked backlog the field grew
+past 70 and the titles were effectively gone.
+
+That is the wrong trade. A listing is scanned for titles; the full dependency
+list is one `mac task show` away. What the listing does owe the reader is the
+COUNT -- how many things are holding this task -- which is why the overflow
+marker carries a number rather than trailing off.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.cli import MAX_DEPENDENCIES_WIDTH, _elide_dependencies, _render_task_table
+
+
+def _rows(dep_counts, title="A task title long enough to be worth reading in full"):
+    return [
+        {
+            "id": "task_%012d" % i,
+            "state": "blocked",
+            "dependencies": ["task_%08d" % j for j in range(n)],
+            "title": title,
+        }
+        for i, n in enumerate(dep_counts)
+    ]
+
+
+def _column_starts(rendered):
+    """Where each column begins, read off the rule line."""
+    rule = rendered.splitlines()[1]
+    starts, in_run = [], False
+    for i, ch in enumerate(rule):
+        if ch == "─" and not in_run:
+            starts.append(i)
+            in_run = True
+        elif ch != "─":
+            in_run = False
+    return starts
+
+
+def test_one_task_with_many_blockers_does_not_starve_every_title():
+    """The reported bug, reduced."""
+    wide = _render_task_table(_rows([1, 6]), show_project=False, width=100)
+
+    title_start = _column_starts(wide)[-1]
+    title_width = 100 - title_start
+
+    assert title_width >= 40, (
+        "titles were squeezed to %d columns by one task's dependency list"
+        % title_width
+    )
+
+
+def test_the_dependencies_column_is_capped():
+    rendered = _render_task_table(_rows([12]), show_project=False, width=200)
+    starts = _column_starts(rendered)
+    dependencies_width = starts[-1] - starts[-2] - 2
+
+    assert dependencies_width <= MAX_DEPENDENCIES_WIDTH
+
+
+def test_a_short_dependency_list_is_not_padded_out():
+    """The cap is a ceiling, not a fixed width: the common case is 0 or 1."""
+    rendered = _render_task_table(_rows([0, 1]), show_project=False, width=120)
+    starts = _column_starts(rendered)
+
+    assert starts[-1] - starts[-2] - 2 < MAX_DEPENDENCIES_WIDTH
+
+
+# --------------------------------------------------------------------------
+# the overflow marker
+# --------------------------------------------------------------------------
+
+
+def test_elision_reports_how_many_were_dropped():
+    """A bare truncation tells the reader neither the count nor that anything
+    is missing -- and the count is what a listing is scanned for."""
+    out = _elide_dependencies("[task_a,task_b,task_c,task_d,task_e,task_f]", 20)
+
+    assert out.endswith("]")
+    assert "+" in out
+    assert len(out) <= 20
+    kept = out[1:-1].split(",")
+    dropped = int(kept[-1].lstrip("+"))
+    assert len(kept) - 1 + dropped == 6, "kept + dropped must equal the real total"
+
+
+def test_a_cell_that_already_fits_is_untouched():
+    assert _elide_dependencies("[task_a]", 20) == "[task_a]"
+    assert _elide_dependencies("[]", 20) == "[]"
+
+
+def test_a_single_id_too_wide_reports_the_count_not_a_fragment():
+    """A truncated id looks like a real id and resolves to nothing."""
+    out = _elide_dependencies("[task_averylongidentifier,task_b]", 8)
+
+    assert out == "[+2]"
+    assert "task_" not in out
+
+
+@pytest.mark.parametrize("count", [2, 3, 7, 25])
+def test_the_total_is_always_recoverable(count):
+    cell = "[" + ",".join("task_%08d" % i for i in range(count)) + "]"
+    out = _elide_dependencies(cell, MAX_DEPENDENCIES_WIDTH)
+
+    inner = out[1:-1]
+    parts = inner.split(",")
+    dropped = int(parts[-1].lstrip("+")) if parts[-1].startswith("+") else 0
+    kept = len(parts) - (1 if dropped else 0)
+    assert kept + dropped == count
+
+
+def test_the_table_never_exceeds_the_terminal():
+    rendered = _render_task_table(_rows([9, 0, 3]), show_project=False, width=90)
+
+    assert max(len(line) for line in rendered.splitlines()) <= 90


### PR DESCRIPTION
Reported: *"mac task list is severely truncated and I don't see project names or titles now at all."*

Every column in the task table was capped **except one**. `project_width` is `min(18, ...)`, ids are a fixed 13, the state cell is bounded — but `dependencies_width` was sized to the longest dependency cell in the *whole table*:

```python
dependencies_width = max(
    len("DEPENDENCIES"),
    max(len(cell) for cell in dependency_cells),   # unbounded
)
```

So one task with six blockers took **49 columns** and squeezed every title in the listing to 23 characters. On the real blocked backlog the field grew past 70 and the titles were effectively gone.

Same data, same 100-column terminal:

```
DEPENDENCIES                                       TITLE
[task_c0,task_c1,task_c2,task_c3,task_c4,task_c5]  Another title

DEPENDENCIES          TITLE
[task_c0,task_c1,+4]  Another title that used to be cut to ribbons
```

23 columns of title → **52**.

## The overflow marker carries a count

`[task_c0,task_c1,+4]`, not `[task_c0,task_c1,ta…`. A bare truncation tells the reader neither how many blockers there are nor that any are missing — and **the number of things holding a task is exactly what a listing is scanned for**. The full list is one `mac task show` away.

When even one id will not fit it reports `[+2]` rather than a fragment: a truncated id looks like a real id and resolves to nothing.

The cap (20) holds one real short id — 13 chars — plus the marker, matching the common case: on this hub almost every blocked task has exactly one unsatisfied blocker.

## On the missing PROJECT column

Not a bug, but reported alongside so worth naming: the table drops PROJECT when the listing is already scoped to one project, which is the default since #407. `mac task list --all` restores it, and the `scoping to project 'mac'` banner says which one you're in.

## Verification

11 new tests, all failing without the change. `tests/cli` — **622 passed**. One existing test asserted `[task_root,task_peer]` in full; its synthetic 9-char ids are two-thirds of a real pair, so it now asserts the surviving property — the first blocker **and** the count of the rest. Dead-code clean; registry and docs current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
