### PR TITLE
Tell the client when it is older than the hub

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -1029,6 +1029,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_SUPERVISOR_COMMAND_TIMEOUT_SECONDS` | int | consumer-defined | core | Core setting: supervisor command timeout seconds. |
 | `MAC_SUPERVISOR_INCLUDE_ROOT` | str | consumer-defined | core | Core setting: supervisor include root. |
 | `MAC_SUPERVISOR_KIND` | str | consumer-defined | core | Core setting: supervisor kind. |
+| `MAC_SUPPRESS_VERSION_WARNING` | str | consumer-defined | core | Core setting: suppress version warning. |
 | `MAC_SYSTEMD_COMMAND_TIMEOUT_SECONDS` | int | consumer-defined | core | Core setting: systemd command timeout seconds. |
 | `MAC_TAILSCALE_HOSTNAME` | str | consumer-defined | core | Core setting: tailscale hostname. |
 | `MAC_TAILSCALE_IP` | str | consumer-defined | core | Core setting: tailscale ip. |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -4667,6 +4667,32 @@ def create_app(
         )
 
     @app.middleware("http")
+    async def advertise_version(request: Request, call_next: Any) -> Any:
+        """Stamp the hub's version on every response.
+
+        A HEADER rather than an endpoint, so a client learns the hub's version
+        from a request it was already making. Version skew is worth telling
+        people about; it is not worth a round trip per command.
+
+        This exists because a stale CLI fails in a way that names nothing
+        useful. After the publication lane was removed the hub stopped
+        returning `publication_route`, so an older CLI took its backfill path
+        and reported:
+
+            `mac task_publication_routes` is not yet supported in hub mode.
+
+        `mac task list` was simply broken, and nothing in that message says
+        "you are several versions behind". See `mac.http_client`, which turns
+        this header into one line that does.
+        """
+        response = await call_next(request)
+        try:
+            response.headers["X-MAC-Version"] = __version__
+        except Exception:  # noqa: BLE001 - a header must never fail a response
+            pass
+        return response
+
+    @app.middleware("http")
     async def authenticate(request: Request, call_next: Any) -> Any:
         started = time.monotonic()
         status_code = 500

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -12145,6 +12145,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: suppress version warning.",
+    "family": "core",
+    "name": "MAC_SUPPRESS_VERSION_WARNING",
+    "retired": false,
+    "sources": [
+      "src/mac/http_client.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: systemd command timeout seconds.",
     "family": "core",
     "name": "MAC_SYSTEMD_COMMAND_TIMEOUT_SECONDS",

--- a/src/mac/http_client.py
+++ b/src/mac/http_client.py
@@ -142,7 +142,13 @@ class HubClient:
         try:
             with urllib.request.urlopen(request, timeout=30) as response:
                 payload = response.read().decode("utf-8")
-                _note_hub_version(response.headers.get("X-MAC-Version"))
+                # getattr, not response.headers: a transport is anything with
+                # .read(), and tests/test_infrastructure_coverage.py passes a
+                # fake that has no headers at all. A version check must not be
+                # able to break a request -- see _note_hub_version.
+                headers = getattr(response, "headers", None)
+                if headers is not None:
+                    _note_hub_version(headers.get("X-MAC-Version"))
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
             raise HubClientError("HTTP %s %s: %s" % (exc.code, exc.reason, detail))

--- a/src/mac/http_client.py
+++ b/src/mac/http_client.py
@@ -10,13 +10,56 @@ without round-tripping through ``urllib``.
 from __future__ import annotations
 
 import json
+import os
+import sys
 import urllib.error
 import urllib.request
 from typing import Any, Callable, Dict, Optional
 
 
 JsonDict = Dict[str, Any]
+from mac import __version__
+
 Transport = Callable[[str, str, Optional[JsonDict], Optional[str]], Any]
+
+
+_VERSION_WARNED = False
+
+
+def _note_hub_version(hub_version: Optional[str]) -> None:
+    """Warn once if this client is older than the hub it is talking to.
+
+    A stale client does not fail with "you are out of date"; it fails with
+    whatever internal seam happens to break first. When the publication lane
+    was removed the hub stopped returning `publication_route`, an older CLI
+    took its backfill path, and `mac task list` died with:
+
+        `mac task_publication_routes` is not yet supported in hub mode.
+
+    Nothing in that names the actual problem. One line here does.
+
+    Deliberately NOT an error and never a refusal: an old client mostly works,
+    and breaking it outright is worse than the skew. Warn once per process, on
+    stderr so it cannot corrupt `--json` output, and suppressible for anyone
+    who has decided to live with it.
+    """
+    global _VERSION_WARNED
+    if _VERSION_WARNED or not hub_version:
+        return
+    hub = str(hub_version).strip()
+    if not hub or hub == __version__:
+        return
+    if os.environ.get("MAC_SUPPRESS_VERSION_WARNING") == "1":
+        _VERSION_WARNED = True
+        return
+    _VERSION_WARNED = True
+    print(
+        "mac: this client is %s but the hub is %s. Re-run `make install` in "
+        "your mac checkout if commands start failing in ways that name "
+        "internal methods. (MAC_SUPPRESS_VERSION_WARNING=1 to silence.)"
+        % (__version__, hub),
+        file=sys.stderr,
+    )
 
 
 class HubClientError(RuntimeError):
@@ -99,6 +142,7 @@ class HubClient:
         try:
             with urllib.request.urlopen(request, timeout=30) as response:
                 payload = response.read().decode("utf-8")
+                _note_hub_version(response.headers.get("X-MAC-Version"))
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", errors="replace")
             raise HubClientError("HTTP %s %s: %s" % (exc.code, exc.reason, detail))

--- a/tests/test_cli_hub_version_skew.py
+++ b/tests/test_cli_hub_version_skew.py
@@ -1,0 +1,141 @@
+"""A client that is older than the hub should say so.
+
+WHY THIS EXISTS. A stale client does not fail with "you are out of date"; it
+fails at whatever internal seam breaks first. When the publication lane was
+removed the hub stopped returning `publication_route`, an older CLI took its
+backfill path, and `mac task list` died with:
+
+    `mac task_publication_routes` is not yet supported in hub mode.
+    Pass --db <path> to run against a database directly, or wait for the
+    matching hub endpoint to be wrapped in RemoteDispatch.
+
+Nothing in that names the real problem, and the suggested remedies are both
+wrong for it. This turns that into one line naming both versions.
+
+DESIGN. A response HEADER, not an endpoint: the client learns the hub's version
+from a request it was already making. Skew is worth reporting; it is not worth
+a round trip per command.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mac import __version__
+from mac import http_client as hc
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned():
+    hc._VERSION_WARNED = False
+    yield
+    hc._VERSION_WARNED = False
+
+
+def _stderr(monkeypatch):
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stderr", buf)
+    return buf
+
+
+# --------------------------------------------------------------------------
+# the hub advertises
+# --------------------------------------------------------------------------
+
+
+def test_every_response_carries_the_hub_version():
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+
+    assert client.get("/health").headers.get("X-MAC-Version") == __version__
+
+
+def test_the_header_is_on_authenticated_routes_too():
+    """The auth middleware has two return paths -- a public-route early return
+    and the relay-scoped one. A header on only one of them is a header the
+    client sees intermittently, which is worse than none."""
+    client = TestClient(create_app(control_plane=ControlPlane.in_memory()))
+
+    resp = client.get("/tasks")
+
+    assert resp.headers.get("X-MAC-Version") == __version__
+
+
+# --------------------------------------------------------------------------
+# the client notices
+# --------------------------------------------------------------------------
+
+
+def test_a_newer_hub_produces_one_warning(monkeypatch):
+    buf = _stderr(monkeypatch)
+    monkeypatch.delenv("MAC_SUPPRESS_VERSION_WARNING", raising=False)
+
+    hc._note_hub_version("99.0.0")
+
+    out = buf.getvalue()
+    assert __version__ in out and "99.0.0" in out
+    assert "make install" in out, "the warning must say what to do about it"
+
+
+def test_it_warns_only_once_per_process(monkeypatch):
+    buf = _stderr(monkeypatch)
+    monkeypatch.delenv("MAC_SUPPRESS_VERSION_WARNING", raising=False)
+
+    for _ in range(5):
+        hc._note_hub_version("99.0.0")
+
+    assert buf.getvalue().count("make install") == 1
+
+
+def test_a_matching_version_says_nothing(monkeypatch):
+    buf = _stderr(monkeypatch)
+
+    hc._note_hub_version(__version__)
+
+    assert buf.getvalue() == ""
+
+
+def test_a_hub_that_sends_no_header_says_nothing(monkeypatch):
+    """An older hub predates the header. Silence, not a false alarm."""
+    buf = _stderr(monkeypatch)
+
+    hc._note_hub_version(None)
+    hc._note_hub_version("")
+
+    assert buf.getvalue() == ""
+
+
+def test_it_can_be_suppressed(monkeypatch):
+    buf = _stderr(monkeypatch)
+    monkeypatch.setenv("MAC_SUPPRESS_VERSION_WARNING", "1")
+
+    hc._note_hub_version("99.0.0")
+
+    assert buf.getvalue() == ""
+
+
+def test_it_goes_to_stderr_so_json_output_stays_parseable(monkeypatch):
+    """`mac --json ... | jq` must not break because the client is a version
+    behind."""
+    out_buf = io.StringIO()
+    err_buf = _stderr(monkeypatch)
+    monkeypatch.setattr(sys, "stdout", out_buf)
+    monkeypatch.delenv("MAC_SUPPRESS_VERSION_WARNING", raising=False)
+
+    hc._note_hub_version("99.0.0")
+
+    assert out_buf.getvalue() == ""
+    assert err_buf.getvalue() != ""
+
+
+def test_it_never_raises(monkeypatch):
+    """A version check must not be able to fail a command."""
+    monkeypatch.delenv("MAC_SUPPRESS_VERSION_WARNING", raising=False)
+    _stderr(monkeypatch)
+
+    hc._note_hub_version(object())  # type: ignore[arg-type]


### PR DESCRIPTION
A stale client doesn't fail with "you are out of date" — it fails at whatever internal seam breaks first.

Removing the publication lane (#424) stopped the hub returning `publication_route`. An older CLI took its backfill path, and `mac task list` died with:

```
`mac task_publication_routes` is not yet supported in hub mode.
Pass --db <path> to run against a database directly, or wait for the
matching hub endpoint to be wrapped in RemoteDispatch.
```

Nothing there names the real problem, and **both suggested remedies are wrong for it**. This happened twice today on two different machines, and I misread it as a CLI bug the first time.

## A header, not an endpoint

The hub stamps `X-MAC-Version` on every response, so a client learns the hub's version from a request it was already making. Skew is worth reporting; it isn't worth a round trip per command.

Implemented as a **separate middleware** rather than an edit to `authenticate`, which has two return paths — the public-route early return and the relay-scoped one. A header on only one of them is a header the client sees intermittently, which is worse than none. There's a test for exactly that.

## Warn, never refuse

An old client mostly works, and breaking it outright is worse than the skew. So:

- **one line per process**, not per request
- **stderr**, so `mac --json … | jq` stays parseable
- `MAC_SUPPRESS_VERSION_WARNING=1` to silence
- **cannot raise** — a version check must not be able to fail a command
- a hub with no header predates it → silence, not a false alarm

```
mac: this client is 1.0.0 but the hub is 1.1.0. Re-run `make install` in your
mac checkout if commands start failing in ways that name internal methods.
```

## Verification

9 tests. 604 passed across the new suite, `tests/api/test_api.py` and the public contract. Dead-code clean; env registry regenerated.

Closes `task_6a328dfe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
