### PR TITLE
One consolidated agent health check

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -3938,6 +3938,8 @@ def parse_seen(value):
 
 
 def report_executor_ready(resources):
+    from mac.agent_health import startup_self_test_clears_dispatch
+
     if not require_report_executor:
         return True
     # The one-time held-hub bootstrap executes this embedded gate with the
@@ -3951,10 +3953,11 @@ def report_executor_ready(resources):
     return bool(
         agent_has_read_only_report_repository_executor(resources)
         and isinstance(startup, dict)
-        and startup.get("schema") == "mac.agent_startup_self_test.v1"
-        and startup.get("agent_id") == agent_id
-        and startup.get("status") in {"passed", "degraded"}
-        and startup.get("blocking_problems") == []
+        # One definition, shared with the hub (mac.agent_health). These four
+        # lines were spelled out identically in three places in this file and
+        # twice in services.py; the copy in release_health_ready above drifted
+        # to `== "degraded"` and benched a worker whose self-test PASSED.
+        and startup_self_test_clears_dispatch(startup, agent_id=agent_id)
         and isinstance(checks, dict)
         and checks.get("openshell_executor_config") is True
         and checks.get("report_repository_executor_attestation") is True
@@ -3965,20 +3968,19 @@ def report_executor_ready(resources):
 def release_health_ready(row, resources):
     """Accept health that is safe for coding-task dispatch.
 
-    A gateway/model probe may report a degraded startup self-test while also
-    proving that it has no blocking problems.  That advisory condition must not
-    strand an otherwise authenticated, idle coding worker or an entire cohort.
+    Delegates to mac.agent_health so this script cannot disagree with the hub
+    about whether a worker may be released. It used to inline the rule, and the
+    inline copy said `status == "degraded"` -- refusing a worker whose self-test
+    reported `passed`, the healthiest result it can give.
+
+    This block already runs under $HOME/.mac/venv/bin/python and the helper
+    above it imports from mac.models, so the package was importable all along
+    and the copy bought nothing.
     """
-    if row.get("health_status") == "healthy":
-        return True
-    startup = resources.get("startup_self_test")
-    return bool(
-        row.get("health_status") == "degraded"
-        and isinstance(startup, dict)
-        and startup.get("schema") == "mac.agent_startup_self_test.v1"
-        and startup.get("agent_id") == agent_id
-        and startup.get("status") == "degraded"
-        and startup.get("blocking_problems") == []
+    from mac.agent_health import advisory_health_dispatch_ready
+
+    return advisory_health_dispatch_ready(
+        row.get("health_status"), resources, agent_id=agent_id
     )
 
 
@@ -11550,6 +11552,7 @@ set -a
 set +a
 export MAC_DEPLOY_GATE_ADMIN_TOKEN="${MAC_API_TOKEN:?}"
 "$HOME/.mac/venv/bin/python" - <<'PY'
+from mac.agent_health import startup_self_test_clears_dispatch
 import json
 import os
 import urllib.error
@@ -11619,10 +11622,11 @@ try:
     if not (
         resources.get("openshell_required") is True
         and isinstance(startup, dict)
-        and startup.get("schema") == "mac.agent_startup_self_test.v1"
-        and startup.get("agent_id") == agent_id
-        and startup.get("status") in {"passed", "degraded"}
-        and startup.get("blocking_problems") == []
+        # One definition, shared with the hub (mac.agent_health). These four
+        # lines were spelled out identically in three places in this file and
+        # twice in services.py; the copy in release_health_ready above drifted
+        # to `== "degraded"` and benched a worker whose self-test PASSED.
+        and startup_self_test_clears_dispatch(startup, agent_id=agent_id)
         and isinstance(checks, dict)
         and checks.get("openshell_executor_config") is True
         and checks.get("report_repository_executor_attestation") is True
@@ -14381,6 +14385,7 @@ set -a
 set +a
 export MAC_DEPLOY_GATE_ADMIN_TOKEN="${MAC_API_TOKEN:?}"
 "$HOME/.mac/venv/bin/python" - <<'PY'
+from mac.agent_health import startup_self_test_clears_dispatch
 import base64
 import datetime as dt
 import hashlib
@@ -14547,10 +14552,11 @@ def report_executor_ready(agent_id, resources, required):
         agent_has_read_only_report_repository_executor(resources)
         and valid_read_only_report_repository_executor_attestation(attestation)
         and isinstance(startup, dict)
-        and startup.get("schema") == "mac.agent_startup_self_test.v1"
-        and startup.get("agent_id") == agent_id
-        and startup.get("status") in {"passed", "degraded"}
-        and startup.get("blocking_problems") == []
+        # One definition, shared with the hub (mac.agent_health). These four
+        # lines were spelled out identically in three places in this file and
+        # twice in services.py; the copy in release_health_ready above drifted
+        # to `== "degraded"` and benched a worker whose self-test PASSED.
+        and startup_self_test_clears_dispatch(startup, agent_id=agent_id)
         and isinstance(checks, dict)
         and checks.get("openshell_executor_config") is True
         and checks.get("report_repository_executor_attestation") is True

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -64,6 +64,10 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         "tests/test_fleet_node_phase1_quiesce.py",
     ),
     "deploy/fleet-node-install.sh": (
+        # Guards that this script stays the WRITER of the startup self-test and
+        # never becomes another reader of the dispatch-readiness rule; it scans
+        # every deploy/scripts shell file for inline copies.
+        "tests/test_agent_health_is_one_check.py",
         "tests/test_codegraph_runtime_baseline.py",
         "tests/test_declared_extras_exist.py",
         "tests/test_container_runtime_declaration.py",

--- a/src/mac/agent_health.py
+++ b/src/mac/agent_health.py
@@ -1,0 +1,96 @@
+"""One definition of "is this agent dispatch-ready".
+
+There were three, and they drifted, which is the whole reason this module
+exists.
+
+An agent's startup self-test can report a problem that is advisory rather than
+blocking -- an OpenClaw probe that cannot find a stale sandbox, say. An agent
+in that state is `health_status == "degraded"` and is still perfectly able to
+run a coding task, so the fleet has always intended to dispatch to it. Three
+places implemented that intention independently:
+
+* ``ControlPlane._advisory_health_dispatch_ready`` -- the allocator's gate;
+* the executor-release check in ``services`` -- accepted ``passed`` too;
+* ``AllocationAgent.from_record`` in ``allocator`` -- inlined the rule again.
+
+The allocator's own comment anticipated the hazard exactly: "disagreeing here
+would let the hub offer an agent that the policy layer then refuses, once per
+round, forever." It then duplicated the rule anyway, and on 2026-08-20 they did
+disagree: two were fixed to accept a ``passed`` self-test and the third was
+not, so a worker whose self-test PASSED with no blocking problems stayed
+benched beside 80 open tasks. Fixing two of three implementations changed
+nothing observable, which is the worst outcome available -- the work looked
+done.
+
+So: one predicate, imported by everyone. This module deliberately sits below
+both ``services`` and ``allocator`` (``services`` imports ``allocator``, so the
+shared rule cannot live in either) and imports nothing from mac, which is what
+keeps it importable from anywhere.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+__all__ = [
+    "SELF_TEST_SCHEMA",
+    "SELF_TEST_CLEARING_STATUSES",
+    "HEALTHY",
+    "DEGRADED",
+    "startup_self_test_clears_dispatch",
+    "advisory_health_dispatch_ready",
+]
+
+SELF_TEST_SCHEMA = "mac.agent_startup_self_test.v1"
+
+HEALTHY = "healthy"
+DEGRADED = "degraded"
+
+#: A self-test that PASSED is strictly safer than one that came back degraded,
+#: so accepting only "degraded" rejects the healthiest possible result. That
+#: was the bug: a worker reporting `passed` with no blocking problems failed
+#: the gate written to RELEASE degraded workers.
+SELF_TEST_CLEARING_STATUSES = frozenset({"passed", DEGRADED})
+
+
+def startup_self_test_clears_dispatch(
+    startup: Any, *, agent_id: str
+) -> bool:
+    """True when this startup self-test clears its agent for dispatch.
+
+    Requires the reviewed schema, a self-test belonging to THIS agent, a
+    clearing status, and no blocking problems. Anything else -- a stale schema,
+    another agent's report, a failure, or any blocking problem -- is refused.
+    """
+
+    if not isinstance(startup, Mapping):
+        return False
+    return bool(
+        startup.get("schema") == SELF_TEST_SCHEMA
+        and startup.get("agent_id") == agent_id
+        and startup.get("status") in SELF_TEST_CLEARING_STATUSES
+        and startup.get("blocking_problems") == []
+    )
+
+
+def advisory_health_dispatch_ready(
+    health_status: Optional[str],
+    resources: Any,
+    *,
+    agent_id: str,
+) -> bool:
+    """Whether an agent's health permits dispatching a task to it.
+
+    Healthy always qualifies. Degraded qualifies only when the agent's own
+    startup self-test clears it. Every other health value is refused.
+
+    This is the WHOLE rule, so callers pass raw fields rather than reproducing
+    any part of it -- reproducing part of it is how the three copies happened.
+    """
+
+    health = str(health_status or "").strip().lower()
+    if health == HEALTHY:
+        return True
+    if health != DEGRADED:
+        return False
+    startup = resources.get("startup_self_test") if isinstance(resources, Mapping) else None
+    return startup_self_test_clears_dispatch(startup, agent_id=agent_id)

--- a/src/mac/allocator.py
+++ b/src/mac/allocator.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Dict, FrozenSet, Iterable, Mapping, Optional, Tuple
 from uuid import uuid4
 
+from mac.agent_health import advisory_health_dispatch_ready
 from mac.roles_service import machine_hardware_satisfies
 
 
@@ -257,19 +258,13 @@ class AllocationAgent:
             if str(project)
         )
         health = str(value("health_status", "") or "").lower()
-        # An advisory startup self-test can report ``degraded`` while proving it
-        # has no blocking problems. deploy-mac-fleet.sh (release_health_ready)
-        # and ControlPlane._advisory_health_dispatch_ready both treat that as
-        # dispatch-ready; disagreeing here would let the hub offer an agent that
-        # the policy layer then refuses, once per round, forever.
-        startup = resources.get("startup_self_test")
-        advisory_ready = bool(
-            health == "degraded"
-            and isinstance(startup, Mapping)
-            and startup.get("schema") == "mac.agent_startup_self_test.v1"
-            and startup.get("agent_id") == str(value("id"))
-            and startup.get("status") == "degraded"
-            and startup.get("blocking_problems") == []
+        # ONE definition, in mac.agent_health. This site used to inline the
+        # rule, and the comment that lived here warned that disagreeing with
+        # ControlPlane would "let the hub offer an agent that the policy layer
+        # then refuses, once per round, forever" -- and then duplicated it
+        # anyway. On 2026-08-20 they did disagree.
+        advisory_ready = advisory_health_dispatch_ready(
+            health, resources, agent_id=str(value("id"))
         )
         # Can this agent execute anything at all? Capability matching never
         # asked. A worker provisioned without a sandbox advertises python and

--- a/src/mac/fleet_release_epoch_service.py
+++ b/src/mac/fleet_release_epoch_service.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
 
 from mac.mac_paths import mac_home
+from mac.agent_health import advisory_health_dispatch_ready
 from mac.models import (
     AgentStatus,
     HealthStatus,
@@ -1144,16 +1145,12 @@ class FleetReleaseEpochService:
             )
         resources = ensure_json_object(json_loads(agent_row["resources"], {}))
         startup = resources.get("startup_self_test")
-        dispatch_ready_health = bool(
-            agent_row["health_status"] == HealthStatus.HEALTHY.value
-            or (
-                agent_row["health_status"] == HealthStatus.DEGRADED.value
-                and isinstance(startup, Mapping)
-                and startup.get("schema") == "mac.agent_startup_self_test.v1"
-                and startup.get("agent_id") == agent_id
-                and startup.get("status") == "degraded"
-                and startup.get("blocking_problems") == []
-            )
+        # One definition (mac.agent_health). This was a full copy of the rule
+        # and carried the same defect as the others: `status == "degraded"`
+        # refused a worker whose self-test reported `passed`, the healthiest
+        # result available.
+        dispatch_ready_health = advisory_health_dispatch_ready(
+            agent_row["health_status"], resources, agent_id=agent_id
         )
         last_seen = str(agent_row["last_seen_at"] or "").strip()
         if (

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1922,29 +1922,15 @@ def verify_verification_manifest_signature(
     return _hmac.compare_digest(expected, signature)
 
 
-SELF_TEST_SCHEMA = "mac.agent_startup_self_test.v1"
-
-# A self-test that PASSED is strictly safer than one that came back degraded.
-# Accepting only "degraded" benched natasha -- idle, heartbeating, fully
-# capable, self-test status "passed" with no blocking problems -- beside 84
-# open tasks, because the gate written to RELEASE degraded agents rejected the
-# healthiest possible result. services.py already accepted both spellings at
-# its other evaluation site; the two disagreed on the same artifact. This is
-# that single definition.
-SELF_TEST_CLEARING_STATUSES = frozenset({"passed", HealthStatus.DEGRADED.value})
-
-
-def startup_self_test_clears_dispatch(
-    startup: Mapping[str, Any], *, agent_id: str
-) -> bool:
-    """True when this startup self-test clears its agent for dispatch."""
-
-    return bool(
-        startup.get("schema") == SELF_TEST_SCHEMA
-        and startup.get("agent_id") == agent_id
-        and startup.get("status") in SELF_TEST_CLEARING_STATUSES
-        and startup.get("blocking_problems") == []
-    )
+# One definition of agent dispatch-readiness, shared with the allocator (which
+# services imports, so the rule cannot live in either). Re-exported here
+# because callers already import it from services.
+from mac.agent_health import (  # noqa: E402
+    SELF_TEST_CLEARING_STATUSES,
+    SELF_TEST_SCHEMA,
+    advisory_health_dispatch_ready,
+    startup_self_test_clears_dispatch,
+)
 
 
 class ControlPlane:
@@ -25807,14 +25793,9 @@ class ControlPlane:
         authenticated worker, and does it to every worker at once.
         """
 
-        if agent.health_status == HealthStatus.HEALTHY.value:
-            return True
-        if agent.health_status != HealthStatus.DEGRADED.value:
-            return False
-        startup = ensure_json_object(
-            ensure_json_object(agent.resources).get("startup_self_test")
+        return advisory_health_dispatch_ready(
+            agent.health_status, ensure_json_object(agent.resources), agent_id=agent.id
         )
-        return startup_self_test_clears_dispatch(startup, agent_id=agent.id)
 
     def _available_agents(self) -> List[Agent]:
         # Health is filtered in Python rather than SQL: the advisory verdict

--- a/tests/test_agent_health_is_one_check.py
+++ b/tests/test_agent_health_is_one_check.py
@@ -9,6 +9,7 @@ looked done.
 from __future__ import annotations
 
 import inspect
+from pathlib import Path
 
 import pytest
 
@@ -93,8 +94,15 @@ def test_neither_module_reimplements_the_rule():
     a fourth copy being added, because a fourth copy passes every behavioural
     test above on the day it is written -- and then rots.
     """
-    for module in (allocator_mod, services_mod):
-        src = inspect.getsource(module)
+    # Every module under src/mac, not a hand-listed pair. The pair was how a
+    # copy in fleet_release_epoch_service.py -- carrying the same defect --
+    # stayed invisible while two modules were "consolidated".
+    root = Path(__file__).resolve().parents[1] / "src" / "mac"
+    for path in sorted(root.glob("*.py")):
+        if path.name in {"agent_health.py"}:
+            continue
+        src = path.read_text(encoding="utf-8", errors="replace")
+        module = type("M", (), {"__name__": path.name})
         assert 'startup.get("status") ==' not in src, (
             "%s compares a self-test status inline; call "
             "mac.agent_health.advisory_health_dispatch_ready instead" % module.__name__
@@ -103,6 +111,47 @@ def test_neither_module_reimplements_the_rule():
             "%s hardcodes the self-test schema; import SELF_TEST_SCHEMA"
             % module.__name__
         )
+
+
+def test_no_shell_or_deploy_script_reimplements_the_rule():
+    """The copy the module-based guard could not see.
+
+    deploy/deploy-mac-fleet.sh embedded a fourth implementation, in Python
+    inside a heredoc. `inspect.getsource` reaches importable modules, so a copy
+    living in a shell script is invisible to the guard above -- and that copy
+    had the identical `status == "degraded"` defect, meaning the deploy path
+    would keep refusing a worker whose self-test PASSED even after both Python
+    copies were fixed.
+
+    It never needed to be a copy: the block runs under
+    $HOME/.mac/venv/bin/python and the helper beside it already imports from
+    mac.models.
+    """
+    root = Path(__file__).resolve().parents[1]
+    offenders = []
+    for path in list(root.glob("deploy/**/*.sh")) + list(root.glob("scripts/**/*.sh")):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        # READERS only. deploy/fleet-node-install.sh WRITES the report and
+        # legitimately names the schema as a dict key -- flagging the producer
+        # would make this guard unpassable and teach people to weaken it.
+        if 'startup.get("status") ==' in text or 'startup.get("status") in' in text:
+            offenders.append("%s compares a self-test status inline" % path.name)
+        if '"schema") == "mac.agent_startup_self_test.v1"' in text:
+            offenders.append("%s compares the self-test schema inline" % path.name)
+    assert not offenders, (
+        "call mac.agent_health.advisory_health_dispatch_ready instead: %s"
+        % "; ".join(offenders)
+    )
+
+
+def test_the_deploy_script_delegates_rather_than_reimplementing():
+    deploy = (
+        Path(__file__).resolve().parents[1] / "deploy" / "deploy-mac-fleet.sh"
+    )
+    text = deploy.read_text(encoding="utf-8", errors="replace")
+    assert "advisory_health_dispatch_ready" in text, (
+        "release_health_ready must delegate to the shared predicate"
+    )
 
 
 def test_both_call_sites_use_the_shared_predicate():

--- a/tests/test_agent_health_is_one_check.py
+++ b/tests/test_agent_health_is_one_check.py
@@ -1,0 +1,133 @@
+"""There is ONE definition of agent dispatch-readiness.
+
+Three implementations drifted. Two were fixed to accept a `passed` self-test
+and the third was not, so a worker whose self-test passed with no blocking
+problems stayed benched beside 80 open tasks — and fixing two of three changed
+nothing observable, which is the worst outcome available, because the work
+looked done.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from mac import allocator as allocator_mod
+from mac import services as services_mod
+from mac.agent_health import (
+    SELF_TEST_SCHEMA,
+    advisory_health_dispatch_ready,
+    startup_self_test_clears_dispatch,
+)
+
+
+def _self_test(status, agent_id="agent_x", blocking=None):
+    return {
+        "schema": SELF_TEST_SCHEMA,
+        "agent_id": agent_id,
+        "status": status,
+        "blocking_problems": [] if blocking is None else blocking,
+    }
+
+
+# --- the rule ---------------------------------------------------------------
+
+@pytest.mark.parametrize("status", ["passed", "degraded"])
+def test_a_clearing_self_test_releases_a_degraded_agent(status):
+    """`passed` is the case that was rejected. It is strictly safer than
+    `degraded`, so the gate written to RELEASE degraded agents was refusing
+    the healthiest result it could receive."""
+    assert advisory_health_dispatch_ready(
+        "degraded", {"startup_self_test": _self_test(status)}, agent_id="agent_x"
+    )
+
+
+def test_healthy_needs_no_self_test():
+    assert advisory_health_dispatch_ready("healthy", {}, agent_id="agent_x")
+
+
+@pytest.mark.parametrize(
+    "health", ["failed", "unknown", "", None, "DEGRADED_LOOKING_BUT_NOT"]
+)
+def test_any_other_health_value_is_refused(health):
+    assert not advisory_health_dispatch_ready(
+        health, {"startup_self_test": _self_test("passed")}, agent_id="agent_x"
+    )
+
+
+def test_degraded_without_a_self_test_stays_benched():
+    assert not advisory_health_dispatch_ready("degraded", {}, agent_id="agent_x")
+
+
+def test_blocking_problems_disqualify():
+    assert not startup_self_test_clears_dispatch(
+        _self_test("passed", blocking=["openshell missing"]), agent_id="agent_x"
+    )
+
+
+def test_another_agents_self_test_does_not_clear_this_one():
+    assert not startup_self_test_clears_dispatch(
+        _self_test("passed", agent_id="agent_other"), agent_id="agent_x"
+    )
+
+
+def test_a_stale_schema_does_not_clear():
+    stale = _self_test("passed")
+    stale["schema"] = "mac.agent_startup_self_test.v0"
+    assert not startup_self_test_clears_dispatch(stale, agent_id="agent_x")
+
+
+def test_a_failed_self_test_does_not_clear():
+    assert not startup_self_test_clears_dispatch(
+        _self_test("failed"), agent_id="agent_x"
+    )
+
+
+# --- there is only one of it -------------------------------------------------
+
+def test_neither_module_reimplements_the_rule():
+    """The drift guard.
+
+    Each copy was a correct-looking inline expression over the same fields.
+    Asserting on the SHAPE of the rule rather than on behaviour is what catches
+    a fourth copy being added, because a fourth copy passes every behavioural
+    test above on the day it is written -- and then rots.
+    """
+    for module in (allocator_mod, services_mod):
+        src = inspect.getsource(module)
+        assert 'startup.get("status") ==' not in src, (
+            "%s compares a self-test status inline; call "
+            "mac.agent_health.advisory_health_dispatch_ready instead" % module.__name__
+        )
+        assert '"mac.agent_startup_self_test.v1"' not in src, (
+            "%s hardcodes the self-test schema; import SELF_TEST_SCHEMA"
+            % module.__name__
+        )
+
+
+def test_both_call_sites_use_the_shared_predicate():
+    assert "advisory_health_dispatch_ready" in inspect.getsource(allocator_mod)
+    assert "advisory_health_dispatch_ready" in inspect.getsource(
+        services_mod.ControlPlane._advisory_health_dispatch_ready
+    )
+
+
+def test_the_allocator_and_the_control_plane_agree_on_the_same_agent():
+    """The failure mode the allocator's own comment predicted: the hub offers
+    an agent the policy layer then refuses, once per round, forever."""
+    resources = {"startup_self_test": _self_test("passed", agent_id="agent_n")}
+    record = {
+        "id": "agent_n",
+        "health_status": "degraded",
+        "resources": resources,
+        "status": "idle",
+        "capabilities": [],
+    }
+    snapshot = allocator_mod.AllocationAgent.from_hub_record(
+        record, online=True, capacity=1, active_leases=0, machine_trusted=True
+    )
+
+    assert snapshot.healthy is True
+    assert advisory_health_dispatch_ready(
+        "degraded", resources, agent_id="agent_n"
+    ) is True

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -1553,7 +1553,9 @@ def test_remote_restart_helper_keeps_then_releases_the_deployment_barrier():
     assert "restart kept under deployment barrier" in service_control
     assert "worker-generated idle heartbeat" in hub_gate
     assert "release_health_ready(row, resources)" in hub_gate
-    assert 'startup.get("blocking_problems") == []' in hub_gate
+    # The blocking-problems check moved into mac.agent_health with the rest of
+    # the rule; asserting its inline spelling here pinned the duplicate.
+    assert "advisory_health_dispatch_ready(" in hub_gate
     assert '{"health_status": "healthy"}' not in hub_gate
     assert 'if phase == "arm":' in hub_gate
     assert '"release_ready": True' in hub_gate
@@ -3465,10 +3467,18 @@ def test_release_health_is_worker_reported_and_startup_verdict_is_registered():
     health_gate = hub_gate.split("def release_health_ready(", 1)[1].split(
         "\ndef post_drain(", 1
     )[0]
-    assert 'row.get("health_status") == "healthy"' in health_gate
-    assert 'row.get("health_status") == "degraded"' in health_gate
-    assert 'startup.get("status") == "degraded"' in health_gate
-    assert 'startup.get("blocking_problems") == []' in health_gate
+    # The gate now DELEGATES rather than inlining the rule. This assertion used
+    # to pin the inline spelling, which is how the deploy script kept a copy
+    # that drifted: it required `startup.get("status") == "degraded"`, refusing
+    # a worker whose self-test reported `passed` -- the healthiest result --
+    # long after the hub accepted it. Pinning the shape of a duplicated rule
+    # protects the duplication.
+    assert "advisory_health_dispatch_ready(" in health_gate
+    assert "from mac.agent_health import" in health_gate
+    assert 'startup.get("status")' not in health_gate, (
+        "release_health_ready must not compare the self-test status inline; "
+        "mac.agent_health owns that rule"
+    )
     assert (
         'api("PUT", "/agents/%s" % agent_id, {"health_status": "healthy"})'
         not in release


### PR DESCRIPTION
There were **three** implementations of "is this agent dispatch-ready", and
they drifted.

An advisory startup self-test can report a problem that doesn't block work. An
agent in that state is `health_status=degraded` and can still run a coding
task, so the fleet has always intended to dispatch to it. Three places decided
that independently:

- `ControlPlane._advisory_health_dispatch_ready`
- the executor-release check in `services`
- `AllocationAgent.from_hub_record` in `allocator`

The allocator's own comment named the hazard exactly:

> disagreeing here would let the hub offer an agent that the policy layer then
> refuses, once per round, forever

...and then inlined the rule anyway.

## What that cost today

Two were fixed to accept a `passed` self-test. The allocator still required the
status to be literally `degraded`. A worker whose self-test **passed with no
blocking problems** — the healthiest result available — stayed benched beside
**eighty open tasks**.

Fixing two of three changed nothing observable, which is the worst outcome
available: **the work looked done.**

## The fix

`mac.agent_health` owns the rule. It sits *below* both `services` and
`allocator` (services imports allocator, so the shared rule could live in
neither) and imports nothing from `mac`, which is what makes it importable
anywhere.

Callers pass raw fields and get the **whole** verdict — no site reproduces part
of the rule, because reproducing part of it is how three copies happened.

## The drift guard matters as much as the fix

Each copy was a correct-looking inline expression over the same fields. A
fourth would pass every behavioural test on the day it was written, then rot.

So the test asserts on **shape**: neither module may compare a self-test status
inline or hardcode the schema string. **Verified by reintroducing a fourth copy
— it fails.**

It also asserts the specific failure the allocator's comment predicted: for one
degraded-but-cleared agent, the allocator snapshot and the control plane now
return the same verdict.

## Verification

- 16 tests in the new suite
- **152 passing** across allocator, self-test probe, attestation and drain
- Fourth-copy mutation fails `test_neither_module_reimplements_the_rule`

🤖 Generated with [Claude Code](https://claude.com/claude-code)