### PR TITLE
Add a capabilities deck, and the release skill that produces it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,10 @@ mac-evidence.json
 .mac-openshell-build-assets/
 .vendor-check.sh
 .vendor-check-work/
+
+# Generated deck outputs. docs/presentation/ keeps only text: the SVG diagram
+# sources are the durable artifact, the rendered PNGs and built .pptx are
+# reproducible from them, and the deck itself is published to Google Slides.
+# See docs/presentation/README.md.
+docs/presentation/*/images/*.png
+docs/presentation/*/*.pptx

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ do, before you do it:
 | `skills/record-user-directed-work/SKILL.md` | acting on user direction, or finding a defect while working — conversation is not a record |
 | `skills/setup-mac-fleet/SKILL.md` | standing up or reconfiguring fleet hosts |
 | `skills/mac-agent-terminal-timeout/SKILL.md` | an agent terminal hangs or times out |
+| `skills/cut-a-release/SKILL.md` | the release gates are green and the next step is tagging — the documentation pass, the pinned capabilities deck, and the traps that make a docs gate fail |
 
 The CLI skill is enforced: `tests/test_mac_cli_skill.py` fails if it names a
 command the parser does not have, so it cannot rot into confident nonsense.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The guide is in [`docs/guide/`](docs/guide/README.md):
 | [The UI](docs/guide/04-ui.md) | the read-only console and the mutating Fleet IDE |
 | [Developer Guide](docs/guide/05-developer-guide.md) | how to hack on mac |
 | [Contributing](CONTRIBUTING.md) | filing issues and PRs that are actually tested |
+| [Presentations](docs/presentation/README.md) | capabilities decks, each pinned to the commit it describes and published to Google Slides |
 
 Those pages are written from the code and gated by
 `tests/test_guide_docs_are_true.py`, which checks that every file they name

--- a/docs/presentation/20260820T011224Z-8b424c20/AUDIT.md
+++ b/docs/presentation/20260820T011224Z-8b424c20/AUDIT.md
@@ -1,0 +1,167 @@
+# Audit — every claim in this deck, traced to source
+
+Audited at commit `8b424c20` on 2026-08-20T01:12:24Z, by reading the tree directly. Generated
+references (`docs/reference/cli.md`, `docs/reference/openapi.md`) are treated as authoritative for
+surface counts because CI fails when they drift from the live parser and OpenAPI schema.
+
+**Where the README and the code disagree, this audit follows the code**, and says so.
+
+---
+
+## 1. Counts
+
+| Claim | How it was obtained |
+|---|---|
+| 195,764 lines of Python under `src/` | `find src -name "*.py" \| xargs wc -l` |
+| 201 modules in `src/mac` | `ls src/mac/*.py \| wc -l` |
+| 470 test files | `ls tests/*.py \| wc -l` |
+| 408 HTTP routes | `grep -cE "^\| \`(GET\|POST\|PUT\|PATCH\|DELETE)\`" docs/reference/openapi.md` |
+| 123 CLI verbs | Parsed from `docs/reference/cli.md`: task 44, admin 53, agent 17, project 9 |
+| 18 book chapters | `nav:` in `mkdocs.yml`, `book/01`–`book/18` |
+| 18 ADRs | `docs/adr/0001`–`0018` |
+| 5 coding-agent routes | `src/mac/coding_agent.py` — `claude`, `codex`, `cursor`, `opencode`, `pi` |
+
+## 2. The object model (diagram 01)
+
+| Claim | Source |
+|---|---|
+| The CLI is organised around project / task / agent / admin | `docs/reference/cli.md`, `mac --help`: "The objects mac models. Start here: project … task … agent" |
+| project = "a unit of work ownership: repositories, policy, dispatch state" | `mac --help` verbatim |
+| task = "one unit of work: the thing agents claim, run, and publish" | `mac --help` verbatim |
+| agent = "a worker that claims and executes tasks on a machine" | `mac --help` verbatim |
+| Project dispatch pause is separate from per-task staging | `README.md` Core Contracts: "project-level dispatch pause is a separate gate" |
+| Recovery verbs | `mac task --help`: `recover-stranded`, `recover-finalizer`, `recover-stalled-finalizer` |
+| Break-glass is grantable/listable/revocable | `mac task --help`: `break-glass`, `break-glass-list`, `break-glass-revoke` |
+| Visibility is not a dispatch gate | `docs/adr/0014-visibility-is-not-a-dispatch-gate.md`; commit `6526dd65` "Stop treating agent visibility as a dispatch gate" |
+| Normalized effective allocation in the hardware snapshot | commit `c6766a14` |
+| Repository runtime contract before bootstrap | `README.md` Core Contracts; `docs/repository-runtime-contract.md` |
+| Generated CLI reference is checked, not hand-written | `scripts/generate-docs-reference.py`; `Makefile` target `docs-build` runs it with `--check` |
+| MCP server is a client, not a second implementation | commit `efb428e9`: "Every tool goes through RemoteDispatch… A test asserts the module contains no urllib/requests/HubClient" |
+| Python client is contract-checked against the hub | commit `58d71fc8`; `tests/test_dispatch_route_contract.py` referenced by `efb428e9` |
+| Client warns when older than the hub | commit `1e747d35` |
+| ACP and A2A are implemented specifications | `README.md` lineage section; routes `/.well-known/acp`, `/.well-known/agent-card.json`, `/a2a` in `docs/reference/openapi.md` |
+| `/ui` is read-only observability; the C2 dashboard was retired | commits `d725fa12`, `43887f68`, `27ed8af9` |
+| Scoped bearer tokens | `README.md`: "Optional scoped API bearer tokens for read/write/agent/dispatch/secret/admin access" |
+
+## 3. Task lifecycle (diagram 02)
+
+| Claim | Source |
+|---|---|
+| Eleven states | `src/mac/models.py`, `class TaskState`: open, waiting, blocked, claimed, running, needs_review, needs_input, reviewing, completed, failed, cancelled |
+| Three terminal states | `src/mac/models.py`, `TERMINAL_TASK_STATES` = completed, failed, cancelled |
+| Non-terminal work is the default list view | `src/mac/models.py` comment: "Every state that is NOT terminal: work that still wants something from somebody. This is the default view for `mac task list`"; commit `975827d9` |
+| Hub drives RUNNING → NEEDS_REVIEW → REVIEWING → COMPLETED | `docs/adr/0016-agent-initiated-review.md`, Context |
+| Leases and fences authorize mutations | `README.md` Core Contracts; ADR 0016 "What must not be lost — Liveness" |
+| Dispatcher accounts for pool policy, resources, capacity, stale heartbeats, expired leases | `README.md` Core Contracts |
+| Approval binds to current executor evidence for that exact attempt | `README.md` Core Contracts; `docs/review-strategy-experiments.md` |
+| Reviewer must differ by agent and by model | `docs/review-strategy-experiments.md` |
+| Blind arm physically renames `executor-evidence.json` out of the workspace | `docs/review-strategy-experiments.md`, "Evidence-withheld discovery" |
+| Reviews record what was said, not only the vote | commit `7927dc16` |
+| CodeGraph source-change audit is mandatory; affected-test selection | `README.md` lineage: "repository analysis, affected-test selection, and the mandatory source-change audit"; ADR 0011 |
+| Short-retention command audit | `README.md` Core Contracts |
+| Work lands via a pull request the agent owns | commits `484baceb`, `44e81d5a` |
+| Native merge queue, Zuul-style speculative train, AIMD window floor 1 / ceiling 4, eviction | commit `2b49fb23`; `src/mac/native_merge_queue.py` |
+| "never land an untested tree" | commit `2b49fb23`: "THE INVARIANT, enforced structurally rather than asserted" |
+| An entry that cannot progress must say so | commit `03da7f63` |
+| Failure causes are classified | `src/mac/review_failure_classifier.py`, `src/mac/attempt_failure_classifier.py` |
+
+## 4. Coordination (diagram 03)
+
+All from commit `73476fc6` ("Make AgentBus a bus") unless noted.
+
+| Claim | Source |
+|---|---|
+| Point-to-point messages are no longer private | "SEMANTIC CHANGE: … `_authorized` … now returns True for any agent on the bus" |
+| The two near-miss incidents | "a `git add -A` moments from sweeping ~1,200 lines of another agent's half-finished work into an unrelated commit, and a `git commit -a` that did" |
+| A convention agents could follow but not verify | "a rule agents can follow but cannot verify, because nothing tells one agent what another is doing" |
+| The quoted rationale for not enforcing silence | "an enforced silence would stop an agent from volunteering the one fact that keeps another from destroying work" |
+| Roll call and traffic endpoints | `GET /agents/{id}/agentbus/roll-call`, `GET /agents/{id}/agentbus/traffic` |
+| Inbox is scoped by addressing, not access | "the inbox is scoped by ADDRESSING, not access" |
+| `mac.debug.terminal.*` carve-out | `PARTICIPANT_SCOPED_TOPICS` consulted by `_may_read` |
+| Typed schema registry, enforced at publish, advisory for unknown | `src/mac/agentbus_schemas.py` module docstring |
+| Lifecycle verbs and scopes | `src/mac/agentbus_control.py`: `LIFECYCLE_VERBS` = stand_down, abort, pause, resume, status; `LIFECYCLE_SCOPES` = fleet, project, agent; task scope added in commit `454f48bb` |
+| `abort` is flagged destructive | `LIFECYCLE_DESTRUCTIVE_VERBS = frozenset({LIFECYCLE_ABORT})` |
+| Stand-down is not abort | `agentbus_control.py`: "A single button labelled 'stop' that means ABORT destroys work in flight; one that means PAUSE does not stop a runaway." |
+| The console speaks on the bus rather than mutating | commit `e0136d06`: "it never mutates the control plane directly, it speaks on the bus like any other participant" |
+| An unknown verb fails where built | `LifecycleVerbError` docstring |
+| A directive with no target is refused | commit `e0136d06` body |
+| GitHub merge queues are organization-only, HTTP 422 verified | commit `2b49fb23`: "adding a `merge_queue` rule to ruleset 20954943 returns HTTP 422 `Invalid rule 'merge_queue'`" |
+| Priority ageing prevents starvation | `docs/dispatch-priority-bias-audit.md`; `MAC_DISPATCH_PRIORITY_AGING_SECONDS` in `docs/review-strategy-experiments.md` |
+
+## 5. Fleet and execution (diagram 04)
+
+| Claim | Source |
+|---|---|
+| macOS nodes are host installs under launchd, not containers | `docs/adr/0015-macos-nodes-are-host-installs.md` — **Accepted**, 2026-08-17; supersedes the "macOS fleet nodes via Docker" amendment to ADR 0008 |
+| Linux: native steward + containerized execution | `docs/adr/0012-hybrid-native-steward-containerized-execution.md`; ADR 0015 amends it so "the containerized-execution half now applies to Linux nodes only" |
+| Node supervisors: launchd / systemd / supervisord | ADR 0012 Context: "a macOS host managed by launchd, Linux hosts managed by systemd, and Kubernetes pods managed by supervisord" |
+| Docker Engine/Moby is the only container runtime | `docs/adr/0008-openshell-docker-engine-runtime.md` |
+| OpenShell owns process trees, filesystem/network policy, sandbox lifecycle, normalized action events | `README.md` lineage section |
+| HGX elastic capacity | `docs/hgx-elastic-capacity.md` |
+| Five coding-agent routes | `src/mac/coding_agent.py`; commits `4f9bd4d1` (opencode), `885cd400`, `c4f90d0f` (pi) |
+| Sandbox derives its coding agents from the router | commit `d696855f` |
+| Preflight sentinel | `src/mac/coding_agent.py`, `PREFLIGHT_SENTINEL = "MAC_CODING_AGENT_SANDBOX_OK"` |
+| A test asserts the sandbox's MCP config launches mac's server | commit `efb428e9` |
+| Sandbox policy changes announced on the bus, acted on between tasks | commit `b3c35a55` |
+| Reproducible runtime manifests with digests and secret-value checks | `README.md` Core Contracts |
+| `tested-<inputs-sha>` image tag | `docs/adr/0016`, "Problem" — lists it among the deterministic gates that worked |
+| Synchronized cutover | `docs/synchronized-fleet-cutover.md`, `docs/fleet-cutover-transaction-protocol.md` |
+| A rollout can require a passing `eval_run` before promote | `README.md` Core Contracts, evaluation contract |
+| Secrets are tenant-scoped handles with audit records and redacted output | `README.md` Core Contracts |
+| Credentials never remain in the review checkout's origin URL | `docs/fleet-operational-learning.md` |
+| Egress declared per project and per task | `mac project egress`, `mac task egress` in `docs/reference/cli.md` |
+
+## 6. Measurement (diagram 05)
+
+| Claim | Source |
+|---|---|
+| Review experiment assignment is deterministic from `(experiment_id, task_id, policy_version)` | `docs/review-strategy-experiments.md` |
+| The optimizer emits a policy candidate, never an automatic change | `docs/review-strategy-experiments.md`; `docs/scientific-optimizer.md` |
+| Dreaming gates: provenance, contradiction reduction, privacy, retrieval quality, compression, win balance | `docs/dreaming-rewrite.md`, "Gates" |
+| Compression gate quarantines output above 0.75× input; promotion retires superseded rows | `docs/dreaming-rewrite.md` |
+| Fleet operational learning changes reviewer routing on proven success/failure | `docs/fleet-operational-learning.md` |
+| Eval sets carry scoring direction, baseline and regression threshold | `README.md` Core Contracts |
+| Hub event-loop stall detection | commit `44cc3b2a` |
+| **28,352 `llm.route` events; 481.8M input / 5.05M output; 64% streaming; 29.5% null `input_tokens`; 0 cached** | `docs/adr/0017-token-spend-is-metered-at-the-router.md`, "Measured over the seven days to 2026-08-19" |
+| Cost is priced at read time and reports say missing, not zero | ADR 0017: "`estimate_route_cost()` … prices `resolved_model` against a models catalog at read time and returns `(cost, was_priceable)`" |
+| **Ledger census 2026-08-19: blocked 355, waiting 19, failed 2,105, cancelled 3,531, open 84, running 2** | `docs/adr/0018-task-graph-progressive-disclosure.md` |
+| **165 of 355 blocked tasks wait on dependencies that can never complete** | ADR 0018, citing `task_9f3b80b8` |
+| "A state whose p50 dwell is measured in days is not a queue, it is a graveyard" | ADR 0018, quoting `StuckView`'s own docstring |
+| ADR 0016 session figures (764,172 tokens; 52 reviews / 38 tasks / 0 findings; 18 ready / 3 idle / 0 assignments) | `docs/adr/0016-agent-initiated-review.md`, "The evidence from one session (2026-08-16/17)" |
+
+## 7. Statuses, stated precisely
+
+| ADR | Status in the file |
+|---|---|
+| 0012 native steward + containerized execution | **Accepted; implementation deferred pending fleet measurement** |
+| 0015 macOS nodes are host installs | **Accepted** |
+| 0016 agents decide what a task needs | **Proposed** (2026-08-17) |
+| 0017 token spend metered at the router | **Proposed** (2026-08-19) |
+| 0018 task view is a graph | **Proposed** (2026-08-19) |
+
+## 8. Where the README is stale
+
+Noted because the deck contradicts it deliberately, and because it is worth fixing separately:
+
+- `README.md` still documents **`src/mac/_hermes` as a vendored Hermes Agent 0.15.1 snapshot**
+  supplying "the agent loop, gateways, tools, plugins, and skills". That directory does not exist
+  at this commit — verified with `ls -d src/mac/_hermes` → *No such file or directory*. The vendored
+  tree was removed in commit `3ebde2dd`, its fate recorded in `d43996c8`, and the Hermes persona
+  plugin removed in `42897e08`.
+- The same entry carries a "snapshot contract" link pointing at deploy/hermes/SNAPSHOT.md. That
+  directory was deleted by the same commit, so the link is broken. (Written unlinked here on
+  purpose: the documentation accessibility gate resolves relative links under `docs/`, and quoting
+  a dead one verbatim reproduces the defect in this file.)
+- The testing and linting sections both claim `src/mac/_hermes` is **excluded** from coverage and
+  from Ruff. Nothing in `pyproject.toml`, `setup.cfg` or the `Makefile` references `_hermes`.
+
+**Not stale, despite appearances:** the Core Contracts entry for the **`mac-hermes` adapter** is
+correct. `mac-hermes = "mac.hermes_adapter:main"` is a live console script in `pyproject.toml` and
+`src/mac/hermes_adapter.py` exists. The adapter is clean-room MAC code and was never part of the
+vendored snapshot; only the snapshot was removed. Likewise the "Boundary With Hermes" section
+describes a design boundary rather than a vendored tree, and
+`docs/hermes-retirement-premises.md` records that both premises for retiring Hermes "neither holds
+as stated" — so it is not safe to read the deleted tree as Hermes having been fully retired.
+
+The deck therefore does not describe the vendored Hermes runtime as present, and does not claim
+Hermes has been retired as an interaction boundary.

--- a/docs/presentation/20260820T011224Z-8b424c20/README.md
+++ b/docs/presentation/20260820T011224Z-8b424c20/README.md
@@ -1,0 +1,90 @@
+# MAC capabilities deck — `8b424c20`
+
+A point-in-time capabilities deck for MAC, built by auditing the source and documentation at
+commit `8b424c20`, captured `2026-08-20T01:12:24Z`.
+
+## The deck
+
+**[MAC — What the control plane can do today (`8b424c20`)](https://docs.google.com/presentation/d/1DXgpB-3fy4IDLynGloaAP349BWrwoVSw8T46VyPdT3M/edit)**
+
+13 slides, 16:9, speaker notes on every slide. Published as a native Google Slides presentation
+rather than committed as a binary — see "What is checked in, and what is not" below.
+
+## What is in this directory
+
+| File | Purpose |
+|---|---|
+| `AUDIT.md` | Every claim in the deck traced to a file, commit or generated reference |
+| `images/*.svg` | The five diagrams, hand-authored, and the durable source for them |
+| `build_deck.py` | Rebuilds the `.pptx` from the diagrams so it can be re-published |
+| `README.md` | This file |
+
+## What is checked in, and what is not
+
+**Checked in: text only.** The SVG diagram sources are the durable artifact — they diff, they
+review, and they regenerate everything else.
+
+**Not checked in: the rendered PNGs and the built `.pptx`.** Both are generated outputs, and
+committing them would put megabytes of opaque binary under `docs/` for no reviewable gain. It also
+breaks a gate: `tests/test_docs_no_operator_identity.py` greps every tracked file under `docs/` for
+fleet-identity tokens, and compressed image data eventually contains one by coincidence — the first
+PNG tried here matched `JKH` inside its pixel data. Keeping `docs/` text-only means that gate keeps
+reading prose, which is the only place identity can actually leak.
+
+## This is a pinned artifact
+
+It describes `8b424c20` and nothing later, and is **not** updated as the code moves. Build a new
+sibling directory instead — see the convention in [`../README.md`](../README.md). An old deck should
+keep meaning what it meant when it was shown.
+
+Figures carry the date they were measured for the same reason. The token-routing and ledger-census
+numbers were true for the seven days to 2026-08-19; the dreaming figures cited in `AUDIT.md` are
+from 2026-07-28.
+
+## Slides
+
+1. Title — commit and capture time
+2. What MAC is, and what it deliberately is not
+3. *Part one: the model*
+4. **One control plane, four objects** — the CLI as the object model, and six surfaces onto it
+5. **A task is a state machine with receipts** — 11 states and the four gates between them
+6. *Part two: coordination and execution*
+7. **A town square, not a switchboard** — the broadcast AgentBus, lifecycle verbs, dispatch, merge queue
+8. **A heterogeneous fleet, honestly modelled** — node classes, coding-agent routes, images, secrets
+9. *Part three: measurement*
+10. **The fleet measures itself** — what it measures, what it found, and the three ADRs that resulted
+11. Scale at this commit
+12. Proposed, deferred, or stale — stated up front
+13. Provenance
+
+Slide 12 is deliberate. ADRs 0016–0018 are **Proposed**, not shipped; ADR 0012 is Accepted with
+implementation deferred; and at this commit the repository README still documented a vendored
+Hermes runtime that no longer existed in the tree (`AUDIT.md` §8). A capabilities deck that omits
+those is marketing.
+
+## Rebuilding and re-publishing
+
+Render the diagrams to PNG with headless Chrome at 2× device scale:
+
+```console
+$ CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+$ cd docs/presentation/20260820T011224Z-8b424c20/images
+$ "$CHROME" --headless --disable-gpu --hide-scrollbars \
+    --force-device-scale-factor=2 --window-size=1520,900 \
+    --default-background-color=FFFFFF \
+    --screenshot=01-object-model.png "file://$PWD/01-object-model.svg"
+```
+
+Window sizes: `01` 1520×900 · `02` 1520×880 · `03` 1520×900 · `04` 1520×900 · `05` 1520×930.
+
+Then build the deck. `python-pptx` is deliberately **not** a repository dependency — this is a
+documentation artifact, not part of the shipped runtime:
+
+```console
+$ python3 -m venv /tmp/deckvenv && /tmp/deckvenv/bin/pip install python-pptx
+$ /tmp/deckvenv/bin/python docs/presentation/20260820T011224Z-8b424c20/build_deck.py
+```
+
+Upload the result to Drive and open it with Google Slides, or use **File → Import slides**.
+Full-bleed diagram images and speaker notes both survive the conversion. The rendered PNGs and the
+built `.pptx` are ignored by git, so a rebuild leaves the working tree clean.

--- a/docs/presentation/20260820T011224Z-8b424c20/README.md
+++ b/docs/presentation/20260820T011224Z-8b424c20/README.md
@@ -28,8 +28,11 @@ review, and they regenerate everything else.
 committing them would put megabytes of opaque binary under `docs/` for no reviewable gain. It also
 breaks a gate: `tests/test_docs_no_operator_identity.py` greps every tracked file under `docs/` for
 fleet-identity tokens, and compressed image data eventually contains one by coincidence — the first
-PNG tried here matched `JKH` inside its pixel data. Keeping `docs/` text-only means that gate keeps
-reading prose, which is the only place identity can actually leak.
+PNG tried here matched one of them inside its pixel data. Keeping `docs/` text-only means that gate
+keeps reading prose, which is the only place identity can actually leak.
+
+(Which token is deliberately not written here. Naming it would put it in a checked-in doc and trip
+the very gate this paragraph is about. Only the test file itself is exempt from the scan.)
 
 ## This is a pinned artifact
 

--- a/docs/presentation/20260820T011224Z-8b424c20/build_deck.py
+++ b/docs/presentation/20260820T011224Z-8b424c20/build_deck.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Build the MAC capabilities deck for commit 8b424c20 as a 16:9 .pptx.
+
+This deck is a point-in-time artifact. It is pinned to the commit named in its
+directory and is NOT regenerated as the code moves — build a new timestamped
+directory instead, so an old deck keeps meaning what it meant when it was shown.
+
+Requires python-pptx, which is deliberately not a repository dependency:
+
+    python3 -m venv /tmp/deckvenv
+    /tmp/deckvenv/bin/pip install python-pptx
+    /tmp/deckvenv/bin/python build_deck.py
+
+Diagram PNGs are rendered from the SVGs beside them; see README.md for the exact
+render commands.
+
+Both the PNGs this reads and the .pptx it writes are gitignored: docs/ keeps only
+text, and the deck is published to Google Slides. README.md holds the link.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from struct import unpack
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Emu, Inches, Pt
+
+HERE = Path(__file__).resolve().parent
+IMAGES = HERE / "images"
+COMMIT = "8b424c20"
+CAPTURED = "2026-08-20T01:12:24Z"
+OUT = HERE / f"mac-capabilities-{COMMIT}.pptx"
+
+SLIDE_W = Inches(13.333)
+SLIDE_H = Inches(7.5)
+
+INK = RGBColor(0x1B, 0x25, 0x30)
+SLATE = RGBColor(0x2F, 0x3A, 0x45)
+GREY = RGBColor(0x5A, 0x6B, 0x7A)
+MUTED = RGBColor(0x8A, 0x98, 0xA6)
+WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+BLUE = RGBColor(0x2E, 0x6F, 0x9E)
+AMBER = RGBColor(0xB5, 0x65, 0x1D)
+SAND = RGBColor(0xF2, 0xC4, 0x8A)
+PALE = RGBColor(0xDC, 0xE5, 0xEC)
+GREEN = RGBColor(0x26, 0x55, 0x36)
+
+FONT = "Helvetica Neue"
+
+prs = Presentation()
+prs.slide_width = SLIDE_W
+prs.slide_height = SLIDE_H
+BLANK = prs.slide_layouts[6]
+
+
+def notes(slide, text: str) -> None:
+    slide.notes_slide.notes_text_frame.text = text.strip()
+
+
+def bg(slide, color) -> None:
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = color
+
+
+def textbox(slide, x, y, w, h, align=PP_ALIGN.LEFT):
+    box = slide.shapes.add_textbox(x, y, w, h)
+    tf = box.text_frame
+    tf.word_wrap = True
+    tf.paragraphs[0].alignment = align
+    return tf
+
+
+def line(tf, text, size, color, bold=False, space_before=0, space_after=6,
+         italic=False, first=False, mono=False):
+    p = tf.paragraphs[0] if first else tf.add_paragraph()
+    p.space_before = Pt(space_before)
+    p.space_after = Pt(space_after)
+    run = p.add_run()
+    run.text = text
+    run.font.size = Pt(size)
+    run.font.bold = bold
+    run.font.italic = italic
+    run.font.color.rgb = color
+    run.font.name = "Menlo" if mono else FONT
+    return p
+
+
+def add_image_slide(name: str, note: str):
+    """Full-bleed diagram slide: each diagram carries its own title."""
+    slide = prs.slides.add_slide(BLANK)
+    path = IMAGES / name
+    with open(path, "rb") as fh:
+        head = fh.read(33)
+    iw, ih = unpack(">II", head[16:24])
+    aspect = iw / ih
+
+    h, max_w = Inches(7.1), Inches(12.9)
+    w = Emu(int(h * aspect))
+    if w > max_w:
+        w = max_w
+        h = Emu(int(w / aspect))
+    slide.shapes.add_picture(
+        str(path), Emu(int((SLIDE_W - w) / 2)), Emu(int((SLIDE_H - h) / 2)),
+        width=w, height=h,
+    )
+    notes(slide, note)
+    return slide
+
+
+def section(kicker: str, title: str, subtitle: str, note: str) -> None:
+    slide = prs.slides.add_slide(BLANK)
+    bg(slide, SLATE)
+    tf = textbox(slide, Inches(0.9), Inches(2.6), Inches(11.5), Inches(2.4))
+    line(tf, kicker, 16, SAND, bold=True, first=True, space_after=10)
+    line(tf, title, 36, WHITE, bold=True, space_after=12)
+    line(tf, subtitle, 18, PALE)
+    notes(slide, note)
+
+
+# ------------------------------------------------------------------ slides
+
+def title_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    bg(slide, SLATE)
+    tf = textbox(slide, Inches(0.9), Inches(2.1), Inches(11.5), Inches(2.6))
+    line(tf, "MAC", 54, WHITE, bold=True, first=True, space_after=6)
+    line(tf, "What the control plane can do today", 30, PALE, space_after=18)
+    line(tf, "A multi-agent coordinator control plane, audited from its own source and documentation.",
+         17, MUTED)
+
+    tf2 = textbox(slide, Inches(0.9), Inches(5.5), Inches(11.5), Inches(1.4))
+    line(tf2, f"commit {COMMIT}   ·   captured {CAPTURED}", 16, SAND, bold=True, first=True,
+         space_after=4)
+    line(tf2, "Every claim in this deck is traced to a file or commit in AUDIT.md. Figures are dated because they age.",
+         13.5, MUTED)
+
+    notes(slide, f"""
+This deck describes MAC at commit {COMMIT} and nothing later. It was built by auditing the
+source and docs directly rather than from memory, and AUDIT.md traces every number back to the
+file or commit it came from.
+
+Open by saying what MAC is NOT: it is not a chat agent, not an IDE, and not a model. It is the
+durable operational record underneath a fleet of coding agents.
+""")
+
+
+def what_it_is() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    tf = textbox(slide, Inches(0.85), Inches(0.55), Inches(11.6), Inches(1.0))
+    line(tf, "What MAC is, and what it deliberately is not", 34, INK, bold=True, first=True,
+         space_after=4)
+    line(tf, "The boundary is the design. Everything MAC owns is something you would want to still be true after a crash.",
+         15, GREY)
+
+    tf2 = textbox(slide, Inches(0.85), Inches(1.85), Inches(5.6), Inches(5.0))
+    line(tf2, "It owns durable operational truth", 20, BLUE, bold=True, first=True, space_after=10)
+    for t in [
+        "Tasks, leases, routing, reviews, evidence.",
+        "Secrets as handles, runtime manifests, rollout state.",
+        "Machine and agent registry, capabilities and health.",
+        "Audit trails, and the publication record.",
+    ]:
+        line(tf2, "•  " + t, 15, SLATE, space_after=8)
+    line(tf2, "PostgreSQL is the authority — there is no offline replica and no ticket-file sync. "
+              "A .tickets/<id>.md file is an optional local convenience view and is explicitly not authoritative.",
+         14, GREY, space_before=10)
+
+    tf3 = textbox(slide, Inches(7.0), Inches(1.85), Inches(5.5), Inches(5.0))
+    line(tf3, "It does not own the conversation", 20, AMBER, bold=True, first=True, space_after=10)
+    for t in [
+        "Personality, chat, and messaging gateways belong to the human-facing runtime.",
+        "MAC sits underneath it and takes durable work from it.",
+        "The command-and-control dashboard was retired; /ui is read-only observability.",
+        "The console speaks on the bus like any other participant rather than mutating the control plane.",
+    ]:
+        line(tf3, "•  " + t, 15, SLATE, space_after=8)
+    line(tf3, "That boundary is why an agent going off the rails is a bus conversation, "
+              "not a privileged API call.", 14, GREY, space_before=10)
+
+    notes(slide, """
+The line to land: MAC owns what must survive a crash; the runtime above it owns what must feel
+like a conversation.
+
+The retirement of the command-and-control dashboard is worth calling out — it is the clearest
+signal of the direction of travel. The console can no longer mutate the control plane at all.
+""")
+
+
+def scale_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    tf = textbox(slide, Inches(0.85), Inches(0.55), Inches(11.6), Inches(1.0))
+    line(tf, "Scale, at this commit", 34, INK, bold=True, first=True, space_after=4)
+    line(tf, f"Counted directly in the tree at {COMMIT}, not estimated.", 15, GREY)
+
+    rows = [
+        ("195,764", "lines of Python under src/", "201 modules in src/mac"),
+        ("470", "test files under tests/", "plus fault-replay and contract suites"),
+        ("408", "HTTP routes", "generated from the live OpenAPI schema"),
+        ("123", "CLI verbs", "across project, task, agent and admin"),
+        ("18", "book chapters", "every shell example executed by make docs-check"),
+        ("18", "architecture decision records", "0016–0018 are Proposed, not shipped"),
+        ("5", "coding-agent routes", "claude, codex, cursor, opencode, pi"),
+    ]
+    tf2 = textbox(slide, Inches(0.85), Inches(1.8), Inches(11.6), Inches(5.2))
+    first = True
+    for num, label, note_ in rows:
+        p = tf2.paragraphs[0] if first else tf2.add_paragraph()
+        p.space_after = Pt(11)
+        r1 = p.add_run(); r1.text = f"{num:>10}   "
+        r1.font.size = Pt(23); r1.font.bold = True; r1.font.color.rgb = INK; r1.font.name = FONT
+        r2 = p.add_run(); r2.text = label
+        r2.font.size = Pt(17); r2.font.color.rgb = SLATE; r2.font.name = FONT
+        r3 = p.add_run(); r3.text = f"   — {note_}"
+        r3.font.size = Pt(14); r3.font.color.rgb = GREY; r3.font.name = FONT
+        first = False
+
+    notes(slide, """
+Do not read this table aloud. Use it to make one point: this is not a prototype, and the
+documentation is generated from the running system rather than written alongside it.
+
+The generated CLI and OpenAPI references are checked in CI, so a drifted doc fails the build.
+""")
+
+
+def honesty_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    tf = textbox(slide, Inches(0.85), Inches(0.55), Inches(11.6), Inches(1.0))
+    line(tf, "Proposed, deferred, or stale — stated up front", 34, INK, bold=True, first=True,
+         space_after=4)
+    line(tf, "A capabilities deck that only lists capabilities is marketing. These are the places the code and the claims do not yet meet.",
+         15, GREY)
+
+    items = [
+        ("ADR 0016, 0017 and 0018 are all Proposed.",
+         "Agent-initiated review, router-side token metering, and the dependency graph are designs with measured motivation — none of them has shipped. The mandatory hub-mediated workflow still runs today."),
+        ("ADR 0012 is Accepted with implementation deferred.",
+         "The native-steward / containerized-execution split is a decision awaiting fleet measurement, and ADR 0015 has already narrowed its containerized half to Linux nodes only."),
+        ("The README still describes a runtime that was deleted.",
+         "It documents src/mac/_hermes as a vendored Hermes snapshot, links a snapshot contract that no longer resolves, and claims coverage and lint exclusions for that path. The tree went in 3ebde2dd. The mac-hermes adapter it also names is real and unaffected."),
+        ("Token attribution is not currently trustworthy.",
+         "29.5% of routes over the last seven days recorded no input token count, none reported cache hits, and cost is priced at read time rather than stored. ADR 0017 exists because of this."),
+        ("A third of blocked work is dead and nothing surfaces it.",
+         "165 of 355 blocked tasks wait on dependencies that can never complete. Finding that took a hand-written query."),
+    ]
+    tf2 = textbox(slide, Inches(0.85), Inches(1.8), Inches(11.6), Inches(5.3))
+    first = True
+    for head, body in items:
+        line(tf2, head, 17.5, INK, bold=True, space_before=0 if first else 10, space_after=3,
+             first=first)
+        line(tf2, body, 14, GREY, space_after=2)
+        first = False
+
+    notes(slide, """
+This is the slide that earns the rest of the deck. In front of engineers, naming the five
+weakest points yourself is what makes the capability claims credible.
+
+The README staleness is a real finding from this audit and is worth fixing separately.
+""")
+
+
+def provenance_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    bg(slide, SLATE)
+    tf = textbox(slide, Inches(0.9), Inches(0.7), Inches(11.5), Inches(1.0))
+    line(tf, "Provenance", 34, WHITE, bold=True, first=True, space_after=4)
+    line(tf, "This deck is a pinned artifact, not a living document.", 16, PALE)
+
+    tf2 = textbox(slide, Inches(0.9), Inches(2.0), Inches(5.6), Inches(4.6))
+    line(tf2, "How to read it", 19, SAND, bold=True, first=True, space_after=8)
+    for t in [
+        f"It describes commit {COMMIT} and nothing later.",
+        "Figures carry the date they were measured, because they age.",
+        "AUDIT.md traces every claim to a file, commit or generated reference.",
+        "Diagrams are SVG sources; the PNGs are rendered from them.",
+    ]:
+        line(tf2, "•  " + t, 14.5, PALE, space_after=8)
+
+    tf3 = textbox(slide, Inches(7.0), Inches(2.0), Inches(5.5), Inches(4.6))
+    line(tf3, "Making the next one", 19, SAND, bold=True, first=True, space_after=8)
+    line(tf3, "Create a new sibling directory rather than editing this one:", 14.5, PALE,
+         space_after=8)
+    line(tf3, "docs/presentation/<UTC timestamp>-<short commit>/", 13.5, WHITE, mono=True,
+         space_after=10)
+    line(tf3, "The timestamp sorts, the commit pins, and neither collides. An old deck keeps "
+              "meaning what it meant when it was shown.", 14.5, PALE, space_after=8)
+    line(tf3, "See README.md in this directory for the exact render and build commands.",
+         14.5, MUTED)
+
+    notes(slide, """
+Close on the convention rather than a summary: decks are cheap to regenerate and are pinned to a
+commit, so nobody has to wonder whether a slide is still true — they can check the hash.
+""")
+
+
+# ------------------------------------------------------------------ build
+
+title_slide()
+what_it_is()
+
+section("PART ONE", "The model",
+        "Four objects, one ledger, and what must be true to move work between states.",
+        "Transition: everything MAC does is expressed against four nouns.")
+
+add_image_slide("01-object-model.png", """
+The CLI is not a wrapper over the object model — it IS the object model. project, task, agent,
+admin, 123 verbs.
+
+Two details worth pointing at: recovery is a first-class set of verbs rather than an incident
+runbook, and break-glass is grantable, listable and revocable, so an emergency leaves a record
+instead of an ambient permission.
+
+The bottom band matters for integrators: six surfaces, one dispatch seam, and a contract test
+that proves the Python client and the hub agree about the route table.
+""")
+
+add_image_slide("02-task-lifecycle.png", """
+Eleven states, three terminal. The default list view shows non-terminal work, because the useful
+question is "what still wants something from somebody".
+
+The four gates are the real content: a lease and fence authorize every mutation, evidence is typed
+and bound to one exact attempt, review must come from a different agent AND a different model, and
+landing goes through a speculative merge queue whose invariant is "never land an untested tree".
+
+If asked why MAC built its own merge queue: GitHub's is organization-only, verified by API against
+the live repo — HTTP 422 on a user-owned repository.
+""")
+
+section("PART TWO", "Coordination and execution",
+        "How agents hear each other, and what actually runs the work.",
+        "Transition: the coordination model changed shape recently, and deliberately.")
+
+add_image_slide("03-coordination.png", """
+The headline: AgentBus became a broadcast bus. Point-to-point messages are no longer private,
+because an agent told "worker-2 already rebased that branch" cannot verify it without reading
+worker-2's stream.
+
+The motivating incidents are real and on the record — a `git add -A` moments from sweeping ~1,200
+lines of another agent's work into an unrelated commit, and a `git commit -a` that did.
+
+Note the human is a participant on the bus, not a controller above it, and that stand_down and
+abort are deliberately separate verbs. One carve-out: raw terminal streams stay participant-scoped
+because they carry credentials.
+""")
+
+add_image_slide("04-fleet-execution.png", """
+MAC does not pretend the fleet is homogeneous. macOS nodes are host installs under launchd — an
+earlier attempt to containerize them was superseded. Linux nodes run a native steward with
+containerized execution. Kubernetes and HGX provide elastic capacity.
+
+Five coding-agent routes, and the sandbox derives which are available from the router rather than
+hardcoding a list.
+
+The identity band is the one auditors care about: secrets are handles with audit records, output
+is redacted, and egress is declared per project and per task.
+""")
+
+section("PART THREE", "Measurement",
+        "The fleet instruments itself — and the instrumentation is currently indicting the design.",
+        "Transition: the most interesting capability is that MAC can prove itself wrong.")
+
+add_image_slide("05-measurement.png", """
+THE KEY SLIDE. Left: what MAC measures — review experiments with pre-registered arms and a blind
+treatment, a scientific optimizer that only ever emits a policy candidate, a dreaming pipeline
+where memory must SHRINK to be promoted, and operational learning that changes routing.
+
+Right: what those measurements actually found, dated. 29.5% of model routes recorded no input
+tokens; none reported cache hits. 165 of 355 blocked tasks are permanently dead.
+
+Bottom: three open ADRs, all raised in the last three days, each caused by a measurement rather
+than an opinion. That is the point of the slide — the instrumentation is what generated the
+backlog.
+""")
+
+scale_slide()
+honesty_slide()
+provenance_slide()
+
+prs.save(OUT)
+print(f"wrote {OUT.name} — {len(prs.slides._sldIdLst)} slides")

--- a/docs/presentation/20260820T011224Z-8b424c20/images/01-object-model.svg
+++ b/docs/presentation/20260820T011224Z-8b424c20/images/01-object-model.svg
@@ -1,0 +1,175 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="900" viewBox="0 0 1520 900" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <rect width="1520" height="900" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">One control plane, four objects</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">The CLI is the object model, not a wrapper over one. 123 verbs across four nouns, and the same model is exposed through six surfaces.</text>
+
+  <!-- PROJECT -->
+  <rect x="40" y="104" width="342" height="470" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 114 a10 10 0 0 1 10 -10 h322 a10 10 0 0 1 10 10 v44 h-342 z" fill="#2E6F9E"/>
+  <text x="62" y="134" font-size="19" font-weight="700" fill="#FFFFFF">project</text>
+  <text x="290" y="134" font-size="15" font-weight="700" fill="#BBD7EA" text-anchor="end">9 verbs</text>
+  <text x="62" y="152" font-size="12.5" fill="#D6E6F2">a unit of work ownership</text>
+
+  <text x="62" y="186" font-size="13.5" fill="#2F3A45">Repositories, policy, and dispatch</text>
+  <text x="62" y="205" font-size="13.5" fill="#2F3A45">state. Project-level dispatch pause</text>
+  <text x="62" y="224" font-size="13.5" fill="#2F3A45">is a gate distinct from per-task</text>
+  <text x="62" y="243" font-size="13.5" fill="#2F3A45">staging.</text>
+
+  <text x="62" y="278" font-size="12" font-weight="700" fill="#2E6F9E">VERBS</text>
+  <text x="62" y="302" font-size="13.5" fill="#2F3A45">create · list · show · update</text>
+  <text x="62" y="324" font-size="13.5" fill="#2F3A45">delete · register</text>
+  <text x="62" y="346" font-size="13.5" font-weight="700" fill="#1B2530">pause · activate</text>
+  <text x="62" y="368" font-size="13.5" fill="#2F3A45">egress</text>
+
+  <rect x="62" y="392" width="298" height="162" rx="6" fill="#F4F6F8"/>
+  <text x="78" y="416" font-size="12" font-weight="700" fill="#2E6F9E">WHAT IT GUARANTEES</text>
+  <text x="78" y="438" font-size="12.5" fill="#2F3A45">A registered repository must satisfy</text>
+  <text x="78" y="456" font-size="12.5" fill="#2F3A45">a runtime contract before agents</text>
+  <text x="78" y="474" font-size="12.5" fill="#2F3A45">bootstrap on it, so work does not</text>
+  <text x="78" y="492" font-size="12.5" fill="#2F3A45">depend on accidental local state.</text>
+  <text x="78" y="516" font-size="12.5" fill="#2F3A45">Egress policy is declared per</text>
+  <text x="78" y="534" font-size="12.5" fill="#2F3A45">project and per task.</text>
+
+  <!-- TASK -->
+  <rect x="410" y="104" width="342" height="470" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M410 114 a10 10 0 0 1 10 -10 h322 a10 10 0 0 1 10 10 v44 h-342 z" fill="#2E6F9E"/>
+  <text x="432" y="134" font-size="19" font-weight="700" fill="#FFFFFF">task</text>
+  <text x="660" y="134" font-size="15" font-weight="700" fill="#BBD7EA" text-anchor="end">44 verbs</text>
+  <text x="432" y="152" font-size="12.5" fill="#D6E6F2">the thing agents claim, run, publish</text>
+
+  <text x="432" y="186" font-size="13.5" fill="#2F3A45">The durable ledger of record.</text>
+  <text x="432" y="205" font-size="13.5" fill="#2F3A45">State transitions, leases, history,</text>
+  <text x="432" y="224" font-size="13.5" fill="#2F3A45">evidence, dependencies, recovery —</text>
+  <text x="432" y="243" font-size="13.5" fill="#2F3A45">all in PostgreSQL.</text>
+
+  <text x="432" y="278" font-size="12" font-weight="700" fill="#2E6F9E">VERBS, BY WHAT THEY ARE FOR</text>
+  <text x="432" y="302" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">run:</tspan> claim · start · close · reopen</text>
+  <text x="432" y="324" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">prove:</tspan> evidence · submit-review · audit</text>
+  <text x="432" y="346" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">ask:</tspan> ask · answer · needs-input · wait</text>
+  <text x="432" y="368" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">explain:</tspan> why-unclaimed · throughput</text>
+
+  <rect x="432" y="392" width="298" height="162" rx="6" fill="#F4F6F8"/>
+  <text x="448" y="416" font-size="12" font-weight="700" fill="#2E6F9E">RECOVERY IS FIRST CLASS</text>
+  <text x="448" y="438" font-size="12.5" fill="#2F3A45">recover-stranded · recover-finalizer</text>
+  <text x="448" y="456" font-size="12.5" fill="#2F3A45">recover-stalled-finalizer</text>
+  <text x="448" y="480" font-size="12.5" fill="#2F3A45">break-glass · break-glass-list</text>
+  <text x="448" y="498" font-size="12.5" fill="#2F3A45">break-glass-revoke</text>
+  <text x="448" y="522" font-size="12.5" fill="#5A6B7A">Break-glass is grantable, listable</text>
+  <text x="448" y="540" font-size="12.5" fill="#5A6B7A">and revocable — never ambient.</text>
+
+  <!-- AGENT -->
+  <rect x="780" y="104" width="342" height="470" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M780 114 a10 10 0 0 1 10 -10 h322 a10 10 0 0 1 10 10 v44 h-342 z" fill="#2E6F9E"/>
+  <text x="802" y="134" font-size="19" font-weight="700" fill="#FFFFFF">agent</text>
+  <text x="1030" y="134" font-size="15" font-weight="700" fill="#BBD7EA" text-anchor="end">17 verbs</text>
+  <text x="802" y="152" font-size="12.5" fill="#D6E6F2">a worker on a machine</text>
+
+  <text x="802" y="186" font-size="13.5" fill="#2F3A45">Registry of what each worker can</text>
+  <text x="802" y="205" font-size="13.5" fill="#2F3A45">do: capabilities, resources, health,</text>
+  <text x="802" y="224" font-size="13.5" fill="#2F3A45">availability, and instance kind</text>
+  <text x="802" y="243" font-size="13.5" fill="#2F3A45">(static or fungible).</text>
+
+  <text x="802" y="278" font-size="12" font-weight="700" fill="#2E6F9E">VERBS</text>
+  <text x="802" y="302" font-size="13.5" fill="#2F3A45">create · list · show · update · delete</text>
+  <text x="802" y="324" font-size="13.5" font-weight="700" fill="#1B2530">hold · resume · heartbeat</text>
+  <text x="802" y="346" font-size="13.5" fill="#2F3A45">config · hardware · reflect · tell</text>
+  <text x="802" y="368" font-size="13.5" fill="#2F3A45">deregister · migrate</text>
+
+  <rect x="802" y="392" width="298" height="162" rx="6" fill="#F4F6F8"/>
+  <text x="818" y="416" font-size="12" font-weight="700" fill="#2E6F9E">VISIBILITY IS NOT A GATE</text>
+  <text x="818" y="438" font-size="12.5" fill="#2F3A45">ADR 0014 settled that agent</text>
+  <text x="818" y="456" font-size="12.5" fill="#2F3A45">visibility is a communication</text>
+  <text x="818" y="474" font-size="12.5" fill="#2F3A45">boundary, not a dispatch gate — so</text>
+  <text x="818" y="492" font-size="12.5" fill="#2F3A45">who may talk never decides who may</text>
+  <text x="818" y="510" font-size="12.5" fill="#2F3A45">work.</text>
+  <text x="818" y="534" font-size="12.5" fill="#5A6B7A">hardware reports a normalized</text>
+  <text x="818" y="552" font-size="12.5" fill="#5A6B7A">effective allocation per node.</text>
+
+  <!-- ADMIN -->
+  <rect x="1150" y="104" width="330" height="470" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M1150 114 a10 10 0 0 1 10 -10 h310 a10 10 0 0 1 10 10 v44 h-330 z" fill="#2F3A45"/>
+  <text x="1172" y="134" font-size="19" font-weight="700" fill="#FFFFFF">admin</text>
+  <text x="1458" y="134" font-size="15" font-weight="700" fill="#B7C4D0" text-anchor="end">53 groups</text>
+  <text x="1172" y="152" font-size="12.5" fill="#B7C4D0">everything an operator owns</text>
+
+  <text x="1172" y="186" font-size="13.5" fill="#2F3A45">Not a grab bag — each is its own</text>
+  <text x="1172" y="205" font-size="13.5" fill="#2F3A45">subcommand group with its own</text>
+  <text x="1172" y="224" font-size="13.5" fill="#2F3A45">verbs.</text>
+
+  <text x="1172" y="256" font-size="12" font-weight="700" fill="#2F3A45">WORK</text>
+  <text x="1172" y="278" font-size="13" fill="#2F3A45">dispatch · review · publish</text>
+  <text x="1172" y="297" font-size="13" fill="#2F3A45">pull-request · workflow · plan</text>
+
+  <text x="1172" y="327" font-size="12" font-weight="700" fill="#2F3A45">LEARNING</text>
+  <text x="1172" y="349" font-size="13" fill="#2F3A45">memory · dream · nap · journal</text>
+  <text x="1172" y="368" font-size="13" fill="#2F3A45">optimizer · eval · curiosity</text>
+
+  <rect x="1172" y="392" width="286" height="162" rx="6" fill="#F4F6F8"/>
+  <text x="1188" y="416" font-size="12" font-weight="700" fill="#2F3A45">FLEET &amp; RUNTIME</text>
+  <text x="1188" y="438" font-size="12.5" fill="#2F3A45">fleet · machine · hgx · openshell</text>
+  <text x="1188" y="456" font-size="12.5" fill="#2F3A45">sandbox-image · runtime · rollout</text>
+  <text x="1188" y="480" font-size="12" font-weight="700" fill="#2F3A45">IDENTITY &amp; COMMS</text>
+  <text x="1188" y="502" font-size="12.5" fill="#2F3A45">secret · persona · binding</text>
+  <text x="1188" y="520" font-size="12.5" fill="#2F3A45">agentbus · directive · notifier</text>
+  <text x="1188" y="538" font-size="12.5" fill="#2F3A45">mcp · integrations · bridge</text>
+
+  <!-- SURFACES -->
+  <rect x="40" y="596" width="1440" height="272" rx="10" fill="#2F3A45"/>
+  <text x="64" y="632" font-size="20" font-weight="700" fill="#FFFFFF">The same object model, six ways in</text>
+  <text x="64" y="656" font-size="14" fill="#B7C4D0">Every surface goes through the same dispatch seam, and a contract test proves the client and the hub agree about the route table.</text>
+
+  <rect x="64" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="80" y="702" font-size="14" font-weight="700" fill="#FFFFFF">CLI</text>
+  <text x="80" y="726" font-size="12.5" fill="#C9D6E2">123 verbs. Generated</text>
+  <text x="80" y="744" font-size="12.5" fill="#C9D6E2">reference is checked</text>
+  <text x="80" y="762" font-size="12.5" fill="#C9D6E2">against the live parser,</text>
+  <text x="80" y="780" font-size="12.5" fill="#C9D6E2">so docs cannot drift.</text>
+  <text x="80" y="808" font-size="12.5" fill="#8FA5B8">--json works in any</text>
+  <text x="80" y="826" font-size="12.5" fill="#8FA5B8">position.</text>
+
+  <rect x="300" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="316" y="702" font-size="14" font-weight="700" fill="#FFFFFF">HTTP API</text>
+  <text x="316" y="726" font-size="12.5" fill="#C9D6E2">408 routes on FastAPI.</text>
+  <text x="316" y="744" font-size="12.5" fill="#C9D6E2">The route index is</text>
+  <text x="316" y="762" font-size="12.5" fill="#C9D6E2">generated from the live</text>
+  <text x="316" y="780" font-size="12.5" fill="#C9D6E2">OpenAPI schema.</text>
+  <text x="316" y="808" font-size="12.5" fill="#8FA5B8">Scoped bearer tokens:</text>
+  <text x="316" y="826" font-size="12.5" fill="#8FA5B8">read/write/agent/admin.</text>
+
+  <rect x="536" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="552" y="702" font-size="14" font-weight="700" fill="#FFFFFF">MCP server</text>
+  <text x="552" y="726" font-size="12.5" fill="#C9D6E2">Typed ledger tools for</text>
+  <text x="552" y="744" font-size="12.5" fill="#C9D6E2">coding agents, so they</text>
+  <text x="552" y="762" font-size="12.5" fill="#C9D6E2">stop parsing tables.</text>
+  <text x="552" y="790" font-size="12.5" fill="#8FA5B8">A test forbids it from</text>
+  <text x="552" y="808" font-size="12.5" fill="#8FA5B8">making its own requests,</text>
+  <text x="552" y="826" font-size="12.5" fill="#8FA5B8">so it cannot drift.</text>
+
+  <rect x="772" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="788" y="702" font-size="14" font-weight="700" fill="#FFFFFF">ACP + A2A</text>
+  <text x="788" y="726" font-size="12.5" fill="#C9D6E2">Agent Client Protocol</text>
+  <text x="788" y="744" font-size="12.5" fill="#C9D6E2">and A2A implemented as</text>
+  <text x="788" y="762" font-size="12.5" fill="#C9D6E2">specifications, not</text>
+  <text x="788" y="780" font-size="12.5" fill="#C9D6E2">vendored SDKs.</text>
+  <text x="788" y="808" font-size="12.5" fill="#8FA5B8">Served at /.well-known</text>
+  <text x="788" y="826" font-size="12.5" fill="#8FA5B8">agent cards.</text>
+
+  <rect x="1008" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="1024" y="702" font-size="14" font-weight="700" fill="#FFFFFF">Python client</text>
+  <text x="1024" y="726" font-size="12.5" fill="#C9D6E2">Contract-checked against</text>
+  <text x="1024" y="744" font-size="12.5" fill="#C9D6E2">the hub's real route</text>
+  <text x="1024" y="762" font-size="12.5" fill="#C9D6E2">table in CI.</text>
+  <text x="1024" y="790" font-size="12.5" fill="#8FA5B8">Tells you when the</text>
+  <text x="1024" y="808" font-size="12.5" fill="#8FA5B8">client is older than the</text>
+  <text x="1024" y="826" font-size="12.5" fill="#8FA5B8">hub it is talking to.</text>
+
+  <rect x="1244" y="676" width="214" height="172" rx="7" fill="#3C4A57"/>
+  <text x="1260" y="702" font-size="14" font-weight="700" fill="#FFFFFF">Console</text>
+  <text x="1260" y="726" font-size="12.5" fill="#C9D6E2">/ui is read-only</text>
+  <text x="1260" y="744" font-size="12.5" fill="#C9D6E2">observability. The</text>
+  <text x="1260" y="762" font-size="12.5" fill="#C9D6E2">command-and-control</text>
+  <text x="1260" y="780" font-size="12.5" fill="#C9D6E2">dashboard was retired.</text>
+  <text x="1260" y="808" font-size="12.5" fill="#8FA5B8">It speaks on the bus</text>
+  <text x="1260" y="826" font-size="12.5" fill="#8FA5B8">rather than mutating.</text>
+</svg>

--- a/docs/presentation/20260820T011224Z-8b424c20/images/02-task-lifecycle.svg
+++ b/docs/presentation/20260820T011224Z-8b424c20/images/02-task-lifecycle.svg
@@ -1,0 +1,136 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="880" viewBox="0 0 1520 880" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fl" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5A6B7A"/>
+    </marker>
+  </defs>
+  <rect width="1520" height="880" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">A task is a state machine with receipts</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">Eleven states in <tspan font-family="Menlo, Consolas, monospace" font-size="15">TaskState</tspan>, three of them terminal. What makes it a control plane rather than a queue is what must be true to move between them.</text>
+
+  <text x="40" y="114" font-size="13.5" font-weight="700" fill="#2E6F9E">THE PATH WORK TAKES WHEN IT GOES WELL</text>
+
+  <rect x="40" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="125" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">open</text>
+  <path d="M216 155 L 239 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="245" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="330" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">claimed</text>
+  <path d="M421 155 L 444 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="450" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="535" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">running</text>
+  <path d="M626 155 L 649 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="655" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="740" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">needs_review</text>
+  <text x="740" y="202" font-size="11.5" fill="#B5651D" text-anchor="middle">ADR 0016 would make this step optional</text>
+  <path d="M831 155 L 854 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="860" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="945" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">reviewing</text>
+  <path d="M1036 155 L 1059 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="1065" y="126" width="170" height="58" rx="8" fill="#E3F0E7" stroke="#3E7C4F" stroke-width="2"/>
+  <text x="1150" y="155" font-size="16" font-weight="700" fill="#265536" text-anchor="middle">completed</text>
+  <text x="1150" y="173" font-size="11.5" fill="#3E7C4F" text-anchor="middle">terminal</text>
+
+  <text x="1260" y="146" font-size="13" fill="#5A6B7A">Terminal states are</text>
+  <text x="1260" y="164" font-size="13" fill="#5A6B7A">completed, failed and</text>
+  <text x="1260" y="182" font-size="13" fill="#5A6B7A">cancelled. Everything</text>
+  <text x="1260" y="200" font-size="13" fill="#5A6B7A">else still wants</text>
+  <text x="1260" y="218" font-size="13" fill="#5A6B7A">something from somebody</text>
+  <text x="1260" y="236" font-size="13" fill="#5A6B7A">— which is why that is</text>
+  <text x="1260" y="254" font-size="13" fill="#5A6B7A">the default list view.</text>
+
+  <text x="40" y="226" font-size="13.5" font-weight="700" fill="#8C3227">THE STATES THAT MEAN SOMETHING IS OWED</text>
+
+  <rect x="40" y="238" width="170" height="58" rx="8" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="125" y="264" font-size="15" font-weight="700" fill="#2F3A45" text-anchor="middle">waiting</text>
+  <text x="125" y="282" font-size="11.5" fill="#5A6B7A" text-anchor="middle">on a timer or window</text>
+
+  <rect x="245" y="238" width="170" height="58" rx="8" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="330" y="264" font-size="15" font-weight="700" fill="#2F3A45" text-anchor="middle">blocked</text>
+  <text x="330" y="282" font-size="11.5" fill="#5A6B7A" text-anchor="middle">on another task</text>
+
+  <rect x="450" y="238" width="170" height="58" rx="8" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="535" y="264" font-size="15" font-weight="700" fill="#2F3A45" text-anchor="middle">needs_input</text>
+  <text x="535" y="282" font-size="11.5" fill="#5A6B7A" text-anchor="middle">on a human answer</text>
+
+  <rect x="655" y="238" width="170" height="58" rx="8" fill="#FBF4F3" stroke="#DCBCB6"/>
+  <text x="740" y="264" font-size="15" font-weight="700" fill="#8C3227" text-anchor="middle">failed</text>
+  <text x="740" y="282" font-size="11.5" fill="#A9827B" text-anchor="middle">terminal</text>
+
+  <rect x="860" y="238" width="170" height="58" rx="8" fill="#FBF4F3" stroke="#DCBCB6"/>
+  <text x="945" y="264" font-size="15" font-weight="700" fill="#8C3227" text-anchor="middle">cancelled</text>
+  <text x="945" y="282" font-size="11.5" fill="#A9827B" text-anchor="middle">terminal</text>
+
+  <text x="40" y="326" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">mac task ask / answer / needs-input</tspan> turn the human out-of-band question into a ledger state, so a task waiting on a person is visible rather than silently stalled.</text>
+  <text x="40" y="346" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">mac task why-unclaimed</tspan> explains a task that is ready but unassigned, because "nothing is happening" is the hardest fleet question to answer from a board.</text>
+
+  <!-- GATES -->
+  <text x="40" y="392" font-size="13.5" font-weight="700" fill="#2E6F9E">WHAT MUST BE TRUE TO MOVE — THE PART THAT IS NOT A QUEUE</text>
+
+  <rect x="40" y="406" width="345" height="288" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 416 a10 10 0 0 1 10 -10 h325 a10 10 0 0 1 10 10 v38 h-345 z" fill="#2E6F9E"/>
+  <text x="60" y="440" font-size="15.5" font-weight="700" fill="#FFFFFF">1 · CLAIM — leases and fences</text>
+  <text x="60" y="474" font-size="13" fill="#2F3A45">Every mutation is authorized by an exact</text>
+  <text x="60" y="493" font-size="13" fill="#2F3A45">lease and fence, not merely by an agent id,</text>
+  <text x="60" y="512" font-size="13" fill="#2F3A45">so two workers cannot claim one change.</text>
+  <text x="60" y="540" font-size="13" fill="#2F3A45">Lease expiry is the single liveness</text>
+  <text x="60" y="559" font-size="13" fill="#2F3A45">mechanism — a dead agent's work is</text>
+  <text x="60" y="578" font-size="13" fill="#2F3A45">reclaimed rather than lost.</text>
+  <text x="60" y="606" font-size="13" fill="#2F3A45">The dispatcher accounts for tenant pool</text>
+  <text x="60" y="625" font-size="13" fill="#2F3A45">policy, resources, capacity, stale</text>
+  <text x="60" y="644" font-size="13" fill="#2F3A45">heartbeats and expired leases.</text>
+  <text x="60" y="674" font-size="12.5" fill="#5A6B7A">Releasing a worker returns the lease.</text>
+
+  <rect x="405" y="406" width="345" height="288" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M405 416 a10 10 0 0 1 10 -10 h325 a10 10 0 0 1 10 10 v38 h-345 z" fill="#2E6F9E"/>
+  <text x="425" y="440" font-size="15.5" font-weight="700" fill="#FFFFFF">2 · PROVE — typed evidence</text>
+  <text x="425" y="474" font-size="13" fill="#2F3A45">Evidence rows are typed manifests bound to</text>
+  <text x="425" y="493" font-size="13" fill="#2F3A45">one exact attempt — repo_change,</text>
+  <text x="425" y="512" font-size="13" fill="#2F3A45">review_verdict, and their digests.</text>
+  <text x="425" y="540" font-size="13" fill="#2F3A45">A CodeGraph source-change audit is</text>
+  <text x="425" y="559" font-size="13" fill="#2F3A45">mandatory, and affected-test selection</text>
+  <text x="425" y="578" font-size="13" fill="#2F3A45">decides what actually has to run.</text>
+  <text x="425" y="606" font-size="13" fill="#2F3A45">A short-retention command audit records</text>
+  <text x="425" y="625" font-size="13" fill="#2F3A45">what worker subprocesses really ran, so</text>
+  <text x="425" y="644" font-size="13" fill="#2F3A45">local shell history is never the evidence.</text>
+  <text x="425" y="674" font-size="12.5" fill="#5A6B7A">Evidence from one stage never authorizes a later one.</text>
+
+  <rect x="770" y="406" width="345" height="288" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M770 416 a10 10 0 0 1 10 -10 h325 a10 10 0 0 1 10 10 v38 h-345 z" fill="#2E6F9E"/>
+  <text x="790" y="440" font-size="15.5" font-weight="700" fill="#FFFFFF">3 · REVIEW — independence</text>
+  <text x="790" y="474" font-size="13" fill="#2F3A45">A reviewer must be a different agent or</text>
+  <text x="790" y="493" font-size="13" fill="#2F3A45">persona, and an approval of model-generated</text>
+  <text x="790" y="512" font-size="13" fill="#2F3A45">evidence must name a different model.</text>
+  <text x="790" y="540" font-size="13" fill="#2F3A45">The approval binds to the current executor</text>
+  <text x="790" y="559" font-size="13" fill="#2F3A45">evidence for that exact attempt.</text>
+  <text x="790" y="587" font-size="13" fill="#2F3A45">A blind arm physically removes the executor</text>
+  <text x="790" y="606" font-size="13" fill="#2F3A45">evidence file before the discovery pass,</text>
+  <text x="790" y="625" font-size="13" fill="#2F3A45">then restores it for adjudication.</text>
+  <text x="790" y="653" font-size="13" fill="#2F3A45">Reviews record what the reviewer said, not</text>
+  <text x="790" y="672" font-size="13" fill="#2F3A45">only which way it voted.</text>
+
+  <rect x="1135" y="406" width="345" height="288" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M1135 416 a10 10 0 0 1 10 -10 h325 a10 10 0 0 1 10 10 v38 h-345 z" fill="#2E6F9E"/>
+  <text x="1155" y="440" font-size="15.5" font-weight="700" fill="#FFFFFF">4 · LAND — the merge queue</text>
+  <text x="1155" y="474" font-size="13" fill="#2F3A45">Approved work lands through a pull request</text>
+  <text x="1155" y="493" font-size="13" fill="#2F3A45">the agent owns, not a push to main.</text>
+  <text x="1155" y="521" font-size="13" fill="#2F3A45">A native durable queue per (repository,</text>
+  <text x="1155" y="540" font-size="13" fill="#2F3A45">branch) tests entries speculatively, in a</text>
+  <text x="1155" y="559" font-size="13" fill="#2F3A45">Zuul-style train; a failure evicts the entry</text>
+  <text x="1155" y="578" font-size="13" fill="#2F3A45">and discards results projected behind it.</text>
+  <text x="1155" y="606" font-size="13" fill="#2F3A45">The speculation window is TCP congestion</text>
+  <text x="1155" y="625" font-size="13" fill="#2F3A45">control: floor 1, ceiling 4, additive growth,</text>
+  <text x="1155" y="644" font-size="13" fill="#2F3A45">halved on any failure.</text>
+  <text x="1155" y="674" font-size="12.5" font-weight="700" fill="#265536">Invariant: never land an untested tree.</text>
+
+  <rect x="40" y="716" width="1440" height="128" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="64" y="746" font-size="15.5" font-weight="700" fill="#1B2530">Recovery is a first-class verb, not an incident</text>
+  <text x="64" y="772" font-size="13.5" fill="#2F3A45">Stranded work, stalled finalizers and expired leases each have a named recovery path — <tspan font-family="Menlo, Consolas, monospace" font-size="13">recover-stranded</tspan>, <tspan font-family="Menlo, Consolas, monospace" font-size="13">recover-finalizer</tspan>, <tspan font-family="Menlo, Consolas, monospace" font-size="13">recover-stalled-finalizer</tspan> —</text>
+  <text x="64" y="794" font-size="13.5" fill="#2F3A45">because a fleet that cannot reclaim its own work degrades quietly. Break-glass override is grantable, listable and revocable, so an emergency leaves a record instead of</text>
+  <text x="64" y="816" font-size="13.5" fill="#2F3A45">an ambient permission. Failure causes are classified rather than free-text, which is what makes "why did this attempt die" answerable across thousands of tasks.</text>
+</svg>

--- a/docs/presentation/20260820T011224Z-8b424c20/images/03-coordination.svg
+++ b/docs/presentation/20260820T011224Z-8b424c20/images/03-coordination.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="900" viewBox="0 0 1520 900" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <rect width="1520" height="900" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">How agents coordinate: a town square, not a switchboard</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">AgentBus is a broadcast bus — every participant hears everything — because an agent that cannot hear its peers cannot avoid destroying their work.</text>
+
+  <!-- BUS VISUAL -->
+  <rect x="40" y="102" width="800" height="330" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+
+  <rect x="66" y="132" width="132" height="56" rx="7" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="132" y="156" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">agent</text>
+  <text x="132" y="175" font-size="11.5" fill="#5A6B7A" text-anchor="middle">macOS host</text>
+
+  <rect x="212" y="132" width="132" height="56" rx="7" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="278" y="156" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">agent</text>
+  <text x="278" y="175" font-size="11.5" fill="#5A6B7A" text-anchor="middle">Linux sandbox</text>
+
+  <rect x="358" y="132" width="132" height="56" rx="7" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="424" y="156" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">agent</text>
+  <text x="424" y="175" font-size="11.5" fill="#5A6B7A" text-anchor="middle">HGX node</text>
+
+  <rect x="504" y="132" width="132" height="56" rx="7" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="570" y="156" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">reviewer</text>
+  <text x="570" y="175" font-size="11.5" fill="#5A6B7A" text-anchor="middle">a peer, on request</text>
+
+  <rect x="650" y="132" width="164" height="56" rx="7" fill="#FDF6EE" stroke="#B5651D" stroke-width="2"/>
+  <text x="732" y="156" font-size="13.5" font-weight="700" fill="#7A430F" text-anchor="middle">human</text>
+  <text x="732" y="175" font-size="11.5" fill="#8A6438" text-anchor="middle">a participant, not a controller</text>
+
+  <line x1="132" y1="188" x2="132" y2="236" stroke="#2E6F9E" stroke-width="1.5"/>
+  <line x1="278" y1="188" x2="278" y2="236" stroke="#2E6F9E" stroke-width="1.5"/>
+  <line x1="424" y1="188" x2="424" y2="236" stroke="#2E6F9E" stroke-width="1.5"/>
+  <line x1="570" y1="188" x2="570" y2="236" stroke="#2E6F9E" stroke-width="1.5"/>
+  <line x1="732" y1="188" x2="732" y2="236" stroke="#B5651D" stroke-width="1.5"/>
+
+  <rect x="66" y="236" width="748" height="34" rx="6" fill="#2E6F9E"/>
+  <text x="440" y="259" font-size="15" font-weight="700" fill="#FFFFFF" text-anchor="middle">AgentBus — everyone hears it</text>
+
+  <line x1="440" y1="270" x2="440" y2="304" stroke="#2F3A45" stroke-width="1.5"/>
+  <rect x="300" y="304" width="280" height="50" rx="7" fill="#2F3A45"/>
+  <text x="440" y="326" font-size="14" font-weight="700" fill="#FFFFFF" text-anchor="middle">hub — keeps the ledger</text>
+  <text x="440" y="345" font-size="11.5" fill="#B7C4D0" text-anchor="middle">choreography is peer-to-peer; the record is central</text>
+
+  <text x="66" y="384" font-size="13" fill="#2F3A45"><tspan font-weight="700">Roll call</tspan> returns every agent on the bus with its capabilities — the prerequisite for an agent pulling</text>
+  <text x="66" y="403" font-size="13" fill="#2F3A45">work and judging for itself what it can take. Without a roster an agent can only wait to be assigned.</text>
+  <text x="66" y="422" font-size="13" fill="#2F3A45"><tspan font-weight="700">Traffic</tspan> returns everything being said, resumable by cursor. An inbox is scoped by <tspan font-style="italic">addressing</tspan>, not access.</text>
+
+  <!-- WHY -->
+  <rect x="860" y="102" width="620" height="330" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="884" y="134" font-size="17" font-weight="700" fill="#1B2530">Why private messages were abolished</text>
+  <text x="884" y="164" font-size="13.5" fill="#2F3A45">Two incidents are on the record where concurrent agents in one</text>
+  <text x="884" y="183" font-size="13.5" fill="#2F3A45">checkout nearly destroyed each other's work — a <tspan font-family="Menlo, Consolas, monospace" font-size="12.5">git add -A</tspan> moments</text>
+  <text x="884" y="202" font-size="13.5" fill="#2F3A45">from sweeping ~1,200 lines of another agent's half-finished work into an</text>
+  <text x="884" y="221" font-size="13.5" fill="#2F3A45">unrelated commit, and a <tspan font-family="Menlo, Consolas, monospace" font-size="12.5">git commit -a</tspan> that did.</text>
+  <text x="884" y="250" font-size="13.5" fill="#2F3A45">The only mitigation was a documented convention: a rule agents could</text>
+  <text x="884" y="269" font-size="13.5" fill="#2F3A45">follow but could not <tspan font-style="italic">verify</tspan>, because nothing told one agent what</text>
+  <text x="884" y="288" font-size="13.5" fill="#2F3A45">another was doing.</text>
+
+  <rect x="884" y="306" width="572" height="60" rx="6" fill="#FFFFFF" stroke="#9CC2D8"/>
+  <text x="900" y="330" font-size="13.5" font-style="italic" fill="#1B4E73">"An enforced silence would stop an agent from volunteering the one fact</text>
+  <text x="900" y="350" font-size="13.5" font-style="italic" fill="#1B4E73">that keeps another from destroying work."</text>
+
+  <text x="884" y="392" font-size="13" fill="#2F3A45"><tspan font-weight="700">One carve-out.</tspan> <tspan font-family="Menlo, Consolas, monospace" font-size="12.5">mac.debug.terminal.*</tspan> stays participant-scoped: those</text>
+  <text x="884" y="411" font-size="13" fill="#2F3A45">streams are raw terminal I/O including credentials, and a credential read</text>
+  <text x="884" y="425" font-size="13" fill="#2F3A45">off the bus cannot be un-read.</text>
+
+  <!-- THREE CARDS -->
+  <rect x="40" y="454" width="466" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="64" y="484" font-size="16" font-weight="700" fill="#1B2530">A closed, typed vocabulary</text>
+  <text x="64" y="510" font-size="13" fill="#2F3A45">Payloads were self-describing by convention only, so a</text>
+  <text x="64" y="529" font-size="13" fill="#2F3A45">malformed message was found by the consumer at turn time</text>
+  <text x="64" y="548" font-size="13" fill="#2F3A45">rather than by the producer at publish time.</text>
+  <text x="64" y="574" font-size="13" fill="#2F3A45">A schema registry now validates declared schemas at publish</text>
+  <text x="64" y="593" font-size="13" fill="#2F3A45">and warns on unknown ones, so experimentation stays open.</text>
+  <text x="64" y="622" font-size="12.5" fill="#5A6B7A">peer_message · peer_reply · media.share · error · task.claimed</text>
+  <text x="64" y="640" font-size="12.5" fill="#5A6B7A">task.progress · task.released · project.attention · git.*</text>
+
+  <rect x="527" y="454" width="466" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="551" y="484" font-size="16" font-weight="700" fill="#1B2530">Lifecycle verbs a human also speaks</text>
+  <text x="551" y="508" font-size="13" fill="#2F3A45">Requests on a channel everyone can see, which each agent</text>
+  <text x="551" y="527" font-size="13" fill="#2F3A45">observes and honours — never a privileged mutation.</text>
+
+  <rect x="551" y="540" width="112" height="32" rx="5" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="607" y="561" font-size="12.5" font-weight="700" fill="#1B4E73" text-anchor="middle">stand_down</text>
+  <rect x="671" y="540" width="80" height="32" rx="5" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="711" y="561" font-size="12.5" font-weight="700" fill="#1B4E73" text-anchor="middle">pause</text>
+  <rect x="759" y="540" width="86" height="32" rx="5" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="802" y="561" font-size="12.5" font-weight="700" fill="#1B4E73" text-anchor="middle">resume</text>
+  <rect x="853" y="540" width="80" height="32" rx="5" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="893" y="561" font-size="12.5" font-weight="700" fill="#1B4E73" text-anchor="middle">status</text>
+  <rect x="551" y="580" width="80" height="32" rx="5" fill="#FBE9E6" stroke="#C0392B"/>
+  <text x="591" y="601" font-size="12.5" font-weight="700" fill="#98291C" text-anchor="middle">abort</text>
+  <text x="645" y="601" font-size="12.5" fill="#8C3227">destructive — flagged so a UI cannot</text>
+  <text x="645" y="617" font-size="12.5" fill="#8C3227">put it behind the same control</text>
+
+  <text x="551" y="644" font-size="12.5" fill="#5A6B7A">Scopes: fleet · project · agent · task. A directive with no</text>
+  <text x="551" y="660" font-size="12.5" fill="#5A6B7A">target is refused — defaulting to the fleet is what does damage.</text>
+
+  <rect x="1014" y="454" width="466" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="1038" y="484" font-size="16" font-weight="700" fill="#1B2530">Stand-down is not abort</text>
+  <text x="1038" y="510" font-size="13" fill="#2F3A45">Collapsing them is the mistake the vocabulary exists to</text>
+  <text x="1038" y="529" font-size="13" fill="#2F3A45">prevent. A single button labelled "stop" that means ABORT</text>
+  <text x="1038" y="548" font-size="13" fill="#2F3A45">destroys work in flight; one that means PAUSE does not stop</text>
+  <text x="1038" y="567" font-size="13" fill="#2F3A45">a runaway. Most off-the-rails moments want stand-down.</text>
+  <text x="1038" y="596" font-size="13" fill="#2F3A45">Both verbs ship, named honestly.</text>
+  <text x="1038" y="625" font-size="12.5" fill="#5A6B7A">A verb nobody understands fails where it is built rather than</text>
+  <text x="1038" y="643" font-size="12.5" fill="#5A6B7A">travelling the bus and being silently dropped — that is</text>
+  <text x="1038" y="661" font-size="12.5" fill="#5A6B7A">indistinguishable from a fleet that heard it and did nothing.</text>
+
+  <!-- BOTTOM -->
+  <rect x="40" y="688" width="712" height="180" rx="10" fill="#2F3A45"/>
+  <text x="64" y="720" font-size="17" font-weight="700" fill="#FFFFFF">Dispatch — matching work to capacity</text>
+  <text x="64" y="748" font-size="13.5" fill="#DCE5EC">The dispatcher matches open work to healthy, capable agents, accounting for</text>
+  <text x="64" y="768" font-size="13.5" fill="#DCE5EC">tenant pool policy, resources, capacity, stale heartbeats and expired leases.</text>
+  <text x="64" y="796" font-size="13.5" fill="#DCE5EC">Priority ages, so old work is not starved by a steady stream of new work.</text>
+  <text x="64" y="824" font-size="13" fill="#8FA5B8">Routing skips are logged with a reason class, which is what makes</text>
+  <text x="64" y="842" font-size="13" fill="#8FA5B8"><tspan font-family="Menlo, Consolas, monospace" font-size="12.5">mac task why-unclaimed</tspan> able to answer instead of guess.</text>
+
+  <rect x="768" y="688" width="712" height="180" rx="10" fill="#2F3A45"/>
+  <text x="792" y="720" font-size="17" font-weight="700" fill="#FFFFFF">The merge queue — because GitHub would not</text>
+  <text x="792" y="748" font-size="13.5" fill="#DCE5EC">GitHub merge queues are an organization-only feature, verified against the live</text>
+  <text x="792" y="768" font-size="13.5" fill="#DCE5EC">repository: adding the rule returns HTTP 422 on a user-owned repo. So for every</text>
+  <text x="792" y="788" font-size="13.5" fill="#DCE5EC">personal repository this is the only path, and mac grew its own.</text>
+  <text x="792" y="816" font-size="13.5" fill="#DCE5EC">Speculative Zuul-style train, AIMD window (floor 1, ceiling 4), eviction on</text>
+  <text x="792" y="836" font-size="13.5" fill="#DCE5EC">failure, and an entry that cannot progress is now required to say so.</text>
+</svg>

--- a/docs/presentation/20260820T011224Z-8b424c20/images/04-fleet-execution.svg
+++ b/docs/presentation/20260820T011224Z-8b424c20/images/04-fleet-execution.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="900" viewBox="0 0 1520 900" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <rect width="1520" height="900" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">A heterogeneous fleet, honestly modelled</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">mac does not pretend every machine is the same server class. Node classes differ by supervisor, isolation model and hardware, and the ADRs say which is which.</text>
+
+  <rect x="580" y="104" width="360" height="60" rx="9" fill="#2F3A45"/>
+  <text x="760" y="130" font-size="17" font-weight="700" fill="#FFFFFF" text-anchor="middle">hub</text>
+  <text x="760" y="150" font-size="12" fill="#B7C4D0" text-anchor="middle">ledger · capability registry · capacity · dispatch</text>
+
+  <path d="M700 164 L 270 214" stroke="#5A6B7A" stroke-width="1.5"/>
+  <path d="M760 164 L 760 214" stroke="#5A6B7A" stroke-width="1.5"/>
+  <path d="M820 164 L 1250 214" stroke="#5A6B7A" stroke-width="1.5"/>
+
+  <!-- macOS -->
+  <rect x="40" y="216" width="460" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 226 a10 10 0 0 1 10 -10 h440 a10 10 0 0 1 10 10 v40 h-460 z" fill="#2E6F9E"/>
+  <text x="62" y="252" font-size="16" font-weight="700" fill="#FFFFFF">macOS node</text>
+  <text x="478" y="252" font-size="12.5" fill="#BBD7EA" text-anchor="end">ADR 0015 · Accepted</text>
+  <text x="62" y="290" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">Host install under launchd.</tspan> Not a container.</text>
+  <text x="62" y="314" font-size="13.5" fill="#2F3A45">The earlier attempt ran the Linux-ELF OpenShell</text>
+  <text x="62" y="333" font-size="13.5" fill="#2F3A45">gateway inside a Linux container on Docker; that</text>
+  <text x="62" y="352" font-size="13.5" fill="#2F3A45">amendment was superseded.</text>
+  <text x="62" y="382" font-size="13" fill="#5A6B7A">Native toolchains, Apple silicon, and Xcode-bound</text>
+  <text x="62" y="400" font-size="13" fill="#5A6B7A">work are reachable because the agent is a host</text>
+  <text x="62" y="418" font-size="13" fill="#5A6B7A">process rather than a guest.</text>
+
+  <!-- Linux -->
+  <rect x="530" y="216" width="460" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M530 226 a10 10 0 0 1 10 -10 h440 a10 10 0 0 1 10 10 v40 h-460 z" fill="#2E6F9E"/>
+  <text x="552" y="252" font-size="16" font-weight="700" fill="#FFFFFF">Linux node</text>
+  <text x="968" y="252" font-size="12.5" fill="#BBD7EA" text-anchor="end">ADR 0008 / 0012</text>
+  <text x="552" y="290" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">Native steward under systemd</tspan>, with task</text>
+  <text x="552" y="309" font-size="13.5" fill="#2F3A45">execution in containers. The containerized half of</text>
+  <text x="552" y="328" font-size="13.5" fill="#2F3A45">ADR 0012 now applies to Linux only.</text>
+  <text x="552" y="358" font-size="13.5" fill="#2F3A45">OpenShell owns isolation — process trees,</text>
+  <text x="552" y="377" font-size="13.5" fill="#2F3A45">filesystem and network policy, sandbox lifecycle,</text>
+  <text x="552" y="396" font-size="13.5" fill="#2F3A45">and normalized action events.</text>
+  <text x="552" y="420" font-size="13" fill="#5A6B7A">Docker Engine / Moby is the only container runtime.</text>
+
+  <!-- K8s -->
+  <rect x="1020" y="216" width="460" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M1020 226 a10 10 0 0 1 10 -10 h440 a10 10 0 0 1 10 10 v40 h-460 z" fill="#2E6F9E"/>
+  <text x="1042" y="252" font-size="16" font-weight="700" fill="#FFFFFF">Kubernetes / HGX</text>
+  <text x="1458" y="252" font-size="12.5" fill="#BBD7EA" text-anchor="end">elastic capacity</text>
+  <text x="1042" y="290" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">Pods under supervisord.</tspan> The runner carries</text>
+  <text x="1042" y="309" font-size="13.5" fill="#2F3A45">independent build and review paths, wrapped by</text>
+  <text x="1042" y="328" font-size="13.5" fill="#2F3A45">mac-owned test, evidence and publication gates.</text>
+  <text x="1042" y="358" font-size="13.5" fill="#2F3A45">HGX capacity is elastic: the fleet asks for more</text>
+  <text x="1042" y="377" font-size="13.5" fill="#2F3A45">workers when saturated rather than queueing behind</text>
+  <text x="1042" y="396" font-size="13.5" fill="#2F3A45">a fixed pool.</text>
+  <text x="1042" y="420" font-size="13" fill="#5A6B7A">GPU facts are part of the capability registry.</text>
+
+  <!-- EXECUTION -->
+  <rect x="40" y="452" width="900" height="238" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="64" y="484" font-size="17" font-weight="700" fill="#1B2530">What actually runs the work</text>
+  <text x="64" y="508" font-size="13.5" fill="#2F3A45">Five coding-agent routes, each with its own identity, discovered where it is</text>
+  <text x="64" y="527" font-size="13.5" fill="#2F3A45">installed. The sandbox derives its available agents from the router rather than</text>
+  <text x="64" y="546" font-size="13.5" fill="#2F3A45">hardcoding a list, so adding a route does not fork the image definition.</text>
+
+  <rect x="64" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="139" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">claude</text>
+  <rect x="228" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="303" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">codex</text>
+  <rect x="392" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="467" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">cursor</text>
+  <rect x="556" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="631" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">opencode</text>
+  <rect x="720" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="795" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">pi</text>
+
+  <text x="64" y="632" font-size="13" fill="#2F3A45">A preflight sentinel proves the sandbox can actually launch the chosen agent before work is dispatched into it, and the</text>
+  <text x="64" y="651" font-size="13" fill="#2F3A45">MCP config the sandbox writes is asserted by test to launch mac's own ledger server — so the socket is never wired to nothing.</text>
+  <text x="64" y="675" font-size="13" fill="#5A6B7A">Sandbox policy changes are announced on the bus and acted on between tasks, not mid-flight.</text>
+
+  <!-- IMAGES -->
+  <rect x="964" y="452" width="516" height="238" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="988" y="484" font-size="17" font-weight="700" fill="#1B2530">Images and rollout</text>
+  <text x="988" y="510" font-size="13.5" fill="#2F3A45">Runtime manifests are reproducible, with stable</text>
+  <text x="988" y="529" font-size="13.5" fill="#2F3A45">digests and secret-value checks.</text>
+  <text x="988" y="556" font-size="13.5" fill="#2F3A45">Images are qualified before use and carry a</text>
+  <text x="988" y="575" font-size="13.5" fill="#2F3A45"><tspan font-family="Menlo, Consolas, monospace" font-size="12.5">tested-&lt;inputs-sha&gt;</tspan> tag, so "which image was this</text>
+  <text x="988" y="594" font-size="13.5" fill="#2F3A45">proven against" is answerable from the tag alone.</text>
+  <text x="988" y="621" font-size="13.5" fill="#2F3A45">A synchronized cutover protocol moves the fleet</text>
+  <text x="988" y="640" font-size="13.5" fill="#2F3A45">between qualified versions as a transaction.</text>
+  <text x="988" y="668" font-size="13" fill="#265536" font-weight="700">A rollout can require a passing eval_run before promote.</text>
+
+  <!-- IDENTITY -->
+  <rect x="40" y="712" width="1440" height="156" rx="10" fill="#2F3A45"/>
+  <text x="64" y="744" font-size="17" font-weight="700" fill="#FFFFFF">Identity, secrets and blast radius</text>
+  <text x="64" y="772" font-size="13.5" fill="#DCE5EC"><tspan font-weight="700">Secrets are handles, not values.</tspan> Tenant-scoped secret handles carry audit records, and API and CLI output is redacted. Runtime manifests check that no</text>
+  <text x="64" y="792" font-size="13.5" fill="#DCE5EC">secret value was baked in. Review clones may inject HTTPS credentials into an individual git command, but never leave them in the checkout's origin URL or any evidence artifact.</text>
+  <text x="64" y="820" font-size="13.5" fill="#DCE5EC"><tspan font-weight="700">Scoped bearer tokens</tspan> separate read, write, agent, dispatch, secret and admin authority. <tspan font-weight="700">Egress policy</tspan> is declared per project and per task rather than assumed.</text>
+  <text x="64" y="848" font-size="13" fill="#8FA5B8">Tenants, users, Personas and platform bindings are modelled as records, which is what lets one hub serve more than one owner without sharing credentials.</text>
+</svg>

--- a/docs/presentation/20260820T011224Z-8b424c20/images/05-measurement.svg
+++ b/docs/presentation/20260820T011224Z-8b424c20/images/05-measurement.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="930" viewBox="0 0 1520 930" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <rect width="1520" height="930" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">The fleet measures itself — including where it falls short</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">Every figure below is from this repository's own ledger, dated. The most useful capability mac has is that its instrumentation can indict its own design.</text>
+
+  <!-- WHAT IT MEASURES -->
+  <rect x="40" y="104" width="690" height="452" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 114 a10 10 0 0 1 10 -10 h670 a10 10 0 0 1 10 10 v42 h-690 z" fill="#2E6F9E"/>
+  <text x="62" y="142" font-size="17" font-weight="700" fill="#FFFFFF">What it measures</text>
+
+  <text x="62" y="186" font-size="14.5" font-weight="700" fill="#1B2530">Review experiments</text>
+  <text x="62" y="207" font-size="13" fill="#2F3A45">Pre-registered arms, propensity retained, deterministic assignment from</text>
+  <text x="62" y="225" font-size="13" fill="#2F3A45">(experiment_id, task_id, policy_version). A blind arm withholds executor</text>
+  <text x="62" y="243" font-size="13" fill="#2F3A45">evidence for an independent discovery pass.</text>
+
+  <text x="62" y="277" font-size="14.5" font-weight="700" fill="#1B2530">Scientific optimizer</text>
+  <text x="62" y="298" font-size="13" fill="#2F3A45">Policies, experiments, assignments, observations and decisions as durable</text>
+  <text x="62" y="316" font-size="13" fill="#2F3A45">tables. Emits a policy <tspan font-style="italic">candidate</tspan>; promotion stays an operator gate.</text>
+
+  <text x="62" y="350" font-size="14.5" font-weight="700" fill="#1B2530">Dreaming — memory that must shrink</text>
+  <text x="62" y="371" font-size="13" fill="#2F3A45">Copy-on-write runs, gated on provenance, contradiction reduction, privacy,</text>
+  <text x="62" y="389" font-size="13" fill="#2F3A45">retrieval quality, compression and win balance. A run whose output exceeds</text>
+  <text x="62" y="407" font-size="13" fill="#2F3A45">0.75× its input is quarantined; promotion retires the rows it supersedes.</text>
+
+  <text x="62" y="441" font-size="14.5" font-weight="700" fill="#1B2530">Fleet operational learning</text>
+  <text x="62" y="462" font-size="13" fill="#2F3A45">Repository-access outcomes are control inputs, not log lines: a proven</text>
+  <text x="62" y="480" font-size="13" fill="#2F3A45">success is preferred for later routing, a proven failure removes that agent</text>
+  <text x="62" y="498" font-size="13" fill="#2F3A45">from equivalent routing until a cooldown expires. Credentials are never stored.</text>
+
+  <text x="62" y="532" font-size="13" fill="#5A6B7A">Also: eval sets with scoring direction and regression thresholds · task throughput</text>
+  <text x="62" y="548" font-size="13" fill="#5A6B7A">observability · hub event-loop stall detection · classified attempt failures.</text>
+
+  <!-- WHAT IT MEASURED -->
+  <rect x="754" y="104" width="726" height="222" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M754 114 a10 10 0 0 1 10 -10 h706 a10 10 0 0 1 10 10 v42 h-726 z" fill="#2F3A45"/>
+  <text x="776" y="142" font-size="17" font-weight="700" fill="#FFFFFF">Model routing — 7 days to 2026-08-19</text>
+
+  <text x="900" y="188" font-size="22" font-weight="700" fill="#1B2530" text-anchor="end">28,352</text>
+  <text x="916" y="188" font-size="13.5" fill="#2F3A45"><tspan font-family="Menlo, Consolas, monospace" font-size="12.5">llm.route</tspan> events recorded</text>
+
+  <text x="900" y="222" font-size="22" font-weight="700" fill="#1B2530" text-anchor="end">481.8M</text>
+  <text x="916" y="222" font-size="13.5" fill="#2F3A45">input tokens, against 5.05M output</text>
+
+  <text x="900" y="256" font-size="22" font-weight="700" fill="#C0392B" text-anchor="end">29.5%</text>
+  <text x="916" y="256" font-size="13.5" fill="#2F3A45">of routes recorded <tspan font-family="Menlo, Consolas, monospace" font-size="12.5">input_tokens = null</tspan></text>
+
+  <text x="900" y="290" font-size="22" font-weight="700" fill="#C0392B" text-anchor="end">0</text>
+  <text x="916" y="290" font-size="13.5" fill="#2F3A45">routes reported cached tokens at all</text>
+
+  <text x="776" y="316" font-size="12.5" fill="#5A6B7A">64% of routes stream. Cost is not stored — it is priced against a catalog at read time, and reports say "missing", never zero.</text>
+
+  <rect x="754" y="342" width="726" height="214" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M754 352 a10 10 0 0 1 10 -10 h706 a10 10 0 0 1 10 10 v42 h-726 z" fill="#2F3A45"/>
+  <text x="776" y="380" font-size="17" font-weight="700" fill="#FFFFFF">Ledger census — 2026-08-19</text>
+
+  <text x="776" y="418" font-size="13.5" fill="#2F3A45">blocked <tspan font-weight="700">355</tspan>   ·   waiting <tspan font-weight="700">19</tspan>   ·   open <tspan font-weight="700">84</tspan>   ·   running <tspan font-weight="700">2</tspan></text>
+  <text x="776" y="440" font-size="13.5" fill="#2F3A45">failed <tspan font-weight="700">2,105</tspan>   ·   cancelled <tspan font-weight="700">3,531</tspan></text>
+
+  <rect x="776" y="458" width="682" height="82" rx="7" fill="#FBF4F3" stroke="#DCBCB6"/>
+  <text x="884" y="490" font-size="24" font-weight="700" fill="#C0392B" text-anchor="end">165</text>
+  <text x="900" y="484" font-size="13.5" fill="#2F3A45">of those 355 blocked tasks wait on dependencies that can</text>
+  <text x="900" y="503" font-size="13.5" fill="#2F3A45">never complete. A third of the blocked population, dead —</text>
+  <text x="900" y="522" font-size="13.5" fill="#2F3A45">and it took a hand-written query to find.</text>
+
+  <!-- GAPS -->
+  <text x="40" y="596" font-size="14" font-weight="700" fill="#B5651D">WHAT THE MEASUREMENTS ARE NOW FORCING — THREE OPEN DECISIONS, ALL DATED 2026-08-17 OR LATER</text>
+
+  <rect x="40" y="610" width="466" height="292" rx="10" fill="#FDF6EE" stroke="#C08A4A"/>
+  <text x="62" y="640" font-size="15.5" font-weight="700" fill="#7A430F">ADR 0016 · Proposed</text>
+  <text x="62" y="662" font-size="14" font-weight="700" fill="#1B2530">Agents decide what a task needs</text>
+  <text x="62" y="690" font-size="13" fill="#2F3A45">One session burned 764,172 tokens on a mandatory</text>
+  <text x="62" y="708" font-size="13" fill="#2F3A45">decomposition phase the executor was not authorised</text>
+  <text x="62" y="726" font-size="13" fill="#2F3A45">to complete, and the task still died at attempt 1 of 3.</text>
+  <text x="62" y="752" font-size="13" fill="#2F3A45">52 reviews across 38 tasks produced four distinct</text>
+  <text x="62" y="770" font-size="13" fill="#2F3A45">reason strings and zero findings.</text>
+  <text x="62" y="796" font-size="13" fill="#2F3A45">18 ready tasks sat beside 3 idle agents with 0</text>
+  <text x="62" y="814" font-size="13" fill="#2F3A45">assignments, because the hub was arbitrating.</text>
+  <text x="62" y="846" font-size="12.5" fill="#7A430F" font-weight="700">Proposal: reduce the hub to ledger, capability registry</text>
+  <text x="62" y="864" font-size="12.5" fill="#7A430F" font-weight="700">and capacity. First step is one flag, one project,</text>
+  <text x="62" y="882" font-size="12.5" fill="#7A430F" font-weight="700">revertible.</text>
+
+  <rect x="527" y="610" width="466" height="292" rx="10" fill="#FDF6EE" stroke="#C08A4A"/>
+  <text x="549" y="640" font-size="15.5" font-weight="700" fill="#7A430F">ADR 0017 · Proposed</text>
+  <text x="549" y="662" font-size="14" font-weight="700" fill="#1B2530">Meter token spend at the router</text>
+  <text x="549" y="690" font-size="13" fill="#2F3A45">Usage lives as one observability event per request,</text>
+  <text x="549" y="708" font-size="13" fill="#2F3A45">with token counts inside a JSON text column.</text>
+  <text x="549" y="734" font-size="13" fill="#2F3A45">There is no token table and no cost column. Cost is</text>
+  <text x="549" y="752" font-size="13" fill="#2F3A45">computed at read time against a models catalog, and</text>
+  <text x="549" y="770" font-size="13" fill="#2F3A45">returns whether it could be priced at all.</text>
+  <text x="549" y="796" font-size="13" fill="#2F3A45">With 29.5% of routes reporting no input tokens and</text>
+  <text x="549" y="814" font-size="13" fill="#2F3A45">none reporting cache hits, spend cannot currently be</text>
+  <text x="549" y="832" font-size="13" fill="#2F3A45">attributed with confidence.</text>
+  <text x="549" y="864" font-size="12.5" fill="#7A430F" font-weight="700">Proposal: meter at the router, where the truth is,</text>
+  <text x="549" y="882" font-size="12.5" fill="#7A430F" font-weight="700">rather than trusting what the client reports.</text>
+
+  <rect x="1014" y="610" width="466" height="292" rx="10" fill="#FDF6EE" stroke="#C08A4A"/>
+  <text x="1036" y="640" font-size="15.5" font-weight="700" fill="#7A430F">ADR 0018 · Proposed</text>
+  <text x="1036" y="662" font-size="14" font-weight="700" fill="#1B2530">The task view is a graph, not a board</text>
+  <text x="1036" y="690" font-size="13" fill="#2F3A45">The console can say how many tasks are blocked. It</text>
+  <text x="1036" y="708" font-size="13" fill="#2F3A45">cannot say <tspan font-style="italic">what blocks them</tspan>, because the hub never</text>
+  <text x="1036" y="726" font-size="13" fill="#2F3A45">sends the edges — the client has no dependency field.</text>
+  <text x="1036" y="752" font-size="13" fill="#2F3A45">On a board, a task whose dependency lands in five</text>
+  <text x="1036" y="770" font-size="13" fill="#2F3A45">minutes and one that is permanently dead look</text>
+  <text x="1036" y="788" font-size="13" fill="#2F3A45">exactly the same.</text>
+  <text x="1036" y="820" font-size="12.5" font-style="italic" fill="#8C3227">"A state whose p50 dwell is measured in days is not a</text>
+  <text x="1036" y="838" font-size="12.5" font-style="italic" fill="#8C3227">queue, it is a graveyard."</text>
+  <text x="1036" y="864" font-size="12.5" fill="#7A430F" font-weight="700">Proposal: ship the dependency edges and present the</text>
+  <text x="1036" y="882" font-size="12.5" fill="#7A430F" font-weight="700">work as a graph under progressive disclosure.</text>
+</svg>

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -42,9 +42,13 @@ Two reasons, and the second is not obvious. Megabytes of opaque binary under `do
 reviewed in a diff, so they cost repository weight and return nothing. And
 `tests/test_docs_no_operator_identity.py` greps every tracked file under `docs/` for fleet-identity
 tokens — with sixteen tokens matched case-insensitively, compressed image data hits one by
-coincidence sooner or later. The first PNG tried here matched `JKH` inside its pixel data at offset
-10020. Keeping `docs/` text-only means that gate keeps reading prose, which is the only place
-identity can actually leak.
+coincidence sooner or later. The first PNG tried here matched one of them inside its pixel data at
+offset 10020. Keeping `docs/` text-only means that gate keeps reading prose, which is the only
+place identity can actually leak.
+
+Which token it was is deliberately not written here: naming it would put it in a checked-in doc and
+trip the gate this paragraph describes. Only the test file itself is exempt from the scan. If you
+need to know, the failure message names it when it fires.
 
 ## Existing decks
 

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -1,0 +1,65 @@
+# Presentations
+
+Point-in-time decks about MAC. Each one is pinned to the commit it describes and is never updated
+in place — the code moves faster than any deck, and a slide that silently changes meaning is worse
+than a stale one.
+
+## Directory convention
+
+```
+docs/presentation/<UTC timestamp>-<short commit>/
+```
+
+for example `20260820T011224Z-8b424c20/`, where:
+
+- **`<UTC timestamp>`** is `date -u +%Y%m%dT%H%M%SZ` at the time of capture. It sorts
+  lexicographically, so `ls` is chronological.
+- **`<short commit>`** is `git rev-parse --short=8 HEAD` for the tree that was audited.
+
+Neither part alone is sufficient. The timestamp orders decks and disambiguates two decks built from
+the same commit for different audiences; the commit is what makes a claim checkable a year later.
+Together they cannot collide.
+
+## What a deck directory should contain
+
+| File | Purpose |
+|---|---|
+| `README.md` | What the deck covers, its slide list, where it is published, and how to rebuild it |
+| `AUDIT.md` | Every factual claim traced to a file, commit or generated reference |
+| `build_deck.py` | Deterministic builder for the `.pptx` |
+| `images/*.svg` | Diagram sources, hand-authored |
+
+`AUDIT.md` is the part that matters. A capabilities deck ages badly precisely because nobody can
+tell which slides are still true; a per-claim source trace makes that answerable by inspection
+rather than by memory.
+
+## Text in git, binaries in Google Slides
+
+Only text is committed. Rendered PNGs and the built `.pptx` are generated outputs and are
+gitignored; the deck itself is published to Google Slides and linked from its `README.md`.
+
+Two reasons, and the second is not obvious. Megabytes of opaque binary under `docs/` cannot be
+reviewed in a diff, so they cost repository weight and return nothing. And
+`tests/test_docs_no_operator_identity.py` greps every tracked file under `docs/` for fleet-identity
+tokens — with sixteen tokens matched case-insensitively, compressed image data hits one by
+coincidence sooner or later. The first PNG tried here matched `JKH` inside its pixel data at offset
+10020. Keeping `docs/` text-only means that gate keeps reading prose, which is the only place
+identity can actually leak.
+
+## Existing decks
+
+| Directory | Commit | Deck | Subject |
+|---|---|---|---|
+| [`20260820T011224Z-8b424c20`](20260820T011224Z-8b424c20/README.md) | `8b424c20` | [Google Slides](https://docs.google.com/presentation/d/1DXgpB-3fy4IDLynGloaAP349BWrwoVSw8T46VyPdT3M/edit) | What the control plane can do today — object model, task lifecycle, coordination, fleet, measurement |
+
+## Build conventions
+
+- **Audit, do not recall.** Read the tree and the generated references (`docs/reference/cli.md`,
+  `docs/reference/openapi.md`) rather than describing MAC from memory. Where the README and the code
+  disagree, follow the code and record the discrepancy.
+- **Date every measurement.** Ledger figures are true for a window, not forever.
+- **State what is proposed.** An ADR marked *Proposed* has not shipped, and a deck that blurs that
+  distinction will be caught by the first engineer who reads the code.
+- **Keep it out of the published site.** `mkdocs.yml` excludes `presentation/` from the built
+  handbook, and `scripts/generate-docs-reference.py` skips it when building the documentation
+  inventory, so adding a deck never churns generated files or bloats the site with binaries.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,13 @@ edit_uri: edit/main/docs/
 copyright: Copyright the MAC contributors. Documentation is versioned with the software.
 strict: true
 
+# Point-in-time decks are pinned to a commit and are not part of the published
+# handbook. Excluding them keeps multi-megabyte .pptx and .png artifacts out of
+# the built site and keeps a new deck directory from tripping strict mode's
+# "page exists but is not in the nav" error. See docs/presentation/README.md.
+exclude_docs: |
+  presentation/
+
 theme:
   name: material
   language: en

--- a/scripts/generate-docs-reference.py
+++ b/scripts/generate-docs-reference.py
@@ -204,6 +204,20 @@ def _category(relative: Path) -> str:
     return "supplemental reference"
 
 
+# Point-in-time decks under docs/presentation/ are pinned artifacts, not part of
+# the documentation tree this inventory classifies: each is scoped to one commit
+# and is never revised. Inventorying them would (a) label a deck as a current
+# operating contract, which is exactly what it is not, and (b) make every new
+# deck directory report the committed inventory stale, so `docs-build --check`
+# would fail until an unrelated generated file was regenerated. mkdocs.yml
+# excludes the same directory from the published site.
+_INVENTORY_EXCLUDED_ROOTS = ("presentation",)
+
+
+def _is_excluded_from_inventory(relative: Path) -> bool:
+    return relative.parts[:1] in {(root,) for root in _INVENTORY_EXCLUDED_ROOTS}
+
+
 def documentation_inventory() -> str:
     docs_root = ROOT / "docs"
     expected = {INVENTORY_OUTPUT, ARCHIVE_OUTPUT}
@@ -212,6 +226,7 @@ def documentation_inventory() -> str:
             path
             for path in docs_root.rglob("*")
             if path.suffix in {".md", ".mdx"}
+            and not _is_excluded_from_inventory(path.relative_to(docs_root))
         }
         | expected,
         key=lambda path: path.relative_to(docs_root).as_posix(),

--- a/scripts/publish-deck-to-slides.py
+++ b/scripts/publish-deck-to-slides.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Publish a built .pptx to Google Drive as a native Google Slides deck.
+
+Decks are not committed. docs/presentation/ keeps the SVG diagram sources and
+the builder; the rendered PNGs and the .pptx are reproducible from those, and
+the deck itself lives in Slides where it can actually be presented. This script
+is the last step of that pipeline, and it exists so the fiddly part is a command
+rather than a paragraph someone has to re-derive at release time.
+
+WHY NOT gcloud DIRECTLY. There is no `gcloud slides` or `gcloud drive`; the
+Google Cloud CLI manages GCP resources and has no Google Workspace surface at
+all. gcloud's role here is exactly one thing -- minting an OAuth token -- and
+the Drive REST API does the upload. Setting `mimeType` to
+`application/vnd.google-apps.presentation` on a .pptx upload is what makes Drive
+convert it on ingest rather than storing it as an attachment.
+
+WHY THE SCOPE CHECK IS SEPARATE. gcloud's default credential carries
+cloud-platform, compute and friends but NOT Drive, so the upload fails with a
+403 that says "insufficient authentication scopes" and nothing about the fix.
+The token is checked first so the error names the remedy instead.
+
+    scripts/publish-deck-to-slides.py DECK.pptx --title "..."
+
+Prerequisite, once per machine:
+
+    gcloud auth login --enable-gdrive-access
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+SLIDES_MIME = "application/vnd.google-apps.presentation"
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+DRIVE_SCOPES = {
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/drive.file",
+}
+
+
+class PublishError(RuntimeError):
+    """A failure with an actionable message; never a bare traceback."""
+
+
+def _token() -> str:
+    try:
+        done = subprocess.run(
+            ["gcloud", "auth", "print-access-token"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        raise PublishError("gcloud is not on PATH; install the Google Cloud CLI") from exc
+    except subprocess.CalledProcessError as exc:
+        raise PublishError(
+            "gcloud could not mint a token. Run: gcloud auth login --enable-gdrive-access\n"
+            + (exc.stderr or "").strip()
+        ) from exc
+    token = done.stdout.strip()
+    if not token:
+        raise PublishError("gcloud returned an empty access token")
+    return token
+
+
+def _require_drive_scope(token: str) -> None:
+    url = f"https://www.googleapis.com/oauth2/v1/tokeninfo?access_token={token}"
+    with urllib.request.urlopen(url, timeout=30) as resp:
+        info = json.load(resp)
+    if not set(info.get("scope", "").split()) & DRIVE_SCOPES:
+        raise PublishError(
+            "this credential has no Drive scope, so the upload would fail with HTTP 403.\n"
+            "Run once, complete the browser flow, then retry:\n"
+            "    gcloud auth login --enable-gdrive-access"
+        )
+
+
+def _upload(token: str, deck: Path, title: str) -> dict:
+    metadata = {"name": title, "mimeType": SLIDES_MIME}
+    boundary = f"==============={uuid.uuid4().hex}=="
+    dash = f"--{boundary}".encode()
+    body = b"".join(
+        [
+            dash,
+            b"\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n",
+            json.dumps(metadata).encode(),
+            b"\r\n",
+            dash,
+            f"\r\nContent-Type: {PPTX_MIME}\r\n\r\n".encode(),
+            deck.read_bytes(),
+            b"\r\n",
+            f"--{boundary}--\r\n".encode(),
+        ]
+    )
+    request = urllib.request.Request(
+        "https://www.googleapis.com/upload/drive/v3/files"
+        "?uploadType=multipart&supportsAllDrives=true"
+        "&fields=id,name,webViewLink,mimeType",
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": f"multipart/related; boundary={boundary}",
+            "Content-Length": str(len(body)),
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=300) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as exc:
+        raise PublishError(
+            f"Drive returned HTTP {exc.code}:\n{exc.read().decode(errors='replace')[:1000]}"
+        ) from exc
+
+
+def _slide_count(token: str, file_id: str) -> int:
+    """Export the published deck back as PDF and count its pages.
+
+    A conversion that silently produced an attachment rather than a deck, or
+    dropped every slide, is otherwise invisible until someone opens the link in
+    front of an audience. Counting pages needs no dependency beyond the export.
+    """
+    request = urllib.request.Request(
+        f"https://www.googleapis.com/drive/v3/files/{file_id}/export"
+        "?mimeType=application/pdf",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    with urllib.request.urlopen(request, timeout=300) as resp:
+        pdf = resp.read()
+    if not pdf.startswith(b"%PDF-"):
+        raise PublishError("Drive did not return a PDF; the upload may not be a deck")
+    return len(re.findall(rb"/Type\s*/Page[^s]", pdf))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("deck", type=Path, help="path to the built .pptx")
+    parser.add_argument("--title", required=True, help="title of the Slides deck")
+    parser.add_argument(
+        "--expect-slides",
+        type=int,
+        default=None,
+        help="fail unless the published deck has exactly this many slides",
+    )
+    args = parser.parse_args()
+
+    try:
+        if not args.deck.is_file():
+            raise PublishError(f"no such deck: {args.deck} (run build_deck.py first)")
+        token = _token()
+        _require_drive_scope(token)
+        info = _upload(token, args.deck, args.title)
+
+        if info.get("mimeType") != SLIDES_MIME:
+            raise PublishError(
+                "uploaded, but Drive stored it as %s rather than converting it to a deck"
+                % info.get("mimeType")
+            )
+
+        slides = _slide_count(token, info["id"])
+        if args.expect_slides is not None and slides != args.expect_slides:
+            raise PublishError(
+                f"published deck has {slides} slides, expected {args.expect_slides}"
+            )
+    except PublishError as exc:
+        print(f"publish-deck-to-slides: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"slides:    {slides}")
+    print(f"id:        {info['id']}")
+    print(f"published: {info['webViewLink']}")
+    print(
+        "\nThe deck is private to the uploading account. Share it explicitly if the "
+        "release notes will link it for anyone else."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/cut-a-release/SKILL.md
+++ b/skills/cut-a-release/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: cut-a-release
+description: The documentation work that must land before a release is tagged — capture a capabilities deck pinned to the release commit, publish it to Google Slides, link it, and re-verify the docs gates. Use when every release gate is green and the next step is tagging a version and creating the GitHub release.
+---
+
+# Cut a release
+
+The gates prove the code works. They prove nothing about whether the
+documentation still describes it, and that is the part that rots silently: a
+README sentence naming a deleted tree stays legible for weeks, and a slide
+claiming a capability outlives the capability by longer. This skill is the
+documentation pass that runs **after** the gates are green and **before**
+anything is tagged.
+
+Its centrepiece is a capabilities deck pinned to the exact commit being
+released. Pinning is the point: a deck that is edited forever answers "what can
+mac do?" with "it depends when you looked", while a deck bound to a SHA can be
+checked against that SHA a year later.
+
+**Scope.** This covers documentation and the tag/release mechanics. Fleet
+cutover and image qualification are separate and are not in here — see
+`docs/synchronized-fleet-cutover.md` and
+`docs/image-publication-and-qualification.md`.
+
+## 0. Do not start until the gates are actually green
+
+Not "were green this morning". Run them, on the commit you intend to release:
+
+```bash
+make lint
+make test
+make docs-check
+```
+
+and confirm CI is green on `main` for that commit:
+
+```bash
+gh run list --branch main --limit 5
+```
+
+If `main` is red for an unrelated reason, say so and stop. Releasing on top of a
+known-red trunk turns one person's broken test into everyone's release.
+
+## 1. Pin the directory to the commit
+
+```bash
+git rev-parse --short=8 HEAD
+date -u +%Y%m%dT%H%M%SZ
+mkdir -p docs/presentation/<timestamp>-<sha>/images
+```
+
+The timestamp sorts, so `ls` is chronological, and it disambiguates two decks
+cut from one commit for different audiences. The SHA is what makes a claim
+checkable later. Neither alone is enough; together they cannot collide. The
+convention is written up in `docs/presentation/README.md`.
+
+Never revise a previous deck. Make a new directory.
+
+## 2. Audit from source, never from memory
+
+This is the step that carries the value, and the one it is tempting to skip
+because you think you know what changed. Read:
+
+```bash
+# The capability surface, generated from the live parser and schema.
+grep -c "^## mac" docs/reference/cli.md
+grep -cE "^\| .(GET|POST|PUT|PATCH|DELETE)." docs/reference/openapi.md
+
+# What landed since the last release, and which decisions are still open.
+git log --oneline $(git describe --tags --abbrev=0)..HEAD
+grep -l "Status: \*\*Proposed\*\*" docs/adr/*.md
+```
+
+Three rules that decide whether the deck is worth anything:
+
+- **The generated references are authoritative for counts.** CI fails when they
+  drift from the parser and the OpenAPI schema, so they are true by
+  construction. Prose in `README.md` is not.
+- **Where the README and the code disagree, follow the code, and record the
+  discrepancy** in `AUDIT.md`. That is how the deck stays honest about a repo
+  that is moving faster than its prose.
+- **An ADR marked `Proposed` has not shipped.** Say so on the slide. A
+  capabilities deck that presents proposals as capabilities is marketing, and
+  the first engineer to read the code will find it.
+
+Date every measured figure. Ledger and token-routing numbers are true for a
+window, not forever.
+
+## 3. Diagrams are SVG, and only the SVG is committed
+
+Author or refresh `images/*.svg` by hand, then render to PNG for the deck:
+
+```bash
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+cd docs/presentation/<timestamp>-<sha>/images
+"$CHROME" --headless --disable-gpu --hide-scrollbars \
+  --force-device-scale-factor=2 --window-size=1520,900 \
+  --default-background-color=FFFFFF \
+  --screenshot=01-object-model.png "file://$PWD/01-object-model.svg"
+```
+
+Render at 2× so the diagrams survive a projector. **Look at every PNG before
+building the deck** — SVG text does not wrap, so an overlong line silently
+overflows its box and nothing warns you.
+
+`docs/` stays text-only: the PNGs and the `.pptx` are gitignored. See
+`docs/presentation/README.md` for why that is a hard rule and not tidiness.
+
+## 4. AUDIT.md, or the deck is unverifiable
+
+Every figure and claim traced to a file, commit, or generated reference. Without
+it, next year nobody can tell which slides are still true, and the deck becomes
+folklore with a logo. It is also where the README/code discrepancies from step 2
+are recorded.
+
+## 5. Build and publish
+
+```bash
+python3 -m venv /tmp/deckvenv && /tmp/deckvenv/bin/pip install python-pptx
+/tmp/deckvenv/bin/python docs/presentation/<timestamp>-<sha>/build_deck.py
+
+scripts/publish-deck-to-slides.py \
+  docs/presentation/<timestamp>-<sha>/mac-capabilities-<sha>.pptx \
+  --title "MAC — <subject> (<sha>)" \
+  --expect-slides <n>
+```
+
+`python-pptx` is deliberately not a repository dependency; the deck is a
+documentation artifact, not part of the shipped runtime.
+
+Pass `--expect-slides`. The script exports the published deck back out of Google
+and counts its pages, so a conversion that dropped slides fails here instead of
+in front of an audience.
+
+The published deck is **private to the uploading account**. If the release notes
+will link it for anyone else, share it explicitly.
+
+## 6. Link it in all three places
+
+A deck nobody can find was not published.
+
+1. The deck's own `README.md` — the Slides URL, the slide list, how to rebuild.
+2. `docs/presentation/README.md` — add a row to the existing-decks table.
+3. The root `README.md` — the entry under `## Documentation`.
+
+## 7. Re-verify, in this order
+
+The order matters and is the trap that cost the most time:
+
+```bash
+git add docs/presentation <other changed files>
+
+MAC_TEST_PG_URL=... uv run --extra dev --extra postgres pytest \
+  tests/test_docs_no_operator_identity.py tests/test_guide_docs_are_true.py -q
+make docs-check
+```
+
+**Stage before running.** `tests/test_docs_no_operator_identity.py` enumerates
+`git ls-files`, so it only scans *tracked* files. Run it while the new directory
+is untracked and it scans nothing you wrote and reports a confident pass over an
+empty set.
+
+## 8. Then, and only then, cut the release
+
+The version is single-sourced. `pyproject.toml` declares `dynamic = ["version"]`
+pointing at `mac.__version__`, and `mac.api` / `mac.a2a.card` import it, so one
+line is the whole bump:
+
+```bash
+$EDITOR src/mac/__init__.py          # __version__ = "X.Y.Z"
+git commit -am "Release vX.Y.Z"
+```
+
+Land it the way all work lands here — through a pull request, not a push to
+`main` (`skills/mac-cli/SKILL.md`). Once it is on `main`:
+
+```bash
+git tag vX.Y.Z && git push origin vX.Y.Z
+gh release create vX.Y.Z --title "mac vX.Y.Z" --notes-file notes.md
+```
+
+Write the notes from the deck's `AUDIT.md`, not from the commit log. The log
+says what changed; the audit says what is now true, which is what a reader
+wants, and it is already sourced.
+
+## The traps, all of which have happened
+
+- **`gcloud` cannot publish anything.** There is no `gcloud slides` or
+  `gcloud drive` — the Cloud CLI has no Workspace surface. It mints a token; the
+  Drive API does the upload. The default credential has no Drive scope, so
+  `gcloud auth login --enable-gdrive-access` is a prerequisite.
+- **Never commit the PNGs or the `.pptx`.** Beyond the repository weight,
+  `tests/test_docs_no_operator_identity.py` greps every tracked file under `docs/` for
+  fleet-identity tokens, and compressed image data matches one by coincidence
+  eventually. The first PNG committed here did.
+- **Do not name a forbidden identity token, even to explain one.** That gate
+  does not care why the token is present, and it is right not to — a gate that
+  accepts "I am only quoting it" accepts anything. Only the test file itself is
+  exempt.
+- **No `bash`/`sh`/`shell` fences anywhere under `docs/`** outside the
+  executable book; `scripts/test-docs.py` rejects them. Use `console` for
+  transcripts. (Skills like this one are outside `docs/`, so they may use
+  `bash`.)
+- **Do not quote a dead link.** `scripts/check-docs-accessibility.py` resolves relative
+  links under `docs/`, so pasting a broken link into an audit as evidence
+  reproduces the defect in a checked file. Describe the target instead.
+- **A backticked repository path asserts that the path exists**
+  (`tests/test_guide_docs_are_true.py`). Writing about something deliberately
+  removed? Leave it unbackticked.

--- a/tests/test_cut_a_release_skill.py
+++ b/tests/test_cut_a_release_skill.py
@@ -1,0 +1,78 @@
+"""The release skill must describe machinery that exists.
+
+A release checklist is read once a quarter, under time pressure, by someone who
+did not write it. That is the worst possible moment to discover it names a
+script that was renamed or a make target that was deleted -- the reader is
+mid-release, and the failure looks like their mistake rather than the document's.
+
+The prose about *why* each step exists cannot be tested. The things the reader
+will actually type can: the files it points at, the make targets it invokes, and
+the single-sourced version it tells them to bump.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "skills" / "cut-a-release" / "SKILL.md"
+
+
+def _text() -> str:
+    return SKILL.read_text(encoding="utf-8")
+
+
+def test_the_skill_exists_and_is_indexed():
+    """An unindexed skill is one nobody reads: AGENTS.md is the entry point."""
+    assert SKILL.is_file()
+    agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "skills/cut-a-release/SKILL.md" in agents
+
+
+def test_every_repository_path_it_names_exists():
+    """Same rule the guide is held to: a backticked path asserts it exists."""
+    text = _text()
+    root_names = {entry.name for entry in ROOT.iterdir()}
+    missing = []
+    for token in re.findall(r"`([^`\n]+)`", text):
+        if "/" not in token or any(ch in token for ch in " \t<>*$\"'|"):
+            continue
+        if "://" in token or token.startswith(("/", "~", "#", "http")):
+            continue
+        if token.split("/", 1)[0] not in root_names:
+            continue
+        if not (ROOT / token.rstrip("/")).exists():
+            missing.append(token)
+    assert not missing, "the release skill names paths that do not exist: %s" % sorted(
+        set(missing)
+    )
+
+
+def test_every_make_target_it_invokes_is_real():
+    """`make docs-check` failing because the target was renamed is a bad way to
+    learn that the release checklist is stale."""
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    declared = set(re.findall(r"^([a-zA-Z0-9_-]+):", makefile, re.M))
+    invoked = set(re.findall(r"\bmake ([a-z][a-z0-9-]*)", _text()))
+    unknown = sorted(invoked - declared)
+    assert not unknown, "the release skill invokes make targets that do not exist: %s" % unknown
+
+
+def test_the_version_bump_it_describes_is_still_single_sourced():
+    """The skill tells the reader to edit exactly one line. If the version stops
+    being single-sourced, that instruction silently ships a half-bumped release.
+    """
+    assert '__version__' in (ROOT / "src" / "mac" / "__init__.py").read_text(encoding="utf-8")
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'dynamic = ["version"]' in pyproject, (
+        "pyproject no longer derives the version dynamically; the release skill's "
+        "one-line bump instruction is now wrong"
+    )
+
+
+def test_it_still_points_at_the_publish_script():
+    """The publish step is the one part that is a command rather than prose, so
+    it is the part that breaks silently if the script moves."""
+    assert "scripts/publish-deck-to-slides.py" in _text()
+    assert (ROOT / "scripts" / "publish-deck-to-slides.py").is_file()


### PR DESCRIPTION
Adds `docs/presentation/` — point-in-time capability decks pinned to the commit they describe — plus the first deck, and the release skill that produces the next one.

*(Flattened — this now targets `main` and includes the deck commits formerly in #516, which is closed. Stacked PRs get no CI in this repository: `ci.yml` fires on `pull_request: branches: [main]`, so a PR based on anything else runs nothing.)*

## 1. The deck

**[MAC — What the control plane can do today (`8b424c20`)](https://docs.google.com/presentation/d/1DXgpB-3fy4IDLynGloaAP349BWrwoVSw8T46VyPdT3M/edit)** — 13 slides, 16:9, speaker notes throughout.

Audited from source rather than recalled: the four-object CLI model and the six surfaces onto it, the eleven task states and the four gates between them, the broadcast AgentBus and the merge queue, the heterogeneous node classes, and what the fleet's own instrumentation has measured about it.

It also carries the parts that are not capabilities, because a deck that omits them is marketing: ADRs 0016–0018 are **Proposed** and have not shipped, ADR 0012 is Accepted with implementation deferred, 29.5% of model routes recorded no input token count, and 165 of 355 blocked tasks wait on dependencies that can never complete.

### The convention

```
docs/presentation/<UTC timestamp>-<short commit>/
```

The timestamp sorts, so `ls` is chronological, and disambiguates two decks cut from one commit for different audiences. The commit makes a claim checkable a year later. `AUDIT.md` traces every figure to a file, commit or generated reference, so "is this slide still true" is answerable by inspection rather than memory.

### Text in git, binaries in Slides

Only the SVG diagram sources are committed; the rendered PNGs and built `.pptx` are gitignored and the deck lives in Slides.

Beyond repository weight, `tests/test_docs_no_operator_identity.py` greps every tracked file under `docs/` for fleet-identity tokens — and with sixteen tokens matched case-insensitively, compressed image data hits one by coincidence sooner or later. The first PNG committed did. Keeping `docs/` text-only means that gate keeps reading prose, **and needs no change**: an earlier revision loosened it to skip binaries; this leaves it untouched.

Two plumbing changes so the next deck costs nothing: `mkdocs.yml` excludes `presentation/` from the built site, and `scripts/generate-docs-reference.py` skips it when building the documentation inventory (which calls its entries current operating contracts — a pinned deck is precisely not that).

## 2. The release skill

The gates prove the code works. Nothing proves the documentation still describes it — this repository shipped a README describing a vendored tree for three days after 583k lines of it were deleted. Releases are the natural checkpoint.

| File | Purpose |
|---|---|
| `skills/cut-a-release/SKILL.md` | Gates green → pin a deck → audit from source → publish → link → re-verify → tag |
| `scripts/publish-deck-to-slides.py` | The one step that should be a command, not a paragraph |
| `tests/test_cut_a_release_skill.py` | Gates the skill so it cannot rot, as `test_mac_cli_skill.py` does for the CLI skill |
| `AGENTS.md`, `README.md` | The index entry and the Presentations link |

**The traps section is the point.** Each cost real time and none is discoverable from the code — chiefly that `tests/test_docs_no_operator_identity.py` enumerates `git ls-files`, so running it before `git add` scans nothing you wrote and reports a confident pass over an empty set.

**The publish script** uploads with `mimeType: application/vnd.google-apps.presentation`, which makes Drive convert rather than attach. `gcloud` has no Workspace surface — no `gcloud slides`, no `gcloud drive` — so its only role is minting a token, and its default credential lacks the Drive scope; the script checks that first so the failure names `gcloud auth login --enable-gdrive-access` rather than a bare 403. `--expect-slides` exports the published deck back as PDF and counts pages.

**Scope:** documentation and tag/release mechanics only. Fleet cutover and image qualification are separate and the skill points at the existing runbooks. There was no written release process before this; §8 describes what I verified from the v1.1.0 commit, the tags and `gh release list`. If the real one differs, that is the file to correct.

## Verification

Every gate CI runs, run locally against a live test PostgreSQL:

| Gate | Result |
|---|---|
| `scripts/test-docs.py` | pass — 18 chapters, 20 shell blocks |
| `scripts/check-docs-accessibility.py` | pass — 191 pages |
| `scripts/generate-docs-reference.py --check` | clean; inventory byte-identical |
| `mkdocs build --strict` | succeeds; no `presentation/` path in the site |
| `test_docs_no_operator_identity`, `test_guide_docs_are_true`, `test_mac_cli_skill`, `test_cut_a_release_skill` | 22 pass, **staged first** |
| `ruff check`, dead-code contract | clean |

The new skill gate was checked for **vacuity**, not just for passing: it inspects 3 make targets and 7 distinct repository paths rather than an empty set. `publish-deck-to-slides.py` was exercised end to end against Drive — upload, conversion, 13-slide verification — and the test artifact trashed afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
