### PR TITLE
Hub API: make project-name path routes tolerate slashes (fix 404 on repo@feat/branch) (task_6ec2e3a6e5d048d7998150b590bfe5c6)

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -5786,13 +5786,28 @@ def create_app(
             policy_id, actor=body.actor, reason=body.reason
         )
 
-    @app.post("/optimizer/projects/{project}/rollback/{policy_id}")
-    def rollback_scientific_policy(
+    def _rollback_scientific_policy(
         project: str, policy_id: str, body: ScientificPolicyAction
     ) -> Dict[str, Any]:
         return scientific_optimizer.rollback_policy(
             project, policy_id, actor=body.actor, reason=body.reason
         )
+
+    @app.post("/optimizer/projects/{project}/rollback/{policy_id}")
+    def rollback_scientific_policy(
+        project: str, policy_id: str, body: ScientificPolicyAction
+    ) -> Dict[str, Any]:
+        return _rollback_scientific_policy(project, policy_id, body)
+
+    # ``{project:path}`` twin so a ``repo@feat/branch`` project name (which
+    # contains a decoded ``/``) still resolves for the optimizer rollback route.
+    # ``{policy_id}`` stays a single trailing segment, so the greedy project
+    # match stops at ``/rollback/<policy_id>``.
+    @app.post("/optimizer/projects/{project:path}/rollback/{policy_id}")
+    def rollback_scientific_policy_slash(
+        project: str, policy_id: str, body: ScientificPolicyAction
+    ) -> Dict[str, Any]:
+        return _rollback_scientific_policy(project, policy_id, body)
 
     @app.post("/optimizer/experiments")
     def create_scientific_experiment(
@@ -5975,23 +5990,59 @@ def create_app(
         actor = data.pop("actor", "human")
         return cp.register_project(actor=actor, **data).to_dict()
 
-    @app.post("/projects/{project}/dispatch")
-    def set_project_dispatch(project: str, body: ProjectDispatch) -> Dict[str, Any]:
+    # Project names are ``repo@branch`` (services.create/register_project) and
+    # Git branches legitimately contain ``/`` (e.g. ``repo@feat/ros-sim``).
+    # Clients percent-encode the name, but the ASGI server decodes ``%2F`` to a
+    # real ``/`` before Starlette routes, so a single-segment ``{project}``
+    # converter never matches such a name and returns 404. Register a
+    # ``{project:path}`` twin for every project-name route so the whole decoded
+    # tail is captured as the name. The exact ``/projects`` and
+    # ``/projects/register`` routes are declared above these path twins, so they
+    # keep winning (FastAPI matches routes in declaration order); the coverage
+    # and slash-name suites assert that ordering rather than assume it.
+
+    def _dispatch_project(project: str, body: ProjectDispatch) -> Dict[str, Any]:
         return cp.set_project_dispatch(
             project, paused=body.paused, actor=body.actor
         ).to_dict()
 
-    @app.get("/projects/{project}")
-    def get_project(project: str) -> Dict[str, Any]:
+    @app.post("/projects/{project}/dispatch")
+    def set_project_dispatch(project: str, body: ProjectDispatch) -> Dict[str, Any]:
+        return _dispatch_project(project, body)
+
+    @app.post("/projects/{project:path}/dispatch")
+    def set_project_dispatch_slash(project: str, body: ProjectDispatch) -> Dict[str, Any]:
+        return _dispatch_project(project, body)
+
+    def _read_project(project: str) -> Dict[str, Any]:
         return cp.get_project(project)
 
-    @app.put("/projects/{project}")
-    def update_project(project: str, body: ProjectUpdate) -> Dict[str, Any]:
+    @app.get("/projects/{project}")
+    def get_project(project: str) -> Dict[str, Any]:
+        return _read_project(project)
+
+    @app.get("/projects/{project:path}")
+    def get_project_slash(project: str) -> Dict[str, Any]:
+        return _read_project(project)
+
+    def _write_project(project: str, body: ProjectUpdate) -> Dict[str, Any]:
         data = _data(body)
         actor = data.pop("actor", "human")
         if data.get("metadata") is not None:
             _ensure_payload_bounded(data["metadata"], "project.metadata")
         return cp.update_project(project, actor=actor, **data).to_dict()
+
+    @app.put("/projects/{project}")
+    def update_project(project: str, body: ProjectUpdate) -> Dict[str, Any]:
+        return _write_project(project, body)
+
+    @app.put("/projects/{project:path}")
+    def update_project_slash(project: str, body: ProjectUpdate) -> Dict[str, Any]:
+        return _write_project(project, body)
+
+    def _remove_project(project: str, force: bool, actor: str) -> Dict[str, Any]:
+        cp.delete_project(project, force=force, actor=actor)
+        return {"deleted": project}
 
     @app.delete("/projects/{project}")
     def delete_project(
@@ -5999,8 +6050,15 @@ def create_app(
         force: bool = Query(default=False),
         actor: str = Query(default="human"),
     ) -> Dict[str, Any]:
-        cp.delete_project(project, force=force, actor=actor)
-        return {"deleted": project}
+        return _remove_project(project, force, actor)
+
+    @app.delete("/projects/{project:path}")
+    def delete_project_slash(
+        project: str,
+        force: bool = Query(default=False),
+        actor: str = Query(default="human"),
+    ) -> Dict[str, Any]:
+        return _remove_project(project, force, actor)
 
     @app.post("/tasks/{task_id}/transition")
     def transition_task(

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from urllib.parse import quote
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, Mapping, Tuple
 
@@ -310,6 +311,14 @@ def _seed_route_state(client: TestClient, cp: ControlPlane, tmp_path) -> Dict[st
     ctx["delete_project_name"] = _ok(
         client.post("/projects", json={"name": "route-project-delete"})
     )["name"]
+    # Slash-containing project name (``repo@feat/branch``) for the
+    # ``{project:path}`` route twins added by the slash-tolerant routing fix.
+    ctx["slash_project_name"] = _ok(
+        client.post("/projects", json={"name": "route-project@feat/slash"})
+    )["name"]
+    ctx["slash_delete_project_name"] = _ok(
+        client.post("/projects", json={"name": "route-project@feat/slash-delete"})
+    )["name"]
     route_repo = tmp_path / "route-repo"
     (route_repo / ".mac").mkdir(parents=True)
     (route_repo / ".mac" / "project.yaml").write_text(
@@ -564,6 +573,10 @@ network_policies:
         "parameters": {"plan_first": False}, "created_by": "route-coverage"}))
     ctx["sci_policy_id"] = sci_control["id"]
     ctx["sci_policy2_id"] = sci_treatment["id"]
+    sci_slash = _ok(client.post("/optimizer/policies", json={
+        "name": "route-sci-slash", "project": ctx["slash_project_name"],
+        "parameters": {"plan_first": True}, "created_by": "route-coverage"}))
+    ctx["slash_sci_policy_id"] = sci_slash["id"]
     sci_exp = _ok(client.post("/optimizer/experiments", json={
         "name": "route-sci-experiment", "project": ctx["project_name"],
         "hypothesis": "treatment beats control on route coverage",
@@ -1341,6 +1354,7 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("POST", "/tasks/{task_id}/reviews"): {"task_id": "review_task_id"},
         ("DELETE", "/fleets/{fleet_id_or_name}"): {"fleet_id_or_name": "delete_fleet_id"},
         ("DELETE", "/projects/{project}"): {"project": "delete_project_name"},
+        ("DELETE", "/projects/{project:path}"): {"project": "slash_delete_project_name"},
         ("POST", "/agents/{agent_id}/attestation-key/rotate"): {"agent_id": "attest_rotate_agent_id"},
         ("POST", "/agents/{agent_id}/attestation-key/verify"): {"agent_id": "attest_verify_agent_id"},
         ("POST", "/agents/{agent_id}/attestation-key/recover"): {
@@ -1446,6 +1460,10 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("GET", "/optimizer/policies/{policy_id}"): {"policy_id": "sci_policy_id"},
         ("POST", "/optimizer/policies/{policy_id}/promote"): {"policy_id": "sci_policy_id"},
         ("POST", "/optimizer/projects/{project}/rollback/{policy_id}"): {"policy_id": "sci_policy_id"},
+        ("POST", "/optimizer/projects/{project:path}/rollback/{policy_id}"): {
+            "project": "slash_project_name",
+            "policy_id": "slash_sci_policy_id",
+        },
         ("GET", "/optimizer/experiments/{experiment_id}"): {"experiment_id": "sci_experiment_id"},
         ("POST", "/optimizer/experiments/{experiment_id}/start"): {"experiment_id": "sci_experiment_id"},
         ("POST", "/optimizer/experiments/{experiment_id}/pause"): {"experiment_id": "sci_experiment_id"},
@@ -1511,6 +1529,12 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
     for param, ctx_key in special.get((method, path_template), {}).items():
         values[param] = ctx[ctx_key]
     path = path_template
+    if "{project:path}" in path:
+        # The slash-tolerant twin captures the whole decoded tail as the name.
+        # Send it the way a real client does -- percent-encoded, safe="" -- so
+        # the %2F -> "/" decode that broke the single-segment route is covered.
+        project_name = values.get("project", ctx["slash_project_name"])
+        path = path.replace("{project:path}", quote(str(project_name), safe=""))
     for param, value in values.items():
         path = path.replace("{%s}" % param, str(value))
     return path
@@ -1814,6 +1838,10 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
         ("POST", "/projects"): {"name": "route-project-case", "description": "created by route coverage"},
         ("PUT", "/projects/{project}"): {
             "description": "updated route project",
+            "metadata": {"route_case": True},
+        },
+        ("PUT", "/projects/{project:path}"): {
+            "description": "updated slash route project",
             "metadata": {"route_case": True},
         },
         ("POST", "/tasks/{task_id}/transition"): {
@@ -2596,6 +2624,10 @@ edges:
             "paused": False,
             "actor": "operator",
         },
+        ("POST", "/projects/{project:path}/dispatch"): {
+            "paused": False,
+            "actor": "operator",
+        },
         ("POST", "/tasks/{task_id}/release"): {"actor": "operator"},
         ("POST", "/optimizer/policies"): {
             "name": "route-sci-extra", "project": ctx["project_name"],
@@ -2603,6 +2635,8 @@ edges:
         ("POST", "/optimizer/policies/{policy_id}/promote"): {
             "actor": "route-coverage", "reason": "route coverage"},
         ("POST", "/optimizer/projects/{project}/rollback/{policy_id}"): {
+            "actor": "route-coverage", "reason": "route coverage"},
+        ("POST", "/optimizer/projects/{project:path}/rollback/{policy_id}"): {
             "actor": "route-coverage", "reason": "route coverage"},
         ("POST", "/optimizer/experiments"): {
             "name": "route-sci-exp-2", "project": ctx["project_name"],

--- a/tests/api/test_project_slash_names.py
+++ b/tests/api/test_project_slash_names.py
@@ -1,0 +1,155 @@
+"""Slash-containing project names must resolve on every project-name route.
+
+Project names are generated as ``repo@branch`` (services.register_project) and
+Git branches legitimately contain ``/`` (e.g. ``isaacsim7-poc@feat/ros-sim``).
+Clients percent-encode the name with ``quote(safe="")``, but the ASGI server
+decodes ``%2F`` back to a real ``/`` before Starlette routes the request, so a
+single-segment ``{project}`` converter can never match such a name and the hub
+answers 404. ``mac project list`` shows the project while ``mac project show``
+404s -- the client is correct; the server routing was not.
+
+These tests pin the fix: a ``{project:path}`` twin on every project-name route
+so the whole decoded tail is captured as the name, without letting the catch-all
+shadow ``/projects`` (list/create) or ``/projects/register``.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+SLASH_PROJECT = "isaacsim7-poc@feat/ros-sim"
+
+
+def _client() -> TestClient:
+    return TestClient(create_app(control_plane=ControlPlane.in_memory()))
+
+
+def _create_project(client: TestClient, name: str) -> str:
+    response = client.post("/projects", json={"name": name})
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == name
+    return name
+
+
+def _encoded(name: str) -> str:
+    # Exactly how the client quotes the name on the wire (dispatch.py uses
+    # quote(..., safe="")): every slash becomes %2F.
+    return quote(name, safe="")
+
+
+def test_get_project_resolves_slash_name():
+    client = _client()
+    _create_project(client, SLASH_PROJECT)
+
+    response = client.get("/projects/%s" % _encoded(SLASH_PROJECT))
+
+    assert response.status_code == 200, response.text
+    assert response.json()["project"] == SLASH_PROJECT
+
+
+def test_put_project_resolves_slash_name():
+    client = _client()
+    _create_project(client, SLASH_PROJECT)
+
+    response = client.put(
+        "/projects/%s" % _encoded(SLASH_PROJECT),
+        json={"description": "updated via slash route", "actor": "operator"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == SLASH_PROJECT
+    assert response.json()["description"] == "updated via slash route"
+
+
+def test_dispatch_post_resolves_slash_name():
+    client = _client()
+    _create_project(client, SLASH_PROJECT)
+
+    response = client.post(
+        "/projects/%s/dispatch" % _encoded(SLASH_PROJECT),
+        json={"paused": True, "actor": "operator"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["name"] == SLASH_PROJECT
+
+
+def test_delete_project_resolves_slash_name():
+    client = _client()
+    _create_project(client, SLASH_PROJECT)
+
+    response = client.delete("/projects/%s" % _encoded(SLASH_PROJECT))
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"deleted": SLASH_PROJECT}
+
+    # The row is really gone: a follow-up read 404s.
+    follow_up = client.get("/projects/%s" % _encoded(SLASH_PROJECT))
+    assert follow_up.status_code == 404, follow_up.text
+
+
+def test_optimizer_rollback_resolves_slash_name():
+    client = _client()
+    _create_project(client, SLASH_PROJECT)
+    policy = client.post(
+        "/optimizer/policies",
+        json={
+            "name": "slash-rollback-policy",
+            "project": SLASH_PROJECT,
+            "parameters": {"plan_first": True},
+            "created_by": "operator",
+        },
+    )
+    assert policy.status_code == 200, policy.text
+    policy_id = policy.json()["id"]
+
+    response = client.post(
+        "/optimizer/projects/%s/rollback/%s" % (_encoded(SLASH_PROJECT), policy_id),
+        json={"actor": "operator", "reason": "slash rollback route coverage"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["project"] == SLASH_PROJECT
+
+
+def test_slash_route_does_not_shadow_projects_collection():
+    client = _client()
+    _create_project(client, SLASH_PROJECT)
+
+    # GET /projects still lists (not captured by GET /projects/{project:path}).
+    listing = client.get("/projects")
+    assert listing.status_code == 200, listing.text
+    assert any(item.get("project") == SLASH_PROJECT for item in listing.json())
+
+    # POST /projects still creates (not captured by any dispatch/path route).
+    created = client.post("/projects", json={"name": "plain-collection-project"})
+    assert created.status_code == 200, created.text
+    assert created.json()["name"] == "plain-collection-project"
+
+
+def test_slash_route_does_not_shadow_projects_register():
+    client = _client()
+
+    # POST /projects/register keeps its own handler: an empty body is rejected
+    # by that handler's schema (422), proving the request was NOT swallowed by
+    # POST /projects/{project:path}/dispatch or any catch-all.
+    response = client.post("/projects/register", json={})
+
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert any(err.get("loc", [])[:2] == ["body", "repository_url"] for err in detail)
+
+
+def test_single_segment_project_names_still_resolve():
+    client = _client()
+    _create_project(client, "plain-project")
+
+    response = client.get("/projects/plain-project")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["project"] == "plain-project"


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_6ec2e3a6e5d048d7998150b590bfe5c6`
- head: `763fe05804024873ef0651cdf78628254e540b0a`
- base at push: `d06e4f41fec3b15045faafa64bc5f2155e7ff6a9`
