### PR TITLE
Announce sandbox policy changes on the bus, and act on them between tasks

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -717,7 +717,10 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_OPENSHELL_IMAGE_TAG` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell image tag. |
 | `MAC_OPENSHELL_KEEP` | bool | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell keep. |
 | `MAC_OPENSHELL_POLICY` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell policy. |
+| `MAC_OPENSHELL_POLICY_BUS_GATE` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell policy bus gate. |
+| `MAC_OPENSHELL_POLICY_BUS_PAGE` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell policy bus page. |
 | `MAC_OPENSHELL_POLICY_SYNC` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell policy sync. |
+| `MAC_OPENSHELL_POLICY_WAIT_SECONDS` | int | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell policy wait seconds. |
 | `MAC_OPENSHELL_PROGRESS_INTERVAL` | int | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell progress interval. |
 | `MAC_OPENSHELL_REAP_ORPHANS` | str | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell reap orphans. |
 | `MAC_OPENSHELL_REBUILD_ON_SOURCE_UPDATE` | bool | consumer-defined | openshell-sandbox | Openshell Sandbox setting: openshell rebuild on source update. |

--- a/src/mac/agentbus_broadcast.py
+++ b/src/mac/agentbus_broadcast.py
@@ -73,6 +73,17 @@ BROADCAST_EVENT_TYPES: Tuple[str, ...] = (
     "git.force_push",
     # Capacity pressure, consumed by the HGX autoscaler.
     "capacity.saturated",
+    # The sandbox guardrail moved. ``sandbox.policy_changed`` says WHICH
+    # direction it moved in (see mac.openshell_policy_diff); a worker that
+    # hears a revocation must not start new work in the sandbox it built from
+    # the superseded policy.
+    "sandbox.policy_changed",
+    # ...and the terminating event for the wait that follows. Without it,
+    # "wait for the new policy" has no completion signal and degrades into an
+    # arbitrary timeout poll — the worker would either resume too early, under
+    # the policy it was told to stop using, or sit out a fixed sleep that has
+    # nothing to do with when the policy actually landed.
+    "sandbox.policy_published",
 )
 
 BROADCAST_EVENT_TYPE_SET = frozenset(BROADCAST_EVENT_TYPES)
@@ -112,7 +123,29 @@ BROADCAST_RATE_LIMIT_WINDOW_SECONDS = 60.0
 BROADCAST_COALESCE_SECONDS = 10.0
 
 #: Payload fields that identify "the same event happening again".
-BROADCAST_COALESCE_FIELDS = ("project", "task_id", "branch", "sha", "worktree")
+#:
+#: ``policy_id``/``to_checksum``/``change_kind`` are here for the sandbox
+#: policy events: they carry none of the git-shaped fields, so without them
+#: every policy change inside the coalesce window would look like a repeat of
+#: the first one and the later — possibly restricting — change would be
+#: dropped. Coalescing may suppress noise; it must never suppress a distinct
+#: guardrail decision.
+BROADCAST_COALESCE_FIELDS = (
+    "project",
+    "task_id",
+    "branch",
+    "sha",
+    "worktree",
+    "policy_id",
+    "to_checksum",
+    "change_kind",
+)
+
+#: Emitter id for announcements the HUB makes about itself rather than on
+#: behalf of an agent. It is not an agent row and cannot be, so system
+#: announcements take :meth:`BroadcastService.publish_system` — an in-process
+#: seam with no HTTP route behind it, so no token can publish as the hub.
+BROADCAST_SYSTEM_AGENT_ID = "hub"
 
 #: Event types the hub derives a ledger fact from. Deliberately the two
 #: low-frequency, high-consequence git events: one per publication attempt,
@@ -183,13 +216,61 @@ class BroadcastService:
         ``rate_limited`` is a NORMAL outcome, not an error — the caller is
         telemetry-shaped and must not treat suppression as failure.
         """
+        return self._publish(
+            agent_id,
+            event_type,
+            project=project,
+            task_id=task_id,
+            payload=payload,
+            require_agent=True,
+        )
+
+    def publish_system(
+        self,
+        event_type: str,
+        *,
+        project: Optional[str] = None,
+        task_id: Optional[str] = None,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> JsonDict:
+        """Announce something the HUB did, as the hub.
+
+        Used for facts no agent is in a position to state — a guardrail policy
+        being republished or reassigned happens in the control plane, and
+        attributing it to the affected agent would make ``agent_id`` a lie and
+        make the affected agent skip its own "echo".
+
+        Deliberately not reachable over HTTP: the route calls :meth:`publish`,
+        which still requires a real agent row, so a token cannot speak as the
+        hub.
+        """
+        return self._publish(
+            BROADCAST_SYSTEM_AGENT_ID,
+            event_type,
+            project=project,
+            task_id=task_id,
+            payload=payload,
+            require_agent=False,
+        )
+
+    def _publish(
+        self,
+        agent_id: str,
+        event_type: str,
+        *,
+        project: Optional[str],
+        task_id: Optional[str],
+        payload: Optional[Dict[str, Any]],
+        require_agent: bool,
+    ) -> JsonDict:
         event_type = str(event_type or "").strip()
         if event_type not in BROADCAST_EVENT_TYPE_SET:
             raise ValidationError(
                 "unknown broadcast event_type: %s (allowed: %s)"
                 % (event_type, ", ".join(BROADCAST_EVENT_TYPES))
             )
-        self._require_agent(agent_id)
+        if require_agent:
+            self._require_agent(agent_id)
         project_value = (str(project).strip() or None) if project else None
         task_value = (str(task_id).strip() or None) if task_id else None
         body = self._bounded_payload(payload, project_value, task_value)

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -8493,6 +8493,28 @@
   },
   {
     "default": null,
+    "description": "Openshell Sandbox setting: openshell policy bus gate.",
+    "family": "openshell-sandbox",
+    "name": "MAC_OPENSHELL_POLICY_BUS_GATE",
+    "retired": false,
+    "sources": [
+      "src/mac/worker.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Openshell Sandbox setting: openshell policy bus page.",
+    "family": "openshell-sandbox",
+    "name": "MAC_OPENSHELL_POLICY_BUS_PAGE",
+    "retired": false,
+    "sources": [
+      "src/mac/worker.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Openshell Sandbox setting: openshell policy sync.",
     "family": "openshell-sandbox",
     "name": "MAC_OPENSHELL_POLICY_SYNC",
@@ -8501,6 +8523,17 @@
       "src/mac/worker.py"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Openshell Sandbox setting: openshell policy wait seconds.",
+    "family": "openshell-sandbox",
+    "name": "MAC_OPENSHELL_POLICY_WAIT_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/worker.py"
+    ],
+    "type": "int"
   },
   {
     "default": null,

--- a/src/mac/openshell_policy_diff.py
+++ b/src/mac/openshell_policy_diff.py
@@ -1,0 +1,267 @@
+"""Structural diff of two OpenShell guardrail policies, and its announcement.
+
+Why this exists as a *structural* diff rather than a checksum comparison or a
+text diff: the question a running agent has to answer when the sandbox policy
+moves under it is not "did it change" but "which DIRECTION did it change in".
+
+* The new policy **expands** — an endpoint, a binary, or a filesystem path was
+  added. A sandbox created from the old policy is still compliant with the
+  reviewed intent; it is merely less capable than a freshly created one.
+* The new policy **restricts** — something the running sandbox still holds was
+  revoked. The sandbox is now over-permissioned relative to what a human
+  approved, and that is the case a boolean "changed" flag cannot express.
+
+Both can be true at once (a policy that swaps one endpoint for another), and
+that is deliberately representable: it is a revocation *and* a grant, and a
+consumer that treats it as merely "changed" would keep working under the
+revoked capability.
+
+The comparison is over the parsed YAML, never the text. Reordering blocks,
+reflowing lists, or editing a comment changes every line of a text diff and
+revokes nothing; that is exactly the false alarm that would train a worker to
+ignore the signal.
+
+Filesystem paths carry their access mode (``rw:/tmp`` vs ``ro:/tmp``) because
+demoting a path from writable to read-only is a revocation, not a rename.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+import yaml
+
+from mac.models import JsonDict
+
+POLICY_DIFF_SCHEMA = "mac.openshell.policy.diff.v1"
+
+#: ``change_kind`` values: what happened to the policy, not what it means.
+POLICY_CHANGE_KINDS: Tuple[str, ...] = (
+    "published",
+    "updated",
+    "assigned",
+    "unassigned",
+    "deleted",
+)
+
+#: ``action_hint`` values: what a worker should DO about it. Deliberately a
+#: closed, tiny set — a hint a consumer has to parse is not a hint.
+ACTION_NO_ACTION = "no_action"
+ACTION_RECREATE = "recreate_before_next_task"
+ACTION_ABANDON = "abandon_current"
+POLICY_ACTION_HINTS: Tuple[str, ...] = (
+    ACTION_NO_ACTION,
+    ACTION_RECREATE,
+    ACTION_ABANDON,
+)
+
+
+def _load(policy_text: Optional[str]) -> Tuple[Optional[Dict[str, Any]], bool]:
+    """Parse policy YAML. Returns ``(mapping, parsed_ok)``.
+
+    Never raises: this runs on the mutating path (a policy write already
+    committed), and an unparseable policy must not turn a successful update
+    into a failure. An unparsed side is reported instead, and the caller fails
+    SAFE by treating the change as restricting.
+    """
+    if policy_text is None:
+        # "No policy" is a KNOWN state, not an unreadable one: it grants
+        # nothing. Conflating it with a parse failure would mark every first
+        # assignment as a revocation.
+        return {}, True
+    try:
+        parsed = yaml.safe_load(policy_text)
+    except yaml.YAMLError:
+        return None, False
+    if parsed is None:
+        return {}, True
+    if not isinstance(parsed, dict):
+        return None, False
+    return parsed, True
+
+
+def _endpoint_key(entry: Any) -> Optional[str]:
+    if isinstance(entry, dict):
+        host = entry.get("host") or entry.get("domain") or entry.get("name")
+        if host is None:
+            return None
+        port = entry.get("port")
+        return "%s:%s" % (str(host).strip(), "" if port is None else str(port).strip())
+    if isinstance(entry, str) and entry.strip():
+        return entry.strip()
+    return None
+
+
+def _binary_key(entry: Any) -> Optional[str]:
+    if isinstance(entry, dict):
+        path = entry.get("path") or entry.get("binary") or entry.get("name")
+        return str(path).strip() if path is not None else None
+    if isinstance(entry, str) and entry.strip():
+        return entry.strip()
+    return None
+
+
+def _as_list(value: Any) -> List[Any]:
+    if isinstance(value, list):
+        return value
+    if value is None:
+        return []
+    return [value]
+
+
+def policy_capabilities(policy_text: Optional[str]) -> JsonDict:
+    """The capability sets a sandbox built from ``policy_text`` would hold.
+
+    Returns ``{"endpoints": set, "binaries": set, "paths": set, "parsed": bool}``.
+    Sets are global across ``network_policies`` blocks: renaming a block moves
+    no capability, and treating it as one would report a revocation that did
+    not happen.
+    """
+    parsed, ok = _load(policy_text)
+    endpoints: Set[str] = set()
+    binaries: Set[str] = set()
+    paths: Set[str] = set()
+    if not ok or parsed is None:
+        return {
+            "endpoints": endpoints,
+            "binaries": binaries,
+            "paths": paths,
+            "parsed": False,
+        }
+    network = parsed.get("network_policies")
+    if isinstance(network, dict):
+        for block in network.values():
+            if not isinstance(block, dict):
+                continue
+            for entry in _as_list(block.get("endpoints")):
+                key = _endpoint_key(entry)
+                if key:
+                    endpoints.add(key)
+            for entry in _as_list(block.get("binaries")):
+                key = _binary_key(entry)
+                if key:
+                    binaries.add(key)
+    filesystem = parsed.get("filesystem_policy")
+    if not isinstance(filesystem, dict):
+        filesystem = parsed.get("landlock") if isinstance(parsed.get("landlock"), dict) else {}
+    if isinstance(filesystem, dict):
+        for mode, key in (("ro", "read_only"), ("rw", "read_write"), ("x", "execute")):
+            for entry in _as_list(filesystem.get(key)):
+                if isinstance(entry, str) and entry.strip():
+                    paths.add("%s:%s" % (mode, entry.strip()))
+        if filesystem.get("include_workdir"):
+            paths.add("rw:<workdir>")
+    return {
+        "endpoints": endpoints,
+        "binaries": binaries,
+        "paths": paths,
+        "parsed": True,
+    }
+
+
+def diff_policy_texts(
+    old_text: Optional[str], new_text: Optional[str]
+) -> JsonDict:
+    """Structural diff of two policies, in terms of DIRECTION.
+
+    ``old_text``/``new_text`` may be ``None`` for "no policy" (first
+    publication, or an unassignment/deletion that leaves the target with
+    nothing). A side that will not parse yields ``parsed=False`` and is treated
+    as restricting: an unknown guardrail must never read as safe to keep
+    working under.
+    """
+    before = policy_capabilities(old_text)
+    after = policy_capabilities(new_text)
+    counts: JsonDict = {}
+    restricts = False
+    expands = False
+    for field, key in (
+        ("endpoints", "endpoints"),
+        ("binaries", "binaries"),
+        ("paths", "paths"),
+    ):
+        added = after[key] - before[key]
+        removed = before[key] - after[key]
+        counts["%s_added" % field] = len(added)
+        counts["%s_removed" % field] = len(removed)
+        restricts = restricts or bool(removed)
+        expands = expands or bool(added)
+    parsed = bool(before["parsed"] and after["parsed"])
+    if not parsed:
+        # Fail safe. We cannot show that nothing was revoked, so we must not
+        # claim it.
+        restricts = True
+    return {
+        "schema": POLICY_DIFF_SCHEMA,
+        "restricts": restricts,
+        "expands": expands,
+        "parsed": parsed,
+        **counts,
+    }
+
+
+def action_hint_for(change_kind: str, diff: JsonDict) -> str:
+    """What a worker should do about this change, in one closed-set token.
+
+    * A revocation, an unassignment, or a deletion → ``abandon_current``: the
+      running sandbox holds something no longer approved.
+    * A pure grant → ``recreate_before_next_task``: the running sandbox is
+      still compliant, so nothing has to stop, but the next one should be
+      built from the new policy.
+    * Neither → ``no_action``: metadata moved, capabilities did not.
+    """
+    kind = str(change_kind or "")
+    if kind in {"unassigned", "deleted"}:
+        return ACTION_ABANDON
+    if diff.get("restricts"):
+        return ACTION_ABANDON
+    if diff.get("expands"):
+        return ACTION_RECREATE
+    return ACTION_NO_ACTION
+
+
+def policy_change_payload(
+    *,
+    change_kind: str,
+    policy_id: str,
+    policy_name: str = "",
+    from_text: Optional[str] = None,
+    to_text: Optional[str] = None,
+    from_version: Optional[int] = None,
+    to_version: Optional[int] = None,
+    from_checksum: str = "",
+    to_checksum: str = "",
+    target_type: str = "policy",
+    target_id: str = "",
+) -> JsonDict:
+    """The broadcast payload for one policy change.
+
+    Deliberately all scalars, all small: the bus is announcements, not
+    transport. Detail (the policy TEXT) is fetched by the agent through the
+    existing policy routes, which already authorise per-agent access to it.
+    """
+    if change_kind not in POLICY_CHANGE_KINDS:
+        raise ValueError("unknown OpenShell policy change_kind: %s" % change_kind)
+    diff = diff_policy_texts(from_text, to_text)
+    payload: JsonDict = {
+        "change_kind": change_kind,
+        "policy_id": policy_id,
+        "policy_name": policy_name or "",
+        "from_version": from_version,
+        "to_version": to_version,
+        "from_checksum": from_checksum or "",
+        "to_checksum": to_checksum or "",
+        "target_type": target_type,
+        "target_id": target_id or "",
+        "restricts": bool(diff["restricts"]),
+        "expands": bool(diff["expands"]),
+        "diff_parsed": bool(diff["parsed"]),
+        "endpoints_added": diff["endpoints_added"],
+        "endpoints_removed": diff["endpoints_removed"],
+        "binaries_added": diff["binaries_added"],
+        "binaries_removed": diff["binaries_removed"],
+        "paths_added": diff["paths_added"],
+        "paths_removed": diff["paths_removed"],
+    }
+    payload["action_hint"] = action_hint_for(change_kind, diff)
+    return payload

--- a/src/mac/openshell_service.py
+++ b/src/mac/openshell_service.py
@@ -32,6 +32,12 @@ from mac.openshell_runtime import (
 )
 
 
+#: Deleting a policy orphans every target assigned to it. Each orphan gets its
+#: own announcement so a listener can match itself by name, but the fan-out is
+#: bounded: this is a firehose candidate and the bus already rate-limits.
+_MAX_ANNOUNCED_ORPHANS = 25
+
+
 def policy_checksum(policy_text: str) -> str:
     """Return the SHA-256 checksum of the OpenShell policy text."""
     return "sha256:%s" % hashlib.sha256(policy_text.encode("utf-8")).hexdigest()
@@ -56,9 +62,43 @@ def parse_policy_metadata(policy_text: str) -> JsonDict:
 
 
 class OpenShellService:
-    def __init__(self, store: Any, *, get_agent: Any) -> None:
+    def __init__(self, store: Any, *, get_agent: Any, on_policy_change: Any = None) -> None:
         self.store = store
         self._get_agent = get_agent
+        # Optional hub hook, invoked AFTER a policy mutation is durable. It is
+        # handed what actually happened (both sides of the change), never a
+        # scrape of current state, so an announcement cannot describe a write
+        # that did not land. See ControlPlane._announce_openshell_policy_change.
+        self._on_policy_change = on_policy_change
+
+    def _announce_policy_change(self, **fields: Any) -> None:
+        """Tell the hub a policy mutation happened. Never breaks the mutation.
+
+        The write is already committed by the time this runs; a failure to
+        announce it is an observability loss, not a policy loss, and must not
+        be reported to the caller as a failed update.
+        """
+        if self._on_policy_change is None:
+            return
+        try:
+            self._on_policy_change(**fields)
+        except Exception:  # noqa: BLE001 - announcing must never fail a write.
+            return
+
+    def version_text(self, policy_id: str, version: int) -> Optional[str]:
+        """The stored text of one policy version, or ``None`` if unknown.
+
+        Used to diff against the version a target was actually ASSIGNED, which
+        can lag the policy's current version.
+        """
+        row = self.store.query_one(
+            """
+            SELECT policy_text FROM openshell_policy_versions
+            WHERE policy_id = ? AND version = ?
+            """,
+            (policy_id, int(version)),
+        )
+        return row["policy_text"] if row is not None else None
 
     def create_policy(
         self,
@@ -117,7 +157,21 @@ class OpenShellService:
                     now,
                 ),
             )
-        return self.get_policy(row_id)
+        created = self.get_policy(row_id)
+        self._announce_policy_change(
+            change_kind="published",
+            policy_id=created.id,
+            policy_name=created.name,
+            from_text=None,
+            to_text=created.policy_text,
+            from_version=None,
+            to_version=created.version,
+            from_checksum="",
+            to_checksum=created.checksum,
+            target_type="policy",
+            target_id=created.id,
+        )
+        return created
 
     def list_policies(self, *, include_deleted: bool = False) -> List[OpenShellPolicy]:
         sql = "SELECT * FROM openshell_policies"
@@ -212,10 +266,32 @@ class OpenShellService:
                         now,
                     ),
                 )
-        return self.get_policy(current.id)
+        updated = self.get_policy(current.id)
+        # Only a text change is announced. A rename or a description edit moves
+        # no capability, and a bus that reports it teaches every consumer that
+        # the signal is noise.
+        if bump_version:
+            self._announce_policy_change(
+                change_kind="updated",
+                policy_id=updated.id,
+                policy_name=updated.name,
+                from_text=current.policy_text,
+                to_text=updated.policy_text,
+                from_version=current.version,
+                to_version=updated.version,
+                from_checksum=current.checksum,
+                to_checksum=updated.checksum,
+                target_type="policy",
+                target_id=updated.id,
+            )
+        return updated
 
     def delete_policy(self, policy_id_or_name: str, *, actor: str = "human") -> OpenShellPolicy:
         policy = self.get_policy(policy_id_or_name)
+        # Read the affected targets BEFORE the delete deactivates them: after
+        # the write there is nothing left to name, and an announcement nobody
+        # can match to themselves is not an announcement.
+        orphaned = self.list_assignments(policy_id=policy.id, active_only=True)
         now = utcnow()
         with self.store.transaction() as conn:
             conn.execute(
@@ -234,7 +310,35 @@ class OpenShellService:
                 """,
                 (now, policy.id),
             )
-        return self.get_policy(policy.id, include_deleted=True)
+        deleted = self.get_policy(policy.id, include_deleted=True)
+        self._announce_policy_change(
+            change_kind="deleted",
+            policy_id=policy.id,
+            policy_name=policy.name,
+            from_text=policy.policy_text,
+            to_text=None,
+            from_version=policy.version,
+            to_version=None,
+            from_checksum=policy.checksum,
+            to_checksum="",
+            target_type="policy",
+            target_id=policy.id,
+        )
+        for assignment in orphaned[:_MAX_ANNOUNCED_ORPHANS]:
+            self._announce_policy_change(
+                change_kind="unassigned",
+                policy_id=policy.id,
+                policy_name=policy.name,
+                from_text=self.version_text(policy.id, assignment.policy_version),
+                to_text=None,
+                from_version=assignment.policy_version,
+                to_version=None,
+                from_checksum=policy.checksum,
+                to_checksum="",
+                target_type=assignment.target_type,
+                target_id=assignment.target_id,
+            )
+        return deleted
 
     def versions(self, policy_id_or_name: str) -> List[OpenShellPolicyVersion]:
         policy = self.get_policy(policy_id_or_name, include_deleted=True)
@@ -311,6 +415,17 @@ class OpenShellService:
                 "host-scoped OpenShell assignments are not enforced and are refused; "
                 "assign the policy to an agent or a fleet instead"
             )
+        # The guardrail this target is losing, read before it is deactivated.
+        # Without it the announcement could only say "you have a new policy",
+        # which cannot distinguish a widening from a revocation — the one
+        # distinction the listener needs.
+        superseded = self.list_assignments(
+            target_type=target_type_value, target_id=target_id_value, active_only=True
+        )
+        prior = superseded[0] if superseded else None
+        prior_text = (
+            self.version_text(prior.policy_id, prior.policy_version) if prior else None
+        )
         now = utcnow()
         assignment_id = new_id("ospola")
         with self.store.transaction() as conn:
@@ -340,6 +455,21 @@ class OpenShellService:
                     now,
                 ),
             )
+        self._announce_policy_change(
+            change_kind="assigned",
+            policy_id=policy.id,
+            policy_name=policy.name,
+            from_text=prior_text,
+            to_text=policy.policy_text,
+            from_version=prior.policy_version if prior else None,
+            to_version=policy.version,
+            from_checksum=(
+                policy_checksum(prior_text) if isinstance(prior_text, str) else ""
+            ),
+            to_checksum=policy.checksum,
+            target_type=target_type_value,
+            target_id=target_id_value,
+        )
         return self.get_assignment(assignment_id)
 
     def get_assignment(self, assignment_id: str) -> OpenShellPolicyAssignment:

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1957,7 +1957,11 @@ class ControlPlane:
             observability_recorder=self._retention_obs_recorder,
         )
         self._configure_default_retention_policies()
-        self.openshell = OpenShellService(self.store, get_agent=self.get_agent)
+        self.openshell = OpenShellService(
+            self.store,
+            get_agent=self.get_agent,
+            on_policy_change=self._announce_openshell_policy_change,
+        )
         self.agentbus = AgentBusService(self.store, self.observability)
         # The hub is a listener on its own bus: broadcasts it hears become
         # ledger facts without the worker making a second call.
@@ -18288,6 +18292,59 @@ class ControlPlane:
 
     def read_agentbus_broadcasts(self, *args: Any, **kwargs: Any) -> List[JsonDict]:
         return self.agentbus_broadcast.read(*args, **kwargs)
+
+    def _announce_openshell_policy_change(self, **fields: Any) -> List[JsonDict]:
+        """Announce a sandbox guardrail change on the bus.
+
+        Called from the OpenShell service's mutating paths, with both sides of
+        the change in hand, so the announcement describes what actually
+        happened rather than a later re-read of state that a second writer may
+        already have moved.
+
+        The DIFF is computed here, hub-side, at change time: it is the only
+        place where both policy texts are already loaded, so it costs nothing,
+        and the only place where the answer is certainly right. A worker
+        deriving it later would have to fetch both versions and would be
+        answering about a policy that may have moved again.
+
+        Two events, not one:
+
+        * ``sandbox.policy_changed`` — the guardrail in EFFECT for a target
+          moved. This is the one that can say ``restricts``.
+        * ``sandbox.policy_published`` — a new version became fetchable. This
+          is the terminating event for a worker that decided to wait: without
+          it, "wait for the new policy" has no completion signal.
+
+        Payload carries identity, direction, and counts — never the policy
+        text. A worker fetches the text through the routes that already
+        authorise it per agent.
+        """
+        from mac.openshell_policy_diff import policy_change_payload
+
+        try:
+            payload = policy_change_payload(**fields)
+        except Exception:  # noqa: BLE001 - a write already landed; never undo it.
+            return []
+        change_kind = str(payload.get("change_kind") or "")
+        if change_kind == "published":
+            # A newly created policy is assigned to nobody: it changes no
+            # guardrail in effect, so it is a publication and nothing else.
+            events = ["sandbox.policy_published"]
+        elif change_kind == "updated":
+            # Both: the version became fetchable (releasing any waiter) AND the
+            # guardrail moved for every target already assigned to it.
+            events = ["sandbox.policy_published", "sandbox.policy_changed"]
+        else:
+            events = ["sandbox.policy_changed"]
+        published: List[JsonDict] = []
+        for event_type in events:
+            try:
+                published.append(
+                    self.agentbus_broadcast.publish_system(event_type, payload=payload)
+                )
+            except Exception:  # noqa: BLE001 - announcing is never load-bearing.
+                continue
+        return published
 
     def _derive_broadcast_ledger_fact(self, envelope: JsonDict) -> Optional[str]:
         """Turn an overheard git event into a ledger entry.

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -1385,6 +1385,12 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         self._maybe_start_workspace_gc()
         self._maybe_sync_service_claims()
         self._maybe_sync_openshell_policy()
+        # Between tasks is the ONLY point where a guardrail change can be acted
+        # on: the running agent's stdin is closed, but the next sandbox has not
+        # been created yet.
+        policy_gate = self._openshell_policy_gate()
+        if policy_gate is not None:
+            return policy_gate
         self._maintain_openclaw_gateway_leases()
         self._process_human_delivery_outbox()
         review_result = self._process_review_nudges()
@@ -5308,6 +5314,11 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
         checksum = str(assigned.get("checksum") or "")
         if not isinstance(text, str) or not text.strip() or not checksum:
             return
+        # Remember WHICH policy is ours. A `sandbox.policy_changed` broadcast
+        # about a policy names the policy, not its targets (one update can move
+        # the guardrail for a whole fleet), so this is how the gate below
+        # recognises a change that applies to this worker.
+        self._openshell_policy_id = str(assigned.get("policy_id") or "")
         target = self._mac_home() / "openshell-policy.yaml"
         try:
             if target.is_file() and policy_checksum(
@@ -5366,6 +5377,227 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
             )
         except Exception:  # noqa: BLE001 - reporting is observability, not control
             pass
+
+    # --- sandbox guardrail gate (AgentBus consumer) ---------------------------
+    #
+    # The one place a policy change can actually be acted on. A coding agent
+    # cannot be interrupted mid-task — it runs as subprocess.run(argv,
+    # input=prompt) with stdin closed, so nothing reaches it once started (see
+    # mac/agent_command.py). The decision point is therefore HERE, in the outer
+    # loop, between finishing one task and claiming the next: the sandbox for
+    # the next task has not been created yet, so declining to claim is the
+    # cheapest possible enforcement and costs no work in flight.
+
+    def _openshell_policy_state(self) -> JsonDict:
+        """Mutable gate state, created on first use.
+
+        Held in memory only. A restart re-reads the feed and re-derives the
+        same conclusion from the policy on disk, so there is no state file to
+        go stale or to disagree with the hub.
+        """
+        state = getattr(self, "_openshell_gate_state", None)
+        if state is None:
+            state = {"cursor": 0, "pending": None}
+            self._openshell_gate_state = state
+        return state
+
+    def _installed_openshell_policy_checksum(self) -> str:
+        """Checksum of the policy this worker's next sandbox would be built from."""
+        target = self._mac_home() / "openshell-policy.yaml"
+        try:
+            return policy_checksum(target.read_text(encoding="utf-8"))
+        except OSError:
+            return ""
+
+    def _openshell_broadcast_applies(self, payload: JsonDict) -> bool:
+        """Is this guardrail change about THIS worker?
+
+        Two ways to match, because the hub announces both shapes: a change
+        aimed at a target (``target_type=agent``), and a change to a policy
+        that some set of targets happens to be assigned (``target_type=policy``
+        — one edit, every holder affected). The second is matched by the policy
+        id this worker last installed, which is the only thing that reliably
+        identifies "mine" without the worker knowing its own fleet membership.
+        """
+        target_type = str(payload.get("target_type") or "")
+        target_id = str(payload.get("target_id") or "")
+        if target_type == "agent" and target_id == self.agent_id:
+            return True
+        mine = str(getattr(self, "_openshell_policy_id", "") or "")
+        return bool(mine) and str(payload.get("policy_id") or "") == mine
+
+    def _read_openshell_policy_broadcasts(self) -> List[JsonDict]:
+        """Drain new guardrail announcements from the broadcast feed.
+
+        Read UNFILTERED and filtered here, deliberately. The hub's filtered
+        read scans a bounded number of pages and returns nothing if the filter
+        misses in all of them — which leaves the caller's cursor where it was,
+        so on a busy feed a rare event type can sit permanently beyond the
+        scan window and never be delivered. Reading the feed itself always
+        advances the cursor, so this worker cannot be starved by other agents'
+        chatter.
+        """
+        state = self._openshell_policy_state()
+        wanted = {"sandbox.policy_changed", "sandbox.policy_published"}
+        found: List[JsonDict] = []
+        page_size = max(1, _env_int("MAC_OPENSHELL_POLICY_BUS_PAGE", 200))
+        for _page in range(5):
+            try:
+                events = self.client.get(
+                    "/agents/%s/agentbus/broadcast?%s"
+                    % (
+                        quote(self.agent_id, safe=""),
+                        urlencode(
+                            {
+                                "after_sequence": int(state["cursor"]),
+                                "limit": page_size,
+                            }
+                        ),
+                    )
+                )
+            except Exception:  # noqa: BLE001 - hub unreachable: gate stays closed-open
+                return found
+            if not isinstance(events, list) or not events:
+                return found
+            for event in events:
+                if not isinstance(event, dict):
+                    continue
+                state["cursor"] = max(int(state["cursor"]), int(event.get("sequence") or 0))
+                if str(event.get("event_type") or "") in wanted:
+                    found.append(event)
+            if len(events) < page_size:
+                return found
+        return found
+
+    def _absorb_openshell_policy_broadcast(self, event: JsonDict) -> None:
+        """Fold one announcement into the gate's decision."""
+        payload = event.get("payload")
+        if not isinstance(payload, dict) or not self._openshell_broadcast_applies(payload):
+            return
+        state = self._openshell_policy_state()
+        event_type = str(event.get("event_type") or "")
+        if event_type == "sandbox.policy_published":
+            pending = state["pending"]
+            if pending is None:
+                return
+            if str(payload.get("policy_id") or "") != pending["policy_id"]:
+                return
+            to_version = payload.get("to_version")
+            wanted_version = pending.get("to_version")
+            if (
+                wanted_version is None
+                or to_version is None
+                or int(to_version) >= int(wanted_version)
+            ):
+                # The version the change named is now fetchable. This is what
+                # ends the wait; without it the worker could only sleep an
+                # arbitrary interval and hope.
+                pending["published"] = True
+            return
+        hint = str(payload.get("action_hint") or "")
+        if hint not in {"recreate_before_next_task", "abandon_current"}:
+            return
+        to_checksum = str(payload.get("to_checksum") or "")
+        if to_checksum and to_checksum == self._installed_openshell_policy_checksum():
+            # Already converged (the periodic sync beat the announcement).
+            return
+        state["pending"] = {
+            "policy_id": str(payload.get("policy_id") or ""),
+            "change_kind": str(payload.get("change_kind") or ""),
+            "action_hint": hint,
+            "restricts": bool(payload.get("restricts")),
+            "expands": bool(payload.get("expands")),
+            "to_version": payload.get("to_version"),
+            "to_checksum": to_checksum,
+            "published": to_checksum == "",
+            "deadline": time.monotonic()
+            + _env_float("MAC_OPENSHELL_POLICY_WAIT_SECONDS", 300.0),
+        }
+
+    def _openshell_policy_gate(self) -> Optional[WorkerRunResult]:
+        """Refuse to start new work under a superseded guardrail.
+
+        Returns a ``held`` result — the same shape the dispatch holds already
+        use — when this worker should not claim a task yet, or ``None`` to
+        proceed. The wait is BOUNDED: a hub that never publishes the promised
+        version must not park a worker forever, so on expiry the gate records
+        why it gave up and resumes. That is a deliberate availability choice,
+        and the recorded reason is what makes it auditable rather than silent.
+        """
+        if not _env_bool("MAC_OPENSHELL_POLICY_BUS_GATE", True):
+            return None
+        for event in self._read_openshell_policy_broadcasts():
+            try:
+                self._absorb_openshell_policy_broadcast(event)
+            except Exception:  # noqa: BLE001 - a malformed announcement is not fatal
+                continue
+        state = self._openshell_policy_state()
+        pending = state["pending"]
+        if pending is None:
+            return None
+        if pending.get("published"):
+            # Re-converge NOW rather than waiting for the sync's own throttle:
+            # the whole point of the hold is to end as soon as it can.
+            self._last_openshell_policy_sync = None
+            self._maybe_sync_openshell_policy()
+            wanted = str(pending.get("to_checksum") or "")
+            if wanted and wanted == self._installed_openshell_policy_checksum():
+                state["pending"] = None
+                self._observe_log(
+                    "worker.openshell_policy.gate_cleared",
+                    subject_type="agent",
+                    subject_id=self.agent_id,
+                    detail={
+                        "policy_id": pending.get("policy_id"),
+                        "to_version": pending.get("to_version"),
+                        "checksum": wanted,
+                        "restricts": pending.get("restricts"),
+                    },
+                )
+                return None
+        if time.monotonic() >= float(pending.get("deadline") or 0.0):
+            state["pending"] = None
+            reason = (
+                "openshell policy %s v%s never became installable; resuming under the "
+                "policy on disk after the bounded wait"
+                % (pending.get("policy_id"), pending.get("to_version"))
+            )
+            self._observe_log(
+                "worker.openshell_policy.gate_expired",
+                level="warning",
+                subject_type="agent",
+                subject_id=self.agent_id,
+                detail={
+                    "reason": reason,
+                    "policy_id": pending.get("policy_id"),
+                    "change_kind": pending.get("change_kind"),
+                    "action_hint": pending.get("action_hint"),
+                    "restricts": pending.get("restricts"),
+                    "to_version": pending.get("to_version"),
+                    "installed_checksum": self._installed_openshell_policy_checksum(),
+                },
+            )
+            return None
+        reason = (
+            "sandbox policy %s superseded (%s, restricts=%s); waiting for v%s before "
+            "claiming"
+            % (
+                pending.get("policy_id"),
+                pending.get("change_kind"),
+                pending.get("restricts"),
+                pending.get("to_version"),
+            )
+        )
+        if getattr(self, "_last_openshell_gate_reason", None) != reason:
+            self._last_openshell_gate_reason = reason
+            self._observe_log(
+                "worker.openshell_policy.gate_held",
+                level="warning" if pending.get("restricts") else "info",
+                subject_type="agent",
+                subject_id=self.agent_id,
+                detail=dict(pending, reason=reason, agent_id=self.agent_id),
+            )
+        return WorkerRunResult(status="held", evidence=dict(pending), error=reason)
 
     # --- autonomous self-install (pip/npm into the agent's OWN environment) ----
     # Fully unrestricted by decision: install only into the agent venv / local

--- a/tests/test_openshell_policy_broadcast.py
+++ b/tests/test_openshell_policy_broadcast.py
@@ -1,0 +1,412 @@
+"""A sandbox guardrail change is announced on the bus, with its DIRECTION.
+
+The distinction these tests exist to pin is not "did the policy change" — a
+checksum already answers that, and a worker that learns only that much has to
+either ignore it or stop for every comment edit. It is which way it moved:
+
+* the new policy REVOKES something the running sandbox still holds, so that
+  sandbox is now over-permissioned relative to what a human approved; or
+* the new policy only GRANTS, so the running sandbox is still compliant and
+  merely less capable than a fresh one.
+
+The diff is structural (over parsed YAML), because a text diff answers a
+different question: reordering blocks or editing a comment rewrites every line
+and revokes nothing, and a signal that fires on that trains its consumer to
+ignore it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.agentbus_broadcast import (
+    BROADCAST_EVENT_TYPE_SET,
+    BROADCAST_MAX_PAYLOAD_BYTES,
+    BROADCAST_MAX_PAYLOAD_KEYS,
+    BROADCAST_MAX_VALUE_CHARS,
+    BROADCAST_SYSTEM_AGENT_ID,
+)
+from mac.models import NotFoundError, json_dumps
+from mac.openshell_policy_diff import (
+    diff_policy_texts,
+    policy_change_payload,
+)
+from mac.services import ControlPlane
+
+WIDE = """version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+  read_write:
+    - /tmp
+
+network_policies:
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: hub.example.com
+        port: 8789
+    binaries:
+      - { path: /usr/bin/python3 }
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+    binaries:
+      - { path: /usr/bin/git }
+"""
+
+# Same policy, github revoked: an endpoint and a binary the running sandbox
+# still holds are gone.
+NARROW = """version: 1
+
+filesystem_policy:
+  include_workdir: true
+  read_only:
+    - /usr
+  read_write:
+    - /tmp
+
+network_policies:
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: hub.example.com
+        port: 8789
+    binaries:
+      - { path: /usr/bin/python3 }
+"""
+
+# Same policy plus one endpoint: nothing the running sandbox holds is revoked.
+WIDER = WIDE + """  pypi:
+    name: pypi
+    endpoints:
+      - host: pypi.org
+        port: 443
+"""
+
+
+def _agent(cp: ControlPlane):
+    machine = cp.register_machine("rocky", resources={"openshell_required": True})
+    return cp.register_agent(
+        machine.id, "rocky", capabilities=["python"], resources={"openshell_required": True}
+    )
+
+
+def _policy_events(cp: ControlPlane, agent_id: str):
+    return [
+        event
+        for event in cp.read_agentbus_broadcasts(agent_id, limit=500)
+        if str(event["event_type"]).startswith("sandbox.policy")
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The diff, in isolation: direction, not change
+# ---------------------------------------------------------------------------
+
+
+def test_a_revocation_restricts():
+    diff = diff_policy_texts(WIDE, NARROW)
+
+    assert diff["restricts"] is True
+    assert diff["expands"] is False
+    assert diff["endpoints_removed"] == 1
+    assert diff["binaries_removed"] == 1
+    assert diff["endpoints_added"] == 0
+
+
+def test_a_pure_addition_does_not_restrict():
+    diff = diff_policy_texts(WIDE, WIDER)
+
+    assert diff["restricts"] is False
+    assert diff["expands"] is True
+    assert diff["endpoints_added"] == 1
+    assert diff["endpoints_removed"] == 0
+
+
+def test_a_swap_is_both_a_revocation_and_a_grant():
+    """Representable on purpose: "changed" would hide the revoked half."""
+    swapped = WIDE.replace("github.com", "gitlab.com")
+
+    diff = diff_policy_texts(WIDE, swapped)
+
+    assert diff["restricts"] is True
+    assert diff["expands"] is True
+
+
+def test_reordering_and_comments_move_nothing():
+    """The false alarm a text diff would raise, and the reason this is structural."""
+    reordered = """version: 1
+
+# a comment that did not exist before
+network_policies:
+  github:
+    name: github
+    endpoints:
+      - {host: github.com, port: 443}
+    binaries:
+      - /usr/bin/git
+  mac_hub:
+    name: mac-hub
+    binaries:
+      - { path: /usr/bin/python3 }
+    endpoints:
+      - host: hub.example.com
+        port: 8789
+
+filesystem_policy:
+  read_write: [/tmp]
+  read_only: [/usr]
+  include_workdir: true
+"""
+
+    diff = diff_policy_texts(WIDE, reordered)
+
+    assert diff["restricts"] is False
+    assert diff["expands"] is False
+
+
+def test_demoting_a_writable_path_is_a_revocation():
+    """rw -> ro is a revocation, not a rename; the mode is part of the identity."""
+    demoted = WIDE.replace("  read_write:\n    - /tmp", "  read_write: []").replace(
+        "  read_only:\n    - /usr", "  read_only:\n    - /usr\n    - /tmp"
+    )
+
+    diff = diff_policy_texts(WIDE, demoted)
+
+    assert diff["restricts"] is True
+    assert diff["paths_removed"] == 1
+
+
+def test_an_unreadable_policy_fails_safe():
+    """We cannot show that nothing was revoked, so we must not claim it."""
+    diff = diff_policy_texts(WIDE, "network_policies: [oops\n")
+
+    assert diff["parsed"] is False
+    assert diff["restricts"] is True
+
+
+def test_losing_the_policy_entirely_restricts():
+    diff = diff_policy_texts(WIDE, None)
+
+    assert diff["restricts"] is True
+    assert diff["expands"] is False
+
+
+# ---------------------------------------------------------------------------
+# The payload: small enough to be an announcement, complete enough to decide on
+# ---------------------------------------------------------------------------
+
+
+def test_the_payload_fits_the_caps_and_is_not_truncated():
+    """The module refuses silent truncation; a partial answer must never ship.
+
+    Checked through the real publish path, since that is where the bounding
+    happens — asserting on the dict we built would prove nothing about what a
+    consumer receives.
+    """
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    policy = cp.create_openshell_policy("x" * 120, WIDE, created_by="operator")
+    cp.assign_openshell_policy(policy.id, target_type="agent", target_id=agent.id)
+
+    events = _policy_events(cp, agent.id)
+    assert events
+    for event in events:
+        payload = event["payload"]
+        assert "truncated" not in payload
+        assert len(payload) <= BROADCAST_MAX_PAYLOAD_KEYS
+        assert len(json_dumps(payload).encode("utf-8")) <= BROADCAST_MAX_PAYLOAD_BYTES
+        for value in payload.values():
+            assert not isinstance(value, str) or len(value) <= BROADCAST_MAX_VALUE_CHARS
+        # Detail is FETCHED, never embedded: the bus is announcements.
+        assert "policy_text" not in payload
+
+
+def test_the_payload_answers_what_a_worker_has_to_decide():
+    payload = policy_change_payload(
+        change_kind="updated",
+        policy_id="ospol-1",
+        policy_name="default",
+        from_text=WIDE,
+        to_text=NARROW,
+        from_version=3,
+        to_version=4,
+        from_checksum="sha256:aaa",
+        to_checksum="sha256:bbb",
+        target_type="policy",
+        target_id="ospol-1",
+    )
+
+    assert payload["restricts"] is True
+    assert payload["action_hint"] == "abandon_current"
+    assert payload["from_version"] == 3 and payload["to_version"] == 4
+    assert payload["to_checksum"] == "sha256:bbb"
+
+
+def test_a_widening_asks_only_for_a_fresh_sandbox_next_time():
+    payload = policy_change_payload(
+        change_kind="updated",
+        policy_id="ospol-1",
+        from_text=WIDE,
+        to_text=WIDER,
+        to_version=2,
+    )
+
+    assert payload["restricts"] is False
+    assert payload["action_hint"] == "recreate_before_next_task"
+
+
+def test_an_unknown_change_kind_is_refused():
+    with pytest.raises(ValueError):
+        policy_change_payload(change_kind="mutated", policy_id="ospol-1")
+
+
+# ---------------------------------------------------------------------------
+# The hub emits, from the paths that actually performed the change
+# ---------------------------------------------------------------------------
+
+
+def test_the_verbs_are_in_the_closed_vocabulary():
+    assert "sandbox.policy_changed" in BROADCAST_EVENT_TYPE_SET
+    assert "sandbox.policy_published" in BROADCAST_EVENT_TYPE_SET
+
+
+def test_creating_a_policy_publishes_but_changes_nothing_in_effect():
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+
+    policy = cp.create_openshell_policy("default", WIDE, created_by="operator")
+
+    events = _policy_events(cp, agent.id)
+    assert [event["event_type"] for event in events] == ["sandbox.policy_published"]
+    assert events[0]["agent_id"] == BROADCAST_SYSTEM_AGENT_ID
+    assert events[0]["payload"]["policy_id"] == policy.id
+    assert events[0]["payload"]["change_kind"] == "published"
+
+
+def test_restricting_an_update_announces_the_revocation_and_the_publication():
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    policy = cp.create_openshell_policy("default", WIDE, created_by="operator")
+    cp.assign_openshell_policy(policy.id, target_type="agent", target_id=agent.id)
+
+    cp.update_openshell_policy(policy.id, policy_text=NARROW, updated_by="operator")
+
+    kinds = {
+        event["event_type"]: event["payload"]
+        for event in _policy_events(cp, agent.id)
+        if event["payload"].get("change_kind") == "updated"
+    }
+    assert set(kinds) == {"sandbox.policy_changed", "sandbox.policy_published"}
+    changed = kinds["sandbox.policy_changed"]
+    assert changed["restricts"] is True
+    assert changed["expands"] is False
+    assert changed["action_hint"] == "abandon_current"
+    assert changed["from_version"] == 1 and changed["to_version"] == 2
+    assert changed["to_checksum"] == cp.get_openshell_policy(policy.id).checksum
+
+
+def test_a_metadata_only_update_says_nothing():
+    """A rename moves no capability. A bus that reports it teaches its own noise."""
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    policy = cp.create_openshell_policy("default", WIDE, created_by="operator")
+    before = len(_policy_events(cp, agent.id))
+
+    cp.update_openshell_policy(policy.id, description="now documented")
+
+    assert len(_policy_events(cp, agent.id)) == before
+
+
+def test_assigning_a_narrower_policy_names_the_target_and_the_revocation():
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    wide = cp.create_openshell_policy("wide", WIDE, created_by="operator")
+    narrow = cp.create_openshell_policy("narrow", NARROW, created_by="operator")
+    cp.assign_openshell_policy(wide.id, target_type="agent", target_id=agent.id)
+
+    cp.assign_openshell_policy(narrow.id, target_type="agent", target_id=agent.id)
+
+    assigned = [
+        event["payload"]
+        for event in _policy_events(cp, agent.id)
+        if event["payload"].get("change_kind") == "assigned"
+        and event["payload"].get("policy_id") == narrow.id
+    ]
+    assert len(assigned) == 1
+    assert assigned[0]["target_type"] == "agent"
+    assert assigned[0]["target_id"] == agent.id
+    assert assigned[0]["restricts"] is True
+    assert assigned[0]["from_checksum"] == wide.checksum
+
+
+def test_a_first_assignment_grants_and_does_not_revoke():
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    policy = cp.create_openshell_policy("wide", WIDE, created_by="operator")
+
+    cp.assign_openshell_policy(policy.id, target_type="agent", target_id=agent.id)
+
+    assigned = [
+        event["payload"]
+        for event in _policy_events(cp, agent.id)
+        if event["payload"].get("change_kind") == "assigned"
+    ]
+    assert assigned[0]["restricts"] is False
+    assert assigned[0]["expands"] is True
+    assert assigned[0]["action_hint"] == "recreate_before_next_task"
+
+
+def test_deleting_a_policy_tells_every_target_it_lost_its_guardrail():
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    policy = cp.create_openshell_policy("wide", WIDE, created_by="operator")
+    cp.assign_openshell_policy(policy.id, target_type="agent", target_id=agent.id)
+
+    cp.delete_openshell_policy(policy.id)
+
+    payloads = [event["payload"] for event in _policy_events(cp, agent.id)]
+    deleted = [p for p in payloads if p.get("change_kind") == "deleted"]
+    unassigned = [p for p in payloads if p.get("change_kind") == "unassigned"]
+    assert deleted and deleted[0]["restricts"] is True
+    assert unassigned and unassigned[0]["target_id"] == agent.id
+    assert unassigned[0]["action_hint"] == "abandon_current"
+
+
+def test_announcing_never_breaks_the_write(monkeypatch):
+    """The policy write is already durable; a broken bus must not undo it."""
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+
+    def _explode(*_args, **_kwargs):
+        raise RuntimeError("bus down")
+
+    monkeypatch.setattr(cp.agentbus_broadcast, "publish_system", _explode)
+    policy = cp.create_openshell_policy("default", WIDE, created_by="operator")
+
+    assert cp.get_openshell_policy(policy.id).checksum == policy.checksum
+    assert _policy_events(cp, agent.id) == []
+
+
+def test_the_hub_speaks_as_itself_and_no_token_can():
+    """publish_system has no HTTP route behind it; the agent route still checks.
+
+    If the hub announced as the affected agent, that agent would see its own
+    "echo" and skip the one event it exists to act on.
+    """
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+    cp.create_openshell_policy("default", WIDE, created_by="operator")
+
+    event = _policy_events(cp, agent.id)[0]
+    assert event["agent_id"] == BROADCAST_SYSTEM_AGENT_ID
+    assert event["self_emitted"] is False
+    with pytest.raises(NotFoundError):
+        cp.publish_agentbus_broadcast(
+            BROADCAST_SYSTEM_AGENT_ID, "sandbox.policy_changed", payload={}
+        )

--- a/tests/test_worker_openshell_policy_gate.py
+++ b/tests/test_worker_openshell_policy_gate.py
@@ -1,0 +1,320 @@
+"""The worker's outer loop acts on a sandbox guardrail change.
+
+An agent cannot be interrupted mid-task: the coding agent runs as
+``subprocess.run(argv, input=prompt)`` with stdin closed, so nothing reaches it
+once it has started. The decision point is therefore the OUTER loop — after one
+task finishes, before the next is claimed, while the next sandbox does not yet
+exist. Declining to claim is the whole enforcement mechanism, and it costs no
+work in flight.
+
+What these tests pin:
+
+* a REVOCATION stops the worker claiming under the sandbox it would build from
+  the superseded policy;
+* the wait ENDS on the publication of the version the change named — not on a
+  timeout, which is what "wait for the new policy" degrades into without a
+  terminating event;
+* the wait is BOUNDED, and giving up records why, because a worker parked
+  forever by a hub that never published is an outage;
+* a change that grants nothing and revokes nothing does not stop anyone.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from mac import worker
+from mac.openshell_service import policy_checksum
+
+WIDE = """version: 1
+network_policies:
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: hub.example.com
+        port: 8789
+  github:
+    name: github
+    endpoints:
+      - host: github.com
+        port: 443
+"""
+
+NARROW = """version: 1
+network_policies:
+  mac_hub:
+    name: mac-hub
+    endpoints:
+      - host: hub.example.com
+        port: 8789
+"""
+
+
+class _Client:
+    """Serves the assigned policy and a scripted broadcast feed."""
+
+    def __init__(self, *, policy=None, events=None):
+        self.posts = []
+        self.policy = policy
+        self.events = list(events or [])
+        self.broadcast_reads = 0
+
+    def post(self, path, payload):
+        self.posts.append((path, payload))
+        return {}
+
+    def get(self, path):
+        parsed = urlparse(path)
+        if parsed.path.endswith("/agentbus/broadcast"):
+            self.broadcast_reads += 1
+            after = int(parse_qs(parsed.query).get("after_sequence", ["0"])[0])
+            return [e for e in self.events if int(e["sequence"]) > after]
+        if parsed.path.endswith("/openshell/policy"):
+            if self.policy is None:
+                raise RuntimeError("no assignment")
+            return self.policy
+        return {}
+
+
+def _assigned(text, *, version, policy_id="ospol_1"):
+    return {
+        "schema": "mac.openshell.assigned_policy.v1",
+        "agent_id": "agent-1",
+        "policy_id": policy_id,
+        "policy_name": "fleet",
+        "version": version,
+        "checksum": policy_checksum(text),
+        "policy_text": text,
+    }
+
+
+def _changed_event(sequence, *, to_text, restricts=True, to_version=2, policy_id="ospol_1"):
+    return {
+        "sequence": sequence,
+        "event_type": "sandbox.policy_changed",
+        "agent_id": "hub",
+        "payload": {
+            "change_kind": "updated",
+            "policy_id": policy_id,
+            "target_type": "policy",
+            "target_id": policy_id,
+            "restricts": restricts,
+            "expands": not restricts,
+            "to_version": to_version,
+            "to_checksum": policy_checksum(to_text),
+            "action_hint": "abandon_current" if restricts else "recreate_before_next_task",
+        },
+        "self_emitted": False,
+    }
+
+
+def _published_event(sequence, *, to_text, to_version=2, policy_id="ospol_1"):
+    event = _changed_event(
+        sequence, to_text=to_text, to_version=to_version, policy_id=policy_id
+    )
+    event["event_type"] = "sandbox.policy_published"
+    return event
+
+
+@pytest.fixture
+def mac_home(tmp_path, monkeypatch):
+    home = tmp_path / "machome"
+    home.mkdir()
+    monkeypatch.setattr(worker.mac_paths, "mac_home", lambda: home)
+    monkeypatch.delenv("MAC_OPENSHELL_POLICY", raising=False)
+    monkeypatch.delenv("MAC_OPENSHELL_POLICY_BUS_GATE", raising=False)
+    return home
+
+
+def _worker(tmp_path, client):
+    return worker.MacWorker(
+        client,
+        "agent-1",
+        tmp_path,
+        lambda _task, _path: worker.WorkerExecution(0, "ok"),
+        self_update_repo=tmp_path,
+    )
+
+
+def _converged(instance, mac_home, text, client):
+    """Put the worker in the steady state: the wide policy installed and known."""
+    client.policy = _assigned(text, version=1)
+    instance._maybe_sync_openshell_policy()
+    assert (mac_home / "openshell-policy.yaml").read_text(encoding="utf-8") == text
+
+
+# ---------------------------------------------------------------------------
+# A revocation stops the next claim
+# ---------------------------------------------------------------------------
+
+
+def test_a_revocation_holds_the_worker_before_it_claims(mac_home, tmp_path):
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+    # The hub announced the revocation; the narrower policy is not servable yet.
+    client.events = [_changed_event(11, to_text=NARROW)]
+
+    held = instance._openshell_policy_gate()
+
+    assert held is not None
+    assert held.status == "held"
+    assert "restricts=True" in held.error
+    # ...and the sandbox on disk is still the OLD one: the worker did not
+    # quietly proceed on the assumption that a resync had happened.
+    assert (mac_home / "openshell-policy.yaml").read_text(encoding="utf-8") == WIDE
+
+
+def test_the_hold_reaches_the_outer_loop_and_no_task_is_claimed(mac_home, tmp_path, monkeypatch):
+    """The gate is only worth anything if it sits ahead of the claim."""
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+    client.events = [_changed_event(11, to_text=NARROW)]
+
+    claims = []
+    monkeypatch.setattr(worker, "_deployment_barrier_state", lambda: (0, False))
+    monkeypatch.setattr(worker, "_synchronize_directive_policy", lambda *_a, **_k: None)
+    for name, result in (
+        ("_heartbeat", None),
+        ("_current_dispatch_hold", None),
+        ("_process_agentbus_control", {}),
+        ("_poll_debug_terminal_sessions", None),
+        ("_local_repo_update_dispatch_blocker", None),
+        ("_maybe_start_workspace_gc", None),
+        ("_maybe_sync_service_claims", None),
+        ("_maintain_openclaw_gateway_leases", None),
+        ("_process_human_delivery_outbox", None),
+        ("_process_review_nudges", None),
+        ("apply_pending_repo_update_if_idle", None),
+        ("_observe_policy_once", None),
+        ("_maybe_hub_load_shed", None),
+    ):
+        monkeypatch.setattr(
+            instance, name, (lambda _r=result: (lambda *_a, **_k: _r))()
+        )
+    monkeypatch.setattr(
+        instance, "_claim_next_for_agent", lambda *_a, **_k: claims.append(1)
+    )
+
+    outcome = instance.run_once()
+
+    assert outcome.status == "held"
+    assert claims == []
+
+
+def test_the_wait_ends_on_the_publication_of_the_named_version(mac_home, tmp_path):
+    """The terminating event. Without it this is a timeout poll wearing a hat."""
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+    client.events = [_changed_event(11, to_text=NARROW)]
+    assert instance._openshell_policy_gate() is not None
+
+    # The hub publishes v2 and starts serving it; the worker re-converges and
+    # resumes claiming in the same pass.
+    client.events.append(_published_event(12, to_text=NARROW))
+    client.policy = _assigned(NARROW, version=2)
+
+    assert instance._openshell_policy_gate() is None
+    assert (mac_home / "openshell-policy.yaml").read_text(encoding="utf-8") == NARROW
+
+
+def test_a_publication_of_an_older_version_does_not_end_the_wait(mac_home, tmp_path):
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+    client.events = [_changed_event(11, to_text=NARROW, to_version=5)]
+    assert instance._openshell_policy_gate() is not None
+
+    client.events.append(_published_event(12, to_text=NARROW, to_version=4))
+
+    assert instance._openshell_policy_gate() is not None
+
+
+def test_the_wait_is_bounded_and_says_why_it_gave_up(mac_home, tmp_path, monkeypatch):
+    """A hub that never publishes must not park a worker forever.
+
+    Resuming is a deliberate availability choice over an indefinite stall; the
+    recorded reason is what keeps it auditable instead of silent.
+    """
+    monkeypatch.setenv("MAC_OPENSHELL_POLICY_WAIT_SECONDS", "0")
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+    client.events = [_changed_event(11, to_text=NARROW)]
+
+    assert instance._openshell_policy_gate() is None
+    reason = next(
+        payload
+        for path, payload in client.posts
+        if payload.get("name") == "worker.openshell_policy.gate_expired"
+    )
+    assert "never became installable" in reason["detail"]["reason"]
+    assert reason["detail"]["restricts"] is True
+
+
+def test_an_unrelated_policy_does_not_stop_this_worker(mac_home, tmp_path):
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+    client.events = [
+        _changed_event(11, to_text=NARROW, policy_id="ospol_other"),
+    ]
+
+    assert instance._openshell_policy_gate() is None
+
+
+def test_a_change_aimed_at_this_agent_by_name_is_heard(mac_home, tmp_path):
+    """Assignments name the agent; policy edits name the policy. Both are ours."""
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+    event = _changed_event(11, to_text=NARROW, policy_id="ospol_other")
+    event["payload"]["change_kind"] = "assigned"
+    event["payload"]["target_type"] = "agent"
+    event["payload"]["target_id"] = "agent-1"
+    client.events = [event]
+
+    assert instance._openshell_policy_gate() is not None
+
+
+def test_a_change_already_on_disk_does_not_hold(mac_home, tmp_path):
+    """The periodic sync can beat the announcement; that is convergence, not drift."""
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, NARROW, client)
+    client.events = [_changed_event(11, to_text=NARROW)]
+
+    assert instance._openshell_policy_gate() is None
+
+
+def test_the_gate_can_be_switched_off(mac_home, tmp_path, monkeypatch):
+    monkeypatch.setenv("MAC_OPENSHELL_POLICY_BUS_GATE", "0")
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+    client.events = [_changed_event(11, to_text=NARROW)]
+
+    assert instance._openshell_policy_gate() is None
+    assert client.broadcast_reads == 0
+
+
+def test_an_unreachable_hub_does_not_hold_the_worker(mac_home, tmp_path, monkeypatch):
+    """Fail open on the READ: a hub outage already stops dispatch by itself.
+
+    Holding here too would turn every hub blip into a second, longer stall for
+    a policy change that may not exist.
+    """
+    client = _Client()
+    instance = _worker(tmp_path, client)
+    _converged(instance, mac_home, WIDE, client)
+
+    def _boom(_path):
+        raise RuntimeError("hub down")
+
+    monkeypatch.setattr(client, "get", _boom)
+
+    assert instance._openshell_policy_gate() is None


### PR DESCRIPTION
Closes task_4b611fbb.

## Why this is buildable, and where the boundary is

An agent cannot be interrupted mid-task: the coding agent runs as `subprocess.run(argv, input=prompt)` with stdin closed, so nothing reaches it once started (task_358589ed). This does **not** attempt mid-run steering.

The decision point is the worker's **outer loop** — the code that claims work and builds sandboxes. That loop can read the bus. So: hold before claiming, wait for the policy the assignment names to be published, resync, verify, resume.

## The payload carries direction, not just change

"Policy changed" cannot drive the decision, because the two cases are opposite:

- **expands** — the new policy grants more. A running sandbox is still compliant, merely less capable than a fresh one.
- **restricts** — the new policy revokes something the running sandbox still has. That sandbox is now over-permissioned relative to reviewed intent.

`src/mac/openshell_policy_diff.py` computes both **independently** (a swap is both) from a structural comparison of the parsed YAML: network endpoints as `host:port`, binaries, and filesystem paths **tagged with access mode** — `rw:/tmp` vs `ro:/tmp` — so a write→read demotion reads as the revocation it is. Block renames, reordering and comment edits move nothing.

Two fail-safe decisions worth calling out:

- An unparseable side yields `parsed=false` and is treated as **restricting**. An unknown guardrail must never read as safe to keep working under.
- "No policy" (`None`) is a *known state granting nothing*, not a parse failure — otherwise every first assignment would look like a revocation.

Payload is 19 scalar keys, ~600 bytes, asserted through the real publish path to be uncapped and untruncated. No policy text; detail is fetched.

## A coalescing bug this would have shipped into

`BROADCAST_COALESCE_FIELDS` was `(project, task_id, branch, sha, worktree)` — all git-shaped. Policy events carry **none** of them, so two distinct policy changes inside the 10s coalesce window would have looked like a repeat of the first, and the second — possibly the restricting one — would have been dropped silently.

`policy_id`, `to_checksum` and `change_kind` are now coalesce fields. Coalescing may suppress noise; it must never suppress a distinct guardrail decision.

## Emission and the spoofing seam

`OpenShellService` takes an additive `on_policy_change=` hook, called at the end of `create_policy`, `update_policy` (only when the text actually changed), `assign_policy` (prior assignment read *before* deactivation, so the diff has a real "from"), and `delete_policy`. Resolution functions are untouched — deliberately, since fleet-scoped resolution is landing concurrently in #452.

Announcing can never fail an already-durable write.

The hub speaks as `"hub"` through a new `BroadcastService.publish_system()`: an in-process seam with **no HTTP route behind it**. The public route still calls `publish()`, which requires a real agent row. So no token can spoof a policy announcement, and the affected agent does not skip the event as its own echo.

## Worker gate

`_openshell_policy_gate()` runs in `run_once` after policy sync and **before** claiming. It matches by agent name or by the policy id last installed, holds rather than claims, ends the wait on `sandbox.policy_published` for the named version, force-resyncs, verifies the on-disk checksum, then resumes. Bounded by `MAC_OPENSHELL_POLICY_WAIT_SECONDS` (default 300), recording `worker.openshell_policy.gate_expired` when it gives up. Disable with `MAC_OPENSHELL_POLICY_BUS_GATE=0`.

## Tests

```
tests/test_openshell_policy_broadcast.py + tests/test_worker_openshell_policy_gate.py   30 passed
dead-code-check                                                                         clean
tests/test_env_config.py (registry regenerated)                                         11 passed
```

## Known follow-ups, not fixed here

**A latent trap for any filtered bus consumer.** The hub's filtered `read()` scans a bounded 10 pages and returns `[]` on a miss, leaving the caller's cursor unmoved — so on a busy feed a rare event type can sit permanently beyond the scan window and never be delivered. This gate therefore reads the feed **unfiltered** and filters client-side. Filed separately; it affects every future consumer, not just this one.

**Fleet-scoped assignments** reach the worker only via the policy-id match, since a worker does not know its own fleet membership. Once #452 lands, `_openshell_broadcast_applies` should gain that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)