### PR TITLE
Add the ACL evaluator: resource paths, permissions, inheritance

### DIFF
--- a/src/mac/acl.py
+++ b/src/mac/acl.py
@@ -1,0 +1,311 @@
+"""Access control as ACEs on a resource tree (ADR 0019).
+
+The model this replaces was nine flat scopes matched by a 204-line ordered
+if/elif chain, with two invisible implicit grants (``admin`` implied
+everything; ``write`` silently also granted ``roles`` and ``workflow``) and no
+resource binding at all -- ``_assert_task_actor`` accepted a ``task_id`` and
+never read it. Least privilege was therefore inexpressible: the narrowest
+useful credential was a whole fleet worker token, which is why a sandboxed
+executor was given none and could not file a child of its own task.
+
+Here, authority is a set of (resource path, permission) grants that inherit
+down a tree, as filesystem ACLs do. The properties that matter are all
+negative ones -- what this refuses, and refusing predictably:
+
+* deny by default: a path with no matching entry is refused;
+* longest path wins, deterministically, NOT by evaluation order;
+* an explicit deny beats an allow at the same or any shorter path;
+* no permission implies another, ever.
+
+This module is pure decision logic. It performs no I/O and knows nothing about
+routes; wiring it to the API is a separate change, so this can be tested
+adversarially on its own (ADR 0019 acceptance record).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+__all__ = [
+    "Permission",
+    "PERMISSIONS",
+    "AccessControlEntry",
+    "Grant",
+    "AclError",
+    "fleet_path",
+    "project_path",
+    "task_path",
+    "task_evidence_path",
+    "agent_path",
+    "machine_path",
+    "secret_path",
+    "workflow_path",
+    "normalize_path",
+    "ancestors",
+    "AclEvaluator",
+]
+
+
+class AclError(ValueError):
+    """Malformed resource path, permission, or entry."""
+
+
+# --- permissions -----------------------------------------------------------
+#
+# Listed weakest-first for human reading ONLY. The order carries no semantics:
+# holding `write` does not confer `control`, and holding `grant` does not
+# confer `read`. Implicit implication is precisely what let the old `write`
+# scope silently mean three domains, and it is not reintroduced here under a
+# new spelling. A principal that needs several permissions is granted several,
+# visibly, where a reviewer can see them.
+
+class Permission:
+    READ = "read"        # observe the resource
+    APPEND = "append"    # add to it without altering what is there
+    CREATE = "create"    # create children beneath it
+    WRITE = "write"      # modify or delete the resource itself
+    CONTROL = "control"  # lifecycle: claim, heartbeat, lease, transition
+    GRANT = "grant"      # change the ACL
+
+
+PERMISSIONS: FrozenSet[str] = frozenset(
+    {
+        Permission.READ,
+        Permission.APPEND,
+        Permission.CREATE,
+        Permission.WRITE,
+        Permission.CONTROL,
+        Permission.GRANT,
+    }
+)
+
+
+# --- resource paths --------------------------------------------------------
+#
+# One function per resource kind, and exactly one canonical path per object.
+# Two places that both compute paths is how a scheme like this drifts into
+# disagreeing with itself, so callers must come through here.
+
+FLEET = "/fleet"
+
+
+def normalize_path(path: str) -> str:
+    """Canonical form: leading slash, no trailing slash, no empty segments."""
+
+    if not isinstance(path, str) or not path.strip():
+        raise AclError("resource path must be a non-empty string")
+    parts = [p for p in path.strip().split("/") if p]
+    if not parts:
+        raise AclError("resource path must not be empty")
+    return "/" + "/".join(parts)
+
+
+def fleet_path() -> str:
+    return FLEET
+
+
+def _segment(kind: str, value: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AclError("%s identifier must be a non-empty string" % kind)
+    if "/" in value:
+        raise AclError("%s identifier must not contain '/': %r" % (kind, value))
+    return value.strip()
+
+
+def project_path(project: str) -> str:
+    return "%s/project/%s" % (FLEET, _segment("project", project))
+
+
+def task_path(project: str, task_id: str) -> str:
+    return "%s/task/%s" % (project_path(project), _segment("task", task_id))
+
+
+def task_evidence_path(project: str, task_id: str) -> str:
+    return "%s/evidence" % task_path(project, task_id)
+
+
+def agent_path(agent_id: str) -> str:
+    return "%s/agent/%s" % (FLEET, _segment("agent", agent_id))
+
+
+def machine_path(machine_id: str) -> str:
+    return "%s/machine/%s" % (FLEET, _segment("machine", machine_id))
+
+
+def secret_path(name: str) -> str:
+    return "%s/secret/%s" % (FLEET, _segment("secret", name))
+
+
+def workflow_path(workflow_id: str) -> str:
+    return "%s/workflow/%s" % (FLEET, _segment("workflow", workflow_id))
+
+
+def ancestors(path: str) -> List[str]:
+    """``path`` and every ancestor, longest first.
+
+    Longest-first is the evaluation order, and it is derived from the path
+    rather than from the order entries were written or loaded. That is the
+    whole point: the model it replaces resolved ties by position in an if/elif
+    chain, where a broad early prefix shadowed a narrow later one and nothing
+    detected it.
+    """
+
+    canonical = normalize_path(path)
+    parts = canonical.strip("/").split("/")
+    out = []
+    for i in range(len(parts), 0, -1):
+        out.append("/" + "/".join(parts[:i]))
+    return out
+
+
+# --- entries ---------------------------------------------------------------
+
+@dataclass(frozen=True)
+class AccessControlEntry:
+    """One (principal, resource, permission, allow|deny) statement.
+
+    ``principal`` is a principal id or a role id; the evaluator resolves role
+    membership before matching, so a role is simply a principal that other
+    principals inherit from -- users and groups, as on a filesystem.
+    """
+
+    principal: str
+    resource: str
+    permission: str
+    allow: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.principal or not isinstance(self.principal, str):
+            raise AclError("entry requires a principal")
+        if self.permission not in PERMISSIONS:
+            raise AclError(
+                "unknown permission %r (known: %s)"
+                % (self.permission, ", ".join(sorted(PERMISSIONS)))
+            )
+        object.__setattr__(self, "resource", normalize_path(self.resource))
+
+
+@dataclass(frozen=True)
+class Grant:
+    """Why a decision came out the way it did.
+
+    ``inherited_from`` is the path the deciding entry was written at, which is
+    the ancestor of the requested resource when the grant was inherited. ADR
+    0019 requires this: inheritance makes a high grant powerful and easy to
+    make carelessly, so "you may do this, because of an entry at /fleet" has to
+    be answerable without reading storage by hand.
+    """
+
+    allowed: bool
+    permission: str
+    resource: str
+    inherited_from: Optional[str] = None
+    via_role: Optional[str] = None
+    reason: str = ""
+
+    @property
+    def inherited(self) -> bool:
+        return bool(self.inherited_from) and self.inherited_from != self.resource
+
+
+class AclEvaluator:
+    """Decides (principal, resource, permission) against a set of entries."""
+
+    def __init__(
+        self,
+        entries: Iterable[AccessControlEntry],
+        roles: Optional[Mapping[str, Sequence[str]]] = None,
+    ) -> None:
+        self._entries: Tuple[AccessControlEntry, ...] = tuple(entries)
+        self._roles: Dict[str, Tuple[str, ...]] = {
+            str(k): tuple(str(v) for v in vals) for k, vals in (roles or {}).items()
+        }
+
+    # -- principal expansion ------------------------------------------------
+
+    def _principals_for(self, principal: str) -> List[str]:
+        """``principal`` plus its roles, transitively, without cycling."""
+
+        seen: List[str] = []
+        stack = [str(principal)]
+        while stack:
+            current = stack.pop()
+            if current in seen:
+                continue
+            seen.append(current)
+            stack.extend(self._roles.get(current, ()))
+        return seen
+
+    # -- decision -----------------------------------------------------------
+
+    def check(self, principal: str, resource: str, permission: str) -> Grant:
+        if permission not in PERMISSIONS:
+            raise AclError("unknown permission %r" % permission)
+        target = normalize_path(resource)
+        holders = self._principals_for(principal)
+
+        # Longest path first. The first path with ANY matching entry decides,
+        # and within that path a deny beats an allow. Nothing below this loop
+        # depends on the order entries were supplied.
+        for path in ancestors(target):
+            matches = [
+                e
+                for e in self._entries
+                if e.permission == permission
+                and e.resource == path
+                and e.principal in holders
+            ]
+            if not matches:
+                continue
+            denial = next((m for m in matches if not m.allow), None)
+            decided = denial or matches[0]
+            return Grant(
+                allowed=decided.allow,
+                permission=permission,
+                resource=target,
+                inherited_from=path,
+                via_role=(
+                    decided.principal if decided.principal != principal else None
+                ),
+                reason=(
+                    "explicit deny at %s" % path
+                    if denial is not None
+                    else "allowed by entry at %s" % path
+                ),
+            )
+
+        # Deny by default. An unmapped resource is refused, not defaulted to
+        # some ambient scope.
+        return Grant(
+            allowed=False,
+            permission=permission,
+            resource=target,
+            inherited_from=None,
+            reason="no matching entry (deny by default)",
+        )
+
+    def allows(self, principal: str, resource: str, permission: str) -> bool:
+        return self.check(principal, resource, permission).allowed
+
+    # -- required tooling (ADR 0019 makes these part of the mechanism) ------
+
+    def effective_permissions(self, principal: str, resource: str) -> Dict[str, Grant]:
+        """Every permission on one resource, each with its provenance."""
+
+        return {p: self.check(principal, resource, p) for p in sorted(PERMISSIONS)}
+
+    def who_can_reach(self, resource: str, permission: str) -> List[str]:
+        """Principals allowed ``permission`` on ``resource``.
+
+        Role members are expanded, so this answers "who can actually do this",
+        not "which entries mention it" -- the question an operator is really
+        asking, and the one an entry listing answers misleadingly.
+        """
+
+        candidates = {e.principal for e in self._entries}
+        for role, members in self._roles.items():
+            candidates.add(role)
+            candidates.update(members)
+        # A principal reaches a resource through its roles, so ask about every
+        # known principal rather than only those named on a matching entry.
+        return sorted(p for p in candidates if self.allows(p, resource, permission))

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1,0 +1,260 @@
+"""ACL evaluator (ADR 0019), tested from the refusal side.
+
+A suite that proves permitted operations succeed cannot detect fail-open, and
+fail-open is the entire risk this model carries. So most of these assert that
+something is REFUSED.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mac.acl import (
+    AccessControlEntry as ACE,
+    AclError,
+    AclEvaluator,
+    PERMISSIONS,
+    Permission,
+    ancestors,
+    normalize_path,
+    project_path,
+    secret_path,
+    task_path,
+)
+
+TASK_A = task_path("mac", "task_aaa")
+TASK_B = task_path("mac", "task_bbb")
+PROJECT = project_path("mac")
+FLEET = "/fleet"
+
+SANDBOX = "principal_sandbox_task_aaa"
+
+
+def sandbox_evaluator():
+    """The ADR's motivating credential, verbatim."""
+    return AclEvaluator(
+        [
+            ACE(SANDBOX, TASK_A, Permission.READ),
+            ACE(SANDBOX, TASK_A, Permission.APPEND),
+            ACE(SANDBOX, TASK_A, Permission.CREATE),
+        ]
+    )
+
+
+# --- deny by default -------------------------------------------------------
+
+def test_a_resource_with_no_entry_is_refused():
+    acl = AclEvaluator([])
+    grant = acl.check("nobody", TASK_A, Permission.READ)
+    assert grant.allowed is False
+    assert "deny by default" in grant.reason
+
+
+def test_an_unknown_principal_is_refused_even_where_others_are_allowed():
+    acl = sandbox_evaluator()
+    assert acl.allows("someone_else", TASK_A, Permission.READ) is False
+
+
+# --- the motivating case: what the sandbox may and may not do --------------
+
+def test_the_sandbox_may_work_its_own_task():
+    acl = sandbox_evaluator()
+    for perm in (Permission.READ, Permission.APPEND, Permission.CREATE):
+        assert acl.allows(SANDBOX, TASK_A, perm) is True
+
+
+def test_the_sandbox_cannot_touch_another_task():
+    """The probe that matters: a valid narrow credential exceeding itself."""
+    acl = sandbox_evaluator()
+    for perm in sorted(PERMISSIONS):
+        assert acl.allows(SANDBOX, TASK_B, perm) is False
+
+
+def test_the_sandbox_cannot_control_even_its_own_task():
+    """No heartbeat, no claim, no transition -- the rationale for withholding
+    hub credentials in the first place."""
+    acl = sandbox_evaluator()
+    assert acl.allows(SANDBOX, TASK_A, Permission.CONTROL) is False
+
+
+def test_the_sandbox_cannot_read_a_secret_or_reach_the_fleet_root():
+    acl = sandbox_evaluator()
+    assert acl.allows(SANDBOX, secret_path("ANTHROPIC_API_KEY"), Permission.READ) is False
+    assert acl.allows(SANDBOX, FLEET, Permission.READ) is False
+
+
+def test_the_sandbox_cannot_widen_its_own_grants():
+    acl = sandbox_evaluator()
+    assert acl.allows(SANDBOX, TASK_A, Permission.GRANT) is False
+
+
+# --- no permission implies another ----------------------------------------
+
+def test_no_permission_implies_any_other():
+    """The defect that made the old `write` scope mean three domains."""
+    for held in sorted(PERMISSIONS):
+        acl = AclEvaluator([ACE("p", TASK_A, held)])
+        for other in sorted(PERMISSIONS):
+            expected = held == other
+            assert acl.allows("p", TASK_A, other) is expected, (
+                "holding %s must not confer %s" % (held, other)
+            )
+
+
+# --- inheritance -----------------------------------------------------------
+
+def test_a_project_grant_reaches_tasks_created_later():
+    """The property that makes this usable at 6,849-task scale."""
+    acl = AclEvaluator([ACE("worker", PROJECT, Permission.READ)])
+    assert acl.allows("worker", task_path("mac", "task_created_tomorrow"), Permission.READ)
+
+
+def test_inheritance_is_reported_with_its_source():
+    acl = AclEvaluator([ACE("worker", PROJECT, Permission.READ)])
+    grant = acl.check("worker", TASK_A, Permission.READ)
+    assert grant.allowed is True
+    assert grant.inherited is True
+    assert grant.inherited_from == PROJECT
+
+
+def test_a_grant_does_not_leak_upward():
+    """Authority on a task says nothing about the project containing it."""
+    acl = AclEvaluator([ACE("p", TASK_A, Permission.WRITE)])
+    assert acl.allows("p", PROJECT, Permission.WRITE) is False
+    assert acl.allows("p", FLEET, Permission.WRITE) is False
+
+
+# --- longest path wins, deterministically ---------------------------------
+
+def test_explicit_deny_carves_one_task_out_of_a_project_grant():
+    acl = AclEvaluator(
+        [
+            ACE("worker", PROJECT, Permission.READ),
+            ACE("worker", TASK_B, Permission.READ, allow=False),
+        ]
+    )
+    assert acl.allows("worker", TASK_A, Permission.READ) is True
+    assert acl.allows("worker", TASK_B, Permission.READ) is False
+
+
+def test_a_deeper_allow_overrides_a_shallower_deny():
+    acl = AclEvaluator(
+        [
+            ACE("worker", PROJECT, Permission.READ, allow=False),
+            ACE("worker", TASK_A, Permission.READ),
+        ]
+    )
+    assert acl.allows("worker", TASK_A, Permission.READ) is True
+    assert acl.allows("worker", TASK_B, Permission.READ) is False
+
+
+def test_deny_beats_allow_at_the_same_path():
+    acl = AclEvaluator(
+        [
+            ACE("worker", TASK_A, Permission.READ),
+            ACE("worker", TASK_A, Permission.READ, allow=False),
+        ]
+    )
+    assert acl.allows("worker", TASK_A, Permission.READ) is False
+
+
+@pytest.mark.parametrize("rotation", range(4))
+def test_the_decision_does_not_depend_on_entry_order(rotation):
+    """The specific failure of the model this replaces.
+
+    `_required_scope` was an ordered if/elif chain where a broad early prefix
+    shadowed a narrow later one by accident of position. Shuffle the entries;
+    the answer must not move.
+    """
+    entries = [
+        ACE("worker", FLEET, Permission.READ),
+        ACE("worker", PROJECT, Permission.READ, allow=False),
+        ACE("worker", TASK_A, Permission.READ),
+        ACE("worker", TASK_B, Permission.READ, allow=False),
+    ]
+    rotated = entries[rotation:] + entries[:rotation]
+    acl = AclEvaluator(rotated)
+    assert acl.allows("worker", TASK_A, Permission.READ) is True
+    assert acl.allows("worker", TASK_B, Permission.READ) is False
+    assert acl.allows("worker", PROJECT, Permission.READ) is False
+    assert acl.allows("worker", FLEET, Permission.READ) is True
+
+
+# --- roles are groups ------------------------------------------------------
+
+def test_a_principal_inherits_through_a_role():
+    acl = AclEvaluator(
+        [ACE("role_reviewers", PROJECT, Permission.READ)],
+        roles={"alice": ["role_reviewers"]},
+    )
+    grant = acl.check("alice", TASK_A, Permission.READ)
+    assert grant.allowed is True
+    assert grant.via_role == "role_reviewers"
+
+
+def test_role_membership_is_transitive_and_terminates_on_a_cycle():
+    acl = AclEvaluator(
+        [ACE("role_root", FLEET, Permission.GRANT)],
+        roles={"a": ["b"], "b": ["role_root", "a"]},  # deliberate cycle
+    )
+    assert acl.allows("a", FLEET, Permission.GRANT) is True
+
+
+def test_admin_is_not_magic_it_is_grant_at_the_fleet_root():
+    """`admin` no longer short-circuits every check."""
+    acl = AclEvaluator([ACE("operator", FLEET, Permission.GRANT)])
+    assert acl.allows("operator", TASK_A, Permission.GRANT) is True
+    # ...and it confers nothing else, because no permission implies another.
+    assert acl.allows("operator", TASK_A, Permission.WRITE) is False
+
+
+# --- paths -----------------------------------------------------------------
+
+def test_paths_are_canonical_regardless_of_spelling():
+    assert normalize_path("/fleet/project/mac/") == "/fleet/project/mac"
+    assert normalize_path("fleet//project///mac") == "/fleet/project/mac"
+
+
+def test_ancestors_are_longest_first():
+    assert ancestors(TASK_A)[0] == TASK_A
+    assert ancestors(TASK_A)[-1] == FLEET
+
+
+def test_a_sibling_prefix_is_not_an_ancestor():
+    """String-prefix matching would make /fleet/project/mac-dev inherit from
+    /fleet/project/mac. Segment matching must not."""
+    acl = AclEvaluator([ACE("p", project_path("mac"), Permission.READ)])
+    assert acl.allows("p", task_path("mac-dev", "task_x"), Permission.READ) is False
+
+
+def test_identifiers_containing_a_slash_are_rejected():
+    with pytest.raises(AclError):
+        task_path("mac", "task_a/../../fleet")
+
+
+def test_an_unknown_permission_is_an_error_not_a_denial():
+    """Silently returning False would let a typo read as a policy decision."""
+    acl = sandbox_evaluator()
+    with pytest.raises(AclError):
+        acl.check(SANDBOX, TASK_A, "delete_everything")
+    with pytest.raises(AclError):
+        ACE("p", TASK_A, "sudo")
+
+
+# --- tooling ---------------------------------------------------------------
+
+def test_effective_permissions_answers_what_can_this_principal_do():
+    acl = sandbox_evaluator()
+    eff = acl.effective_permissions(SANDBOX, TASK_A)
+    assert {p for p, g in eff.items() if g.allowed} == {"read", "append", "create"}
+
+
+def test_who_can_reach_expands_roles():
+    acl = AclEvaluator(
+        [ACE("role_reviewers", PROJECT, Permission.READ)],
+        roles={"alice": ["role_reviewers"], "bob": ["role_reviewers"]},
+    )
+    assert acl.who_can_reach(TASK_A, Permission.READ) == [
+        "alice",
+        "bob",
+        "role_reviewers",
+    ]


### PR DESCRIPTION
First step of **ADR 0019** (accepted, immediate adoption). Decision logic only
— no I/O, no route wiring, **no behaviour change**. The ADR scopes it this way
so the mechanism can be attacked on its own before anything depends on it.

Implements `task_f33a2da7`.

## What it replaces

| Old | New |
| --- | --- |
| 9 flat scopes, 204-line ordered `if/elif`, 33 branches | `(resource path, permission)` grants on a tree |
| `admin` implies everything; `write` silently also grants `roles` + `workflow` | **no permission implies another, ever** |
| No resource binding at all (`_assert_task_actor` ignores its `task_id`) | Paths: `/fleet/project/<name>/task/<id>/evidence` |
| Overlaps resolved by position in the chain | **Longest path wins**, computed from the path |

## The four properties, all negative

- **Deny by default** — no matching entry is a refusal, not a fallback to an ambient scope
- **Longest path wins**, deterministically — order-independent, unlike the chain it replaces
- **Explicit deny** beats an allow at the same or any shorter path, so one task can be carved out of a project grant
- **No implication** — holding `write` confers nothing else. That's the defect that made `write` mean three domains

`admin` stops being magic: it's `grant` at `/fleet`, and confers nothing else.
Roles are groups; cycles terminate.

Provenance is part of the mechanism rather than later tooling — inheritance
makes a high grant easy to make carelessly, so every decision reports the path
it was inherited from and the role it came through.
`effective_permissions` / `who_can_reach` answer the two questions the ADR
audit had to answer by reading control flow.

## The motivating case, as an ordinary entry

```python
ACE(sandbox, "/fleet/project/mac/task/<id>", "read")
ACE(sandbox, "/fleet/project/mac/task/<id>", "append")
ACE(sandbox, "/fleet/project/mac/task/<id>", "create")
```

Tested: it works its own task, and is refused on another task, on `control` of
its own task, on any secret, on `/fleet`, and on widening itself.

## Verification

28 tests, **written from the refusal side** — a suite proving permitted
operations succeed cannot detect fail-open, and fail-open is the whole risk.

Proven by mutation:

| Mutation | Result |
| --- | --- |
| deny-by-default → allow-by-default | **11 tests fail** |
| explicit deny no longer wins | **1 test fails** |

Also covered: a sibling prefix (`mac-dev`) must not inherit from `mac` —
string-prefix matching would get that wrong; path traversal in identifiers is
rejected; an unknown permission raises rather than silently returning `False`,
since a typo reading as a policy decision is its own fail-open.

## Not in this change

Route migration (`task_724567cc`), the task-scoped credential
(`task_4d756013`), and the adversarial post-deploy suite (`task_c4ddff27`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)