### PR TITLE
Fix latent quality-gate failures

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -2002,7 +2002,6 @@ def cmd_interaction_task(args: argparse.Namespace) -> None:
             metadata=_json_arg(args.metadata, {}),
             max_attempts=args.max_attempts,
             actor=args.actor,
-            created_by_human=kwargs_human,
         )
     )
 

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -48,6 +48,7 @@ works without changes to the handlers.
 """
 from __future__ import annotations
 
+import json
 import os
 import sys
 import urllib.error

--- a/src/mac/human_interface_profile.py
+++ b/src/mac/human_interface_profile.py
@@ -47,7 +47,7 @@ import os
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from mac.atomic_file import fsync_directory
 

--- a/src/mac/sandbox_bom.py
+++ b/src/mac/sandbox_bom.py
@@ -36,6 +36,7 @@ Two deliberate limits:
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
 
 #: Sandbox binary name for each coding agent mac can route to.
@@ -383,15 +384,13 @@ def manifest_has_drift(drift: Mapping[str, Sequence[str]]) -> bool:
     return any(drift.values())
 
 
-def committed_manifest_path() -> Optional["Path"]:
+def committed_manifest_path() -> Optional[Path]:
     """The reviewed manifest inside the installed tree, if it is there.
 
     Returns None rather than raising when it is absent. The hub can run from a
     packaged install that ships no deploy/ directory, and a drift check is a
     diagnostic -- it must never be the reason a project cannot be registered.
     """
-    from pathlib import Path
-
     root = Path(__file__).resolve().parents[2]
     candidate = root / MANIFEST_PATH
     return candidate if candidate.is_file() else None

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -60,6 +60,7 @@ from mac.agentbus_control import (
 if TYPE_CHECKING:
     from mac.executor_directive import TaskOwnershipVerdict
 from mac.attempt_failure_classifier import classify_attempt_failure
+from mac.dispatch_advisor import DISPATCH_ASSIGNMENT_ADVISOR_VERSION
 from mac.gitops import validate_git_ref
 from mac.repository_contract import (
     canonical_git_remote_identity,
@@ -17829,7 +17830,7 @@ class ControlPlane:
                 subject_id=task.id,
                 detail={
                     "schema": "mac.dispatch.assignment_advice.v1",
-                    "allocator_version": WORK_PACKAGE_ASSIGNMENT_ADVISOR_VERSION,
+                    "allocator_version": DISPATCH_ASSIGNMENT_ADVISOR_VERSION,
                     "advisory_only": True,
                     "route": "dispatch_push",
                     "reason": "no_authoritative_claim_succeeded",

--- a/src/mac/task_batch.py
+++ b/src/mac/task_batch.py
@@ -907,8 +907,6 @@ class TaskBatchService:
             # Cancellation is close_task to CANCELLED with a disposition, the
             # same shape `mac task cancel` uses -- so the disposition rules
             # (superseded needs a replacement, and so on) apply unchanged.
-            from mac.models import TaskState
-
             detail = _batch_detail(
                 batch_id, options.get("reason") or "batch cancellation"
             )

--- a/tests/test_source_convergence_service.py
+++ b/tests/test_source_convergence_service.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from mac.models import json_dumps, new_id, utcnow
 from mac.services import ControlPlane
+from mac.test_support import table_names
 
 
 OLD_SHA = "1" * 40

--- a/tests/test_worker_control_edges.py
+++ b/tests/test_worker_control_edges.py
@@ -401,6 +401,7 @@ def test_repo_update_exact_sha_fetches_proves_and_fast_forwards(monkeypatch, tmp
 def test_repo_update_rejects_exact_source_before_managed_runtime_diverges(
     monkeypatch, tmp_path
 ) -> None:
+    monkeypatch.setattr(worker.sys, "platform", "linux")
     instance = _instance(tmp_path)
     old = "a" * 40
     target = "b" * 40
@@ -508,6 +509,7 @@ def test_worker_source_state_reports_commit_tree_and_dirty(monkeypatch, tmp_path
 
 
 def test_openshell_image_rebuild_gates_and_drift(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(worker.sys, "platform", "linux")
     instance = _instance(tmp_path)
     monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
     assert instance._maybe_rebuild_openshell_image_after_update(tmp_path, "a", "b") is None
@@ -527,6 +529,7 @@ def test_openshell_image_rebuild_gates_and_drift(monkeypatch, tmp_path) -> None:
 def test_digest_managed_openshell_image_never_rebuilds_locally(
     monkeypatch, tmp_path
 ) -> None:
+    monkeypatch.setattr(worker.sys, "platform", "linux")
     instance = _instance(tmp_path)
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_REBUILD_ON_SOURCE_UPDATE", "1")
@@ -558,6 +561,7 @@ def test_digest_managed_openshell_image_never_rebuilds_locally(
 
 
 def test_openshell_image_rebuild_failures_and_success(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(worker.sys, "platform", "linux")
     instance = _instance(tmp_path)
     containerfile = tmp_path / worker._OPENSHELL_CONTAINERFILE_RELPATH
     containerfile.parent.mkdir(parents=True)
@@ -590,6 +594,7 @@ def test_openshell_image_rebuild_failures_and_success(monkeypatch, tmp_path) -> 
 
 
 def test_openshell_image_podman_mirror_success_and_failure(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(worker.sys, "platform", "linux")
     instance = _instance(tmp_path)
     containerfile = tmp_path / worker._OPENSHELL_CONTAINERFILE_RELPATH
     containerfile.parent.mkdir(parents=True)
@@ -651,6 +656,7 @@ _ADOPT_PREV = "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "d" * 64
 
 
 def _managed_markers(monkeypatch, tmp_path):
+    monkeypatch.setattr(worker.sys, "platform", "linux")
     source_marker = tmp_path / "image-source-sha"
     managed_marker = tmp_path / "runtime-image-ref"
     source_marker.write_text(_ADOPT_SHA_OLD + "\n")


### PR DESCRIPTION
## Summary
- fix undefined names exposed by the lint gate
- use the current dispatch advisor version constant
- make Linux-only OpenShell tests platform-independent

## Verification
- make lint
- 158 focused tests passed

These fixes were first discovered while synchronizing mac into AgentFabric; upstreaming them prevents every future synchronization from carrying a permanent downstream patch.