### PR TITLE
Name the persona-instance commands for what they register; print a hub's URL next to its token

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -280,16 +280,16 @@ What agents know:
   persona          Hermes personas and their memory scopes
 
 Talking to people and systems:
-  message        messages between agents and humans
-  agentbus       the agent-to-agent message bus
-  communication  communication channels and routing
-  notifier       outbound notification channels
-  directive      operator directives issued to agents
-  hermes         Hermes instances and their context
-  binding        Hermes platform bindings
-  interaction    durable work created from a conversation
-  bridge         external system bridges
-  integrations   third-party integrations
+  message           messages between agents and humans
+  agentbus          the agent-to-agent message bus
+  communication     communication channels and routing
+  notifier          outbound notification channels
+  directive         operator directives issued to agents
+  persona-instance  bind a persona (SOUL.md) to an agent, and its context (alias: hermes)
+  binding           Hermes platform bindings
+  interaction       durable work created from a conversation
+  bridge            external system bridges
+  integrations      third-party integrations
 
 Who can do what:
   tenant  tenant boundaries

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -1570,6 +1570,108 @@ def cmd_optimizer_experiment_analyze(args: argparse.Namespace) -> None:
     _print(_plane(args).analyze_scientific_experiment(args.experiment_id))
 
 
+def cmd_fleet_connect(args: argparse.Namespace) -> None:
+    """Print a fleet's hub URL and bearer token together, ready to paste.
+
+    Both halves already exist -- the URL in ~/.mac/fleets.yaml, the token as
+    MAC_API_TOKEN__<FLEET> in ~/.mac/.env -- but nothing put them side by side,
+    so connecting to a hub you had just built meant reading a tailscale address
+    off one command and grepping a token out of a file.
+
+    The token is MASKED by default. It carries full control-plane authority, so
+    a command that printed it unasked would leak it into scrollback, shared
+    terminals and CI logs. --show-token is the deliberate act.
+    """
+    from mac.fleet_env import resolve as resolve_fleet_env, scoped_var
+    from mac.fleet_move import fleet_hub_url, resolve_fleet_key
+    from mac.fleet_creds import load_fleets_config
+    from mac import mac_paths
+
+    registry = load_fleets_config(getattr(args, "fleets_config", None))
+    fleets = registry.get("fleets") or {}
+    requested = getattr(args, "fleet", None) or os.environ.get("MAC_FLEET")
+    fleet_key = resolve_fleet_key(registry, requested) if requested else None
+    if fleet_key is None:
+        # One fleet is the unambiguous case and by far the common one right
+        # after setup.sh; more than one must be named rather than guessed.
+        if not requested and len(fleets) == 1:
+            fleet_key = next(iter(fleets))
+        else:
+            known = ", ".join(sorted(fleets)) or "(none registered)"
+            raise SystemExit(
+                "no such fleet: %s\nknown fleets: %s"
+                % (requested or "(none given; pass --fleet)", known)
+            )
+    url = fleet_hub_url(registry, fleet_key)
+    # The environment first, then ~/.mac/.env. setup.sh WRITES the token to
+    # that file without exporting it, so a shell that has not sourced it -- the
+    # shell you are in seconds after building a hub, which is exactly when you
+    # want this -- would otherwise be told the token is unset while it sits on
+    # disk.
+    token = (
+        resolve_fleet_env("MAC_API_TOKEN", fleet_key)
+        or _env_file_values(mac_paths.deploy_env_file()).get(
+            scoped_var("MAC_API_TOKEN", fleet_key)
+        )
+        or ""
+    )
+
+    if _OUTPUT_JSON:
+        _print({
+            "fleet": fleet_key,
+            "url": url,
+            "token": token if args.show_token else None,
+            "token_var": scoped_var("MAC_API_TOKEN", fleet_key),
+            "token_present": bool(token),
+        })
+        return
+
+    if not url:
+        print("fleet %r has no hub_url in the registry" % fleet_key)
+    if not token:
+        print(
+            "no bearer token found; expected %s in the environment or %s"
+            % (scoped_var("MAC_API_TOKEN", fleet_key), mac_paths.deploy_env_file())
+        )
+
+    shown = token if args.show_token else _mask_token(token)
+    print(fleet_key)
+    print("  URL    %s" % (url or "(unset)"))
+    print("  token  %s" % (shown or "(unset)"))
+    if token and not args.show_token:
+        print("\n  (masked -- pass --show-token to print it in full)")
+
+
+def _env_file_values(path: "Path") -> Dict[str, str]:
+    """KEY=VALUE pairs from a dotenv-style file; {} when it is unreadable.
+
+    Deliberately not a dotenv dependency: this reads one file to answer one
+    question, and a missing or malformed line must degrade to "not found"
+    rather than failing a command whose job is to print what it can find.
+    """
+    values: Dict[str, str] = {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return values
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        key, _, raw = line.partition("=")
+        values[key.strip()] = raw.strip().strip("'\"")
+    return values
+
+
+def _mask_token(token: str) -> str:
+    """Enough to recognise which token this is, too little to use it."""
+    if not token:
+        return ""
+    return "%s...%s" % (token[:6], token[-4:]) if len(token) > 14 else "*" * len(token)
+
+
 def cmd_fleet_creds_status(args: argparse.Namespace) -> None:
     """Per-agent coding-CLI auth status from the agents' heartbeat reports.
 
@@ -7676,7 +7778,17 @@ def build_parser() -> argparse.ArgumentParser:
     hi_cov.add_argument("--home")
     _set(cmd_human_interface_coverage, hi_cov)
 
-    hermes = sub.add_parser("hermes", help="Hermes instance commands").add_subparsers(dest="hermes_command", required=True)
+    # Named for what it registers, not for the runtime it was built against.
+    # Every agent runs OpenClaw now, and a personality is a SOUL.md file
+    # (human_interface_profile.IDENTITY_FILES); these subcommands register and
+    # inspect the persona INSTANCE that binds one to an agent. `hermes` stays
+    # as an alias because the deploy script, the adapter's emitted command
+    # strings and the integration docs all still spell it that way.
+    hermes = sub.add_parser(
+        "persona-instance",
+        aliases=["hermes"],
+        help="persona instance commands: bind a persona (SOUL.md) to an agent",
+    ).add_subparsers(dest="hermes_command", required=True)
     hermes_register = hermes.add_parser("register")
     hermes_register.add_argument("tenant_id")
     hermes_register.add_argument("name")
@@ -9869,6 +9981,18 @@ def build_parser() -> argparse.ArgumentParser:
     # Coding-CLI credential fabric: the operator's CURRENT workstation is the
     # source of truth for claude/codex/cursor auth; workers get it over the
     # fleet's SSH routes, on demand.
+    fleet_connect = fleet.add_parser(
+        "connect",
+        help="print this fleet's hub URL and bearer token together, ready to "
+        "paste into the UI (token masked unless --show-token)",
+    )
+    fleet_connect.add_argument(
+        "--show-token",
+        action="store_true",
+        help="print the bearer token in full instead of masking it",
+    )
+    _set(cmd_fleet_connect, fleet_connect)
+
     fleet_creds_status = fleet.add_parser(
         "creds-status",
         help="per-agent coding-CLI (claude/codex/cursor) auth status, from the "

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -241,7 +241,7 @@ COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
             ("communication", "communication channels and routing"),
             ("notifier", "outbound notification channels"),
             ("directive", "operator directives issued to agents"),
-            ("hermes", "Hermes instances and their context"),
+            ("persona-instance", "bind a persona (SOUL.md) to an agent, and its context (alias: hermes)"),
             ("binding", "Hermes platform bindings"),
             ("interaction", "durable work created from a conversation"),
             ("bridge", "external system bridges"),

--- a/tests/cli/test_cli_coverage_gate.py
+++ b/tests/cli/test_cli_coverage_gate.py
@@ -229,10 +229,10 @@ KNOWN_UNTESTED: frozenset[tuple[str, str]] = frozenset(
         ("fleet", "sync-token"),
         ("fleet", "validate"),
         # hermes domain
-        ("hermes", "context"),
-        ("hermes", "register"),
-        ("hermes", "runtime-proof"),
-        ("hermes", "work-context"),
+        ("persona-instance", "context"),
+        ("persona-instance", "register"),
+        ("persona-instance", "runtime-proof"),
+        ("persona-instance", "work-context"),
         # integrations domain
         ("integrations", "findings"),
         ("integrations", "observations"),

--- a/tests/cli/test_cli_fleet_connect.py
+++ b/tests/cli/test_cli_fleet_connect.py
@@ -1,0 +1,121 @@
+"""`mac admin fleet connect` -- the hub URL and its bearer token, together.
+
+Both halves already existed: the URL in fleets.yaml, the token as
+MAC_API_TOKEN__<FLEET>. Nothing put them side by side, so connecting to a hub
+you had just built meant reading a tailscale address off one command and
+grepping a token out of a file -- in front of an audience, during the demo this
+command exists to serve.
+
+This lives in tests/cli/ deliberately: the coverage gate discovers tested
+subcommands by scanning THIS directory for `_run(...)` calls, so a CLI test
+filed anywhere else leaves the subcommand looking untested.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+
+TOKEN = "yLVmgAsecrettokenvaluedAfU"
+
+
+@pytest.fixture
+def fleet_home(tmp_path, monkeypatch):
+    """A registry and a deploy env file that are not the operator's own."""
+    fleets = tmp_path / "fleets.yaml"
+    fleets.write_text(
+        "fleets:\n"
+        "  hazel:\n"
+        "    fleet_name: watership-down\n"
+        "    hub_url: http://100.64.0.9:8789\n",
+        encoding="utf-8",
+    )
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# a comment\nexport MAC_API_TOKEN__HAZEL='%s'\n" % TOKEN, encoding="utf-8"
+    )
+    monkeypatch.setenv("MAC_FLEETS_CONFIG", str(fleets))
+    monkeypatch.setenv("MAC_DEPLOY_ENV_FILE", str(env_file))
+    monkeypatch.delenv("MAC_API_TOKEN__HAZEL", raising=False)
+    monkeypatch.delenv("MAC_API_TOKEN", raising=False)
+    monkeypatch.delenv("MAC_FLEET", raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def text_output():
+    """tests/conftest.py forces JSON for the whole suite; these assertions are
+    about the human layout, so opt back into text explicitly."""
+    from mac import cli
+
+    cli._set_output_json(False)
+    yield
+    cli._set_output_json(True)
+
+
+def _run(*args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(list(args))
+    finally:
+        sys.stdout = old
+    return rc, out.getvalue()
+
+
+def test_the_url_and_the_token_arrive_together(fleet_home):
+    """The whole point: one command, both halves, ready to paste."""
+    _rc, out = _run("--json", "admin", "fleet", "connect", "--show-token")
+    doc = json.loads(out)
+
+    assert doc["url"] == "http://100.64.0.9:8789"
+    assert doc["token"] == TOKEN
+
+
+def test_the_token_is_masked_unless_asked_for(fleet_home, text_output):
+    """It carries full control-plane authority. A command that printed it
+    unasked would leak it into scrollback, shared terminals and CI logs."""
+    _rc, out = _run("admin", "fleet", "connect")
+
+    assert TOKEN not in out
+    assert "http://100.64.0.9:8789" in out
+    assert "yLVmgA" in out and "dAfU" in out  # recognisable, not usable
+
+
+def test_the_token_is_read_from_the_env_file_not_only_the_environment(fleet_home):
+    """setup.sh WRITES the token without exporting it, so the shell you are in
+    seconds after building a hub does not have it. That is precisely when this
+    command is used."""
+    _rc, out = _run("--json", "admin", "fleet", "connect", "--show-token")
+
+    assert json.loads(out)["token"] == TOKEN
+
+
+def test_a_fleet_can_be_named_by_its_human_label(fleet_home):
+    """Fleets are keyed by hub-agent name but carry a separate fleet_name.
+    An operator naturally passes either."""
+    _rc, out = _run("--json", "--fleet", "watership-down", "admin", "fleet", "connect")
+
+    assert json.loads(out)["url"] == "http://100.64.0.9:8789"
+
+
+def test_an_unknown_fleet_names_the_ones_that_exist(fleet_home):
+    """A bare 'no such fleet' sends the operator back to reading YAML."""
+    with pytest.raises(SystemExit) as excinfo:
+        _run("--fleet", "efrafa", "admin", "fleet", "connect")
+
+    assert "hazel" in str(excinfo.value)
+
+
+def test_json_omits_the_token_unless_show_token_is_given(fleet_home):
+    _rc, out = _run("--json", "admin", "fleet", "connect")
+    doc = json.loads(out)
+
+    assert doc["token"] is None
+    assert doc["token_present"] is True
+    assert doc["token_var"] == "MAC_API_TOKEN__HAZEL"

--- a/tests/cli/test_cli_persona_instance_name.py
+++ b/tests/cli/test_cli_persona_instance_name.py
@@ -1,0 +1,44 @@
+"""The persona-instance commands are named for what they register.
+
+Every agent runs OpenClaw; a personality is a SOUL.md file
+(`human_interface_profile.IDENTITY_FILES`). The command group that binds a
+persona to an agent was still called `hermes`, after a runtime nothing uses, so
+staffing an OpenClaw fleet meant typing `mac admin hermes register` in front of
+an audience.
+
+`hermes` stays as an alias: the deploy script, the adapter's emitted command
+strings and the integration docs all still spell it that way, and renaming
+those is a separate, larger piece of work (task_2a7df680).
+"""
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from mac.cli import main
+
+
+def _run(*args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(list(args))
+    finally:
+        sys.stdout = old
+    return rc, out.getvalue()
+
+
+def test_the_group_is_reachable_by_its_new_name():
+    rc, out = _run("admin", "persona-instance", "help")
+    assert rc in (None, 0)
+    assert "register" in out
+
+
+def test_hermes_still_works_as_an_alias():
+    """Breaking it would break the deploy script mid-release."""
+    rc, out = _run("admin", "hermes", "help")
+    assert rc in (None, 0)
+    assert "register" in out

--- a/tests/cli/test_cli_top_level_is_the_object_model.py
+++ b/tests/cli/test_cli_top_level_is_the_object_model.py
@@ -111,7 +111,7 @@ def test_all_still_lists_everything(tmp_path):
     """The escape hatch has to stay complete, or hiding becomes losing."""
     text = _help(tmp_path, "help", "--all")
 
-    for name in ("fleet", "memory", "hermes", "optimizer", "agentbus"):
+    for name in ("fleet", "memory", "persona-instance", "optimizer", "agentbus"):
         assert name in text
 
 


### PR DESCRIPTION
Two operator-facing fixes, both found by running a demo script against the CLI
as it actually is rather than as it reads.

## `mac admin hermes` → `mac admin persona-instance`

Every agent runs OpenClaw, and a personality is a `SOUL.md` file
(`human_interface_profile.IDENTITY_FILES`). The group that binds a persona to an
agent was still named after a runtime nothing uses, so staffing an OpenClaw
fleet meant typing `mac admin hermes register`.

`hermes` stays as an argparse alias, deliberately — `deploy/fleet-node-install.sh`,
the adapter's emitted command strings and `docs/hermes-integration.md` all still
spell it that way. Renaming those is the larger work tracked as `task_2a7df680`.
This is only the name an operator types.

## `mac admin fleet connect`

```
watership-down
  URL    http://100.64.0.9:8789
  token  yLVmgA...dAfU

  (masked -- pass --show-token to print it in full)
```

The URL lived in `fleets.yaml`, the token in `~/.mac/.env`, and nothing put them
together — so connecting to a hub you had just built meant reading a tailscale
address off one command and grepping a token out of a file.

**Masked by default.** That token carries full control-plane authority; a command
that printed it unasked would leak it into scrollback, shared terminals and CI
logs. `--show-token` is the deliberate act.

It reads the environment first, then the deploy env file — `setup.sh` *writes*
the token without exporting it, so the shell you are in seconds after building a
hub does not have it, which is exactly when this is used.

Two things I got wrong first, both caught by tests:
- read `mac_env_file()` (`$MAC_HOME/mac.env`, the hub's own service secrets)
  instead of `deploy_env_file()` (the client's scoped fleet tokens)
- checked `args.json`, but `--json` is stripped from argv into a module global

## Governance

The group is catalogued in `cli_surface`, the four subcommands keep their
`KNOWN_UNTESTED` entries under the new name, and the `--all` listing test samples
the new name. `fleet connect` needs no allowlist entry because it has tests.

All 646 `tests/cli/` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)