### PR TITLE
Stop the README describing a deleted runtime, and make the gate catch it next time

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,19 @@ vacuum. It has learned from, interoperates with, or substantially relies on the
 following projects. The relationship is stated explicitly so that an
 integration or protocol influence is not mistaken for copied source:
 
-- **[Hermes Agent](https://github.com/NousResearch/hermes-agent) — vendored
-  runtime:** `src/mac/_hermes` is a pruned, MAC-modified snapshot of Hermes
-  Agent 0.15.1 at
-  [`b1a25404b`](https://github.com/NousResearch/hermes-agent/commit/b1a25404b638bfbd79ce4d08b49afc0ee1361528).
-  It supplies the agent loop, gateways, tools, plugins, and skills. See
-  [ADR 0001](docs/adr/0001-unify-hermes-runtime-into-mac.md) and the
-  [snapshot contract](deploy/hermes/SNAPSHOT.md).
+- **[Hermes Agent](https://github.com/NousResearch/hermes-agent) — former
+  vendored runtime, removed:** `src/mac/_hermes` held a pruned, MAC-modified
+  snapshot of Hermes Agent 0.15.1 at
+  [`b1a25404b`](https://github.com/NousResearch/hermes-agent/commit/b1a25404b638bfbd79ce4d08b49afc0ee1361528),
+  supplying the agent loop, gateways, tools, plugins, and skills. That tree and
+  its `deploy/hermes/` snapshot contract were deleted in `3ebde2dd`
+  (2026-08-16); no vendored Hermes source remains in this repository. The entry
+  stays because this section records what was once copied in, not only what is
+  copied in today — see
+  [ADR 0001](docs/adr/0001-unify-hermes-runtime-into-mac.md) for why it was
+  vendored and [the retirement premises](docs/hermes-retirement-premises.md) for
+  what the removal was argued on. MAC's own `mac-hermes` adapter is unaffected:
+  it is clean-room MAC code, not part of the snapshot.
 - **[NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) — execution
   security foundation:** MAC's agent process trees, filesystem/network policy,
   sandbox lifecycle, and normalized action-event collection integrate with
@@ -82,9 +88,8 @@ integration or protocol influence is not mistaken for copied source:
 
 This is a direct-lineage and architectural acknowledgement, not an exhaustive
 transitive dependency list. Python and Node dependencies remain documented in
-their manifests and lockfiles; additional skill- and plugin-level notices are
-kept with the vendored Hermes files that require them. Each upstream project
-remains subject to its own license.
+their manifests and lockfiles. Each upstream project remains subject to its own
+license.
 
 ## Core Contracts
 
@@ -192,8 +197,7 @@ make run-gui
 ```
 
 `make test` runs the complete hermetic pytest suite with statement, branch, and
-Python-subprocess coverage for MAC-owned `src/mac` code. Vendored Hermes
-internals under `src/mac/_hermes` are excluded. Coverage is a regression safety
+Python-subprocess coverage for `src/mac`. Coverage is a regression safety
 floor rather than a target for generating tests; see
 [the test portfolio strategy](docs/testing-strategy.md). Use `make coverage`
 for the same full-suite report, `make test-portfolio` to audit redundant
@@ -214,9 +218,7 @@ The enforced lint set starts at the always-green correctness floor (pyflakes
 logic errors and undefined names, plus syntax errors) so `make lint` is red only
 for a real regression; widen `[tool.ruff.lint].select` as the codebase is
 cleaned up. Ruff is a dev-only tool pinned in the `dev` extra and fetched on
-demand with `uv run --with ruff`; it is not a runtime dependency. The vendored
-Hermes runtime under `src/mac/_hermes` keeps its own upstream lint discipline
-and is excluded.
+demand with `uv run --with ruff`; it is not a runtime dependency.
 
 The common lifecycle is deliberately conventional:
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,14 @@ following projects. The relationship is stated explicitly so that an
 integration or protocol influence is not mistaken for copied source:
 
 - **[Hermes Agent](https://github.com/NousResearch/hermes-agent) — former
-  vendored runtime, removed:** `src/mac/_hermes` held a pruned, MAC-modified
-  snapshot of Hermes Agent 0.15.1 at
+  vendored runtime, removed:** the former *src/mac/\_hermes* held a pruned,
+  MAC-modified snapshot of Hermes Agent 0.15.1 at
   [`b1a25404b`](https://github.com/NousResearch/hermes-agent/commit/b1a25404b638bfbd79ce4d08b49afc0ee1361528),
   supplying the agent loop, gateways, tools, plugins, and skills. That tree and
-  its `deploy/hermes/` snapshot contract were deleted in `3ebde2dd`
-  (2026-08-16); no vendored Hermes source remains in this repository. The entry
+  its *deploy/hermes/* snapshot contract were deleted in `3ebde2dd`
+  (2026-08-16); no vendored Hermes source remains in this repository. Both are
+  written unbackticked on purpose: a backticked repository path asserts that the
+  path exists, and `tests/test_guide_docs_are_true.py` enforces it. The entry
   stays because this section records what was once copied in, not only what is
   copied in today — see
   [ADR 0001](docs/adr/0001-unify-hermes-runtime-into-mac.md) for why it was
@@ -872,4 +874,4 @@ explicit login server, enrollment-key source, DNS assumption, and health check.
 - [Review-strategy experiments](docs/review-strategy-experiments.md)
 - [Integration Authority Contract](docs/integration-authority-contract.md)
 - [Soul Preservation Runbook](docs/soul-preservation-runbook.md)
-- [Scaling Plan](docs/scaling-plan.md)
+- [Learning, Evals, and Scaling](docs/book/17-learning-evals-scaling.md)

--- a/tests/test_guide_docs_are_true.py
+++ b/tests/test_guide_docs_are_true.py
@@ -5,6 +5,12 @@ and a vendored xterm tree for some time after all three were deleted. The docs
 gates check GENERATED references and EXECUTABLE shell blocks; prose naming a
 deleted file is exactly what they do not cover, which is why nobody noticed.
 
+It happened again with the vendored Hermes tree, and this file did not catch it
+either: the root README was not among the pages checked, and the check matched
+only backticked paths ending in a source-file suffix -- so an extension-less
+`src/mac/_hermes` and a markdown link to a deleted deploy/hermes/SNAPSHOT.md
+both went straight through. README.md is now checked, and so are both shapes.
+
 Documentation that quietly diverges is worse than none, because it is trusted.
 These tests check the parts of the guide a machine can check: that every file
 it names exists, that every `mac` command it shows resolves against the real
@@ -21,11 +27,48 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 GUIDE = ROOT / "docs" / "guide"
-PAGES = sorted(GUIDE.glob("*.md")) + [ROOT / "CONTRIBUTING.md"]
+# README.md is here because it is the page most readers start from and the one
+# the original bug was in. It was outside this gate until the Hermes removal
+# repeated the xterm mistake in it, unnoticed, for three days.
+PAGES = sorted(GUIDE.glob("*.md")) + [ROOT / "CONTRIBUTING.md", ROOT / "README.md"]
+
+CODE_SUFFIXES = ("py", "ts", "tsx", "toml", "sql", "json", "sh", "md")
+
+_BACKTICK = re.compile(r"`([^`\n]+)`")
+_MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
 
 
 def _text() -> str:
     return "\n".join(p.read_text(encoding="utf-8") for p in PAGES)
+
+
+def _repo_root_names() -> set[str]:
+    return {entry.name for entry in ROOT.iterdir()}
+
+
+def _is_repo_path(token: str, root_names: set[str]) -> bool:
+    """Is this backticked token claiming a path in this repository?
+
+    Two ways to qualify, and both are needed. A source-file suffix catches
+    `foo/bar.py` under a directory that never existed. A first segment that
+    exists at the repository root catches an extension-less directory --
+    `src/mac/_hermes` -- which a suffix-only rule skips, which is exactly how
+    the Hermes prose survived.
+
+    Requiring one of the two is what keeps prose out. The README backticks
+    `read/write/agent/dispatch/secret/admin` for token scopes: slashes, no
+    spaces, no suffix, and `read` is not a directory here, so it is not a path.
+    """
+    if "/" not in token:
+        return False
+    if any(ch in token for ch in " \t<>*$\"'|"):
+        return False  # placeholders, globs, shell fragments, prose
+    if "://" in token or token.startswith(("/", "~", "#", "http")):
+        return False  # URLs, HTTP routes, home-relative, absolute
+    stem = token.rstrip("/")
+    if "." in stem and stem.rsplit(".", 1)[-1] in CODE_SUFFIXES:
+        return True
+    return token.split("/", 1)[0] in root_names
 
 
 def test_the_guide_exists_and_is_indexed():
@@ -42,21 +85,43 @@ def test_the_guide_exists_and_is_indexed():
 
 
 def test_every_file_the_guide_names_exists():
-    """The README-describing-deleted-files bug, prevented."""
+    """The README-describing-deleted-files bug, prevented.
+
+    Both shapes it actually took, because the first version of this check caught
+    neither. When `src/mac/_hermes` and `deploy/hermes/` were deleted, the README
+    went on naming the tree in backticks -- no file suffix, so a suffix-only
+    regex skipped it -- and linking [snapshot contract](deploy/hermes/SNAPSHOT.md),
+    which was never in backticks at all. The regex matched two paths in that
+    README, both of which existed, and the gate passed.
+    """
+    root_names = _repo_root_names()
     missing = []
     for page in PAGES:
-        for match in re.finditer(
-            r"`([a-zA-Z0-9_./-]+\.(?:py|ts|tsx|toml|sql|json|sh|md))`",
-            page.read_text(encoding="utf-8"),
-        ):
-            candidate = match.group(1)
-            if "/" not in candidate or "<" in candidate:
-                continue
-            if not (ROOT / candidate).exists():
-                missing.append("%s names %s" % (page.name, candidate))
+        text = page.read_text(encoding="utf-8")
 
-    assert not missing, "the guide names files that do not exist:\n  " + "\n  ".join(
-        sorted(set(missing))
+        for token in _BACKTICK.findall(text):
+            if _is_repo_path(token, root_names) and not (ROOT / token.rstrip("/")).exists():
+                missing.append("%s names `%s`" % (page.name, token))
+
+        for raw in _MD_LINK.findall(text):
+            target = raw.split("#", 1)[0].strip()
+            if not target or "://" in target:
+                continue
+            if target.startswith(("http", "mailto:", "#", "/")):
+                continue
+            if any(ch in target for ch in " <>*$"):
+                continue
+            # Relative to the PAGE, not the root: docs/guide/README.md links
+            # 01-architecture.md as a sibling, and README.md links docs/ from
+            # the top. Resolving both against ROOT would invent failures.
+            if not (page.parent / target).exists():
+                missing.append("%s links %s" % (page.name, target))
+
+    assert not missing, (
+        "documentation names files that do not exist:\n  "
+        + "\n  ".join(sorted(set(missing)))
+        + "\n\nA backticked repository path asserts the path exists. When writing about "
+        "something deliberately removed, leave it unbackticked."
     )
 
 


### PR DESCRIPTION
Two commits, one story: the README described a runtime that had been deleted, and the gate written for exactly that bug class did not catch it. This fixes the prose and closes the hole.

*(Flattened — this now targets `main` and includes the README fix formerly in #501, which is closed. Stacked PRs get no CI in this repository: `ci.yml` fires on `pull_request: branches: [main]`, so a PR based on anything else runs nothing.)*

## 1. The README fix

`src/mac/_hermes` and `deploy/hermes/` were removed in `3ebde2dd` (2026-08-16) — 1,282 files, ~583k lines. The README kept describing both as present:

| Where | Claim | Reality |
|---|---|---|
| Lineage | "`src/mac/_hermes` **is** a pruned, MAC-modified snapshot… It **supplies** the agent loop, gateways, tools, plugins, and skills" | Directory does not exist |
| Lineage | Links `[snapshot contract](deploy/hermes/SNAPSHOT.md)` | Broken link; removed in the same commit |
| Testing | "Vendored Hermes internals under `src/mac/_hermes` are excluded" from coverage | Nothing in `pyproject.toml`, `setup.cfg` or the `Makefile` references it |
| Linting | Same claim for Ruff | Same |

The lineage entry moves to past tense and names the removing commit rather than being deleted — that section exists to record what was *once* copied in, *"so that an integration or protocol influence is not mistaken for copied source"*.

**Deliberately unchanged:** `mac-hermes` is still a real console script backed by `src/mac/hermes_adapter.py`, so the Core Contracts entry stays and the lineage entry now says so explicitly. "Boundary With Hermes" is a design boundary, and `docs/hermes-retirement-premises.md` records that both premises for retiring Hermes *"neither holds as stated"*.

## 2. Closing the hole

`tests/test_guide_docs_are_true.py` exists because the README described a vendored xterm tree after deletion. It missed this one for two independent reasons:

1. **The root README was not a checked page.** `PAGES` was `docs/guide/*.md` plus `CONTRIBUTING.md`.
2. **Adding it would not have been enough.** The check matched backticked paths ending in a source-file suffix — but `src/mac/_hermes` is a directory with no suffix, and `deploy/hermes/SNAPSHOT.md` was a markdown link, never backticked.

Measured against the pre-fix README, the old regex matched exactly two paths — **both of which existed**. It passed a README containing three dead paths.

### What now counts as a path

A backticked token qualifies if it ends in a source suffix **or** its first segment names something at the repository root. The second half catches extension-less directories; requiring one of the two keeps prose out — the README backticks `read/write/agent/dispatch/secret/admin` for token scopes, which has slashes and no spaces but is not a path.

Markdown link targets resolve against the **page**, not the root: `docs/guide/README.md` links `01-architecture.md` as a sibling, while `README.md` links `docs/` from the top.

A backticked repository path now asserts the path exists, and the failure message says so. I considered a marker comment for deliberate exceptions and decided against machinery for a case this rare.

### It found a real one

`README.md` linked `docs/scaling-plan.md`, deleted in `55033232` when the book absorbed it. Dangling ever since, because nothing was looking. Repointed at the chapter that replaced it.

## Verification

- **Proof it catches the original bug:** reverting `README.md` to its pre-fix state makes the gate fail, naming all three — `` `src/mac/_hermes` ``, `deploy/hermes/SNAPSHOT.md`, `docs/scaling-plan.md`.
- With the README fixed, all 8 tests pass (run against a live test Postgres, since the suite's conftest requires a DSN).
- Adding README to `PAGES` also subjects its ~100 command examples to the existing parser check and its fences to the balance check — verified passing *before* strengthening anything, so this is new coverage rather than docs bent to fit.
- `ruff check` clean. The file was already outside `ruff format` before this change and `scripts/run-lint.sh` treats formatting as advisory, so no unrelated reformat churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
