### PR TITLE
Measure whether the hub's event loop stops running

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -590,6 +590,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_LINUX_SERVICE_TX_SAVED_HUP_TRAP` | str | consumer-defined | core | Core setting: linux service tx saved hup trap. |
 | `MAC_LINUX_SERVICE_TX_SAVED_INT_TRAP` | str | consumer-defined | core | Core setting: linux service tx saved int trap. |
 | `MAC_LINUX_SERVICE_TX_SAVED_TERM_TRAP` | str | consumer-defined | core | Core setting: linux service tx saved term trap. |
+| `MAC_LOOP_HEARTBEAT_SECONDS` | int | consumer-defined | core | Core setting: loop heartbeat seconds. |
+| `MAC_LOOP_STALL_THRESHOLD_SECONDS` | int | consumer-defined | core | Core setting: loop stall threshold seconds. |
 | `MAC_MACHINE_ID` | str | consumer-defined | core | Core setting: machine id. |
 | `MAC_MANAGED_REVERSE_TUNNEL` | str | consumer-defined | core | Core setting: managed reverse tunnel. |
 | `MAC_MAX_CHILD_TASKS_PER_PARENT` | str | consumer-defined | core | Core setting: max child tasks per parent. |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -56,6 +56,7 @@ from mac.hermes_config_surface import (
     build_hermes_config_surfaces,
 )
 from mac.hermes_startup import build_hermes_startup_report
+from mac.loop_stall_detector import LoopStallDetector
 from mac.observability_console import (
     build_console_snapshot,
     build_task_drilldown,
@@ -4478,6 +4479,7 @@ def create_app(
     # Default-ON only when the authority is PostgreSQL (MAC_DATABASE_URL);
     # a no-op on the SQLite tier and with MAC_PG_BACKUP_ENABLED=0. A
     # PostgreSQL backup failure is surfaced loudly, never downgraded to SQLite.
+    loop_stall_detector = LoopStallDetector(cp)
     pg_backup_scheduler = PgBackupScheduler(cp, PgBackupConfig.from_env())
 
     @asynccontextmanager
@@ -4509,6 +4511,11 @@ def create_app(
             ("self_healing_sentinel", self_healing_sentinel.start, self_healing_sentinel.stop),
             ("hgx_autoscaler", hgx_autoscaler.start, hgx_autoscaler.stop),
             ("pg_backup_scheduler", pg_backup_scheduler.start, pg_backup_scheduler.stop),
+            # Last, and started from the lifespan so it runs on the SAME loop
+            # uvicorn accepts connections on. A gap between its beats is time
+            # that loop was not running anything -- which is what turns "the
+            # hub wedged and the supervisor restarted it" into a measurement.
+            ("loop_stall_detector", loop_stall_detector.start, loop_stall_detector.stop),
         ]
         started: List[Tuple[str, Callable[[], Any]]] = []
 

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -6982,6 +6982,28 @@
   },
   {
     "default": null,
+    "description": "Core setting: loop heartbeat seconds.",
+    "family": "core",
+    "name": "MAC_LOOP_HEARTBEAT_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/loop_stall_detector.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Core setting: loop stall threshold seconds.",
+    "family": "core",
+    "name": "MAC_LOOP_STALL_THRESHOLD_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/loop_stall_detector.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Core setting: machine id.",
     "family": "core",
     "name": "MAC_MACHINE_ID",

--- a/src/mac/loop_stall_detector.py
+++ b/src/mac/loop_stall_detector.py
@@ -1,0 +1,190 @@
+"""Measure whether the hub's asyncio event loop stops running.
+
+WHY THIS EXISTS
+
+The hub wedges: probes fail for minutes and the supervisor eventually restarts
+it. task_c429b062 narrowed the cause by elimination, and a thread dump taken
+during a nine-minute hang ruled out everything obvious:
+
+    65 threads, 54 idle          the request threadpool is NOT exhausted
+    0 in publication_serialization   not the barrier fixed in #359
+    Postgres: 12 conns, 1 active, longest query 0s   not the database
+
+Meanwhile the CLI saw "Connection reset by peer" and "Connection refused" --
+the ACCEPT path, not a slow handler. uvicorn accepts connections on the event
+loop, so if anything runs blocking work there, accepts stall while worker
+threads sit idle. That is exactly the observed shape.
+
+But it was inference. `py-spy dump` without `--native` cannot show what the
+loop thread is executing inside a C frame, so "the loop is blocked" remained a
+hypothesis that no measurement confirmed. This module is the measurement the
+task asked for: a heartbeat scheduled ON the loop, so a gap between beats is
+time the loop was not running anything else.
+
+WHAT A GAP MEANS, AND WHAT IT DOES NOT
+
+A gap proves the loop did not get to us for that long. It does NOT say what
+occupied it -- that still needs `py-spy dump --native`, or a narrowing of which
+coroutine ran between two beats. What it does provide is the trigger: something
+that knows a stall is happening WHILE it happens, rather than a supervisor
+restart afterwards and a dump nobody caught in time.
+
+THE RECORDING RUNS OFF THE LOOP, DELIBERATELY
+
+Writing the observation to Postgres from the loop would be synchronous I/O on
+the event loop -- the precise defect under investigation. A detector that
+caused the fault it measures would be worse than none, so the beat happens on
+the loop and the write happens in a thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any, Optional
+
+LOGGER = logging.getLogger("mac.loop_stall")
+
+#: Seconds between heartbeats. One second is frequent enough to bound the
+#: attribution window without being a meaningful load: the coroutine does a
+#: clock read and a comparison.
+INTERVAL_ENV = "MAC_LOOP_HEARTBEAT_SECONDS"
+DEFAULT_INTERVAL = 1.0
+
+#: A beat later than interval + this is reported. Ordinary scheduling noise on
+#: a busy loop is milliseconds; the hangs under investigation are minutes. The
+#: default is deliberately far above the noise and far below the fault, so a
+#: report means something happened rather than that the box was busy.
+THRESHOLD_ENV = "MAC_LOOP_STALL_THRESHOLD_SECONDS"
+DEFAULT_THRESHOLD = 2.0
+
+OBSERVABILITY_NAME = "hub.event_loop.stalled"
+
+
+def _float_env(name: str, default: float, environ: Optional[dict] = None) -> float:
+    raw = (environ if environ is not None else os.environ).get(name)
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+class LoopStallDetector:
+    """Heartbeat on the event loop; report the gaps.
+
+    Start/stop are shaped like the other lifespan services so it can join that
+    list and be unwound with them.
+    """
+
+    def __init__(
+        self,
+        control_plane: Any,
+        *,
+        interval: Optional[float] = None,
+        threshold: Optional[float] = None,
+        environ: Optional[dict] = None,
+        clock: Any = time.monotonic,
+    ) -> None:
+        self._cp = control_plane
+        self._interval = (
+            interval
+            if interval is not None
+            else _float_env(INTERVAL_ENV, DEFAULT_INTERVAL, environ)
+        )
+        self._threshold = (
+            threshold
+            if threshold is not None
+            else _float_env(THRESHOLD_ENV, DEFAULT_THRESHOLD, environ)
+        )
+        self._clock = clock
+        self._task: Optional[asyncio.Task] = None
+        self._stop = False
+        #: Secret-free, in-process summary for tests and for /health-style
+        #: callers that want the number without querying observability.
+        self.worst_gap_seconds = 0.0
+        self.stall_count = 0
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stop = False
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop (a sync caller, or a test constructing the app). There is
+            # nothing to measure, and refusing loudly here would break app
+            # construction for a diagnostic.
+            LOGGER.debug("no running event loop; loop stall detector not started")
+            return
+        self._task = loop.create_task(self._run(), name="mac-loop-stall-detector")
+
+    def stop(self) -> None:
+        self._stop = True
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+
+    # -- the beat ----------------------------------------------------------
+
+    async def _run(self) -> None:
+        last = self._clock()
+        while not self._stop:
+            try:
+                await asyncio.sleep(self._interval)
+            except asyncio.CancelledError:
+                return
+            now = self._clock()
+            elapsed = now - last
+            last = now
+            gap = elapsed - self._interval
+            if gap <= self._threshold:
+                continue
+            self.stall_count += 1
+            self.worst_gap_seconds = max(self.worst_gap_seconds, gap)
+            LOGGER.warning(
+                "event loop stalled for %.1fs (expected a beat every %.1fs)",
+                gap,
+                self._interval,
+            )
+            await self._record(gap, elapsed)
+
+    async def _record(self, gap: float, elapsed: float) -> None:
+        """Persist the observation WITHOUT touching the loop.
+
+        `record_log` is synchronous database I/O. Calling it here would block
+        the event loop -- the exact fault this detector exists to find -- so it
+        goes to a thread. A detector that caused the defect it measures would
+        be worse than no detector.
+        """
+        record = getattr(self._cp, "record_log", None)
+        if record is None:
+            return
+        try:
+            await asyncio.to_thread(
+                record,
+                OBSERVABILITY_NAME,
+                layer="control_plane",
+                source="hub",
+                level="warning",
+                detail={
+                    "gap_seconds": round(gap, 3),
+                    "elapsed_seconds": round(elapsed, 3),
+                    "interval_seconds": self._interval,
+                    "threshold_seconds": self._threshold,
+                    "stall_count": self.stall_count,
+                    # Names the hypothesis this measurement tests, so a reader
+                    # of the row knows what to do with it.
+                    "next_step": (
+                        "py-spy dump --native on the hub pid during a gap: the loop "
+                        "thread's C frames name what ran between two beats"
+                    ),
+                },
+            )
+        except Exception:  # noqa: BLE001 - a diagnostic must never break the hub
+            LOGGER.warning("failed to record loop stall", exc_info=True)

--- a/tests/test_loop_stall_detector.py
+++ b/tests/test_loop_stall_detector.py
@@ -1,0 +1,157 @@
+"""The hub's event loop is measured, not inferred.
+
+task_c429b062 narrowed a nine-minute hang by elimination -- not the threadpool
+(54 of 65 threads idle), not the publication barrier (0 waiters), not Postgres
+(1 active connection, longest query 0s) -- and the CLI's "Connection refused"
+pointed at the ACCEPT path, which uvicorn runs on the event loop.
+
+But `py-spy dump` without `--native` cannot see inside a C frame, so "the loop
+is blocked" stayed a hypothesis. These tests cover the measurement that settles
+it, and the property that matters most: the detector must not cause the fault
+it measures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mac.loop_stall_detector import (
+    DEFAULT_INTERVAL,
+    DEFAULT_THRESHOLD,
+    OBSERVABILITY_NAME,
+    LoopStallDetector,
+    _float_env,
+)
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def record_log(self, name, **kwargs):
+        self.calls.append((name, kwargs))
+
+
+class _Clock:
+    """A monotonic clock the test advances by hand."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+
+def test_a_punctual_beat_reports_nothing():
+    cp = _Recorder()
+    clock = _Clock()
+    det = LoopStallDetector(cp, interval=0.01, threshold=1.0, clock=clock)
+
+    async def scenario():
+        det.start()
+        for _ in range(3):
+            await asyncio.sleep(0.02)
+            clock.now += 0.01  # exactly the interval: no gap
+        det.stop()
+
+    asyncio.run(scenario())
+    assert det.stall_count == 0
+    assert cp.calls == []
+
+
+def test_a_gap_is_measured_and_recorded():
+    cp = _Recorder()
+    clock = _Clock()
+    det = LoopStallDetector(cp, interval=0.01, threshold=0.5, clock=clock)
+
+    async def scenario():
+        det.start()
+        await asyncio.sleep(0.03)
+        clock.now += 47.0  # the loop did not run for 47 seconds
+        await asyncio.sleep(0.05)
+        det.stop()
+
+    asyncio.run(scenario())
+    assert det.stall_count >= 1
+    assert det.worst_gap_seconds > 45
+    assert cp.calls, "a stall must be recorded, not only logged"
+    name, kwargs = cp.calls[0]
+    assert name == OBSERVABILITY_NAME
+    assert kwargs["level"] == "warning"
+    assert kwargs["detail"]["gap_seconds"] > 45
+
+
+def test_recording_happens_off_the_event_loop():
+    """The property that makes this detector safe to run in production.
+
+    `record_log` is synchronous database I/O. Doing it on the loop would block
+    the loop -- the exact defect under investigation. A detector that caused
+    the fault it measures would be worse than no detector, so the write must
+    land on a worker thread.
+    """
+    seen_threads = []
+
+    class _ThreadWatchingRecorder:
+        def record_log(self, name, **kwargs):
+            import threading
+
+            seen_threads.append(threading.current_thread().name)
+
+    clock = _Clock()
+    det = LoopStallDetector(_ThreadWatchingRecorder(), interval=0.01, threshold=0.5, clock=clock)
+
+    async def scenario():
+        det.start()
+        await asyncio.sleep(0.03)
+        clock.now += 10.0
+        await asyncio.sleep(0.05)
+        det.stop()
+
+    asyncio.run(scenario())
+    assert seen_threads, "nothing was recorded"
+    import threading
+
+    assert all(t != threading.current_thread().name for t in seen_threads), (
+        "record_log ran on the event loop thread: the detector would itself "
+        "stall the loop it measures"
+    )
+
+
+def test_a_failing_recorder_never_breaks_the_hub():
+    class _Broken:
+        def record_log(self, *a, **k):
+            raise RuntimeError("observability is down")
+
+    clock = _Clock()
+    det = LoopStallDetector(_Broken(), interval=0.01, threshold=0.5, clock=clock)
+
+    async def scenario():
+        det.start()
+        await asyncio.sleep(0.03)
+        clock.now += 10.0
+        await asyncio.sleep(0.05)
+        det.stop()
+
+    asyncio.run(scenario())
+    # The stall is still counted in-process even though persisting it failed.
+    assert det.stall_count >= 1
+
+
+def test_start_without_a_running_loop_is_a_no_op():
+    """App construction and sync callers must not fail for a diagnostic."""
+    det = LoopStallDetector(_Recorder())
+    det.start()  # no running loop
+    det.stop()
+    assert det.stall_count == 0
+
+
+def test_thresholds_come_from_the_environment_and_reject_nonsense():
+    assert _float_env("X", 1.5, {}) == 1.5
+    assert _float_env("X", 1.5, {"X": "4"}) == 4.0
+    # Zero or negative would mean "report every beat" or never sleep.
+    assert _float_env("X", 1.5, {"X": "0"}) == 1.5
+    assert _float_env("X", 1.5, {"X": "-3"}) == 1.5
+    assert _float_env("X", 1.5, {"X": "banana"}) == 1.5
+    assert DEFAULT_THRESHOLD > DEFAULT_INTERVAL


### PR DESCRIPTION
Advances **task_c429b062** — the hub wedges, the supervisor restarts it, and the cause was narrowed to the event loop by elimination but never measured.

## Where the diagnosis stood

A thread dump during a **nine-minute** hang ruled out everything obvious:

```
65 threads, 54 idle              the request threadpool is NOT exhausted
0 in publication_serialization   not the barrier fixed in #359
Postgres: 12 conns, 1 active     not database saturation
          longest query 0s
```

Meanwhile the CLI saw `Connection reset by peer` and `Connection refused` — the **accept** path, not a slow handler. uvicorn accepts on the event loop, so blocking work there stalls accepts while worker threads sit idle. Exactly the shape observed.

But it stayed inference: `py-spy dump` without `--native` cannot see inside a C frame, so "the loop is blocked" was a hypothesis no measurement confirmed.

## What this adds

A heartbeat scheduled **on** the loop — a gap between beats is time the loop was not running anything else. 1s interval, reported above a 2s gap: far above ordinary scheduling noise (milliseconds), far below the fault (minutes), so a report means something happened rather than that the box was busy.

Each stall records `hub.event_loop.stalled` with the measured gap, and carries the next step in the row itself (`py-spy dump --native` on the hub pid **during** a gap) so whoever reads it knows what to do with it.

## The property that makes it safe in production

**The recording runs off the loop.** `record_log` is synchronous database I/O; doing it on the loop would block the loop — the precise defect under investigation. A detector that caused the fault it measures would be worse than none, so the beat is on the loop and the write goes to a thread.

`test_recording_happens_off_the_event_loop` asserts it by capturing the thread name at the record call and requiring it differs from the loop thread.

## Honest about what a gap proves

That the loop did not get to us for that long — **not** what occupied it. That still needs `--native`. What this provides is the trigger: something that knows a stall is happening *while* it happens, instead of a supervisor restart afterwards and a dump nobody caught in time.

## Tests

```
tests/test_loop_stall_detector.py + test_env_config.py   17 passed
dead-code-check                                          clean
```

A punctual beat reports nothing; a 47s gap is measured and recorded; recording lands off the loop; a failing recorder never breaks the hub (the stall is still counted in-process); `start()` without a running loop is a no-op, so app construction never fails for a diagnostic; env thresholds reject zero, negative and garbage.

Sync tests driving their own loop with `asyncio.run()` — this repo has no `pytest-asyncio`, and a diagnostic isn't worth a new test dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)