### PR TITLE
Fix main: an operator's agent name leaked into ADR 0022

### DIFF
--- a/docs/adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md
+++ b/docs/adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md
@@ -15,9 +15,9 @@ Four separate gates failed silently on 2026-08-19/20, and each cost real time:
 
 - `mac task why-unclaimed` printed a title and two attempt counters for a task
   no agent could take. The payload had every reason; the renderer dropped it.
-- `_advisory_health_dispatch_ready` returned `False` for natasha — idle,
-  heartbeating, fully capable — and said nothing. It sat out beside 84 open
-  tasks.
+- `_advisory_health_dispatch_ready` returned `False` for a worker that was
+  idle, heartbeating and fully capable — and said nothing. It sat out beside 84
+  open tasks.
 - The contract gate failed 24 of 24 tasks with one message, `verification
   contract failed — work was not pushed/accepted`, which is true of every
   failure and diagnostic of none.


### PR DESCRIPTION
**main is red** and this fixes it.

`tests/test_docs_no_operator_identity.py` asserts checked-in docs carry no
operator or per-fleet identity, so the repo reads as generic for any fleet
owner. ADR 0022 named one of this fleet's agents while describing a gate that
benched it — exactly the leak that test exists to catch. It merged in #506, and
main's Documentation job has failed since.

```
operator/per-fleet identity leaked into checked-in docs — the repo must read as
generic for any fleet owner. Replace with readable role names (hub / worker-1 /
worker-2 / gpu-worker) or placeholders (<user> / <host> / <mesh-ip>)
```

The example never needed the name, only the shape: *"a worker that was idle,
heartbeating and fully capable"* carries the entire point — the gate refused
something obviously healthy and said nothing about why.

Verified: `test_docs_no_operator_identity` passes, and a sweep of
`docs/adr/`, `skills/` and `CONTRIBUTING.md` for this fleet's host and agent
names now comes back empty.

Worth noting for future ADRs written from live incidents: **the evidence that
makes them convincing is exactly the evidence that carries this fleet's
names.** Four other ADRs I wrote today survived only because they happened to
quote code and counts rather than hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)