### PR TITLE
Check a repository contract against the repository it describes

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -38,6 +38,7 @@ from mac.models import (
     utcnow,
 )
 from mac import sandbox_bom
+from mac import contract_coverage
 from mac.task_wait import WAIT_SCHEMA, TaskWait, dedupe_events, waitable_tasks
 from mac.repository_hygiene import (
     CANCELLATION_DISPOSITIONS,
@@ -3553,6 +3554,53 @@ def cmd_sandbox_bom(args: argparse.Namespace) -> None:
         return
 
     _print(derived)
+
+
+def cmd_sandbox_contract_coverage(args: argparse.Namespace) -> None:
+    """Diff what a checkout NEEDS against what its contract DECLARES.
+
+    The sandbox image is built from the union of DECLARED contracts, and
+    nothing has ever checked a declaration against the repository it describes.
+    Under-declaration is therefore silent: the image omits the tool, and the
+    task dies inside the sandbox on a missing binary that reads as the task's
+    fault rather than the contract's.
+
+    This reports; it never edits a contract, never selects a package, and never
+    touches an image. A suggested command with no curated package mapping in
+    sandbox_bom is reported as unmapped -- guessing an apt package from a binary
+    name would install something plausible into the security boundary.
+    """
+    suggestion = contract_coverage.suggest_required_commands(args.repo)
+
+    if args.declared is not None:
+        declared = {item.strip() for item in args.declared.split(",") if item.strip()}
+        source = "--declared"
+    elif args.project:
+        # The hub's registration is what the BOM derivation actually reads, so
+        # when a project is named that is the set worth diffing against.
+        declared = sandbox_bom.contract_commands(_plane(args).get_project(args.project))
+        source = "hub registration"
+    else:
+        declared = contract_coverage.declared_commands_from_checkout(args.repo)
+        source = "checkout .mac/project.yaml"
+
+    report = contract_coverage.coverage_report(
+        suggestion, declared, project=args.project
+    )
+    report["declared_source"] = source
+    report["evidence_lines"] = contract_coverage.evidence_lines(suggestion)
+
+    if args.file_task:
+        report["report_task"] = _plane(args).file_contract_coverage_report(
+            report, project=args.project, actor=args.actor
+        )
+
+    _print(report)
+    # --check makes this usable as a gate. Only the undeclared half exits
+    # non-zero: a declared command no manifest implies is hygiene, and failing
+    # CI on it would train everyone to pass --no-check.
+    if args.check and report["undeclared_commands"]:
+        raise SystemExit(1)
 
 
 def cmd_sandbox_rollout(args: argparse.Namespace) -> None:
@@ -8581,6 +8629,42 @@ def build_parser() -> argparse.ArgumentParser:
         help="also report what the derived BOM requires that this image never mentions",
     )
     _set(cmd_sandbox_bom, sandbox_bom_cmd)
+    sandbox_coverage_cmd = sandbox.add_parser(
+        "contract-coverage",
+        help=(
+            "diff a checkout's implied commands against its declared contract "
+            "(reports only; never edits a contract or an image)"
+        ),
+    )
+    sandbox_coverage_cmd.add_argument(
+        "--repo",
+        required=True,
+        metavar="PATH",
+        help="the checkout to scan for manifests",
+    )
+    sandbox_coverage_cmd.add_argument(
+        "--project",
+        default=None,
+        help="diff against this project's registered contract instead of the checkout's",
+    )
+    sandbox_coverage_cmd.add_argument(
+        "--declared",
+        default=None,
+        metavar="CMD,CMD",
+        help="declared commands to diff against, bypassing hub and checkout",
+    )
+    sandbox_coverage_cmd.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 when a manifest implies a command the contract never declares",
+    )
+    sandbox_coverage_cmd.add_argument(
+        "--file-task",
+        action="store_true",
+        help="stage a non-dispatchable report task for review (deduplicated)",
+    )
+    sandbox_coverage_cmd.add_argument("--actor", default="human")
+    _set(cmd_sandbox_contract_coverage, sandbox_coverage_cmd)
     sandbox_rollout_cmd = sandbox.add_parser(
         "rollout",
         help="roll a reviewed sandbox image onto each worker, after it drains",

--- a/src/mac/contract_coverage.py
+++ b/src/mac/contract_coverage.py
@@ -1,0 +1,397 @@
+"""Compare what a repository NEEDS against what its contract DECLARES.
+
+Two halves of the same question have never been connected.
+
+``mac.environment_contract`` reads a checkout -- package.json, pyproject.toml,
+Cargo.toml, .nvmrc, lockfiles -- and works out what the repo actually needs. It
+runs per task, in the worker's worktree, and is thrown away when the task ends.
+
+``mac.sandbox_bom`` decides what goes into the shared sandbox image. It reads
+exactly one thing: ``metadata.repository_contract.toolchain.required_commands``
+-- a list a human TYPED into ``.mac/project.yaml``.
+
+So the image is derived from a memory, while the code that can observe the truth
+runs metres away and is discarded. The failure that allows is under-declaration,
+and it is silent: a contract that omits a needed tool produces a sandbox without
+it, and the task then dies inside the sandbox on a missing binary that reads as
+a task problem rather than a contract problem. ``mac.sandbox_excursion`` exists
+to paper over exactly this after the fact.
+
+This module closes the loop by REPORTING, never by acting:
+
+* it reuses :func:`mac.environment_contract.derive_environment_contract` rather
+  than writing a second scanner -- one place learns to read repos;
+* it maps manifests to commands through a CURATED table, and carries the
+  evidence for every suggestion ("node <- package.json") so a reviewer can
+  disagree with a specific inference instead of the whole report;
+* it diffs both directions -- needed-but-undeclared (work breaks) and
+  declared-but-unused (dead weight in the security boundary);
+* it changes NOTHING. No contract is edited, no package is installed.
+
+The invariant :mod:`mac.sandbox_bom` states -- *a required COMMAND is not a
+package name; the mapping is CURATED, and a command with no mapping is
+REPORTED, never guessed* -- is strictly preserved here, and is in fact doubly
+load-bearing now. A suggestion is an inference about a REPO; turning it into an
+apt package would be an inference about the IMAGE stacked on top of it, and the
+image is the security boundary. So a suggested command with no curated package
+mapping is reported as unmapped, with an empty package list, forever.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+
+from .environment_contract import derive_environment_contract
+from .sandbox_bom import COMMAND_PACKAGES, MAC_CORE_COMMANDS
+
+JsonDict = Dict[str, Any]
+
+COVERAGE_SCHEMA = "mac.contract_command_coverage.v1"
+
+#: Marker on a filed report task, so dedupe does not depend on title text.
+COVERAGE_METADATA_KEY = "contract_command_coverage"
+
+#: Curated manifest -> commands that manifest implies.
+#:
+#: Deliberately conservative and deliberately boring. Every entry is a command
+#: you cannot run the manifest's own standard workflow without: package.json
+#: without node is not a project, Cargo.toml without cargo is not a build. The
+#: temptation is to be clever here -- parse scripts, chase toolchain files,
+#: guess from directory names -- and the cost of a wrong entry is a report that
+#: cries wolf, which is read once and then never again.
+#:
+#: This table produces SUGGESTIONS for a human to accept or reject. It never
+#: edits a contract and never selects a package.
+MANIFEST_COMMANDS: Dict[str, Tuple[str, ...]] = {
+    "CMakeLists.txt": ("cmake",),
+    "Cargo.toml": ("cargo",),
+    "Gemfile": ("ruby",),
+    "Makefile": ("make",),
+    "binding.gyp": ("node", "make", "cc"),
+    "build.gradle": ("java",),
+    "build.gradle.kts": ("java",),
+    "go.mod": ("go",),
+    "package-lock.json": ("node", "npm"),
+    "package.json": ("node",),
+    "pnpm-lock.yaml": ("pnpm", "node"),
+    "pnpm-workspace.yaml": ("pnpm", "node"),
+    "pom.xml": ("java",),
+    "project.clj": ("lein",),
+    "pyproject.toml": ("python3",),
+    "requirements.txt": ("python3",),
+    "setup.cfg": ("python3",),
+    "setup.py": ("python3",),
+    "uv.lock": ("uv",),
+    "yarn.lock": ("yarn", "node"),
+}
+
+#: Commands implied by ``native_build.required``, whatever produced the signal.
+#: A repo that compiles needs a compiler and something to drive it; which apt
+#: package supplies them is sandbox_bom's curated business, not this table's.
+NATIVE_BUILD_COMMANDS: Tuple[str, ...] = ("cc", "make")
+
+
+# ===========================================================================
+# Suggestion
+# ===========================================================================
+
+
+def suggest_required_commands(
+    repo_path: str | Path,
+    *,
+    contract: Optional[Mapping[str, Any]] = None,
+) -> JsonDict:
+    """Commands a checkout's manifests imply, each with its evidence.
+
+    Reuses the environment contract derivation rather than re-reading the
+    checkout: ``manifests`` is that derivation's inventory of what exists, and
+    ``native_build.signals`` is its judgement about compilation. Pass a
+    previously derived ``contract`` to avoid scanning twice.
+
+    A repo whose manifests imply nothing returns an EMPTY suggestion. That is
+    the common case for a docs repo or a scratch checkout, and inventing a
+    baseline for it would make every such repo a finding.
+    """
+    root = Path(repo_path)
+    derived = dict(contract) if contract is not None else derive_environment_contract(root)
+
+    evidence: Dict[str, List[str]] = {}
+
+    for manifest_name in derived.get("manifests") or []:
+        for command in MANIFEST_COMMANDS.get(str(manifest_name), ()):
+            evidence.setdefault(command, [])
+            if manifest_name not in evidence[command]:
+                evidence[command].append(str(manifest_name))
+
+    native = derived.get("native_build") or {}
+    if native.get("required"):
+        signals = [str(item) for item in (native.get("signals") or [])]
+        label = "native build (%s)" % ("; ".join(signals) if signals else "detected")
+        for command in NATIVE_BUILD_COMMANDS:
+            evidence.setdefault(command, [])
+            if label not in evidence[command]:
+                evidence[command].append(label)
+
+    return {
+        "schema": COVERAGE_SCHEMA,
+        "repository_path": str(root),
+        "suggested_commands": sorted(evidence),
+        "evidence": {command: list(sorted(items)) for command, items in evidence.items()},
+    }
+
+
+def evidence_lines(suggestion: Mapping[str, Any]) -> List[str]:
+    """``"node <- package.json"`` for each suggested command, sorted."""
+    evidence = suggestion.get("evidence") or {}
+    return [
+        "%s <- %s" % (command, ", ".join(evidence.get(command) or []) or "(no evidence)")
+        for command in sorted(suggestion.get("suggested_commands") or [])
+    ]
+
+
+# ===========================================================================
+# The diff
+# ===========================================================================
+
+
+def coverage_report(
+    suggestion: Mapping[str, Any],
+    declared: Iterable[str],
+    *,
+    project: Optional[str] = None,
+    core_commands: Sequence[str] = MAC_CORE_COMMANDS,
+    command_packages: Optional[Mapping[str, Sequence[str]]] = None,
+) -> JsonDict:
+    """Diff a repo's implied commands against the ones its contract declares.
+
+    Both directions are reported because they are different problems:
+
+    ``undeclared``
+        A manifest implies a command the contract never names, and the command
+        is not one the sandbox core guarantees. This is the silent failure --
+        the image will not carry it, and the task dies inside the sandbox on a
+        missing binary that looks like the task's fault.
+
+    ``unused``
+        The contract names a command nothing in the checkout implies. Dead
+        weight in the image, and the image is the security boundary. Worth
+        deleting, never urgent -- and explicitly NOT a thing to act on
+        automatically, because a manifest table cannot see a tool invoked only
+        by a shell script.
+
+    Commands in ``core_commands`` appear in neither list. mac's own executor
+    puts them in every sandbox regardless of any contract, so a Python repo
+    "failing" to declare python3 is not a finding, it is noise -- and noise is
+    the only way this report can fail. They are surfaced separately in
+    ``core_supplied`` so the reasoning stays visible.
+    """
+    packages_for = dict(command_packages or COMMAND_PACKAGES)
+    core = {str(item).strip() for item in core_commands if str(item).strip()}
+
+    suggested = {
+        str(item).strip() for item in (suggestion.get("suggested_commands") or []) if str(item).strip()
+    }
+    declared_set = {str(item).strip() for item in declared if str(item).strip()}
+    evidence = suggestion.get("evidence") or {}
+
+    undeclared_commands = sorted(suggested - declared_set - core)
+    undeclared: List[JsonDict] = []
+    unmapped: List[str] = []
+    for command in undeclared_commands:
+        mapped = command in packages_for
+        if not mapped:
+            unmapped.append(command)
+        undeclared.append(
+            {
+                "command": command,
+                "evidence": list(evidence.get(command) or []),
+                # NEVER guessed. An unmapped command carries an empty package
+                # list and says so; the alternative is inferring an apt package
+                # from a binary name and installing it into the sandbox.
+                "packages": sorted(packages_for.get(command, ())) if mapped else [],
+                "package_mapping_known": mapped,
+            }
+        )
+
+    return {
+        "schema": COVERAGE_SCHEMA,
+        "project": project,
+        "repository_path": suggestion.get("repository_path"),
+        "suggested_commands": sorted(suggested),
+        "declared_commands": sorted(declared_set),
+        "undeclared_commands": undeclared,
+        "unused_declared_commands": sorted(declared_set - suggested - core),
+        "satisfied_commands": sorted(suggested & declared_set),
+        "core_supplied_commands": sorted(suggested & core),
+        "unmapped_commands": unmapped,
+    }
+
+
+def coverage_has_findings(report: Mapping[str, Any]) -> bool:
+    return bool(
+        report.get("undeclared_commands") or report.get("unused_declared_commands")
+    )
+
+
+def coverage_signature(report: Mapping[str, Any]) -> JsonDict:
+    """The identity of a finding, for dedupe.
+
+    Keyed on the two command sets and the project -- not on evidence text or
+    path, which move with checkouts and reword with scanner changes without the
+    finding itself being different.
+    """
+    return {
+        "schema": COVERAGE_SCHEMA,
+        "project": report.get("project"),
+        "undeclared": [entry["command"] for entry in report.get("undeclared_commands") or []],
+        "unused": list(report.get("unused_declared_commands") or []),
+    }
+
+
+# ===========================================================================
+# The review surface: a staged, non-dispatchable task
+# ===========================================================================
+
+
+def coverage_task_title(report: Mapping[str, Any]) -> str:
+    """Name the half that breaks work first, because that is what gets read."""
+    project = report.get("project") or "this repository"
+    if report.get("undeclared_commands"):
+        return (
+            "Contract coverage: %s's manifests imply commands its contract does "
+            "not declare" % project
+        )
+    return (
+        "Contract coverage: %s declares commands nothing in the repo implies" % project
+    )
+
+
+def coverage_task_description(report: Mapping[str, Any]) -> str:
+    """What a reviewer needs to decide -- and what they must decide, not us."""
+    project = report.get("project") or "this repository"
+    lines = [
+        "A static scan of %s's checkout (mac.environment_contract) implies a set "
+        "of required commands. Its repository contract declares a different set. "
+        "This task reports the difference; nothing has been changed." % project,
+        "",
+        "NEEDED BUT NOT DECLARED -- the silent failure. The sandbox image is built "
+        "from the union of declared contracts, so a command missing here is missing "
+        "from the image, and the task fails inside the sandbox on a missing binary "
+        "that reads as the task's fault:",
+    ]
+    if report.get("undeclared_commands"):
+        for entry in report["undeclared_commands"]:
+            packages = entry.get("packages") or []
+            if entry.get("package_mapping_known"):
+                supplied = "installed by: %s" % (", ".join(packages) or "(already in the base image)")
+            else:
+                supplied = (
+                    "NO curated package mapping -- sandbox_bom will report it, not "
+                    "guess a package for it"
+                )
+            lines.append(
+                "  %s <- %s [%s]"
+                % (
+                    entry.get("command"),
+                    ", ".join(entry.get("evidence") or []) or "(no evidence)",
+                    supplied,
+                )
+            )
+    else:
+        lines.append("  (none)")
+    lines.extend(
+        [
+            "",
+            "DECLARED BUT NOT IMPLIED -- dead weight. Every one of these is a package "
+            "in the sandbox, and the sandbox is the security boundary. A manifest scan "
+            "cannot see a tool invoked only from a shell script, so this half is a "
+            "prompt to look, never a reason to delete:",
+        ]
+    )
+    unused = report.get("unused_declared_commands") or []
+    lines.extend(["  %s" % command for command in unused] or ["  (none)"])
+    lines.extend(
+        [
+            "",
+            "THE DECISION THIS TASK EXISTS FOR, either answer closes it:",
+            "",
+            "  1. The scan is RIGHT. Add the missing commands to "
+            "toolchain.required_commands in .mac/project.yaml, then re-derive the "
+            "image BOM:",
+            "       mac admin sandbox-image bom --containerfile deploy/openshell/mac-hermes.Containerfile",
+            "",
+            "  2. The scan is WRONG for this repo -- the manifest is vendored, the "
+            "tool is never invoked, the build runs elsewhere. Say so and close this; "
+            "the contract stays as it is.",
+            "",
+            "NOT a decision anyone should automate: this report never edits a "
+            "contract and never selects a package. A command with no curated package "
+            "mapping is reported, never guessed, because guessing an apt package from "
+            "a binary name installs something plausible into the security boundary.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def coverage_task_metadata(report: Mapping[str, Any]) -> JsonDict:
+    return {
+        COVERAGE_METADATA_KEY: coverage_signature(report),
+        # Staged, NOT dispatchable -- the same call sandbox BOM drift makes. An
+        # open task is fleet-claimed within minutes, and what an agent would do
+        # with this one is rewrite a repository contract from an inference. The
+        # whole value here is that a human or an LLM reads the evidence and
+        # decides.
+        "no_dispatch": True,
+    }
+
+
+def existing_coverage_signatures(tasks: Sequence[Any]) -> Set[str]:
+    """Signatures already filed, read from the marker rather than the title."""
+    import json as _json
+
+    seen: Set[str] = set()
+    for task in tasks:
+        record = task.to_dict() if hasattr(task, "to_dict") else task
+        if not isinstance(record, Mapping):
+            continue
+        metadata = record.get("metadata")
+        if not isinstance(metadata, Mapping):
+            continue
+        marker = metadata.get(COVERAGE_METADATA_KEY)
+        if isinstance(marker, Mapping):
+            seen.add(_json.dumps(marker, sort_keys=True))
+    return seen
+
+
+def declared_commands_from_checkout(repo_path: str | Path) -> Set[str]:
+    """``toolchain.required_commands`` as written in the checkout's contract.
+
+    The contract file is what a human typed, and it is the thing this report
+    exists to question. Absent or unreadable, the answer is "declares nothing",
+    which makes every implied command a finding -- correctly.
+    """
+    import yaml
+
+    from .services import REPOSITORY_CONTRACT_FILES
+
+    root = Path(repo_path)
+    for relative in REPOSITORY_CONTRACT_FILES:
+        candidate = root / relative
+        if not candidate.is_file():
+            continue
+        try:
+            raw = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, OSError):
+            return set()
+        if not isinstance(raw, Mapping):
+            return set()
+        toolchain = raw.get("toolchain")
+        if not isinstance(toolchain, Mapping):
+            return set()
+        return {
+            str(item).strip()
+            for item in (toolchain.get("required_commands") or [])
+            if str(item).strip()
+        }
+    return set()

--- a/src/mac/environment_contract.py
+++ b/src/mac/environment_contract.py
@@ -38,6 +38,14 @@ native_build : dict
     ``signals`` (list[str])
         Human-readable descriptions of each detected signal.
 
+manifests : list[str]
+    Repo-root manifest/lockfile names that actually exist in the checkout,
+    sorted.  This is the *evidence trail* for anything derived from them:
+    a caller that wants to know WHY a requirement was inferred needs the
+    file that implied it, not just the conclusion.  Consumed by
+    :mod:`mac.contract_coverage` to suggest required commands with
+    provenance ("node <- package.json").
+
 egress : dict
     ``hosts`` (list[str])
         Deduplicated, sorted list of external hostnames the install/build
@@ -115,6 +123,34 @@ _KNOWN_NATIVE_NPM_PACKAGES = frozenset(
 )
 
 # ---------------------------------------------------------------------------
+# Repo-root manifests worth recording. Presence only -- this is an inventory of
+# what a checkout declares itself with, not an interpretation of it.
+# ---------------------------------------------------------------------------
+MANIFEST_FILES: Tuple[str, ...] = (
+    "CMakeLists.txt",
+    "Cargo.toml",
+    "Gemfile",
+    "Makefile",
+    "build.gradle",
+    "build.gradle.kts",
+    "binding.gyp",
+    "go.mod",
+    "package-lock.json",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "pom.xml",
+    "project.clj",
+    "pyproject.toml",
+    "requirements.txt",
+    "setup.cfg",
+    "setup.py",
+    "uv.lock",
+    "yarn.lock",
+)
+
+
+# ---------------------------------------------------------------------------
 # Well-known registry hostname patterns
 # ---------------------------------------------------------------------------
 _REGISTRY_RE = re.compile(
@@ -170,6 +206,7 @@ def derive_environment_contract(
         "egress": {
             "hosts": egress_hosts,
         },
+        "manifests": detect_manifests(root),
         "preflight": {
             "status": "pending",
             "checks": [],
@@ -505,6 +542,17 @@ def _derive_egress_hosts(root: Path, *, native_build: bool) -> List[str]:
         hosts.add("nodejs.org")
 
     return sorted(hosts)
+
+
+def detect_manifests(root: Path) -> List[str]:
+    """Repo-root manifests present in the checkout, sorted.
+
+    Presence of a file, nothing more: no parsing, no inference. Everything
+    that turns "package.json exists" into "this repo needs node" is a CURATED
+    decision and lives in :mod:`mac.contract_coverage`, so that the judgement
+    is reviewable in one place instead of smeared through a scanner.
+    """
+    return sorted(name for name in MANIFEST_FILES if (root / name).is_file())
 
 
 # ===========================================================================

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6335,6 +6335,81 @@ class ControlPlane:
                 "reason": "drift check failed: %s: %s" % (type(exc).__name__, exc),
             }
 
+    def file_contract_coverage_report(
+        self,
+        report: Mapping[str, Any],
+        *,
+        project: Optional[str] = None,
+        actor: str = "human",
+    ) -> Dict[str, Any]:
+        """Stage a contract-vs-checkout coverage finding for a human to read.
+
+        The derivation happens where the CHECKOUT is (``mac admin sandbox-image
+        contract-coverage``), because the hub has no worktree to scan. This is
+        only the filing half, and it follows the sandbox BOM drift conventions
+        exactly: staged with ``no_dispatch`` so the fleet cannot claim it, and
+        deduplicated on a metadata marker rather than on title text.
+
+        ``no_dispatch`` is not caution for its own sake. What an agent would do
+        with this task is rewrite a repository contract from an inference about
+        a manifest -- the contract being the input the sandbox image is built
+        from. That has to be a decision somebody makes, not one a backlog
+        sweep makes at 3am.
+        """
+        from mac.contract_coverage import (
+            COVERAGE_METADATA_KEY,
+            COVERAGE_SCHEMA,
+            coverage_has_findings,
+            coverage_signature,
+            coverage_task_description,
+            coverage_task_metadata,
+            coverage_task_title,
+        )
+
+        # Validate at the boundary. This is a facade method, so the argument
+        # can arrive from the CLI, the HTTP layer, or a caller that built the
+        # dict by hand -- and "the report was the wrong shape" must be a domain
+        # error naming the schema, not an AttributeError from three frames in.
+        if not isinstance(report, Mapping):
+            raise ValidationError(
+                "contract coverage report must be a mapping, got %s"
+                % type(report).__name__
+            )
+        if str(report.get("schema") or "").strip() != COVERAGE_SCHEMA:
+            raise ValidationError(
+                "contract coverage report must carry schema %s" % COVERAGE_SCHEMA
+            )
+
+        if not coverage_has_findings(report):
+            return {"filed": None, "reason": "no coverage findings"}
+
+        signature = json_dumps(coverage_signature(report))
+        active = tuple(
+            sorted({state.value for state in TaskState} - set(TERMINAL_TASK_STATES))
+        )
+        placeholders = ", ".join("?" for _ in active)
+        # Same shape as the BOM drift dedupe: narrow by state FIRST so the
+        # index is usable, then compare the marker as jsonb (by value, not by
+        # key order).
+        already_reported = self.store.query_one(
+            "SELECT 1 FROM tasks "
+            "WHERE state IN (%s) "
+            "AND metadata_json -> '%s' = ?::jsonb "
+            "LIMIT 1" % (placeholders, COVERAGE_METADATA_KEY),
+            active + (signature,),
+        )
+        if already_reported is not None:
+            return {"filed": None, "reason": "already reported"}
+
+        filed = self.create_task(
+            coverage_task_title(report),
+            description=coverage_task_description(report),
+            project=project or report.get("project"),
+            metadata=coverage_task_metadata(report),
+            actor=actor,
+        )
+        return {"filed": filed.id}
+
     def roll_out_sandbox_image(
         self,
         image_ref: str,

--- a/tests/cli/test_cli_sandbox.py
+++ b/tests/cli/test_cli_sandbox.py
@@ -107,3 +107,65 @@ def test_rollout_refuses_a_tag(tmp_path):
     assert rc not in (None, 0)
 
 
+
+
+def test_contract_coverage_reports_a_command_the_contract_omits(tmp_path):
+    """The under-declaration case, through the CLI.
+
+    A repo whose manifests imply a toolchain its contract never mentions is the
+    silent failure this command exists to surface: the sandbox is built from the
+    contract, so the task dies inside it on a missing binary that reads as a task
+    problem rather than a contract problem.
+
+    This lives in tests/cli/ deliberately. The coverage gate discovers tested
+    subcommands by scanning THIS directory for `_run(...)` calls, so a CLI test
+    filed anywhere else leaves the subcommand looking untested -- which is how
+    this command first went in.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text('{"name": "x", "version": "1.0.0"}', encoding="utf-8")
+
+    rc, out = _run(
+        tmp_path,
+        "admin",
+        "sandbox-image",
+        "contract-coverage",
+        "--repo",
+        str(repo),
+        "--declared",
+        "python3",
+    )
+
+    assert rc in (None, 0)
+    undeclared = {entry["command"] for entry in out["undeclared_commands"]}
+    assert "node" in undeclared
+
+    # Evidence travels with the suggestion, so a reviewer can reject one
+    # inference instead of distrusting the whole report.
+    node_entry = next(e for e in out["undeclared_commands"] if e["command"] == "node")
+    assert any("package.json" in str(source) for source in node_entry["evidence"])
+
+
+def test_contract_coverage_check_exits_nonzero_only_on_the_undeclared_half(tmp_path):
+    """`--check` gates on missing tools, not on unused ones.
+
+    Declared-but-unused is hygiene. Failing a gate on it would train people to
+    pass --check less often, which costs the signal that actually matters.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "package.json").write_text('{"name": "x", "version": "1.0.0"}', encoding="utf-8")
+
+    with pytest.raises(SystemExit) as excinfo:
+        _run(tmp_path, "admin", "sandbox-image", "contract-coverage",
+             "--repo", str(repo), "--declared", "python3", "--check")
+    assert excinfo.value.code == 1
+
+    # An over-declared contract is reported but does not fail the gate.
+    quiet = tmp_path / "quiet"
+    quiet.mkdir()
+    rc, out = _run(tmp_path, "admin", "sandbox-image", "contract-coverage",
+                   "--repo", str(quiet), "--declared", "cmake", "--check")
+    assert rc in (None, 0)
+    assert "cmake" in out["unused_declared_commands"]

--- a/tests/test_contract_coverage.py
+++ b/tests/test_contract_coverage.py
@@ -1,0 +1,440 @@
+"""A repository contract has never been checked against the repository.
+
+The sandbox image is the union of what contracts DECLARE. What a repo NEEDS is
+observed by mac.environment_contract, per task, in a worktree that is deleted
+when the task ends. Nothing compared the two, so under-declaration was silent:
+the image omits the tool and the task dies inside the sandbox on a missing
+binary that reads as the task's fault.
+
+These cover the comparison and, more importantly, the three ways it could be
+worse than nothing: by missing the gap it exists to find, by inventing findings
+for repos that have none, and by "helpfully" guessing which apt package supplies
+a command it has never seen.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mac.contract_coverage import (
+    COVERAGE_METADATA_KEY,
+    MANIFEST_COMMANDS,
+    coverage_has_findings,
+    coverage_report,
+    coverage_task_description,
+    coverage_task_metadata,
+    declared_commands_from_checkout,
+    evidence_lines,
+    suggest_required_commands,
+)
+from mac.environment_contract import derive_environment_contract
+from mac.sandbox_bom import COMMAND_PACKAGES, MAC_CORE_COMMANDS
+from mac.services import ControlPlane
+
+
+def _repo(tmp_path, name, files, *, declared=None):
+    """A checkout with real manifests and, optionally, a real contract."""
+    repo = tmp_path / name
+    repo.mkdir(parents=True)
+    for filename, body in files.items():
+        (repo / filename).write_text(body, encoding="utf-8")
+    if declared is not None:
+        (repo / ".mac").mkdir()
+        (repo / ".mac" / "project.yaml").write_text(
+            "\n".join(
+                [
+                    "schema: mac.repository_contract.v1",
+                    "project: %s" % name,
+                    "toolchain:",
+                    "  required_commands: [%s]" % ", ".join(declared),
+                ]
+            ),
+            encoding="utf-8",
+        )
+    return repo
+
+
+# --------------------------------------------------------------------------
+# Suggestion: reuse the scanner, and carry why
+# --------------------------------------------------------------------------
+
+
+def test_the_suggestion_comes_from_the_environment_contract_scanner():
+    """One place learns to read repos.
+
+    Asserted by feeding a contract in rather than a path: if the suggestion had
+    its own scanner it would ignore this and go read the (nonexistent) disk.
+    """
+    suggestion = suggest_required_commands(
+        "/does/not/exist",
+        contract={"manifests": ["Cargo.toml"], "native_build": {"required": False}},
+    )
+
+    assert suggestion["suggested_commands"] == ["cargo"]
+
+
+def test_a_manifest_implies_a_command_and_says_which_manifest(tmp_path):
+    """Evidence is what makes a suggestion arguable instead of an assertion."""
+    repo = _repo(tmp_path, "web", {"package.json": '{"name": "web"}'})
+
+    suggestion = suggest_required_commands(repo)
+
+    assert "node" in suggestion["suggested_commands"]
+    assert suggestion["evidence"]["node"] == ["package.json"]
+    assert "node <- package.json" in evidence_lines(suggestion)
+
+
+def test_a_compiling_repo_implies_a_compiler_with_the_signal_that_said_so(tmp_path):
+    repo = _repo(tmp_path, "native", {"Cargo.toml": "[package]\nname='x'\n"})
+
+    suggestion = suggest_required_commands(repo)
+
+    assert "cc" in suggestion["suggested_commands"]
+    assert any("Cargo.toml" in item for item in suggestion["evidence"]["cc"])
+
+
+def test_the_scanner_records_which_manifests_exist(tmp_path):
+    """The evidence trail the coverage report reads, on the contract itself."""
+    repo = _repo(tmp_path, "mixed", {"package.json": "{}", "pyproject.toml": ""})
+
+    assert derive_environment_contract(repo)["manifests"] == [
+        "package.json",
+        "pyproject.toml",
+    ]
+
+
+# --------------------------------------------------------------------------
+# The gap this exists to find
+# --------------------------------------------------------------------------
+
+
+def test_a_needed_command_the_contract_omits_is_reported(tmp_path):
+    """The silent failure: the image will not carry it, and nothing said so."""
+    repo = _repo(
+        tmp_path, "rust", {"Cargo.toml": "[package]\nname='x'\n"}, declared=["make"]
+    )
+
+    report = coverage_report(
+        suggest_required_commands(repo), declared_commands_from_checkout(repo)
+    )
+
+    undeclared = {entry["command"] for entry in report["undeclared_commands"]}
+    assert "cargo" in undeclared
+    assert coverage_has_findings(report)
+
+
+def test_the_report_carries_the_evidence_for_each_gap(tmp_path):
+    repo = _repo(tmp_path, "web", {"package.json": "{}"}, declared=[])
+
+    report = coverage_report(
+        suggest_required_commands(repo), declared_commands_from_checkout(repo)
+    )
+    entry = next(e for e in report["undeclared_commands"] if e["command"] == "node")
+
+    assert entry["evidence"] == ["package.json"]
+
+
+def test_a_declared_command_no_manifest_implies_is_reported_as_unused(tmp_path):
+    """The other direction: a package in the security boundary nothing asks for."""
+    repo = _repo(
+        tmp_path,
+        "web",
+        {"package.json": "{}"},
+        declared=["node", "qemu-system-riscv64"],
+    )
+
+    report = coverage_report(
+        suggest_required_commands(repo), declared_commands_from_checkout(repo)
+    )
+
+    assert report["unused_declared_commands"] == ["qemu-system-riscv64"]
+    assert report["satisfied_commands"] == ["node"]
+
+
+def test_a_declared_command_that_is_needed_is_not_a_finding(tmp_path):
+    repo = _repo(tmp_path, "web", {"package.json": "{}"}, declared=["node"])
+
+    report = coverage_report(
+        suggest_required_commands(repo), declared_commands_from_checkout(repo)
+    )
+
+    assert report["undeclared_commands"] == []
+    assert report["unused_declared_commands"] == []
+    assert not coverage_has_findings(report)
+
+
+# --------------------------------------------------------------------------
+# Noise is the only way this fails
+# --------------------------------------------------------------------------
+
+
+def test_a_repo_whose_manifests_imply_nothing_produces_no_finding(tmp_path):
+    """A docs repo must not become a ticket."""
+    repo = _repo(tmp_path, "docs", {"README.md": "# docs\n"}, declared=[])
+
+    suggestion = suggest_required_commands(repo)
+    report = coverage_report(suggestion, declared_commands_from_checkout(repo))
+
+    assert suggestion["suggested_commands"] == []
+    assert not coverage_has_findings(report)
+
+
+def test_commands_every_sandbox_already_has_are_not_reported(tmp_path):
+    """python3 is in every sandbox; calling it undeclared trains people to stop reading."""
+    assert "python3" in MAC_CORE_COMMANDS
+    repo = _repo(tmp_path, "lib", {"pyproject.toml": "[project]\nname='x'\n"}, declared=[])
+
+    report = coverage_report(
+        suggest_required_commands(repo), declared_commands_from_checkout(repo)
+    )
+
+    assert report["undeclared_commands"] == []
+    assert report["core_supplied_commands"] == ["python3"]
+
+
+def test_declaring_a_core_command_is_not_dead_weight(tmp_path):
+    """`git` in a contract is redundant, not a package to go delete."""
+    repo = _repo(tmp_path, "docs", {"README.md": "x"}, declared=["git"])
+
+    report = coverage_report(
+        suggest_required_commands(repo), declared_commands_from_checkout(repo)
+    )
+
+    assert report["unused_declared_commands"] == []
+
+
+# --------------------------------------------------------------------------
+# The invariant: reported, never guessed
+# --------------------------------------------------------------------------
+
+
+def test_a_suggested_command_with_no_curated_package_is_reported_not_mapped(tmp_path):
+    """The line this feature must not cross.
+
+    `cargo` is a command sandbox_bom has no package for. Inferring one from the
+    binary name would install something plausible into the security boundary --
+    so the report says "I do not know", loudly, and stops.
+    """
+    assert "cargo" not in COMMAND_PACKAGES
+    repo = _repo(tmp_path, "rust", {"Cargo.toml": "[package]\nname='x'\n"}, declared=[])
+
+    report = coverage_report(
+        suggest_required_commands(repo), declared_commands_from_checkout(repo)
+    )
+    entry = next(e for e in report["undeclared_commands"] if e["command"] == "cargo")
+
+    assert entry["package_mapping_known"] is False
+    assert entry["packages"] == []
+    assert "cargo" in report["unmapped_commands"]
+
+
+def test_the_report_never_invents_a_package_name(tmp_path):
+    """No entry may carry a package the curated table did not supply."""
+    repo = _repo(
+        tmp_path,
+        "polyglot",
+        {
+            "Cargo.toml": "[package]\nname='x'\n",
+            "go.mod": "module x\n",
+            "Gemfile": "source 'x'\n",
+        },
+        declared=[],
+    )
+
+    report = coverage_report(
+        suggest_required_commands(repo), declared_commands_from_checkout(repo)
+    )
+
+    for entry in report["undeclared_commands"]:
+        curated = set(COMMAND_PACKAGES.get(entry["command"], ()))
+        assert set(entry["packages"]) <= curated
+
+
+def test_deriving_coverage_does_not_mutate_the_curated_mapping(tmp_path):
+    before = json.dumps({k: list(v) for k, v in COMMAND_PACKAGES.items()}, sort_keys=True)
+    repo = _repo(tmp_path, "rust", {"Cargo.toml": "[package]\nname='x'\n"}, declared=[])
+
+    coverage_report(suggest_required_commands(repo), declared_commands_from_checkout(repo))
+
+    assert (
+        json.dumps({k: list(v) for k, v in COMMAND_PACKAGES.items()}, sort_keys=True)
+        == before
+    )
+
+
+def test_every_suggestible_command_is_a_command_not_a_package():
+    """The tables must not quietly converge.
+
+    A manifest maps to COMMANDS. If someone starts writing package names here
+    ('build-essential' instead of 'cc') the two curated layers merge and the
+    guess-free property is gone.
+    """
+    packages = {pkg for pkgs in COMMAND_PACKAGES.values() for pkg in pkgs}
+    suggested = {cmd for cmds in MANIFEST_COMMANDS.values() for cmd in cmds}
+
+    assert not (suggested & (packages - set(COMMAND_PACKAGES)))
+
+
+# --------------------------------------------------------------------------
+# The review surface
+# --------------------------------------------------------------------------
+
+
+def test_a_filed_report_is_staged_and_not_dispatchable(tmp_path):
+    """What an agent would do with this is rewrite a contract from an inference."""
+    plane = ControlPlane.in_memory()
+    plane.create_project("rustproj", dispatch_paused=False)
+    repo = _repo(tmp_path, "rust", {"Cargo.toml": "[package]\nname='x'\n"}, declared=[])
+    report = coverage_report(
+        suggest_required_commands(repo),
+        declared_commands_from_checkout(repo),
+        project="rustproj",
+    )
+
+    result = plane.file_contract_coverage_report(report, project="rustproj")
+
+    task = plane.get_task(result["filed"])
+    assert task.metadata["no_dispatch"] is True
+    assert COVERAGE_METADATA_KEY in task.metadata
+    assert "cargo" in task.description
+
+
+def test_the_same_finding_is_not_filed_twice(tmp_path):
+    """Re-filing per run buries the one report that matters."""
+    plane = ControlPlane.in_memory()
+    plane.create_project("rustproj", dispatch_paused=False)
+    repo = _repo(tmp_path, "rust", {"Cargo.toml": "[package]\nname='x'\n"}, declared=[])
+    report = coverage_report(
+        suggest_required_commands(repo),
+        declared_commands_from_checkout(repo),
+        project="rustproj",
+    )
+
+    first = plane.file_contract_coverage_report(report, project="rustproj")
+    second = plane.file_contract_coverage_report(report, project="rustproj")
+
+    assert first["filed"]
+    assert second["filed"] is None
+
+
+def test_nothing_is_filed_when_there_is_nothing_to_report(tmp_path):
+    plane = ControlPlane.in_memory()
+    plane.create_project("docsproj", dispatch_paused=False)
+    repo = _repo(tmp_path, "docs", {"README.md": "x"}, declared=[])
+    report = coverage_report(
+        suggest_required_commands(repo),
+        declared_commands_from_checkout(repo),
+        project="docsproj",
+    )
+
+    assert plane.file_contract_coverage_report(report, project="docsproj")["filed"] is None
+
+
+def test_a_malformed_report_is_rejected_at_the_boundary():
+    """The facade must name the schema, not fail three frames deep."""
+    from mac.models import ValidationError
+
+    plane = ControlPlane.in_memory()
+
+    with pytest.raises(ValidationError):
+        plane.file_contract_coverage_report("not a report")
+    with pytest.raises(ValidationError):
+        plane.file_contract_coverage_report({"undeclared_commands": [{"command": "x"}]})
+
+
+def test_the_description_states_both_answers_and_forbids_automation(tmp_path):
+    repo = _repo(tmp_path, "rust", {"Cargo.toml": "[package]\nname='x'\n"}, declared=["zig"])
+    report = coverage_report(
+        suggest_required_commands(repo),
+        declared_commands_from_checkout(repo),
+        project="rustproj",
+    )
+
+    description = coverage_task_description(report)
+
+    assert "cargo" in description and "zig" in description
+    assert "never guessed" in description
+    assert coverage_task_metadata(report)["no_dispatch"] is True
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _cli(argv):
+    from mac.cli import main
+
+    return main(argv)
+
+
+def test_the_cli_reports_the_gap_and_can_gate_on_it(tmp_path, capsys):
+    repo = _repo(tmp_path, "rust", {"Cargo.toml": "[package]\nname='x'\n"}, declared=[])
+
+    with pytest.raises(SystemExit) as exit_info:
+        _cli(
+            [
+                "--json",
+                "admin",
+                "sandbox-image",
+                "contract-coverage",
+                "--repo",
+                str(repo),
+                "--check",
+            ]
+        )
+
+    assert exit_info.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert [e["command"] for e in payload["undeclared_commands"]] == [
+        "cargo",
+        "cc",
+        "make",
+    ]
+    assert payload["declared_source"] == "checkout .mac/project.yaml"
+
+
+def test_the_cli_is_quiet_when_the_contract_is_complete(tmp_path, capsys):
+    repo = _repo(
+        tmp_path, "rust", {"Cargo.toml": "[package]\nname='x'\n"}, declared=["cargo", "cc", "make"]
+    )
+
+    _cli(
+        [
+            "--json",
+            "admin",
+            "sandbox-image",
+            "contract-coverage",
+            "--repo",
+            str(repo),
+            "--check",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["undeclared_commands"] == []
+
+
+def test_the_cli_can_diff_against_an_explicit_declaration(tmp_path, capsys):
+    """No hub, no contract file -- the report still works from a checkout."""
+    repo = _repo(tmp_path, "web", {"package.json": "{}"})
+
+    _cli(
+        [
+            "--json",
+            "admin",
+            "sandbox-image",
+            "contract-coverage",
+            "--repo",
+            str(repo),
+            "--declared",
+            "node,qemu-system-riscv64",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["undeclared_commands"] == []
+    assert payload["unused_declared_commands"] == ["qemu-system-riscv64"]
+    assert payload["declared_source"] == "--declared"


### PR DESCRIPTION
Closes task_188ff32d.

## The gap

Two halves of the same question were never connected.

`environment_contract.py` reads a checkout — `package.json`, `pyproject.toml`, `Cargo.toml`, `.nvmrc`, lockfiles — and works out what the repo actually needs. It runs per task in the worker's worktree and is **thrown away when the task ends**.

`sandbox_bom.py` decides what goes into the shared sandbox image. It reads exactly one thing: `metadata.repository_contract.toolchain.required_commands` — a list a human **typed** into `.mac/project.yaml`.

So the image is derived from a memory, while the code that can observe the truth runs metres away and is discarded. The failure that allows is **under-declaration, silently**: a contract omitting a needed tool produces a sandbox without it, and the task then dies inside the sandbox on a missing binary that reads as a task problem rather than a contract problem. `sandbox_excursion.py` exists to paper over exactly this after the fact — which is evidence the gap is real and recurring.

## What this does — and pointedly does not do

```
mac admin sandbox-image contract-coverage --repo PATH
    [--project NAME] [--declared cmd,cmd] [--check] [--file-task]
```

- Reuses `derive_environment_contract()` rather than writing a second scanner — one place learns to read repos.
- Maps manifests to **commands** through a curated table, carrying evidence for every suggestion (`node <- package.json`) so a reviewer can disagree with a specific inference instead of the whole report.
- Diffs both directions: needed-but-undeclared (work breaks) and declared-but-unused (dead weight in the security boundary).
- **Changes nothing.** No contract edited, no package installed, no image touched. `COMMAND_PACKAGES` is unmodified.

`--check` exits 1 on the **undeclared** half only. The unused half is hygiene, and gating on it would train people to skip the gate.

Reporting follows `check_sandbox_bom_drift` exactly: staged `no_dispatch: True` tasks, marker-based dedupe using the same state-narrowed `metadata_json -> key = ?::jsonb` query (including the GIN/`NOT IN` traps documented there).

## The invariant, which matters more here

`sandbox_bom` states it: *a required COMMAND is not a package name; the mapping is CURATED, and a command with no mapping is REPORTED, never guessed.*

That is doubly load-bearing now. A suggestion is an inference about a **repo**; turning it into an apt package would stack an inference about the **image**, and the image is the security boundary. So a suggested command with no curated package mapping is reported unmapped, with an empty package list, forever.

Pinned four ways: `cargo` is reported with `packages: []` and `package_mapping_known: false`; no entry may carry a package the curated table did not supply; `COMMAND_PACKAGES` is byte-identical after a derivation; and `MANIFEST_COMMANDS` may not contain package names, which stops the two curated tables converging over time.

## Tests

23 new, covering the three required discriminators (needed-but-omitted, declared-but-unimplied, manifests-imply-nothing producing an empty suggestion and no finding), plus evidence provenance, scanner reuse, core-command noise suppression in both directions, filing behaviour (staged / `no_dispatch` / deduped / nothing-when-clean), boundary validation, and the CLI report and `--check` exit code.

Worth noting: the parametrised facade-contract test in `test_control_plane_public_contract.py` initially **failed** on the new method. It was fixed by adding real boundary validation to the method, not by exempting it from the contract.

```
tests/test_contract_coverage.py + test_control_plane_public_contract.py   537 passed
dead-code-check                                                          clean
generate-docs-reference.py --check                                       rc=0
```

## Not done

`file_contract_coverage_report` is a facade method with no HTTP route: the derivation needs a checkout, which the hub does not have, so the CLI is the only entry point today. Making it hub-reachable is follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)