### PR TITLE
Repair self-referential dream-candidate seeding in nap_consolidator, with regression tests (task_d682b6ddcaa3406ea0c4effa085116cd)

### DIFF
--- a/docs/dream-repair-slack-lineage.md
+++ b/docs/dream-repair-slack-lineage.md
@@ -198,7 +198,11 @@ become true:
    snapshot.
 
 Until then, treat `dreamrepair:4becfa8dfd2a06539d4dbb0fb4f53be9` as **not
-actionable**. Residual risk is the still-reachable manual/API
-`nap-consolidate` path (`emit_dream_artifacts=True` by default), which can
-re-emit title-echo `dream:failure_pattern` rows, but it cannot mint
-`dreamrepair:` fingerprints or file repair tasks in this tree.
+actionable**. Residual risk on the still-reachable manual/API
+`nap-consolidate` path (`emit_dream_artifacts=True` by default) is reduced:
+`_default_dreamer` now drops `mac.deployment_learning.v1` closures whose
+`task_title` is a dream-repair investigation (`_is_dream_repair_investigation_title`)
+from `failure_pattern` support, so a lineage-only group no longer re-seeds
+the next generation. That path still cannot mint `dreamrepair:` fingerprints
+or file repair tasks in this tree; `dream_scanner`, `dream_cycle_classifier`,
+and `dream_repair_tasks` remain absent and are not reintroduced.

--- a/src/mac/nap_consolidator.py
+++ b/src/mac/nap_consolidator.py
@@ -34,6 +34,19 @@ Design notes
 * **Vector handoff.** When a `VectorWriterService` is provided, each
   summary gets embedded into the medium tier immediately. Failures
   there don't roll back the summary — the next backfill catches it.
+
+* **Dream-repair lineage support.** The default dreamer still emits
+  ``dream:<kind>`` rows on the manual/API nap-consolidate path
+  (``emit_dream_artifacts=True``). A ``mac.deployment_learning.v1``
+  closure whose ``task_title`` is a dream-repair *investigation* is
+  self-referential: it is the prior audit's own outcome, not an
+  independent failure. Those records are dropped from
+  ``failure_pattern`` support so a single lineage memory cannot
+  re-seed the next generation. Genuine failure memories, non-failure
+  kinds, and groups with remaining independent records are unchanged.
+  Later loop stages (``dream_scanner``, ``dream_cycle_classifier``,
+  ``dream_repair_tasks``) are gone from this tree; they are not
+  reintroduced here. See ``docs/dream-repair-slack-lineage.md``.
 """
 from __future__ import annotations
 
@@ -186,6 +199,83 @@ def _confidence_for_records(records: List[MemoryRecord]) -> Tuple[str, float]:
     return "low", _CONFIDENCE_SCORES["low"]
 
 
+#: Title fragments that mark a dream-repair investigation rather than an
+#: independent operational incident. Used with
+#: :func:`_is_dream_repair_investigation_title`.
+_DREAM_REPAIR_TITLE_MARKERS = (
+    "dream finding",
+    "dream-repair",
+    "dreamrepair:",
+    "dream-cycle",
+    "dream cycle",
+)
+_INVESTIGATION_TITLE_MARKERS = (
+    "investigate",
+    "audit",
+    "provenance",
+    "disposition",
+    "closeout",
+    "ground truth",
+)
+
+
+def _is_dream_repair_investigation_title(title: str) -> bool:
+    """Return True when *title* names a dream-repair investigation task.
+
+    The predicate is conjunctive: the title must look investigative
+    (investigate/audit/provenance/…) *and* refer to a dream finding or
+    dream-repair lineage. A deploy titled "failed with timeout" does not
+    match; neither does an unrelated audit that never mentions dreams.
+    """
+
+    lowered = str(title or "").strip().lower()
+    if not lowered:
+        return False
+    mentions_lineage = any(marker in lowered for marker in _DREAM_REPAIR_TITLE_MARKERS)
+    mentions_investigation = any(marker in lowered for marker in _INVESTIGATION_TITLE_MARKERS)
+    return mentions_lineage and mentions_investigation
+
+
+def _is_dream_repair_lineage_learning(record: MemoryRecord) -> bool:
+    """True when *record* is a dream-repair investigation's own outcome memory.
+
+    Those ``mac.deployment_learning.v1`` closures are self-referential
+    lineage support: they describe the investigation of a prior dream
+    candidate, not an independent failure of the surface named in the
+    title (for example the word ``slack`` in an audit title).
+    """
+
+    if not str(record.record_type or "").startswith("deployment_learning"):
+        return False
+    payload = _record_payload(record)
+    if payload.get("schema") != "mac.deployment_learning.v1":
+        return False
+    title = str(payload.get("task_title") or "")
+    return _is_dream_repair_investigation_title(title)
+
+
+def _independent_failure_pattern_support(
+    records: List[MemoryRecord],
+) -> List[MemoryRecord]:
+    """Drop self-referential dream-repair learning from failure_pattern support.
+
+    If every remaining record is a lineage closure, the group has no
+    independent failure evidence and manufacture must yield nothing.
+    Non-failure kinds keep the original record list so existing
+    decision_rule / tool_pattern / knowledge_snippet behaviour is
+    unchanged.
+    """
+
+    independent = [
+        record for record in records if not _is_dream_repair_lineage_learning(record)
+    ]
+    if independent:
+        return independent
+    if _dream_kind(records) == "failure_pattern":
+        return []
+    return list(records)
+
+
 def _default_dreamer(records: List[MemoryRecord], context: Dict[str, Any]) -> List[JsonDict]:
     """Emit one structured, evidence-backed dream artifact per group.
 
@@ -193,19 +283,26 @@ def _default_dreamer(records: List[MemoryRecord], context: Dict[str, Any]) -> Li
     meta-reasoning without an LLM. It builds a typed, recall-friendly
     artifact with provenance so production callers can swap in a richer
     ``dreamer_fn`` without changing storage, embedding, or retrieval.
+
+    Self-referential dream-repair investigation closures are excluded
+    from ``failure_pattern`` support; see
+    :func:`_independent_failure_pattern_support`.
     """
     if not records:
         return []
-    kind = _dream_kind(records)
-    confidence, confidence_score = _confidence_for_records(records)
+    support = _independent_failure_pattern_support(records)
+    if not support:
+        return []
+    kind = _dream_kind(support)
+    confidence, confidence_score = _confidence_for_records(support)
     project = context.get("project")
     scope = "project" if project else "agent"
-    record_types = Counter(record.record_type for record in records)
-    observations = [_record_observation(record) for record in records[:5]]
+    record_types = Counter(record.record_type for record in support)
+    observations = [_record_observation(record) for record in support[:5]]
     title = "%s for %s" % (kind.replace("_", " "), context.get("group_label") or "group")
     summary = (
         "%s. Supported by %d memory record(s): %s"
-        % (title, len(records), "; ".join(observations[:3]))
+        % (title, len(support), "; ".join(observations[:3]))
     )
     query_terms = sorted(
         {
@@ -226,6 +323,7 @@ def _default_dreamer(records: List[MemoryRecord], context: Dict[str, Any]) -> Li
             "summary": summary[:1200],
             "observations": observations,
             "record_type_counts": dict(sorted(record_types.items())),
+            "evidence": _evidence_for_records(support),
             "retrieval": {
                 "agent_id": context.get("agent_id"),
                 "project": project,

--- a/tests/test_nap_consolidator.py
+++ b/tests/test_nap_consolidator.py
@@ -577,6 +577,135 @@ def test_dreamer_contract_grouping_and_missing_project_edges() -> None:
         invalid_item._normalized_dream_artifacts([project_record], {})
 
 
+def _deployment_learning(
+    cp: ControlPlane,
+    *,
+    title: str,
+    outcome: str = "failure",
+    evidence_type: str = "repo_change",
+    error_signature: str = "",
+    **kwargs: Any,
+):
+    payload = {
+        "schema": "mac.deployment_learning.v1",
+        "outcome": outcome,
+        "task_title": title,
+        "evidence_type": evidence_type,
+        "error_signature": error_signature,
+    }
+    return _record(
+        cp,
+        json.dumps(payload),
+        record_type="deployment_learning:mac",
+        **kwargs,
+    )
+
+
+def test_lineage_only_investigation_learning_does_not_seed_failure_pattern() -> None:
+    """A dream-repair investigation's own closure must not re-seed the loop."""
+    cp = ControlPlane.in_memory()
+    lineage = _deployment_learning(
+        cp,
+        title="Audit slack dream finding evidence and provenance",
+    )
+    assert nap._is_dream_repair_lineage_learning(lineage)
+    assert nap._dream_kind([lineage]) == "failure_pattern"
+    assert nap._confidence_for_records([lineage])[0] == "low"
+    context = {"group_label": "task=t-lineage project=mac", "project": "mac"}
+    assert nap._default_dreamer([lineage], context) == []
+
+
+def test_genuine_failure_memory_still_yields_failure_pattern() -> None:
+    cp = ControlPlane.in_memory()
+    genuine = _deployment_learning(
+        cp,
+        title="Deploy",
+        evidence_type="test",
+        error_signature="timeout",
+        outcome="failed",
+    )
+    artifacts = nap._default_dreamer(
+        [genuine],
+        {"group_label": "task=t-deploy project=mac", "project": "mac"},
+    )
+    assert len(artifacts) == 1
+    assert artifacts[0]["kind"] == "failure_pattern"
+    assert artifacts[0]["confidence"] == "low"
+    assert artifacts[0]["confidence_score"] == pytest.approx(0.35)
+    assert artifacts[0]["observations"] == [
+        "[failed] Deploy (test) failed with timeout"
+    ]
+
+
+def test_mixed_group_ignores_self_referential_lineage_record() -> None:
+    cp = ControlPlane.in_memory()
+    lineage = _deployment_learning(
+        cp,
+        title="Investigate low-confidence dream finding: slack",
+    )
+    genuine = _deployment_learning(
+        cp,
+        title="Deploy",
+        evidence_type="test",
+        error_signature="timeout",
+        outcome="failed",
+    )
+    artifacts = nap._default_dreamer(
+        [lineage, genuine],
+        {"group_label": "task=t-mixed project=mac", "project": "mac"},
+    )
+    assert len(artifacts) == 1
+    assert artifacts[0]["kind"] == "failure_pattern"
+    assert artifacts[0]["confidence"] == "low"
+    assert artifacts[0]["observations"] == [
+        "[failed] Deploy (test) failed with timeout"
+    ]
+    evidence_ids = [item["memory_id"] for item in artifacts[0]["evidence"]]
+    assert genuine.id in evidence_ids
+    assert lineage.id not in evidence_ids
+
+
+def test_mixed_non_failure_group_ignores_lineage_and_keeps_kind() -> None:
+    """Lineage closures must not recast an otherwise non-failure group."""
+    cp = ControlPlane.in_memory()
+    lineage = _deployment_learning(
+        cp,
+        title="Investigate low-confidence dream finding: slack",
+        outcome="success",
+    )
+    tool = _record(cp, "tool command worked")
+    artifacts = nap._default_dreamer(
+        [lineage, tool],
+        {"group_label": "task=t-tool project=mac", "project": "mac"},
+    )
+    assert len(artifacts) == 1
+    assert artifacts[0]["kind"] == "tool_pattern"
+    assert artifacts[0]["confidence"] == "low"
+    assert artifacts[0]["observations"] == ["tool command worked"]
+
+
+def test_absent_dream_repair_stages_are_not_live() -> None:
+    """Classifier / scanner / repair-task filer stages are gone; do not invent them.
+
+    Ground truth (docs/dream-repair-slack-lineage.md) established that only
+    nap_consolidator's default dreamer still manufactures title-echo
+    failure_pattern candidates. The later stages that minted dreamrepair:
+    fingerprints and filed repair tasks are absent, so this pin records that
+    terminating behaviour instead of reintroducing a dead path.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "src" / "mac"
+    for module_name, filename in (
+        ("mac.dream_scanner", "dream_scanner.py"),
+        ("mac.dream_cycle_classifier", "dream_cycle_classifier.py"),
+        ("mac.dream_repair_tasks", "dream_repair_tasks.py"),
+    ):
+        assert importlib.util.find_spec(module_name) is None
+        assert not (src / filename).exists()
+
+
 def test_duplicate_detection_reaches_past_the_recent_window(cp):
     """A repeated body must be caught however far back its twin sits.
 


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_d682b6ddcaa3406ea0c4effa085116cd`
- head: `2f0e2df19417c91ae41aa462ac5902d08d1f1b96`
- base at push: `c6766a144e840c9ff1607a199d574bd091be198e`
