### PR TITLE
Stop the README describing a runtime that was deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,19 @@ vacuum. It has learned from, interoperates with, or substantially relies on the
 following projects. The relationship is stated explicitly so that an
 integration or protocol influence is not mistaken for copied source:
 
-- **[Hermes Agent](https://github.com/NousResearch/hermes-agent) — vendored
-  runtime:** `src/mac/_hermes` is a pruned, MAC-modified snapshot of Hermes
-  Agent 0.15.1 at
-  [`b1a25404b`](https://github.com/NousResearch/hermes-agent/commit/b1a25404b638bfbd79ce4d08b49afc0ee1361528).
-  It supplies the agent loop, gateways, tools, plugins, and skills. See
-  [ADR 0001](docs/adr/0001-unify-hermes-runtime-into-mac.md) and the
-  [snapshot contract](deploy/hermes/SNAPSHOT.md).
+- **[Hermes Agent](https://github.com/NousResearch/hermes-agent) — former
+  vendored runtime, removed:** `src/mac/_hermes` held a pruned, MAC-modified
+  snapshot of Hermes Agent 0.15.1 at
+  [`b1a25404b`](https://github.com/NousResearch/hermes-agent/commit/b1a25404b638bfbd79ce4d08b49afc0ee1361528),
+  supplying the agent loop, gateways, tools, plugins, and skills. That tree and
+  its `deploy/hermes/` snapshot contract were deleted in `3ebde2dd`
+  (2026-08-16); no vendored Hermes source remains in this repository. The entry
+  stays because this section records what was once copied in, not only what is
+  copied in today — see
+  [ADR 0001](docs/adr/0001-unify-hermes-runtime-into-mac.md) for why it was
+  vendored and [the retirement premises](docs/hermes-retirement-premises.md) for
+  what the removal was argued on. MAC's own `mac-hermes` adapter is unaffected:
+  it is clean-room MAC code, not part of the snapshot.
 - **[NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) — execution
   security foundation:** MAC's agent process trees, filesystem/network policy,
   sandbox lifecycle, and normalized action-event collection integrate with
@@ -82,9 +88,8 @@ integration or protocol influence is not mistaken for copied source:
 
 This is a direct-lineage and architectural acknowledgement, not an exhaustive
 transitive dependency list. Python and Node dependencies remain documented in
-their manifests and lockfiles; additional skill- and plugin-level notices are
-kept with the vendored Hermes files that require them. Each upstream project
-remains subject to its own license.
+their manifests and lockfiles. Each upstream project remains subject to its own
+license.
 
 ## Core Contracts
 
@@ -192,8 +197,7 @@ make run-gui
 ```
 
 `make test` runs the complete hermetic pytest suite with statement, branch, and
-Python-subprocess coverage for MAC-owned `src/mac` code. Vendored Hermes
-internals under `src/mac/_hermes` are excluded. Coverage is a regression safety
+Python-subprocess coverage for `src/mac`. Coverage is a regression safety
 floor rather than a target for generating tests; see
 [the test portfolio strategy](docs/testing-strategy.md). Use `make coverage`
 for the same full-suite report, `make test-portfolio` to audit redundant
@@ -214,9 +218,7 @@ The enforced lint set starts at the always-green correctness floor (pyflakes
 logic errors and undefined names, plus syntax errors) so `make lint` is red only
 for a real regression; widen `[tool.ruff.lint].select` as the codebase is
 cleaned up. Ruff is a dev-only tool pinned in the `dev` extra and fetched on
-demand with `uv run --with ruff`; it is not a runtime dependency. The vendored
-Hermes runtime under `src/mac/_hermes` keeps its own upstream lint discipline
-and is excluded.
+demand with `uv run --with ruff`; it is not a runtime dependency.
 
 The common lifecycle is deliberately conventional:
 


### PR DESCRIPTION
`src/mac/_hermes` and `deploy/hermes/` were removed in `3ebde2dd` (2026-08-16) — 1,282 files, ~583k lines. The README kept describing both as present.

Four false claims, in the file most readers start from:

| Where | Claim | Reality |
|---|---|---|
| Lineage | "`src/mac/_hermes` **is** a pruned, MAC-modified snapshot… It **supplies** the agent loop, gateways, tools, plugins, and skills" | Directory does not exist |
| Lineage | Links `[snapshot contract](deploy/hermes/SNAPSHOT.md)` | Broken link; removed in the same commit |
| Testing | "Vendored Hermes internals under `src/mac/_hermes` are excluded" from coverage | Nothing in `pyproject.toml`, `setup.cfg` or the `Makefile` references `_hermes` |
| Linting | "The vendored Hermes runtime under `src/mac/_hermes` keeps its own upstream lint discipline and is excluded" | Same |

## What changed

The lineage entry moves to the past tense and names the removing commit. It is **not** deleted — that section exists to record what was once copied in, *"so that an integration or protocol influence is not mistaken for copied source"*, and someone auditing provenance needs to know a vendored snapshot was here and when it left. The broken link is replaced with ADR 0001 (why it was vendored) and `docs/hermes-retirement-premises.md` (what the removal was argued on); both files exist.

The coverage and lint paragraphs lose their exclusion sentences, which described configuration that is also gone.

## What deliberately did not change

- **`mac-hermes` stays.** It is still a real console script backed by `src/mac/hermes_adapter.py`. The Core Contracts entry is correct, and the lineage entry now says so explicitly, so nobody reads this and deletes the adapter as dead Hermes code.
- **"Boundary With Hermes" stays.** It is a design boundary, not a claim about a vendored tree. `docs/hermes-retirement-premises.md` records that both premises for retiring Hermes *"neither holds as stated"*, so rewriting it would assert something the repository does not.

## Why the existing gate missed this

`tests/test_guide_docs_are_true.py` was written for exactly this bug class — its docstring cites the README describing a vendored xterm tree after deletion. It does not cover this case, for two independent reasons:

1. Its `PAGES` are `docs/guide/*.md` plus `CONTRIBUTING.md`. The root `README.md` is not among them.
2. Adding it would not have helped. The file-existence check matches backticked paths ending in a code-file extension; `src/mac/_hermes` has no extension, and `deploy/hermes/SNAPSHOT.md` appeared as a markdown link rather than in backticks.

Verified empirically against the pre-fix README: the gate's regex matches exactly two paths in it, `observe/tests/readonly.test.ts` and `tests/test_guide_docs_are_true.py`, **both of which exist**. The stale prose would have sailed through.

Closing that hole means changing the gate's matching rules — extension-less directory paths, and markdown link targets — which is a real change with false-positive risk. **Left as follow-up rather than smuggled into a docs fix.** Happy to do it as a separate PR if you want it.

## Verification

- No `_hermes` or `deploy/hermes` reference remains except the new past-tense prose describing the removal.
- Both newly linked docs exist; `3ebde2dd` is an ancestor of `HEAD`.
- Every other lineage entry re-checked for the same defect: `src/mac/firecrawl_gateway.py`, `docs/openclaw-identities.md` and `docs/superpowers` all exist. The xterm.js entry that motivated the original gate is already gone from the README.

Independent of #496; both branch from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
