### PR TITLE
Write the user guide from the code, and gate it so it stays true

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing to mac
+
+The bar here is not "tests pass". It is **a reviewer can tell what would have
+to be true for this to be wrong, and the tests check exactly that.**
+
+Everything below is derived from failures this repository actually had. None of
+it is style preference.
+
+## Filing an issue
+
+Issues live in the mac task ledger, not GitHub Issues:
+
+```console
+mac task create "one-line summary" --description-file=desc.txt
+```
+
+Use `--description-file` for anything with parentheses, backticks, `$VAR` or
+newlines — shell quoting will otherwise mangle it silently.
+
+A good issue answers four questions. The order matters, because most bad issues
+skip straight to the fourth.
+
+**1. What did you observe?** Real output, not a paraphrase.
+
+```
+mac task list --project nanolang
+(none)
+
+mac task list --project nanolang --all-states
+task_de63afed  running  ...
+```
+
+**2. How do you know?** Numbers with their provenance. *"498 failures"* is a
+claim; *"498 rows from `select count(*) ... where action_name=... and
+timestamp > '2026-08-19T00:00'`"* is a measurement someone can re-run — and can
+catch you being wrong. Two "measurements" filed here were later found to be
+all-time totals from a broken timestamp filter.
+
+**3. What is the actual mechanism?** Not the symptom. *"`mac task list` is
+empty"* is the symptom; *"the CLI sends repeated `state=` and the route
+declares `Optional[str]`, so FastAPI keeps only the last"* is the bug.
+
+**4. What should happen instead?** Including what must NOT change.
+
+If you cannot answer 3, file it anyway — say so explicitly. An honest *"I do
+not know why"* is more useful than a confident wrong diagnosis, which sends the
+next person somewhere real problems are not.
+
+## Opening a pull request
+
+### Work in a worktree
+
+```console
+git -C ~/Src/mac worktree add /tmp/mac-<task> -b <you>/<task>
+```
+
+Multiple agents run against this repository at once. Sharing the main checkout
+has silently swept unrelated half-finished work into commits. Never `git add
+-A` or `git commit -a` there.
+
+### Before you push
+
+```console
+scripts/run-contract-tests.sh
+bash scripts/dead-code-check.sh
+uv run python scripts/generate-env-config-registry.py --check
+uv run python scripts/generate-docs-reference.py --check
+npx playwright test          # if you touched any UI
+```
+
+Regenerate what you invalidated. Adding an env var, a CLI flag or a route
+staleness-fails a generated artifact, and the gate will catch it 40 minutes
+later instead of now.
+
+### Prove the tests would have caught it
+
+The single most valuable thing in a PR description:
+
+```console
+git stash            # or revert just the source change
+pytest -q tests/test_the_thing.py     # MUST be red
+git stash pop
+```
+
+Then say so: *"11 of 27 tests fail without the change."* A test suite that
+passes before and after the fix has verified nothing, and this is the cheapest
+possible check that yours does not.
+
+### Write the description for the next person
+
+Explain **what was wrong**, **why it was not caught**, and **what you chose not
+to do**. That last one prevents the same debate being re-run in six months.
+
+The good ones here read like:
+
+> `dependencies_width` was the only uncapped column. One task with six blockers
+> took 49 columns and squeezed every title to 23 characters. The overflow marker
+> carries a **count** — `[task_a,+4]` — because a bare truncation tells the
+> reader neither how many blockers there are nor that any are hidden.
+
+### Say what is still broken
+
+If you fixed three of four cases, say which one you did not, and why. A PR that
+implies completeness it does not have is worse than one that scopes itself
+honestly. Several PRs here carry an explicit "what this does not do" section
+and are better for it.
+
+## What gets a PR sent back
+
+- **A test that passes without the change.** It documents nothing.
+- **Weakening a gate to go green.** If `dead-code-check` or the coverage floor
+  fails, fix the code. Lowering a floor to land a change removes the thing that
+  found the change was incomplete.
+- **A generated artifact edited by hand.** Regenerate it. Hand-merging a
+  generated file makes it a lie about what its generator produces.
+- **A claim you did not verify.** "Should be fine on Linux" is not a result. If
+  you did not run it, say you did not.
+- **Silent scope reduction.** Capping, sampling or skipping is fine; doing it
+  without saying so reads as "covered everything" when it did not.
+
+## Reviewing
+
+Ask three questions:
+
+1. **What would have to be true for this to be wrong?** Is that checked?
+2. **What did this stop testing?** A deleted or re-pointed assertion may have
+   been the only thing pinning a real property.
+3. **Does the failure mode announce itself?** The recurring bug class here is
+   the *silent* one — a filter that matches everything, a write that updates
+   zero rows and reports success, a gate that validates a proxy for the thing
+   instead of the thing.
+
+## The house rule
+
+Prefer a system that fails loudly to one that looks healthy.
+
+Nearly every expensive bug in this repository has been the same shape: a check
+that validated something adjacent to what it claimed. A staleness gate that
+checked function names instead of collected tests. A contract that checked
+paths but not parameter shapes. A metadata write that matched zero rows and
+returned success. An injection path fully wired to a value that was always
+`None`.
+
+Each looked correct and enforced nothing. When you add a guarantee, ask what it
+would do if the thing it guards were already broken — and make sure the answer
+is "say so".

--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ The identity framework reflects that split:
 - `platform_binding`: a Slack workspace/channel, Telegram chat, or similar binding.
 - interaction task: a durable task created from a Hermes conversation with origin metadata, not copied private memory.
 
+## Documentation
+
+The guide is in [`docs/guide/`](docs/guide/README.md):
+
+| | |
+|---|---|
+| [System Architecture](docs/guide/01-architecture.md) | what the pieces are and how work flows — mostly diagrams |
+| [Getting Started](docs/guide/02-getting-started.md) | stand up a fleet, run a task, diagnose one that does not move |
+| [Advanced Concepts](docs/guide/03-advanced.md) | leases, evidence, review, publication, and the known gaps |
+| [The UI](docs/guide/04-ui.md) | the read-only console and the mutating Fleet IDE |
+| [Developer Guide](docs/guide/05-developer-guide.md) | how to hack on mac |
+| [Contributing](CONTRIBUTING.md) | filing issues and PRs that are actually tested |
+
+Those pages are written from the code and gated by
+`tests/test_guide_docs_are_true.py`, which checks that every file they name
+exists, every `mac` command they show resolves against the real parser, and
+every edge in the task state diagram is one the control plane allows.
+
 ## Quick Start
 
 ```bash

--- a/docs/guide/01-architecture.md
+++ b/docs/guide/01-architecture.md
@@ -1,0 +1,218 @@
+# System Architecture
+
+This page is generated from reading the code, not from memory. Every state,
+transition and object named here is checked against `src/mac/models.py`,
+`src/mac/data/postgres/schema.sql` and the live route table. Where a capability
+is partial or unwired, it says so.
+
+## The shape of the system
+
+mac is a hub-and-spoke control plane. One **hub** owns the durable state and
+serves an HTTP API; **worker agents** on other machines claim work from it and
+execute that work inside a sandbox. Nothing else is authoritative — an agent's
+local disk is scratch, and the ledger is the truth.
+
+```mermaid
+graph TB
+    subgraph Operator
+        CLI["mac CLI"]
+        UI["Console /ui<br/><i>read-only</i>"]
+        IDE["Fleet IDE<br/><i>mutating</i>"]
+    end
+
+    subgraph Hub["Hub (one per fleet)"]
+        API["FastAPI control plane :8789"]
+        DB[("PostgreSQL<br/>the ledger")]
+        SWEEP["publication worker<br/>review → publish"]
+        RET["retention loop"]
+        MQ["native merge queue"]
+    end
+
+    subgraph Workers["Worker agents (many)"]
+        W1["mac-agent<br/>claim · lease · execute"]
+        SB["OpenShell sandbox"]
+        CA["coding agent CLI<br/>claude / codex / cursor"]
+    end
+
+    FORGE["GitHub"]
+
+    CLI -->|HTTP + bearer| API
+    UI -->|GET only| API
+    IDE -->|HTTP| API
+    API --- DB
+    SWEEP --- DB
+    RET --- DB
+    MQ --- DB
+    W1 -->|heartbeat, claim-next| API
+    W1 --> SB --> CA
+    SWEEP -->|open / merge PR| FORGE
+    W1 -->|push branch, open PR| FORGE
+```
+
+The hub never executes task work. It stores, schedules, reviews and publishes.
+Workers never own state: they lease it.
+
+## First-class objects
+
+Three objects are first-class at the CLI (`mac <object> <verb>`), and the rest
+of the model hangs off them. This is `FIRST_CLASS` in `src/mac/cli_surface.py`,
+not a taxonomy invented for this page:
+
+| object | one line | where it lives |
+|---|---|---|
+| **project** | a unit of work ownership: repositories, policy, dispatch state | `projects`, `project_repositories` |
+| **task** | one unit of work: the thing agents claim, run, and publish | `tasks`, `task_history`, `task_edges` |
+| **agent** | a worker that claims and executes tasks on a machine | `agents`, `machines`, `leases` |
+
+Everything else is administered under `mac admin ...` — fleets, secrets,
+runtimes, AgentBus, observability, memory, reviews, publications.
+
+```mermaid
+erDiagram
+    PROJECT ||--o{ TASK : owns
+    PROJECT ||--o{ REPOSITORY : registers
+    TASK ||--o{ TASK_HISTORY : records
+    TASK ||--o{ EVIDENCE : accumulates
+    TASK ||--o{ REVIEW : "is judged by"
+    TASK ||--o{ LEASE : "is held under"
+    TASK ||--o{ TASK_EDGE : "depends on"
+    MACHINE ||--o{ AGENT : hosts
+    AGENT ||--o{ LEASE : holds
+    FLEET ||--o{ AGENT : registers
+    TASK ||--o{ MERGE_QUEUE_ENTRY : "lands through"
+```
+
+## Actors
+
+An **actor** is anything that can change the ledger. Naming them matters
+because authority differs:
+
+- **Human operator** — full authority through the CLI or the Fleet IDE. Some
+  routes (`/agentbus/human-directive`) *refuse* agent tokens entirely, so
+  operator speech is distinguishable from agent speech by construction.
+- **Hub** — schedules dispatch, runs the review sweep, publishes, prunes. It
+  observes runaway conditions but, today, cannot act on them (see
+  [Advanced Concepts](03-advanced.md#what-the-hub-cannot-do-yet)).
+- **Worker agent** (`mac-agent`) — registers, heartbeats, claims one task at a
+  time under a lease, executes it, submits evidence.
+- **Coding agent** — the CLI (Claude Code, Codex, Cursor) the worker spawns
+  *inside* a sandbox to do the actual work. It is not a mac principal; the
+  worker is.
+- **Reviewer** — an agent or the default review workflow, producing a verdict
+  that gates publication.
+
+## The life of a task
+
+The state machine is enforced by the control plane. These are the real edges
+from `TASK_TRANSITIONS` in `src/mac/models.py`:
+
+```mermaid
+stateDiagram-v2
+    [*] --> open
+    open --> claimed
+    claimed --> running
+    running --> needs_review
+    needs_review --> reviewing
+    reviewing --> completed
+
+    open --> waiting
+    open --> blocked
+    running --> blocked
+    running --> needs_input
+    needs_input --> open
+    blocked --> open
+    waiting --> open
+
+    running --> failed
+    reviewing --> failed
+    failed --> open
+    open --> cancelled
+    cancelled --> open
+
+    completed --> [*]
+```
+
+Two properties surprise people, and both are deliberate:
+
+- **`completed` is the only truly terminal state.** `failed` and `cancelled`
+  both allow `-> open`, because a task that died is often a task to retry.
+- **You cannot jump to `completed`.** It is reachable only from `reviewing`,
+  and only with durable canonical integration proof — a merged commit on the
+  canonical branch. `mac task force-complete` exists as audited break-glass and
+  still refuses without that proof.
+
+## How work actually flows
+
+```mermaid
+sequenceDiagram
+    participant H as Human
+    participant Hub
+    participant W as Worker agent
+    participant S as Sandbox
+    participant G as GitHub
+
+    H->>Hub: mac task create
+    W->>Hub: claim-next (capability + hardware match)
+    Hub-->>W: task + lease
+    W->>S: run coding agent, confined
+    S-->>W: diff, tests, transcript
+    W->>Hub: evidence + submit-for-review
+    Hub->>Hub: review verdict
+    Hub->>G: open / merge pull request
+    G-->>Hub: merged SHA
+    Hub->>Hub: canonical integration proof → completed
+```
+
+The lease is the concurrency primitive: one live lease per task, renewed by
+heartbeat, reclaimed on expiry. A worker that dies mid-task loses its lease and
+the task returns to the pool rather than being stranded.
+
+## Publication and the merge queue
+
+GitHub merge queues are an **organization-only** feature, so a personal
+repository gets no forge-side serialization. mac provides its own
+(`src/mac/native_merge_queue.py`): an ordered queue per
+`(repository, canonical branch)` with an AIMD speculation window.
+
+The safety property is structural rather than bookkeeping: each entry records
+the *tree* it was tested against, and the land gate refuses unless the
+canonical tip's tree is byte-identical. Trees rather than SHAs is what survives
+a squash merge.
+
+```mermaid
+graph LR
+    A["approved task"] --> B["claim_slot"]
+    B --> C{"window has room?"}
+    C -->|no| D["defer<br/>keeps its place"]
+    C -->|yes| E["test on projected base"]
+    E --> F{"tree matches tip?"}
+    F -->|no| G["evict, with a reason"]
+    F -->|yes| H["merge → landed"]
+    H --> I["window += 1"]
+    G --> J["window ÷ 2"]
+```
+
+## Sandboxing
+
+Task execution is confined by OpenShell, and the gate fails closed: if no
+verified sandbox is available, the task fails rather than running unconfined.
+Running unsandboxed requires explicit break-glass.
+
+## AgentBus
+
+A fleet-wide message bus. Workers **emit** typed events from their own git and
+task paths — `git.pushed`, `git.branch_created`, `task.claimed`,
+`task.released`, `capacity.saturated` — and the hub relays them.
+
+**Nothing consumes them yet.** The emit half is built and used; no worker,
+executor or harness reads the bus back. This is a known gap with measured cost,
+documented in [Advanced Concepts](03-advanced.md#agentbus-is-write-only).
+
+## Where to go next
+
+- [Getting Started](02-getting-started.md) — stand up a fleet and run a task
+- [Advanced Concepts](03-advanced.md) — leases, evidence, review, publication,
+  and the known gaps
+- [The UI](04-ui.md) — the console and the Fleet IDE
+- [Developer Guide](05-developer-guide.md) — how to hack on mac
+- [Contributing](https://github.com/jordanhubbard/mac/blob/main/CONTRIBUTING.md) — filing issues and well-tested PRs

--- a/docs/guide/02-getting-started.md
+++ b/docs/guide/02-getting-started.md
@@ -1,0 +1,164 @@
+# Getting Started
+
+From nothing to a fleet that claims and publishes work. Every command here is
+real; where a step can fail in a way that is hard to diagnose, this page says
+so rather than assuming it will not happen.
+
+## What you need first
+
+- **Python 3.11+**. `make install` checks the interpreter *and* the one inside
+  an existing `.venv`, recreating a stale environment rather than installing
+  into it.
+- **PostgreSQL.** The only supported backend. `scripts/start-test-postgres.sh`
+  finds a local server or starts a container and prints the DSN.
+- **`MAC_SECRET_KEY`**, 32+ characters. It derives the Fernet key for the
+  secrets table. Without it the CLI and API both refuse to start — deliberately,
+  because a control plane that boots without its secret key would be storing
+  credentials it cannot protect.
+- **SSH key access** to every host you plan to use, working *before* you begin.
+  The setup wizard configures mac; it does not fix SSH.
+- **At least one LLM provider key** (nvidia / openai / anthropic / perplexity).
+  The wizard will not finish without one, because a fleet with no provider
+  cannot execute a task.
+
+## Install the CLI
+
+```console
+make install
+```
+
+This links `mac` into `~/.local/bin`, builds the Fleet IDE, and installs
+CodeGraph if it is missing. CodeGraph is not needed to build or test mac, but
+`litai init`, the skills and the coding-CLI paths expect it, so `install`
+provisions it rather than leaving you to discover the gap later. Decline with
+`MAC_SKIP_CODEGRAPH_INSTALL=1`.
+
+```console
+mac --version
+```
+
+## Create a fleet
+
+Run the wizard on the machine that will be the hub:
+
+```console
+bash setup.sh
+```
+
+It asks two questions before anything else — whether you are on the machine
+being configured, and whether this is a **hub** or a **worker**. Choose `hub`.
+
+It then collects the fleet name, supervisor (`auto` selects launchd on macOS,
+systemd on Linux), network provider (Tailscale by default), and your provider
+key; writes `~/.mac/fleets.yaml` and `~/.mac/.env`; and deploys.
+
+To write config without deploying:
+
+```console
+bash setup.sh --configure-only
+```
+
+Neither file belongs in version control. Fleet topology and provider keys are
+yours, not the product's.
+
+## Add workers
+
+Run the wizard again on (or pointed at) each additional host and choose
+`worker`. It looks up the fleet by hub name and asks only what is new: the
+worker's name, SSH target, OS, supervisor, and mode.
+
+Workers do **not** need a checkout of this repository — deploy ships the source
+to each host.
+
+## Check it came up
+
+```console
+mac --fleet <name> agent list
+mac --fleet <name> task ready
+```
+
+`agent list` shows each agent's status and probed hardware. `task ready` shows
+what could be claimed *right now* — open, unclaimed, no unfinished
+dependencies.
+
+If `agent list` shows an agent as `idle` that you know is down, trust the
+process over the record: the hub stores a *reported* status, and the console's
+Agents view exists to put that next to the last time the agent was actually
+heard from.
+
+## Run your first task
+
+```console
+mac --fleet <name> task create "Add a --version flag to the CLI" \
+    --description-file=brief.txt
+```
+
+Watch it move:
+
+```console
+mac --fleet <name> task list          # active work only, by default
+mac --fleet <name> task show <id>     # state, history, evidence, reviews
+```
+
+Open `http://<hub>:8789/ui` in a browser for the live view.
+
+## When a task does not move
+
+This is the most common early frustration, and it has three usual causes.
+
+**It was never claimable.** Ask before filing:
+
+```console
+mac task preflight --capabilities python --hardware '{"os":["linux"]}'
+```
+
+The classic mistake is asking for a *capability* that is really a host fact.
+Agents advertise `python`, `testing`, `review`. They never advertise `linux` —
+that is probed into `resources.hardware`. A task requiring capability `linux`
+is accepted and then never claimed, with nothing obviously wrong.
+
+```
+WRONG   --capabilities linux
+RIGHT   --hardware '{"os": ["linux"], "cpu_arch": ["x86_64"]}'
+```
+
+**It is blocked on something that can never finish.**
+
+```console
+mac task why-unclaimed <id>
+```
+
+A blocked task waiting on a `failed` or `cancelled` dependency will never
+release under the default `all_success` join policy — only a *completed*
+dependency releases it.
+
+**It was filed with a dispatch hold.** `mac task create --no-dispatch` stages a
+task without making it claimable. Release it:
+
+```console
+mac task release <id>
+```
+
+## Everyday commands
+
+```console
+mac task list                     # active work (add --all-states for everything)
+mac task list --all               # every project, not just the inferred one
+mac task ready --limit 10
+mac task show <id>
+mac task create "title" --description-file=f.txt
+mac task ask <id> --question "..."     # park a task pending an answer
+mac task answer <id> --answer "..." --disposition resume
+mac agent list
+mac agent hold/resume <id>
+mac project list
+mac admin fleet doctor
+```
+
+`mac task list` prints short ids (git-style, 8 hex) and accepts them anywhere a
+full id is accepted.
+
+## Next
+
+- [Advanced Concepts](03-advanced.md)
+- [The UI](04-ui.md)

--- a/docs/guide/03-advanced.md
+++ b/docs/guide/03-advanced.md
@@ -1,0 +1,159 @@
+# Advanced Concepts
+
+The mechanisms that decide whether work actually lands, and the places where
+mac currently cannot do something it looks like it should. The gaps are listed
+because a system that hides them is one you cannot operate.
+
+## Leases: how one task stays one task
+
+A worker does not "own" a task, it holds a **lease** on it. One live lease per
+task, enforced by a unique index. The lease has an expiry, renewed by
+heartbeat; a worker that dies stops renewing and the task returns to the pool.
+
+This is why a task can be re-claimed while the previous attempt's process is
+technically still alive: the lease expired, and the lease is what counts. It
+also means lease expiry is a *retry*, not an error — and a task whose work
+cannot land will be retried until `max_attempts`, which is exactly how one task
+can produce many pull requests.
+
+## Evidence and review
+
+Work is not accepted because an agent says it succeeded. It is accepted because
+**evidence** was recorded and a **review** judged it.
+
+- Evidence is typed. A `code` deliverable expects a repository change; a
+  `report` deliverable is satisfied by an `operator_result` — a substantive
+  summary with no diff. That distinction exists so a non-code task cannot be
+  closed by a diff, and a code task cannot be closed by prose.
+- The default review workflow runs on the hub's publication worker, clones the
+  repository, and runs a contract gate.
+
+## Publication: the hard part
+
+A task is not complete when a pull request opens. It is complete when the work
+is on the canonical branch and the ledger can *prove* it:
+
+```
+repository task completion requires durable canonical integration proof
+(canonical_integration.status=pass, remote_verified=true, and a matching
+canonical branch SHA)
+```
+
+That proof is attached by the publication pipeline. Work landed by hand — a
+human opening and merging a PR — does not produce it, and such a task cannot be
+marked completed even with `force-complete`. This is deliberate: the gate
+refuses to believe a claim it cannot verify.
+
+### The native merge queue
+
+GitHub merge queues are organization-only, so personal repositories get no
+forge-side serialization. mac provides its own, with two properties worth
+knowing:
+
+- **Tree identity, not SHA identity.** An entry records the tree it was tested
+  against and refuses to land unless the canonical tip's tree matches
+  byte-for-byte. This is what makes speculation safe and what survives a squash
+  merge changing the SHA.
+- **Fail toward not landing.** Every failure kind — deferred, waiting,
+  unreadable state, slot lost, speculation unavailable — routes through the
+  existing backoff. None can reach "merge anyway".
+
+The AIMD window grows by one on a land and halves on a failure, floor 1 and
+ceiling 4. `MAC_MERGE_QUEUE_WINDOW_CEILING=1` disables speculation without
+disabling the queue.
+
+## Dispatch: why a task is or is not claimable
+
+Claimability is a conjunction, and all of it must hold:
+
+- state is `open`
+- no unfinished dependencies, under the task's **join policy**
+- no `no_dispatch` hold
+- the project is not paused
+- some agent's **capabilities** cover the requirement
+- some agent's **hardware** matches
+
+### Join policy is the subtle one
+
+- `all_success` (the default): only a **completed** dependency releases the
+  parent. A `failed` or `cancelled` blocker holds it forever.
+- `all_settled`: any terminal dependency releases it.
+
+Under `all_success`, cancelling a stuck dependency does **not** free its
+dependents. This is the mechanism behind large blocked backlogs.
+
+## Observability
+
+Every state change writes history; the hub emits `action_events` and
+`observability_events`. Signals are derived and named, e.g.
+`high_token_work_without_publication` (a task burning model time without
+landing) and `command_failure_churn` (repeated terminal command failures).
+
+**A caution learned the hard way:** `action_events.timestamp` is a **text**
+column holding ISO-8601 with a `T`. Comparing it against
+`(now() - interval '1 hour')::text` silently matches everything, because the
+cast produces a space-separated string and `'T' > ' '`. Filter with an
+ISO-formatted literal instead. The same trap has produced wrong retention
+metrics and wrong incident rates.
+
+## Known gaps
+
+These are real, measured, and tracked. They are here so you can operate around
+them.
+
+### AgentBus is write-only
+
+Workers emit typed events (`git.pushed`, `task.claimed`, `capacity.saturated`
+and others) from their own git and task paths. **Nothing reads them back** —
+searching `src/`, `scripts/` and `deploy/` for a consumer finds only the
+`mac admin agentbus read` command a human types.
+
+Consequence: an agent cannot learn that its own work has landed. This produced
+a task that opened eight pull requests across eight leases, one every ~30
+minutes, before exhausting `max_attempts`. There is also no terminal
+`git.merged` event to learn from even if something were listening.
+
+### What the hub cannot do yet
+
+The hub *detects* runaway conditions — the signal above fired on that task
+while it was happening — but cannot act. The AgentBus lifecycle vocabulary has
+`fleet`, `project`, `agent` and `task` scopes, and the verbs `stand_down`,
+`abort`, `pause`, `resume`, `status`; but nothing consumes a directive, and the
+hub has no authority to issue one. Detection without a channel is a report
+nobody reads.
+
+### Permanent failures are retried as transient
+
+Publication treats every failure as retryable. That is right for a network
+error, a lease conflict or a full queue window, and wrong for a reviewed commit
+that no longer exists:
+
+```
+git publication verify_commit failed:
+fatal: Not a valid object name <sha>^{commit}
+```
+
+No number of retries makes that SHA resolve. Until classification lands, a task
+in this state consumes publication sweep slots indefinitely. The mitigation is
+to park it: `mac task ask <id> --question "..."` moves it to `needs_input` and
+out of the sweep.
+
+### Dead dependencies are indistinguishable from live ones
+
+A task blocked on a `failed` dependency looks exactly like one legitimately
+sequenced behind live work, in every list view. Nothing computes whether a
+blocker can still arrive.
+
+## Operating notes
+
+- **`MAC_REVIEW_TICK_LIMIT`** caps how many tasks the publication sweep
+  advances per cycle. Raising it to work around a starved sweep gives the
+  starving task more slots too; fix the cause instead.
+- **The hub serves code from `~/.mac/src/mac`**, not from a developer checkout.
+  Deploy is a fast-forward there plus a supervisor restart, and it is verified
+  by PID change rather than checkout SHA — `refresh-source` has reported
+  `restart_requested: false` while the checkout advanced.
+- **`schema.sql` is `CREATE TABLE IF NOT EXISTS` with no migration framework.**
+  It creates missing *tables* on restart, so a new table provisions itself. It
+  is a **no-op for a new column on an existing table** — those need a
+  hand-applied `ALTER`, and `migrations/` is manual-only; nothing reads it.

--- a/docs/guide/04-ui.md
+++ b/docs/guide/04-ui.md
@@ -1,0 +1,92 @@
+# The UI
+
+mac ships two browser surfaces with deliberately opposite jobs. Knowing which
+one you are in tells you whether anything you do can change the fleet.
+
+```mermaid
+graph LR
+    subgraph "Observability Console — /ui"
+        C1["Live movement"]
+        C2["Stuck work"]
+        C3["Agents · Projects"]
+        C4["Pipelines · Dream & nap"]
+        C5["Merge queue · Telemetry"]
+        C6["Task drill-down"]
+    end
+    subgraph "Fleet IDE — ide/"
+        I1["Task Kanban"]
+        I2["Task Inspector"]
+        I3["Project tree"]
+    end
+    API["hub API"]
+    C1 & C2 & C3 & C4 & C5 & C6 -->|GET only| API
+    I1 & I2 & I3 -->|GET + mutations| API
+```
+
+## The observability console (`/ui`)
+
+Served at `/ui` and `/ui/console`. Built from `observe/` (React + Vite) into
+`src/mac/ui/console/`, which is committed — so serving it needs no Node.js at
+runtime. Rebuild with `npm --prefix observe run build`; CI fails if the
+committed bundle drifts from source.
+
+**It is read-only, and that is the design.** `observe/tests/readonly.test.ts`
+asserts it. The command-and-control dashboard that used to live here was
+retired: it called `/dispatch/tick`, `/agents/bulk`, `/roles/seed`,
+`/notifier/deliver` and `/secrets`, and a UI whose job is to observe cannot
+also be the one that commands.
+
+### Views
+
+| view | answers |
+|---|---|
+| **Live** | what is moving right now — transitions per time bucket, stacked by the state work moved *into* |
+| **Stuck work** | what has not moved, oldest first |
+| **Agents** | who is registered, and whether the hub's belief is supported by evidence |
+| **Projects** | per-project counts and repository registration |
+| **Pipelines** | publication and review progress |
+| **Dream & nap** | reflection cycles |
+| **Merge queue** | depth against the AIMD window, and why changes did not land |
+| **Telemetry** | model and command usage |
+| **Task** | drill-down: history with detail, evidence, reviews, transcripts |
+
+### Two properties it will not trade
+
+**A section it could not read is absent, not zero.** If the hub fails to answer
+for one section, that section is omitted and named in `degraded` — never
+rendered as a plausible empty result. A merge queue showing "depth 0" because a
+table is missing is exactly the failure the queue exists to catch.
+
+**Unknown is not a default.** A queue that has never sized its window shows
+`—`, not `1`; a land rate with no attempts shows `—`, not `0%`. Never-happened
+and happened-badly are different facts.
+
+### The live view
+
+The Live chart is the one worth understanding. A count tells you 360 tasks are
+blocked. Only a series over time tells you whether they are *arriving or
+draining* — which is the difference between a backlog and a leak.
+
+## The Fleet IDE (`ide/`)
+
+The mutating surface: a task Kanban laned by state, a task inspector, and a
+project tree. It is where you answer a parked task, direct an agent, or work a
+queue.
+
+The Kanban lanes are task **states**, and it deliberately has no drag-and-drop:
+task states are a control-plane state machine with legal-move rules, leases and
+evidence requirements, so most lane-to-lane drags would be illegal. A board
+that offers a move it cannot make teaches you the UI lies about what it can do.
+
+Run it with `make run-gui` after `mac admin login`.
+
+## Which one am I in?
+
+If you can change something, you are in the Fleet IDE. If you cannot, you are
+in the console — and that is a guarantee, not an oversight.
+
+## Getting a token in
+
+The console reads a bearer token from `?t=<token>` on first load and moves it
+into session storage, stripping it from the URL. It shares the storage key with
+the IDE, so a session in one carries into the other.

--- a/docs/guide/05-developer-guide.md
+++ b/docs/guide/05-developer-guide.md
@@ -1,0 +1,163 @@
+# Developer Guide
+
+How to work on mac itself. The conventions here are not stylistic preferences —
+each one exists because its absence caused a specific, recoverable-but-expensive
+incident.
+
+## Set up
+
+```console
+eval "$(scripts/start-test-postgres.sh)"   # exports MAC_TEST_PG_URL
+uv run --extra dev pytest -q -n 8          # full suite, ~10 min
+```
+
+The suite runs against **PostgreSQL, not SQLite**, because that is what the
+fleet runs. Without `MAC_TEST_PG_URL` the suite fails fast with instructions
+rather than skipping — a suite that silently covers nothing is worse than a red
+one.
+
+`start-test-postgres.sh` sets `max_locks_per_transaction=1024`. Each test gets
+its own schema and applying the DDL takes one lock per object in a single
+transaction; at Postgres' default of 64 a parallel run fails with "out of
+shared memory", which looks nothing like a test failure.
+
+## Always work in a worktree
+
+```console
+git -C ~/Src/mac worktree add /tmp/mac-<task> -b <you>/<task>
+cd /tmp/mac-<task>
+```
+
+This is mandatory, not advisory. Multiple agents run against this repository
+concurrently. Two sharing the main checkout collided twice in one day: one
+`git add -A` nearly swept ~1,200 lines of another's half-finished work into an
+unrelated commit, and a `git commit -a` actually did — landing someone else's
+retry implementation inside a commit titled for something else. Both failures
+are silent; the tests pass and the damage is only visible later in `git log`.
+
+Remove it when the work has landed:
+
+```console
+git -C ~/Src/mac worktree remove /tmp/mac-<task>
+```
+
+If you must use the main checkout, never `git add -A`, `git add .` or
+`git commit -a`. Stage explicit paths.
+
+## The gates
+
+`sanity` is the one that counts — roughly 11,000 tests, 40–55 minutes. Others
+are fast and worth running locally first:
+
+```console
+scripts/run-contract-tests.sh            # the fail-fast preflight
+bash scripts/dead-code-check.sh          # vulture, ≥90% confidence
+uv run python scripts/generate-env-config-registry.py --check
+uv run python scripts/generate-docs-reference.py --check
+uv run python scripts/test-docs.py --static-only
+npm --prefix observe test                # console
+npm --prefix ide test                    # Fleet IDE typecheck
+npx playwright test                      # Fleet IDE browser tests (~9s)
+```
+
+**Run the browser tests.** `tsc --noEmit` passing is not the same as the UI
+working: deleting a rendered element typechecks perfectly. A missed Playwright
+spec has cost a CI cycle more than once, and it runs in nine seconds.
+
+## Test selection, and the traps in it
+
+`sanity` does not always run everything. `scripts/resolve-impacted-tests.py`
+selects tests from a committed impact map plus CodeGraph, and fails **closed**
+to a full run when it cannot map a change.
+
+Two things to know:
+
+- **The impact map interns node ids and references them by integer index.**
+  Deleting or renaming a test strands ids. There is a gate for it, and it now
+  compares against actual `pytest --collect-only` output rather than function
+  names — because an empty `@pytest.mark.parametrize` list produces **zero**
+  tests while the function still exists, which a name-based check cannot see.
+  That left 180 stale ids that failed unrelated PRs with a pytest *usage*
+  error.
+- **Changing the selector forces a full run.** `test-policy.toml`,
+  `select-sanity-tests.py`, `resolve-impacted-tests.py`,
+  `build-test-impact-map.py` and `src/mac/test_checkpoint.py` are all in
+  `global_full_paths`, so the component that decides what gets verified cannot
+  narrow its own verification.
+
+## Writing tests that are worth having
+
+The house style, and the reasoning:
+
+- **A test must fail without the change.** Verify it: revert the source, run
+  the test, confirm red. A test that passes both ways documents nothing.
+- **Assert the property, not the incident.** Pin what must be true, not the
+  shape of one bug.
+- **Say why in the docstring.** The best tests in this repository open with the
+  failure that motivated them, including the real error text. That is what
+  stops someone "simplifying" the test later.
+- **Test the layer that ships.** The CLI's default view broke because its tests
+  drove `ControlPlane.list_tasks` directly while the bug was in the HTTP route
+  signature. If a client talks over HTTP, test over HTTP.
+- **Beware tests that pin an absence.** Several tests asserted a feature was
+  *not* present, purely because a constant disabled it. When the feature
+  arrived they read as intent. Prefer asserting what *is* allowed.
+
+## Client and API stay in step
+
+`RemoteDispatch` is the single seam every hub-mode client crosses.
+`tests/test_dispatch_route_contract.py` extracts all ~260 call sites and
+asserts each resolves against the live FastAPI route table, and that every
+query parameter sent is declared. It found a real bug on its first run: the CLI
+sent `eval_set` where the route declared `eval_set_id`, and FastAPI drops an
+undeclared parameter *silently* — the request succeeded and the filter did
+nothing.
+
+An unresolvable call site **fails** that gate rather than being skipped.
+Coverage that shrinks quietly is the failure the equivalent Fleet IDE canary
+was rewritten to fix.
+
+## Schema changes
+
+`src/mac/data/postgres/schema.sql` is applied at hub start and is
+`CREATE TABLE IF NOT EXISTS` throughout.
+
+- A **new table** provisions itself on restart.
+- A **new column on an existing table does not.** It works on a fresh database
+  and in CI (fresh schema per test) and silently does nothing on a long-lived
+  hub. Hand-apply the `ALTER`, and diff `schema.sql` across the deploy range
+  before deploying.
+- `migrations/` is **manual only**. Nothing in mac reads it, and it is not
+  shipped in the wheel.
+
+## Deploying the hub
+
+The hub serves from `~/.mac/src/mac` on the hub host — **not** a developer
+checkout.
+
+```console
+git -C ~/.mac/src/mac fetch origin && git -C ~/.mac/src/mac merge --ff-only origin/main
+sudo launchctl kickstart -k system/com.mac.control-plane
+```
+
+Verify by **PID change**, not checkout SHA: `refresh-source` has reported
+`restart_requested: false` while the checkout advanced. `/health` returns empty
+for ~10s during startup; that is not a failure.
+
+After a manual pull on the hub host, also restart the co-located agent
+(`com.mac.agent`) — it shares that checkout and will otherwise keep running
+stale code through several refreshes.
+
+## Debugging the fleet
+
+```console
+mac admin fleet doctor
+mac task why-unclaimed <id>
+mac admin observability list --name executor.agent_completed
+mac agent list --json                     # hardware under resources.hardware
+```
+
+Read the hub's own log at `~/.mac/logs/mac-service.log`. Watch for
+best-effort `except Exception` blocks: one swallowed a `NameError` and
+presented it as a `None` return, which cost an hour of misdirected debugging.
+`--log-cli-level=WARNING` surfaces those in tests.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -1,0 +1,41 @@
+# mac documentation
+
+Read in order if you are new; jump if you are not.
+
+| | |
+|---|---|
+| **[1. System Architecture](01-architecture.md)** | What the pieces are and how work flows. Mostly diagrams. |
+| **[2. Getting Started](02-getting-started.md)** | Stand up a fleet, run a task, diagnose one that does not move. |
+| **[3. Advanced Concepts](03-advanced.md)** | Leases, evidence, review, publication, the merge queue — and the known gaps. |
+| **[4. The UI](04-ui.md)** | The read-only console and the mutating Fleet IDE. |
+| **[5. Developer Guide](05-developer-guide.md)** | How to hack on mac: tests, gates, schema, deploys. |
+| **[Contributing](https://github.com/jordanhubbard/mac/blob/main/CONTRIBUTING.md)** | Filing issues and PRs that are actually tested. |
+
+## What these pages promise
+
+They are written from the code. Every state, transition, table, route and
+environment variable named here was read out of the source or the live route
+table at the time of writing, and anything partial, unwired or broken is
+labelled as such rather than omitted.
+
+That constraint exists because the alternative was demonstrated: this
+repository's README described a dashboard source file, its compiled output and
+a vendored dependency for some time after all three were deleted. Documentation
+that quietly diverges is worse than none, because it is trusted.
+
+If you find a page describing something that does not exist, that is a bug —
+file it.
+
+## Reference material
+
+The pages above are the guide. These are the reference and the record:
+
+- `docs/reference/cli.md`, `docs/reference/openapi.md` — **generated**; do not
+  hand-edit
+- `docs/env-config-reference.md` — **generated** registry of every
+  `MAC_*` variable
+- `docs/adr/` — architecture decision records, including what was tried and
+  removed
+- `docs/archive/field-notes/` — incident write-ups and investigations
+- `skills/` — task-shaped instructions for coding agents, gated by tests that
+  check every command and flag they name against the real parser

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -144,6 +144,12 @@ for provenance and is not a current operating contract.
 | supplemental reference | `fleet-operational-learning.md` | Fleet operational learning |
 | supplemental reference | `fleet-registry-schema.md` | Fleet registry schema |
 | supplemental reference | `getting-started.md` | MAC Quickstart |
+| supplemental reference | `guide/01-architecture.md` | System Architecture |
+| supplemental reference | `guide/02-getting-started.md` | Getting Started |
+| supplemental reference | `guide/03-advanced.md` | Advanced Concepts |
+| supplemental reference | `guide/04-ui.md` | The UI |
+| supplemental reference | `guide/05-developer-guide.md` | Developer Guide |
+| supplemental reference | `guide/README.md` | mac documentation |
 | supplemental reference | `hermes-boundary.md` | Hermes Boundary |
 | supplemental reference | `hermes-integration.md` | Hermes Integration |
 | supplemental reference | `hermes-retirement-premises.md` | Testing the premises for retiring the vendored Hermes tree |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,13 @@ extra_css:
 
 nav:
   - Home: index.md
+  - Guide:
+      - Overview: guide/README.md
+      - "System Architecture": guide/01-architecture.md
+      - "Getting Started": guide/02-getting-started.md
+      - "Advanced Concepts": guide/03-advanced.md
+      - "The UI": guide/04-ui.md
+      - "Developer Guide": guide/05-developer-guide.md
   - Book:
       - "1. MAC as a System": book/01-system.md
       - "2. Install and Start Locally": book/02-local-start.md

--- a/tests/test_guide_docs_are_true.py
+++ b/tests/test_guide_docs_are_true.py
@@ -117,31 +117,70 @@ def test_completed_is_documented_as_the_only_terminal_state():
 
 def test_every_mac_command_shown_resolves():
     """A documented command that does not exist sends the reader to a usage
-    error, mid-incident."""
+    error, mid-incident.
+
+    This checks the VERB, not just the object. An earlier version accepted a
+    command when any prefix of it resolved, which meant `mac task frobnicate`
+    passed on the strength of `mac task` -- it could only ever catch a bad
+    object, which is the mistake nobody makes.
+    """
     sys.argv = ["mac"]
+    import argparse
+
     from mac.cli import build_parser
 
-    def walk(node, prefix=()):
-        found = set()
+    def children(node):
+        """Verbs one level below `node`.
+
+        Subparsers are the usual shape, but not the only one: `mac admin login`
+        takes `status`/`renew` as a positional with `choices`, so a checker that
+        walks only `_name_parser_map` reports a real command as missing.
+        """
+        subs, choices = {}, set()
         for action in node._actions:
             mapping = getattr(action, "_name_parser_map", None)
-            if not mapping:
-                continue
-            for name, sub in mapping.items():
-                found.add(prefix + (name,))
-                found |= walk(sub, prefix + (name,))
-        return found
+            if mapping:
+                subs.update(mapping)
+            elif not action.option_strings and action.choices:
+                choices |= {str(c) for c in action.choices}
+        return subs, choices
 
-    real = walk(build_parser())
-    tops = {path[0] for path in real if len(path) == 1}
+    def command_lines(text):
+        """Only what is shown AS a command: inline code spans and fenced blocks.
+
+        Checking raw prose does not work -- "the mac task ledger" is a noun
+        phrase, not a command, and no stopword list separates the two reliably.
+        """
+        for span in re.findall(r"`([^`\n]+)`", text):
+            yield span
+        for block in re.findall(r"```[a-z]*\n(.*?)```", text, re.S):
+            for line in block.splitlines():
+                yield line.strip().lstrip("$ ").strip()
+
+    top_subs, _ = children(build_parser())
     unknown = []
     for page in PAGES:
-        for match in re.finditer(r"mac ((?:[a-z][a-z0-9-]*)(?: [a-z][a-z0-9-]*)*)", page.read_text(encoding="utf-8")):
-            parts = match.group(1).split()
-            if not parts or parts[0] not in tops:
+        for line in command_lines(page.read_text(encoding="utf-8")):
+            match = re.match(r"mac ((?:[a-z][a-z0-9-]*)(?: [a-z][a-z0-9-]*)*)", line)
+            if not match:
                 continue
-            if not any(tuple(parts[:n]) in real for n in range(len(parts), 0, -1)):
-                unknown.append("%s: mac %s" % (page.name, " ".join(parts)))
+            parts = match.group(1).split()
+            if parts[0] not in top_subs:
+                continue
+            node, path = top_subs[parts[0]], [parts[0]]
+            for token in parts[1:]:
+                subs, choices = children(node)
+                if token in subs:
+                    node, _ = subs[token], path.append(token)
+                    continue
+                if token in choices or token == "help":
+                    path.append(token)
+                    break
+                # Not a verb here. If this parser has no verbs at all the token
+                # is an argument (`mac task show <id>`); otherwise it is wrong.
+                if subs or choices:
+                    unknown.append("%s: mac %s" % (page.name, " ".join(path + [token])))
+                break
 
     assert not unknown, "commands that do not exist:\n  " + "\n  ".join(sorted(set(unknown)))
 

--- a/tests/test_guide_docs_are_true.py
+++ b/tests/test_guide_docs_are_true.py
@@ -1,0 +1,176 @@
+"""The guide must describe software that exists.
+
+This repository's README described `src/mac/ui/app.ts`, its compiled `app.js`
+and a vendored xterm tree for some time after all three were deleted. The docs
+gates check GENERATED references and EXECUTABLE shell blocks; prose naming a
+deleted file is exactly what they do not cover, which is why nobody noticed.
+
+Documentation that quietly diverges is worse than none, because it is trusted.
+These tests check the parts of the guide a machine can check: that every file
+it names exists, that every `mac` command it shows resolves against the real
+parser, and that the states and transitions it documents match models.py.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+GUIDE = ROOT / "docs" / "guide"
+PAGES = sorted(GUIDE.glob("*.md")) + [ROOT / "CONTRIBUTING.md"]
+
+
+def _text() -> str:
+    return "\n".join(p.read_text(encoding="utf-8") for p in PAGES)
+
+
+def test_the_guide_exists_and_is_indexed():
+    assert (GUIDE / "README.md").is_file()
+    for name in (
+        "01-architecture.md",
+        "02-getting-started.md",
+        "03-advanced.md",
+        "04-ui.md",
+        "05-developer-guide.md",
+    ):
+        assert (GUIDE / name).is_file(), name
+        assert name in (GUIDE / "README.md").read_text(encoding="utf-8")
+
+
+def test_every_file_the_guide_names_exists():
+    """The README-describing-deleted-files bug, prevented."""
+    missing = []
+    for page in PAGES:
+        for match in re.finditer(
+            r"`([a-zA-Z0-9_./-]+\.(?:py|ts|tsx|toml|sql|json|sh|md))`",
+            page.read_text(encoding="utf-8"),
+        ):
+            candidate = match.group(1)
+            if "/" not in candidate or "<" in candidate:
+                continue
+            if not (ROOT / candidate).exists():
+                missing.append("%s names %s" % (page.name, candidate))
+
+    assert not missing, "the guide names files that do not exist:\n  " + "\n  ".join(
+        sorted(set(missing))
+    )
+
+
+def test_every_documented_task_state_is_real():
+    from mac.models import TaskState
+
+    real = {state.value for state in TaskState}
+    text = _text()
+    # Every state name the guide uses in a state-machine context must be real.
+    for documented in (
+        "open",
+        "waiting",
+        "blocked",
+        "claimed",
+        "running",
+        "needs_review",
+        "needs_input",
+        "reviewing",
+        "completed",
+        "failed",
+        "cancelled",
+    ):
+        assert documented in real
+        assert documented in text, "state %s is undocumented" % documented
+
+
+def test_the_documented_transitions_are_legal():
+    """The architecture page draws a state diagram. Every edge in it must be an
+    edge the control plane actually allows, or the diagram teaches a move that
+    will be refused."""
+    from mac.models import TASK_TRANSITIONS
+
+    diagram = (GUIDE / "01-architecture.md").read_text(encoding="utf-8")
+    edges = re.findall(r"^\s{4}(\w+) --> (\w+)$", diagram, re.M)
+    assert edges, "no state-diagram edges found; the diagram or this test moved"
+
+    illegal = [
+        "%s -> %s" % (src, dst)
+        for src, dst in edges
+        if src not in ("[*]",)
+        and dst not in ("[*]",)
+        and dst not in TASK_TRANSITIONS.get(src, set())
+    ]
+
+    assert not illegal, "the diagram shows transitions the control plane refuses: %s" % illegal
+
+
+def test_completed_is_documented_as_the_only_terminal_state():
+    """`failed` and `cancelled` both allow -> open. Documenting them as terminal
+    would hide the retry path, which is how a stuck task gets recovered."""
+    from mac.models import TASK_TRANSITIONS
+
+    assert not TASK_TRANSITIONS["completed"]
+    assert "open" in TASK_TRANSITIONS["failed"]
+    assert "open" in TASK_TRANSITIONS["cancelled"]
+    assert "only truly terminal state" in _text()
+
+
+def test_every_mac_command_shown_resolves():
+    """A documented command that does not exist sends the reader to a usage
+    error, mid-incident."""
+    sys.argv = ["mac"]
+    from mac.cli import build_parser
+
+    def walk(node, prefix=()):
+        found = set()
+        for action in node._actions:
+            mapping = getattr(action, "_name_parser_map", None)
+            if not mapping:
+                continue
+            for name, sub in mapping.items():
+                found.add(prefix + (name,))
+                found |= walk(sub, prefix + (name,))
+        return found
+
+    real = walk(build_parser())
+    tops = {path[0] for path in real if len(path) == 1}
+    unknown = []
+    for page in PAGES:
+        for match in re.finditer(r"mac ((?:[a-z][a-z0-9-]*)(?: [a-z][a-z0-9-]*)*)", page.read_text(encoding="utf-8")):
+            parts = match.group(1).split()
+            if not parts or parts[0] not in tops:
+                continue
+            if not any(tuple(parts[:n]) in real for n in range(len(parts), 0, -1)):
+                unknown.append("%s: mac %s" % (page.name, " ".join(parts)))
+
+    assert not unknown, "commands that do not exist:\n  " + "\n  ".join(sorted(set(unknown)))
+
+
+def test_the_known_gaps_are_still_gaps():
+    """The guide tells operators to work around three gaps. If one is fixed and
+    the page still claims it, the page is now misinformation.
+
+    This is a canary, not a prohibition: closing a gap SHOULD fail here, and the
+    fix is to update the page in the same change.
+    """
+    advanced = (GUIDE / "03-advanced.md").read_text(encoding="utf-8")
+    assert "AgentBus is write-only" in advanced
+
+    consumers = []
+    for path in (ROOT / "src").rglob("*.py"):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if "/agentbus/traffic" in text and path.name not in ("api.py", "cli.py", "dispatch.py"):
+            consumers.append(str(path.relative_to(ROOT)))
+
+    assert not consumers, (
+        "something now consumes AgentBus traffic (%s) -- update "
+        "docs/guide/03-advanced.md, which still tells operators nothing does"
+        % consumers
+    )
+
+
+def test_mermaid_blocks_are_balanced():
+    for page in PAGES:
+        text = page.read_text(encoding="utf-8")
+        assert text.count("```mermaid") <= text.count("```") // 2, page.name
+        assert text.count("```") % 2 == 0, "unclosed code fence in %s" % page.name


### PR DESCRIPTION
## Why

The README described `src/mac/ui/app.ts`, its compiled `app.js` and a vendored xterm tree for some time after all three were deleted. Nobody noticed, and the reason is structural: the docs gates check *generated* references (`scripts/generate-docs-reference.py`) and *executable* shell blocks (`scripts/test-docs.py`). Prose naming a deleted file falls exactly between them.

Docs that quietly diverge are worse than no docs, because they are trusted.

## What

A guide organized the way someone actually arrives at the system:

| Page | |
|---|---|
| [`01-architecture.md`](docs/guide/01-architecture.md) | what the pieces are and how work flows — five mermaid diagrams: system graph, ER model, task state machine, dispatch sequence, merge queue |
| [`02-getting-started.md`](docs/guide/02-getting-started.md) | install, stand up a hub and a worker, file a task, diagnose one that will not move |
| [`03-advanced.md`](docs/guide/03-advanced.md) | leases, evidence, review, canonical integration proof, merge queue, dispatch and join policy |
| [`04-ui.md`](docs/guide/04-ui.md) | the read-only console at `/ui` vs the mutating Fleet IDE |
| [`05-developer-guide.md`](docs/guide/05-developer-guide.md) | worktrees, gates, test-selection traps, schema changes, hub deploy |
| [`CONTRIBUTING.md`](CONTRIBUTING.md) | filing issues, and what makes a PR land instead of bounce |

Everything is taken from the code, not from intent. The first-class objects are the three in `FIRST_CLASS` (`src/mac/cli_surface.py`), not the ones an older design doc wanted. The state diagram is the edges in `TASK_TRANSITIONS` (`src/mac/models.py`). The UI section describes the console and IDE that exist today.

Where the system does not do something, `03-advanced.md` says so under **Known gaps** rather than letting the reader infer capability from silence: the AgentBus has no consumer, the hub observes but cannot act, permanent failures are retried as though transient, and a dead dependency looks the same as a slow one.

## The gate

`tests/test_guide_docs_are_true.py` (8 tests) checks the parts a machine can check:

- every file the guide names in backticks exists
- every `mac` command it shows resolves against the real argument parser
- every documented state is a `TaskState` member
- **every edge in the state diagram is a transition the control plane will accept**
- the known-gaps section still names the gaps (a canary — closing one should force a docs edit)

The state-diagram check was verified by injecting `completed -> running` into `01-architecture.md`:

```
E  AssertionError: the diagram shows transitions the control plane refuses: ['completed -> running']
1 failed, 7 deselected
```

## Also

- `mkdocs.yml` gains a **Guide** nav section, so the pages are published rather than repo-only. Links to `CONTRIBUTING.md` use the GitHub URL because a relative link escaping `docs/` fails `mkdocs build --strict`.
- README links the guide from above Quick Start.
- Fences are `console`, not `bash` — the documentation contract reserves executable fences for the book.

## Verification

```
scripts/test-docs.py --static-only    {"status": "pass", "chapter_count": 18}
pytest tests/test_guide_docs_are_true.py tests/test_docs_accessibility.py
      tests/test_mac_cli_skill.py tests/test_docs_no_operator_identity.py
                                      22 passed
scripts/dead-code-check.sh            clean
```

No source behaviour changes; the only non-docs file is a new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)