### PR TITLE
Move the cheap repository contracts to the fail-fast preflight

### DIFF
--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -283,7 +283,36 @@ if [ "$#" -eq 0 ] && [ "$_MAC_TEST_NESTED_PYTEST" = "0" ]; then
     "$PY" scripts/test-docs.py --static-only
     "$PY" scripts/generate-env-config-registry.py --check
     "$PY" scripts/generate-docs-reference.py --check
-    "$PY" -m pytest -q -x tests/test_control_plane_public_contract.py
+    # Repository-wide consistency contracts, run as ONE pytest invocation so
+    # the whole set costs a single interpreter start (~2s together; the
+    # slowest is 0.4s).
+    #
+    # These belong here for the same reason as the generated-artifact checks
+    # above: they are properties of the repository rather than of the change,
+    # they are near-instant, and they were previously reported only after the
+    # complete suite had run. On 2026-08-20 that cost three sequential ~45
+    # minute CI round trips to learn three things detectable in under a second
+    # -- an agent name left in a checked-in ADR, a CLI subcommand added without
+    # a tests/cli/ test, and a stale generated registry.
+    #
+    # Measured on this repository: failing CI runs average 47 minutes against
+    # 11 for passing ones, because a failure at the END of the suite still pays
+    # for the whole suite. Moving the cheap invariants to the front is the
+    # single largest available reduction in iteration time.
+    #
+    # -x so the first failure stops the preflight: everything here is a
+    # separate contract, and reporting six at once is no more actionable than
+    # reporting the first.
+    "$PY" -m pytest -q -x \
+        tests/test_control_plane_public_contract.py \
+        tests/test_docs_no_operator_identity.py \
+        tests/test_docs_accessibility.py \
+        tests/test_docs_reference_interpreter_independence.py \
+        tests/test_generated_artifact_guards_always_run.py \
+        tests/test_repository_hygiene.py \
+        tests/test_no_dead_indexes.py \
+        tests/cli/test_cli_coverage_gate.py \
+        tests/cli/test_cli_human_interface_coverage.py
 fi
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## The measurement

Recent CI on this repository:

| Outcome | n | mean | median |
| --- | --- | --- | --- |
| **failure** | 13 | **47.1m** | 43.4m |
| success | 16 | 11.0m | 3.3m |

**Failing runs cost 4× more than passing ones** — because a failure at the *end*
of the suite still pays for the whole suite.

And `sanity` is the entire turnaround:

| Job | mean | max |
| --- | --- | --- |
| **sanity** | **25.7m** | **43.9m** |
| compatibility | 1.4m | 2.2m |
| IDE typecheck + browser | 1.2m | 1.4m |
| Live PostgreSQL contract | 0.7m | 0.8m |
| Dead-code contract | 0.3m | 0.4m |

Everything else finishes under 2½ minutes.

## The fix was already there, just underpopulated

`run-contract-tests.sh` has a fail-fast preflight whose own comment states the
principle — *fail the cheapest repository-wide consistency contracts before
paying for xdist startup, subprocess tests and full coverage*. It just didn't
include most of them.

Adds seven, as **one** pytest invocation so the set costs a single interpreter
start:

```
test_docs_no_operator_identity                0.27s
test_docs_accessibility                       0.12s
test_docs_reference_interpreter_independence  0.38s
test_generated_artifact_guards_always_run     0.22s
test_repository_hygiene                       0.30s
test_no_dead_indexes                          0.04s
cli/test_cli_coverage_gate                    0.19s
cli/test_cli_human_interface_coverage         0.23s
```

**595 tests in 12 seconds** with the public-contract test already there.

Every one is a property of the **repository**, not of the change — which is why
waiting for a change-scoped suite to reach them is the wrong shape. None is in
the impact map's `always_run` set (which holds *two* entries), so in focused
mode they didn't run at all, and in full mode they ran last.

## Not hypothetical tuning

Three CI round trips on 2026-08-20 — ~45 minutes each, taken **sequentially**
because each fix revealed the next — were spent learning three things
detectable in under a second: an agent name left in a checked-in ADR, a CLI
subcommand added without a `tests/cli/` test, and a stale generated registry.

The first two are in this list. **The third already was**, and caught its defect
in seconds — which is what suggested the rest belonged here too.

## Verified both directions

- Against main **while it still carried** the ADR 0022 identity leak: preflight
  failed in **10 seconds** instead of 44 minutes
- Against fixed main: **595 passed in 12s**

`-x` stops at the first failure — each entry is an independent contract, and
reporting six at once is no more actionable than reporting one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)