### PR TITLE
Record how token spend is metered, and the traps that cost us a day

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,38 @@ If you cannot answer 3, file it anyway — say so explicitly. An honest *"I do
 not know why"* is more useful than a confident wrong diagnosis, which sends the
 next person somewhere real problems are not.
 
+## A feature needs an ADR before it needs code
+
+Change management here runs through architecture decision records in
+`docs/adr/`, numbered sequentially. Anything that changes a contract, a schema,
+a boundary between components, or how the fleet behaves gets one FIRST. Bug
+fixes and mechanical changes do not.
+
+An ADR is not a design doc and not a proposal to be approved. It is the record
+of a decision and, more importantly, **of the alternatives that were rejected
+and why** — so that the next person to have the same idea finds out it was
+already considered, instead of relitigating it or quietly re-introducing it.
+
+Follow the shape of the existing ones (`0016-agent-initiated-review.md` is a
+good model):
+
+- **Status / Date / Decision owner / Related** — link the ADRs this touches.
+- **Context** — the measured problem. Numbers with provenance, same standard as
+  an issue. An ADR whose context is "it would be nice if" has no way to be
+  wrong, and no way to be checked later.
+- **Decision** — what will be true, stated in the present tense.
+- **Consequences** — including the bad ones. If reported cost jumps 30% the day
+  this lands, say so here, or someone will read the step change as a runaway.
+- **Alternatives considered** — each with the reason it lost.
+
+Reference the ADR from the task and from the PR description. A PR that
+implements a decision nobody recorded is how this codebase accumulated
+subsystems whose rationale exists only in a chat log.
+
+Prior art from other projects is worth reading and worth citing — ADR 0017
+adopts a token-accounting model from `NVIDIA-dev/horde-claw-fleet` rather than
+deriving one, and says so.
+
 ## Opening a pull request
 
 ### Work in a worktree
@@ -57,6 +89,24 @@ git -C ~/Src/mac worktree add /tmp/mac-<task> -b <you>/<task>
 Multiple agents run against this repository at once. Sharing the main checkout
 has silently swept unrelated half-finished work into commits. Never `git add
 -A` or `git commit -a` there.
+
+### Check whether your task already has a PR
+
+```console
+gh pr list --search "<task_id>" --state all
+```
+
+A retried task currently opens a NEW pull request instead of updating the
+existing one. On 2026-08-19 the open queue held 23 PRs covering 12 distinct
+pieces of work — 11 were duplicates, one task having produced five of them from
+two different agents, with five genuinely divergent implementations.
+
+So: an open PR carrying your task id does not mean the work is finished, and it
+does not mean you should open a second one. Read it, then either continue it or
+say in your own PR why it was not salvageable.
+
+If you are the second agent to arrive at a task that another agent is actively
+running, stop. Concurrent work on one task is a claim bug, not a race to win.
 
 ### Before you push
 

--- a/docs/adr/0017-token-spend-is-metered-at-the-router.md
+++ b/docs/adr/0017-token-spend-is-metered-at-the-router.md
@@ -1,0 +1,162 @@
+# ADR 0017 - Token spend is metered at the router, not reported by the client
+
+- Status: **Proposed**
+- Date: 2026-08-19
+- Decision owner: MAC fleet owner
+- Related: ADR 0003 (tokenhub core into mac), ADR 0013 (one authoritative hub
+  allocator)
+- Prior art: `NVIDIA-dev/horde-claw-fleet` ADR-0020, ADR-0030, ADR-0053,
+  ADR-0067
+
+## Context
+
+MAC records model usage as one observability event per request, `llm.route`,
+whose token counts live inside `observability_events.detail` — a `text` column
+holding JSON. There is no token table and no token column. Cost is not stored;
+`estimate_route_cost()` in `src/mac/scientific_optimizer.py` prices
+`resolved_model` against a models catalog at read time and returns
+`(cost, was_priceable)`.
+
+Measured over the seven days to 2026-08-19, on 28,352 `llm.route` events:
+
+| Fact | Value |
+| --- | --- |
+| Input tokens recorded | 481.8M |
+| Output tokens recorded | 5.05M |
+| Streaming routes | 18,222 (64%) |
+| Routes flagged `stream_no_usage` | 5,948 |
+| Routes with `input_tokens = null` | 8,352 (**29.5%**) |
+| Routes reporting cached tokens | **0** |
+| Attributed to `agent` | 17,541 routes / 30.4M input tokens |
+| Attributed to `task` | 8,333 routes / 431.1M input tokens |
+| Attributed to nothing | 2,474 routes / 20.2M input tokens |
+
+Three defects follow.
+
+### 1. Metering is delegated to the caller, so a third of traffic is unmetered
+
+`src/mac/router_app.py` captures streamed usage from the terminal SSE frame,
+and its own comment states the assumption plainly:
+
+> the client asked for include_usage, so the terminal SSE frame carries the
+> token counts
+
+That is a pass-through, not a policy. MAC injects
+`stream_options: {"include_usage": true}` in exactly one place —
+`src/mac/responses_adapter.py:145` — so a coding agent that streams without
+requesting usage produces a route MAC cannot meter. The router then records
+`input_tokens: null` and `stream_no_usage: true` and moves on. That is 8,352
+requests in a week, and they book as **$0**.
+
+This is not a provider limitation. `horde-claw-fleet`'s
+`investigations/opus-4-7-telemetry.md` reproduced streaming requests against
+`https://inference-api.nvidia.com/v1/chat/completions` — the same endpoint and
+the same `provider: "nvidia"` MAC routes through — and confirmed the terminal
+chunk carries a full `usage` object, including
+`prompt_tokens_details.cached_tokens` and `cache_read_input_tokens`, whenever
+`stream_options.include_usage` is set on the request.
+
+MAC is not being denied the data. It is not asking for it.
+
+### 2. Attribution is split across incompatible keys
+
+A route is subject to an `agent`, or to a `task`, or to nothing. The three sets
+do not reconcile: task-attributed routes carry 431M of the 482M input tokens,
+while agent-attributed routes are 62% of the row count. No query can total
+spend per project without either double-counting the overlap or silently
+dropping the 2,474 unattributed routes.
+
+`horde-claw-fleet` solved this with a `source` discriminator
+(`task | gateway | cron | heartbeat | subagent`) over a nullable `task_id`, so
+that non-task inference is explicitly classified rather than left null. Their
+ADR-0020 names the same failure we have: *"we can answer 'how many tokens did
+task X spend?' but not 'how much did the entire system spend today?'"*
+
+### 3. There is no budget, and the one signal that exists is advisory
+
+Nothing in MAC caps spend. The single guard is a KPI signal,
+`high_token_work_without_publication`, which warns at 250,000 tokens with no
+publication (`src/mac/services.py:8156`). During the same week that signal had
+every reason to fire: 23 open pull requests covered 12 distinct pieces of work,
+one task having emitted five divergent implementations. Nothing acted on it.
+
+## Decision
+
+### 1. The router meters; the client cannot opt out
+
+The router injects `stream_options: {"include_usage": true}` on every
+OpenAI-compatible upstream streaming request, regardless of what the client
+sent. If the client did not ask for usage, the router strips the usage frame
+from the response it returns downstream, so client behaviour is unchanged while
+the hub still meters.
+
+`stream_no_usage` remains, but changes meaning: it becomes a genuine provider
+fault worth alerting on, rather than the expected outcome for two thirds of
+traffic.
+
+### 2. Usage is a column, not a substring
+
+Token spend moves out of JSON-in-text into a first-class table with typed
+columns: `input_tokens`, `output_tokens`, `cache_read_tokens`,
+`cache_write_tokens`, `estimated_cost_usd`, `api_calls`, `provider`, `model`,
+`source`, `subject_id`, `latency_ms`, `outcome`.
+
+Two properties are non-negotiable, both learned from `horde-claw-fleet`:
+
+- **Cost is computed and stored at write time.** Pricing at read time, as
+  `estimate_route_cost()` does now, silently re-prices historical spend
+  whenever the catalog changes, so last month's bill moves. Store the cost that
+  applied when the call was made.
+- **Rows are events and are summed; they are not cumulative snapshots.**
+  `horde-claw-fleet` ADR-0053 records a real bug where cumulative per-task
+  snapshot rows were `SUM()`ed instead of `MAX()`ed, inflating spend. MAC's
+  rows are per-request events, so summation is correct — but the table must
+  state which it is, in a comment and in a test, or the same bug arrives later.
+
+### 3. Every route carries exactly one attribution key
+
+`source` classifies the surface (`task`, `agent`, `gateway`, `cron`,
+`review`, `subagent`), and `subject_id` names the specific one. A route with no
+attributable subject is recorded as `source = 'gateway'` with a null
+`subject_id`, never as an unclassified row. "Unattributed" stops being a
+silent category and becomes a countable one.
+
+### 4. A daily budget that can refuse
+
+Adopt `horde-claw-fleet`'s shape directly (`fleet-model/src/budget.rs`): a
+`DailySpend {input_tokens, output_tokens, estimated_cost_usd}`, a
+classification of `allowed | exhausted`, and a decision record carrying
+`spent_usd`, `budget_usd` and the classification.
+
+The budget is enforced at dispatch, not mid-stream: a task is not dispatched
+once the day's spend is exhausted, and the refusal is recorded with the numbers
+that produced it. Killing an in-flight request wastes what was already spent on
+it; refusing the next one does not.
+
+## Consequences
+
+- The ~30% of spend currently invisible becomes visible. Reported cost will
+  **rise sharply** on the day this lands. That is the correction, not a
+  regression, and it should be announced before it lands so nobody reads the
+  step change as a runaway.
+- Cache accounting starts working. Given a 95:1 input:output ratio, cached
+  input is likely a large share of real cost, and every one of those tokens is
+  currently priced at full rate.
+- `estimate_route_cost()` becomes a fallback for historical rows only. New rows
+  carry their own cost.
+- A budget that can refuse work can also stall the fleet. The ceiling must be
+  operator-set, visible in `mac`, and overridable, or an exhausted budget
+  becomes an outage with no obvious cause.
+
+## Alternatives considered
+
+**Keep pricing at read time.** Rejected: it makes historical spend a function
+of the current catalog, so the same query answers differently over time.
+
+**Ask clients to send `include_usage`.** Rejected: this is the status quo. It
+depends on every coding agent, now and in future, opting into being metered.
+Metering must not be the caller's choice.
+
+**A separate gateway telemetry table.** Rejected for the reason
+`horde-claw-fleet` rejected it in ADR-0020: it duplicates the schema and forces
+every cost query to become a union.

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -23,6 +23,7 @@ their retained sources.
 - [ADR 0014: Agent visibility is a communication boundary, not a dispatch gate](../adr/0014-visibility-is-not-a-dispatch-gate.md) — `adr/0014-visibility-is-not-a-dispatch-gate.md`
 - [ADR 0015: macOS nodes are host installs, not containers](../adr/0015-macos-nodes-are-host-installs.md) — `adr/0015-macos-nodes-are-host-installs.md`
 - [ADR 0016 - Agents decide what a task needs; review is agent-initiated](../adr/0016-agent-initiated-review.md) — `adr/0016-agent-initiated-review.md`
+- [ADR 0017 - Token spend is metered at the router, not reported by the client](../adr/0017-token-spend-is-metered-at-the-router.md) — `adr/0017-token-spend-is-metered-at-the-router.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -28,6 +28,7 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0014-visibility-is-not-a-dispatch-gate.md` | ADR 0014: Agent visibility is a communication boundary, not a dispatch gate |
 | architecture decision | `adr/0015-macos-nodes-are-host-installs.md` | ADR 0015: macOS nodes are host installs, not containers |
 | architecture decision | `adr/0016-agent-initiated-review.md` | ADR 0016 - Agents decide what a task needs; review is agent-initiated |
+| architecture decision | `adr/0017-token-spend-is-metered-at-the-router.md` | ADR 0017 - Token spend is metered at the router, not reported by the client |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/skills/mac-cli/SKILL.md
+++ b/skills/mac-cli/SKILL.md
@@ -104,6 +104,67 @@ called "help".
     mac admin human register <username>
     mac admin dispatch submit <file>    literate-ai execution requests
 
+## Priority is inverted, and 0 is the bottom
+
+`priority` is an integer sorted DESCENDING — the allocator sorts on
+`-int(task.priority)`. **Higher is more urgent.** The convention on the live
+hub is:
+
+    P0  ->  priority 100      the top of the open queue
+    escalations above it      900, 1000, 2000 (used sparingly)
+
+So "make this P0" means `--priority 100`. `mac task update <id> --priority 0`
+does the exact opposite of what it reads like: it sends the task to the back
+of the queue, behind everything. There is at least one `P0:`-titled task on
+the hub sitting at priority 0 for this reason.
+
+`mac task update <id> --priority N` is a targeted field write. It preserves
+description, metadata, dependencies, capabilities, `max_attempts`, state and
+project — verified across 18 tasks. You do not need to re-send the
+description to change a priority, and you should not: passing
+`--description-file` rewrites the whole field.
+
+## Before you work a task, check whether it already has a PR
+
+A retried task currently files a NEW pull request on each attempt rather than
+updating the existing one. On 2026-08-19 the open queue held 23 PRs covering
+12 distinct pieces of work; one task had emitted five, by two different
+agents, with five divergent implementations (+598 to +2285 lines).
+
+Two consequences for anyone working a task:
+
+- Search for the task id before starting. PR titles carry it, so
+  `gh pr list --search "<task_id>"` finds prior attempts.
+- Finding an open PR for your task does not mean the work is done. It means
+  an earlier attempt got that far. Read it before writing a second one.
+
+Until the idempotency fix lands, this is manual. It is the single largest
+source of wasted fleet capacity observed to date.
+
+## Reading agent state
+
+**`mac agent show <name>` often fails for an agent that `mac agent list`
+displays.** `show` resolves by id, and an agent registered before the current
+id convention has an opaque uuid that matches neither its name nor the id the
+code expects. `hub-reviewer` is the live example: it is
+`agent_da539e43b3e147ffb580ebdd9f7cde6b`, while the constant in
+`services.py` says `agent_hub-reviewer`, and both `mac agent show
+hub-reviewer` and `mac agent show agent_hub-reviewer` return "agent not
+found". Get the real id from `mac agent list --json`.
+
+**Virtual agents flap.** `hub-reviewer` is registered by the hub itself so
+hub-side contract verification has an identity to sign with. It has no worker
+process, so nothing heartbeats for it, and `health_status` is only whatever
+was last written. It moves between `idle`, `offline` and `degraded` with no
+underlying fault. Do not diagnose it as a broken worker; it is not a worker.
+
+**`why-unclaimed` may name no reason at all.** For a task that is genuinely
+eligible and simply not being dispatched, it prints attempt counts and
+nothing else. `attempt_count: 0` with idle capable agents and no dispatch
+hold is a real state, and it means the fault is in dispatch rather than in
+anything about the task. Do not read a bare `why-unclaimed` as "nothing is
+wrong".
+
 ## Requirements: capabilities versus hardware
 
 Capabilities are set membership over a DECLARED vocabulary — agents advertise


### PR DESCRIPTION
Docs only. No behaviour change — this records decisions and lessons so the
implementation work can be reviewed against something.

## ADR 0017 — token spend is metered at the router

MAC keeps model usage as one `llm.route` event with token counts inside
`observability_events.detail`, a **`text`** column. Seven days to 2026-08-19,
28,352 routes:

| | |
| --- | --- |
| input / output tokens recorded | 481.8M / 5.05M |
| streaming routes | 18,222 (64%) |
| `input_tokens = null` | **8,352 (29.5%)** — books as $0 |
| routes reporting cached tokens | **0** |
| attributed to `agent` / `task` / nothing | 17,541 / 8,333 / **2,474** |

The cause is a single policy choice. `router_app.py` captures streamed usage
only when the client asked for it — its own comment says *"the client asked for
include_usage"* — and MAC injects `stream_options.include_usage` in exactly one
place, `responses_adapter.py:145`. Any coding agent that streams without
requesting usage is unmeterable.

Not a provider limitation: `NVIDIA-dev/horde-claw-fleet` reproduced streaming
against the same `inference-api.nvidia.com` endpoint MAC routes through and
captured a full `usage` object, cache counters included, whenever
`stream_options.include_usage` was set.

The ADR **adopts their model rather than deriving one**: a `source`
discriminator over a nullable subject, cost stored at write time (read-time
pricing silently re-prices last month's bill), and the daily budget shape from
`fleet-model/src/budget.rs`. Their ADR-0053 also records a `SUM()`-vs-`MAX()`
bug on cumulative snapshot rows — worth stating in a comment and a test before
we grow the same trap.

**Consequence worth flagging:** when the implementation lands, reported cost
will rise sharply. That is the correction, not a regression.

## SKILL.md — four things that cost time today

- **Priority sorts DESCENDING. P0 is 100.** `--priority 0` sends a task to the
  back of the queue. There is already a `P0:`-titled task sitting at 0.
- **Check for an existing PR before working a task.** A retried task opens a
  new PR rather than updating the existing one — 23 open PRs covered 12 pieces
  of work; one task produced five divergent implementations from two agents.
- **`mac agent show <name>` fails for agents `mac agent list` displays**, and
  virtual agents flap between idle/degraded/offline with no worker to heartbeat.
- **`why-unclaimed` can name no gate at all**, which reads as "nothing is wrong".

## CONTRIBUTING.md — features need an ADR first

With the emphasis on recording *rejected* alternatives, which is the part that
keeps an idea from being relitigated or quietly reintroduced.

## Follow-up tasks filed

| Task | |
| --- | --- |
| `task_45927341` | Meter at the router (ADR 0017) — P0 |
| `task_e13a133d` | Daily budget that can refuse work (ADR 0017 s4) |
| `task_f1733885` | hub-reviewer identity + health flapping |

Generated artifacts (`documentation-inventory.md`, `archive/index.md`)
regenerated via `scripts/generate-docs-reference.py --write`; the diff is one
line each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)