### PR TITLE
Repair self-referential dream-candidate seeding in nap_consolidator, with regression tests (task_d682b6ddcaa3406ea0c4effa085116cd)

### DIFF
--- a/docs/dream-repair-slack-lineage.md
+++ b/docs/dream-repair-slack-lineage.md
@@ -202,3 +202,14 @@ actionable**. Residual risk is the still-reachable manual/API
 `nap-consolidate` path (`emit_dream_artifacts=True` by default), which can
 re-emit title-echo `dream:failure_pattern` rows, but it cannot mint
 `dreamrepair:` fingerprints or file repair tasks in this tree.
+
+## Loop-break repair (live stage only)
+
+The only remaining seed path is `_default_dreamer` in
+`src/mac/nap_consolidator.py`. `_independent_dream_support` now drops
+`mac.deployment_learning.v1` closures whose task title names a
+dream-repair investigation, so a lineage-only group yields no new
+`failure_pattern`. Later loop stages (`dream_scanner`,
+`dream_cycle_classifier`, `dream_repair_tasks`, `dreamrepair:` key
+minting, and the nap-cycle repair-task filer) are absent; this repair
+does not recreate them.

--- a/src/mac/nap_consolidator.py
+++ b/src/mac/nap_consolidator.py
@@ -34,6 +34,16 @@ Design notes
 * **Vector handoff.** When a `VectorWriterService` is provided, each
   summary gets embedded into the medium tier immediately. Failures
   there don't roll back the summary — the next backfill catches it.
+
+* **Dream-candidate lineage filter.** ``_default_dreamer`` still runs on
+  the manual/API nap-consolidate path (``emit_dream_artifacts=True``).
+  A ``mac.deployment_learning.v1`` closure of a dream-repair
+  investigation task is not independent failure evidence: on its own it
+  must not mint a new low-confidence ``failure_pattern``. Mixed groups
+  drop only those self-referential rows. Scheduled ``run_nap_cycle``
+  already disables this dreamer; ``mac.dream_scanner``,
+  ``mac.dream_cycle_classifier``, and ``mac.dream_repair_tasks`` are
+  gone and are not reintroduced here.
 """
 from __future__ import annotations
 
@@ -186,6 +196,53 @@ def _confidence_for_records(records: List[MemoryRecord]) -> Tuple[str, float]:
     return "low", _CONFIDENCE_SCORES["low"]
 
 
+#: Title fragments that mark a task as a dream-repair investigation rather
+#: than an independent operational failure. Matched case-insensitively
+#: against ``mac.deployment_learning.v1`` ``task_title``.
+_DREAM_REPAIR_INVESTIGATION_TITLE_MARKERS = (
+    "dream finding",
+    "dream-repair",
+    "dream repair",
+    "dreamrepair",
+)
+
+
+def _is_dream_repair_investigation_learning(record: MemoryRecord) -> bool:
+    """True when ``record`` is the outcome memory of a dream-repair investigation.
+
+    Predicate: schema is ``mac.deployment_learning.v1`` (or the record type
+    is a ``deployment_learning:*`` lesson) **and** the task title names a
+    dream-repair / dream-finding investigation. Those closures echo the
+    investigation's own ``failure``/``failed`` outcome into
+    ``_dream_kind``, which would otherwise mint a new ``failure_pattern``
+    about the same lineage. Unrelated deployment lessons are not matched.
+    """
+    payload = _record_payload(record)
+    is_learning = payload.get("schema") == "mac.deployment_learning.v1" or str(
+        record.record_type or ""
+    ).startswith("deployment_learning")
+    if not is_learning:
+        return False
+    title = str(payload.get("task_title") or "").lower()
+    return any(marker in title for marker in _DREAM_REPAIR_INVESTIGATION_TITLE_MARKERS)
+
+
+def _independent_dream_support(records: List[MemoryRecord]) -> List[MemoryRecord]:
+    """Records that may count as evidence for a new dream candidate.
+
+    Dream-repair investigation closures are dropped from ``failure_pattern``
+    support. If a group is *only* those closures, the result is empty and
+    candidate manufacture stops. Non-failure kinds keep the original list
+    so existing decision-rule / tool / knowledge behaviour is unchanged.
+    """
+    independent = [record for record in records if not _is_dream_repair_investigation_learning(record)]
+    if independent:
+        return independent
+    if records and _dream_kind(records) == "failure_pattern":
+        return []
+    return list(records)
+
+
 def _default_dreamer(records: List[MemoryRecord], context: Dict[str, Any]) -> List[JsonDict]:
     """Emit one structured, evidence-backed dream artifact per group.
 
@@ -193,7 +250,10 @@ def _default_dreamer(records: List[MemoryRecord], context: Dict[str, Any]) -> Li
     meta-reasoning without an LLM. It builds a typed, recall-friendly
     artifact with provenance so production callers can swap in a richer
     ``dreamer_fn`` without changing storage, embedding, or retrieval.
+    Self-referential dream-repair investigation closures are excluded
+    from failure-pattern support via :func:`_independent_dream_support`.
     """
+    records = _independent_dream_support(records)
     if not records:
         return []
     kind = _dream_kind(records)

--- a/tests/test_nap_consolidator.py
+++ b/tests/test_nap_consolidator.py
@@ -506,6 +506,85 @@ def test_pure_summary_observation_and_classification_edges() -> None:
     assert nap._default_dreamer([], {}) == []
 
 
+def test_dreamer_excludes_self_referential_investigation_lineage() -> None:
+    """A dream-repair investigation's own closure must not re-seed failure_pattern."""
+    cp = ControlPlane.in_memory()
+    lineage = _record(
+        cp,
+        json.dumps(
+            {
+                "schema": "mac.deployment_learning.v1",
+                "outcome": "failure",
+                "task_title": "Audit slack dream finding evidence and provenance",
+                "evidence_type": "repo_change",
+                "error_signature": "",
+            }
+        ),
+        record_type="deployment_learning:mac",
+    )
+    genuine = _record(
+        cp,
+        json.dumps(
+            {
+                "schema": "mac.deployment_learning.v1",
+                "outcome": "failed",
+                "task_title": "Deploy",
+                "evidence_type": "test",
+                "error_signature": "timeout",
+            }
+        ),
+        record_type="deployment_learning:mac",
+    )
+    success_ship = _record(
+        cp,
+        json.dumps(
+            {
+                "schema": "mac.deployment_learning.v1",
+                "outcome": "success",
+                "task_title": "Ship the feature",
+                "evidence_type": "repo_change",
+            }
+        ),
+        record_type="deployment_learning:mac",
+    )
+    context = {
+        "group_label": "task=t1 project=mac",
+        "project": "mac",
+        "agent_id": "agent-1",
+    }
+    assert nap._default_dreamer([lineage], context) == []
+    genuine_candidates = nap._default_dreamer([genuine], context)
+    assert len(genuine_candidates) == 1
+    assert genuine_candidates[0]["kind"] == "failure_pattern"
+    assert genuine_candidates[0]["confidence"] == "low"
+    mixed = nap._default_dreamer([lineage, genuine], context)
+    assert len(mixed) == 1
+    assert mixed[0]["kind"] == "failure_pattern"
+    assert mixed[0]["confidence"] == "low"
+    assert mixed[0]["observations"] == [nap._record_observation(genuine)]
+    assert "dream finding" not in mixed[0]["summary"]
+    kept = nap._default_dreamer([success_ship], context)
+    assert len(kept) == 1
+    assert kept[0]["kind"] == "decision_rule"
+
+
+def test_removed_dream_repair_stages_do_not_reseed_lineage() -> None:
+    """Classifier, repair-task filer, and dreamrepair: keys are gone; do not invent them."""
+    import importlib.util
+    import inspect
+    from pathlib import Path
+
+    for mod in ("mac.dream_scanner", "mac.dream_cycle_classifier", "mac.dream_repair_tasks"):
+        assert importlib.util.find_spec(mod) is None
+    src_root = Path(__file__).resolve().parents[1] / "src" / "mac"
+    for name in ("dream_scanner.py", "dream_cycle_classifier.py", "dream_repair_tasks.py"):
+        assert not (src_root / name).exists()
+    cycle_source = inspect.getsource(ControlPlane.run_nap_cycle)
+    assert "emit_dream_artifacts=False" in cycle_source
+    assert "repair_task_report" in cycle_source
+    assert "dreamrepair:" not in Path(nap.__file__).read_text(encoding="utf-8")
+
+
 def test_consolidate_validation_blank_summary_and_disabled_dreams() -> None:
     cp = ControlPlane.in_memory()
     _record(cp, 'fact')


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_d682b6ddcaa3406ea0c4effa085116cd`
- head: `81d470104577da4ca6c01f1e0cef2773184134e7`
- base at push: `d06e4f41fec3b15045faafa64bc5f2155e7ff6a9`
