### PR TITLE
Add normalized effective_allocation and preserved host_inventory to the hardware snapshot (task_832c4d72e96843d980fd016ee115317f)

### DIFF
--- a/src/mac/hardware.py
+++ b/src/mac/hardware.py
@@ -23,6 +23,16 @@ Unified-memory GPUs (GB10, Apple Silicon) share system memory; they are
 reported with ``shared=True`` and a structured ``memory.type`` of ``unified``.
 When system memory is measurable, the compatibility ``vram_mb`` field is set to
 that capacity so existing route filters can still reason about usable memory.
+
+Schema versioning: the snapshot additionally carries two normalized blocks --
+``effective_allocation`` (measured from this worker's OWN execution boundary,
+with per-dimension ``{value, known, source}`` provenance) and ``host_inventory``
+(the preserved raw provider/physical inventory). This is an ADDITIVE change:
+``SCHEMA`` stays ``mac.hardware.v1`` and every prior top-level key
+(``cpu_count``, ``memory_mb``, ``memory_gb``, ``disk_gb``, ``gpu``, ``gpus``,
+``accelerators``, ``capacity``, ``topology``, ``flavor``) remains byte-compatible
+for existing consumers (cli.py, roles_service.py, allocator.py,
+local_gen_catalog.py, media_routing.py). No v2 was required.
 """
 from __future__ import annotations
 
@@ -235,12 +245,30 @@ def _cpu_model() -> str:
         return ""
 
 
-def _disk_usage_mb() -> Dict[str, int]:
-    """Return total and currently available capacity of the worker filesystem."""
+def _workspace_path(workspace: Optional[Path] = None) -> Path:
+    """Resolve the filesystem path whose quota/free space bounds the task.
+
+    ``workspace`` is injectable so a fixture tree can drive detection; when it
+    is omitted the worker's declared ``MAC_WORKER_WORKSPACE`` is used, falling
+    back to the home directory. A configured-but-missing path degrades to home
+    so detection stays best-effort.
+    """
+    if workspace is not None:
+        return Path(workspace).expanduser()
     configured = str(os.environ.get("MAC_WORKER_WORKSPACE") or "").strip()
     path = Path(configured).expanduser() if configured else Path.home()
     if not path.exists():
         path = Path.home()
+    return path
+
+
+def _disk_usage_mb(workspace: Optional[Path] = None) -> Dict[str, int]:
+    """Return total and currently available capacity of the worker filesystem.
+
+    ``workspace`` is injectable (defaults to :func:`_workspace_path`) so tests
+    can point detection at a fixture directory.
+    """
+    path = _workspace_path(workspace)
     try:
         usage = shutil.disk_usage(path)
     except Exception:  # noqa: BLE001 - inventory is best-effort
@@ -554,6 +582,274 @@ def detect_apple_metal() -> Optional[Dict[str, Any]]:
     return result
 
 
+# --- Normalized effective allocation vs. preserved host inventory ----------
+#
+# ``detect_hardware`` historically COLLAPSED host inventory into the reported
+# top-level values: ``cpu_count`` / ``memory_mb`` were already ``min(host,
+# cgroup)`` and the raw host numbers survived only inside ``capacity``. On
+# workers where the cgroup probes do not resolve (some HGX/GKE nodes), the
+# snapshot then advertised host-node inventory as if it were schedulable task
+# capacity. To make the two independently readable from a single snapshot,
+# ``detect_hardware`` now emits two additive blocks:
+#
+#   * ``effective_allocation`` -- measured from the worker's OWN execution
+#     boundary (cgroup v2 ``cpu.max``/``cpuset.cpus.effective`` with cgroup v1
+#     ``cpu.cfs_quota_us``/``cpu.cfs_period_us`` + ``memory.limit_in_bytes``
+#     fallbacks, ``memory.max``, workspace filesystem quota/free, and the
+#     accelerators/MIG slices actually visible in the sandbox). Every dimension
+#     carries explicit ``{value, known, source}`` provenance. Unknown /
+#     unlimited (``"max"``, missing cgroup files, non-Linux) stays UNKNOWN --
+#     host inventory is never silently substituted. A static bare-metal worker
+#     may report allocation EQUAL to host inventory ONLY when that equality is
+#     proven (no cgroup confinement and no accelerator visibility filtering),
+#     flagged with the ``host_equals_allocation`` source so it is distinguishable
+#     from ``unknown``.
+#
+#   * ``host_inventory`` -- the raw provider/physical inventory (host logical
+#     CPUs, host total memory, physical GPU *parts* -- the parent device, not
+#     the MIG slice -- and device-level disk totals) preserved for diagnostics
+#     and drift analysis. It is NEVER overwritten with allocation data.
+#
+# The change is additive: ``SCHEMA`` stays ``mac.hardware.v1`` and every prior
+# top-level key remains byte-compatible for existing consumers.
+
+_UNKNOWN_SOURCE = "unknown"
+
+
+def _dimension(value: Any, known: bool, source: str) -> Dict[str, Any]:
+    """Provenance-carrying allocation dimension: ``{value, known, source}``."""
+    return {"value": value if known else None, "known": bool(known), "source": source}
+
+
+def _cpu_allocation(host_count: int, cgroup_root: Path) -> Dict[str, Any]:
+    """Effective CPU allocation with per-dimension provenance.
+
+    Priority (most authoritative confinement first): cgroup v2 ``cpu.max``
+    quota, cgroup v1 CFS quota, cpuset (v2 effective then v1), scheduler
+    affinity. When no confinement is proven the allocation equals host inventory
+    and is flagged ``host_equals_allocation``; a missing host count with no
+    other signal stays ``unknown``.
+    """
+    # Quota: cgroup v2 cpu.max, then cgroup v1 cfs_quota/period.
+    cpu_max = _read_text(cgroup_root / "cpu.max")
+    if cpu_max:
+        fields = cpu_max.split()
+        if len(fields) >= 2 and fields[0] != "max":
+            try:
+                quota = float(fields[0])
+                period = float(fields[1])
+                if quota >= 0 and period > 0:
+                    cores = quota / period
+                    return _dimension(_int_if_integral(cores), True, "cgroup_v2_cpu_max")
+            except ValueError:
+                pass
+
+    quota_text = _read_text(cgroup_root / "cpu" / "cpu.cfs_quota_us")
+    period_text = _read_text(cgroup_root / "cpu" / "cpu.cfs_period_us")
+    try:
+        quota = float(quota_text) if quota_text is not None else -1
+        period = float(period_text) if period_text is not None else 0
+        if quota >= 0 and period > 0:
+            cores = quota / period
+            return _dimension(_int_if_integral(cores), True, "cgroup_v1")
+    except ValueError:
+        pass
+
+    # cpuset (an explicit CPU mask still confines the worker).
+    cpuset_v2 = _parse_cpuset_count(
+        _first_text([cgroup_root / "cpuset.cpus.effective", cgroup_root / "cpuset.cpus"])
+    )
+    if cpuset_v2:
+        return _dimension(cpuset_v2, True, "cpuset")
+    cpuset_v1 = _parse_cpuset_count(_read_text(cgroup_root / "cpuset" / "cpuset.cpus"))
+    if cpuset_v1:
+        return _dimension(cpuset_v1, True, "cpuset")
+
+    # Scheduler affinity narrows the allocation even without cgroup files, but
+    # only when it is strictly below the host count -- an affinity that equals
+    # the host is not proof of confinement.
+    try:
+        affinity_count = len(os.sched_getaffinity(0))
+    except (AttributeError, OSError):
+        affinity_count = 0
+    if affinity_count and host_count and affinity_count < host_count:
+        return _dimension(affinity_count, True, "affinity")
+
+    # No confinement proven: allocation equals host inventory when we know it.
+    if host_count > 0:
+        return _dimension(host_count, True, "host_equals_allocation")
+    return _dimension(None, False, _UNKNOWN_SOURCE)
+
+
+def _memory_allocation(host_mb: int, cgroup_root: Path) -> Dict[str, Any]:
+    """Effective memory allocation (MB) with per-dimension provenance."""
+    raw_v2 = _read_text(cgroup_root / "memory.max")
+    if raw_v2 is not None and raw_v2 != "max":
+        limit = _memory_limit_mb(raw_v2)
+        if limit is not None:
+            return _dimension(limit, True, "cgroup_v2_memory_max")
+
+    raw_v1 = _read_text(cgroup_root / "memory" / "memory.limit_in_bytes")
+    if raw_v1 is not None:
+        limit = _memory_limit_mb(raw_v1)
+        if limit is not None:
+            return _dimension(limit, True, "cgroup_v1")
+
+    if host_mb > 0:
+        return _dimension(host_mb, True, "host_equals_allocation")
+    return _dimension(None, False, _UNKNOWN_SOURCE)
+
+
+def _memory_limit_mb(raw: str) -> Optional[int]:
+    """Parse a cgroup memory limit (bytes) into MB, or None when unlimited."""
+    if raw == "max":
+        return None
+    try:
+        limit_bytes = int(raw)
+    except ValueError:
+        return None
+    # cgroup v1 uses a near-LONG_MAX sentinel to mean unlimited.
+    if 0 <= limit_bytes < (1 << 60):
+        return int(limit_bytes / _MIB)
+    return None
+
+
+def _int_if_integral(value: float) -> float | int:
+    return int(value) if float(value).is_integer() else value
+
+
+def _disk_allocation(workspace: Optional[Path]) -> Dict[str, Any]:
+    """Effective filesystem allocation (quota/free) for the task workspace."""
+    usage = _disk_usage_mb(workspace)
+    if not usage:
+        return _dimension(None, False, _UNKNOWN_SOURCE)
+    return _dimension(
+        {
+            "total_mb": usage["total_mb"],
+            "available_mb": usage["available_mb"],
+        },
+        True,
+        "workspace_statvfs",
+    )
+
+
+def _accelerator_allocation(gpus: list[Dict[str, Any]]) -> Dict[str, Any]:
+    """Accelerators/MIG slices actually visible in the sandbox with provenance.
+
+    ``gpus`` is the already-visibility-filtered inventory (``detect_nvidia``
+    applies ``_parse_nvidia_mig_devices`` + ``_cuda_visible_devices``). When
+    ``CUDA_VISIBLE_DEVICES`` is set the allocation is proven from that mask;
+    otherwise it is the runtime-visible set. Non-CUDA / no-GPU hosts report a
+    known allocation of zero accelerators.
+    """
+    visible = [g for g in gpus if isinstance(g, dict)]
+    mig_count = sum(1 for g in visible if g.get("flavor") == "mig")
+    filtered = "CUDA_VISIBLE_DEVICES" in os.environ
+    source = "cuda_visible_devices" if filtered else "runtime"
+    value = {
+        "count": len(visible),
+        "mig_count": mig_count,
+        "uuids": [str(g.get("uuid")) for g in visible if g.get("uuid")],
+    }
+    return _dimension(value, True, source)
+
+
+def effective_allocation(
+    *,
+    host_cpu_count: int,
+    host_memory_mb: int,
+    visible_gpus: list[Dict[str, Any]],
+    cgroup_root: Optional[Path] = None,
+    workspace: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Normalized allocation measured from this worker's execution boundary.
+
+    Every dimension carries ``{value, known, source}``. Probe roots are
+    injectable so fixture trees can drive detection: ``cgroup_root`` overrides
+    the cgroup filesystem (defaults to module ``_CGROUP_ROOT``) and
+    ``workspace`` overrides the filesystem-capacity path. Never raises.
+    """
+    root = cgroup_root if cgroup_root is not None else _CGROUP_ROOT
+    cpu = _cpu_allocation(host_cpu_count, root)
+    memory = _memory_allocation(host_memory_mb, root)
+    disk = _disk_allocation(workspace)
+    accelerators = _accelerator_allocation(visible_gpus)
+    confined = (
+        any(
+            block["known"] and block["source"] not in ("host_equals_allocation",)
+            for block in (cpu, memory)
+        )
+        or accelerators["source"] == "cuda_visible_devices"
+    )
+    return {
+        "confined": confined,
+        "cpu": cpu,
+        "memory_mb": memory,
+        "disk": disk,
+        "accelerators": accelerators,
+    }
+
+
+def host_inventory(
+    *,
+    host_cpu_count: int,
+    host_memory_mb: int,
+    physical_gpus: list[Dict[str, Any]],
+    workspace: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Raw provider/physical inventory preserved for diagnostics + drift.
+
+    Records host logical CPU count, host total memory, the PHYSICAL GPU parts
+    (parent devices, not MIG slices), and device-level disk totals. This block
+    is never overwritten with allocation data. Never raises.
+    """
+    parents: Dict[Any, Dict[str, Any]] = {}
+    for gpu in physical_gpus:
+        if not isinstance(gpu, dict):
+            continue
+        # Collapse MIG slices onto their parent so we report the physical part.
+        if gpu.get("flavor") == "mig":
+            key = gpu.get("parent_uuid") or gpu.get("parent_index")
+            name = str(gpu.get("name") or "GPU")
+            parent_name = name.split(" MIG ")[0] if " MIG " in name else name
+            entry = parents.setdefault(
+                ("mig", key),
+                {
+                    "index": gpu.get("parent_index"),
+                    "uuid": gpu.get("parent_uuid"),
+                    "name": parent_name,
+                    "accelerator": gpu.get("accelerator", "cuda"),
+                    "mig_slice_count": 0,
+                },
+            )
+            entry["mig_slice_count"] += 1
+            continue
+        key = gpu.get("uuid") or gpu.get("index")
+        entry = {
+            "index": gpu.get("index"),
+            "name": str(gpu.get("name") or "GPU"),
+            "accelerator": gpu.get("accelerator", "none"),
+        }
+        if gpu.get("uuid"):
+            entry["uuid"] = gpu["uuid"]
+        if gpu.get("flavor"):
+            entry["flavor"] = gpu["flavor"]
+        capacity_mb = _gpu_capacity_mb(gpu)
+        if capacity_mb:
+            entry["vram_mb"] = capacity_mb
+        parents[("gpu", key)] = entry
+
+    inventory: Dict[str, Any] = {
+        "cpu_count": host_cpu_count if host_cpu_count > 0 else None,
+        "memory_mb": host_memory_mb if host_memory_mb > 0 else None,
+        "gpus": list(parents.values()),
+    }
+    usage = _disk_usage_mb(workspace)
+    if usage:
+        inventory["disk_total_mb"] = usage["total_mb"]
+    return inventory
+
+
 def detect_hardware() -> Dict[str, Any]:
     """Best-effort local hardware snapshot for the agent registry. Never raises."""
     architecture = platform.machine()
@@ -676,6 +972,35 @@ def detect_hardware() -> Dict[str, Any]:
     flavors = info["topology"].get("flavors") or []
     if len(flavors) == 1:
         info["flavor"] = flavors[0]
+    # Additive normalized blocks: the effective allocation measured from THIS
+    # worker's boundary and the preserved raw host inventory, independently
+    # readable from the one snapshot. Never let a probe failure break detection.
+    try:
+        info["effective_allocation"] = effective_allocation(
+            host_cpu_count=host_cpu_count,
+            host_memory_mb=host_memory_mb,
+            visible_gpus=gpu_list,
+        )
+    except Exception:  # noqa: BLE001 - detection must never raise
+        info["effective_allocation"] = {
+            "confined": False,
+            "cpu": _dimension(None, False, _UNKNOWN_SOURCE),
+            "memory_mb": _dimension(None, False, _UNKNOWN_SOURCE),
+            "disk": _dimension(None, False, _UNKNOWN_SOURCE),
+            "accelerators": _dimension(None, False, _UNKNOWN_SOURCE),
+        }
+    try:
+        info["host_inventory"] = host_inventory(
+            host_cpu_count=host_cpu_count,
+            host_memory_mb=host_memory_mb,
+            physical_gpus=gpu_list,
+        )
+    except Exception:  # noqa: BLE001 - detection must never raise
+        info["host_inventory"] = {
+            "cpu_count": host_cpu_count if host_cpu_count > 0 else None,
+            "memory_mb": host_memory_mb if host_memory_mb > 0 else None,
+            "gpus": [],
+        }
     return info
 
 

--- a/tests/test_hardware.py
+++ b/tests/test_hardware.py
@@ -795,3 +795,352 @@ def test_summarize_surfaces_hgx_baseboard():
     )
     assert "hgx-baseboard" in summary
     assert "NVIDIA H100 80GB HGX x8" in summary
+
+
+# --- Normalized effective_allocation vs. preserved host_inventory ----------
+#
+# These blocks are measured from the worker's OWN execution boundary and must be
+# independently readable from a single snapshot. Probe roots (cgroup, workspace,
+# nvidia) are injectable so fixture trees can drive detection without touching
+# the real host.
+
+
+def _write_cgroup(root, files):
+    for relative, contents in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(contents, encoding="utf-8")
+
+
+def test_cpu_allocation_prefers_cgroup_v2_quota_with_provenance(tmp_path):
+    root = tmp_path / "cgroup"
+    _write_cgroup(root, {"cpu.max": "150000 100000"})
+    dim = hw._cpu_allocation(192, root)
+    assert dim == {"value": 1.5, "known": True, "source": "cgroup_v2_cpu_max"}
+
+
+def test_cpu_allocation_falls_back_to_cgroup_v1_quota(tmp_path):
+    root = tmp_path / "cgroup"
+    _write_cgroup(
+        root,
+        {
+            "cpu.max": "max 100000",
+            "cpu/cpu.cfs_quota_us": "400000",
+            "cpu/cpu.cfs_period_us": "100000",
+        },
+    )
+    dim = hw._cpu_allocation(192, root)
+    assert dim == {"value": 4, "known": True, "source": "cgroup_v1"}
+
+
+def test_cpu_allocation_uses_cpuset_when_no_quota(tmp_path):
+    root = tmp_path / "cgroup"
+    _write_cgroup(root, {"cpuset.cpus.effective": "0-3,8"})
+    dim = hw._cpu_allocation(192, root)
+    assert dim == {"value": 5, "known": True, "source": "cpuset"}
+
+
+def test_cpu_allocation_uses_affinity_only_when_below_host(tmp_path, monkeypatch):
+    root = tmp_path / "empty-cgroup"
+    root.mkdir()
+    monkeypatch.setattr(
+        hw.os, "sched_getaffinity", lambda _pid: set(range(8)), raising=False
+    )
+    dim = hw._cpu_allocation(192, root)
+    assert dim == {"value": 8, "known": True, "source": "affinity"}
+
+    # Affinity equal to the host is NOT proof of confinement.
+    monkeypatch.setattr(
+        hw.os, "sched_getaffinity", lambda _pid: set(range(192)), raising=False
+    )
+    dim = hw._cpu_allocation(192, root)
+    assert dim == {"value": 192, "known": True, "source": "host_equals_allocation"}
+
+
+def test_cpu_allocation_unknown_when_no_signal(tmp_path, monkeypatch):
+    root = tmp_path / "empty-cgroup"
+    root.mkdir()
+    monkeypatch.setattr(hw.os, "sched_getaffinity", lambda _pid: set(), raising=False)
+    dim = hw._cpu_allocation(0, root)
+    assert dim == {"value": None, "known": False, "source": "unknown"}
+
+
+def test_memory_allocation_v2_v1_and_unlimited(tmp_path):
+    root = tmp_path / "cgroup"
+    _write_cgroup(root, {"memory.max": str(4 * 1024 * 1024 * 1024)})
+    assert hw._memory_allocation(724000, root) == {
+        "value": 4096,
+        "known": True,
+        "source": "cgroup_v2_memory_max",
+    }
+
+    root_v1 = tmp_path / "cgroup-v1"
+    _write_cgroup(
+        root_v1,
+        {
+            "memory.max": "max",
+            "memory/memory.limit_in_bytes": str(8 * 1024 * 1024 * 1024),
+        },
+    )
+    assert hw._memory_allocation(724000, root_v1) == {
+        "value": 8192,
+        "known": True,
+        "source": "cgroup_v1",
+    }
+
+
+def test_memory_allocation_unlimited_stays_host_equals_not_host_substitution(tmp_path):
+    # cgroup reports "max" (unlimited) and v1 uses a near-LONG_MAX sentinel: the
+    # allocation must NOT silently become a distinct host number -- it is proven
+    # equal to host inventory and flagged as such.
+    root = tmp_path / "cgroup"
+    _write_cgroup(
+        root,
+        {
+            "memory.max": "max",
+            "memory/memory.limit_in_bytes": str(1 << 62),
+        },
+    )
+    dim = hw._memory_allocation(724000, root)
+    assert dim == {"value": 724000, "known": True, "source": "host_equals_allocation"}
+
+
+def test_memory_allocation_unknown_when_host_unmeasured(tmp_path):
+    root = tmp_path / "empty"
+    root.mkdir()
+    dim = hw._memory_allocation(0, root)
+    assert dim == {"value": None, "known": False, "source": "unknown"}
+
+
+def test_disk_allocation_reports_workspace_quota_and_never_raises(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        hw.shutil,
+        "disk_usage",
+        lambda _path: SimpleNamespace(total=20 * 1024 * 1024, used=0, free=5 * 1024 * 1024),
+    )
+    dim = hw._disk_allocation(tmp_path)
+    assert dim == {
+        "value": {"total_mb": 20, "available_mb": 5},
+        "known": True,
+        "source": "workspace_statvfs",
+    }
+
+    def _boom(_path):
+        raise OSError("statvfs failed")
+
+    monkeypatch.setattr(hw.shutil, "disk_usage", _boom)
+    assert hw._disk_allocation(tmp_path) == {
+        "value": None,
+        "known": False,
+        "source": "unknown",
+    }
+
+
+def test_accelerator_allocation_reflects_cuda_visible_filtering(monkeypatch):
+    gpus = [
+        {"index": 0, "uuid": "MIG-a", "flavor": "mig"},
+        {"index": 1, "uuid": "MIG-b", "flavor": "mig"},
+    ]
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "MIG-a")
+    dim = hw._accelerator_allocation(gpus)
+    assert dim["known"] is True
+    assert dim["source"] == "cuda_visible_devices"
+    assert dim["value"] == {"count": 2, "mig_count": 2, "uuids": ["MIG-a", "MIG-b"]}
+
+
+def test_accelerator_allocation_zero_gpus_is_known_not_unknown(monkeypatch):
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    dim = hw._accelerator_allocation([])
+    assert dim == {
+        "value": {"count": 0, "mig_count": 0, "uuids": []},
+        "known": True,
+        "source": "runtime",
+    }
+
+
+def test_effective_allocation_injects_cgroup_and_workspace(tmp_path, monkeypatch):
+    root = tmp_path / "cgroup"
+    _write_cgroup(
+        root,
+        {
+            "cpu.max": "200000 100000",
+            "memory.max": str(16 * 1024 * 1024 * 1024),
+        },
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    monkeypatch.setattr(
+        hw.shutil,
+        "disk_usage",
+        lambda _path: SimpleNamespace(
+            total=100 * 1024 * 1024, used=0, free=40 * 1024 * 1024
+        ),
+    )
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    alloc = hw.effective_allocation(
+        host_cpu_count=192,
+        host_memory_mb=724000,
+        visible_gpus=[],
+        cgroup_root=root,
+        workspace=workspace,
+    )
+
+    assert alloc["confined"] is True
+    assert alloc["cpu"] == {"value": 2, "known": True, "source": "cgroup_v2_cpu_max"}
+    assert alloc["memory_mb"] == {
+        "value": 16384,
+        "known": True,
+        "source": "cgroup_v2_memory_max",
+    }
+    assert alloc["disk"]["value"] == {"total_mb": 100, "available_mb": 40}
+    assert alloc["accelerators"]["value"]["count"] == 0
+
+
+def test_effective_allocation_bare_metal_equals_host_is_not_confined(tmp_path, monkeypatch):
+    root = tmp_path / "no-cgroup"  # no cgroup files at all
+    monkeypatch.setattr(
+        hw.os, "sched_getaffinity", lambda _pid: set(range(64)), raising=False
+    )
+    monkeypatch.setattr(
+        hw.shutil, "disk_usage", lambda _path: SimpleNamespace(total=0, used=0, free=0)
+    )
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    alloc = hw.effective_allocation(
+        host_cpu_count=64,
+        host_memory_mb=131072,
+        visible_gpus=[],
+        cgroup_root=root,
+        workspace=tmp_path,
+    )
+
+    assert alloc["confined"] is False
+    assert alloc["cpu"]["source"] == "host_equals_allocation"
+    assert alloc["memory_mb"]["source"] == "host_equals_allocation"
+
+
+def test_host_inventory_preserves_physical_gpu_parent_not_mig_slice():
+    gpus = [
+        {
+            "index": 0,
+            "parent_index": 0,
+            "parent_uuid": "GPU-parent",
+            "uuid": "MIG-a",
+            "flavor": "mig",
+            "name": "NVIDIA A100-SXM4-40GB MIG 1g.10gb",
+            "accelerator": "cuda",
+        },
+        {
+            "index": 1,
+            "parent_index": 0,
+            "parent_uuid": "GPU-parent",
+            "uuid": "MIG-b",
+            "flavor": "mig",
+            "name": "NVIDIA A100-SXM4-40GB MIG 2g.20gb",
+            "accelerator": "cuda",
+        },
+    ]
+    inventory = hw.host_inventory(
+        host_cpu_count=192, host_memory_mb=724000, physical_gpus=gpus
+    )
+    assert inventory["cpu_count"] == 192
+    assert inventory["memory_mb"] == 724000
+    assert inventory["gpus"] == [
+        {
+            "index": 0,
+            "uuid": "GPU-parent",
+            "name": "NVIDIA A100-SXM4-40GB",
+            "accelerator": "cuda",
+            "mig_slice_count": 2,
+        }
+    ]
+
+
+def test_host_inventory_reports_discrete_parts_with_vram():
+    gpus = [
+        {
+            "index": 0,
+            "uuid": "GPU-0",
+            "flavor": "pcie",
+            "name": "NVIDIA RTX PRO 6000 Blackwell",
+            "accelerator": "cuda",
+            "vram_mb": 98304,
+            "memory": {"type": "dedicated", "vram_mb": 98304},
+        }
+    ]
+    inventory = hw.host_inventory(
+        host_cpu_count=32, host_memory_mb=131072, physical_gpus=gpus
+    )
+    assert inventory["gpus"] == [
+        {
+            "index": 0,
+            "name": "NVIDIA RTX PRO 6000 Blackwell",
+            "accelerator": "cuda",
+            "uuid": "GPU-0",
+            "flavor": "pcie",
+            "vram_mb": 98304,
+        }
+    ]
+
+
+def test_host_inventory_unmeasured_values_are_none():
+    inventory = hw.host_inventory(host_cpu_count=0, host_memory_mb=0, physical_gpus=[])
+    assert inventory["cpu_count"] is None
+    assert inventory["memory_mb"] is None
+    assert inventory["gpus"] == []
+
+
+def test_detect_hardware_emits_both_blocks_without_collapsing(monkeypatch, tmp_path):
+    # The regression this feature fixes: on a worker whose cgroup probes do not
+    # resolve, host inventory must NOT be advertised as schedulable allocation.
+    root = tmp_path / "cgroup"
+    _write_cgroup(
+        root,
+        {"cpu.max": "400000 100000", "memory.max": str(8 * 1024 * 1024 * 1024)},
+    )
+    monkeypatch.setattr(hw, "_CGROUP_ROOT", root)
+    monkeypatch.setattr(hw.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(hw.platform, "machine", lambda: "x86_64")
+    monkeypatch.setattr(hw.os, "cpu_count", lambda: 192)
+    monkeypatch.setattr(hw, "_memory_mb", lambda: 724000)
+    monkeypatch.setattr(hw, "detect_nvidia", lambda: None)
+    monkeypatch.setattr(hw, "detect_apple_metal", lambda: None)
+    monkeypatch.setattr(
+        hw, "_disk_usage_mb", lambda *a, **k: {"total_mb": 100, "available_mb": 40}
+    )
+    monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+
+    info = hw.detect_hardware()
+
+    # Additive: schema and legacy keys unchanged.
+    assert info["schema"] == "mac.hardware.v1"
+    # Effective allocation is the cgroup-bounded value, with provenance.
+    assert info["effective_allocation"]["cpu"] == {
+        "value": 4,
+        "known": True,
+        "source": "cgroup_v2_cpu_max",
+    }
+    assert info["effective_allocation"]["memory_mb"]["value"] == 8192
+    assert info["effective_allocation"]["confined"] is True
+    # Host inventory preserves the raw provider numbers unchanged.
+    assert info["host_inventory"]["cpu_count"] == 192
+    assert info["host_inventory"]["memory_mb"] == 724000
+    # The two blocks disagree -- exactly the drift the fleet needs to see.
+    assert info["effective_allocation"]["cpu"]["value"] != info["host_inventory"]["cpu_count"]
+
+
+def test_detect_hardware_never_raises_yields_unknown_allocation(monkeypatch):
+    def _boom(*_a, **_k):
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(hw, "effective_allocation", _boom)
+    monkeypatch.setattr(hw, "host_inventory", _boom)
+    monkeypatch.setattr(hw, "detect_nvidia", lambda: None)
+    monkeypatch.setattr(hw, "detect_apple_metal", lambda: None)
+
+    info = hw.detect_hardware()
+
+    assert info["effective_allocation"]["cpu"]["known"] is False
+    assert info["effective_allocation"]["cpu"]["source"] == "unknown"
+    assert "host_inventory" in info


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_832c4d72e96843d980fd016ee115317f`
- head: `fadeff9b11307f1d559270a570bd1edb32ce2349`
- base at push: `d696855f7f6fa6a2a1c122c6a5a0f9ce6e45e7ed`
