### PR TITLE
Make a fleet-scoped OpenShell assignment actually confine the agent

### DIFF
--- a/docs/openshell-sandbox.md
+++ b/docs/openshell-sandbox.md
@@ -196,6 +196,30 @@ Deliberate properties:
   malformed response leaves the existing policy in place. Confinement is never
   dropped because delivery failed.
 
+### Assignment scope and precedence
+
+An assignment targets an **agent** or a **fleet**. Resolution is explicit:
+
+1. An agent-scoped assignment wins over any fleet-scoped one. The more specific
+   target is the more deliberate one, so pinning a single agent overrides the
+   fleet default without editing the fleet.
+2. Otherwise a fleet-scoped assignment applies to the fleet's *configured*
+   members (`fleet_agents`). Runtime observations do not count: an agent must
+   not be able to observe itself into someone else's policy.
+3. An agent in several fleets whose assignments name different policies is a
+   misconfiguration, and resolution fails loud rather than picking whichever
+   row sorts first. Fleets naming the same policy and version agree, so those
+   resolve normally. Pinning the agent directly resolves a conflict.
+4. When an assignment is superseded, deactivated, or the agent leaves the
+   fleet, resolution falls through to the next matching rule — possibly to no
+   hub policy at all, which leaves the worker's existing policy in place
+   (fail-safe, as above).
+
+`--target-type host` is **refused**. Nothing resolves a host to the agents
+running on it (`machines.hostname` is not unique), so a host assignment could
+only ever be a row nobody enforces; on a confinement boundary an unenforceable
+assignment that lists as "assigned" is worse than no assignment at all.
+
 ### Who can read a policy
 
 The guardrail text names the fleet's hub and gateway hosts, their ports, and the

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -8996,7 +8996,14 @@ def build_parser() -> argparse.ArgumentParser:
     osh_policy_assign = osh_policy.add_parser("assign")
     osh_policy_assign.add_argument("policy")
     osh_policy_assign.add_argument("target_id")
-    osh_policy_assign.add_argument("--target-type", default="agent", choices=("agent", "fleet", "host"))
+    # "host" stays a parseable choice so the refusal comes from the service with
+    # its reason attached, rather than as a bare argparse "invalid choice".
+    osh_policy_assign.add_argument(
+        "--target-type",
+        default="agent",
+        choices=("agent", "fleet", "host"),
+        help="agent (pins one agent, wins over fleet) or fleet (its configured members); host is refused",
+    )
     osh_policy_assign.add_argument("--created-by", default="human")
     _set(cmd_openshell_policy_assign, osh_policy_assign)
 

--- a/src/mac/openshell_service.py
+++ b/src/mac/openshell_service.py
@@ -294,6 +294,23 @@ class OpenShellService:
             raise ValidationError("OpenShell assignment requires target_id")
         if target_type_value == "agent":
             self._get_agent(target_id_value)
+        elif target_type_value == "fleet":
+            # Store the fleet *id*, never the name: resolution joins
+            # ``fleet_agents.fleet_id``, and a fleet can be renamed after the
+            # assignment is written. Normalizing here keeps a rename from
+            # silently disarming a confinement policy.
+            target_id_value = self._resolve_fleet_id(target_id_value)
+        else:
+            # target_type == "host". Refused rather than stored: nothing
+            # resolves a host to the agents running on it (``agents.machine_id``
+            # points at ``machines``, whose ``hostname`` is not unique), so a
+            # host assignment could only ever be a row nobody enforces. On a
+            # confinement boundary an unenforceable assignment that lists as
+            # "assigned" is worse than no assignment at all, so this fails loud.
+            raise ValidationError(
+                "host-scoped OpenShell assignments are not enforced and are refused; "
+                "assign the policy to an agent or a fleet instead"
+            )
         now = utcnow()
         assignment_id = new_id("ospola")
         with self.store.transaction() as conn:
@@ -362,9 +379,80 @@ class OpenShellService:
         sql += " ORDER BY updated_at DESC, id DESC"
         return [self._assignment_from_row(row) for row in self.store.query_all(sql, tuple(params))]
 
+    def _resolve_fleet_id(self, fleet_id_or_name: str) -> str:
+        # Id before name, in two queries rather than one OR: a name that happens
+        # to equal another fleet's id must not decide the target by row order.
+        for sql in ("SELECT id FROM fleets WHERE id = ?", "SELECT id FROM fleets WHERE name = ?"):
+            row = self.store.query_one(sql, (fleet_id_or_name,))
+            if row is not None:
+                return str(row["id"])
+        raise NotFoundError("fleet not found: %s" % fleet_id_or_name)
+
+    def _fleet_ids_for_agent(self, agent_id: str) -> List[str]:
+        """Configured fleet membership for ``agent_id``.
+
+        Deliberately ``fleet_agents`` (the reconciled, configured membership)
+        and not ``fleet_agent_observations``: an observation is unmanaged
+        runtime drift, so letting an agent *observe* itself into a fleet would
+        let it choose its own confinement policy.
+        """
+        rows = self.store.query_all(
+            "SELECT fleet_id FROM fleet_agents WHERE agent_id = ? ORDER BY fleet_id",
+            (agent_id,),
+        )
+        return [str(row["fleet_id"]) for row in rows]
+
     def active_assignment_for_agent(self, agent_id: str) -> Optional[OpenShellPolicyAssignment]:
+        """The assignment that actually governs ``agent_id``.
+
+        Precedence is explicit, not emergent:
+
+        1. **Agent-scoped wins over fleet-scoped.** The more specific target is
+           the more deliberate one; an operator pinning one agent must be able
+           to override the fleet default without editing the fleet.
+        2. **Fleet-scoped applies to configured members.** Before this, a fleet
+           assignment was accepted, listed, and enforced nothing — the agent
+           quietly kept whatever local policy file it already had, so
+           "assigned" and "enforced" were indistinguishable from outside.
+        3. **Multiple fleets that disagree are an error, not a race.** An agent
+           may belong to several fleets. Picking "whichever row sorts first"
+           would make confinement depend on insertion order, so conflicting
+           fleet assignments fail loud instead. Several fleets naming the same
+           policy *and* version agree, so that resolves normally.
+        4. **Deactivation falls through.** When a fleet assignment goes
+           inactive the agent is simply back to the next rule that matches
+           (agent-scoped, another fleet, or no hub policy at all) — the same
+           behaviour deactivating an agent-scoped assignment has always had.
+        """
         rows = self.list_assignments(target_type="agent", target_id=agent_id, active_only=True)
-        return rows[0] if rows else None
+        if rows:
+            return rows[0]
+        fleet_ids = self._fleet_ids_for_agent(agent_id)
+        candidates: List[OpenShellPolicyAssignment] = []
+        for fleet_id in fleet_ids:
+            candidates.extend(
+                self.list_assignments(target_type="fleet", target_id=fleet_id, active_only=True)
+            )
+        if not candidates:
+            return None
+        distinct = {(item.policy_id, item.policy_version) for item in candidates}
+        if len(distinct) > 1:
+            raise ValidationError(
+                "agent %s is in fleets with conflicting OpenShell policy assignments (%s); "
+                "assign the policy to the agent directly to resolve it"
+                % (
+                    agent_id,
+                    ", ".join(
+                        sorted(
+                            "%s@%s via fleet %s" % (item.policy_id, item.policy_version, item.target_id)
+                            for item in candidates
+                        )
+                    ),
+                )
+            )
+        # All remaining candidates name the same policy and version, so any of
+        # them is the same answer; sort for a stable assignment id in output.
+        return sorted(candidates, key=lambda item: item.id)[0]
 
     def report_agent_status(
         self,

--- a/tests/test_openshell_fleet_assignment.py
+++ b/tests/test_openshell_fleet_assignment.py
@@ -1,0 +1,234 @@
+"""Fleet-scoped OpenShell assignments must actually reach the agent.
+
+A fleet assignment used to be accepted, listed by `policy assignments`, and
+enforced nothing: resolution queried ``target_type = 'agent'`` only, so the
+worker fell back to whatever local policy file it already had. On a confinement
+boundary that made "assigned" and "enforced" indistinguishable from outside.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import NotFoundError, ValidationError
+from mac.services import ControlPlane
+
+POLICY_TEXT = """version: 1
+
+network_policies:
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: hub.example.com
+        port: 8789
+"""
+
+
+def _policy_text(host: str) -> str:
+    return POLICY_TEXT.replace("hub.example.com", host)
+
+
+def _agent(cp: ControlPlane, name: str = "worker"):
+    machine = cp.register_machine("host-%s" % name)
+    return cp.register_agent(machine.id, name, capabilities=[])
+
+
+def test_fleet_assignment_delivers_the_policy_text_to_a_member_agent() -> None:
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    fleet = cp.create_fleet("edge", agent_ids=[agent.id])
+    policy = cp.openshell.create_policy("edge-policy", _policy_text("fleet.example.com"))
+
+    cp.openshell.assign_policy(policy.id, target_type="fleet", target_id=fleet.id)
+
+    assigned = cp.assigned_openshell_policy(agent.id)
+    assert assigned["policy_id"] == policy.id
+    assert assigned["policy_text"] == policy.policy_text
+    assert "fleet.example.com" in assigned["policy_text"]
+    assert assigned["checksum"] == policy.checksum
+
+
+def test_fleet_assignment_does_not_leak_to_non_members() -> None:
+    cp = ControlPlane.in_memory()
+    member = _agent(cp, "member")
+    outsider = _agent(cp, "outsider")
+    fleet = cp.create_fleet("edge", agent_ids=[member.id])
+    policy = cp.openshell.create_policy("edge-policy", _policy_text("fleet.example.com"))
+    cp.openshell.assign_policy(policy.id, target_type="fleet", target_id=fleet.id)
+
+    assert cp.assigned_openshell_policy(member.id)["policy_id"] == policy.id
+    with pytest.raises(NotFoundError, match="no OpenShell policy assigned"):
+        cp.assigned_openshell_policy(outsider.id)
+
+
+def test_agent_scoped_assignment_beats_fleet_scoped() -> None:
+    """The more specific target is the more deliberate one: pinning one agent
+    must override the fleet default without editing the fleet."""
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    fleet = cp.create_fleet("edge", agent_ids=[agent.id])
+    fleet_policy = cp.openshell.create_policy("fleet-policy", _policy_text("fleet.example.com"))
+    agent_policy = cp.openshell.create_policy("agent-policy", _policy_text("pinned.example.com"))
+
+    cp.openshell.assign_policy(fleet_policy.id, target_type="fleet", target_id=fleet.id)
+    cp.openshell.assign_policy(agent_policy.id, target_type="agent", target_id=agent.id)
+
+    assigned = cp.assigned_openshell_policy(agent.id)
+    assert assigned["policy_id"] == agent_policy.id
+    assert "pinned.example.com" in assigned["policy_text"]
+    assert "fleet.example.com" not in assigned["policy_text"]
+
+
+def test_fleet_assignment_accepts_a_fleet_name_but_stores_the_id() -> None:
+    """A rename must not silently disarm the assignment."""
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    fleet = cp.create_fleet("edge", agent_ids=[agent.id])
+    policy = cp.openshell.create_policy("edge-policy", _policy_text("fleet.example.com"))
+
+    assignment = cp.openshell.assign_policy(policy.id, target_type="fleet", target_id="edge")
+    assert assignment.target_id == fleet.id
+
+    cp.update_fleet(fleet.id, name="edge-renamed")
+    assert cp.assigned_openshell_policy(agent.id)["policy_id"] == policy.id
+
+
+def test_assigning_to_an_unknown_fleet_is_refused() -> None:
+    cp = ControlPlane.in_memory()
+    policy = cp.openshell.create_policy("edge-policy", POLICY_TEXT)
+    with pytest.raises(NotFoundError, match="fleet not found"):
+        cp.openshell.assign_policy(policy.id, target_type="fleet", target_id="no-such-fleet")
+
+
+def test_two_fleets_naming_different_policies_fail_loud() -> None:
+    """`whichever row sorts first` would make confinement depend on insert order."""
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    left = cp.create_fleet("left", agent_ids=[agent.id])
+    right = cp.create_fleet("right", agent_ids=[agent.id])
+    left_policy = cp.openshell.create_policy("left-policy", _policy_text("left.example.com"))
+    right_policy = cp.openshell.create_policy("right-policy", _policy_text("right.example.com"))
+    cp.openshell.assign_policy(left_policy.id, target_type="fleet", target_id=left.id)
+    cp.openshell.assign_policy(right_policy.id, target_type="fleet", target_id=right.id)
+
+    with pytest.raises(ValidationError, match="conflicting OpenShell policy assignments"):
+        cp.assigned_openshell_policy(agent.id)
+
+
+def test_two_fleets_naming_the_same_policy_resolve() -> None:
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    left = cp.create_fleet("left", agent_ids=[agent.id])
+    right = cp.create_fleet("right", agent_ids=[agent.id])
+    policy = cp.openshell.create_policy("shared-policy", _policy_text("shared.example.com"))
+    cp.openshell.assign_policy(policy.id, target_type="fleet", target_id=left.id)
+    cp.openshell.assign_policy(policy.id, target_type="fleet", target_id=right.id)
+
+    assigned = cp.assigned_openshell_policy(agent.id)
+    assert assigned["policy_id"] == policy.id
+    assert "shared.example.com" in assigned["policy_text"]
+
+
+def test_an_agent_scoped_pin_resolves_a_conflict_between_fleets() -> None:
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    left = cp.create_fleet("left", agent_ids=[agent.id])
+    right = cp.create_fleet("right", agent_ids=[agent.id])
+    left_policy = cp.openshell.create_policy("left-policy", _policy_text("left.example.com"))
+    right_policy = cp.openshell.create_policy("right-policy", _policy_text("right.example.com"))
+    pinned = cp.openshell.create_policy("pinned-policy", _policy_text("pinned.example.com"))
+    cp.openshell.assign_policy(left_policy.id, target_type="fleet", target_id=left.id)
+    cp.openshell.assign_policy(right_policy.id, target_type="fleet", target_id=right.id)
+    cp.openshell.assign_policy(pinned.id, target_type="agent", target_id=agent.id)
+
+    assert "pinned.example.com" in cp.assigned_openshell_policy(agent.id)["policy_text"]
+
+
+def test_reassigning_a_fleet_supersedes_the_previous_policy() -> None:
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    fleet = cp.create_fleet("edge", agent_ids=[agent.id])
+    first = cp.openshell.create_policy("first", _policy_text("first.example.com"))
+    second = cp.openshell.create_policy("second", _policy_text("second.example.com"))
+    cp.openshell.assign_policy(first.id, target_type="fleet", target_id=fleet.id)
+    assert "first.example.com" in cp.assigned_openshell_policy(agent.id)["policy_text"]
+
+    cp.openshell.assign_policy(second.id, target_type="fleet", target_id=fleet.id)
+    assigned = cp.assigned_openshell_policy(agent.id)
+    assert assigned["policy_id"] == second.id
+    assert "second.example.com" in assigned["policy_text"]
+
+
+def test_dropping_membership_returns_the_agent_to_no_hub_policy() -> None:
+    """Deactivation semantics: falling out of the fleet falls through to the
+    next matching rule — here, none — rather than pinning the last policy."""
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    other = _agent(cp, "other")
+    fleet = cp.create_fleet("edge", agent_ids=[agent.id, other.id])
+    policy = cp.openshell.create_policy("edge-policy", _policy_text("fleet.example.com"))
+    cp.openshell.assign_policy(policy.id, target_type="fleet", target_id=fleet.id)
+    assert cp.assigned_openshell_policy(agent.id)["policy_id"] == policy.id
+
+    cp.update_fleet(fleet.id, agent_ids=[other.id])
+
+    with pytest.raises(NotFoundError, match="no OpenShell policy assigned"):
+        cp.assigned_openshell_policy(agent.id)
+    assert cp.assigned_openshell_policy(other.id)["policy_id"] == policy.id
+
+
+def test_deactivated_fleet_assignment_leaves_no_hub_policy() -> None:
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    fleet = cp.create_fleet("edge", agent_ids=[agent.id])
+    fleet_policy = cp.openshell.create_policy("fleet-policy", _policy_text("fleet.example.com"))
+    cp.openshell.assign_policy(fleet_policy.id, target_type="fleet", target_id=fleet.id)
+    assert "fleet.example.com" in cp.assigned_openshell_policy(agent.id)["policy_text"]
+
+    cp.store.execute(
+        "UPDATE openshell_policy_assignments SET active = 0 "
+        "WHERE target_type = ? AND target_id = ?",
+        ("fleet", fleet.id),
+    )
+
+    with pytest.raises(NotFoundError, match="no OpenShell policy assigned"):
+        cp.assigned_openshell_policy(agent.id)
+
+
+def test_runtime_observation_alone_does_not_confer_a_fleet_policy() -> None:
+    """An agent must not be able to observe itself into someone else's policy."""
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    fleet = cp.create_fleet("edge")
+    policy = cp.openshell.create_policy("edge-policy", _policy_text("fleet.example.com"))
+    cp.openshell.assign_policy(policy.id, target_type="fleet", target_id=fleet.id)
+
+    cp.observe_fleet_agent(fleet.id, agent.id)
+
+    with pytest.raises(NotFoundError, match="no OpenShell policy assigned"):
+        cp.assigned_openshell_policy(agent.id)
+
+
+def test_host_scoped_assignment_is_refused_rather_than_silently_inert() -> None:
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    policy = cp.openshell.create_policy("edge-policy", POLICY_TEXT)
+
+    with pytest.raises(ValidationError, match="host-scoped OpenShell assignments are not enforced"):
+        cp.openshell.assign_policy(policy.id, target_type="host", target_id=agent.machine_id)
+
+    assert cp.openshell.list_assignments(target_type="host") == []
+
+
+def test_agent_status_reports_the_fleet_assignment() -> None:
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    fleet = cp.create_fleet("edge", agent_ids=[agent.id])
+    policy = cp.openshell.create_policy("edge-policy", _policy_text("fleet.example.com"))
+    cp.openshell.assign_policy(policy.id, target_type="fleet", target_id=fleet.id)
+
+    status = cp.get_openshell_status(agent.id)
+    assert status["effective"]["assigned"] is True
+    assert status["assignment"]["target_type"] == "fleet"
+    assert status["assignment"]["target_id"] == fleet.id
+    assert status["policy"]["id"] == policy.id


### PR DESCRIPTION
Closes task_995edbe0.

## The bug

`openshell_service.py:291` accepts `target_type` in {agent, fleet, host} and the CLI offers `--target-type`. But `active_assignment_for_agent` queried `target_type = "agent"` ONLY, and `assigned_policy` — the function behind `GET /agents/{id}/openshell/policy`, which is how a worker learns its policy — called exactly that.

So a fleet-scoped assignment was accepted by the API, returned by `policy list`, visible in `policy assignments`, and **enforced nothing**. The agent quietly kept whatever local policy file it already had. On a confinement boundary, "assigned" and "enforced" were indistinguishable from outside.

## Approach: implement fleet, refuse host

**Fleet is enforceable** — `fleet_agents` is an exact, hub-owned membership set — so a fleet assignment now reaches the worker.

**Host is not.** Nothing maps a host to the agents running on it (`agents.machine_id` points at `machines`, whose `hostname` is not unique in the schema), so any resolution would be a guess on a confinement boundary. `target_type="host"` is now **refused at assignment time** with a message naming why. Nothing unenforceable is accepted silently — a loud refusal beats a row nobody enforces.

## Precedence, explicit rather than emergent

1. **Agent-scoped beats fleet-scoped.** The more specific target is the more deliberate one; pinning one agent must override the fleet default without editing the fleet.
2. **Fleet-scoped applies to configured members** — `fleet_agents`, deliberately **not** `fleet_agent_observations`. An observation is unmanaged runtime drift, so letting an agent *observe itself* into a fleet would let it choose its own confinement policy.
3. **Multiple fleets that disagree are an error, not a race.** An agent may belong to several fleets; picking "whichever row sorts first" would make confinement depend on insertion order. Conflicting assignments fail loud, naming every conflicting fleet. Fleets naming the same policy *and version* agree, so they resolve normally. An agent-scoped pin resolves a conflict.
4. **Deactivation falls through** to the next matching rule, possibly to no hub policy — leaving the worker's existing policy in place, the pre-existing fail-safe, unchanged.

Fleet targets are normalized to the fleet **id** at assign time (id checked before name, in two separate queries so a name colliding with another fleet's id cannot decide by row order), so a later rename cannot silently disarm a policy.

## Tests

14 new tests that assert the policy **text** a worker would receive — distinct `*.example.com` hosts per policy — not merely that a lookup returns non-None.

Covered: fleet delivery, non-member isolation, agent-beats-fleet (asserting the fleet's host string is *absent*), name→id normalization surviving a rename, unknown fleet refused, conflicting fleets failing loud, agreeing fleets resolving, pin resolving a conflict, reassignment, membership drop, explicit deactivation, observation-only membership conferring nothing, host refusal leaving no row, and `agent_status` reporting the fleet assignment.

**Discrimination verified:** with `openshell_service.py` reverted to its pre-fix state, **11 of the 14 fail**. The 3 that pass are fall-through-to-nothing cases that trivially held before.

```
tests/test_openshell_fleet_assignment.py    14 passed
test-docs.py --static-only                  pass
dead-code-check                             clean
```

## Note on unrelated failures

`tests/test_worker_control_edges.py` has 4 failures in `-k "openshell or policy or fleet"` runs. They are **pre-existing on main** — I confirmed them on a pristine `origin/main` worktree at `885cd400`, with none of this branch's changes present. They concern OpenShell container-image rebuild/podman-mirror behaviour on macOS and appear to be platform-dependent (CI sanity runs ubuntu-latest). Filed separately rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)