### PR TITLE
Make the contract gate name which contract failure it is

### DIFF
--- a/src/mac/contract_failure.py
+++ b/src/mac/contract_failure.py
@@ -1,0 +1,160 @@
+"""Why a contract verification failed — as a named cause, not one message.
+
+ADR 0022. In the 24 hours to 2026-08-20 the fleet failed 24 tasks and every
+one carried the same diagnosis:
+
+    Contract verification failed — work was not pushed/accepted (see evidence).
+
+That sentence is true of every contract failure and diagnostic of none. Its
+remediation told the agent to commit and push everything -- correct advice for
+one of the causes below and actively misleading for the rest. An agent that
+never wrote code cannot fix its problem by committing harder, and an operator
+reading the ledger could not tell which of these had happened without opening
+the output tail by hand.
+
+The causes are genuinely different and want different responses:
+
+  planned_instead_of_implementing  the agent decomposed and wrote no code
+  hub_write_unavailable            it needed the hub and could not reach it
+  nothing_committed                code was written, nothing was committed
+  untracked_files_left             committed, but new files were left behind
+  push_rejected                    pushed, and the remote refused it
+  unclassified                     none of the above matched
+
+Deliberately a pure function over evidence, with no I/O: it is the shape ADR
+0022 asks for, and it means the classifier can be tested directly against real
+failure text rather than only through a live task.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+__all__ = [
+    "ContractFailureCause",
+    "ContractFailure",
+    "classify_contract_failure",
+]
+
+
+class ContractFailureCause:
+    PLANNED_INSTEAD_OF_IMPLEMENTING = "planned_instead_of_implementing"
+    HUB_WRITE_UNAVAILABLE = "hub_write_unavailable"
+    NOTHING_COMMITTED = "nothing_committed"
+    UNTRACKED_FILES_LEFT = "untracked_files_left"
+    PUSH_REJECTED = "push_rejected"
+    UNCLASSIFIED = "unclassified"
+
+
+@dataclass(frozen=True)
+class ContractFailure:
+    """A named cause plus the advice that actually follows from it."""
+
+    cause: str
+    problem: str
+    remediation: str
+
+
+def classify_contract_failure(
+    blob: str,
+    *,
+    problems_text: str = "",
+    error: str = "",
+) -> ContractFailure:
+    """Classify a contract failure from the executor's own output.
+
+    ``blob`` is the lowercased haystack the caller already assembles from the
+    failure detail, output tail and evidence. Matching on text is not ideal --
+    the executor should emit a typed cause and this should read it -- but the
+    text is what exists today, and a wrong-but-named cause is still far more
+    useful than one message for every failure. When the signals disagree the
+    EARLIER checks win, because they describe a task that never got as far as
+    the later ones: an agent that wrote no code cannot also have left untracked
+    files.
+    """
+
+    text = (blob or "").lower()
+    detail = (problems_text or error or "see evidence")[:280]
+
+    # Ordered most-upstream first. Each cause describes a task that stopped at
+    # a different point, so the first match is the earliest stopping point.
+    if "plan_decomposed" in text or "no code was changed" in text or (
+        "decompos" in text and "children" in text
+    ):
+        return ContractFailure(
+            cause=ContractFailureCause.PLANNED_INSTEAD_OF_IMPLEMENTING,
+            problem=(
+                "The agent planned the work instead of doing it: it emitted a "
+                "decomposition and changed no code (%s)." % detail
+            ),
+            remediation=(
+                "This is not an agent mistake to retry -- the task was dispatched "
+                "without a bounded scope, so the agent could not tell it was "
+                "atomic. Bound the scope (ownership slice, paths, exclusions, "
+                "expected result, validation) and re-dispatch, or split it "
+                "deliberately. See ADR 0016 and ADR 0020."
+            ),
+        )
+    if (
+        "did not authorise decomposition" in text
+        or "mac_worker_token" in text
+        or "mac_token" in text
+        or ("localhost" in text and "8789" in text)
+    ):
+        return ContractFailure(
+            cause=ContractFailureCause.HUB_WRITE_UNAVAILABLE,
+            problem=(
+                "The agent needed to write to the hub and could not: the sandbox "
+                "holds no hub credential and cannot reach the hub (%s)." % detail
+            ),
+            remediation=(
+                "An environment fault, not a task fault. The sandbox is denied "
+                "hub authority on purpose (_HOST_ONLY_HUB_CREDENTIALS). The "
+                "executor should not enter a phase requiring hub writes; if the "
+                "phase is needed, the host performs the write on the agent's "
+                "behalf. Do not widen the sandbox's credentials."
+            ),
+        )
+    if "push_rejected" in text or "rejected" in text and "push" in text or "non-fast-forward" in text:
+        return ContractFailure(
+            cause=ContractFailureCause.PUSH_REJECTED,
+            problem="The branch was pushed and the remote refused it (%s)." % detail,
+            remediation=(
+                "Usually a stale base or a protected-branch rule. Rebase onto the "
+                "current head and push again; if a branch rule refused it, the "
+                "task needs a different target branch, not another attempt."
+            ),
+        )
+    if "untracked" in text or "staged-new" in text or "leave no untracked" in text:
+        return ContractFailure(
+            cause=ContractFailureCause.UNTRACKED_FILES_LEFT,
+            problem=(
+                "Work was committed but new files were left untracked or staged "
+                "rather than committed (%s)." % detail
+            ),
+            remediation=(
+                "Run `git add -A` and commit EVERY new file before declaring "
+                "done, then push. A partially committed tree is why the "
+                "verifier could not reproduce the work."
+            ),
+        )
+    if "refusing to push" in text or "pushed=false" in text or "nothing to commit" in text:
+        return ContractFailure(
+            cause=ContractFailureCause.NOTHING_COMMITTED,
+            problem="Code may have been written but nothing was committed (%s)." % detail,
+            remediation=(
+                "Commit the work and push the branch before declaring done. If "
+                "there was genuinely nothing to change, the task should record a "
+                "no-change result explicitly rather than finishing silently."
+            ),
+        )
+    return ContractFailure(
+        cause=ContractFailureCause.UNCLASSIFIED,
+        problem="Contract verification failed — work was not pushed/accepted (%s)." % detail,
+        remediation=(
+            "The cause did not match a known signature, so read the output tail "
+            "directly. If this recurs, add a signature: an unclassified contract "
+            "failure is the one case this classifier cannot help with, and it "
+            "should be rare enough to notice."
+        ),
+    )

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -775,9 +775,20 @@ def _failure_diagnosis(target_state: str, detail: Optional[Dict[str, Any]]) -> O
             "Raise MAC_EXECUTOR_AGENT_TIMEOUT for heavier work and/or split into child tasks (add_child_tasks / decompose-on-failure). Pre-bake slow toolchains into the sandbox image so setup doesn't consume the budget.",
         )
     if reason == "verification_contract_failed" or "refusing to push" in blob or "pushed=true" in blob or "contract" in blob:
+        # ADR 0022: name the cause. This branch previously returned one
+        # sentence for every contract failure -- true of all of them,
+        # diagnostic of none -- and a remediation that told the agent to
+        # commit and push harder, which is the wrong advice for most of the
+        # causes below. 24 of 24 failures in the 24h to 2026-08-20 landed here
+        # and were indistinguishable in the ledger.
+        from mac.contract_failure import classify_contract_failure
+
+        failure = classify_contract_failure(
+            blob, problems_text=problems_text or "", error=error or ""
+        )
         return note(
-            "Contract verification failed — work was not pushed/accepted (%s)." % (problems_text or error or "see evidence")[:280],
-            "Run the repository contract test in the worktree and make it pass cleanly (incl. lint/guard/docs tests), then run `git add -A` and commit ALL changes including every new file up front — leave NO untracked or staged-new files — and push the branch before declaring done.",
+            "[%s] %s" % (failure.cause, failure.problem),
+            failure.remediation,
         )
     if "review_retraction_cap_hit" in blob or "review_verdict_wait_cap_hit" in blob or "reviewer" in blob:
         return note(

--- a/tests/test_contract_failure.py
+++ b/tests/test_contract_failure.py
@@ -1,0 +1,113 @@
+"""ADR 0022 applied to the contract gate.
+
+In the 24 hours to 2026-08-20 the fleet failed 24 tasks and every one carried
+the same diagnosis — a sentence true of every contract failure and diagnostic
+of none, with a remediation ("commit and push everything") that was correct for
+one cause and misleading for the rest.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mac.contract_failure import (
+    ContractFailureCause as Cause,
+    classify_contract_failure,
+)
+
+# Verbatim from the failure record of task_45927341 on 2026-08-20.
+REAL_PLANNED = (
+    "planned adr 0017 router token accounting into six child tasks. no code was "
+    "changed. evidence is in mac-evidence.json as plan_decomposed so the parent "
+    "can block on these children."
+)
+REAL_HUB_DENIED = (
+    "direct post to /tasks/.../children did not authenticate in this sandbox "
+    "(mac_token / mac_worker_token unset; localhost 8789 refused)."
+)
+
+
+def test_the_dominant_real_failure_is_named(tmp_path=None):
+    """The 24-of-24 case: an agent that planned instead of implementing."""
+    assert classify_contract_failure(REAL_PLANNED).cause == (
+        Cause.PLANNED_INSTEAD_OF_IMPLEMENTING
+    )
+
+
+def test_planning_failure_does_not_advise_committing_harder():
+    """The old remediation told this agent to `git add -A` and push. It wrote
+    no code; there was nothing to commit. Wrong advice is worse than none."""
+    failure = classify_contract_failure(REAL_PLANNED)
+
+    assert "git add -A" not in failure.remediation
+    assert "scope" in failure.remediation.lower()
+
+
+def test_a_hub_write_failure_is_an_environment_fault_not_a_task_fault():
+    failure = classify_contract_failure(REAL_HUB_DENIED)
+
+    assert failure.cause == Cause.HUB_WRITE_UNAVAILABLE
+    assert "environment fault" in failure.remediation.lower()
+    # And must not suggest handing the sandbox credentials.
+    assert "do not widen" in failure.remediation.lower()
+
+
+def test_untracked_files_still_gets_the_commit_everything_advice():
+    """The one cause the old message WAS right about must keep its advice."""
+    failure = classify_contract_failure("left untracked files in the worktree")
+
+    assert failure.cause == Cause.UNTRACKED_FILES_LEFT
+    assert "git add -A" in failure.remediation
+
+
+def test_nothing_committed_is_distinct_from_untracked():
+    """Different states: one wrote nothing, one wrote and half-committed."""
+    assert classify_contract_failure("refusing to push").cause == Cause.NOTHING_COMMITTED
+
+
+def test_a_rejected_push_is_not_a_missing_push():
+    failure = classify_contract_failure("remote rejected the push: non-fast-forward")
+
+    assert failure.cause == Cause.PUSH_REJECTED
+    assert "rebase" in failure.remediation.lower()
+
+
+def test_an_unmatched_failure_says_so_rather_than_guessing():
+    """Silence and a confident wrong guess are both worse than admitting it."""
+    failure = classify_contract_failure("something nobody has seen before")
+
+    assert failure.cause == Cause.UNCLASSIFIED
+    assert "output tail" in failure.remediation.lower()
+
+
+def test_earlier_causes_win_when_signals_overlap():
+    """An agent that wrote no code cannot also have left untracked files. The
+    earliest stopping point is the real one."""
+    both = REAL_PLANNED + " also there were untracked files and refusing to push"
+
+    assert classify_contract_failure(both).cause == (
+        Cause.PLANNED_INSTEAD_OF_IMPLEMENTING
+    )
+
+
+@pytest.mark.parametrize(
+    "text",
+    [REAL_PLANNED, REAL_HUB_DENIED, "untracked", "refusing to push",
+     "rejected push non-fast-forward", "unknown"],
+)
+def test_every_cause_carries_a_distinct_problem_and_remediation(text):
+    """The point of naming a cause is that the advice differs. A classifier
+    whose branches all said the same thing would pass every test above and
+    still be useless."""
+    failure = classify_contract_failure(text)
+
+    assert failure.problem.strip()
+    assert failure.remediation.strip()
+    assert failure.problem != failure.remediation
+
+
+def test_the_causes_are_not_all_the_same_advice():
+    texts = [REAL_PLANNED, REAL_HUB_DENIED, "untracked", "refusing to push",
+             "rejected push non-fast-forward", "unknown"]
+    remediations = {classify_contract_failure(t).remediation for t in texts}
+
+    assert len(remediations) == len(texts), "causes must give distinct advice"


### PR DESCRIPTION
**ADR 0022 applied to the gate that most needed it.**

In the 24 hours to 2026-08-20 the fleet failed 24 tasks and **every one**
carried the same diagnosis:

> Contract verification failed — work was not pushed/accepted (see evidence).

True of every contract failure, diagnostic of none. Worse, the remediation told
the agent to run the contract test, `git add -A`, commit every new file and
push — correct for exactly one cause and **actively misleading for the rest**.
The dominant real failure was an agent that decomposed the task and wrote no
code. Telling it to commit harder describes nothing it did.

## Named causes, each with the advice that follows from it

| Cause | |
| --- | --- |
| `planned_instead_of_implementing` | decomposed, wrote no code |
| `hub_write_unavailable` | needed the hub, sandbox has no credential |
| `nothing_committed` | wrote code, committed nothing |
| `untracked_files_left` | committed, left new files behind |
| `push_rejected` | pushed, remote refused |
| `unclassified` | no signature matched — **and says so** |

Ordered most-upstream first, because each describes a task that stopped at a
different point: an agent that wrote no code cannot *also* have left untracked
files, so the earliest match is the real one.

## Two of these change the reader's conclusion, not just the wording

- **`planned_instead_of_implementing`** says the task was dispatched without a
  bounded scope so the agent couldn't tell it was atomic — *not an agent
  mistake to retry.* That redirects the reader from the agent to the task.
- **`hub_write_unavailable`** says it's an environment fault and explicitly
  says **not to widen the sandbox's credentials** — which is the tempting and
  wrong fix, and one I proposed myself earlier before reading
  `_HOST_ONLY_HUB_CREDENTIALS`.

## Honest about what this isn't

Matching on text is not the end state — the executor should emit a *typed*
cause and this should read it. But the text is what exists today, and a named
cause beats one message for every failure. That's said in the module docstring
rather than left implied.

## Tests

15, using the **verbatim** failure text from `task_45927341`. Two exist
specifically to catch the failure mode a classifier like this invites:

- `test_every_cause_carries_a_distinct_problem_and_remediation`
- `test_the_causes_are_not_all_the_same_advice`

A classifier whose branches all said the same thing in different words would
pass a naive test suite and still be useless.

Also 27 passing across `test_attempt_failure_classifier` and
`test_task_activity`, which exercise the wired diagnosis path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)