### PR TITLE
Hub verify discarded the reason it failed before classifying it (task_68ed61db520d438ca8304979e58ac755)

### DIFF
--- a/src/mac/contract_failure.py
+++ b/src/mac/contract_failure.py
@@ -28,12 +28,14 @@ failure text rather than only through a live task.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional, Sequence, Tuple
 
 __all__ = [
     "ContractFailureCause",
     "ContractFailure",
     "classify_contract_failure",
+    "CONTRACT_FAILURE_ANCHORS",
+    "capture_failure_window",
 ]
 
 
@@ -158,3 +160,125 @@ def classify_contract_failure(
             "should be rare enough to notice."
         ),
     )
+
+
+#: Generic text that ANNOUNCES a failure, used to choose which bytes of a huge
+#: contract-test log to keep. These are a *capture* heuristic, never a verdict:
+#: a wrong entry here costs one wasted window, not a misclassification, because
+#: the caller's classifier still decides what the surviving text means. That is
+#: the opposite of the discipline governing verdict signatures, where a wrong
+#: entry signs a rejection nobody judged -- so this list can afford to be
+#: generous where that one must not be.
+CONTRACT_FAILURE_ANCHORS: Tuple[str, ...] = (
+    "= failures =",                      # pytest section banner
+    "= errors =",
+    "short test summary info",
+    "traceback (most recent call last)",
+    "returned non-zero exit status",
+    "timed out after",
+    "fatal:",
+    "command not found",
+    "no such file or directory",
+    "permission denied",
+)
+
+
+def _merge_spans(spans: Sequence[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    merged: List[Tuple[int, int]] = []
+    for start, end in sorted(span for span in spans if span[1] > span[0]):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _spans_length(spans: Sequence[Tuple[int, int]]) -> int:
+    return sum(end - start for start, end in spans)
+
+
+def _render_spans(body: str, spans: Sequence[Tuple[int, int]]) -> str:
+    parts: List[str] = []
+    cursor = 0
+    for start, end in spans:
+        if start > cursor:
+            parts.append("... [%d chars omitted] ..." % (start - cursor))
+        parts.append(body[start:end])
+        cursor = end
+    if cursor < len(body):
+        parts.append("... [%d chars omitted] ..." % (len(body) - cursor))
+    return "\n".join(parts)
+
+
+def capture_failure_window(
+    text: str,
+    *,
+    anchors: Sequence[str] = (),
+    limit: int = 12000,
+    head: int = 1200,
+    tail: int = 1200,
+    before: int = 700,
+    after: int = 2200,
+) -> str:
+    """Keep the part of a contract-test log that says WHY it failed.
+
+    A blind tail (``out[-2000:]``) discards the reason by construction on this
+    repository's gate. ``run-contract-tests.sh`` prints the pytest failure
+    FIRST, then an unconditional whole-repo ``coverage report`` -- one row per
+    source file, ~14KB here -- then a coverage summary whose floors both
+    PASSED, and only then exits with the saved pytest status. So the last 2000
+    bytes of a *failing* run are the coverage table's tail, a passing coverage
+    line, and the transport's generic "ssh exited with status 1".
+
+    Observed 2026-08-20: every string the hub classifies a rejection by lived
+    in the discarded prefix, so a genuine rejection was unclassifiable *by
+    construction* -- recorded as a dead harness, no verdict signed, review
+    retried, identical output produced again. Six tasks retried 3-4 times over
+    ~6 hours while `completed` stayed frozen and all three agents sat idle.
+    Two earlier fixes only ever changed how the surviving text was CLASSIFIED,
+    which is why neither moved the fleet: the text was already gone.
+
+    Head-and-tail is not sufficient either. The failure sits between several
+    hundred lines of pytest progress and the coverage table -- out of reach of
+    both ends. So this keeps the head, the tail, AND a window around the last
+    occurrence of each anchor, merged and rendered with explicit omission
+    markers.
+
+    ``anchors`` are tried before :data:`CONTRACT_FAILURE_ANCHORS` and are how a
+    caller guarantees its own classifier still has something to classify: pass
+    the exact strings that classifier keys on, and if any of them appears
+    anywhere in ``text``, an occurrence survives into the result. Windows are
+    admitted in that priority order until ``limit`` is reached, so the caller's
+    strings win any contest for the budget.
+
+    Returns ``text`` unchanged when it already fits in ``limit`` -- most gate
+    failures are small, and eliding them would add noise for nothing.
+    """
+
+    body = text or ""
+    if len(body) <= limit:
+        return body
+    head = max(0, min(head, limit))
+    tail = max(0, min(tail, limit - head))
+    kept = _merge_spans([(0, head), (len(body) - tail, len(body))])
+    lowered = body.lower()
+    seen = set()
+    for anchor in list(anchors) + list(CONTRACT_FAILURE_ANCHORS):
+        needle = (anchor or "").strip().lower()
+        if not needle or needle in seen:
+            continue
+        seen.add(needle)
+        index = lowered.rfind(needle)
+        if index < 0:
+            continue
+        window = (
+            max(0, index - before),
+            min(len(body), index + len(needle) + after),
+        )
+        candidate = _merge_spans(list(kept) + [window])
+        if _spans_length(candidate) > limit:
+            # Budget exhausted. Keep going rather than breaking: a later,
+            # cheaper anchor may still fit inside a gap this one could not.
+            continue
+        kept = candidate
+    return _render_spans(body, kept)

--- a/src/mac/merge_queue.py
+++ b/src/mac/merge_queue.py
@@ -56,6 +56,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
+from mac.contract_failure import capture_failure_window
+
 GitRunner = Callable[[Sequence[str]], "subprocess.CompletedProcess"]
 ContractTestRunner = Callable[[str, str, str, str], Tuple[int, str]]
 
@@ -264,7 +266,11 @@ def validate_projected_merge_contract(
             projected_sha=projected_sha,
             test_command=command,
             test_returncode=returncode,
-            output_tail=output_tail[-2000:],
+            # A second blind tail here would undo the anchored capture the
+            # runner already did: it arrives holding the failure in its MIDDLE,
+            # between the pytest progress and the coverage table, and taking
+            # 2000 bytes off the end throws that away again.
+            output_tail=capture_failure_window(output_tail),
             error=error,
         )
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -210,6 +210,7 @@ from mac.agentbus_service import AgentBusService
 from mac.deploy_service import DeployService
 from mac.directive_service import DirectiveService
 from mac.codegraph_audit import codegraph_audit_manifest_problems
+from mac.contract_failure import capture_failure_window
 from mac import evidence_blobs
 from mac.evidence_validators import rejected_verdict_feedback_problems, validate_evidence_type
 from mac.eval_service import EvalService
@@ -1070,8 +1071,50 @@ def hub_verification_unavailable_reason(output: str) -> Optional[str]:
     return None
 
 
+#: How much of a hub verification's output is carried out of the sandbox.
+#:
+#: This is the number that mattered. It was 2000, taken as a blind TAIL before
+#: anything looked at the text, and on this repository's gate the tail of a
+#: failing run is the coverage table's last rows, a PASSING coverage line, and
+#: the transport's generic "ssh exited with status 1" -- the pytest failure is
+#: printed first and then buried under ~14KB of unconditional coverage report.
+#: So every string in _HUB_VERIFY_VERDICT_SIGNATURES was discarded before
+#: hub_verification_unavailable_reason ever ran, and a real rejection could not
+#: be classified as one no matter how that classifier was written. Two prior
+#: fixes changed only the classification and neither moved the fleet.
+HUB_VERIFY_OUTPUT_CAPTURE_LIMIT = 12000
+#: What the rejection's excerpt costs on top of its head and tail. Bounded so
+#: a signed manifest stays a manifest and not a log file.
+_HUB_REVIEW_EXCERPT_WINDOW_BUDGET = 4000
+
+
+def hub_verify_captured_output(output: str) -> str:
+    """Reduce a verification run's raw output to what can still be judged.
+
+    Anchored on _HUB_VERIFY_VERDICT_SIGNATURES, which is the whole point: the
+    strings hub_verification_unavailable_reason keys on are exactly the strings
+    that must survive the reduction, or the classifier is handed a text that
+    cannot express the answer. Anything the anchors miss still leaves the head,
+    the tail, and the generic failure anchors.
+
+    Capturing more does slightly widen the #478 exposure -- a transport death
+    signed as a rejection because some verdict signature appeared earlier in a
+    run that had actually passed. That is accepted deliberately: every
+    signature is required to appear ONLY on failure (a rule tests/
+    test_hub_verify_verdict_vs_transport.py enforces), so text that contains
+    one is text where a gate judged something wanting. Keeping fewer bytes does
+    not make that safer, it only makes the answer unknowable.
+    """
+
+    return capture_failure_window(
+        output,
+        anchors=_HUB_VERIFY_VERDICT_SIGNATURES,
+        limit=HUB_VERIFY_OUTPUT_CAPTURE_LIMIT,
+    )
+
+
 def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 1500) -> str:
-    """Keep the head AND the tail of a rejected verification's output.
+    """Keep the head, the tail, AND the part of the output that says why.
 
     The tail alone was kept, and the tail of a pytest run is its summary line:
     "36 failed, 84 passed, 588 errors". That says the gate failed, which the
@@ -1082,16 +1125,22 @@ def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 15
     Diagnosing one such rejection took a hub-side archaeology session that
     ended in the evidence being gone: the sandbox that produced it had been
     cleaned up, and nothing else recorded the run.
+
+    Head-and-tail fixed that case and not the general one: a pytest failure
+    sits between several hundred lines of progress output and the coverage
+    table, out of reach of BOTH ends. Re-truncating here would also undo the
+    capture that already happened in the sandbox, since the reason survives in
+    the middle of what came back. So the same failure-anchored window applies.
     """
 
-    text = (output or "").strip()
-    if len(text) <= head + tail:
-        return text
-    omitted = len(text) - head - tail
-    return "%s\n... [%d chars omitted] ...\n%s" % (
-        text[:head],
-        omitted,
-        text[-tail:],
+    return capture_failure_window(
+        (output or "").strip(),
+        anchors=_HUB_VERIFY_VERDICT_SIGNATURES,
+        limit=head + tail + _HUB_REVIEW_EXCERPT_WINDOW_BUDGET,
+        head=head,
+        tail=tail,
+        before=400,
+        after=1600,
     )
 
 
@@ -27323,7 +27372,11 @@ class ControlPlane:
             try:
                 proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, check=False)
                 out = (proc.stdout or "") + (proc.stderr or "")
-                return int(proc.returncode), out[-2000:]
+                # NOT a tail. The sandbox is deleted in the `finally` below, so
+                # whatever this drops is gone for good -- and a blind tail
+                # dropped exactly the announcement of the failure, leaving a
+                # rejection that could not be recognised as one.
+                return int(proc.returncode), hub_verify_captured_output(out)
             finally:
                 subprocess.run([openshell, "sandbox", "delete", name], capture_output=True, text=True, timeout=60, check=False)
         finally:

--- a/tests/test_hub_verify_output_capture.py
+++ b/tests/test_hub_verify_output_capture.py
@@ -1,0 +1,272 @@
+"""The hub threw away the reason it failed BEFORE anything classified it.
+
+`_hub_verify_run_contract_test` captured `out[-2000:]` -- a blind tail -- and
+then deleted the sandbox that produced it. On this repository's gate that tail
+is structurally guaranteed to contain no failure:
+
+    run-contract-tests.sh
+      1. prints the pytest failure                       <- the reason
+      2. prints an unconditional whole-repo `coverage report`  (~14KB)
+      3. prints a coverage summary whose floors both PASSED
+      4. exits with the pytest status saved in step 1
+
+so the surviving 2000 bytes are the coverage table's last rows, a PASSING
+coverage line, and OpenShell's generic "ssh exited with status 1". Every string
+in `_HUB_VERIFY_VERDICT_SIGNATURES` lives in the discarded prefix, which made a
+genuine rejection unclassifiable BY CONSTRUCTION: recorded as a dead harness,
+no verdict signed, review retried, identical output produced again.
+
+Observed 2026-08-20: six tasks retried 3-4 times each over ~6 hours while
+`completed` stayed frozen at 724, `reviewing` sat at 19, and all three agents
+were idle. PRs #478 and #522 both changed only how the surviving text was
+CLASSIFIED, and neither moved the fleet, because by then the text was gone.
+
+Head-and-tail is not sufficient either -- `test_head_and_tail_still_misses_it`
+below is the proof. The failure sits between several hundred lines of pytest
+progress and the coverage table, out of reach of both ends.
+"""
+
+from __future__ import annotations
+
+import subprocess as _subprocess
+
+import pytest
+
+from mac.contract_failure import capture_failure_window
+from mac.services import (
+    _HUB_VERIFY_VERDICT_SIGNATURES,
+    _hub_review_failure_excerpt,
+    HUB_VERIFY_OUTPUT_CAPTURE_LIMIT,
+    ControlPlane,
+    hub_verification_unavailable_reason,
+    hub_verify_captured_output,
+)
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+FAILURE_LINE = (
+    "FAILED tests/test_repository_contract.py::test_contract_command "
+    "- AssertionError: expected the scoped selection"
+)
+SSH_TAIL = "Error:   x ssh exited with status exit status: 1"
+
+
+def _coverage_table(rows: int = 400) -> str:
+    """The ~14KB of PASSING per-file rows that displaced the failure."""
+    return "\n".join(
+        "src/mac/module_%03d.py                 %4d   %3d    %4d    %2d  9%d%%"
+        % (index, 300 + index, index % 40, 120 + index, index % 20, index % 10)
+        for index in range(rows)
+    )
+
+
+def _failing_contract_run() -> str:
+    """One realistic failing run of scripts/run-contract-tests.sh."""
+    progress = "\n".join(
+        "tests/test_module_%03d.py ....................  [ %2d%%]"
+        % (index, min(99, index // 4))
+        for index in range(400)
+    )
+    return "\n".join(
+        [
+            "run-contract-tests.sh: running fail-fast repository contract preflight",
+            "sanity selection: full",
+            progress,
+            "=================================== FAILURES ===================================",
+            "____________________________ test_contract_command _____________________________",
+            "E   AssertionError: expected the scoped selection",
+            "=========================== short test summary info ============================",
+            FAILURE_LINE,
+            "1 failed, 4291 passed, 12 skipped in 902.11s",
+            "",
+            "Name                                  Stmts   Miss  Branch  BrPart  Cover",
+            _coverage_table(),
+            "TOTAL                                 76238   6938   24618    4402  90.90%",
+            "coverage safety: statements 69300/76238 (90.90%, floor 90.00%); "
+            "branches 20216/24618 (82.12%, floor 80.00%)",
+            "  + Files uploaded",
+            SSH_TAIL,
+        ]
+    )
+
+
+def _passing_run_that_died_in_transit() -> str:
+    """The #478 case at real scale: the gate PASSED, then the stream died.
+
+    No verdict exists to sign here, and capturing more bytes must not invent
+    one. This is the failure mode that pulls in the opposite direction from
+    everything else in this file, which is why it is tested at the same size.
+    """
+    progress = "\n".join(
+        "tests/test_module_%03d.py ....................  [ %2d%%]"
+        % (index, min(99, index // 4))
+        for index in range(400)
+    )
+    return "\n".join(
+        [
+            "run-contract-tests.sh: running fail-fast repository contract preflight",
+            "sanity selection: full",
+            progress,
+            "4291 passed, 12 skipped in 884.02s",
+            "",
+            "Name                                  Stmts   Miss  Branch  BrPart  Cover",
+            _coverage_table(),
+            "TOTAL                                 77427   7056   25076    4470  90.89%",
+            "coverage safety: statements 70371/77427 (90.89%, floor 90.00%); "
+            "branches 20606/25076 (82.17%, floor 80.00%)",
+            "  + Files uploaded",
+            SSH_TAIL,
+        ]
+    )
+
+
+# --- the bug, stated as an executable fact ---------------------------------
+
+def test_the_blind_tail_could_not_express_a_rejection():
+    """What the hub used to keep, and why no classifier could have saved it.
+
+    This is not a test of dead code -- it is the premise. If this ever stops
+    holding, the fix below is solving a problem this repository no longer has.
+    """
+    output = _failing_contract_run()
+
+    blind_tail = output[-2000:]
+
+    assert FAILURE_LINE not in blind_tail
+    assert not any(sig in blind_tail.lower() for sig in _HUB_VERIFY_VERDICT_SIGNATURES)
+    # ...so the run that failed on a real assertion was filed as a dead harness.
+    assert hub_verification_unavailable_reason(blind_tail) == "ssh exited with status"
+
+
+def test_head_and_tail_still_misses_it():
+    """Why the fix anchors instead of widening both ends.
+
+    The failure is announced after several hundred lines of pytest progress and
+    before ~14KB of coverage table. A generous head and a generous tail both
+    stop short of it.
+    """
+    output = _failing_contract_run()
+
+    head_and_tail = output[:2000] + output[-1500:]
+
+    assert FAILURE_LINE not in head_and_tail
+
+
+# --- the fix ---------------------------------------------------------------
+
+def test_the_captured_output_carries_the_failure():
+    captured = hub_verify_captured_output(_failing_contract_run())
+
+    assert FAILURE_LINE in captured
+    assert "AssertionError: expected the scoped selection" in captured
+    # The gate judged the change wanting, so this is a REJECTION -- even though
+    # the transport's "ssh exited with status" is still present in the tail.
+    assert SSH_TAIL in captured
+    assert hub_verification_unavailable_reason(captured) is None
+
+
+@pytest.mark.parametrize("signature", sorted(_HUB_VERIFY_VERDICT_SIGNATURES))
+def test_every_verdict_signature_survives_being_buried(signature):
+    """The property the classifier depends on.
+
+    A signature the capture drops is a signature that cannot be classified, no
+    matter how carefully `hub_verification_unavailable_reason` is written. So
+    each one is buried in the exact position that defeated the blind tail --
+    the middle -- and must come back out.
+    """
+    noise = "\n".join("progress line %05d ......" % index for index in range(4000))
+    output = "%s\nthe gate said: %s here\n%s\n%s" % (
+        noise, signature, noise, SSH_TAIL
+    )
+
+    captured = hub_verify_captured_output(output)
+
+    assert signature in captured.lower()
+    assert hub_verification_unavailable_reason(captured) is None
+
+
+def test_a_transport_death_after_a_pass_is_still_not_a_rejection():
+    """The #478 regression, re-run against the wider capture.
+
+    Keeping more bytes is only safe because every verdict signature is required
+    to appear ONLY on failure. A passing run has none of them anywhere, so
+    seeing more of it cannot manufacture a verdict.
+    """
+    captured = hub_verify_captured_output(_passing_run_that_died_in_transit())
+
+    assert hub_verification_unavailable_reason(captured) == "ssh exited with status"
+
+
+def test_the_capture_stays_bounded_and_says_what_it_dropped():
+    """Evidence rows are not log files. The window is bounded, and every gap
+    is marked so a reader is never silently handed a doctored transcript."""
+    output = _failing_contract_run()
+    captured = hub_verify_captured_output(output)
+
+    assert len(output) > HUB_VERIFY_OUTPUT_CAPTURE_LIMIT
+    # Omission markers are the only thing added, so the bound holds with a
+    # small allowance for them.
+    assert len(captured) <= HUB_VERIFY_OUTPUT_CAPTURE_LIMIT + 500
+    assert "chars omitted" in captured
+
+
+def test_a_short_failure_is_returned_whole():
+    """Most gate failures fit. Eliding them would add noise for nothing."""
+    short = "documentation contract failed: published shell fences are forbidden"
+
+    assert hub_verify_captured_output(short) == short
+    assert capture_failure_window("") == ""
+
+
+# --- the excerpt written into the signed manifest --------------------------
+
+def test_the_rejection_feedback_keeps_the_reason_too():
+    """`_hub_review_failure_excerpt` re-truncated head-and-tail, which threw
+    the reason away a second time -- after the capture had just rescued it."""
+    excerpt = _hub_review_failure_excerpt(hub_verify_captured_output(_failing_contract_run()))
+
+    assert FAILURE_LINE in excerpt
+
+
+def test_the_observation_excerpt_is_small_and_still_useful():
+    """The unavailable-path observation asks for head=400/tail=400. It must
+    stay small, and it must still be worth reading."""
+    excerpt = _hub_review_failure_excerpt(
+        hub_verify_captured_output(_failing_contract_run()), head=400, tail=400
+    )
+
+    assert FAILURE_LINE in excerpt
+    assert len(excerpt) <= 400 + 400 + 4000 + 500
+
+
+# --- the sandbox boundary itself -------------------------------------------
+
+def test_the_sandbox_runner_captures_instead_of_tailing(cp, monkeypatch):
+    """End to end through `_hub_verify_run_contract_test`.
+
+    The sandbox is deleted in that function's `finally`, so anything it does
+    not return here is unrecoverable.
+    """
+    from mac import services as services_mod
+
+    output = _failing_contract_run()
+
+    def fake_run(argv, **kwargs):
+        if "rev-parse" in argv and "HEAD" in argv:
+            return _subprocess.CompletedProcess(argv, 0, stdout=("a" * 40) + "\n", stderr="")
+        if "create" in argv and "--upload" in argv:
+            return _subprocess.CompletedProcess(argv, 1, stdout=output, stderr="")
+        return _subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(services_mod.subprocess, "run", fake_run)
+
+    returncode, captured = cp._hub_verify_run_contract_test(
+        "git@github.com:org/repo.git", "task/branch", "a" * 40, ""
+    )
+
+    assert returncode == 1
+    assert FAILURE_LINE in captured
+    assert hub_verification_unavailable_reason(captured) is None

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -158,6 +158,38 @@ def test_full_contract_failure_is_fail_closed(repo: Path):
     assert verdict.error == "full repository contract test failed"
 
 
+def test_full_contract_failure_keeps_the_reason_out_of_the_middle(repo: Path):
+    """The verdict took `output_tail[-2000:]`, a second blind tail.
+
+    The runner hands this function output whose failure sits in the MIDDLE --
+    a pytest failure announced before ~14KB of coverage table -- because that
+    is the shape scripts/run-contract-tests.sh produces. Chopping 2000 bytes
+    off the end threw the reason away again, after the sandbox capture had
+    just gone to the trouble of keeping it.
+    """
+    _branch_commit(repo, "topic", "topic.txt", "topic\n")
+    reason = "FAILED tests/test_contract.py::test_scope - AssertionError: nope"
+    coverage_table = "\n".join(
+        "src/mac/module_%03d.py   %4d   %3d   9%d%%" % (i, 300 + i, i % 40, i % 10)
+        for i in range(400)
+    )
+    output = "%s\n%s\ncoverage safety: floors PASSED\nssh exited with status 1" % (
+        reason, coverage_table,
+    )
+
+    verdict = validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (1, output),
+    )
+
+    assert verdict.passed is False
+    assert reason in verdict.output_tail
+    assert output[-2000:].find(reason) == -1  # the premise: a tail cannot reach it
+
+
 def test_full_contract_never_runs_for_conflict_or_empty_command(repo: Path):
     _branch_commit(repo, "topic", "f.txt", "topic\nline2\nline3\n")
     (repo / "f.txt").write_text("main\nline2\nline3\n")


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_68ed61db520d438ca8304979e58ac755`
- head: `8f9d87bb1674cd1d8bbb1df2df837b06a7cb007f`
- base at push: `bac507781a648fabdbf02b2519b2b22f8b8d8648`
