### PR TITLE
Make a merge-queue entry that cannot progress say so

### DIFF
--- a/src/mac/native_merge_queue.py
+++ b/src/mac/native_merge_queue.py
@@ -482,6 +482,13 @@ class NativeMergeQueue:
         evicted = [
             entry for entry in entries if entry.state == STATE_EVICTED
         ][-10:]
+        stalled = [
+            entry
+            for entry in live
+            if entry.state in self.PR_REQUIRING_STATES
+            and entry.attempts >= 1
+            and not entry.pull_request_number
+        ]
         return {
             "schema": "mac.native_merge_queue.snapshot.v1",
             "repository": repository,
@@ -496,6 +503,17 @@ class NativeMergeQueue:
                 1 for entry in live if entry.state == STATE_TESTING
             ),
             "entries_tested": sum(1 for entry in live if entry.state == STATE_TESTED),
+            # Entries that CANNOT progress, counted apart from the state totals
+            # above. Those totals answer "what state is it in"; this answers
+            # "is it going anywhere", and only the second is actionable.
+            #
+            # Without it a permanently stuck entry reads as work in flight:
+            # entries_testing counted one for seventy attempts while the change
+            # it represented had already merged. That is the same defect the
+            # release() fix addressed -- a queue reporting work that is not
+            # happening -- arriving by a different route.
+            "entries_stalled": len(stalled),
+            "stalled_entry_ids": [entry.id for entry in stalled],
             "entries_queued": sum(1 for entry in live if entry.state == STATE_QUEUED),
             "landed_count": int(row["landed_count"]) if row is not None else 0,
             "failure_count": int(row["failure_count"]) if row is not None else 0,
@@ -802,6 +820,34 @@ class NativeMergeQueue:
         )
         return bool(getattr(result, "rowcount", 0))
 
+    #: States in which an entry needs a pull request to make any progress.
+    #: `queued` is deliberately excluded: claim_slot runs BEFORE the agent opens
+    #: the PR, so a queued entry with no number is normal and momentary.
+    PR_REQUIRING_STATES = (STATE_TESTING, STATE_TESTED)
+
+    def stalled_entries(self, repository: str, branch: str) -> List[QueueEntry]:
+        """Live entries that cannot progress, however long they are left.
+
+        An entry needs a pull request to be landed OR to be observed as already
+        merged; with ``pull_request_number = 0`` both paths are closed, so it
+        holds its slot and accrues attempts forever. One on the live hub reached
+        SEVENTY attempts this way while the work it represented had merged hours
+        earlier as #404.
+
+        The condition is ``attempts >= 1``, not merely "no number": an entry
+        between claim_slot and record_pull_request legitimately has none for a
+        moment, and calling that stalled would evict healthy work. Having
+        completed a publication attempt WITHOUT learning the number is the thing
+        that cannot fix itself.
+        """
+        return [
+            entry
+            for entry in self.live_entries(repository, branch)
+            if entry.state in self.PR_REQUIRING_STATES
+            and entry.attempts >= 1
+            and not entry.pull_request_number
+        ]
+
     def evict_exhausted(self, repository: str, branch: str) -> List[str]:
         """Evict live entries that have retried past the cap.
 
@@ -811,6 +857,21 @@ class NativeMergeQueue:
         with no explanation.
         """
         evicted: List[str] = []
+        # Stalled first, and NOT on the attempt cap. An entry that finished an
+        # attempt without learning its PR number will never learn it, so making
+        # it burn MAX_ATTEMPTS_BEFORE_EVICTION cycles first buys nothing and
+        # holds a slot the whole time -- which is how one entry reached 70
+        # attempts and starved the window at its floor.
+        for entry in self.stalled_entries(repository, branch):
+            self.evict(
+                entry.id,
+                reason=(
+                    "cannot progress: no pull request recorded after %d attempt(s), "
+                    "so the entry can neither be landed nor observed as merged"
+                    % entry.attempts
+                ),
+            )
+            evicted.append(entry.id)
         for entry in self.live_entries(repository, branch):
             if entry.attempts < self.MAX_ATTEMPTS_BEFORE_EVICTION:
                 continue

--- a/tests/test_merge_queue_pr_number.py
+++ b/tests/test_merge_queue_pr_number.py
@@ -139,3 +139,75 @@ def test_an_entry_with_a_pr_still_evicts_but_says_so_differently(queue):
     reason = queue.entry(entry.id).eviction_reason
     assert "exhausted" in reason
     assert "no pull request recorded" not in reason
+
+
+# ---------------------------------------------------------------------------
+# Saying so: an entry that cannot progress must not read as work in flight
+# ---------------------------------------------------------------------------
+
+
+def _tested_entry(queue, *, task_id, attempts, pr=0):
+    entry = queue.admit(
+        repository="r", branch="main", task_id=task_id, head_sha="a" * 40,
+        pull_request_number=pr,
+    )
+    queue._store.execute(
+        "UPDATE merge_queue_entries SET state = 'tested', attempts = ? WHERE id = ?",
+        (attempts, entry.id),
+    )
+    return queue.entry(entry.id)
+
+
+def test_an_entry_that_finished_an_attempt_without_a_pr_is_stalled(queue):
+    """The seventy-attempt case, detected on the FIRST attempt instead."""
+    entry = _tested_entry(queue, task_id="t_stalled", attempts=1)
+    stalled = queue.stalled_entries("r", "main")
+    assert [e.id for e in stalled] == [entry.id]
+
+
+def test_an_entry_awaiting_its_first_attempt_is_not_stalled(queue):
+    """The false positive that would evict healthy work.
+
+    claim_slot runs BEFORE the agent opens the pull request, so an entry with
+    no number and no completed attempt is normal and momentary. Treating "no
+    PR" alone as stalled would evict every entry in that window -- worse than
+    the bug, because it breaks work that was about to succeed.
+    """
+    _tested_entry(queue, task_id="t_fresh", attempts=0)
+    assert queue.stalled_entries("r", "main") == []
+
+
+def test_an_entry_with_a_pr_is_never_stalled(queue):
+    _tested_entry(queue, task_id="t_ok", attempts=9, pr=455)
+    assert queue.stalled_entries("r", "main") == []
+
+
+def test_a_queued_entry_is_never_stalled(queue):
+    """`queued` precedes the PR by construction, so it cannot be stuck for it."""
+    queue.admit(repository="r", branch="main", task_id="t_q", head_sha="b" * 40)
+    assert queue.stalled_entries("r", "main") == []
+
+
+def test_the_snapshot_reports_stalled_apart_from_the_state_counts(queue):
+    """entries_testing/tested answer "what state"; entries_stalled answers
+    "is it going anywhere", and only the second is actionable."""
+    entry = _tested_entry(queue, task_id="t_snap", attempts=3)
+    snap = queue.snapshot("r", "main")
+    assert snap["entries_tested"] == 1
+    assert snap["entries_stalled"] == 1
+    assert snap["stalled_entry_ids"] == [entry.id]
+
+
+def test_a_stalled_entry_is_evicted_without_burning_the_attempt_cap(queue):
+    """It will never learn its number, so making it retry twelve times first
+    buys nothing and holds a slot for the whole window."""
+    entry = _tested_entry(queue, task_id="t_evict", attempts=1)
+    assert entry.attempts < queue.MAX_ATTEMPTS_BEFORE_EVICTION
+
+    assert queue.evict_exhausted("r", "main") == [entry.id]
+
+    after = queue.entry(entry.id)
+    assert after.state == "evicted"
+    assert "no pull request recorded" in after.eviction_reason
+    assert "neither be landed nor observed as merged" in after.eviction_reason
+    assert queue.snapshot("r", "main")["entries_stalled"] == 0


### PR DESCRIPTION
Closes task_c8863929 — the third of its three requirements, which #439 did not cover.

## What #439 already fixed

- `record_pull_request` writes the number once the PR exists. **Proven live**: the entry for `task_3141dce7` recorded PR **455** and reached `landed`.
- `evict_exhausted` removes an entry past the attempt cap, with a reason.

## What was left

A permanently stuck entry still **read as work in flight**, and was left to discover that over twelve attempts.

An entry needs a pull request to be landed *or* to be observed as already merged. With `pull_request_number = 0` both paths are closed, so it holds a slot and accrues attempts forever. One on the live hub reached **seventy attempts** while the change it represented had merged hours earlier as #404 — and `entries_testing` counted it as progress the whole time. The same lie `release()` was fixed to stop telling, arriving by a different route.

## Three changes

**`stalled_entries()` names the condition.** The predicate is `attempts >= 1 AND no pull_request_number AND state in (testing, tested)`, and every clause earns its place:

- `queued` is excluded — `claim_slot` runs **before** the agent opens the PR, so a queued entry with no number is normal.
- `attempts >= 1` is load-bearing. An entry between `claim_slot` and `record_pull_request` legitimately has no number *for a moment*, and treating "no PR" alone as stalled would evict healthy work about to succeed — **worse than the bug**. Having *completed* an attempt without learning the number is what cannot fix itself.

**The snapshot reports `entries_stalled` and `stalled_entry_ids` alongside the state counts, not inside them.** `entries_testing`/`entries_tested` answer "what state is it in"; `entries_stalled` answers "is it going anywhere". Only the second is actionable.

**`evict_exhausted` removes stalled entries on their own terms, not on the attempt cap.** An entry that finished an attempt without its number will never learn it, so twelve more cycles buy nothing and hold a slot throughout — which is how one entry starved the window at its floor while the rest of the queue queued behind it.

## Deliberately not done

The task asks for entries to be **refused at enrolment**. That is impossible in this order: `claim_slot` runs before the pull request exists, so no caller can supply a number at admit time, and refusing there would refuse *every* entry. The intent — an entry that does not know its PR must not linger — is met instead by detecting and evicting it as soon as one attempt proves it never will.

## Tests

```
tests/test_merge_queue_pr_number.py    15 passed
pytest -k merge_queue                  86 passed
dead-code-check                        clean
```

The one that matters most is `test_an_entry_awaiting_its_first_attempt_is_not_stalled` — the false positive that would have made this change destructive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)