### PR TITLE
Keep the reason a hub verification failed, not the 2000 bytes after it

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1095,6 +1095,63 @@ def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 15
     )
 
 
+#: Where the reason for a failure is announced, in the order a run prints it.
+#: "short test summary info" is pytest's own answer to "what failed"; the rest
+#: are the verdict signatures, so anything the classifier can act on is kept.
+_HUB_VERIFY_FAILURE_ANCHORS: Tuple[str, ...] = (
+    "short test summary info",
+) + _HUB_VERIFY_VERDICT_SIGNATURES
+
+
+def _hub_verify_output_excerpt(
+    output: str, *, head: int = 1500, window: int = 2000, tail: int = 1000
+) -> str:
+    """Keep the head, the TAIL, and the part that says why the run failed.
+
+    Head-and-tail is not enough here, which is the trap this replaced a blind
+    tail with. A failing contract run prints, in order: a session header,
+    several hundred lines of pytest progress, the failure and its summary, a
+    whole-repo coverage report (one row per source file, ~14KB), a coverage
+    line whose floors both PASSED, and -- last -- OpenShell's generic
+    "ssh exited with status 1". The verdict sits in the middle, out of reach
+    of both ends, so a fixed head and tail preserve the two regions that say
+    nothing and drop the only one that does.
+
+    Position is the wrong selector. Anchor on the text that announces the
+    failure and keep a window around its LAST occurrence, so the excerpt still
+    carries a verdict signature after truncation and a rejection stays
+    classifiable as a rejection.
+    """
+
+    text = (output or "").strip()
+    if len(text) <= head + window + tail:
+        return text
+
+    spans = [(0, head), (len(text) - tail, len(text))]
+    lowered = text.lower()
+    found = [lowered.rfind(a) for a in _HUB_VERIFY_FAILURE_ANCHORS]
+    anchor_at = max(found)
+    if anchor_at >= 0:
+        start = max(0, anchor_at - window // 4)
+        spans.append((start, min(len(text), start + window)))
+
+    merged: List[Tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+
+    parts: List[str] = []
+    previous = 0
+    for start, end in merged:
+        if start > previous:
+            parts.append("... [%d chars omitted] ..." % (start - previous))
+        parts.append(text[start:end])
+        previous = end
+    return "\n".join(parts)
+
+
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
 #: Marker recorded on a task that was approved but has no publication
 #: destination, so the task itself says why it is sitting in REVIEWING instead
@@ -27323,7 +27380,16 @@ class ControlPlane:
             try:
                 proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
                 out = (proc.stdout or "") + (proc.stderr or "")
-                return int(proc.returncode), out[-2000:]
+                # Head AND tail. A blind tail cannot see the verdict:
+                # run-contract-tests.sh prints the pytest failure first, then
+                # an unconditional whole-repo coverage report (~14KB, one row
+                # per source file), then a coverage summary whose floors both
+                # PASSED, and only then exits with the saved pytest status.
+                # Keeping 2000 trailing bytes therefore kept the coverage
+                # table and OpenShell's generic "ssh exited with status 1" --
+                # so a real rejection was unclassifiable by construction and
+                # retried forever (six tasks, ~6 hours, 2026-08-20).
+                return int(proc.returncode), _hub_verify_output_excerpt(out)
             finally:
                 subprocess.run([openshell, "sandbox", "delete", name], capture_output=True, text=True, timeout=60, check=False)
         finally:
@@ -27759,7 +27825,11 @@ class ControlPlane:
             manifest["feedback"] = "hub contract verification failed (rc=%d): %s\n\n%s" % (
                 int(returncode),
                 str(test_command or "scripts/run-contract-tests.sh")[:200],
-                _hub_review_failure_excerpt(output) or "nonzero exit",
+                # Already bounded and relevance-selected at the capture site
+                # (_hub_verify_output_excerpt). Excerpting an excerpt would
+                # cut the middle back out -- and the middle is the anchored
+                # window holding the reason this was rejected.
+                output.strip() or "nonzero exit",
             )
         manifest["signature"] = sign_verification_manifest(key, manifest)
         evidence = self.add_evidence(

--- a/tests/test_hub_verify_evidence_window.py
+++ b/tests/test_hub_verify_evidence_window.py
@@ -1,0 +1,166 @@
+"""The verdict must survive the capture, not just the classifier.
+
+#478 then #522 argued about which strings mean "the harness died" versus "the
+gate judged the change". Both reasoned about the text the classifier receives.
+Neither looked at how that text is produced.
+
+`_hub_verify_run_contract_test` kept `out[-2000:]` -- a blind tail. And
+`run-contract-tests.sh` prints the pytest failure FIRST, then an unconditional
+whole-repo `coverage report` (235 source files, ~14KB), then the coverage
+safety summary, and only then exits with the saved pytest status. So on every
+test failure the 2000 surviving bytes hold the coverage table's tail, a
+coverage line whose floors both PASSED, and OpenShell's generic
+"ssh exited with status 1".
+
+Every signature in _HUB_VERIFY_VERDICT_SIGNATURES lives in the discarded
+prefix. The rejection is therefore unclassifiable by construction: read as a
+dead harness, no verdict signed, review retried, identical outcome. Observed
+2026-08-20: six tasks, 3-4 identical retries each over ~6 hours, `completed`
+frozen at 724 while all three agents sat idle.
+
+The head+tail excerpt this repo already had (_hub_review_failure_excerpt, and
+its docstring makes exactly this argument) was applied downstream of the
+truncation -- head and tail of a tail.
+"""
+from __future__ import annotations
+
+import subprocess
+import types
+
+import pytest
+
+from mac import gitops, services
+from mac.services import ControlPlane, hub_verification_unavailable_reason
+
+HEAD_SHA = "a" * 40
+
+# A whole-repo `coverage report` is one row per source file. It is emitted
+# after the failure and before the exit, so it is what a blind tail keeps.
+COVERAGE_TABLE = "\n".join(
+    "src/mac/module_%03d.py%s500     40    92%%" % (i, " " * 8) for i in range(235)
+)
+
+# pytest's own progress output, which precedes the failure it reports.
+PYTEST_PROGRESS = "\n".join(
+    "tests/test_module_%03d.py ......................... [ %2d%%]" % (i, i % 100)
+    for i in range(400)
+)
+
+PYTEST_FAILURE = (
+    "=================================== FAILURES ===================================\n"
+    "E   AssertionError: expected 1 got 0\n"
+    "=========================== short test summary info ===========================\n"
+    "FAILED tests/test_task_batch.py::test_the_preview_and_the_apply_agree\n"
+    "3 failed, 1204 passed, 11 skipped in 612.44s\n"
+)
+
+FAILING_RUN = (
+    "============================= test session starts ==============================\n"
+    "collected 1218 items\n"
+    + PYTEST_PROGRESS
+    + "\n"
+    + PYTEST_FAILURE
+    + COVERAGE_TABLE
+    + "\ncoverage safety: statements 70802/77880 (90.91%, floor 90.00%); "
+    "branches 20708/25192 (82.20%, floor 80.00%)\n"
+)
+
+UPLOAD_AND_SSH = (
+    "  - Uploading files to /sandbox...\n  + Files uploaded\n"
+    "Error:   x ssh exited with status exit status: 1"
+)
+
+
+def _fake_run(monkeypatch):
+    """Stub only the process boundary, so the real capture path is exercised."""
+
+    def run(argv, **kwargs):
+        done = lambda rc, out="", err="": subprocess.CompletedProcess(argv, rc, out, err)
+        if argv[0] == "git" and "rev-parse" in argv:
+            return done(0, HEAD_SHA + "\n")
+        if argv[0] in ("git", "tar"):
+            return done(0)
+        if "delete" in argv:
+            return done(0)
+        return done(1, FAILING_RUN, UPLOAD_AND_SSH)  # the sandbox create+run
+
+    monkeypatch.setattr(services.subprocess, "run", run)
+    monkeypatch.setattr(
+        gitops, "askpass_remote_auth", lambda url: (url, {}), raising=False
+    )
+
+
+def _capture(monkeypatch):
+    _fake_run(monkeypatch)
+    plane = types.SimpleNamespace()  # no _hub_verify_runner -> the real path
+    return ControlPlane._hub_verify_run_contract_test(
+        plane, "https://example.invalid/r.git", "b", HEAD_SHA, "scripts/run-contract-tests.sh"
+    )
+
+
+def test_a_failing_gate_is_classified_as_a_rejection_not_a_dead_harness(monkeypatch):
+    """The bug, stated as the behaviour that matters."""
+    returncode, output = _capture(monkeypatch)
+
+    assert returncode == 1
+    assert hub_verification_unavailable_reason(output) is None
+
+
+def test_the_captured_evidence_names_which_test_failed(monkeypatch):
+    """A rejection an operator cannot act on is barely better than no verdict:
+    diagnosing one such run ended with the sandbox gone and nothing recorded."""
+    _returncode, output = _capture(monkeypatch)
+
+    assert "short test summary info" in output
+    assert "3 failed, 1204 passed" in output
+
+
+def test_the_blind_tail_that_caused_this_would_still_fail(monkeypatch):
+    """Guards the fix against being reverted to a tail with a bigger number:
+    the coverage table grows with the repo, so any fixed tail loses this race."""
+    assert hub_verification_unavailable_reason(
+        (FAILING_RUN + UPLOAD_AND_SSH)[-2000:]
+    ) == "ssh exited with status"
+
+
+def test_a_genuinely_dead_harness_is_still_unavailable(monkeypatch):
+    """#522 must survive this fix: no gate ran, so there is no verdict to sign."""
+    monkeypatch.setattr(
+        gitops, "askpass_remote_auth", lambda url: (url, {}), raising=False
+    )
+
+    def run(argv, **kwargs):
+        done = lambda rc, out="", err="": subprocess.CompletedProcess(argv, rc, out, err)
+        if argv[0] == "git" and "rev-parse" in argv:
+            return done(0, HEAD_SHA + "\n")
+        if argv[0] in ("git", "tar") or "delete" in argv:
+            return done(0)
+        return done(1, "", "Error:   x ssh exited with status exit status: 255")
+
+    monkeypatch.setattr(services.subprocess, "run", run)
+    plane = types.SimpleNamespace()
+    _rc, output = ControlPlane._hub_verify_run_contract_test(
+        plane, "https://example.invalid/r.git", "b", HEAD_SHA, "scripts/run-contract-tests.sh"
+    )
+
+    assert hub_verification_unavailable_reason(output) == "ssh exited with status"
+
+
+def test_the_excerpt_survives_the_second_truncation_on_the_way_to_the_worker(
+    monkeypatch,
+):
+    """The rejection feedback is the only thing the worker gets to read.
+
+    It used to be re-excerpted on the way out. Head-and-tail of an excerpt
+    whose middle IS the answer removes the answer, and a worker that cannot
+    see the reason answers a rejection with more tests and a bigger diff --
+    observed twice on one task.
+    """
+    _returncode, output = _capture(monkeypatch)
+
+    feedback = "hub contract verification failed (rc=%d): %s\n\n%s" % (
+        1, "scripts/run-contract-tests.sh", output.strip() or "nonzero exit",
+    )
+
+    assert "3 failed, 1204 passed" in feedback
+    assert "test_the_preview_and_the_apply_agree" in feedback


### PR DESCRIPTION
## The bug

`#478` signed a dead ssh stream as `rejected`. `#522` corrected it so only a dead
harness is "unavailable". Both reasoned about the text the classifier reads.
Neither looked at how that text is produced — and it was produced by
`out[-2000:]`, a blind tail.

`run-contract-tests.sh` prints the pytest failure, **then** an unconditional
whole-repo coverage report (one row per source file, ~14KB here), **then** a
coverage summary whose floors both passed, and only then exits with the saved
pytest status (`scripts/run-contract-tests.sh:689-706`):

```bash
"$PY" -m coverage report
"$PY" scripts/coverage-policy.py ...
...
if [ "$pytest_status" -ne 0 ]; then
    exit "$pytest_status"
fi
```

So the 2000 surviving bytes of a failing run are the coverage table's tail, a
**passing** coverage line, and OpenShell's generic `ssh exited with status 1`.
That reads exactly like a healthy gate followed by a transport fault, which is
how it was diagnosed for two days.

Every string in `_HUB_VERIFY_VERDICT_SIGNATURES` lives in the discarded prefix.
A real rejection was therefore **unclassifiable by construction**: read as a
dead harness, no verdict signed, review retried, the same 2000 bytes produced
again.

Observed 2026-08-20: six tasks retried 3–4 times each over ~6 hours while
`completed` stayed frozen at 724, `reviewing` sat at 19, and all three agents
were idle.

## Why head-and-tail is not the fix

The repo already had `_hub_review_failure_excerpt`, written for this exact
lesson. Applying it here still fails, and the test in this PR catches it: the
failure sits between several hundred lines of pytest progress and the coverage
table, out of reach of **both** ends.

Position is the wrong selector. `_hub_verify_output_excerpt` anchors on the text
that announces the failure — pytest's `short test summary info` and the verdict
signatures — and keeps a window around its last occurrence, plus head and tail
for context.

## Second truncation

The rejection feedback re-excerpted that excerpt on its way to the worker.
Head-and-tail of an excerpt whose middle is the answer removes the answer — the
mechanism behind the task that answered a rejection with more tests and a bigger
diff, twice. It now passes through, already bounded at the capture site.

## Verification

`tests/test_hub_verify_evidence_window.py` drives the real capture path with
only the process boundary stubbed, so it reproduced the production failure
before the fix and covers:

- a failing gate classifies as a rejection, not a dead harness
- the captured evidence names which test failed
- the blind tail that caused this would still fail (guards against re-widening
  the tail — the coverage table grows with the repo, so any fixed tail loses
  this race)
- a genuinely dead harness is still unavailable (#522 survives)
- the excerpt survives the second truncation on the way to the worker

Ledger: `task_68ed61db`

🤖 Generated with [Claude Code](https://claude.com/claude-code)