### PR TITLE
Give the ACL update/stop/start, and make task update atomic

### DIFF
--- a/docs/adr/0019-privilege-is-an-acl-on-a-resource-tree.md
+++ b/docs/adr/0019-privilege-is-an-acl-on-a-resource-tree.md
@@ -91,13 +91,23 @@ becomes *(resource path, permission)* — data, not a branch in a chain.
     append    add to it without altering what is there (evidence, annotations,
               comments) — the operation an executor needs
     create    create children beneath it
-    write     modify or delete the resource itself
+    update    modify the resource's own fields
+    write     replace or DELETE the resource itself
+    stop      abort in-flight work and park the resource
+    start     return a stopped resource to the queue
     control   lifecycle: claim, heartbeat, lease, transition
     grant     change the ACL
 
 Ordered by strength but NOT implicitly implied: a grant of `write` does not
 confer `control`. Implicit implication is exactly what made `write` mean three
 things. Where a role needs several, it is granted several, visibly.
+
+`update` is split out of `write`, and `stop`/`start` out of `control`, because
+the common operator case — correcting a task's scope (ADR 0020) — should carry
+neither the destructive nor the lifecycle ones. Someone fixing a bad task
+description should not thereby be able to delete the task, nor to claim work
+and impersonate a worker's lifecycle. `control` is what an EXECUTOR needs;
+`stop`/`start` are what an OPERATOR needs.
 
 ### 3. Principals are users; roles are groups
 

--- a/docs/adr/0020-a-running-task-is-not-editable.md
+++ b/docs/adr/0020-a-running-task-is-not-editable.md
@@ -61,15 +61,25 @@ an edit cycle without mislabelling the task.
 
 ## Decision
 
-### 1. Editing a RUNNING task is refused
+### 1. `update` is atomic at the task layer
 
-`update_task` refuses to modify a task in RUNNING (and CLAIMED, which has the
-same split-brain exposure: an agent holds the lease and is about to read the
-task). The refusal names the verb to use instead. This is enforced in the
-service layer, not the CLI, so hub-mode callers cannot bypass it.
+A RUNNING task is never modified in place. But rather than refusing the edit
+and making the caller compose stop -> modify -> start, `update_task` performs
+that cycle ITSELF, as one operation, when the task is RUNNING or CLAIMED.
 
-Refusing is the point. The current behaviour is not "flexible"; it silently
-produces two versions of the truth.
+The caller asks for an update and gets an update. Underneath, the hub aborts
+the executor, revokes the lease, applies the change, and restarts the task —
+atomically, so no intermediate state is observable and no caller can get the
+sequence wrong or abandon it half-done. An earlier draft of this ADR required
+the three steps not to be separately observable; making the cycle a single
+lower-layer operation is what makes that structural rather than a rule callers
+must remember.
+
+An operator composing the cycle by hand is how a task ends up stopped and
+forgotten, or edited and never restarted. The atomic form has no such state.
+
+CLAIMED is included deliberately: the agent holds the lease and is about to
+read the task, so it has the same split-brain exposure as RUNNING.
 
 ### 2. A new state: STOPPED
 
@@ -81,25 +91,34 @@ meaning "someone must answer a question".
 
 It is explicitly **not** terminal. A stopped task is live work.
 
-### 3. `stop` is one atomic operation
+### 3. `stop` and `start` also exist standalone
 
     mac task stop <id> --reason ...
-
-Abort the running executor, revoke the lease, and transition to STOPPED, as
-one operation that either completes or leaves the task untouched. The three
-steps must not be separately observable: an agent that keeps running against a
-task the ledger has already re-labelled is the split brain this ADR exists to
-remove.
-
-### 4. Edit, then start
-
-While STOPPED the task is freely editable — that is the state's purpose. Then:
-
     mac task start <id>
 
-returns it to OPEN (or WAITING if its dependencies are unmet, evaluated at
-that moment rather than assumed). The next agent to claim it reads the edited
-task, because there is no longer an agent holding a stale copy.
+`update` covers the edit cycle, but stopping has standalone value: halting
+runaway work, freeing an agent, or pausing something to investigate it without
+changing anything. `stop` aborts the executor, revokes the lease and
+transitions to STOPPED as one operation that either completes or leaves the
+task untouched.
+
+These are separate ACL permissions from `update` (ADR 0019). Authorising
+someone to correct a task's description should not authorise them to halt the
+fleet's work, and `stop` should not imply `start` — a principal trusted to
+halt runaway work is not thereby trusted to release it back.
+
+### 4. A STOPPED task is freely editable, and `start` re-evaluates
+
+STOPPED is the one state in which editing is unrestricted — that is its
+purpose. A task stopped standalone can be edited by any number of `update`
+calls before being started; those calls take the ordinary path, because the
+task is not running and there is no executor to contradict.
+
+`start` returns it to OPEN, or to WAITING if its dependencies are unmet,
+**evaluated at that moment** rather than assumed. This matters because the
+edit may have added a dependency: a task edited into a blocked shape must come
+back as blocked, not as claimable. The next agent to claim it reads the edited
+task, because no agent is holding a stale copy.
 
 ### 5. Abort delivery is bounded and its outcome is definite
 
@@ -170,9 +189,12 @@ wrong thing, which is exactly the failure that prompted this ADR.
 - A task can be stopped and forgotten. STOPPED work is invisible to every
   sweeper by design, so it needs to be visible to a person: `mac task list`
   must show it prominently, and stopped-for-a-long-time is worth a report.
-- Under ADR 0019, `stop` and `start` are `control` on the task, and editing
-  while stopped is `write`. An agent's task-scoped credential carries neither,
-  so an agent cannot stop its own task to escape a gate.
+- Under ADR 0019 the permissions are `update`, `stop` and `start`, split out
+  of `write` and `control` precisely so this cycle can be granted without
+  destructive or lifecycle authority. An agent's task-scoped credential
+  (`read`, `append`, `create`) carries none of them, so an agent can neither
+  stop its own task to escape a gate nor rewrite the criteria it is being
+  judged against.
 - Re-entry from the top means a stopped-and-started task pays its evaluation
   cost again. That is the price of the edit being meaningful, and it is small
   next to an agent completing the wrong work confidently.
@@ -192,6 +214,14 @@ exactly what this produces.
 **Keep cancel-and-refile.** Rejected: it loses the task id, history, attempt
 count and evidence, and breaks every reference from other tasks and PR titles.
 Observed consequence: the edge simply never gets added.
+
+**Refuse the edit and make the caller compose stop -> modify -> start.**
+Rejected in favour of making `update` atomic at the task layer. Refusing is
+defensible and was this ADR's first draft, but it pushes atomicity onto every
+caller: a composed cycle can be abandoned between steps, leaving a task
+stopped and forgotten, and each caller must remember the right order. Putting
+the cycle below the API makes the guarantee structural. The standalone verbs
+remain for the cases that genuinely are just a stop or just a start.
 
 **Resume the restarted task where the previous attempt stopped.** Rejected:
 it preserves conclusions drawn from the pre-edit task, which moves the split

--- a/src/mac/acl.py
+++ b/src/mac/acl.py
@@ -63,9 +63,27 @@ class Permission:
     READ = "read"        # observe the resource
     APPEND = "append"    # add to it without altering what is there
     CREATE = "create"    # create children beneath it
-    WRITE = "write"      # modify or delete the resource itself
+    UPDATE = "update"    # modify the resource's own fields
+    WRITE = "write"      # replace or DELETE the resource itself
+    STOP = "stop"        # abort in-flight work and park the resource
+    START = "start"      # return a stopped resource to the queue
     CONTROL = "control"  # lifecycle: claim, heartbeat, lease, transition
     GRANT = "grant"      # change the ACL
+
+
+# `update` is split out of `write`, and `stop`/`start` out of `control`, so the
+# common cases can be granted without the destructive or lifecycle ones.
+#
+# Correcting a task's scope (ADR 0020) needs `update` and nothing else: the
+# holder may fix criteria, priority or dependencies, and still may not delete
+# the task. Likewise `stop` and `start` are the operator's edit cycle, whereas
+# `control` is what an EXECUTOR needs -- claim, heartbeat, lease, transition.
+# Folding them together would mean that letting someone correct a bad task
+# description also let them claim work and impersonate a worker's lifecycle.
+#
+# Because no permission implies another, each of these must be granted
+# explicitly. That is the point: a reviewer reading an ACE sees exactly what it
+# confers, which the old `write`-implies-`roles`-and-`workflow` bridge did not.
 
 
 PERMISSIONS: FrozenSet[str] = frozenset(
@@ -73,7 +91,10 @@ PERMISSIONS: FrozenSet[str] = frozenset(
         Permission.READ,
         Permission.APPEND,
         Permission.CREATE,
+        Permission.UPDATE,
         Permission.WRITE,
+        Permission.STOP,
+        Permission.START,
         Permission.CONTROL,
         Permission.GRANT,
     }

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -258,3 +258,62 @@ def test_who_can_reach_expands_roles():
         "bob",
         "role_reviewers",
     ]
+
+
+# --- update / stop / start (ADR 0020) -------------------------------------
+
+def test_update_does_not_confer_delete():
+    """`update` is split out of `write` so a principal can correct a task's
+    scope without being able to destroy it."""
+    acl = AclEvaluator([ACE("editor", TASK_A, Permission.UPDATE)])
+    assert acl.allows("editor", TASK_A, Permission.UPDATE) is True
+    assert acl.allows("editor", TASK_A, Permission.WRITE) is False
+
+
+def test_update_does_not_confer_stop_or_start():
+    """The atomic edit cycle is authorised by `update` alone; the STANDALONE
+    stop and start verbs are separate grants."""
+    acl = AclEvaluator([ACE("editor", TASK_A, Permission.UPDATE)])
+    assert acl.allows("editor", TASK_A, Permission.STOP) is False
+    assert acl.allows("editor", TASK_A, Permission.START) is False
+
+
+def test_stop_does_not_confer_start():
+    """Deliberate: a principal that may halt runaway work is not thereby
+    trusted to release it back into the fleet."""
+    acl = AclEvaluator([ACE("halter", TASK_A, Permission.STOP)])
+    assert acl.allows("halter", TASK_A, Permission.STOP) is True
+    assert acl.allows("halter", TASK_A, Permission.START) is False
+
+
+def test_stop_and_start_are_not_control():
+    """`control` is what an EXECUTOR needs -- claim, heartbeat, lease. Folding
+    the operator's edit cycle into it would mean letting someone halt a bad
+    task also let them claim work and impersonate a worker's lifecycle."""
+    acl = AclEvaluator([ACE("operator", TASK_A, Permission.STOP),
+                        ACE("operator", TASK_A, Permission.START)])
+    assert acl.allows("operator", TASK_A, Permission.CONTROL) is False
+
+
+def test_the_sandbox_credential_gains_none_of_them():
+    """ADR 0020: an agent must not be able to stop its own task to escape a
+    gate, nor rewrite the criteria it is being judged against."""
+    acl = sandbox_evaluator()
+    for perm in (Permission.UPDATE, Permission.STOP, Permission.START,
+                 Permission.CONTROL, Permission.WRITE, Permission.GRANT):
+        assert acl.allows(SANDBOX, TASK_A, perm) is False
+
+
+def test_an_operator_edit_grant_is_expressible_without_lifecycle_authority():
+    """The grant ADR 0020 actually wants for a human correcting scope."""
+    acl = AclEvaluator([
+        ACE("human_jkh", PROJECT, Permission.READ),
+        ACE("human_jkh", PROJECT, Permission.UPDATE),
+        ACE("human_jkh", PROJECT, Permission.STOP),
+        ACE("human_jkh", PROJECT, Permission.START),
+    ])
+    for perm in (Permission.READ, Permission.UPDATE, Permission.STOP, Permission.START):
+        assert acl.allows("human_jkh", TASK_A, perm) is True
+    # ...and still cannot delete a task or claim work as an agent.
+    assert acl.allows("human_jkh", TASK_A, Permission.WRITE) is False
+    assert acl.allows("human_jkh", TASK_A, Permission.CONTROL) is False


### PR DESCRIPTION
Two changes that belong together: the ACL vocabulary ADR 0020 needs, and the
decision to put the edit cycle *below* the API rather than on the caller.

## Why the permission set changed

ADR 0020 has to authorise correcting a task's scope. Under the set as it stood
that meant granting `write` — which also permits **deleting** the task — and
`control` — which also permits **claiming work and heartbeating as a worker**.
Neither is what someone fixing a bad description should hold.

```
read | append | create | update | write | stop | start | control | grant
```

`update` is split out of `write`; `stop`/`start` out of `control`.
**`control` is what an EXECUTOR needs** (claim, heartbeat, lease, transition);
**`stop`/`start` are what an OPERATOR needs.** Since no permission implies
another, each is granted explicitly and an ACE says exactly what it confers.

## `update` is now atomic at the task layer

This ADR's first draft refused edits to RUNNING tasks and left the caller to
compose stop → modify → start. Replaced: `update_task` performs that cycle
**itself** on a RUNNING or CLAIMED task — abort, revoke lease, apply, restart —
as one operation.

The draft *required* that the three steps not be separately observable. Putting
the cycle below the API is what makes that structural instead of a rule every
caller has to remember. A composed cycle can be abandoned between steps, which
is how a task ends up stopped-and-forgotten or edited-and-never-restarted.

`stop`/`start` remain standalone, because halting runaway work or freeing an
agent without changing anything is a real operation — and `stop` does **not**
imply `start`: a principal trusted to halt work isn't thereby trusted to
release it back.

CLAIMED is covered alongside RUNNING — the agent holds the lease and is about
to read the task, so it has the same split-brain exposure.

## Tests

34 in `test_acl.py` (28 existing + 6 new). The existing
`test_no_permission_implies_any_other` now covers all 9 automatically — it
iterates `PERMISSIONS`, so the new ones can't quietly acquire an implication.

New coverage asserts the separations are real:

| Test | |
| --- | --- |
| `test_update_does_not_confer_delete` | correct scope without being able to destroy |
| `test_stop_does_not_confer_start` | halting ≠ releasing |
| `test_stop_and_start_are_not_control` | operator ≠ executor |
| `test_the_sandbox_credential_gains_none_of_them` | **an agent cannot stop its own task to escape a gate, nor rewrite the criteria it's judged against** |

## Not in this change

The ADR 0020 implementation itself — `STOPPED` state, the `stop`/`start` verbs,
the atomic cycle in `update_task`, and re-entry-from-the-top. This lands the
vocabulary and the decision so that work has something to build against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)