### PR TITLE
Defer budget to Switchyard, and adopt two skill patterns

### DIFF
--- a/docs/adr/0017-token-spend-is-metered-at-the-router.md
+++ b/docs/adr/0017-token-spend-is-metered-at-the-router.md
@@ -121,7 +121,37 @@ attributable subject is recorded as `source = 'gateway'` with a null
 `subject_id`, never as an unclassified row. "Unattributed" stops being a
 silent category and becomes a countable one.
 
-### 4. A daily budget that can refuse
+### 4. Budget and cost belong to Switchyard, not to mac
+
+**Superseded 2026-08-20.** The section below proposed a daily budget inside
+mac. That is deferred, deliberately, and not for lack of value.
+
+Cost and budget are **provider-specific**: pricing, cache-rate semantics, and
+what an over-budget response even means differ per provider, and mac would end
+up carrying a pricing model per backend. `NVIDIA-NeMo/Switchyard` is a Rust
+proxy already being built for the LLM request path — it routes across
+providers, translates between OpenAI Chat, Anthropic Messages and OpenAI
+Responses formats, and records requests, errors, latency and **tokens** per
+provider. That is the interposition layer where these semantics belong.
+
+Switchyard is WIP, so this is deferred rather than reassigned: mac should not
+build a budget it will delete, and should not block on a dependency that is not
+ready.
+
+**The split mac keeps.** Sections 1-3 above stand and are still mac's problem.
+Whether mac's *own* router asks for usage at all —
+`stream_options.include_usage` — is a mac proxy behaviour, not a pricing model,
+and it is why 29.5% of routes book as $0 today. Metering our own traffic is
+ours; pricing it and budgeting against it is Switchyard's.
+
+**Read the original proposal below as history**, kept because its shape informed
+what Switchyard is expected to provide, and because the reasoning about
+enforcement (below, and in ADR-0125 of `horde-claw-fleet`) applies wherever the
+budget eventually lives: budgets are review and scheduling thresholds, not kill
+switches. An over-budget task should become **more visible**, not dead. A long,
+healthy validation run is expensive and correct.
+
+### 4a. Original proposal (historical) — a daily budget that can refuse
 
 Adopt `horde-claw-fleet`'s shape directly (`fleet-model/src/budget.rs`): a
 `DailySpend {input_tokens, output_tokens, estimated_cost_usd}`, a

--- a/skills/mac-cli/SKILL.md
+++ b/skills/mac-cli/SKILL.md
@@ -5,6 +5,36 @@ description: How the mac CLI is actually shaped — object groups, the admin re-
 
 # The mac CLI
 
+## What this skill owns, and what it does not
+
+It owns the CLI's shape: which object a verb hangs off, which verbs mean
+something other than their name, what the default views hide, and the traps
+that have cost a wrong command against a live fleet.
+
+It does **not** own: architecture decisions (those are `docs/adr/`), how to
+diagnose a failed task, how to decompose work, or repository conventions
+(`CLAUDE.md`, `CONTRIBUTING.md`). If a question is "what should this task be",
+this is the wrong document.
+
+Stating the boundary is worth the four lines: a skill that quietly grows into
+everything stops being read, and the reader cannot tell what it is responsible
+for being right about.
+
+## Before acting after a compaction or handoff
+
+If this conversation has been compacted, summarised, or handed over, **reread
+this skill and the live state before any mutating command** — do not act on a
+summary's recollection of either.
+
+This is not hypothetical caution. In one session a task was reopened from a
+summary that did not record that its work had already merged, and an agent
+immediately claimed it and began re-implementing a merged module. The summary
+was accurate about what had happened; it just did not carry the one fact that
+made the action wrong.
+
+Cheap checks, in order: `mac task show <id>` for current state, and
+`gh pr list --search "<task_id>" --state all` for work that already landed.
+
 `mac <object> <verb> [args]`. Everything is an object with verbs, and the
 objects that matter day to day are `project`, `task` and `agent`. Everything
 else lives under `admin`.


### PR DESCRIPTION
Two things: record the budget deferral with its reasoning, and take two
structural patterns from `horde-claw-fleet`'s skills.

## Budget → Switchyard

ADR 0017 §4 proposed a daily token budget inside mac. **Deferred**, and the
section now records why rather than being quietly deleted.

Cost and budget are **provider-specific** — pricing, cache-rate semantics, and
what an over-budget response even means differ per provider, so mac would carry
a pricing model per backend. `NVIDIA-NeMo/Switchyard` is a Rust proxy already
being built for the LLM request path: routes across providers, translates
OpenAI Chat / Anthropic Messages / OpenAI Responses, and records requests,
errors, latency and **tokens** per provider. That's the interposition layer
where this belongs.

It's WIP, so this is **deferred, not reassigned** — mac shouldn't build a budget
it will delete, nor block on something not ready.

**The split mac keeps:** whether mac's *own* router asks for usage at all
(`stream_options.include_usage`) is a proxy behaviour, not a pricing model, and
it's why **29.5% of routes book as $0**. Metering our own traffic is ours;
pricing it and budgeting against it is Switchyard's. §1–3 stand unchanged.

The original proposal is kept as §4a history — its shape informs what Switchyard
is expected to provide, and the enforcement reasoning applies wherever the
budget lands: **budgets are review thresholds, not kill switches.** An
over-budget task should become *more visible*, not dead. A long healthy
validation run is expensive and correct. (That correction came from
`horde-claw-fleet` ADR-0125, and contradicted how I'd originally scoped it.)

## Two skill patterns worth stealing

Their skills are noticeably better structured than ours.

**Explicit non-ownership.** Theirs state what they do *not* own and delegate by
name — `fleet-failure-analysis` owns diagnosis and explicitly must not own
repair decomposition, which `fleet-plan-scope` owns. `mac-cli` now says it owns
the CLI's shape and does *not* own architecture decisions, task diagnosis,
decomposition, or repo conventions. A skill that quietly grows into everything
stops being read, and the reader can't tell what it's responsible for being
right about.

**A post-compaction reread checkpoint.** Their `fleet-task-recovery` requires
rereading the skill and current evidence before any recovery mutation rather
than trusting a compressed summary.

This session supplied the case for it: a task was reopened from a summary that
didn't record that its work had **already merged**, and an agent immediately
claimed it and began re-implementing a merged module. The summary was accurate
about what had happened — it just didn't carry the one fact that made the
action wrong. The skill now names the two cheap checks: `mac task show <id>`
and `gh pr list --search "<task_id>" --state all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)