### PR TITLE
An MCP server for the ledger, wired into the agents that will use it

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -247,6 +247,7 @@ Fleet and machines:
   machine        hosts that agents run on
   hgx            HGX / GPU capacity management
   openshell      sandboxed execution environments for agents
+  mcp            serve the ledger to coding agents as Model Context Protocol tools
   sandbox-image  the sandbox IMAGE: its bill of materials and its rollout
   runtime        runtime images and environment definitions
   rollout        staged rollout of a runtime or configuration

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -802,6 +802,23 @@ def _plane(args: argparse.Namespace) -> Any:
     return resolve_dispatch(args)
 
 
+def cmd_mcp_serve(args: argparse.Namespace) -> None:
+    """Serve the mac ledger to a coding agent as MCP tools, over stdio.
+
+    A subcommand rather than a standalone script so the server resolves
+    wherever the CLI does. `executor_sandbox` notes that MCP wiring is
+    unconfined-only because "the host config path + host MCP-server interpreter
+    do not reliably resolve inside the sandbox" -- `mac admin mcp serve` has no
+    interpreter path to resolve.
+
+    The plane is the same RemoteDispatch the CLI uses, so every route this
+    serves is a route `tests/test_dispatch_route_contract.py` already checks.
+    """
+    from mac.mcp_server import serve
+
+    raise SystemExit(serve(_plane(args)))
+
+
 def cmd_init(args: argparse.Namespace) -> None:
     """Initialize the local mac control-plane database."""
     _plane(args)
@@ -8796,6 +8813,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _set(cmd_hgx_capacity_mark_onboarded, hgx_capacity_mark_onboarded)
 
+    mcp = sub.add_parser(
+        "mcp", help="Model Context Protocol server for coding agents"
+    ).add_subparsers(dest="mcp_command", required=True)
+    mcp_serve = mcp.add_parser(
+        "serve", help="serve the mac ledger to a coding agent over stdio"
+    )
+    _set(cmd_mcp_serve, mcp_serve)
     openshell = sub.add_parser("openshell", help="OpenShell sandbox guardrail commands").add_subparsers(dest="openshell_command", required=True)
     osh_reconcile = openshell.add_parser(
         "reconcile",

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -195,6 +195,7 @@ COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
             ("machine", "hosts that agents run on"),
             ("hgx", "HGX / GPU capacity management"),
             ("openshell", "sandboxed execution environments for agents"),
+            ("mcp", "serve the ledger to coding agents as Model Context Protocol tools"),
             ("sandbox-image", "the sandbox IMAGE: its bill of materials and its rollout"),
             ("runtime", "runtime images and environment definitions"),
             ("rollout", "staged rollout of a runtime or configuration"),

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -52,6 +52,7 @@ import contextlib
 import ctypes
 import hashlib
 import json
+import logging
 import os
 import re as _re
 import shlex
@@ -4884,6 +4885,32 @@ def _record_runner_choice(
         pass
 
 
+def _write_mac_mcp_config(*, task_id: str = "") -> Optional[str]:
+    """Write an MCP client config registering mac's own tool server.
+
+    Best-effort: a coding agent that cannot be handed tools must still run. A
+    failure here returns None, which is exactly the state everything was in
+    before, so the worst case is the previous behaviour rather than a lost task.
+    """
+    try:
+        from mac import coding_agent as _ca
+        from mac.mcp_server import server_command
+
+        document = _ca.mcp_config_document(server_command(), name="mac")
+        directory = Path(tempfile.mkdtemp(prefix="mac-mcp-"))
+        path = directory / "mcp.json"
+        path.write_text(json.dumps(document, indent=2, sort_keys=True), encoding="utf-8")
+        return str(path)
+    except Exception:  # noqa: BLE001 - tools are an enhancement, not a gate
+        logging.getLogger("mac.executor_sandbox").warning(
+            "could not write the mac MCP config for task %s; the agent will run "
+            "without ledger tools",
+            task_id or "<unknown>",
+            exc_info=True,
+        )
+        return None
+
+
 def _coding_agent_required_failure_argv(reason: str) -> List[str]:
     msg = (
         "task execution requires an available coding agent and, when confined, "
@@ -5454,14 +5481,29 @@ def _agent_argv(
         _record_runner_choice("coding-agent-required", rationale, task_id=task_id)
         return _coding_agent_required_failure_argv(reason)
 
-    # MCP wiring is unconfined-only: the host config path + host MCP-server
-    # interpreter do not reliably resolve inside the sandbox (messaging-MCP parity
-    # there is provisioned image-side). Hub parity (mac CLI + runtime context)
-    # still applies regardless.
     # Human-facing delivery is owned exclusively by the OpenClaw gateway.  Do
     # not inject the retired vendored-Hermes messaging MCP into coding agents;
     # task-to-human messages flow through MAC's durable delivery outbox instead.
+    #
+    # What IS injected is mac's own ledger, as typed tools. `mcp_path` sat at
+    # None from the retirement of the messaging MCP until now, which meant the
+    # whole injection path -- mcp_config_document, supports_per_invocation_mcp,
+    # and the --mcp-config insertion in coding_agent_argv -- was built and
+    # never fed. ADR-0006 records the ACP->AgentBus half being removed after a
+    # census found zero streams on its topic; a wired socket with nothing in it
+    # is the same story told slower.
+    #
+    # UNCONFINED ONLY, deliberately. The previous note here said MCP wiring
+    # cannot work confined because "the host config path + host MCP-server
+    # interpreter do not reliably resolve inside the sandbox". The interpreter
+    # half no longer applies -- `mac admin mcp serve` resolves wherever the CLI
+    # does -- but the CONFIG PATH half is unverified: this writes a file on the
+    # host and hands its path to the agent, and that path is not known to exist
+    # inside the sandbox. Enabling it there needs a check that the file is
+    # visible, not an assumption. Tracked rather than guessed.
     mcp_path = None
+    if not confined:
+        mcp_path = _write_mac_mcp_config(task_id=task_id)
     if confined:
         rationale.append("verified inside the OpenShell sandbox")
     _record_runner_choice(

--- a/src/mac/mcp_server.py
+++ b/src/mac/mcp_server.py
@@ -1,0 +1,298 @@
+"""An MCP server exposing the mac ledger to coding agents.
+
+WHY THIS IS A CLIENT AND NOT A SECOND IMPLEMENTATION. Every tool here goes
+through :class:`mac.dispatch.RemoteDispatch` -- the same seam ``cli.py`` uses --
+so the routes it calls are the routes the CLI calls, and
+``tests/test_dispatch_route_contract.py`` proves both against the live FastAPI
+route table. A tool surface that spoke to the hub its own way would be a third
+thing to drift: #418 was the CLI and the API disagreeing about one query
+parameter, with nothing comparing them.
+
+WHY TOOLS RATHER THAN A SHELL. A coding agent driving `mac` today parses a
+table. Nearly every CLI defect this fleet has produced lived in that seam -- a
+LANE column that could only ever print one value, short ids that 500'd
+`mac task release`, `--all-states` failing when `--json` preceded it, a
+DEPENDENCIES column that starved every title. A typed tool call has none of
+those failure modes.
+
+WHY IT IS A ``mac`` SUBCOMMAND. The sandbox notes in ``executor_sandbox`` say
+MCP wiring is unconfined-only because "the host config path + host MCP-server
+interpreter do not reliably resolve inside the sandbox". A server launched as
+``mac admin mcp serve`` has no interpreter path to resolve: it runs wherever
+the CLI already runs.
+
+The protocol is JSON-RPC 2.0 over stdio -- ``initialize``, ``tools/list``,
+``tools/call`` -- implemented directly rather than pulled in, because that is
+about a hundred lines and a dependency is a thing to keep current.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Callable, Dict, List, Optional, TextIO
+
+JsonDict = Dict[str, Any]
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "mac"
+
+
+def _text(payload: Any) -> JsonDict:
+    """An MCP tool result carrying JSON as text.
+
+    Tools return JSON rather than the CLI's table rendering on purpose: the
+    rendering is for eyes, and a model re-parsing it is exactly the seam this
+    server exists to remove.
+    """
+    return {
+        "content": [
+            {"type": "text", "text": json.dumps(payload, indent=2, sort_keys=True, default=str)}
+        ]
+    }
+
+
+def _error(message: str) -> JsonDict:
+    """A tool-level failure.
+
+    ``isError`` rather than a JSON-RPC error: the call was well-formed and the
+    model should see what went wrong and adapt, not have the transport report a
+    protocol fault.
+    """
+    return {"content": [{"type": "text", "text": message}], "isError": True}
+
+
+def _as_dicts(rows: Any) -> List[JsonDict]:
+    out = []
+    for row in rows or []:
+        to_dict = getattr(row, "to_dict", None)
+        out.append(to_dict() if callable(to_dict) else dict(row))
+    return out
+
+
+def _one(record: Any) -> Any:
+    to_dict = getattr(record, "to_dict", None)
+    return to_dict() if callable(to_dict) else record
+
+
+class MacTools:
+    """The tool surface, bound to a dispatch plane.
+
+    Deliberately small. The retired Hermes plugin exposed eight tools including
+    notification acknowledgement, which is a persona concern; a coding agent
+    working a task needs to see its task, find work, and file what it learned.
+    """
+
+    def __init__(self, plane: Any) -> None:
+        self._plane = plane
+
+    def descriptors(self) -> List[JsonDict]:
+        return [
+            {
+                "name": "mac_task_show",
+                "description": (
+                    "Show one task: state, project, dependencies, and metadata. "
+                    "Accepts an abbreviated id (task_1a2b3c4d)."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"task_id": {"type": "string"}},
+                    "required": ["task_id"],
+                },
+            },
+            {
+                "name": "mac_task_list",
+                "description": (
+                    "List tasks. Defaults to active work only; pass all_states "
+                    "to include completed, failed and cancelled."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "project": {"type": "string"},
+                        "state": {"type": "string"},
+                        "all_states": {"type": "boolean"},
+                        "limit": {"type": "integer"},
+                    },
+                },
+            },
+            {
+                "name": "mac_task_ready",
+                "description": (
+                    "Tasks that are open, unclaimed, and have no unfinished "
+                    "dependencies -- what the fleet could actually pick up now."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "project": {"type": "string"},
+                        "limit": {"type": "integer"},
+                    },
+                },
+            },
+            {
+                "name": "mac_task_create",
+                "description": (
+                    "File a task. Use this to record follow-up work rather than "
+                    "leaving a TODO in the code."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "description": {"type": "string"},
+                        "project": {"type": "string"},
+                    },
+                    "required": ["title"],
+                },
+            },
+        ]
+
+    # -- implementations ----------------------------------------------------
+
+    def mac_task_show(self, task_id: str = "", **_: Any) -> JsonDict:
+        if not str(task_id or "").strip():
+            return _error("task_id is required")
+        return _text(_one(self._plane.get_task(str(task_id).strip())))
+
+    def mac_task_list(
+        self,
+        project: Optional[str] = None,
+        state: Optional[str] = None,
+        all_states: bool = False,
+        limit: Optional[int] = None,
+        **_: Any,
+    ) -> JsonDict:
+        from mac.models import ACTIVE_TASK_STATES
+
+        # Mirrors the CLI's default (#407): active work unless asked otherwise.
+        # A tool that returned 3,500 cancelled tasks by default would be the
+        # same unusable view the CLI had before that change.
+        selector: Any = state
+        if not selector and not all_states:
+            selector = ACTIVE_TASK_STATES
+        return _text(
+            _as_dicts(
+                self._plane.list_tasks(selector, project=project, limit=limit)
+            )
+        )
+
+    def mac_task_ready(
+        self, project: Optional[str] = None, limit: Optional[int] = None, **_: Any
+    ) -> JsonDict:
+        return _text(
+            _as_dicts(self._plane.ready_tasks(project=project, limit=limit))
+        )
+
+    def mac_task_create(
+        self,
+        title: str = "",
+        description: str = "",
+        project: Optional[str] = None,
+        **_: Any,
+    ) -> JsonDict:
+        if not str(title or "").strip():
+            return _error("title is required")
+        return _text(
+            _one(
+                self._plane.create_task(
+                    str(title).strip(),
+                    description=str(description or ""),
+                    project=project,
+                )
+            )
+        )
+
+    def call(self, name: str, arguments: JsonDict) -> JsonDict:
+        handler: Optional[Callable[..., JsonDict]] = getattr(self, name, None)
+        if handler is None or name not in {d["name"] for d in self.descriptors()}:
+            return _error("unknown tool: %s" % name)
+        try:
+            return handler(**(arguments or {}))
+        except Exception as exc:  # noqa: BLE001 - surface it to the model
+            # A hub error is information the agent can act on ("that task does
+            # not exist"), not a transport fault. Never let it kill the server:
+            # the agent is mid-task and a dead tool server strands it.
+            return _error("%s: %s" % (type(exc).__name__, exc))
+
+
+class MCPServer:
+    """JSON-RPC 2.0 over stdio."""
+
+    def __init__(self, tools: MacTools) -> None:
+        self.tools = tools
+
+    def handle(self, message: JsonDict) -> Optional[JsonDict]:
+        """Return a response, or None for a notification.
+
+        A notification has no ``id`` and MUST NOT be answered; replying to one
+        is a protocol violation that some clients treat as a fatal desync.
+        """
+        method = str(message.get("method") or "")
+        message_id = message.get("id")
+        if message_id is None:
+            return None
+        if method == "initialize":
+            return self._ok(
+                message_id,
+                {
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": SERVER_NAME, "version": _version()},
+                },
+            )
+        if method == "tools/list":
+            return self._ok(message_id, {"tools": self.tools.descriptors()})
+        if method == "tools/call":
+            params = message.get("params") or {}
+            return self._ok(
+                message_id,
+                self.tools.call(
+                    str(params.get("name") or ""), params.get("arguments") or {}
+                ),
+            )
+        return {
+            "jsonrpc": "2.0",
+            "id": message_id,
+            "error": {"code": -32601, "message": "method not found: %s" % method},
+        }
+
+    @staticmethod
+    def _ok(message_id: Any, result: JsonDict) -> JsonDict:
+        return {"jsonrpc": "2.0", "id": message_id, "result": result}
+
+    def serve(self, stdin: TextIO, stdout: TextIO) -> int:
+        for line in stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                # Malformed input is the client's problem, and a server that
+                # exits on it takes the agent's session with it.
+                continue
+            response = self.handle(message)
+            if response is not None:
+                stdout.write(json.dumps(response) + "\n")
+                stdout.flush()
+        return 0
+
+
+def _version() -> str:
+    from mac import __version__
+
+    return __version__
+
+
+def server_command() -> List[str]:
+    """The argv that launches this server.
+
+    A ``mac`` subcommand, so it resolves wherever the CLI does rather than
+    needing a host interpreter path the sandbox cannot see.
+    """
+    return ["mac", "admin", "mcp", "serve"]
+
+
+def serve(plane: Any, stdin: Optional[TextIO] = None, stdout: Optional[TextIO] = None) -> int:
+    return MCPServer(MacTools(plane)).serve(stdin or sys.stdin, stdout or sys.stdout)

--- a/tests/cli/test_cli_mcp_serve.py
+++ b/tests/cli/test_cli_mcp_serve.py
@@ -1,0 +1,88 @@
+"""`mac mcp serve` at the CLI layer.
+
+The module-level behaviour is covered by tests/test_mcp_server.py. This is the
+layer a coding agent actually launches -- `mac admin mcp serve`, handed to it
+in an --mcp-config -- and a server that works as a module but not as a
+subcommand is a server nothing can start.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import dsn_for
+
+
+def _run(tmp_path, *args, stdin=""):
+    """Run `mac --db <tmp> <args>` with a scripted stdin, returning stdout."""
+    out = io.StringIO()
+    old_out, old_in = sys.stdout, sys.stdin
+    sys.stdout, sys.stdin = out, io.StringIO(stdin)
+    try:
+        rc = main(["--db", dsn_for(tmp_path), *args])
+    except SystemExit as exc:  # serve() exits with its return code
+        rc = exc.code or 0
+    finally:
+        sys.stdout, sys.stdin = old_out, old_in
+    return rc, out.getvalue()
+
+
+def test_mcp_serve_exits_cleanly_on_closed_stdin(tmp_path):
+    """The agent closing the pipe is a normal end, not a failure."""
+    rc, out = _run(tmp_path, "admin", "mcp", "serve")
+
+    assert rc == 0
+    assert out == ""
+
+
+def test_mcp_serve_answers_a_handshake(tmp_path):
+    """The real thing: initialize, then list the tools, over stdio."""
+    stdin = "\n".join(
+        json.dumps(m)
+        for m in (
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        )
+    ) + "\n"
+
+    rc, out = _run(tmp_path, "admin", "mcp", "serve", stdin=stdin)
+
+    assert rc == 0
+    responses = [json.loads(line) for line in out.splitlines() if line.strip()]
+    # Two, not three: the notification must not be answered.
+    assert [r["id"] for r in responses] == [1, 2]
+    assert responses[0]["result"]["serverInfo"]["name"] == "mac"
+    assert {t["name"] for t in responses[1]["result"]["tools"]} == {
+        "mac_task_show",
+        "mac_task_list",
+        "mac_task_ready",
+        "mac_task_create",
+    }
+
+
+def test_mcp_serve_reaches_the_real_control_plane(tmp_path):
+    """A tool call must go through the resolved plane, not a stub."""
+    created = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "mac_task_create",
+                "arguments": {"title": "filed by a coding agent", "project": "mac"},
+            },
+        }
+    )
+
+    rc, out = _run(tmp_path, "admin", "mcp", "serve", stdin=created + "\n")
+
+    assert rc == 0
+    payload = json.loads(json.loads(out.strip())["result"]["content"][0]["text"])
+    assert payload["title"] == "filed by a coding agent"
+    assert payload["id"].startswith("task_")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,244 @@
+"""The MCP server: a client of the hub's routes, with a consumer.
+
+TWO PROPERTIES, and the second is the one this repository keeps failing.
+
+1. It is a CLIENT, not a second implementation. Every tool goes through
+   RemoteDispatch -- the seam cli.py uses -- so the routes it calls are the
+   routes tests/test_dispatch_route_contract.py already proves against the live
+   FastAPI route table. #418 was the CLI and the API disagreeing about one
+   query parameter with nothing comparing them; a third surface speaking to the
+   hub its own way would be that again.
+
+2. It is CONSUMED. `mcp_path` sat at None from the retirement of the vendored
+   Hermes messaging MCP until now, so mcp_config_document,
+   supports_per_invocation_mcp and the --mcp-config insertion were all built
+   and never fed. ADR-0006 records the ACP->AgentBus half being removed after a
+   census found zero streams on its topic. A server nothing launches is that
+   story told slower.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+
+import pytest
+
+from mac.mcp_server import MacTools, MCPServer, server_command
+
+
+class _Plane:
+    """A stand-in for RemoteDispatch that records what it was asked."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get_task(self, task_id):
+        self.calls.append(("get_task", task_id))
+        return {"id": task_id, "state": "open", "title": "a task"}
+
+    def list_tasks(self, state=None, project=None, limit=None, **kw):
+        self.calls.append(("list_tasks", state, project, limit))
+        return [{"id": "task_1", "state": "open"}]
+
+    def ready_tasks(self, project=None, limit=None):
+        self.calls.append(("ready_tasks", project, limit))
+        return [{"id": "task_2", "state": "open"}]
+
+    def create_task(self, title, description="", project=None):
+        self.calls.append(("create_task", title, description, project))
+        return {"id": "task_new", "title": title}
+
+
+def _rpc(server, method, params=None, message_id=1):
+    return server.handle(
+        {"jsonrpc": "2.0", "id": message_id, "method": method, "params": params or {}}
+    )
+
+
+@pytest.fixture()
+def plane():
+    return _Plane()
+
+
+@pytest.fixture()
+def server(plane):
+    return MCPServer(MacTools(plane))
+
+
+# --------------------------------------------------------------------------
+# protocol
+# --------------------------------------------------------------------------
+
+
+def test_initialize_reports_the_protocol_and_the_tool_capability(server):
+    result = _rpc(server, "initialize")["result"]
+
+    assert result["protocolVersion"]
+    assert "tools" in result["capabilities"]
+    assert result["serverInfo"]["name"] == "mac"
+
+
+def test_a_notification_is_never_answered(server):
+    """A message with no id MUST NOT get a response. Replying desyncs clients
+    that treat an unsolicited response as a protocol fault."""
+    assert server.handle({"jsonrpc": "2.0", "method": "notifications/initialized"}) is None
+
+
+def test_an_unknown_method_is_a_jsonrpc_error(server):
+    response = _rpc(server, "tools/nope")
+
+    assert response["error"]["code"] == -32601
+
+
+def test_malformed_input_does_not_kill_the_server(server):
+    """The agent is mid-task; a dead tool server strands it."""
+    out = io.StringIO()
+    server.serve(io.StringIO('not json\n\n{"jsonrpc":"2.0","id":7,"method":"tools/list"}\n'), out)
+
+    lines = [l for l in out.getvalue().splitlines() if l.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["id"] == 7
+
+
+# --------------------------------------------------------------------------
+# the tools
+# --------------------------------------------------------------------------
+
+
+def test_tools_are_listed_with_schemas(server):
+    tools = _rpc(server, "tools/list")["result"]["tools"]
+
+    assert {t["name"] for t in tools} == {
+        "mac_task_show",
+        "mac_task_list",
+        "mac_task_ready",
+        "mac_task_create",
+    }
+    for tool in tools:
+        assert tool["inputSchema"]["type"] == "object"
+        assert tool["description"]
+
+
+def test_every_listed_tool_is_callable(server):
+    """A descriptor without an implementation is a tool that fails only when
+    the model finally tries it."""
+    for tool in _rpc(server, "tools/list")["result"]["tools"]:
+        result = _rpc(server, "tools/call", {"name": tool["name"], "arguments": {}})
+        assert "result" in result
+
+
+def test_show_passes_the_id_through_to_the_plane(server, plane):
+    _rpc(server, "tools/call", {"name": "mac_task_show", "arguments": {"task_id": "task_abc"}})
+
+    assert ("get_task", "task_abc") in plane.calls
+
+
+def test_list_defaults_to_active_work(server, plane):
+    """Same default as the CLI (#407). A tool returning 3,500 cancelled tasks
+    is the unusable view that change removed."""
+    _rpc(server, "tools/call", {"name": "mac_task_list", "arguments": {}})
+
+    _, state, _, _ = plane.calls[0]
+    assert state is not None and "cancelled" not in list(state)
+    assert "open" in list(state)
+
+
+def test_all_states_opts_out(server, plane):
+    _rpc(server, "tools/call", {"name": "mac_task_list", "arguments": {"all_states": True}})
+
+    assert plane.calls[0][1] is None
+
+
+def test_an_explicit_state_wins(server, plane):
+    _rpc(server, "tools/call", {"name": "mac_task_list", "arguments": {"state": "blocked"}})
+
+    assert plane.calls[0][1] == "blocked"
+
+
+def test_create_requires_a_title(server, plane):
+    result = _rpc(server, "tools/call", {"name": "mac_task_create", "arguments": {}})["result"]
+
+    assert result["isError"] is True
+    assert not plane.calls, "an invalid call must not reach the hub"
+
+
+def test_a_hub_failure_is_reported_to_the_model_not_raised(server, plane):
+    """A hub error is information the agent can act on, not a transport fault."""
+    def boom(task_id):
+        raise RuntimeError("task not found: task_zzz")
+
+    plane.get_task = boom
+    result = _rpc(server, "tools/call", {"name": "mac_task_show", "arguments": {"task_id": "task_zzz"}})["result"]
+
+    assert result["isError"] is True
+    assert "task not found" in result["content"][0]["text"]
+
+
+def test_an_unknown_tool_is_an_error_result_not_a_crash(server):
+    result = _rpc(server, "tools/call", {"name": "mac_delete_everything", "arguments": {}})["result"]
+
+    assert result["isError"] is True
+
+
+# --------------------------------------------------------------------------
+# it is a client of the same routes, and it is consumed
+# --------------------------------------------------------------------------
+
+
+def test_the_tools_only_reach_the_hub_through_dispatch():
+    """No direct HTTP. If a tool built its own request the route-contract gate
+    would not see it, and this becomes a third surface that can drift."""
+    import inspect
+
+    from mac import mcp_server
+
+    source = inspect.getsource(mcp_server)
+
+    for forbidden in ("urllib", "requests", "http.client", "HubClient("):
+        assert forbidden not in source, (
+            "%s speaks to the hub directly; every call must go through the "
+            "dispatch plane so tests/test_dispatch_route_contract.py covers it"
+            % forbidden
+        )
+
+
+def test_the_server_command_is_a_mac_subcommand():
+    """It must resolve wherever the CLI does. executor_sandbox notes that a
+    host interpreter path does not reliably resolve inside the sandbox."""
+    assert server_command()[0] == "mac"
+
+    import sys
+
+    sys.argv = ["mac"]
+    from mac.cli import build_parser
+
+    parsed = build_parser().parse_args(server_command()[1:])
+    assert parsed.func.__name__ == "cmd_mcp_serve"
+
+
+def test_the_sandbox_actually_hands_this_config_to_agents():
+    """The property ADR-0006 is a warning about: built, wired, and consumed.
+
+    `mcp_path` was None unconditionally, so the whole injection path existed
+    and was never fed.
+    """
+    from mac.executor_sandbox import _write_mac_mcp_config
+
+    path = _write_mac_mcp_config(task_id="task_t")
+    assert path
+
+    document = json.loads(open(path).read())
+    server = document["mcpServers"]["mac"]
+    assert [server["command"], *server["args"]] == server_command()
+
+
+def test_a_config_write_failure_does_not_stop_the_agent(monkeypatch):
+    """Tools are an enhancement. Losing them must not lose the task."""
+    from mac import executor_sandbox
+
+    monkeypatch.setattr(
+        executor_sandbox.tempfile, "mkdtemp", lambda **kw: (_ for _ in ()).throw(OSError("no space"))
+    )
+
+    assert executor_sandbox._write_mac_mcp_config(task_id="task_t") is None

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -3606,7 +3606,21 @@ def test_invoke_agent_routes_to_coding_agent_when_available(tmp_path, monkeypatc
     assert agent_argv[0] == "/usr/local/bin/claude"
     assert "-p" in agent_argv and agent_argv[-1] == te.PROMPT_SENTINEL
     assert "--dangerously-skip-permissions" in agent_argv
-    assert "--mcp-config" not in agent_argv
+    # An unconfined Claude Code invocation now carries mac's own ledger tools.
+    # This asserted their ABSENCE, which was only ever true because
+    # executor_sandbox set `mcp_path = None` unconditionally -- the whole
+    # injection path was built and never fed. The retired vendored-Hermes
+    # messaging MCP must still stay out; what goes in is mac.
+    assert "--mcp-config" in agent_argv
+    config_path = agent_argv[agent_argv.index("--mcp-config") + 1]
+    servers = json.loads(Path(config_path).read_text(encoding="utf-8"))["mcpServers"]
+    assert set(servers) == {"mac"}, "only mac's tools; no messaging MCP"
+    assert [servers["mac"]["command"], *servers["mac"]["args"]] == [
+        "mac",
+        "admin",
+        "mcp",
+        "serve",
+    ]
     assert not (tmp_path / ".mac-coding-agent-mcp.json").exists()
 
 


### PR DESCRIPTION
Coding agents drive mac by **parsing a table** today — and nearly every CLI defect this fleet has produced lived in that seam: a `LANE` column that could only ever print one value, short ids that 500'd `mac task release`, `--all-states` failing when `--json` preceded it, a `DEPENDENCIES` column that starved every title. A typed tool call has none of those failure modes.

## A client, not a second implementation

Every tool goes through `RemoteDispatch` — the same seam `cli.py` uses — so the routes it calls are the routes **#434 already proves** against the live FastAPI route table.

A test asserts the module contains no `urllib` / `requests` / `HubClient`:

```python
for forbidden in ("urllib", "requests", "http.client", "HubClient("):
    assert forbidden not in source
```

A tool that built its own request would be invisible to that gate and become a third surface free to drift. #418 was two surfaces disagreeing about one query parameter with nothing comparing them.

## And it is consumed

`mcp_path` in `executor_sandbox` sat at `None` from the retirement of the vendored Hermes messaging MCP until now — so `mcp_config_document`, `supports_per_invocation_mcp` and the `--mcp-config` insertion were **all built and never fed**.

ADR-0006 records the ACP→AgentBus half being removed after a census found zero streams on its topic. A wired socket with nothing in it is that story told slower. This feeds it, and a test asserts the config the sandbox writes launches *this* server.

## A `mac` subcommand

So it resolves wherever the CLI does. The old note said MCP wiring couldn't work confined because *"the host config path + host MCP-server interpreter do not reliably resolve inside the sandbox"*. `mac admin mcp serve` has no interpreter path to resolve — but **the config-path half is still unverified**, so this stays unconfined-only and says why, rather than assuming a host temp file is visible inside the sandbox.

## Four tools, deliberately

`mac_task_show`, `mac_task_list`, `mac_task_ready`, `mac_task_create`. The retired Hermes plugin had eight including notification acknowledgement, which is a persona concern.

`mac_task_list` defaults to active work, matching the CLI default from #407 — a tool returning 3,500 cancelled tasks is the unusable view that change removed.

## Protocol

JSON-RPC 2.0 over stdio, implemented directly rather than pulled in: ~100 lines, and a dependency is a thing to keep current.

- a **notification** (no `id`) is never answered — replying desyncs clients that treat it as a protocol fault
- **malformed input** does not kill the server
- a **hub error** becomes an `isError` result rather than a raise — the agent is mid-task, and a dead tool server strands it

## Verification

17 module tests + 3 CLI-level tests, the last of which drives a `tools/call` through `mac admin mcp serve` and asserts the task **really lands in the control plane**. **661 passed** across `tests/cli`, the MCP suites, the route contract and the impact map. Dead-code clean; docs and registry regenerated.

The admin-surface catalogue and CLI-coverage governance gates both required work here and got it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
