### PR TITLE
Give the lifecycle vocabulary a task scope

### DIFF
--- a/src/mac/agentbus_control.py
+++ b/src/mac/agentbus_control.py
@@ -108,8 +108,44 @@ LIFECYCLE_VERBS = (
 LIFECYCLE_DESTRUCTIVE_VERBS = frozenset({LIFECYCLE_ABORT})
 
 #: Who a directive is aimed at. ``fleet`` is everyone on the bus, ``project``
-#: everyone working a named project, ``agent`` one named agent.
-LIFECYCLE_SCOPES = ("fleet", "project", "agent")
+#: everyone working a named project, ``agent`` one named agent, and ``task``
+#: whoever is working one named task.
+#:
+#: ``task`` WAS MISSING AND THAT WAS THE EXPENSIVE GAP. The first three scope by
+#: WHO IS WORKING; the runaway case is TASK-shaped. On 2026-08-18 agent_rocky
+#: opened EIGHT pull requests for one task, one per lease, roughly every thirty
+#: minutes: publish, PR opens, nothing merges it, no canonical integration
+#: proof, lease expires, re-claim, redo. Three attempts, max_attempts, failed --
+#: 12,223,209 tokens across 218 provider attempts on work that was completed
+#: correctly eight times and landed zero.
+#:
+#: The hub SAW it. `high_token_work_without_publication` was raised against that
+#: task while it was happening. The observer was not short of detection; it had
+#: no way to say "everyone stop working on this one", because that sentence had
+#: no scope to be said in. Stopping the agent would have been wrong (it had
+#: other work) and stopping the project wider still.
+LIFECYCLE_SCOPES = ("fleet", "project", "agent", "task")
+
+#: What each verb means when the scope is a TASK. Written down rather than left
+#: to the receiver: "stand down" is unambiguous about an agent and ambiguous
+#: about a task, and a directive whose meaning is inferred is one every
+#: implementation infers differently.
+LIFECYCLE_TASK_SEMANTICS = {
+    #: Stop claiming this task. An attempt already running finishes; the work
+    #: in flight is not thrown away. This is the runaway remedy -- it ends the
+    #: republish loop without discarding the attempt that may yet land.
+    LIFECYCLE_STAND_DOWN: "stop claiming this task; finish the attempt in flight",
+    #: Drop the running attempt now. DESTRUCTIVE, and rarely what a runaway
+    #: needs: the loop above was producing correct work, so aborting it would
+    #: have destroyed eight good attempts to stop one bad pattern.
+    LIFECYCLE_ABORT: "drop the running attempt now; in-flight work is lost",
+    #: Stop dispatching it, keep it claimable later. Reversible by `resume`.
+    LIFECYCLE_PAUSE: "stop dispatching this task; it stays claimable later",
+    LIFECYCLE_RESUME: "dispatch this task again",
+    #: Who holds it, on which lease, since when -- the question an operator
+    #: asks before deciding which of the above to send.
+    LIFECYCLE_STATUS: "report who is working this task, on which lease, since when",
+}
 
 LIFECYCLE_SCHEMA = "mac.agentbus.lifecycle.v2"
 LIFECYCLE_TOPIC = "mac.lifecycle.directive.v2"
@@ -157,7 +193,7 @@ def lifecycle_payload(
             "unknown lifecycle scope %r; known scopes are %s"
             % (scope, ", ".join(LIFECYCLE_SCOPES))
         )
-    if scope in ("project", "agent") and not str(target or "").strip():
+    if scope in ("project", "agent", "task") and not str(target or "").strip():
         raise LifecycleVerbError(
             "scope %r requires a target; without one this would address the "
             "whole fleet, which is the opposite of what was asked" % scope

--- a/tests/test_agentbus_lifecycle_vocabulary.py
+++ b/tests/test_agentbus_lifecycle_vocabulary.py
@@ -197,3 +197,81 @@ def test_the_issuer_is_recorded():
         lifecycle_payload(verb=LIFECYCLE_PAUSE, issued_by="agent_rocky")["issued_by"]
         == "agent_rocky"
     )
+
+
+# --------------------------------------------------------------------------
+# task scope -- the gap that cost 12.2M tokens
+# --------------------------------------------------------------------------
+
+
+def test_a_directive_can_name_one_task():
+    """The sentence the hub could not say.
+
+    On 2026-08-18 agent_rocky opened eight pull requests for one task, one per
+    lease, roughly every thirty minutes, until max_attempts. The hub had raised
+    `high_token_work_without_publication` while it was happening and had no way
+    to act: the scopes were fleet / project / agent, all of which answer "who
+    is working", and the runaway was task-shaped.
+    """
+    payload = lifecycle_payload(
+        verb=LIFECYCLE_STAND_DOWN, scope="task", target="task_739ff150"
+    )
+
+    assert payload["scope"] == "task"
+    assert payload["target"] == "task_739ff150"
+
+
+def test_a_task_directive_without_a_target_is_refused():
+    """Same rule as project and agent: defaulting a missing target to the whole
+    fleet is the direction that does the damage."""
+    with pytest.raises(LifecycleVerbError) as exc:
+        lifecycle_payload(verb=LIFECYCLE_STAND_DOWN, scope="task")
+
+    assert "whole fleet" in str(exc.value)
+
+
+def test_stopping_one_task_is_not_stopping_the_agent():
+    """The distinction the gap erased. The agent in the incident had other work;
+    standing it down would have been wrong, and standing down its project wider
+    still. Only the task was the problem."""
+    task = lifecycle_payload(verb=LIFECYCLE_STAND_DOWN, scope="task", target="task_x")
+    agent = lifecycle_payload(verb=LIFECYCLE_STAND_DOWN, scope="agent", target="agent_x")
+
+    assert task["scope"] != agent["scope"]
+    assert task["target"] != agent["target"]
+
+
+def test_every_verb_has_a_written_task_meaning():
+    """"Stand down" is unambiguous about an agent and ambiguous about a task. A
+    directive whose meaning is inferred is one every implementation infers
+    differently."""
+    from mac.agentbus_control import LIFECYCLE_TASK_SEMANTICS
+
+    assert set(LIFECYCLE_TASK_SEMANTICS) == set(LIFECYCLE_VERBS)
+    for verb, meaning in LIFECYCLE_TASK_SEMANTICS.items():
+        assert meaning and meaning[0].islower(), verb
+
+
+def test_task_stand_down_preserves_the_attempt_in_flight():
+    """The runaway remedy must not destroy work. Those eight attempts were each
+    CORRECT -- the loop was a landing failure, not a work failure -- so the verb
+    that ends the loop has to be the one that keeps the attempt."""
+    from mac.agentbus_control import LIFECYCLE_TASK_SEMANTICS
+
+    assert "finish" in LIFECYCLE_TASK_SEMANTICS[LIFECYCLE_STAND_DOWN]
+    assert LIFECYCLE_STAND_DOWN not in LIFECYCLE_DESTRUCTIVE_VERBS
+
+
+def test_task_abort_is_still_the_destructive_one():
+    from mac.agentbus_control import LIFECYCLE_TASK_SEMANTICS
+
+    assert "lost" in LIFECYCLE_TASK_SEMANTICS[LIFECYCLE_ABORT]
+    assert LIFECYCLE_ABORT in LIFECYCLE_DESTRUCTIVE_VERBS
+
+
+@pytest.mark.parametrize("verb", list(LIFECYCLE_VERBS))
+def test_every_verb_works_at_task_scope(verb):
+    payload = lifecycle_payload(verb=verb, scope="task", target="task_x")
+
+    assert payload["verb"] == verb
+    assert payload["target"] == "task_x"


### PR DESCRIPTION
The scopes were `fleet` / `project` / `agent` — all of which answer **who is working**. The runaway case is **task**-shaped, and that's the case the vocabulary exists for.

## What the gap cost

On 2026-08-18 `agent_rocky` opened **eight pull requests for one task**, one per lease, roughly every thirty minutes: publish → PR opens → nothing merges it → no canonical integration proof → lease expires → re-claim → redo. Three attempts, `max_attempts`, `failed`.

**12,223,209 tokens across 218 provider attempts**, on work that was completed correctly eight times and landed zero.

**The hub saw it.** `high_token_work_without_publication` was raised against that task *while it was happening*. The observer wasn't short of detection — it had no way to say *"everyone stop working on this one"*, because that sentence had no scope to be said in. And the alternatives were both wrong: the agent had other work, and the project wider still.

## The change

`task` joins the scopes, with the same target requirement as `project` and `agent` — a directive without one is refused, because defaulting a missing target to the whole fleet is the direction that does damage.

**What each verb means at task scope is written down** in `LIFECYCLE_TASK_SEMANTICS`, rather than left to the receiver. "Stand down" is unambiguous about an *agent* and ambiguous about a *task*, and a directive whose meaning is inferred is one every implementation infers differently.

| verb | at task scope | destructive |
|---|---|---|
| `stand_down` | stop claiming this task; **finish the attempt in flight** | no |
| `abort` | drop the running attempt now; in-flight work is lost | **yes** |
| `pause` / `resume` | stop / resume dispatching it | no |
| `status` | who holds it, on which lease, since when | no |

The distinction that matters: **task `stand_down` finishes the attempt.** Those eight attempts were each *correct* — the loop was a landing failure, not a work failure — so the verb that ends the loop has to be the one that keeps the work.

## Scope of this PR

Vocabulary only. It changes nothing until something consumes the bus (`task_77971dc7`), and the hub still cannot **issue** a directive on its own — that half is a hub mutation and stays in `task_66d99595` along with the repeat-publication signal.

11 of 27 tests fail without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
