### PR TITLE
A judged failure is a rejection; only a dead harness is unavailable

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -974,6 +974,58 @@ REPOSITORY_CONTRACT_FILES = (
 #: judging the work deficient. One task was rejected, redone more thoroughly
 #: (58 tests -> 60, 2 files -> 11, ruff and a CodeGraph audit added), and
 #: rejected identically, because the verdict never depended on the diff.
+#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING.
+#:
+#: Checked BEFORE the unavailable signatures, and they win, because the two
+#: overlap in exactly the case that matters.
+#:
+#: `ssh exited with status` is the generic wrapper exit printed whenever a
+#: remote command returns non-zero -- it accompanies every failure through the
+#: ssh transport, not only a transport fault. Listing it as "unavailable"
+#: (2026-08-19, PR #478) therefore inverted the original bug instead of fixing
+#: it. Before, a transport death was signed as a rejection. After, a genuine
+#: rejection was swallowed as "could not verify", so NO verdict was signed and
+#: the task sat in REVIEWING forever.
+#:
+#: Observed live on 2026-08-20: twelve `hub_verify_unavailable` events in
+#: ninety minutes whose real failures were
+#:     "documentation contract failed: published shell fences outside the
+#:      executable book are forbidden"
+#: and
+#:     "documentation-inventory.md is stale: regenerate with
+#:      scripts/generate-docs-reference.py --write"
+#: -- both real, actionable, and both discarded. Twenty tasks accumulated in
+#: REVIEWING, five of them for over a hundred hours.
+#:
+#: The discriminator is whether the gate reached a judgement. It is not
+#: "did the gate produce output": in the #478 case the coverage gate ran and
+#: PASSED before the stream died, so output alone would have called that a
+#: rejection too. Only an explicit FAILING verdict counts.
+#: Every entry must appear ONLY on failure. That is the whole discipline here,
+#: and it is easy to get wrong in the direction that reintroduces #478:
+#: `coverage safety:` was an obvious-looking candidate and is emitted whether
+#: the floors pass or fail, so it would have marked the original
+#: passed-then-the-stream-died run as a rejection -- exactly the bug #478
+#: existed to fix. Likewise `repository contract` appears in
+#: "running fail-fast repository contract preflight", which is a start
+#: message, not a verdict.
+#:
+#: When in doubt leave a signature OUT. A missing signature means a real
+#: rejection is retried as "unavailable", which wastes a run. A wrong one
+#: means a transport fault is signed as a rejection, which discards correct
+#: work and is what this pair of fixes is for.
+_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = (
+    "documentation contract failed",
+    "is stale:",
+    "stale generated",
+    "regenerate with",
+    "contract test failed",
+    " failed, ",         # pytest summary: "3 failed, 40 passed"
+    "assertionerror",
+    "error: process completed with exit code",
+)
+
+
 _HUB_VERIFY_UNAVAILABLE_SIGNATURES: Tuple[str, ...] = (
     # cursor-agent's stream transport, the observed cause
     "ssh exited with status",
@@ -1005,6 +1057,13 @@ def hub_verification_unavailable_reason(output: str) -> Optional[str]:
     open on the gate this exists to enforce.
     """
     text = (output or "").lower()
+    # A gate that judged the change wanting is a REJECTION, whatever the
+    # transport did afterwards. Checked first because the two sets overlap:
+    # a real contract failure still exits through ssh and still prints
+    # "ssh exited with status".
+    for verdict in _HUB_VERIFY_VERDICT_SIGNATURES:
+        if verdict in text:
+            return None
     for signature in _HUB_VERIFY_UNAVAILABLE_SIGNATURES:
         if signature in text:
             return signature

--- a/tests/test_hub_verify_verdict_vs_transport.py
+++ b/tests/test_hub_verify_verdict_vs_transport.py
@@ -1,0 +1,104 @@
+"""A gate that judged the change is a REJECTION; a harness that died is not.
+
+These two fixes point in opposite directions and the same string sits between
+them, so each one is easy to make at the other's expense.
+
+#478 (2026-08-19): a coding agent's ssh stream died AFTER the coverage gate
+passed. The non-zero exit was signed as `rejected`, indistinguishable from a
+reviewer judging the work deficient. One task was rejected, redone far more
+thoroughly, and rejected identically, because the verdict never depended on
+the diff.
+
+The fix listed `ssh exited with status` as "verification unavailable". But that
+string is the generic wrapper exit printed whenever a remote command returns
+non-zero -- it accompanies every failure through the ssh transport, not only a
+transport fault. So it inverted the bug: genuine rejections were swallowed as
+"could not verify", no verdict was signed, and tasks sat in REVIEWING forever.
+Observed 2026-08-20: twelve such events in ninety minutes, twenty tasks
+accumulated in REVIEWING, five of them past a hundred hours.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mac.services import (
+    _HUB_VERIFY_VERDICT_SIGNATURES,
+    hub_verification_unavailable_reason,
+)
+
+SSH_TAIL = "\nError:   x ssh exited with status exit status: 1"
+
+
+# --- a real verdict is a rejection, whatever the transport did afterwards ---
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "documentation contract failed: published shell fences outside the "
+        "executable book are forbidden (docs/x.md:132)",
+        "documentation-inventory.md is stale: regenerate with "
+        "scripts/generate-docs-reference.py --write",
+        "FAILED tests/test_x.py::test_y\n3 failed, 40 passed in 9.1s",
+        "E   AssertionError: expected 1 got 0",
+    ],
+)
+def test_a_judged_failure_is_a_rejection_even_through_a_dying_stream(output):
+    """The 2026-08-20 regression. Each of these is real and actionable, and
+    each was discarded as 'could not verify'."""
+    assert hub_verification_unavailable_reason(output + SSH_TAIL) is None
+
+
+# --- a harness that died is not a rejection --------------------------------
+
+def test_the_478_case_stays_unavailable():
+    """Coverage PASSED, then the stream died. No verdict exists to sign."""
+    output = (
+        "coverage safety: statements 69300/76238 (90.90%, floor 90.00%); "
+        "branches 20216/24618 (82.12%, floor 80.00%)\n"
+        "  + Files uploaded" + SSH_TAIL
+    )
+    assert hub_verification_unavailable_reason(output) == "ssh exited with status"
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("Starting sandbox\nconnection reset by peer", "connection reset by peer"),
+        ("connection refused", "connection refused"),
+        ("no acceptable coding agent", "no acceptable coding agent"),
+        ("error: could not create sandbox", "error: could not create sandbox"),
+    ],
+)
+def test_transport_and_environment_faults_stay_unavailable(output, expected):
+    assert hub_verification_unavailable_reason(output) == expected
+
+
+def test_an_unrecognised_failure_is_still_a_rejection():
+    """Fail CLOSED on the gate: an unknown failure must not become
+    'infrastructure' and retry forever."""
+    assert hub_verification_unavailable_reason("something nobody has seen") is None
+
+
+# --- the discipline that keeps this correct --------------------------------
+
+@pytest.mark.parametrize("signature", sorted(_HUB_VERIFY_VERDICT_SIGNATURES))
+def test_no_verdict_signature_appears_in_passing_output(signature):
+    """Every verdict signature must appear ONLY on failure.
+
+    This is the trap. `coverage safety:` is emitted whether the floors pass or
+    fail, and `repository contract` appears in "running fail-fast repository
+    contract preflight" -- a start message. Either would mark the #478
+    passed-then-died run as a rejection, reintroducing the exact bug.
+    """
+    passing = (
+        "sanity selection: full\n"
+        "run-contract-tests.sh: running fail-fast repository contract preflight\n"
+        "  + Files uploaded\n"
+        "coverage safety: statements 70371/77427 (90.89%, floor 90.00%); "
+        "branches 20606/25076 (82.17%, floor 80.00%)\n"
+        "595 passed in 12.11s\n"
+    ).lower()
+    assert signature not in passing, (
+        "%r appears in PASSING output, so it would mark a transport fault as a "
+        "rejection -- the #478 bug" % signature
+    )


### PR DESCRIPTION
**Fixes a regression I introduced in #478**, which inverted the bug it was
meant to fix.

## #478 was right about the problem

A coding agent's ssh stream died *after* the coverage gate passed. The non-zero
exit was signed as `rejected`, indistinguishable from a reviewer judging the
work deficient. One task was rejected, redone far more thoroughly, and rejected
identically — because the verdict never depended on the diff.

## It was wrong about the signature

It listed `ssh exited with status` as "verification unavailable". But that
string is the **generic wrapper exit printed whenever a remote command returns
non-zero** — it accompanies *every* failure through the ssh transport, not only
a transport fault.

So genuine rejections stopped being signed at all. No verdict, and the task
sits in `REVIEWING` forever.

**Observed live today:** twelve `hub_verify_unavailable` events in ninety
minutes whose real failures were

```
documentation contract failed: published shell fences outside the
executable book are forbidden (docs/task-hold-sweep.md:132)
```
```
documentation-inventory.md is stale: regenerate with
scripts/generate-docs-reference.py --write
```

Both real, both actionable, **both discarded**. Twenty tasks accumulated in
`REVIEWING` — five past a hundred hours — and nine approved reviews never
published.

## The fix

Signatures proving the gate **judged** the change are checked first and win. A
real contract failure still exits through ssh and still prints that line; what
distinguishes it is that a judgement exists.

**The discriminator is not "did the gate produce output."** In the #478 case
the coverage gate ran and *passed* before the stream died — output alone would
call that a rejection too. Only an explicit **failing** verdict counts.

## The trap, which I fell into in my first draft

Every verdict signature must appear **only on failure**, and the obvious
candidates don't:

| Rejected candidate | Why |
| --- | --- |
| `coverage safety:` | emitted whether the floors **pass or fail** |
| `repository contract` | appears in *"running fail-fast repository contract preflight"* — a start message |

Either would mark the #478 passed-then-died run as a rejection, **reintroducing
the exact bug**. Both were in my first draft; a test now asserts no verdict
signature appears in passing output.

When in doubt a signature stays **out**: a missing one retries a real rejection
as unavailable and wastes a run; a wrong one discards correct work.

## Verification

18 tests covering **both directions** — the exact #478 output and today's two
live failures. 125 passing across the review and verification suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)