### PR TITLE
Hub API: make project-name path routes tolerate slashes (fix 404 on repo@feat/branch) (task_6ec2e3a6e5d048d7998150b590bfe5c6)

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -5794,6 +5794,12 @@ def create_app(
             project, policy_id, actor=body.actor, reason=body.reason
         )
 
+    @app.post("/optimizer/projects/{project:path}/rollback/{policy_id}")
+    def rollback_scientific_policy_path(
+        project: str, policy_id: str, body: ScientificPolicyAction
+    ) -> Dict[str, Any]:
+        return rollback_scientific_policy(project, policy_id, body)
+
     @app.post("/optimizer/experiments")
     def create_scientific_experiment(
         body: ScientificExperimentCreate,
@@ -5941,7 +5947,11 @@ def create_app(
         return {"deleted": fleet_id_or_name}
 
     @app.get("/projects")
-    def list_projects() -> List[Dict[str, Any]]:
+    def list_projects(
+        name: Optional[str] = Query(default=None),
+    ) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
+        if name:
+            return cp.get_project(name)
         return cp.list_projects()
 
     @app.post("/projects")
@@ -5981,9 +5991,17 @@ def create_app(
             project, paused=body.paused, actor=body.actor
         ).to_dict()
 
+    @app.post("/projects/{project:path}/dispatch")
+    def set_project_dispatch_path(project: str, body: ProjectDispatch) -> Dict[str, Any]:
+        return set_project_dispatch(project, body)
+
     @app.get("/projects/{project}")
     def get_project(project: str) -> Dict[str, Any]:
         return cp.get_project(project)
+
+    @app.get("/projects/{project:path}")
+    def get_project_path(project: str) -> Dict[str, Any]:
+        return get_project(project)
 
     @app.put("/projects/{project}")
     def update_project(project: str, body: ProjectUpdate) -> Dict[str, Any]:
@@ -5993,6 +6011,10 @@ def create_app(
             _ensure_payload_bounded(data["metadata"], "project.metadata")
         return cp.update_project(project, actor=actor, **data).to_dict()
 
+    @app.put("/projects/{project:path}")
+    def update_project_path(project: str, body: ProjectUpdate) -> Dict[str, Any]:
+        return update_project(project, body)
+
     @app.delete("/projects/{project}")
     def delete_project(
         project: str,
@@ -6001,6 +6023,14 @@ def create_app(
     ) -> Dict[str, Any]:
         cp.delete_project(project, force=force, actor=actor)
         return {"deleted": project}
+
+    @app.delete("/projects/{project:path}")
+    def delete_project_path(
+        project: str,
+        force: bool = Query(default=False),
+        actor: str = Query(default="human"),
+    ) -> Dict[str, Any]:
+        return delete_project(project, force=force, actor=actor)
 
     @app.post("/tasks/{task_id}/transition")
     def transition_task(

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -310,6 +310,9 @@ def _seed_route_state(client: TestClient, cp: ControlPlane, tmp_path) -> Dict[st
     ctx["delete_project_name"] = _ok(
         client.post("/projects", json={"name": "route-project-delete"})
     )["name"]
+    ctx["delete_slash_project_name"] = _ok(
+        client.post("/projects", json={"name": "route-project-delete@feat/slash"})
+    )["name"]
     route_repo = tmp_path / "route-repo"
     (route_repo / ".mac").mkdir(parents=True)
     (route_repo / ".mac" / "project.yaml").write_text(
@@ -1341,6 +1344,7 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("POST", "/tasks/{task_id}/reviews"): {"task_id": "review_task_id"},
         ("DELETE", "/fleets/{fleet_id_or_name}"): {"fleet_id_or_name": "delete_fleet_id"},
         ("DELETE", "/projects/{project}"): {"project": "delete_project_name"},
+        ("DELETE", "/projects/{project:path}"): {"project": "delete_slash_project_name"},
         ("POST", "/agents/{agent_id}/attestation-key/rotate"): {"agent_id": "attest_rotate_agent_id"},
         ("POST", "/agents/{agent_id}/attestation-key/verify"): {"agent_id": "attest_verify_agent_id"},
         ("POST", "/agents/{agent_id}/attestation-key/recover"): {
@@ -1446,6 +1450,9 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("GET", "/optimizer/policies/{policy_id}"): {"policy_id": "sci_policy_id"},
         ("POST", "/optimizer/policies/{policy_id}/promote"): {"policy_id": "sci_policy_id"},
         ("POST", "/optimizer/projects/{project}/rollback/{policy_id}"): {"policy_id": "sci_policy_id"},
+        ("POST", "/optimizer/projects/{project:path}/rollback/{policy_id}"): {
+            "policy_id": "sci_policy_id"
+        },
         ("GET", "/optimizer/experiments/{experiment_id}"): {"experiment_id": "sci_experiment_id"},
         ("POST", "/optimizer/experiments/{experiment_id}/start"): {"experiment_id": "sci_experiment_id"},
         ("POST", "/optimizer/experiments/{experiment_id}/pause"): {"experiment_id": "sci_experiment_id"},
@@ -1512,6 +1519,7 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         values[param] = ctx[ctx_key]
     path = path_template
     for param, value in values.items():
+        path = path.replace("{%s:path}" % param, str(value))
         path = path.replace("{%s}" % param, str(value))
     return path
 
@@ -1814,6 +1822,10 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
         ("POST", "/projects"): {"name": "route-project-case", "description": "created by route coverage"},
         ("PUT", "/projects/{project}"): {
             "description": "updated route project",
+            "metadata": {"route_case": True},
+        },
+        ("PUT", "/projects/{project:path}"): {
+            "description": "updated route project via path converter",
             "metadata": {"route_case": True},
         },
         ("POST", "/tasks/{task_id}/transition"): {
@@ -2596,6 +2608,10 @@ edges:
             "paused": False,
             "actor": "operator",
         },
+        ("POST", "/projects/{project:path}/dispatch"): {
+            "paused": False,
+            "actor": "operator",
+        },
         ("POST", "/tasks/{task_id}/release"): {"actor": "operator"},
         ("POST", "/optimizer/policies"): {
             "name": "route-sci-extra", "project": ctx["project_name"],
@@ -2603,6 +2619,8 @@ edges:
         ("POST", "/optimizer/policies/{policy_id}/promote"): {
             "actor": "route-coverage", "reason": "route coverage"},
         ("POST", "/optimizer/projects/{project}/rollback/{policy_id}"): {
+            "actor": "route-coverage", "reason": "route coverage"},
+        ("POST", "/optimizer/projects/{project:path}/rollback/{policy_id}"): {
             "actor": "route-coverage", "reason": "route coverage"},
         ("POST", "/optimizer/experiments"): {
             "name": "route-sci-exp-2", "project": ctx["project_name"],

--- a/tests/api/test_project_slash_names.py
+++ b/tests/api/test_project_slash_names.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from starlette.routing import Match
+
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+SLASH_PROJECT = "isaacsim7-poc@feat/ros-sim"
+
+
+def _matching_route(app, method: str, path: str) -> Optional[APIRoute]:
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("utf-8"),
+        "query_string": b"",
+        "headers": [],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        match, _child = route.matches(scope)
+        if match == Match.FULL:
+            return route
+    return None
+
+
+def test_slash_project_name_routes_resolve_and_static_paths_keep_winning():
+    app = create_app(control_plane=ControlPlane.in_memory())
+    client = TestClient(app)
+
+    created = client.post(
+        "/projects",
+        json={"name": SLASH_PROJECT, "description": "slash-bearing branch name"},
+    )
+    assert created.status_code == 200, created.text
+    assert created.json()["name"] == SLASH_PROJECT
+
+    list_route = _matching_route(app, "GET", "/projects")
+    assert list_route is not None
+    assert list_route.endpoint.__name__ == "list_projects"
+
+    create_route = _matching_route(app, "POST", "/projects")
+    assert create_route is not None
+    assert create_route.endpoint.__name__ == "create_project"
+
+    register_route = _matching_route(app, "POST", "/projects/register")
+    assert register_route is not None
+    assert register_route.endpoint.__name__ == "register_project"
+
+    listed = client.get("/projects")
+    assert listed.status_code == 200, listed.text
+    assert isinstance(listed.json(), list)
+    assert any(item.get("project") == SLASH_PROJECT for item in listed.json())
+
+    registered = client.post(
+        "/projects/register",
+        json={"repository_url": "https://github.com/example/slash-register.git"},
+    )
+    assert registered.status_code == 200, registered.text
+    assert registered.json()["project"]
+
+    looked_up = client.get("/projects", params={"name": SLASH_PROJECT})
+    assert looked_up.status_code == 200, looked_up.text
+    assert looked_up.json()["project"] == SLASH_PROJECT
+
+    shown = client.get("/projects/%s" % SLASH_PROJECT)
+    assert shown.status_code == 200, shown.text
+    assert shown.json()["project"] == SLASH_PROJECT
+    get_route = _matching_route(app, "GET", "/projects/%s" % SLASH_PROJECT)
+    assert get_route is not None
+    assert get_route.path == "/projects/{project:path}"
+
+    updated = client.put(
+        "/projects/%s" % SLASH_PROJECT,
+        json={"description": "updated slash project"},
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["description"] == "updated slash project"
+
+    dispatched = client.post(
+        "/projects/%s/dispatch" % SLASH_PROJECT,
+        json={"paused": True, "actor": "operator"},
+    )
+    assert dispatched.status_code == 200, dispatched.text
+    assert dispatched.json()["name"] == SLASH_PROJECT
+    assert dispatched.json()["metadata"]["dispatch_paused"] is True
+
+    policy = client.post(
+        "/optimizer/policies",
+        json={
+            "name": "slash-policy",
+            "project": SLASH_PROJECT,
+            "parameters": {"plan_first": True},
+            "created_by": "operator",
+        },
+    )
+    assert policy.status_code == 200, policy.text
+    policy_id = policy.json()["id"]
+    rolled_back = client.post(
+        "/optimizer/projects/%s/rollback/%s" % (SLASH_PROJECT, policy_id),
+        json={"actor": "operator", "reason": "slash-name routing"},
+    )
+    assert rolled_back.status_code == 200, rolled_back.text
+
+    deleted = client.delete("/projects/%s" % SLASH_PROJECT, params={"force": True})
+    assert deleted.status_code == 200, deleted.text
+    assert deleted.json()["deleted"] == SLASH_PROJECT
+    missing = client.get("/projects/%s" % SLASH_PROJECT)
+    assert missing.status_code == 404


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_6ec2e3a6e5d048d7998150b590bfe5c6`
- head: `2326baaebcf5a88a9ba3f35f53a919069507aea5`
- base at push: `d696855f7f6fa6a2a1c122c6a5a0f9ce6e45e7ed`
