### PR TITLE
Give opencode its own route identity, and find it where it is installed

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -694,6 +694,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_OPENCLAW_VERIFY_STARTUP_INTERVAL` | int | consumer-defined | openclaw-runtime | Openclaw Runtime setting: openclaw verify startup interval. |
 | `MAC_OPENCLAW_VERIFY_STARTUP_TIMEOUT` | int | consumer-defined | openclaw-runtime | Openclaw Runtime setting: openclaw verify startup timeout. |
 | `MAC_OPENCLAW_WORKSPACE` | str | consumer-defined | openclaw-runtime | Openclaw Runtime setting: openclaw workspace. |
+| `MAC_OPENCODE_MODEL` | str | consumer-defined | core | Core setting: opencode model. |
 | `MAC_OPENSHELL_ADOPT_PUBLISHED_RUNTIME` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell adopt published runtime. |
 | `MAC_OPENSHELL_ALLOW_CODEX_FILE_AUTH` | bool | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell allow codex file auth. |
 | `MAC_OPENSHELL_ALLOW_NO_LANDLOCK` | bool | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell allow no landlock. |

--- a/src/mac/coding_agent.py
+++ b/src/mac/coding_agent.py
@@ -271,22 +271,46 @@ def _route_fields(
             "endpoint": _safe_endpoint(env.get("ANTHROPIC_BASE_URL"), "https://api.anthropic.com"),
             "model": str(env.get("MAC_TASK_MODEL") or env.get("ANTHROPIC_MODEL") or "").strip(),
         }
-    return {
-        "provider": "cursor",
-        "protocol": "cursor-agent",
-        "auth_kind": (
-            "api_key"
-            if auth_source == "CURSOR_API_KEY"
-            else "bearer_env"
-            if auth_source == "CURSOR_AUTH_TOKEN"
-            else "browser_session"
-        ),
-        "endpoint": _safe_endpoint(
-            env.get("MAC_CURSOR_ENDPOINT") or env.get("CURSOR_AGENT_ENDPOINT"),
-            "https://api.cursor.com",
-        ),
-        "model": str(env.get("MAC_TASK_MODEL") or env.get("MAC_CURSOR_MODEL") or "").strip(),
-    }
+    if agent == "opencode":
+        # opencode is a multi-provider client: the provider is chosen per model
+        # in ~/.config/opencode/opencode.json, so there is no single endpoint to
+        # report. Say so rather than inventing one -- an endpoint field that
+        # names the wrong host is worse than an empty one, because the route
+        # fingerprint is what an operator reads to see where a task actually
+        # went.
+        return {
+            "provider": "opencode",
+            "protocol": "opencode-run",
+            "auth_kind": (
+                "bearer_env" if auth_source == "OPENCODE_API_KEY" else "api_key_file"
+            ),
+            "endpoint": "",
+            "model": str(env.get("MAC_TASK_MODEL") or env.get("MAC_OPENCODE_MODEL") or "").strip(),
+        }
+    if agent == "cursor":
+        return {
+            "provider": "cursor",
+            "protocol": "cursor-agent",
+            "auth_kind": (
+                "api_key"
+                if auth_source == "CURSOR_API_KEY"
+                else "bearer_env"
+                if auth_source == "CURSOR_AUTH_TOKEN"
+                else "browser_session"
+            ),
+            "endpoint": _safe_endpoint(
+                env.get("MAC_CURSOR_ENDPOINT") or env.get("CURSOR_AGENT_ENDPOINT"),
+                "https://api.cursor.com",
+            ),
+            "model": str(env.get("MAC_TASK_MODEL") or env.get("MAC_CURSOR_MODEL") or "").strip(),
+        }
+    # No silent fallback. This used to `return` cursor's fields for anything
+    # unrecognized, so adding opencode produced a route that reported
+    # provider=cursor, endpoint=https://api.cursor.com, protocol=cursor-agent
+    # while running the opencode binary -- available and correct-looking, and
+    # describing a provider it never contacts. A new agent must declare its own
+    # identity or fail loudly here.
+    raise ValueError("no route fields defined for coding agent: %r" % agent)
 
 
 def _choice(
@@ -462,6 +486,12 @@ def _service_augmented_which(
         str(home / ".local" / "bin"),
         str(home / "bin"),
         str(home / ".npm-global" / "bin"),
+        # opencode's official installer writes here and ignores XDG_BIN_DIR.
+        # It is on no default PATH, so a worker with opencode correctly
+        # installed reported "not on PATH" from the heartbeat while a login
+        # shell on the same host found it -- the inventory disagreeing with
+        # reality is precisely what this function exists to prevent.
+        str(home / ".opencode" / "bin"),
         "/usr/local/bin",
         "/opt/homebrew/bin",
     ]

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -8203,6 +8203,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: opencode model.",
+    "family": "core",
+    "name": "MAC_OPENCODE_MODEL",
+    "retired": false,
+    "sources": [
+      "src/mac/coding_agent.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Openshell Sandbox setting: openshell adopt published runtime.",
     "family": "openshell-sandbox",
     "name": "MAC_OPENSHELL_ADOPT_PUBLISHED_RUNTIME",

--- a/tests/test_coding_agent_opencode.py
+++ b/tests/test_coding_agent_opencode.py
@@ -136,3 +136,47 @@ def test_missing_binary_is_not_available(tmp_path):
         which=_which({}),
     )
     assert not choice.available
+
+
+def test_service_path_finds_the_official_install_location(tmp_path, monkeypatch):
+    """The heartbeat must see what a login shell sees.
+
+    opencode's installer writes to ~/.opencode/bin and ignores XDG_BIN_DIR.
+    That directory is on no default PATH, so the worker daemon -- which runs
+    under a minimal systemd/launchd PATH -- reported the CLI missing on hosts
+    where it was installed and working.
+    """
+    from mac.coding_agent import _service_augmented_which
+
+    binary = tmp_path / ".opencode" / "bin" / "opencode"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+
+    which = _service_augmented_which({"PATH": "/usr/bin:/bin"}, tmp_path)
+    assert which("opencode") == str(binary)
+
+
+def test_route_fields_do_not_fall_through_to_cursor(tmp_path):
+    """opencode must not inherit cursor's provider identity.
+
+    _route_fields used to `return` cursor's fields for anything unrecognized,
+    so opencode reported provider=cursor, endpoint=https://api.cursor.com and
+    protocol=cursor-agent while running the opencode binary -- available,
+    plausible, and naming a provider it never contacts.
+    """
+    choice = resolve_coding_agent(
+        env={"MAC_CODING_AGENT": "opencode"},
+        home=_home(tmp_path, auth=True),
+        which=_which({"opencode": "/usr/bin/opencode"}),
+    )
+    assert choice.provider == "opencode"
+    assert choice.protocol == "opencode-run"
+    assert "cursor" not in (choice.endpoint or "")
+
+
+def test_an_unknown_agent_raises_instead_of_borrowing_an_identity():
+    from mac.coding_agent import _route_fields
+
+    with pytest.raises(ValueError, match="no route fields"):
+        _route_fields("some-future-agent", {}, "")


### PR DESCRIPTION
Two follow-up defects in the opencode route from #449, both found by deploying it and watching the fleet inventory disagree with a login shell on the same host.

## 1. opencode reported cursor's identity

`python -m mac.coding_agent` on a worker printed:

```json
{
  "agent": "opencode",  "available": true,
  "provider": "cursor",
  "protocol": "cursor-agent",
  "endpoint": "https://api.cursor.com"
}
```

`_route_fields` ended in a bare `return` of cursor's fields for anything it didn't recognize, so adding a fourth agent silently gave it a third agent's identity. The route was available, plausible, and named a provider it never contacts — and the route fingerprint is what an operator reads to see where a task actually went.

opencode now declares its own: `provider=opencode`, `protocol=opencode-run`, `auth_kind=api_key_file` (or `bearer_env` for `OPENCODE_API_KEY`), `endpoint` empty.

**Empty is the honest answer.** opencode is a multi-provider client that picks its provider per model in its own config, so there is no single endpoint. A field naming the wrong host is worse than one naming none.

The fallback is now **closed** — cursor is matched explicitly and an unrecognized agent raises. A silent default that hands a new agent someone else's identity is the same shape as the rest of this week's bugs: nothing errors, and the wrong answer is indistinguishable from the right one.

## 2. The heartbeat could not find the binary

Machines reported `opencode=False` while `opencode --version` worked on the same host.

`_service_augmented_which` searches `~/.local/bin`, `~/bin`, `~/.npm-global/bin`, `/usr/local/bin`, `/opt/homebrew/bin`. opencode's official installer writes to **`~/.opencode/bin`** and ignores `XDG_BIN_DIR` — so the one location the supported installer actually uses was the one place nobody looked.

That function exists precisely so the inventory cannot disagree with what a task run will find. It was one directory short of its own promise.

## Tests

```
tests/test_coding_agent_opencode.py                    12 passed
pytest -k "coding_agent or credential or executor"    764 passed, 1 xfailed
```

Three new: the service path finds the official install location; opencode does not inherit cursor's identity; an unknown agent raises rather than borrowing one.

Env registry regenerated in the same commit this time — third generated artifact to catch me this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)