### PR TITLE
make run-gui serves a different UI from the one the hub runs (task_c948afb58c644b98bbd342caf99b1112)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,22 @@ IDE_OPEN ?= 0
 IDE_PORT ?= 5273
 IDE_PACKAGE ?= dist/mac-ide-web.tar.gz
 IDE_NODE_MODULES_STAMP := $(IDE_DIR)/node_modules/.package-lock.json
+# THE HUB UI. `observe/` is the only browser surface the hub serves: api.py
+# mounts src/mac/ui/console at /ui. Every GUI lifecycle target below --
+# install-gui, build-gui, package-gui, run-gui -- points here, so "the UI you
+# run locally" and "the UI the fleet serves" cannot be different products.
+# tests/ui/test_hub_ui_is_one_tree.py fails if that stops being true.
 OBSERVE_DIR ?= observe
 # Vite writes the console bundle straight into the Python package, so the
 # hub's existing /ui/assets StaticFiles mount serves it with no api.py change.
 OBSERVE_BUNDLE := src/mac/ui/console
+OBSERVE_NODE_MODULES_STAMP := $(OBSERVE_DIR)/node_modules/.package-lock.json
+GUI_HOST ?= 127.0.0.1
+GUI_PORT ?= 5274
+GUI_PACKAGE ?= dist/mac-hub-ui.tar.gz
+# Hub the local console reads during `make run-gui`; blank means observe/'s own
+# default (http://127.0.0.1:8789). Exported into the Vite dev proxy.
+MAC_API_URL ?=
 DESKTOP_NODE_MODULES_STAMP := desktop/node_modules/.package-lock.json
 
 # Console scripts declared in pyproject.toml [project.scripts]; keep in sync.
@@ -36,7 +48,7 @@ CONSOLE_SCRIPTS = mac mac-hermes mac-agent mac-firecrawl-gateway mac-k8s-orchest
 	test-portfolio fault-replay sanity-test compatibility-test \
 	docs docs-install docs-serve docs-test docs-build docs-check docs-accessibility docs-lab docs-reference \
 	ide-install ide-run ide-dev ide-check ide-build ide-preview ide-package \
-	observe-build \
+	observe-build observe-run \
 	desktop-install desktop-check desktop-package desktop-dist link-cli
 
 help: ## Show the supported local build, install, run, test, and cleanup commands.
@@ -45,9 +57,9 @@ help: ## Show the supported local build, install, run, test, and cleanup command
 		'Install prerequisites: Python 3.11+, git, gh, npm, and CodeGraph.' \
 		'Build and test targets also require uv.' \
 		'' \
-		'  make install       Install/link the CLI and prepare the canonical Fleet IDE' \
-		'  make build         Build the CLI wheel and canonical Fleet IDE' \
-		'  make run-gui       Run the Fleet IDE using the active mac login profile' \
+		'  make install       Install/link the CLI and build the hub UI (observe/)' \
+		'  make build         Build the CLI wheel and the hub UI bundle' \
+		'  make run-gui       Run the hub UI -- the same tree the hub serves at /ui' \
 		'  make test          Run the hermetic contract test suite' \
 		'  make lint          Run the shared Ruff lint gate' \
 		'  make clean         Remove generated build artifacts (keep installed dependencies)' \
@@ -64,7 +76,7 @@ require-python:
 
 require-npm:
 	@command -v "$(NPM)" >/dev/null 2>&1 || { \
-		echo "npm is required to build or run the Fleet IDE" >&2; \
+		echo "npm is required to build or run the hub UI" >&2; \
 		exit 127; \
 	}
 
@@ -84,20 +96,20 @@ install-codegraph: ## Install CodeGraph if absent (litai init and the skills nee
 # Common lifecycle: these are the targets a new contributor/client should use.
 # ---------------------------------------------------------------------------
 
-install: install-codegraph install-cli install-gui ## Install the CLI and canonical Fleet IDE from this checkout.
+install: install-codegraph install-cli install-gui ## Install the CLI and the hub UI from this checkout.
 	@printf '%s\n' \
-		'Installed MAC CLI + Fleet IDE.' \
+		'Installed MAC CLI + hub UI.' \
 		'  CLI:  mac --help' \
 		'  GUI:  mac login && make run-gui'
 
 install-cli: require-python codegraph-sync link-cli ## Create the Python environment and link MAC commands into ~/.local/bin.
 	@echo "CLI installed from $(abspath $(VENV))"
 
-install-gui: codegraph-sync build-gui ## Install locked GUI dependencies and build the canonical Fleet IDE.
-	@echo "Fleet IDE installed in $(IDE_DIR)/dist (run with: make run-gui)"
+install-gui: codegraph-sync build-gui ## Install locked GUI dependencies and build the hub UI.
+	@echo "hub UI installed in $(OBSERVE_BUNDLE) (served by the hub at /ui; run locally with: make run-gui)"
 
-build: build-cli build-gui ## Build both the CLI wheel and canonical Fleet IDE.
-	@echo "built CLI wheel + Fleet IDE"
+build: build-cli build-gui ## Build both the CLI wheel and the hub UI.
+	@echo "built CLI wheel + hub UI"
 
 build-cli: require-python require-uv codegraph-sync ## Build the Python wheel into dist/.
 	@mkdir -p dist
@@ -105,11 +117,11 @@ build-cli: require-python require-uv codegraph-sync ## Build the Python wheel in
 	$(UV) build --wheel
 	@ls -1 dist/mac-*.whl
 
-build-gui: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Type-check and build the canonical Fleet IDE.
-	cd $(IDE_DIR) && $(NPM) run build
+build-gui: require-npm codegraph-sync $(OBSERVE_NODE_MODULES_STAMP) ## Type-check and build the hub UI into $(OBSERVE_BUNDLE).
+	cd $(OBSERVE_DIR) && $(NPM) run build
 
-package: package-cli package-gui ## Produce verified CLI and Fleet IDE distribution artifacts.
-	@echo "packaged CLI wheel + Fleet IDE web bundle"
+package: package-cli package-gui ## Produce verified CLI and hub UI distribution artifacts.
+	@echo "packaged CLI wheel + hub UI bundle"
 
 package-cli: build-cli ## Verify the wheel's console-script entry points.
 	@whl=$$(ls dist/mac-*.whl); \
@@ -124,15 +136,19 @@ package-cli: build-cli ## Verify the wheel's console-script entry points.
 		done; \
 		echo "packaged $$whl"
 
-package-gui: build-gui ## Package the Fleet IDE static bundle into dist/.
-	@mkdir -p "$$(dirname "$(IDE_PACKAGE)")"
-	tar -czf "$(IDE_PACKAGE)" -C "$(IDE_DIR)/dist" .
-	@echo "packaged Fleet IDE web bundle: $(IDE_PACKAGE)"
+package-gui: build-gui ## Package the hub UI static bundle into dist/.
+	@mkdir -p "$$(dirname "$(GUI_PACKAGE)")"
+	tar -czf "$(GUI_PACKAGE)" -C "$(OBSERVE_BUNDLE)" .
+	@echo "packaged hub UI bundle: $(GUI_PACKAGE)"
 
 # Backward-compatible name. This target packages locally; it does not upload.
 publish: package-cli ## Backward-compatible alias for package-cli (does not upload).
 
-run-gui: ide-run ## Run the canonical Fleet IDE development server.
+# run-gui runs the SAME tree the hub serves. It used to run ide/, which the hub
+# has never mounted, so an operator opening "the GUI" saw a different product
+# from the one the fleet was running and reported it broken. Keep this pointed
+# at $(OBSERVE_DIR).
+run-gui: observe-run ## Run the hub UI (observability console) against a hub.
 
 clean: clean-cli clean-gui ## Remove generated artifacts while preserving installed dependencies and CodeGraph.
 	@rmdir dist 2>/dev/null || true
@@ -147,9 +163,9 @@ clean-cli: ## Remove Python build, test, and wheel artifacts.
 
 # NB: $(OBSERVE_BUNDLE) is deliberately NOT removed by clean-gui -- it is a
 # committed, shipped artifact, not a scratch build directory.
-clean-gui: ## Remove canonical and legacy GUI build artifacts, but keep node_modules.
+clean-gui: ## Remove hub UI, prototype IDE, and legacy desktop build artifacts, but keep node_modules.
 	rm -rf $(IDE_DIR)/dist desktop/dist
-	rm -f "$(IDE_PACKAGE)"
+	rm -f "$(GUI_PACKAGE)" "$(IDE_PACKAGE)"
 
 distclean: clean uninstall-cli ## Remove generated artifacts and all locally installed dependencies.
 	rm -rf "$(VENV)" "$(IDE_DIR)/node_modules" "$(OBSERVE_DIR)/node_modules" desktop/node_modules
@@ -175,6 +191,9 @@ $(VENV)/bin/mac: pyproject.toml scripts/bootstrap-project.py
 
 $(IDE_NODE_MODULES_STAMP): $(IDE_DIR)/package-lock.json
 	cd $(IDE_DIR) && $(NPM) ci
+
+$(OBSERVE_NODE_MODULES_STAMP): $(OBSERVE_DIR)/package-lock.json
+	cd $(OBSERVE_DIR) && $(NPM) ci --no-audit --no-fund
 
 $(DESKTOP_NODE_MODULES_STAMP): desktop/package-lock.json
 	cd desktop && $(NPM) ci
@@ -247,13 +266,20 @@ test-api: codegraph-sync ## Run API-marked tests.
 test-cli: codegraph-sync ## Run CLI-marked tests.
 	uv run --extra dev pytest -q -m cli tests/
 
-test-ui: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Run API UI contracts, Fleet IDE browser tests and console unit tests.
+test-ui: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Run API UI contracts, hub UI unit tests, and prototype IDE browser tests.
 	uv run --extra dev pytest -q -m ui tests/
 	cd $(IDE_DIR) && $(NPM) run test:ui
 	cd $(OBSERVE_DIR) && $(NPM) ci --no-audit --no-fund && $(NPM) run typecheck && $(NPM) test
 
-observe-build: require-npm ## Rebuild the observability console into src/mac/ui/console.
-	cd $(OBSERVE_DIR) && $(NPM) ci --no-audit --no-fund && $(NPM) run build
+observe-build: build-gui ## Rebuild the hub UI into src/mac/ui/console (alias for build-gui).
+
+observe-run: require-npm codegraph-sync $(OBSERVE_NODE_MODULES_STAMP) ## Serve the hub UI locally from $(OBSERVE_DIR) against a hub.
+	@set -e; \
+	if [ -f "$$HOME/.mac/.env" ]; then set -a; . "$$HOME/.mac/.env"; set +a; fi; \
+	if [ -n "$(MAC_API_URL)" ]; then MAC_API_URL="$(MAC_API_URL)"; export MAC_API_URL; fi; \
+	echo "hub UI (observability console) -> http://$(GUI_HOST):$(GUI_PORT)/ui/assets/console/"; \
+	echo "reading hub $${MAC_API_URL:-http://127.0.0.1:8789}; paste a bearer token in the UI"; \
+	cd $(OBSERVE_DIR) && $(NPM) run dev -- --host $(GUI_HOST) --port $(GUI_PORT)
 
 cli-coverage: codegraph-sync ## Print CLI subcommand coverage.
 	@$(VENV)/bin/python scripts/cli-coverage.py
@@ -297,12 +323,16 @@ docs-lab: docs-install ## Execute one chapter in the isolated docs lab (CHAPTER=
 	$(UV) run --extra docs python scripts/test-docs.py --chapter "$(CHAPTER)" --verbose
 
 # ---------------------------------------------------------------------------
-# Canonical Fleet IDE compatibility targets.
+# Fleet IDE prototype (ide/). NOT the hub UI: no hub mounts this bundle, and
+# nothing deploys it. It is a local, mutating operator surface you run by hand
+# against a hub. Everything here is opt-in -- install/build/package/run-gui all
+# target $(OBSERVE_DIR) instead. Do not label these "canonical" again without
+# first making api.py actually serve them.
 # ---------------------------------------------------------------------------
 
-ide-install: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Install locked Fleet IDE dependencies.
+ide-install: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Install locked Fleet IDE prototype dependencies.
 
-ide-run ide-dev: require-python require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Run the Fleet IDE development server.
+ide-run ide-dev: require-python require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Run the Fleet IDE prototype dev server (not the hub UI).
 	@set -a; \
 	if [ -f "$$HOME/.mac/.env" ]; then set -a; . "$$HOME/.mac/.env"; set +a; fi; \
 	PYTHONPATH="$(abspath src)" \
@@ -318,19 +348,23 @@ ide-run ide-dev: require-python require-npm codegraph-sync $(IDE_NODE_MODULES_ST
 	NPM="$(NPM)" \
 	"$(PYTHON)" -m mac.ide_launcher
 
-ide-check: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Type-check the Fleet IDE.
+ide-check: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Type-check the Fleet IDE prototype.
 	cd $(IDE_DIR) && $(NPM) run typecheck
 
-ide-build: build-gui ## Backward-compatible alias for build-gui.
+ide-build: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Type-check and build the Fleet IDE prototype bundle.
+	cd $(IDE_DIR) && $(NPM) run build
 
-ide-preview: build-gui ## Preview the production Fleet IDE bundle.
+ide-preview: ide-build ## Preview the built Fleet IDE prototype bundle.
 	cd $(IDE_DIR) && $(NPM) run preview -- --host $(IDE_HOST) --port $(IDE_PORT)
 
-ide-package: package-gui ## Backward-compatible alias for package-gui.
+ide-package: ide-build ## Package the Fleet IDE prototype bundle into dist/.
+	@mkdir -p "$$(dirname "$(IDE_PACKAGE)")"
+	tar -czf "$(IDE_PACKAGE)" -C "$(IDE_DIR)/dist" .
+	@echo "packaged Fleet IDE prototype bundle: $(IDE_PACKAGE)"
 
-# Legacy Electron dashboard wrapper. It is not part of install/build because the
-# canonical GUI is ide/. Keep these explicit until Fleet IDE desktop packaging
-# replaces the maintenance-only renderer.
+# Legacy Electron dashboard wrapper. It is not part of install/build; neither is
+# the Fleet IDE prototype it was meant to replace. Keep these explicit and
+# opt-in.
 desktop-install: require-npm codegraph-sync $(DESKTOP_NODE_MODULES_STAMP) ## Install legacy desktop-wrapper dependencies.
 
 desktop-check: require-npm codegraph-sync $(DESKTOP_NODE_MODULES_STAMP) ## Syntax-check the legacy desktop wrapper.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ The guide is in [`docs/guide/`](docs/guide/README.md):
 | [System Architecture](docs/guide/01-architecture.md) | what the pieces are and how work flows — mostly diagrams |
 | [Getting Started](docs/guide/02-getting-started.md) | stand up a fleet, run a task, diagnose one that does not move |
 | [Advanced Concepts](docs/guide/03-advanced.md) | leases, evidence, review, publication, and the known gaps |
-| [The UI](docs/guide/04-ui.md) | the read-only console and the mutating Fleet IDE |
+| [The UI](docs/guide/04-ui.md) | the hub UI (read-only console) and the local Fleet IDE prototype |
 | [Developer Guide](docs/guide/05-developer-guide.md) | how to hack on mac |
 | [Contributing](CONTRIBUTING.md) | filing issues and PRs that are actually tested |
 | [Presentations](docs/presentation/README.md) | capabilities decks, each pinned to the commit it describes and published to Google Slides |
@@ -183,14 +183,18 @@ every edge in the task state diagram is one the control plane allows.
 # See every supported lifecycle target. Bare `make` prints the same help.
 make help
 
-# Install/link the CLI and prepare the canonical Fleet IDE.
+# Install/link the CLI and build the hub UI.
 make install
 
-# Verify the checkout, or log in and launch the GUI against that hub.
+# Verify the checkout, or log in and launch the hub UI against that hub.
 make test
 mac admin login
 make run-gui
 ```
+
+`make run-gui` serves the same `observe/` tree the hub serves at `/ui`, so the
+UI you run locally is the UI the fleet is running. See
+[ADR 0025](docs/adr/0025-one-hub-ui.md).
 
 `make test` runs the complete hermetic pytest suite with statement, branch, and
 Python-subprocess coverage for MAC-owned `src/mac` code. Vendored Hermes
@@ -222,8 +226,8 @@ and is excluded.
 The common lifecycle is deliberately conventional:
 
 ```bash
-make install       # CLI + canonical Fleet IDE
-make build         # Python wheel + production IDE bundle
+make install       # CLI + hub UI (the console the hub serves at /ui)
+make build         # Python wheel + hub UI bundle
 make clean         # generated artifacts only
 make distclean     # also remove .venv and node_modules
 ```
@@ -486,9 +490,11 @@ principals to `MAC_CLIENT_PRINCIPALS_FILE`; the API hot-reloads that registry.
 With no static token or enrolled client configured, the local prototype API
 remains open for development.
 
-The observability console is served at `/ui` (and `/ui/console`). Static assets
-are public so the browser can load the shell, while data requests use the same
-API token rules as the REST API.
+The observability console is **the hub UI** — the only browser surface a hub
+serves. It answers at `/ui` (and `/ui/console`). Static assets and the shell are
+public so the browser can load it, while data requests use the same API token
+rules as the REST API. The bare root `/` and `/dashboard/observe` require the
+`read` scope, so they answer 403 without a token: open `/ui`, not `/`.
 
 It is READ-ONLY, and that is the point rather than a limitation. It answers
 what the fleet is doing — tasks and agents moving through states — with views
@@ -509,11 +515,12 @@ Two properties it will not trade away:
 
 The console is built from `observe/` (React + Vite) into `src/mac/ui/console/`,
 which is committed, so serving it needs no Node.js at runtime. Rebuild with
-`npm --prefix observe run build` after changing the source; CI fails if the
-committed bundle drifts from it.
+`make build-gui` (or `npm --prefix observe run build`) after changing the
+source; CI fails if the committed bundle drifts from it.
 
-Mutating operations live in the CLI (`mac ...`), the REST API, and the Fleet
-IDE (`ide/`).
+Mutating operations live in the CLI (`mac ...`) and the REST API — and, if you
+start it yourself, the local Fleet IDE prototype in `ide/`, which no hub
+serves.
 
 Key route groups:
 
@@ -544,24 +551,31 @@ Key route groups:
 - `/agents/{id}/mood`, `/agents/{id}/mood/history` — agent-self-reported emotional state (warm/cheerful/sad/curt/cold/irritated/angry/enraged) with reason + optional TTL; transitions flow through `/events` as `subject_type=agent`
 - `/agents/{id}/nap-schedule`, `/agents/{id}/nap-schedule/next`, `/nap-schedules`, `/nap-runs`, `/nap-runs/{id}/complete`, `/nap-runs/{id}/fail` — daily memory-consolidation lifecycle. Offset defaults to `md5(agent.name) %% 360` minutes (spreads the fleet across the 0–6h UTC window). mac coordinates `begin → DRAINING → complete/fail`; summarization and vector storage are off-process and linked via `evidence` + `vector_refs`.
 
-## Fleet IDE
+## Fleet IDE (unshipped prototype)
 
-The React + Monaco fleet IDE lives in `ide/`. From the repository root:
+The React + Monaco fleet IDE lives in `ide/`. **No hub serves it**: `api.py`
+mounts only the observability console, and nothing deploys `ide/dist`. It is a
+local, mutating operator surface you start by hand — not the hub UI, and not
+what `make run-gui` runs. [ADR 0025](docs/adr/0025-one-hub-ui.md) explains why,
+and what serving it would take.
+
+From the repository root:
 
 ```bash
-make install-gui
+make ide-install
 mac admin login
-make run-gui
-make build-gui
-make package-gui
+make ide-run
+make ide-build
+make ide-package
 ```
 
-`make run-gui` starts Vite on `http://127.0.0.1:5273`. `make package-gui`
+`make ide-run` starts Vite on `http://127.0.0.1:5273`. `make ide-package`
 writes a static web bundle to `dist/mac-ide-web.tar.gz`. This is separate from
-the maintenance-only Electron dashboard wrapper in `desktop/`. The existing
-`ide-*` target names remain as compatibility aliases.
+the maintenance-only Electron dashboard wrapper in `desktop/`. The GUI
+lifecycle targets (`install-gui`, `build-gui`, `package-gui`, `run-gui`) belong
+to the hub UI and do not touch `ide/`.
 
-For local auth, `make run-gui` first reuses the active scoped client profile
+For local auth, `make ide-run` first reuses the active scoped client profile
 created by `mac admin login`, including its managed SSH tunnel. In an interactive
 terminal it then prompts for the target hub URL; press Enter for the profile
 endpoint, enter another `http://` or `https://` host, or set `IDE_API_URL`
@@ -570,15 +584,15 @@ and is not exposed to browser storage. If no active profile exists, the launcher
 can read a deploy-created owner-only handoff file:
 
 ```bash
-IDE_HANDOFF_FILE="$HOME/.mac/fleet-ide-handoff.json" IDE_OPEN=1 make run-gui
+IDE_HANDOFF_FILE="$HOME/.mac/fleet-ide-handoff.json" IDE_OPEN=1 make ide-run
 ```
 
 The handoff file keeps the bearer out of browser-visible environment, argv,
 stdout, and deploy logs. As a final compatibility fallback the launcher sources
 `~/.mac/.env` and selects a token without printing it. Set `IDE_FLEET=<fleet>` to
 prefer the matching `MAC_API_TOKEN__<FLEET>` key; otherwise the launcher falls
-back to `MAC_DEPLOY_HUB_TOKEN` and then `MAC_API_TOKEN`. The `make ide-run`
-compatibility alias uses the same launcher.
+back to `MAC_DEPLOY_HUB_TOKEN` and then `MAC_API_TOKEN`. The `make ide-dev`
+alias uses the same launcher.
 
 ## Tell Agents To Work On A Project
 

--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -15474,8 +15474,11 @@ PY
     "http://127.0.0.1:8789" "$hub_token" "$hub_agent" "$cohort_fleet_name")"
   echo "==> ${hub_agent}: hub UI access:"
   echo "    1. open tunnel:  ssh -L 8789:127.0.0.1:8789 ${hub_target_str}"
-  echo "    2. open Fleet IDE: IDE_HANDOFF_FILE=$(shell_quote "$ide_handoff_file") IDE_OPEN=1 make run-gui"
-  echo "       (bearer stored in the owner-only handoff file; not printed or placed in the URL)"
+  echo "    2. open the hub UI: http://127.0.0.1:8789/ui  (the console the hub serves)"
+  echo "       paste the bearer from the owner-only handoff file into the token box"
+  echo "       (it is not printed here and never placed in the URL)"
+  echo "    3. optional, unshipped Fleet IDE prototype (runs locally; the hub does not serve it):"
+  echo "       IDE_HANDOFF_FILE=$(shell_quote "$ide_handoff_file") IDE_OPEN=1 make ide-run"
   echo "    token also stored in \${MAC_DEPLOY_ENV_FILE:-\$HOME/.mac/.env} as $hub_token_key"
   rm -rf "$TMPDIR_LOCAL"
   return 0

--- a/docs/adr/0010-fleet-ide-cutover-parity-matrix.md
+++ b/docs/adr/0010-fleet-ide-cutover-parity-matrix.md
@@ -1,7 +1,18 @@
 # ADR 0010 — Fleet IDE Cut-over and Parity Matrix
 
-**Status:** Accepted  
+**Status:** Superseded in part by [ADR 0025](0025-one-hub-ui.md) (2026-08-20)  
 **Date:** 2026-06-27
+
+---
+
+> **What is still true:** `src/mac/ui/` — the legacy vanilla-TS dashboard — is
+> frozen, and the parity matrix below is the record of what `ide/` implemented.
+>
+> **What is not:** the claim that `ide/` is *the canonical browser and desktop
+> UI*. No hub has ever mounted it. The hub serves the observability console
+> built from `observe/` at `/ui`, and ADR 0025 makes that the product; `ide/`
+> is an unshipped local prototype. Read the "canonical" wording below as
+> intent-at-the-time, not as current fact.
 
 ---
 

--- a/docs/adr/0025-one-hub-ui.md
+++ b/docs/adr/0025-one-hub-ui.md
@@ -1,0 +1,94 @@
+# ADR 0025 — There is one hub UI, and it is the one the hub serves
+
+- Status: **Accepted**
+- Date: 2026-08-20
+- Decision owner: MAC fleet owner
+- Supersedes: the canonical-surface half of ADR 0010 (Fleet IDE cut-over)
+- Related: ADR 0018 (task graph under progressive disclosure), ADR 0024 (the
+  dashboard streams the bus) — both assume a single UI and neither named it
+
+## Context
+
+Measured 2026-08-20 against a live hub:
+
+| tree | built by | where it lands | who serves it |
+|---|---|---|---|
+| `observe/` | `make observe-build` | `src/mac/ui/console/` (3 files, committed) | the hub, at `/ui` |
+| `ide/` | `make run-gui` → `ide-run` | a local Vite dev server on `IDE_PORT` | **nobody** |
+
+`api.py` mounts `Path(__file__).with_name("ui")` at `/ui/assets` and every
+`/ui` route returns `ui_dir/"console"/index.html`. `ide/` is not mounted, not
+packaged into the wheel, and not deployed. A live `curl /ui` returns
+`<title>MAC - fleet observability</title>`.
+
+Meanwhile the Makefile called `ide/` **canonical** in six places, `make run-gui`
+ran it, and the deploy script's "hub UI access" banner told operators to open it.
+So an operator who ran `make run-gui` to look at the hub UI got a *different
+application*, found it did not reflect the fleet, and reported the hub UI as
+broken. That report was correct about what they saw and wrong about what it
+was — the worst kind of bug report to receive, and the tree caused it.
+
+Two UIs is survivable. Two UIs where the label says one thing and the
+deployment says another is not: it makes every UI conversation start with a
+disambiguation, and it sends bug reports to the wrong tree.
+
+ADR 0010 declared `ide/` canonical on 2026-06-27 and required that "all new UI
+work must target `ide/`". The eight weeks since say the fleet did the
+opposite: the console got the live view, stuck work, merge queue, telemetry and
+task drill-down, was built into the Python package, and became the thing that is
+actually running. A declaration that operations has already overruled is not a
+decision, it is a stale label.
+
+## Decision
+
+**The hub UI is the observability console built from `observe/`.** It is the
+product. It is what `/ui` serves, what ships in the wheel, and what `make
+run-gui` runs.
+
+**`ide/` is an unshipped local prototype.** It keeps its own explicit entry
+points (`ide-run`, `ide-build`, `ide-preview`, `ide-package`) and is named as a
+prototype everywhere it appears. It is not in `install`, `build`, or `package`,
+and the word *canonical* does not attach to it.
+
+Concretely:
+
+- `run-gui` → `observe-run`: serves `observe/` — the same source tree whose
+  build output the hub serves.
+- `install-gui`, `build-gui`, `package-gui` build and package
+  `$(OBSERVE_BUNDLE)`, not `ide/dist`.
+- The deploy banner points at `http://<hub>/ui` and offers the prototype as an
+  explicitly optional step 3.
+
+### Why not the other way
+
+Making the hub serve the Fleet IDE was the alternative, and it is a real
+option — it is the mutating surface, and the console cannot ever be that by
+design. It was rejected *for now* because it is not a labelling change: it needs
+a bundle committed into the package, an asset base under the existing mount, an
+auth story for a mutating surface reached without a login shell, and a decision
+about whether the read-only guarantee survives being served from the same
+origin. None of that is blocked by this ADR. If the fleet does that work, the
+honest sequence is: serve it, then rename it — not rename it, then hope.
+
+## Consequences
+
+- `make run-gui` no longer starts the IDE. Operators who want it run
+  `make ide-run`; the deploy banner prints that line.
+- `make package-gui` now produces `dist/mac-hub-ui.tar.gz`. The IDE tarball
+  moved to `make ide-package` and keeps its `dist/mac-ide-web.tar.gz` name.
+- `make install` and `make build` no longer require `ide/node_modules`.
+- ADR 0010's parity matrix stays as history; its "canonical" claim does not.
+
+## Enforcement
+
+`tests/ui/test_hub_ui_is_one_tree.py` walks the Makefile's own dependency graph
+and fails if:
+
+1. `run-gui` reaches `ide-run`/`ide-dev` or any `ide/` recipe;
+2. any GUI lifecycle target (`install`, `build`, `install-gui`, `build-gui`,
+   `package-gui`, `run-gui`) builds or runs `ide/`;
+3. `observe/`'s Vite `build.outDir` stops resolving to the directory `api.py`
+   serves, or its `base` stops matching the `/ui/assets` mount;
+4. the Makefile calls the Fleet IDE canonical again.
+
+Prose is what lied last time, so the test reads the wiring, not the docs.

--- a/docs/book/06-hermes-and-ide.md
+++ b/docs/book/06-hermes-and-ide.md
@@ -33,8 +33,12 @@ mac --db "$DOCS_DB" admin hermes context hermes_guide >/dev/null
 ```
 
 The Fleet IDE is a client of the same hub API. A workstation enrolls with
-`mac admin login`, then `make run-gui` uses the active scoped profile. The browser is
+`mac admin login`, then `make ide-run` uses the active scoped profile. The browser is
 not a second control plane and does not carry a private SQLite ledger.
+
+The IDE is a local prototype: no hub serves it. `make run-gui` runs the hub UI —
+the observability console at `/ui` — which is a different, read-only surface.
+See [ADR 0025](../adr/0025-one-hub-ui.md).
 
 Hermes can create tasks from conversation context, inspect current projects and
 work, and write durable memories. It does not silently turn a chat reply into a

--- a/docs/guide/04-ui.md
+++ b/docs/guide/04-ui.md
@@ -1,11 +1,17 @@
 # The UI
 
-mac ships two browser surfaces with deliberately opposite jobs. Knowing which
-one you are in tells you whether anything you do can change the fleet.
+**The hub UI is the observability console.** It is the only browser surface a
+hub serves, it is what `/ui` returns, and it is what `make run-gui` runs. The
+Fleet IDE in `ide/` is a local prototype you start by hand — no hub mounts it
+and nothing deploys it. [ADR 0025](../adr/0025-one-hub-ui.md) records that
+decision and the test that keeps the two from drifting apart.
+
+The two have deliberately opposite jobs. Knowing which one you are in tells you
+whether anything you do can change the fleet.
 
 ```mermaid
 graph LR
-    subgraph "Observability Console — /ui"
+    subgraph "Observability Console — /ui (the hub UI)"
         C1["Live movement"]
         C2["Stuck work"]
         C3["Agents · Projects"]
@@ -13,7 +19,7 @@ graph LR
         C5["Merge queue · Telemetry"]
         C6["Task drill-down"]
     end
-    subgraph "Fleet IDE — ide/"
+    subgraph "Fleet IDE — ide/ (local prototype, not served)"
         I1["Task Kanban"]
         I2["Task Inspector"]
         I3["Project tree"]
@@ -27,8 +33,16 @@ graph LR
 
 Served at `/ui` and `/ui/console`. Built from `observe/` (React + Vite) into
 `src/mac/ui/console/`, which is committed — so serving it needs no Node.js at
-runtime. Rebuild with `npm --prefix observe run build`; CI fails if the
-committed bundle drifts from source.
+runtime. Rebuild with `make build-gui` (or `npm --prefix observe run build`);
+CI fails if the committed bundle drifts from source.
+
+To run it locally against a hub, `make run-gui` — that serves the same
+`observe/` tree, so what you see locally is the product, not a lookalike.
+`MAC_API_URL=https://hub:8789 make run-gui` points it at a remote hub.
+
+> The bare root `/` and `/dashboard/observe` answer **403** without a bearer
+> token, so the obvious URL looks dead. `/ui` is the one to open; it serves the
+> shell unauthenticated and asks for the token in the page.
 
 **It is read-only, and that is the design.** `observe/tests/readonly.test.ts`
 asserts it. The command-and-control dashboard that used to live here was
@@ -67,23 +81,31 @@ The Live chart is the one worth understanding. A count tells you 360 tasks are
 blocked. Only a series over time tells you whether they are *arriving or
 draining* — which is the difference between a backlog and a leak.
 
-## The Fleet IDE (`ide/`)
+## The Fleet IDE (`ide/`) — a local prototype
 
 The mutating surface: a task Kanban laned by state, a task inspector, and a
 project tree. It is where you answer a parked task, direct an agent, or work a
 queue.
+
+**It is not deployed.** `api.py` mounts only the console; nothing serves
+`ide/dist`, and `make install` / `make build` do not build it. You run it
+yourself, against a hub, from a checkout. Treat anything you see here as a
+prototype of a surface the fleet does not yet ship.
 
 The Kanban lanes are task **states**, and it deliberately has no drag-and-drop:
 task states are a control-plane state machine with legal-move rules, leases and
 evidence requirements, so most lane-to-lane drags would be illegal. A board
 that offers a move it cannot make teaches you the UI lies about what it can do.
 
-Run it with `make run-gui` after `mac admin login`.
+Run it with `make ide-run` after `mac admin login`. (`make run-gui` runs the
+hub UI. It used to run this, which is how operators ended up reporting the hub
+UI as broken when what they were looking at was never the hub UI.)
 
 ## Which one am I in?
 
-If you can change something, you are in the Fleet IDE. If you cannot, you are
-in the console — and that is a guarantee, not an oversight.
+If you can change something, you are in the Fleet IDE — which also means you
+started it yourself on your own machine. If you cannot, you are in the console,
+and that is a guarantee, not an oversight.
 
 ## Getting a token in
 

--- a/ide/README.md
+++ b/ide/README.md
@@ -1,8 +1,14 @@
-# MAC — Fleet Workbench
+# MAC — Fleet Workbench (unshipped prototype)
 
-A clean-slate operator IDE over the MAC control plane. It replaces the legacy
-`src/mac/ui` dashboard SPA with a React + TypeScript workbench built around the
-live task graph, agent context, A2A interoperability, and streamed operations.
+A clean-slate operator IDE over the MAC control plane, built around the live
+task graph, agent context, A2A interoperability, and streamed operations.
+
+**No hub serves this.** `src/mac/api.py` mounts only the observability console
+(`observe/` → `src/mac/ui/console/`) at `/ui`; `ide/dist` is not packaged into
+the wheel and not deployed anywhere. This is a local surface you start by hand
+against a hub. `make run-gui` runs the *hub UI*, not this — see
+[ADR 0025](../docs/adr/0025-one-hub-ui.md), which also lists what serving this
+would require.
 
 **Layout:**
 
@@ -19,13 +25,13 @@ live task graph, agent context, A2A interoperability, and streamed operations.
 From the repository root:
 
 ```bash
-make install-gui
+make ide-install
 mac login
-make run-gui
+make ide-run
 # open http://127.0.0.1:5273; the active CLI profile connects automatically
 ```
 
-`make run-gui` reuses the active scoped client profile created by `mac login`,
+`make ide-run` reuses the active scoped client profile created by `mac login`,
 ensures its SSH tunnel is running, and prompts for the target hub host or IP
 before it starts Vite. Press Enter to keep the profile's local SSH tunnel, or
 enter a hostname/IP for a direct connection. Direct connections automatically
@@ -42,12 +48,12 @@ and finally to the browser's manual connection form. `deploy-mac-fleet.sh`
 writes the handoff as an owner-only JSON file and prints a token-free command:
 
 ```bash
-IDE_HANDOFF_FILE="$HOME/.mac/fleet-ide-handoff.json" IDE_OPEN=1 make run-gui
+IDE_HANDOFF_FILE="$HOME/.mac/fleet-ide-handoff.json" IDE_OPEN=1 make ide-run
 ```
 
-Use `IDE_AUTH=manual make run-gui` to force the browser form, or
+Use `IDE_AUTH=manual make ide-run` to force the browser form, or
 `IDE_API_URL=<url>` to select the endpoint without an interactive prompt. The
-existing `make ide-run` target is a compatibility alias. Non-interactive runs
+existing `make ide-dev` target is an alias for the same launcher. Non-interactive runs
 also skip the prompt and retain the resolved profile or default endpoint.
 
 Or from this package:
@@ -70,10 +76,13 @@ removed from the URL immediately.
 From the repository root:
 
 ```bash
-make build-gui
+make ide-build
 make ide-preview       # serves the production build at http://127.0.0.1:5273
-make package-gui       # writes dist/mac-ide-web.tar.gz
+make ide-package       # writes dist/mac-ide-web.tar.gz
 ```
+
+(`build-gui` and `package-gui` build the hub UI from `observe/`; they do not
+touch this package.)
 
 Or from this package:
 
@@ -84,7 +93,7 @@ npm run package
 ```
 
 `npm run package` and `make ide-package` create a static web bundle, not a
-native Electron app. `desktop/package.json` `extraResources` copies from
+native Electron app, and nothing deploys it. `desktop/package.json` `extraResources` copies from
 `../ide/dist` (this package's Vite build output), replacing the legacy
 `../src/mac/ui` SPA path.
 

--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -23,7 +23,11 @@ def test_make_help_exposes_conventional_lifecycle() -> None:
     assert "make clean" in result.stdout
     assert "make distclean" in result.stdout
     assert "make run-gui" in result.stdout
-    assert "canonical Fleet IDE" in result.stdout
+    # help must name the UI the hub actually serves. It used to advertise the
+    # "canonical Fleet IDE", which no hub has ever mounted -- see
+    # tests/ui/test_hub_ui_is_one_tree.py and docs/adr/0025-one-hub-ui.md.
+    assert "the same tree the hub serves at /ui" in result.stdout
+    assert "canonical Fleet IDE" not in result.stdout
     assert "Python 3.11+, git, gh, npm, and CodeGraph" in result.stdout
     assert "Build and test targets also require uv." in result.stdout
 
@@ -57,6 +61,7 @@ def test_source_consuming_make_targets_refresh_codegraph() -> None:
         "build-gui",
         "test",
         "ide-run ide-dev",
+        "observe-run",
         "setup",
         "deploy",
     ):
@@ -95,7 +100,10 @@ def test_gui_launcher_selects_auth_without_printing_the_token() -> None:
     assert "IDE_HANDOFF_FILE ?=" in makefile
     assert "IDE_OPEN ?= 0" in makefile
     assert "IDE_PROFILE ?=" in makefile
-    assert "run-gui: ide-run" in makefile
+    # run-gui belongs to the hub UI; the IDE prototype keeps its own entry
+    # point so the handoff below still has somewhere to go.
+    assert "run-gui: observe-run" in makefile
+    assert "run-gui: ide-run" not in makefile
     assert 'if [ -f "$$HOME/.mac/.env" ]' in makefile
     assert '"$(PYTHON)" -m mac.ide_launcher' in makefile
     assert "IDE auth token: %s" not in makefile
@@ -112,7 +120,10 @@ def test_gui_launcher_selects_auth_without_printing_the_token() -> None:
     assert "http://localhost:8789/ui?t=${hub_token}" not in deploy
     assert "write_ide_handoff_file" in deploy
     assert "mac.ide_handoff.v1" in deploy
-    assert "IDE_OPEN=1 make run-gui" in deploy
+    assert "IDE_OPEN=1 make ide-run" in deploy
+    # The deploy banner's "hub UI access" step must send operators to the UI
+    # the hub serves, not to the local prototype.
+    assert "open the hub UI: http://127.0.0.1:8789/ui" in deploy
 
 
 def test_bootstrap_honors_make_venv_override(monkeypatch) -> None:

--- a/tests/ui/test_hub_ui_is_one_tree.py
+++ b/tests/ui/test_hub_ui_is_one_tree.py
@@ -1,0 +1,215 @@
+"""One hub UI: what `make run-gui` runs is what the hub serves at /ui.
+
+The failure this file exists to prevent, observed 2026-08-20 against a live hub:
+
+    observe/  --(build)--> src/mac/ui/console/ --> served by api.py at /ui
+    ide/      --(make run-gui)--> a local dev server the hub never mounts
+
+`make run-gui` called the unmounted tree "the canonical Fleet IDE", so an
+operator who ran it to look at the hub UI got a different application, found it
+did not reflect the fleet, and reported the hub UI as broken. They were right:
+it was not the hub UI.
+
+The decision (docs/adr/0025-one-hub-ui.md): the observability console built
+from ``observe/`` is the product. ``ide/`` is an unshipped local prototype, not
+a second canonical UI. These tests pin the wiring so the two cannot silently
+drift back apart -- they check the Makefile's own dependency graph rather than
+prose, because prose is what lied last time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MAKEFILE = ROOT / "Makefile"
+
+# The one browser surface the hub serves. Both halves of this claim are
+# re-derived from source below rather than trusted: api.py must serve it and
+# observe/'s Vite config must write it.
+SERVED_BUNDLE = ROOT / "src" / "mac" / "ui" / "console"
+
+# Lifecycle targets an operator reaches for when they mean "the GUI".
+GUI_LIFECYCLE_TARGETS = ("run-gui", "install-gui", "build-gui", "package-gui", "install", "build")
+
+_ASSIGNMENT = re.compile(r"^([A-Z][A-Z0-9_]*)\s*[:?]?=\s*(.*)$")
+_REFERENCE = re.compile(r"\$\(([A-Za-z_][A-Za-z0-9_]*)\)")
+
+
+def _makefile_text() -> str:
+    return MAKEFILE.read_text(encoding="utf-8")
+
+
+def _variables(text: str) -> dict[str, str]:
+    """Simple ``NAME = value`` assignments, recursively expanded."""
+    raw: dict[str, str] = {}
+    for line in text.splitlines():
+        if line.startswith("\t") or line.lstrip().startswith("#"):
+            continue
+        match = _ASSIGNMENT.match(line.strip())
+        if match:
+            raw.setdefault(match.group(1), match.group(2).strip())
+
+    def expand(value: str, seen: frozenset[str] = frozenset()) -> str:
+        def replace(hit: re.Match[str]) -> str:
+            name = hit.group(1)
+            if name in seen or name not in raw:
+                return hit.group(0)
+            return expand(raw[name], seen | {name})
+
+        return _REFERENCE.sub(replace, value)
+
+    return {name: expand(value) for name, value in raw.items()}
+
+
+def _expand(value: str, variables: dict[str, str]) -> str:
+    return _REFERENCE.sub(lambda hit: variables.get(hit.group(1), hit.group(0)), value)
+
+
+def _rules(text: str) -> dict[str, dict[str, list[str]]]:
+    """Map every target to its prerequisites and recipe lines.
+
+    Handles multi-target rules (``ide-run ide-dev:``) and strips the ``##``
+    help comment, which is documentation rather than a dependency.
+    """
+    variables = _variables(text)
+    rules: dict[str, dict[str, list[str]]] = {}
+    current: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("\t"):
+            for target in current:
+                rules[target]["recipe"].append(_expand(line.strip(), variables))
+            continue
+        if not line or line.lstrip().startswith("#") or "=" in line.split(":")[0]:
+            current = []
+            continue
+        if ":" not in line or line.startswith("."):
+            current = []
+            continue
+        head, _, tail = line.partition(":")
+        if head.strip().startswith("."):
+            current = []
+            continue
+        prereqs = [
+            _expand(item, variables)
+            for item in tail.split("##")[0].replace("=", " ").split()
+        ]
+        current = [_expand(name, variables) for name in head.split()]
+        for target in current:
+            rules.setdefault(target, {"prereqs": [], "recipe": []})
+            rules[target]["prereqs"].extend(prereqs)
+    return rules
+
+
+def _closure(rules: dict[str, dict[str, list[str]]], target: str) -> set[str]:
+    """Every target reached from ``target`` through prerequisites."""
+    seen: set[str] = set()
+    pending = [target]
+    while pending:
+        name = pending.pop()
+        if name in seen or name not in rules:
+            continue
+        seen.add(name)
+        pending.extend(rules[name]["prereqs"])
+    return seen
+
+
+def _recipes(rules: dict[str, dict[str, list[str]]], targets: set[str]) -> str:
+    return "\n".join(line for name in sorted(targets) for line in rules[name]["recipe"])
+
+
+def test_run_gui_runs_the_tree_the_hub_serves() -> None:
+    """`make run-gui` must reach observe/ and must not reach ide/.
+
+    This is the whole bug in one assertion: run-gui used to resolve to
+    ide-run, a tree api.py has never mounted.
+    """
+    rules = _rules(_makefile_text())
+
+    assert "run-gui" in rules, "the Makefile no longer defines run-gui"
+    reached = _closure(rules, "run-gui")
+    recipes = _recipes(rules, reached)
+
+    assert "observe" in recipes, (
+        "make run-gui no longer runs the observe/ tree the hub serves at /ui; "
+        f"reached targets: {sorted(reached)}"
+    )
+    assert "ide-run" not in reached and "ide-dev" not in reached, (
+        "make run-gui runs the unshipped Fleet IDE prototype again -- that is "
+        "the exact drift this test exists to catch"
+    )
+    assert not re.search(r"\bide/", recipes), (
+        f"make run-gui touches ide/, which the hub does not serve:\n{recipes}"
+    )
+
+
+def test_gui_lifecycle_targets_all_point_at_the_served_tree() -> None:
+    """install/build/package/run of "the GUI" must mean one product."""
+    rules = _rules(_makefile_text())
+
+    for target in GUI_LIFECYCLE_TARGETS:
+        assert target in rules, f"the Makefile no longer defines {target}"
+        recipes = _recipes(rules, _closure(rules, target))
+        assert not re.search(r"\bide/", recipes), (
+            f"make {target} builds or runs ide/, which is not the UI the hub "
+            f"serves:\n{recipes}"
+        )
+
+    build_gui = _recipes(rules, {"build-gui"})
+    assert "cd observe" in build_gui, (
+        f"build-gui no longer builds the hub UI from observe/:\n{build_gui}"
+    )
+
+
+def test_vite_writes_exactly_the_bundle_api_py_serves() -> None:
+    """The build output path and the served path are re-derived, not asserted.
+
+    If either side moves without the other, the served bundle and the built
+    bundle stop being the same tree and this fails.
+    """
+    api = (ROOT / "src" / "mac" / "api.py").read_text(encoding="utf-8")
+    vite = (ROOT / "observe" / "vite.config.ts").read_text(encoding="utf-8")
+
+    # api.py: StaticFiles over src/mac/ui, and every /ui route returns
+    # <that dir>/console/index.html.
+    assert 'ui_dir = Path(__file__).with_name("ui")' in api
+    assert 'app.mount("/ui/assets", StaticFiles(directory=str(ui_dir))' in api
+    assert 'FileResponse(ui_dir / "console" / "index.html")' in api
+    served = ROOT / "src" / "mac" / "ui" / "console"
+    assert served == SERVED_BUNDLE
+
+    out_dir = re.search(r'outDir:\s*"([^"]+)"', vite)
+    assert out_dir, "observe/vite.config.ts no longer declares a build.outDir"
+    built = (ROOT / "observe" / out_dir.group(1)).resolve()
+
+    assert built == served.resolve(), (
+        f"observe/ builds into {built} but the hub serves {served}; "
+        "make run-gui and /ui would no longer be the same bundle"
+    )
+
+    # The committed bundle really is that build's output.
+    assert (served / "index.html").is_file()
+    assert (served / "console.js").is_file()
+    base = re.search(r'base:\s*"([^"]+)"', vite)
+    assert base and base.group(1) == "/ui/assets/console/", (
+        "the console's asset base must match the hub's /ui/assets mount"
+    )
+
+
+def test_the_ide_prototype_is_not_labelled_canonical() -> None:
+    """Two UIs is survivable. Two UIs where the unserved one is called
+    "canonical" is what sent an operator to the wrong application."""
+    text = _makefile_text()
+
+    offenders = [
+        line
+        for line in text.splitlines()
+        if "canonical" in line.lower() and re.search(r"\bide\b|\bIDE\b", line)
+    ]
+    assert not offenders, (
+        "the Makefile calls the Fleet IDE canonical while the hub serves the "
+        "console; make api.py serve ide/ before restoring that word:\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_c948afb58c644b98bbd342caf99b1112`
- head: `f872b856e66f1ae1a94cd0d02b41df32a7d998bb`
- base at push: `531cb0fae610e03819d73a94deabb365d3a3a285`
