### PR TITLE
Do not sign a rejection for a verification that could not run

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -943,6 +943,62 @@ REPOSITORY_CONTRACT_FILES = (
     Path(".mac") / "project.yml",
 )
 
+#: Output signatures that mean the verification COULD NOT RUN, as opposed to
+#: ran and found the change wanting.
+#:
+#: These are transport and environment faults of the harness itself. On
+#: 2026-08-19 every review in a 90-minute window was rejected, and the signed
+#: verdict for one of them ended:
+#:
+#:     coverage safety: statements 69300/76238 (90.90%, floor 90.00%);
+#:                      branches   20216/24618 (82.12%, floor 80.00%)
+#:       - Uploading files to /sandbox...
+#:       + Files uploaded
+#:     Error:   x ssh exited with status exit status: 1
+#:
+#: BOTH COVERAGE FLOORS PASSED. The gate the run exists to enforce was
+#: satisfied, and the coding-agent's ssh stream then died. That exit status
+#: became `rejected`, signed, and indistinguishable downstream from a reviewer
+#: judging the work deficient. One task was rejected, redone more thoroughly
+#: (58 tests -> 60, 2 files -> 11, ruff and a CodeGraph audit added), and
+#: rejected identically, because the verdict never depended on the diff.
+_HUB_VERIFY_UNAVAILABLE_SIGNATURES: Tuple[str, ...] = (
+    # cursor-agent's stream transport, the observed cause
+    "ssh exited with status",
+    "connection reset by peer",
+    "connection refused",
+    "retriableerror",
+    "resource_exhausted",
+    # no route to run anything at all
+    "no acceptable coding agent",
+    "agent_binary_missing",
+    "sandbox_policy_denied",
+    # the harness never got far enough to test the change
+    "failed to create sandbox",
+    "error: could not create sandbox",
+)
+
+
+def hub_verification_unavailable_reason(output: str) -> Optional[str]:
+    """The signature saying this run could not verify anything, if present.
+
+    Returning a reason means "we do not know whether the change is good" --
+    which must NOT be recorded as a rejection. A signature over "rejected" is
+    a claim the evidence does not support, and downstream nothing can tell it
+    apart from a real verdict.
+
+    Deliberately narrow. An unrecognised failure stays a rejection, because
+    treating unknown failures as infrastructure would let a genuinely broken
+    change pass through as "could not verify" and retry forever -- failing
+    open on the gate this exists to enforce.
+    """
+    text = (output or "").lower()
+    for signature in _HUB_VERIFY_UNAVAILABLE_SIGNATURES:
+        if signature in text:
+            return signature
+    return None
+
+
 def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 1500) -> str:
     """Keep the head AND the tail of a rejected verification's output.
 
@@ -27139,6 +27195,31 @@ class ControlPlane:
                 {"review_id": review.id, "error": str(exc)[:300]}, actor,
             )
             return None
+        if returncode != 0:
+            unavailable = hub_verification_unavailable_reason(output)
+            if unavailable is not None:
+                # The harness failed, not the change. Take the same path a
+                # verify CRASH already takes -- record and sign nothing -- so
+                # the review stays pending and is retried, instead of a signed
+                # "rejected" that no evidence supports.
+                #
+                # An exception here already returned None; a transport fault
+                # that happens to surface as an exit status deserves the same
+                # treatment, and only did not because the two arrive through
+                # different channels.
+                self._record_default_review_observation(
+                    task.id,
+                    "workflow.default_review.hub_verify_unavailable",
+                    "warning",
+                    {
+                        "review_id": review.id,
+                        "reason": unavailable,
+                        "returncode": int(returncode),
+                        "excerpt": _hub_review_failure_excerpt(output, head=400, tail=400),
+                    },
+                    actor,
+                )
+                return None
         verdict = "approved" if returncode == 0 else "rejected"
         current_review = self.get_review(review.id)
         existing = self._existing_hub_review_verification_evidence(
@@ -27241,8 +27322,16 @@ class ControlPlane:
         if isinstance(exec_codegraph, dict) and exec_codegraph:
             manifest["codegraph"] = exec_codegraph
         if verdict == "rejected":
-            manifest["feedback"] = "hub contract verification failed: %s" % (
-                _hub_review_failure_excerpt(output) or "nonzero exit"
+            # Lead with the command and its exit status. The excerpt that
+            # follows is thousands of lines of mostly-PASSING output -- a
+            # coverage table, a pytest summary -- and a worker reading it saw
+            # success everywhere and concluded it had not tried hard enough.
+            # One task answered a rejection with MORE tests and a bigger diff,
+            # twice, because the reason was on the last line.
+            manifest["feedback"] = "hub contract verification failed (rc=%d): %s\n\n%s" % (
+                int(returncode),
+                str(test_command or "scripts/run-contract-tests.sh")[:200],
+                _hub_review_failure_excerpt(output) or "nonzero exit",
             )
         manifest["signature"] = sign_verification_manifest(key, manifest)
         evidence = self.add_evidence(

--- a/tests/test_hub_verification_not_rejection.py
+++ b/tests/test_hub_verification_not_rejection.py
@@ -1,0 +1,110 @@
+"""A verification that could not run must not be signed as a rejection.
+
+On 2026-08-19 every review in a 90-minute window was rejected -- 7 of 7 -- and
+the fleet could complete nothing. The signed verdict for one of them ended:
+
+    coverage safety: statements 69300/76238 (90.90%, floor 90.00%);
+                     branches   20216/24618 (82.12%, floor 80.00%)
+      - Uploading files to /sandbox...
+      + Files uploaded
+    Error:   x ssh exited with status exit status: 1
+
+Both coverage floors PASSED. The gate the run exists to enforce was satisfied,
+and then the coding agent's ssh stream died. That exit status became
+``rejected``, was SIGNED, and downstream was indistinguishable from a reviewer
+judging the work deficient.
+
+The cost was not abstract: task_832c4d72 was rejected, redone more thoroughly
+(58 tests -> 60, 2 files -> 11, ruff and a CodeGraph audit added), and rejected
+identically. Four cycles, 7.9M tokens, against a verdict that never depended on
+the diff.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.services import hub_verification_unavailable_reason
+
+
+def test_the_observed_transport_fault_is_recognised():
+    """The exact tail of the verdict that blocked the fleet."""
+    output = (
+        "coverage safety: statements 69300/76238 (90.90%, floor 90.00%); "
+        "branches 20216/24618 (82.12%, floor 80.00%)\n"
+        "  - Uploading files to /sandbox...\n"
+        "  + Files uploaded\n"
+        "Error:   x ssh exited with status exit status: 1\n"
+    )
+    assert hub_verification_unavailable_reason(output) == "ssh exited with status"
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "Connection reset by peer",
+        "connection refused",
+        "RetriableError: [resource_exhausted] Error",
+        "no acceptable coding agent available/authed; executor will fail closed",
+        "coding-agent sandbox preflight (codex): FAILED (rc=1, class=sandbox_policy_denied)",
+    ],
+)
+def test_other_harness_faults_are_recognised(output):
+    assert hub_verification_unavailable_reason(output) is not None
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "FAILED tests/test_thing.py::test_case - AssertionError: 1 != 2\n3 failed, 5 passed",
+        "coverage safety: statements 60000/76238 (78.70%, floor 90.00%)",
+        "E   ImportError: cannot import name 'thing' from 'mac.module'",
+        "ruff: 4 errors found",
+    ],
+)
+def test_a_real_failure_is_still_a_rejection(output):
+    """The gate must keep working. These are verdicts about the CHANGE."""
+    assert hub_verification_unavailable_reason(output) is None
+
+
+def test_an_unrecognised_failure_stays_a_rejection():
+    """Deliberately narrow, and this is the reason.
+
+    Treating unknown failures as infrastructure would let a genuinely broken
+    change read as "could not verify" and retry forever -- failing OPEN on the
+    gate this whole path exists to enforce. An unfamiliar failure is a
+    rejection until someone adds its signature on purpose.
+    """
+    assert hub_verification_unavailable_reason("segmentation fault (core dumped)") is None
+    assert hub_verification_unavailable_reason("") is None
+    assert hub_verification_unavailable_reason(None) is None
+
+
+def test_the_signature_list_is_about_the_harness_not_the_change():
+    """A signature naming a test outcome would silently disable the gate."""
+    from mac.services import _HUB_VERIFY_UNAVAILABLE_SIGNATURES
+
+    forbidden = ("assertionerror", "failed", "coverage", "error:", "traceback")
+    for signature in _HUB_VERIFY_UNAVAILABLE_SIGNATURES:
+        for word in forbidden:
+            assert signature != word, (
+                "%r would classify ordinary test failures as infrastructure and "
+                "turn every rejection into a retry" % signature
+            )
+
+
+def test_feedback_leads_with_the_command_and_exit_status():
+    """The reason must not be on the last line of a coverage dump.
+
+    A worker that reads thousands of lines of passing coverage and one
+    truncated 'rc' concludes it did not try hard enough. One did exactly that,
+    twice.
+    """
+    import inspect
+
+    from mac import services
+
+    source = inspect.getsource(services.ControlPlane._run_hub_review_verification_locked)
+    assert 'hub contract verification failed (rc=%d): %s' in source, (
+        "rejection feedback must lead with the failing command and its exit status"
+    )


### PR DESCRIPTION
Closes **task_ddab83be** — the constraint that stopped the fleet completing anything.

## What happened

Every review in a 90-minute window was rejected — **7 of 7, zero approvals**. The signed verdict for one ended:

```
coverage safety: statements 69300/76238 (90.90%, floor 90.00%);
                 branches   20216/24618 (82.12%, floor 80.00%)
  - Uploading files to /sandbox...
  + Files uploaded
Error:   x ssh exited with status exit status: 1
```

**Both coverage floors passed.** The gate the run exists to enforce was satisfied, and then the coding agent's ssh stream died. That exit status became `rejected`, was **signed**, and downstream nothing could tell it apart from a reviewer judging the work deficient.

## The defect was one line

```python
verdict = "approved" if returncode == 0 else "rejected"
```

An **exception** from the verify already returned `None` and signed nothing — *"a verify crash must not wedge the workflow"*. A transport fault that surfaces as an **exit status** got the opposite treatment, and only because the two arrive through different channels.

## The fix

A nonzero returncode is classified first. Output matching a harness fault — ssh transport, connection reset/refused, `resource_exhausted`, no acceptable coding agent, `sandbox_policy_denied`, sandbox creation failure — records `workflow.default_review.hub_verify_unavailable` and returns `None`, leaving the review pending to be retried. It signs nothing, because a signature over "rejected" is a claim the evidence does not support.

**The classifier is deliberately narrow: an unrecognised failure stays a rejection.** Treating unknown failures as infrastructure would let a genuinely broken change read as "could not verify" and retry forever — failing *open* on the gate this path exists to enforce. A test asserts no signature is a word like `failed` or `assertionerror`, which would silently disable it.

## Second fix: the feedback buried its own cause

Rejection feedback now leads with the failing command and exit status. It used to be thousands of lines of mostly-*passing* output with the decisive line last.

That is not cosmetic. `task_832c4d72` answered a rejection with **58 tests → 60, 2 files → 11**, ruff and a CodeGraph audit added — and was rejected identically. Four cycles, 7.9M tokens, improving work that was never the problem, because the reason was on the last line of a coverage dump.

## Tests

```
tests/test_hub_verification_not_rejection.py    13 passed
pytest -k "review or hub_verif"                590 passed
dead-code-check                                 clean
```

Including the exact observed output as a fixture, four real failure modes that must **still** reject, and the guard that keeps the signature list about the harness rather than the change.

## Next

Hub verification pins **cursor**, whose transport is what failed. opencode is now in the sandbox image (#451) and doesn't use it — routing hub verification through `resolve_coding_agent`, as task execution already is, would remove the fault rather than tolerate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)