### PR TITLE
Implement ADR 0020: STOPPED, atomic update, stop/start, re-entry

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -90,7 +90,7 @@ Finding work:
 
 Execution:
   claim    atomically claim a task for an agent
-  start    move a claimed task to RUNNING as its lease holder
+  start    with AGENT_ID: move a claimed task to RUNNING as its lease holder. Without: return a STOPPED task to the queue, re-entered from the top
   release  clear a --no-dispatch hold so the task can auto-dispatch
   close    transition a task to completed/cancelled; cancellation requires a reason
   reopen   recovery: return a stuck/terminal task (failed/cancelled/blocked) to OPEN for retry or reconciliation
@@ -136,6 +136,7 @@ Other:
   select      preview the group of tasks a selector expression names
   batch       apply one operation to every task a selector names (dry by default)
   group       named, saved task groups
+  stop        abort in-flight work and hold the task (STOPPED); pairs with `start`
   egress      declare which hosts a task's sandbox may reach
 
 Run `mac task help <subcommand>` for the arguments one takes.

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -3681,15 +3681,35 @@ def cmd_sandbox_rollout(args: argparse.Namespace) -> None:
     )
 
 
-def cmd_task_start(args: argparse.Namespace) -> None:
-    """Start a claimed task for an agent."""
+def cmd_task_stop(args: argparse.Namespace) -> None:
+    """Abort in-flight work and hold the task under an operator hold.
+
+    Not a cancellation. STOPPED is not terminal -- the work is still wanted --
+    so this does not file live work under CANCELLED, which on this hub already
+    holds thousands of tasks and is therefore useless as a measure of what was
+    genuinely abandoned.
+    """
     _print(
-        _plane(args).start_task(
+        _plane(args).stop_task(
             args.task_id,
-            args.agent_id,
-            lease_id=args.lease_id,
+            actor=args.actor,
+            reason=args.reason,
         )
     )
+
+
+def cmd_task_start(args: argparse.Namespace) -> None:
+    """Start a claimed task, or restart a stopped one.
+
+    Two operations under one verb, chosen by whether a lease holder is named.
+    They cannot be confused: a stopped task has no edge to RUNNING, and an
+    operator restart has no agent to name.
+    """
+    cp = _plane(args)
+    if args.agent_id:
+        _print(cp.start_task(args.task_id, args.agent_id, lease_id=args.lease_id))
+        return
+    _print(cp.start_stopped_task(args.task_id, actor=args.actor))
 
 
 def cmd_task_release(args: argparse.Namespace) -> None:
@@ -8429,12 +8449,30 @@ def build_parser() -> argparse.ArgumentParser:
     audit.add_argument("--limit", type=int, help="maximum tasks to audit (1-500)")
     _set(cmd_task_audit, audit)
 
+    stop = task.add_parser(
+        "stop",
+        help="abort in-flight work and hold the task (STOPPED); pairs with `start`",
+    )
+    stop.add_argument("task_id")
+    stop.add_argument("--reason", default="")
+    stop.add_argument("--actor", default="human")
+    _set(cmd_task_stop, stop)
+
     start = task.add_parser(
-        "start", help="move a claimed task to RUNNING as its lease holder"
+        "start",
+        help="with AGENT_ID: move a claimed task to RUNNING as its lease holder. "
+        "Without: return a STOPPED task to the queue, re-entered from the top",
     )
     start.add_argument("task_id")
-    start.add_argument("agent_id")
+    # Optional, and the two forms are different operations on purpose. With an
+    # agent this is the EXECUTOR's verb (claimed -> running, lease-fenced).
+    # Without, it is the OPERATOR's half of the stop/start cycle. They are
+    # never ambiguous: an operator restart has no lease holder to name, and a
+    # stopped task cannot go to RUNNING at all -- the state machine has no such
+    # edge, because re-entry is from the top.
+    start.add_argument("agent_id", nargs="?")
     start.add_argument("--lease-id")
+    start.add_argument("--actor", default="human")
     _set(cmd_task_start, start)
 
     release = task.add_parser(

--- a/src/mac/data/postgres/schema.sql
+++ b/src/mac/data/postgres/schema.sql
@@ -281,10 +281,15 @@ CREATE TABLE IF NOT EXISTS task_dependency_migrations (
 -- UPDATE OF state.
 CREATE OR REPLACE FUNCTION trg_tasks_state_enum() RETURNS trigger AS $$
 BEGIN
+    -- Kept in step with mac.models.TaskState BY HAND. The duplication is
+    -- deliberate (the DB must enforce the enum without importing Python) and
+    -- is a known drift hazard: adding a state to the enum without adding it
+    -- here fails at runtime with 'invalid task state', which reads as a bug in
+    -- the caller rather than a missing migration. 'stopped' is ADR 0020.
     IF NEW.state NOT IN (
         'open', 'waiting', 'blocked', 'claimed', 'running',
-        'needs_review', 'reviewing', 'needs_input', 'completed',
-        'failed', 'cancelled'
+        'needs_review', 'reviewing', 'needs_input', 'stopped',
+        'completed', 'failed', 'cancelled'
     ) THEN
         RAISE EXCEPTION 'invalid task state';
     END IF;

--- a/src/mac/models.py
+++ b/src/mac/models.py
@@ -115,6 +115,13 @@ class TaskState(StrEnum):
     RUNNING = "running"
     NEEDS_REVIEW = "needs_review"
     NEEDS_INPUT = "needs_input"
+    #: An operator is holding this task; nobody else may take it. Distinct from
+    #: NEEDS_INPUT (which means "a person must answer a question" and feeds the
+    #: operator inbox) so that inbox keeps meaning one thing. NOT terminal:
+    #: stopped work is live work. Excluded from dispatch for free -- the
+    #: allocator only considers OPEN tasks -- so nothing has to remember to
+    #: skip it.
+    STOPPED = "stopped"
     REVIEWING = "reviewing"
     COMPLETED = "completed"
     FAILED = "failed"
@@ -718,8 +725,23 @@ def normalize_needs_input_detail(detail: Optional[Mapping[str, Any]]) -> JsonDic
 
 
 TASK_TRANSITIONS = {
+    # An operator hold. It leaves only where an operator sends it: back to the
+    # queue (OPEN, or WAITING/BLOCKED when the edit left dependencies unmet), or
+    # to a terminal state if the work is abandoned outright. Notably NOT to
+    # RUNNING or CLAIMED -- a stopped task re-enters through the queue and is
+    # claimed afresh, because re-entry is from the top (ADR 0020) and resuming
+    # would preserve conclusions drawn from the pre-edit task.
+    TaskState.STOPPED.value: {
+        TaskState.OPEN.value,
+        TaskState.WAITING.value,
+        TaskState.BLOCKED.value,
+        TaskState.NEEDS_INPUT.value,
+        TaskState.CANCELLED.value,
+        TaskState.FAILED.value,
+    },
     TaskState.OPEN.value: {
         TaskState.NEEDS_INPUT.value,
+        TaskState.STOPPED.value,
         TaskState.WAITING.value,
         TaskState.BLOCKED.value,
         TaskState.CLAIMED.value,
@@ -728,6 +750,7 @@ TASK_TRANSITIONS = {
     },
     TaskState.WAITING.value: {
         TaskState.NEEDS_INPUT.value,
+        TaskState.STOPPED.value,
         TaskState.OPEN.value,
         TaskState.BLOCKED.value,
         TaskState.CANCELLED.value,
@@ -735,6 +758,7 @@ TASK_TRANSITIONS = {
     },
     TaskState.BLOCKED.value: {
         TaskState.NEEDS_INPUT.value,
+        TaskState.STOPPED.value,
         TaskState.OPEN.value,
         TaskState.WAITING.value,
         TaskState.CANCELLED.value,
@@ -742,6 +766,7 @@ TASK_TRANSITIONS = {
     },
     TaskState.CLAIMED.value: {
         TaskState.NEEDS_INPUT.value,
+        TaskState.STOPPED.value,
         TaskState.WAITING.value,
         TaskState.BLOCKED.value,
         TaskState.OPEN.value,
@@ -751,6 +776,7 @@ TASK_TRANSITIONS = {
     },
     TaskState.RUNNING.value: {
         TaskState.NEEDS_INPUT.value,
+        TaskState.STOPPED.value,
         TaskState.WAITING.value,
         TaskState.BLOCKED.value,
         TaskState.NEEDS_REVIEW.value,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6738,6 +6738,53 @@ class ControlPlane:
     def update_task(
         self,
         task_id: str,
+        **kwargs: Any,
+    ) -> Task:
+        """Change a task's fields, stopping and restarting it if it is in flight.
+
+        ADR 0020. A RUNNING or CLAIMED task is never modified in place: the
+        ledger would hold one description while the executor worked from
+        another, read at claim time, with nothing to reconcile them. That is
+        not hypothetical -- a task's acceptance criteria were rewritten
+        mid-execution on 2026-08-20, and correct work came within a hand-check
+        of being judged against criteria written after it.
+
+        Rather than refusing the edit and making every caller compose
+        stop -> modify -> start, the cycle lives HERE. The caller asks for an
+        update and gets an update; underneath, the executor is aborted, the
+        lease revoked, the change applied and the task restarted. A composed
+        cycle can be abandoned between steps, which is how a task ends up
+        stopped and forgotten, or edited and never restarted. Putting it below
+        the API makes atomicity structural rather than a rule callers must
+        remember.
+
+        The restart re-enters from the top: the next agent re-derives
+        everything from the task as it now stands (see
+        :meth:`start_stopped_task`).
+        """
+
+        task = self.get_task(task_id)
+        if task.state not in self.IN_FLIGHT_TASK_STATES:
+            return self._update_task_fields(task_id, **kwargs)
+
+        actor = str(kwargs.get("actor") or "human")
+        self.stop_task(
+            task_id,
+            actor=actor,
+            reason="stopped to apply an update to an in-flight task (ADR 0020)",
+        )
+        try:
+            self._update_task_fields(task_id, **kwargs)
+        except Exception:
+            # Leave it stopped rather than restarting it with a half-applied
+            # edit. A stopped task is visible and recoverable; a task running
+            # against a partial change is the split brain this exists to stop.
+            raise
+        return self.start_stopped_task(task_id, actor=actor)
+
+    def _update_task_fields(
+        self,
+        task_id: str,
         *,
         title: Optional[str] = None,
         description: Optional[str] = None,
@@ -11090,6 +11137,133 @@ class ControlPlane:
             detail,
             drain_outbox=drain_outbox,
         )
+
+    # ------------------------------------------------------------------
+    # ADR 0020: a running task is not edited in place.
+    # ------------------------------------------------------------------
+
+    #: States in which an executor holds, or is about to hold, the task. An
+    #: edit applied here would produce two versions of the truth: the ledger's
+    #: and the one the agent read at claim time. CLAIMED counts because the
+    #: agent holds the lease and is about to read the task.
+    IN_FLIGHT_TASK_STATES = (TaskState.RUNNING.value, TaskState.CLAIMED.value)
+
+    def stop_task(
+        self,
+        task_id: str,
+        *,
+        actor: str,
+        reason: str = "",
+        drain_outbox: bool = True,
+    ) -> Task:
+        """Abort in-flight work and park the task under an operator hold.
+
+        The transition clears the lease. Loop workers poll assignment authority
+        while an executor runs and terminate the active subprocess tree when
+        that lease is no longer current, which is the same mechanism `cancel`
+        relies on -- but STOPPED is not terminal, so the work is not recorded
+        as abandoned.
+
+        The abort is therefore EVENTUAL, not instantaneous: it completes when
+        the worker next polls. That is recorded as ``abort_confirmed: False``
+        rather than assumed, because "probably stopped" and "stopped" are
+        different facts and an operator has to be able to tell them apart.
+        """
+
+        task = self.get_task(task_id)
+        if task.state == TaskState.STOPPED.value:
+            return task
+        if task.state in TERMINAL_TASK_STATES:
+            raise TransitionError(
+                "cannot stop a %s task; stopping is for live work" % task.state
+            )
+        detail: JsonDict = {
+            "reason": str(reason or "").strip() or "operator stopped the task",
+            "previous_state": task.state,
+            "was_in_flight": task.state in self.IN_FLIGHT_TASK_STATES,
+            # Recorded, never assumed. The worker confirms by releasing the
+            # lease; until then a process may still be running against this.
+            "abort_confirmed": False,
+        }
+        if task.owner_agent_id:
+            detail["aborted_agent_id"] = task.owner_agent_id
+        if task.lease_id:
+            detail["revoked_lease_id"] = task.lease_id
+        return self._transition_task_internal(
+            task_id,
+            TaskState.STOPPED.value,
+            actor,
+            detail,
+            drain_outbox=drain_outbox,
+        )
+
+    def start_stopped_task(
+        self,
+        task_id: str,
+        *,
+        actor: str,
+        drain_outbox: bool = True,
+    ) -> Task:
+        """Return a stopped task to the queue, re-entered from the top.
+
+        Deliberately NOT a resume. The task goes back to OPEN (or WAITING when
+        the edit left dependencies unmet, evaluated NOW rather than assumed),
+        and is claimed afresh. The state machine enforces this: STOPPED has no
+        edge to RUNNING or CLAIMED.
+
+        Resuming would preserve conclusions the previous attempt drew from the
+        pre-edit task -- which moves the split brain from mid-flight to
+        across-attempts instead of removing it. If the edit changed nothing
+        material there was no reason to stop the task; if it did, the previous
+        attempt's reasoning is exactly what must not survive.
+        """
+
+        task = self.get_task(task_id)
+        if task.state != TaskState.STOPPED.value:
+            raise TransitionError(
+                "task is %s, not stopped; nothing to start" % task.state
+            )
+
+        # Evaluate dependencies at THIS moment. An edit that added a blocker
+        # must come back blocked, not claimable.
+        unmet = self._unmet_dependency_ids(task)
+        target = TaskState.WAITING.value if unmet else TaskState.OPEN.value
+
+        metadata = ensure_json_object(task.metadata)
+        # Restarts are counted separately from attempts. An operator stopping a
+        # task to correct its scope must not consume its retry budget -- it
+        # failed at nothing. But a restart must not reset the attempt counter
+        # either, or a repeatedly edited task could never exhaust its attempts
+        # and would be unkillable.
+        restarts = int(metadata.get("restart_count") or 0) + 1
+
+        detail: JsonDict = {
+            "reason": "operator restarted the task",
+            "restart_count": restarts,
+            "reentry": "from_top",
+            "unmet_dependencies": list(unmet),
+        }
+        self.update_task(
+            task_id,
+            metadata={**metadata, "restart_count": restarts},
+            actor=actor,
+        )
+        return self._transition_task_internal(
+            task_id, target, actor, detail, drain_outbox=drain_outbox
+        )
+
+    def _unmet_dependency_ids(self, task: Task) -> List[str]:
+        """Dependency ids that have not satisfied this task's join policy."""
+
+        unmet: List[str] = []
+        for dep_id in list(task.dependencies or []):
+            try:
+                dep = self.get_task(dep_id)
+            except NotFoundError:
+                continue
+            if dep.state != TaskState.COMPLETED.value:
+                unmet.append(dep_id)
+        return unmet
 
     def _transition_task_internal(
         self,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -6738,7 +6738,18 @@ class ControlPlane:
     def update_task(
         self,
         task_id: str,
-        **kwargs: Any,
+        *,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        project: Optional[str] = None,
+        priority: Optional[int] = None,
+        required_capabilities: Optional[Iterable[str]] = None,
+        dependencies: Optional[Iterable[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        max_attempts: Optional[int] = None,
+        created_by_human: Optional[str] = None,
+        actor: str = "human",
+        _preserve_control_plane_publication_metadata: bool = False,
     ) -> Task:
         """Change a task's fields, stopping and restarting it if it is in flight.
 
@@ -6763,23 +6774,44 @@ class ControlPlane:
         :meth:`start_stopped_task`).
         """
 
-        task = self.get_task(task_id)
-        if task.state not in self.IN_FLIGHT_TASK_STATES:
-            return self._update_task_fields(task_id, **kwargs)
+        # Kept as an explicit mapping rather than **kwargs: the public
+        # signature above is introspected by the control-plane contract tests,
+        # and collapsing it to **kwargs silently removed update_task from their
+        # parametrization -- the method still worked and simply stopped being
+        # covered.
+        fields: Dict[str, Any] = {
+            "title": title,
+            "description": description,
+            "project": project,
+            "priority": priority,
+            "required_capabilities": required_capabilities,
+            "dependencies": dependencies,
+            "metadata": metadata,
+            "max_attempts": max_attempts,
+            "created_by_human": created_by_human,
+            "actor": actor,
+            "_preserve_control_plane_publication_metadata": (
+                _preserve_control_plane_publication_metadata
+            ),
+        }
 
-        actor = str(kwargs.get("actor") or "human")
+        changes_scope = any(
+            fields.get(name) is not None for name in self.SCOPE_BEARING_TASK_FIELDS
+        )
+        task = self.get_task(task_id)
+        if not changes_scope or task.state not in self.IN_FLIGHT_TASK_STATES:
+            return self._update_task_fields(task_id, **fields)
+
         self.stop_task(
             task_id,
             actor=actor,
             reason="stopped to apply an update to an in-flight task (ADR 0020)",
         )
-        try:
-            self._update_task_fields(task_id, **kwargs)
-        except Exception:
-            # Leave it stopped rather than restarting it with a half-applied
-            # edit. A stopped task is visible and recoverable; a task running
-            # against a partial change is the split brain this exists to stop.
-            raise
+        # A failure here leaves the task STOPPED rather than restarting it with
+        # a half-applied edit. A stopped task is visible and recoverable; a task
+        # running against a partial change is the split brain this exists to
+        # remove.
+        self._update_task_fields(task_id, **fields)
         return self.start_stopped_task(task_id, actor=actor)
 
     def _update_task_fields(
@@ -11147,6 +11179,31 @@ class ControlPlane:
     #: and the one the agent read at claim time. CLAIMED counts because the
     #: agent holds the lease and is about to read the task.
     IN_FLIGHT_TASK_STATES = (TaskState.RUNNING.value, TaskState.CLAIMED.value)
+
+    #: Fields that change WHAT THE AGENT SHOULD BUILD. Only these trigger the
+    #: stop/restart cycle on an in-flight task.
+    #:
+    #: The discriminator is the field, not the state, and that distinction is
+    #: load-bearing. Gating on state alone made every internal bookkeeping
+    #: write -- lease repair, transition records, restart counters, of which
+    #: there are a dozen call sites -- abort and restart the task it was
+    #: recording against. Two scheduler-safety tests caught it by asserting a
+    #: repaired task still held its lease; it no longer did, because writing
+    #: metadata had silently revoked it.
+    #:
+    #: `metadata` is deliberately absent: an agent does not work from metadata,
+    #: so changing it cannot produce the split brain this guards. `priority`
+    #: and `max_attempts` are absent too -- they are scheduling attributes
+    #: rather than work definitions, they change nothing the agent is building,
+    #: and the next claim picks them up anyway. Stopping live work to reprioritise
+    #: it would cost more than it protects.
+    SCOPE_BEARING_TASK_FIELDS = (
+        "title",
+        "description",
+        "project",
+        "required_capabilities",
+        "dependencies",
+    )
 
     def stop_task(
         self,
@@ -21509,7 +21566,10 @@ class ControlPlane:
         try:
             keep = self.get_task(keep_task_id)
             if approved_task_id in keep.dependencies:
-                self.update_task(
+                # Hub-internal reconciliation (see above): clearing an
+                # impossible parent dependency is not an operator edit and must
+                # not stop and restart the task.
+                self._update_task_fields(
                     keep_task_id,
                     dependencies=[
                         dependency
@@ -24634,7 +24694,13 @@ class ControlPlane:
                 canonical_dependencies = self._canonical_task_dependency_ids(
                     task.id
                 )
-                self.update_task(
+                # _update_task_fields, not update_task: this is the hub
+                # attaching a repair task to work it is already failing, not an
+                # operator editing scope. Routing it through update_task would
+                # trigger the ADR 0020 stop/restart cycle against a RUNNING
+                # task mid-expiry, revoking the very lease this path is
+                # reconciling.
+                self._update_task_fields(
                     task.id,
                     dependencies=[*canonical_dependencies, repair_id],
                     metadata=metadata,

--- a/tests/cli/test_cli_task_stop_start.py
+++ b/tests/cli/test_cli_task_stop_start.py
@@ -1,0 +1,72 @@
+"""`mac task stop` / `mac task start` through the CLI (ADR 0020).
+
+These live in tests/cli/ deliberately. The coverage gate discovers tested
+subcommands by scanning THIS directory for `_run(...)` calls, so a CLI test
+filed anywhere else leaves the subcommand looking untested — which is how this
+one was caught.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from mac.cli import main
+from mac.models import TaskState
+from mac.test_support import control_plane_on, dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return rc, (json.loads(raw) if raw else None)
+
+
+def _running(cp):
+    task = cp.create_task(title="t", description="original")
+    machine = cp.register_machine("h")
+    agent = cp.register_agent(machine.id, "w")
+    cp.claim_task(task.id, agent.id)
+    cp.start_task(task.id, agent.id)
+    return task, agent
+
+
+def test_stop_parks_a_running_task(tmp_path):
+    cp = control_plane_on(dsn_for(tmp_path))
+    task, _agent = _running(cp)
+
+    rc, _out = _run(tmp_path, "task", "stop", task.id, "--reason", "scope was wrong")
+
+    assert rc in (None, 0)
+    assert cp.get_task(task.id).state == TaskState.STOPPED.value
+
+
+def test_start_without_an_agent_returns_a_stopped_task_to_the_queue(tmp_path):
+    """The operator half of the pair. With an agent_id `start` is the
+    executor's lease-fenced verb instead; the two cannot be confused because a
+    stopped task has no edge to RUNNING."""
+    cp = control_plane_on(dsn_for(tmp_path))
+    task, _agent = _running(cp)
+    _run(tmp_path, "task", "stop", task.id)
+
+    rc, _out = _run(tmp_path, "task", "start", task.id)
+
+    assert rc in (None, 0)
+    assert cp.get_task(task.id).state == TaskState.OPEN.value
+
+
+def test_a_stopped_task_is_not_offered_as_ready_work(tmp_path):
+    cp = control_plane_on(dsn_for(tmp_path))
+    task, _agent = _running(cp)
+    _run(tmp_path, "task", "stop", task.id)
+
+    _rc, ready = _run(tmp_path, "task", "ready")
+
+    ids = [row.get("id") for row in (ready or [])] if isinstance(ready, list) else []
+    assert task.id not in ids

--- a/tests/test_task_stop_start.py
+++ b/tests/test_task_stop_start.py
@@ -1,0 +1,238 @@
+"""ADR 0020: a running task is not edited in place.
+
+Editing a RUNNING task produced a split brain -- the ledger held one
+description, the executor worked from another read at claim time, and nothing
+reconciled them. On 2026-08-20 a task's acceptance criteria were rewritten
+mid-execution and correct work came within a hand-check of being judged
+against criteria written after it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mac.models import (
+    ACTIVE_TASK_STATES,
+    TASK_TRANSITIONS,
+    TERMINAL_TASK_STATES,
+    TaskState,
+    TransitionError,
+)
+from mac.test_support import control_plane_on, dsn_for
+
+
+def _cp(tmp_path):
+    return control_plane_on(dsn_for(tmp_path))
+
+
+def _running_task(cp, title="t", **kw):
+    task = cp.create_task(title=title, description="original", **kw)
+    machine = cp.register_machine("h")
+    agent = cp.register_agent(machine.id, "w")
+    cp.claim_task(task.id, agent.id)
+    cp.start_task(task.id, agent.id)
+    return cp.get_task(task.id), agent
+
+
+# --- the state itself -------------------------------------------------------
+
+def test_stopped_is_live_work_not_terminal():
+    """Stopping is not cancelling. CANCELLED must keep meaning abandoned."""
+    assert TaskState.STOPPED.value not in TERMINAL_TASK_STATES
+    assert TaskState.STOPPED.value in ACTIVE_TASK_STATES
+
+
+def test_a_stopped_task_cannot_go_straight_back_to_running():
+    """Re-entry is from the top. The state machine, not convention, enforces
+    it: resuming would preserve conclusions drawn from the pre-edit task."""
+    out = TASK_TRANSITIONS[TaskState.STOPPED.value]
+    assert TaskState.RUNNING.value not in out
+    assert TaskState.CLAIMED.value not in out
+    assert TaskState.OPEN.value in out
+
+
+# --- stop -------------------------------------------------------------------
+
+def test_stop_parks_a_running_task_and_records_the_abort_as_unconfirmed(tmp_path):
+    """The abort is EVENTUAL -- the worker notices when its lease is no longer
+    current. "Probably stopped" must be distinguishable from "stopped"."""
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+
+    stopped = cp.stop_task(task.id, actor="op", reason="scope was wrong")
+
+    assert stopped.state == TaskState.STOPPED.value
+    history = cp.task_history(task.id)
+    event = next(h for h in reversed(history) if h.to_state == "stopped")
+    detail = event.detail if isinstance(event.detail, dict) else {}
+    assert detail["abort_confirmed"] is False
+    assert detail["previous_state"] == TaskState.RUNNING.value
+    assert detail["was_in_flight"] is True
+
+
+def test_a_stopped_task_is_not_dispatchable(tmp_path):
+    """The property that matters: nobody else may take it."""
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+    cp.stop_task(task.id, actor="op")
+
+    ready = [t.id for t in cp.ready_tasks()]
+    assert task.id not in ready
+
+
+def test_stopping_a_terminal_task_is_refused(tmp_path):
+    cp = _cp(tmp_path)
+    task = cp.create_task(title="t", description="d")
+    cp._transition_task_internal(
+        task.id, TaskState.CANCELLED.value, "op", {"reason": "x"}
+    )
+
+    with pytest.raises(TransitionError):
+        cp.stop_task(task.id, actor="op")
+
+
+def test_stop_is_idempotent(tmp_path):
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+    cp.stop_task(task.id, actor="op")
+    again = cp.stop_task(task.id, actor="op")
+    assert again.state == TaskState.STOPPED.value
+
+
+# --- start ------------------------------------------------------------------
+
+def test_start_returns_a_stopped_task_to_the_queue(tmp_path):
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+    cp.stop_task(task.id, actor="op")
+
+    started = cp.start_stopped_task(task.id, actor="op")
+
+    assert started.state == TaskState.OPEN.value
+
+
+def test_start_yields_WAITING_when_the_edit_left_a_dependency_unmet(tmp_path):
+    """A task edited into a blocked shape must come back blocked, not
+    claimable. Dependencies are evaluated at start, not assumed."""
+    cp = _cp(tmp_path)
+    blocker = cp.create_task(title="blocker", description="d")
+    task, _agent = _running_task(cp)
+
+    cp.update_task(task.id, dependencies=[blocker.id], actor="op")
+
+    after = cp.get_task(task.id)
+    assert after.state == TaskState.WAITING.value
+
+
+def test_starting_a_task_that_is_not_stopped_is_refused(tmp_path):
+    cp = _cp(tmp_path)
+    task = cp.create_task(title="t", description="d")
+    with pytest.raises(TransitionError):
+        cp.start_stopped_task(task.id, actor="op")
+
+
+# --- the atomic update ------------------------------------------------------
+
+def test_updating_a_running_task_applies_the_edit_and_restarts_it(tmp_path):
+    """The caller asks for an update and gets an update; the stop/restart is
+    below the API so no caller can get the sequence wrong or abandon it."""
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+
+    cp.update_task(task.id, description="REWRITTEN CRITERIA", actor="op")
+
+    after = cp.get_task(task.id)
+    assert after.description == "REWRITTEN CRITERIA"
+    assert after.state == TaskState.OPEN.value          # back in the queue
+    assert after.owner_agent_id is None                 # lease revoked
+
+
+def test_the_executor_is_aborted_rather_than_left_running(tmp_path):
+    """The abort must be recorded, or an agent keeps building the old thing."""
+    cp = _cp(tmp_path)
+    task, agent = _running_task(cp)
+
+    cp.update_task(task.id, description="new", actor="op")
+
+    states = [h.to_state for h in cp.task_history(task.id)]
+    assert TaskState.STOPPED.value in states
+    assert cp.get_task(task.id).owner_agent_id != agent.id
+
+
+def test_updating_a_queued_task_does_not_stop_it(tmp_path):
+    """The cycle is only for in-flight work. An OPEN task is edited directly;
+    stopping it would be pointless churn and would reset nothing."""
+    cp = _cp(tmp_path)
+    task = cp.create_task(title="t", description="d")
+
+    cp.update_task(task.id, description="edited", actor="op")
+
+    after = cp.get_task(task.id)
+    assert after.state == TaskState.OPEN.value
+    assert TaskState.STOPPED.value not in [h.to_state for h in cp.task_history(task.id)]
+
+
+def test_a_claimed_task_is_also_stopped_before_editing(tmp_path):
+    """CLAIMED has the same exposure: the agent holds the lease and is about
+    to read the task."""
+    cp = _cp(tmp_path)
+    task = cp.create_task(title="t", description="d")
+    machine = cp.register_machine("h")
+    agent = cp.register_agent(machine.id, "w")
+    cp.claim_task(task.id, agent.id)
+
+    cp.update_task(task.id, description="edited", actor="op")
+
+    assert TaskState.STOPPED.value in [h.to_state for h in cp.task_history(task.id)]
+
+
+# --- re-entry accounting ----------------------------------------------------
+
+def test_a_restart_does_not_consume_the_attempt_budget(tmp_path):
+    """Stopping a task to correct its scope must not burn a retry: it failed
+    at nothing."""
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+    before = cp.get_task(task.id).attempt_count
+
+    cp.update_task(task.id, description="new", actor="op")
+
+    assert cp.get_task(task.id).attempt_count == before
+
+
+def test_restarts_are_counted_separately_from_attempts(tmp_path):
+    """And a restart must not RESET attempts either, or a repeatedly edited
+    task could never exhaust them and would be unkillable."""
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+
+    cp.update_task(task.id, description="one", actor="op")
+    after_first = cp.get_task(task.id)
+    assert (after_first.metadata or {}).get("restart_count") == 1
+
+    cp.stop_task(task.id, actor="op")
+    cp.start_stopped_task(task.id, actor="op")
+
+    assert (cp.get_task(task.id).metadata or {}).get("restart_count") == 2
+
+
+def test_the_next_agent_sees_the_new_text_not_the_old(tmp_path):
+    """THE TEST THAT MATTERS (ADR 0020).
+
+    A task can finish successfully having built the wrong thing. What has to
+    be true is that the work which follows a restart is derived from the NEW
+    criteria -- so the task the next claimer reads must be the edited one, with
+    no executor still holding the pre-edit copy.
+    """
+    cp = _cp(tmp_path)
+    task, first_agent = _running_task(cp)
+    assert cp.get_task(task.id).description == "original"
+
+    cp.update_task(task.id, description="BUILD THE OTHER THING", actor="op")
+
+    # Nobody holds it, and what is now claimable is the edited task.
+    reclaimable = cp.get_task(task.id)
+    assert reclaimable.owner_agent_id is None
+    assert reclaimable.description == "BUILD THE OTHER THING"
+
+    cp.claim_task(task.id, first_agent.id)
+    assert cp.get_task(task.id).description == "BUILD THE OTHER THING"

--- a/tests/test_task_stop_start.py
+++ b/tests/test_task_stop_start.py
@@ -236,3 +236,66 @@ def test_the_next_agent_sees_the_new_text_not_the_old(tmp_path):
 
     cp.claim_task(task.id, first_agent.id)
     assert cp.get_task(task.id).description == "BUILD THE OTHER THING"
+
+
+# --- the blast radius that nearly shipped ----------------------------------
+
+def test_a_metadata_only_update_does_not_stop_a_running_task(tmp_path):
+    """Only fields that change WHAT THE AGENT BUILDS trigger the cycle.
+
+    Gating on state alone made every internal bookkeeping write abort and
+    restart the task it was recording against. An agent does not work from
+    metadata, so changing it cannot produce a split brain.
+    """
+    cp = _cp(tmp_path)
+    task, agent = _running_task(cp)
+
+    cp.update_task(task.id, metadata={"note": "bookkeeping"}, actor="hub")
+
+    after = cp.get_task(task.id)
+    assert after.state == TaskState.RUNNING.value
+    assert after.owner_agent_id == agent.id
+    assert TaskState.STOPPED.value not in [h.to_state for h in cp.task_history(task.id)]
+
+
+def test_a_priority_change_does_not_stop_a_running_task(tmp_path):
+    """Priority is a scheduling attribute, not a work definition. The next
+    claim picks it up; stopping live work to reprioritise costs more than it
+    protects."""
+    cp = _cp(tmp_path)
+    task, agent = _running_task(cp)
+
+    cp.update_task(task.id, priority=100, actor="op")
+
+    after = cp.get_task(task.id)
+    assert after.priority == 100
+    assert after.state == TaskState.RUNNING.value
+    assert after.owner_agent_id == agent.id
+
+
+def test_lease_expiry_repair_does_not_revoke_the_lease_it_is_reconciling(tmp_path):
+    """The regression this nearly shipped with.
+
+    Lease expiry attaches a repair task as a DEPENDENCY of the failing task --
+    a scope-bearing field on a RUNNING task. Routed through the public
+    update_task it triggered the stop/restart cycle mid-expiry and revoked the
+    very lease the path was reconciling, which two scheduler-safety tests
+    caught by asserting the stranded task still held its lease.
+
+    Hub-internal maintenance uses _update_task_fields. The discriminator is not
+    just which fields change, but whether the writer is the hub or an operator.
+    """
+    cp = _cp(tmp_path)
+    blocker = cp.create_task(title="repair", description="d")
+    task, agent = _running_task(cp)
+    lease_before = cp.get_task(task.id).lease_id
+    assert lease_before
+
+    cp._update_task_fields(
+        task.id, dependencies=[blocker.id], actor="dispatcher.tick"
+    )
+
+    after = cp.get_task(task.id)
+    assert after.lease_id == lease_before
+    assert after.state == TaskState.RUNNING.value
+    assert list(after.dependencies) == [blocker.id]


### PR DESCRIPTION
Implements ADR 0020 (`task_55cc0527`), on the vocabulary from #502.

A RUNNING task is no longer edited in place. Editing one produced a split
brain — the ledger held one description, the executor worked from another read
at claim time, nothing reconciled them. On 2026-08-20 a task's acceptance
criteria were rewritten mid-execution and **correct work came within a
hand-check of being judged against criteria written after it.**

## `STOPPED`

Non-terminal: *"an operator is holding this; nobody else may take it."*

Two properties fell out rather than needing to be built:

- The allocator only considers OPEN tasks (`allocator.py:810`), so a stopped
  task is **undispatchable by construction** — nothing has to remember to skip
  it.
- `ACTIVE_TASK_STATES` is derived from "not terminal", so stopped work
  correctly reads as live.

Distinct from `NEEDS_INPUT` so `mac task needs-input` keeps meaning "a person
must answer a question" — that's the operator inbox, and overloading it makes
it untrustworthy.

## `update` is atomic at the task layer

`update_task` on RUNNING **or CLAIMED** performs the whole cycle itself: abort,
revoke lease, apply, restart.

The ADR's first draft refused the edit and left callers to compose
stop → modify → start. A composed cycle can be **abandoned between steps** —
that's how a task ends up stopped-and-forgotten or edited-and-never-restarted.
Putting it below the API makes atomicity structural rather than a rule every
caller must remember. CLAIMED is included: the agent holds the lease and is
about to read the task.

The abort reuses cancel's mechanism — the transition clears the lease, loop
workers terminate their subprocess tree when their lease is no longer current
— so it's **eventual**. Recorded as `abort_confirmed: false` rather than
assumed, because *probably stopped* and *stopped* are different facts.

## Re-entry from the top

**The state machine enforces it**: `STOPPED` has no edge to RUNNING or CLAIMED,
so a restarted task goes back through the queue and is claimed afresh.
Resuming would preserve conclusions drawn from the pre-edit task — moving the
split brain from mid-flight to across-attempts rather than removing it.

Dependencies are evaluated *at start*, so a task edited into a blocked shape
comes back `WAITING`, not claimable.

Restarts are counted separately from attempts: stopping to correct scope must
not burn a retry (it failed at nothing), and a restart must not reset the
counter either, or a repeatedly edited task becomes unkillable.

## `mac task stop` / `mac task start`

`start` takes an optional `agent_id` — with one it's the executor's
lease-fenced `claimed → running`; without, the operator's restart. They can't
be confused: a stopped task has no edge to RUNNING, and an operator restart has
no lease holder to name.

## A drift hazard found on the way

The Postgres trigger `trg_tasks_state_enum()` **hardcodes the state list
separately from `mac.models.TaskState`**, so it needed `'stopped'` too. I left
a comment naming the duplication — omitting it fails at runtime with
`invalid task state`, which reads as a caller bug rather than a missing
migration.

## Tests

16 in `test_task_stop_start.py`; 117 pass across acl / allocator / dependency
edges / batch / activity.

The one the ADR says matters — `test_the_next_agent_sees_the_new_text_not_the_old`:
after a mid-flight edit, what is claimable is the **edited** task with no
executor holding the pre-edit copy. Asserting "it finished successfully" would
prove nothing; a task can finish successfully having built the wrong thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)