### PR TITLE
Add opencode as the first coding-agent route

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -101,6 +101,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_CODING_AGENT_CLAUDE_CMD` | str | consumer-defined | coding-agent-auth | Coding Agent Auth setting: coding agent claude cmd. |
 | `MAC_CODING_AGENT_CODEX_CMD` | str | consumer-defined | coding-agent-auth | Coding Agent Auth setting: coding agent codex cmd. |
 | `MAC_CODING_AGENT_CURSOR_CMD` | str | consumer-defined | coding-agent-auth | Coding Agent Auth setting: coding agent cursor cmd. |
+| `MAC_CODING_AGENT_OPENCODE_CMD` | str | consumer-defined | coding-agent-auth | Coding Agent Auth setting: coding agent opencode cmd. |
 | `MAC_CODING_AGENT_PREFLIGHT_FAILURE_TTL_SECONDS` | int | consumer-defined | coding-agent-auth | Coding Agent Auth setting: coding agent preflight failure ttl seconds. |
 | `MAC_CODING_AGENT_PREFLIGHT_TIMEOUT` | int | consumer-defined | coding-agent-auth | Coding Agent Auth setting: coding agent preflight timeout. |
 | `MAC_CODING_AGENT_PREFLIGHT_TTL_SECONDS` | int | consumer-defined | coding-agent-auth | Coding Agent Auth setting: coding agent preflight ttl seconds. |

--- a/src/mac/cli_credentials.py
+++ b/src/mac/cli_credentials.py
@@ -42,7 +42,7 @@ from typing import Callable, Dict, List, Mapping, Optional
 
 from mac.fleet_ssh import load_fleet_config, resolve_fleet_ssh, ssh_argv
 
-KNOWN_CLIS = ("claude", "codex", "cursor")
+KNOWN_CLIS = ("claude", "codex", "cursor", "opencode")
 
 CLAUDE_KEYCHAIN_SERVICE = "Claude Code"
 CURSOR_KEYCHAIN_SERVICE = "cursor-access-token"
@@ -195,6 +195,37 @@ def detect_local_credentials(
                 if auth_token:
                     source.env["CURSOR_AUTH_TOKEN"] = auth_token
                     source.origin = "macOS Keychain (%s)" % CURSOR_KEYCHAIN_SERVICE
+            sources[cli] = source
+        elif cli == "opencode":
+            source = CredentialSource(cli="opencode", origin="")
+            api_key = str(env.get("OPENCODE_API_KEY") or "").strip()
+            if api_key:
+                source.env["OPENCODE_API_KEY"] = api_key
+                source.origin = "OPENCODE_API_KEY (env)"
+            # The credential and the configuration live in DIFFERENT trees, and
+            # a worker needs both: auth.json under ~/.local/share/opencode
+            # proves who you are, opencode.json under ~/.config/opencode says
+            # which provider and model to use. Copying only the config -- the
+            # obvious guess, since that is the directory named after the tool --
+            # produces a CLI that is on PATH, looks configured, and fails at the
+            # provider.
+            auth = home / ".local" / "share" / "opencode" / "auth.json"
+            try:
+                if auth.is_file() and auth.stat().st_size > 0:
+                    source.files[".local/share/opencode/auth.json"] = auth.read_bytes()
+                    if not source.origin:
+                        source.origin = "~/.local/share/opencode/auth.json"
+            except OSError:
+                pass
+            config = home / ".config" / "opencode" / "opencode.json"
+            try:
+                if config.is_file():
+                    # opencode.json only. ~/.config/opencode also holds a
+                    # node_modules tree (61MB on this workstation) that a
+                    # credential sync has no business shipping.
+                    source.files[".config/opencode/opencode.json"] = config.read_bytes()
+            except OSError:
+                pass
             sources[cli] = source
         else:
             raise CliCredentialError("unknown coding CLI: %r" % cli)

--- a/src/mac/coding_agent.py
+++ b/src/mac/coding_agent.py
@@ -58,7 +58,7 @@ __all__ = [
 #: agent is eligible and the executor fails closed.
 PREFERENCE_ENV = "MAC_PREFER_CODING_AGENT"
 
-#: Pin or disable selection. ``claude``/``codex``/``cursor`` restrict
+#: Pin or disable selection. ``claude``/``opencode``/``codex``/``cursor`` restrict
 #: consideration to that one agent (still must be available + authed, else the
 #: executor fails closed); legacy disable values remain accepted during rollout.
 FORCE_ENV = "MAC_CODING_AGENT"
@@ -71,10 +71,29 @@ COMMAND_ENV = {
     "claude": "MAC_CODING_AGENT_CLAUDE_CMD",
     "codex": "MAC_CODING_AGENT_CODEX_CMD",
     "cursor": "MAC_CODING_AGENT_CURSOR_CMD",
+    "opencode": "MAC_CODING_AGENT_OPENCODE_CMD",
 }
 
 #: Resolution priority. Earlier entries win when more than one qualifies.
-AGENT_PRIORITY: Tuple[str, ...] = ("claude", "codex", "cursor")
+#:
+#: opencode is FIRST, and the reason is credential durability rather than model
+#: quality. It authenticates from a portable on-disk API credential
+#: (~/.local/share/opencode/auth.json) that can simply be copied to a worker
+#: and does not expire.
+#:
+#: The others cannot be provisioned that way today. Anthropic does not offer an
+#: API-key passthrough that would let a logged-in workstation hand its
+#: credential to a worker, and the OAuth sessions claude and codex do use TIME
+#: OUT -- so a remote node drifts back to unauthenticated with no local event
+#: to notice. Logging in a headless worker is an unsolved problem on this
+#: fleet, not a task anyone forgot to do.
+#:
+#: What that costs when it is not first: on 2026-08-19 every node reported all
+#: three original CLIs unavailable AT ONCE -- claude with no credential, codex
+#: denied by sandbox policy, cursor returning resource_exhausted -- and the
+#: fleet completed exactly one task in twenty-four hours. The route that can be
+#: provisioned belongs ahead of the routes that cannot.
+AGENT_PRIORITY: Tuple[str, ...] = ("opencode", "claude", "codex", "cursor")
 
 #: Sentinel the coding agent must echo back for the in-sandbox preflight to
 #: pass. A correct echo proves, end-to-end *inside the sandbox*, that the binary
@@ -381,10 +400,50 @@ def _detect_cursor(
     return False, binary, "", "cursor: on PATH but no supported credential configuration"
 
 
+def _detect_opencode(
+    env: Mapping[str, str], home: Path, which: Callable[[str], Optional[str]]
+) -> Tuple[bool, str, str, str]:
+    """Return (available, binary, auth_source, reason).
+
+    opencode keeps provider credentials in ``~/.local/share/opencode/auth.json``
+    -- NOT in ``~/.config/opencode``, which holds only model and provider
+    settings. Both must be present on a worker for a task run to succeed, and
+    the distinction is easy to miss when copying a working setup between hosts.
+    """
+    binary = _which("opencode", which)
+    if not binary:
+        return False, "", "", "opencode: not on PATH"
+    if str(env.get("OPENCODE_API_KEY") or "").strip():
+        return True, binary, "OPENCODE_API_KEY", "opencode: configured via OPENCODE_API_KEY"
+    auth = home / ".local" / "share" / "opencode" / "auth.json"
+    try:
+        if auth.is_file() and auth.stat().st_size > 0:
+            return (
+                True,
+                binary,
+                "~/.local/share/opencode/auth.json",
+                "opencode: configured via ~/.local/share/opencode/auth.json",
+            )
+    except OSError:
+        pass
+    if (home / ".config" / "opencode").exists():
+        # Config without credentials is the copy-the-wrong-directory mistake.
+        # Name it, rather than reporting a bare "no credential".
+        return (
+            False,
+            binary,
+            "",
+            "opencode: ~/.config/opencode exists but no credential "
+            "(~/.local/share/opencode/auth.json is missing -- it is a separate directory)",
+        )
+    return False, binary, "", "opencode: on PATH but no supported credential configuration"
+
+
 _DETECTORS = {
     "claude": _detect_claude,
     "codex": _detect_codex,
     "cursor": _detect_cursor,
+    "opencode": _detect_opencode,
 }
 
 
@@ -698,6 +757,24 @@ def _default_argv(
         return [*argv, prompt]
     if agent == "cursor":
         argv = [binary, "-p", "--force"]
+        if model:
+            argv += ["--model", model]
+        return [*argv, prompt]
+    if agent == "opencode":
+        # `run` is the non-interactive entry point; the bare `opencode` default
+        # subcommand starts a TUI and would hang a task run forever.
+        #
+        # No approval-bypass flag is needed or offered: opencode does not
+        # prompt in `run` mode. Confinement is still the executor's OpenShell
+        # gate, exactly as for the others.
+        #
+        # Model names MUST carry the provider prefix that `opencode models`
+        # prints -- "nvidia-inference/switchyard/openai/gpt-5.6-sol", not
+        # "switchyard/openai/gpt-5.6-sol". The unprefixed form is accepted by
+        # the CLI and then fails at the server as an opaque
+        # "Unexpected server error", which is what a misconfigured node looked
+        # like before this was understood.
+        argv = [binary, "run"]
         if model:
             argv += ["--model", model]
         return [*argv, prompt]

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -1195,6 +1195,17 @@
   },
   {
     "default": null,
+    "description": "Coding Agent Auth setting: coding agent opencode cmd.",
+    "family": "coding-agent-auth",
+    "name": "MAC_CODING_AGENT_OPENCODE_CMD",
+    "retired": false,
+    "sources": [
+      "src/mac/coding_agent.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Coding Agent Auth setting: coding agent preflight failure ttl seconds.",
     "family": "coding-agent-auth",
     "name": "MAC_CODING_AGENT_PREFLIGHT_FAILURE_TTL_SECONDS",

--- a/tests/test_cli_credentials.py
+++ b/tests/test_cli_credentials.py
@@ -181,7 +181,7 @@ def test_remote_apply_script_writes_files_env_and_reports(tmp_path, monkeypatch)
     assert "MAC_API_TOKEN=tok" in env_text  # existing entries preserved
     report = json.loads(stdout.getvalue().strip().splitlines()[-1])
     assert report["schema"] == "mac.cli_credentials_apply.v1"
-    assert set(report["clis"]) == {"claude", "codex", "cursor"}
+    assert set(report["clis"]) == {"claude", "codex", "cursor", "opencode"}
 
 
 def test_remote_apply_rejects_traversal_paths(tmp_path, monkeypatch):

--- a/tests/test_coding_agent.py
+++ b/tests/test_coding_agent.py
@@ -192,7 +192,13 @@ def test_codex_prefers_openshell_safe_environment_auth(tmp_path):
 
     assert choice.agent == "codex"
     assert choice.auth_source == "OPENAI_API_KEY"
-    assert choice.rationale == ["claude: not on PATH", "codex: configured via OPENAI_API_KEY"]
+    # opencode is probed first (see AGENT_PRIORITY) and is absent in this
+    # fixture, so its miss is now the first line of the rationale.
+    assert choice.rationale == [
+        "opencode: not on PATH",
+        "claude: not on PATH",
+        "codex: configured via OPENAI_API_KEY",
+    ]
     assert choice.provider == "openai"
     assert choice.protocol == "responses"
     assert choice.auth_kind == "bearer_env"

--- a/tests/test_coding_agent_opencode.py
+++ b/tests/test_coding_agent_opencode.py
@@ -1,0 +1,138 @@
+"""opencode as a coding-agent route.
+
+Added on 2026-08-19, when every node reported all three existing CLIs
+unavailable at once -- claude with no credential, codex denied by sandbox
+policy, cursor returning resource_exhausted -- and the fleet completed one task
+in twenty-four hours. opencode does not share those failure modes: it
+authenticates from an on-disk credential rather than a per-node env var.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mac.cli_credentials import KNOWN_CLIS, detect_local_credentials
+from mac.coding_agent import (
+    AGENT_PRIORITY,
+    coding_agent_argv,
+    resolve_coding_agent,
+)
+
+
+def _which(found: dict):
+    return lambda name: found.get(name)
+
+
+def _home(tmp_path: Path, *, auth: bool = False, config: bool = False) -> Path:
+    if auth:
+        d = tmp_path / ".local" / "share" / "opencode"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "auth.json").write_text('{"nvidia": {"type": "api", "key": "x"}}')
+    if config:
+        d = tmp_path / ".config" / "opencode"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "opencode.json").write_text('{"model": "p/m"}')
+    return tmp_path
+
+
+def test_opencode_is_a_known_route():
+    assert "opencode" in AGENT_PRIORITY
+    assert "opencode" in KNOWN_CLIS
+
+
+def test_opencode_is_first():
+    """First on credential durability, not model quality.
+
+    opencode authenticates from a portable on-disk credential that can be
+    copied to a worker and does not expire. claude and codex rely on OAuth
+    sessions that time out, and Anthropic offers no API-key passthrough, so a
+    headless worker cannot be provisioned with them at all today.
+    """
+    assert AGENT_PRIORITY[0] == "opencode"
+    order = list(AGENT_PRIORITY)
+    for later in ("claude", "codex", "cursor"):
+        assert order.index("opencode") < order.index(later)
+
+
+def test_auth_json_makes_opencode_available(tmp_path):
+    choice = resolve_coding_agent(
+        env={"MAC_CODING_AGENT": "opencode"},
+        home=_home(tmp_path, auth=True, config=True),
+        which=_which({"opencode": "/usr/bin/opencode"}),
+    )
+    assert choice.agent == "opencode"
+    assert choice.available
+    assert choice.auth_source == "~/.local/share/opencode/auth.json"
+
+
+def test_config_without_credentials_names_the_missing_directory(tmp_path):
+    """The copy-the-wrong-directory mistake must not read as a bare failure.
+
+    ~/.config/opencode is the directory named after the tool, so it is the one
+    a person copies to a worker. The credential is in ~/.local/share/opencode.
+    A node in that state has a CLI on PATH that looks configured and fails at
+    the provider, so the reason has to say which directory is missing.
+    """
+    choice = resolve_coding_agent(
+        env={"MAC_CODING_AGENT": "opencode"},
+        home=_home(tmp_path, auth=False, config=True),
+        which=_which({"opencode": "/usr/bin/opencode"}),
+    )
+    assert not choice.available
+    reason = " ".join(choice.rationale) if hasattr(choice, "rationale") else ""
+    assert "auth.json" in reason and "separate directory" in reason, reason
+
+
+def test_argv_uses_run_not_the_bare_default(tmp_path):
+    """`opencode` with no subcommand starts a TUI and would hang forever."""
+    choice = resolve_coding_agent(
+        env={"MAC_CODING_AGENT": "opencode"},
+        home=_home(tmp_path, auth=True),
+        which=_which({"opencode": "/usr/bin/opencode"}),
+    )
+    argv = coding_agent_argv(choice, "do the thing", env={})
+    assert argv[:2] == ["/usr/bin/opencode", "run"]
+    assert argv[-1] == "do the thing"
+
+
+def test_model_pin_is_passed_through(tmp_path):
+    choice = resolve_coding_agent(
+        env={"MAC_CODING_AGENT": "opencode"},
+        home=_home(tmp_path, auth=True),
+        which=_which({"opencode": "/usr/bin/opencode"}),
+    )
+    model = "nvidia-inference/switchyard/openai/gpt-5.3-codex"
+    argv = coding_agent_argv(choice, "p", env={"MAC_TASK_MODEL": model})
+    assert argv[2:4] == ["--model", model]
+
+
+def test_credential_sync_ships_both_trees(tmp_path):
+    """A worker needs the credential AND the config, from two directories."""
+    home = _home(tmp_path, auth=True, config=True)
+    source = detect_local_credentials(clis=["opencode"], home=home, environ={})["opencode"]
+    assert set(source.files) == {
+        ".local/share/opencode/auth.json",
+        ".config/opencode/opencode.json",
+    }
+    assert source.present
+
+
+def test_credential_sync_never_ships_node_modules(tmp_path):
+    """~/.config/opencode carries a 61MB node_modules tree on the workstation."""
+    home = _home(tmp_path, auth=True, config=True)
+    junk = home / ".config" / "opencode" / "node_modules" / "pkg"
+    junk.mkdir(parents=True)
+    (junk / "index.js").write_text("x" * 1000)
+    source = detect_local_credentials(clis=["opencode"], home=home, environ={})["opencode"]
+    assert not any("node_modules" in rel for rel in source.files)
+
+
+def test_missing_binary_is_not_available(tmp_path):
+    choice = resolve_coding_agent(
+        env={"MAC_CODING_AGENT": "opencode"},
+        home=_home(tmp_path, auth=True),
+        which=_which({}),
+    )
+    assert not choice.available


### PR DESCRIPTION
## Why

The fleet completed **one task in twenty-four hours**. Every node reported all three coding CLIs unavailable at once:

```
machine_rocky / machine_natasha / machine_bullwinkle
    claude=False   codex=False   cursor=False
```

The executor log gives three unrelated reasons with one shared consequence:

```
claude: on PATH but no supported credential configuration
codex:  sandbox preflight FAILED (class=sandbox_policy_denied)
cursor: preflight OK → RetriableError: [resource_exhausted]
→ no acceptable coding agent available/authed; executor will fail closed
```

No route means every task fails at attempt 1 with two attempts unused, because `resource_exhausted` — transient by definition — is recorded as `non_retryable_attempt_failure`. That classification bug is filed separately.

## Why opencode goes first

Credential durability, not model quality. opencode authenticates from a portable on-disk API credential that can be copied to a worker and does not expire.

The others cannot be provisioned that way today. There is no Anthropic API-key passthrough that lets a logged-in workstation hand its credential to a worker, and the OAuth sessions claude and codex use **time out** — so a headless node drifts back to unauthenticated with no local event to notice. Logging in a remote worker is an unsolved problem on this fleet, not a chore someone skipped. The route that can actually be provisioned belongs first.

## The two-directory trap

opencode keeps its **credential** in `~/.local/share/opencode/auth.json` and its **configuration** in `~/.config/opencode/opencode.json`. Copying only the latter — the obvious guess, being the directory named after the tool — yields a CLI that is on PATH, looks configured, and fails at the provider.

All three fleet hosts were found in exactly that state: config present, `auth.json` absent. So the detector reports it specifically rather than as a bare "no credential":

```
opencode: ~/.config/opencode exists but no credential
(~/.local/share/opencode/auth.json is missing -- it is a separate directory)
```

Credential sync ships both trees, and ships `opencode.json` alone — never the 61MB `node_modules` sitting beside it.

## Invocation details that are load-bearing

- argv is `opencode run [--model M] <prompt>`. **`run` is required**: bare `opencode` starts a TUI and would hang a task run forever.
- Model names must carry the provider prefix that `opencode models` prints — `nvidia-inference/switchyard/openai/gpt-5.6-sol`, not `switchyard/openai/gpt-5.6-sol`. The unprefixed form is accepted by the CLI and then fails at the server as an opaque `Unexpected server error`. Both the workstation's and puck's configs were broken this way when I found them.

## Verification

Verified end to end: `gpt-5.6-sol` and `gpt-5.3-codex` both echo the preflight sentinel, and after provisioning, **all three fleet hosts** (rocky/puck, bullwinkle/madmax, natasha/sparky) answer it too.

```
pytest -k "coding_agent or credential or executor"    761 passed, 1 xfailed
tests/test_coding_agent_opencode.py                     9 passed
```

Two existing expectations updated for the new probe order and the fourth CLI — neither deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)