### PR TITLE
Add a picture-first architecture deck for the current tree

### DIFF
--- a/docs/presentation/20260820T182340Z-bac50778/AUDIT.md
+++ b/docs/presentation/20260820T182340Z-bac50778/AUDIT.md
@@ -1,0 +1,95 @@
+# Audit — every claim in this deck, traced to source
+
+Audited at commit `bac50778` on 2026-08-20T18:23:40Z by reading the tree, plus live measurements
+from a running hub taken the same day. Generated references (`docs/reference/cli.md`,
+`docs/reference/openapi.md`) are authoritative for surface counts because CI fails when they drift
+from the live parser and OpenAPI schema.
+
+---
+
+## 1. Counts (slide 8)
+
+| Claim | Source |
+|---|---|
+| 198,038 lines of Python under `src/` | `find src -name "*.py" \| xargs wc -l` |
+| 205 modules in `src/mac` | `ls src/mac/*.py \| wc -l` |
+| 483 test files | `ls tests/*.py \| wc -l` |
+| 408 HTTP routes | `grep -cE "^\| \`(GET\|POST\|PUT\|PATCH\|DELETE)\`" docs/reference/openapi.md` |
+| 124 CLI verbs | Parsed from `docs/reference/cli.md`: task 45, admin 53, agent 17, project 9 |
+| 31 hub services | `ls src/mac/*_service.py \| wc -l` |
+| 24 ADRs, 11 still Proposed | `ls docs/adr/*.md`; `grep -l "Status: \*\*Proposed\*\*" docs/adr/*.md` |
+
+## 2. Hub and workers (slide 2)
+
+| Claim | Source |
+|---|---|
+| The hub keeps the ledger, the capability registry and capacity | `docs/adr/0016-agent-initiated-review.md`, "The hub keeps only durable, uncontested authority" |
+| It does not decide what a task needs | Same ADR: "`required_capabilities` is a guess made before anyone has read the diff … information the executing agent holds and the hub does not." |
+| macOS nodes are host installs under launchd | `docs/adr/0015-macos-nodes-are-host-installs.md` — **Accepted** |
+| Linux: native steward + containerized execution; OpenShell owns isolation | `docs/adr/0012-hybrid-native-steward-containerized-execution.md`; ADR 0015 narrows the containerized half to Linux; `README.md` lineage for OpenShell's scope |
+| Kubernetes pods under supervisord; HGX elastic | ADR 0012 Context; `docs/hgx-elastic-capacity.md` |
+| Merge queue: speculative train, eviction discards followers, AIMD window floor 1 / ceiling 4 | commit `2b49fb23`; `src/mac/native_merge_queue.py` |
+| Agents land through a PR they own, never a push | commits `484baceb`, `44e81d5a` |
+| AgentBus is broadcast; the human is a participant | commit `73476fc6`; `src/mac/agentbus_control.py` (`LIFECYCLE_VERBS`, and "it never mutates the control plane directly, it speaks on the bus like any other participant") |
+| stand_down is not abort | `src/mac/agentbus_control.py`: "A single button labelled 'stop' that means ABORT destroys work in flight; one that means PAUSE does not stop a runaway." |
+| **Live:** 10 agents; 2 busy / 2 idle / 6 offline; 6 static / 4 fungible; 6 GPU-capable | `mac agent list` against the running hub, 2026-08-20 |
+
+## 3. The life of one task (slide 3)
+
+| Claim | Source |
+|---|---|
+| Eleven states, three terminal | `src/mac/models.py`, `class TaskState`, `TERMINAL_TASK_STATES` |
+| Leases and fences authorize mutation; lease expiry is the single liveness mechanism | `README.md` Core Contracts; ADR 0016 "What must not be lost — Liveness" |
+| Evidence is typed and bound to one exact attempt | `README.md` Core Contracts; `docs/review-strategy-experiments.md` |
+| Approval needs a different agent AND a different model | `docs/review-strategy-experiments.md` |
+| An unanswered peer review completes without review rather than waiting | ADR 0016, "Liveness" |
+| Eviction discards results projected behind the evicted entry | commit `2b49fb23`: those entries "were green against a state that will never exist" |
+| 52 reviews across 38 tasks, four distinct reason strings, zero findings | ADR 0016, "The evidence from one session (2026-08-16/17)" |
+| **ADR 0016 is Accepted, dated 2026-08-20** | `docs/adr/0016-agent-initiated-review.md` header. It was `Proposed` when the previous deck was built; re-read rather than recalled. |
+
+## 4. Inside the hub (slide 4)
+
+All from `src/mac/api.py` and `src/mac/services.py` at this commit.
+
+| Claim | Source |
+|---|---|
+| Exactly three daemon threads | `api.py`: `threading.Thread(... name="mac-hub-tick")`, `"mac-publication"`, `"mac-retention"` |
+| The tick is the self-driver, and nothing drove it before | `_start_hub_tick_loop` docstring: "Nothing drove it periodically, so approved tasks parked forever waiting for an external `POST /dispatch/tick`" |
+| Gated by `MAC_HUB_TICK_INTERVAL_SECONDS` so the CLI/tests/replicas do not compete | same docstring |
+| The publication sweep clones a repo and runs a sandboxed contract gate | `_start_publication_worker` docstring |
+| Heartbeats measured at 250–315s, lease renewals at 33s | same docstring: the sweep ran "on a WORKER'S HEARTBEAT REQUEST THREAD, so the cost landed on the worker" |
+| Tick order: stale agents → ephemerals → leases → workflows → service roles → unblock/auto-retry → retention → dispatch | `ControlPlane.tick()` in `services.py`, read in sequence |
+| Retention runs before the sweep, deliberately | `tick()` comment: "Retention runs HERE -- before the review sweep -- and not further down" |
+| Zero retention events in 48 minutes; 235,615 observability rows and 5,576 action events past cutoff | same comment, observed live 2026-08-17 |
+| Retention's failure is invisible because it is silent when idle; the store reached 16GB / 10.4M rows | same comment |
+| 31 services, grouped six ways | `ls src/mac/*_service.py`; the grouping is editorial, the membership is not |
+| Memory must shrink to be promoted (0.75× gate) | `docs/dreaming-rewrite.md` |
+| Secrets are handles; output redacted; manifests check for baked-in values | `README.md` Core Contracts |
+
+## 5. The console captures (slides 5–7)
+
+Captured 2026-08-20 from a live hub at `/ui`, which accepts a bearer token as `?t=`
+(`observe/src/App.tsx`, `readToken`).
+
+| Claim | Source |
+|---|---|
+| `/ui` is read-only observability; the command-and-control dashboard was retired | commits `d725fa12`, `43887f68`, `27ed8af9` |
+| "Status not believable" counts agents reporting idle/busy but unheard >15m | visible in the capture; the tile states its own definition |
+| 644 tasks in flight, 465 of them blocked | live capture, `live` view, 6h window |
+| Two merge queues, 4 waiting, 2 landed, 211 evicted, 1% land rate | live capture, `merge-queue` view |
+| Every eviction reason is "projected merge conflicts with the queue base" | live capture, "why changes did not land" panel |
+| 165 of 355 blocked tasks wait on dependencies that can never complete | `docs/adr/0018-task-graph-progressive-disclosure.md`, citing `task_9f3b80b8` — dated 2026-08-19, one day before these captures |
+
+**Identity handling.** The `agents` view lists real agent names, several of which are tokens
+`tests/test_docs_no_operator_identity.py` forbids in checked-in docs. That capture is cropped to
+its top stat tiles before use, and the deck says so. Repository names in the merge-queue capture
+are left visible: that test explicitly permits the repo-org slug and forbids only operator and
+fleet identity.
+
+## 6. Where this deck disagrees with the last one
+
+The previous deck (`20260820T011224Z-8b424c20`) recorded that the README described a vendored
+Hermes tree that had been deleted. That has since been fixed, and this deck makes no such claim.
+
+ADR 0016 moved from **Proposed** to **Accepted** between the two decks — same repository, nine
+hours apart. That is the argument for pinning a deck to a commit rather than editing one forever.

--- a/docs/presentation/20260820T182340Z-bac50778/README.md
+++ b/docs/presentation/20260820T182340Z-bac50778/README.md
@@ -1,0 +1,81 @@
+# MAC architecture deck — `bac50778`
+
+A picture-first deck: how the hub relates to its workers, what one task does end to end, and what
+runs inside the hub. Built by auditing the source at commit `bac50778`, captured
+`2026-08-20T18:23:40Z`, with live console captures from a running fleet.
+
+## The deck
+
+**[MAC — How the control plane is put together (`bac50778`)](https://docs.google.com/presentation/d/1vzkNL3_IM-ophzQWUpJl3JE5L-X3MnEva8m6edeEOQk/edit)**
+
+10 slides, 16:9, speaker notes on every slide. Six of the ten are pictures.
+
+## Slides
+
+| | |
+|---|---|
+| 1 | Title — commit and capture time |
+| 2 | **One hub, many workers** — the core relationship, worker classes, AgentBus, the human on the bus |
+| 3 | **The life of one task** — ten steps across five lanes, including the two failure edges |
+| 4 | **Inside the hub** — three daemon threads, the tick in order, 31 services by purpose |
+| 5 | **The fleet, observed** — live console, fleet tiles |
+| 6 | **Movement, not a snapshot** — live task transitions and in-flight state |
+| 7 | **Where changes actually land — and where they do not** — the merge queue at a 1% land rate |
+| 8 | Scale at this commit |
+| 9 | What is decided but not yet true |
+| 10 | Provenance |
+
+Slide 9 is deliberate. Eleven of twenty-four ADRs are still Proposed, ADR 0016 was accepted the day
+this deck was built, and the merge queue is thrashing at a 1% land rate in plain sight on slide 7.
+
+## What is checked in, and what is not
+
+**Checked in: text only** — the three SVG diagram sources, this README, `AUDIT.md`, and the builder.
+
+**Not checked in:** the rendered diagram PNGs, the console captures, and the built `.pptx`. All are
+gitignored. `docs/` stays text-only so `tests/test_docs_no_operator_identity.py` keeps grepping
+prose rather than compressed image bytes — see [`../README.md`](../README.md).
+
+**The console captures cannot be regenerated from this repository.** They come from a hub that was
+running when the deck was made. Rebuilding without a live fleet produces the diagrams and blank
+screenshot slides. That is a property of the evidence, not a defect: a screenshot of a fleet is
+true on a date, which is why the slides carry one.
+
+## Rebuilding
+
+Render the diagrams (headless Chrome, 2× device scale):
+
+```console
+$ CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+$ cd docs/presentation/20260820T182340Z-bac50778/images
+$ "$CHROME" --headless --disable-gpu --hide-scrollbars \
+    --force-device-scale-factor=2 --window-size=1600,940 \
+    --default-background-color=FFFFFF \
+    --screenshot=01-hub-and-workers.png "file://$PWD/01-hub-and-workers.svg"
+```
+
+Window sizes: `01` 1600×940 · `02` 1600×1010 · `03` 1600×900.
+
+Capture the console from a live hub. The console takes a bearer token as `?t=`, and the views are
+`live`, `stuck`, `agents`, `projects`, `pipelines`, `merge-queue`, `cycles`, `telemetry`:
+
+```console
+$ "$CHROME" --headless --disable-gpu --hide-scrollbars \
+    --force-device-scale-factor=2 --window-size=1600,1050 --virtual-time-budget=18000 \
+    --screenshot=05-console-live.png "http://<hub>:8789/ui?t=<token>&view=live"
+```
+
+**Crop the agents view before using it.** Its roster lists real agent names, and this repository's
+docs must read as generic for any fleet owner. Only the top stat tiles are safe.
+
+Then build and publish:
+
+```console
+$ python3 -m venv /tmp/deckvenv && /tmp/deckvenv/bin/pip install python-pptx
+$ /tmp/deckvenv/bin/python docs/presentation/20260820T182340Z-bac50778/build_deck.py
+$ scripts/publish-deck-to-slides.py \
+    docs/presentation/20260820T182340Z-bac50778/mac-architecture-bac50778.pptx \
+    --title "MAC — How the control plane is put together (bac50778)" --expect-slides 10
+```
+
+See `skills/cut-a-release/SKILL.md` for the full procedure and its traps.

--- a/docs/presentation/20260820T182340Z-bac50778/build_deck.py
+++ b/docs/presentation/20260820T182340Z-bac50778/build_deck.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Build the MAC architecture deck for commit bac50778 as a 16:9 .pptx.
+
+Deliberately picture-first: three flow diagrams and three live console captures
+carry the argument, and the text slides only hold what a picture cannot say —
+counts, and what has not shipped.
+
+The console captures are NOT reproducible from this repository. They come from a
+running hub, via the command in README.md, and are gitignored along with every
+other PNG here. Rebuilding this deck without a live fleet gives you the diagrams
+and blank screenshot slides.
+
+Requires python-pptx, which is deliberately not a repository dependency:
+
+    python3 -m venv /tmp/deckvenv && /tmp/deckvenv/bin/pip install python-pptx
+    /tmp/deckvenv/bin/python build_deck.py
+
+Then publish with scripts/publish-deck-to-slides.py. See skills/cut-a-release.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from struct import unpack
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Emu, Inches, Pt
+
+HERE = Path(__file__).resolve().parent
+IMAGES = HERE / "images"
+COMMIT = "bac50778"
+CAPTURED = "2026-08-20T18:23:40Z"
+OUT = HERE / f"mac-architecture-{COMMIT}.pptx"
+
+SLIDE_W, SLIDE_H = Inches(13.333), Inches(7.5)
+INK = RGBColor(0x1B, 0x25, 0x30)
+SLATE = RGBColor(0x2F, 0x3A, 0x45)
+GREY = RGBColor(0x5A, 0x6B, 0x7A)
+MUTED = RGBColor(0x8A, 0x98, 0xA6)
+WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+BLUE = RGBColor(0x2E, 0x6F, 0x9E)
+AMBER = RGBColor(0xB5, 0x65, 0x1D)
+SAND = RGBColor(0xF2, 0xC4, 0x8A)
+PALE = RGBColor(0xDC, 0xE5, 0xEC)
+FONT = "Helvetica Neue"
+
+prs = Presentation()
+prs.slide_width, prs.slide_height = SLIDE_W, SLIDE_H
+BLANK = prs.slide_layouts[6]
+
+
+def notes(slide, text):
+    slide.notes_slide.notes_text_frame.text = text.strip()
+
+
+def bg(slide, color):
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = color
+
+
+def textbox(slide, x, y, w, h, align=PP_ALIGN.LEFT):
+    tf = slide.shapes.add_textbox(x, y, w, h).text_frame
+    tf.word_wrap = True
+    tf.paragraphs[0].alignment = align
+    return tf
+
+
+def line(tf, text, size, color, bold=False, space_before=0, space_after=6, first=False):
+    p = tf.paragraphs[0] if first else tf.add_paragraph()
+    p.space_before, p.space_after = Pt(space_before), Pt(space_after)
+    run = p.add_run()
+    run.text = text
+    run.font.size, run.font.bold, run.font.color.rgb = Pt(size), bold, color
+    run.font.name = FONT
+    return p
+
+
+def _aspect(path: Path) -> float:
+    with open(path, "rb") as fh:
+        head = fh.read(33)
+    iw, ih = unpack(">II", head[16:24])
+    return iw / ih
+
+
+def image_slide(name: str, note: str, caption: str | None = None, sub: str | None = None):
+    """Full-bleed when the diagram carries its own title; captioned for captures."""
+    slide = prs.slides.add_slide(BLANK)
+    path = IMAGES / name
+    if not path.exists():
+        notes(slide, note)
+        return slide
+
+    top_pad = Inches(1.15) if caption else Inches(0.2)
+    if caption:
+        tf = textbox(slide, Inches(0.6), Inches(0.32), Inches(12.2), Inches(0.9))
+        line(tf, caption, 27, INK, bold=True, first=True, space_after=2)
+        if sub:
+            line(tf, sub, 14, GREY)
+
+    avail_h = SLIDE_H - top_pad - Inches(0.25)
+    avail_w = Inches(12.6)
+    aspect = _aspect(path)
+    h, w = avail_h, Emu(int(avail_h * aspect))
+    if w > avail_w:
+        w, h = avail_w, Emu(int(avail_w / aspect))
+    slide.shapes.add_picture(
+        str(path), Emu(int((SLIDE_W - w) / 2)), Emu(int(top_pad + (avail_h - h) / 2)),
+        width=w, height=h,
+    )
+    notes(slide, note)
+    return slide
+
+
+# ------------------------------------------------------------------ slides
+
+slide = prs.slides.add_slide(BLANK)
+bg(slide, SLATE)
+tf = textbox(slide, Inches(0.9), Inches(2.2), Inches(11.5), Inches(2.6))
+line(tf, "MAC", 54, WHITE, bold=True, first=True, space_after=6)
+line(tf, "How the control plane is put together", 30, PALE, space_after=18)
+line(tf, "One hub, many workers, and what runs inside the hub.", 17, MUTED)
+tf2 = textbox(slide, Inches(0.9), Inches(5.6), Inches(11.5), Inches(1.2))
+line(tf2, f"commit {COMMIT}   ·   captured {CAPTURED}", 16, SAND, bold=True, first=True, space_after=4)
+line(tf2, "Diagrams from the source. Screenshots from a hub that was running while this was made.", 13.5, MUTED)
+notes(slide, """
+This deck is deliberately picture-first: three flow diagrams and three live console captures.
+It describes commit bac50778 and nothing later.
+
+Open with the shape, not the philosophy: one hub, many workers, and the hub is smaller than people
+expect.
+""")
+
+image_slide("01-hub-and-workers.png", """
+THE CORE RELATIONSHIP. The hub owns three things — the task ledger, the capability registry, and
+capacity — and hands out leases. Workers hold the actual work.
+
+The amber box is the point: the hub does NOT decide what a task needs. That belongs to the agent
+that read the diff, because it is the only party that can know.
+
+Note the worker classes are genuinely different: macOS is a host install under launchd, Linux runs
+containerized execution under a native steward, Kubernetes/HGX is elastic. MAC does not pretend
+they are one server class.
+
+AgentBus runs underneath all of it, and the human is ON it — the console never mutates the control
+plane, it speaks like any other participant.
+
+Live numbers bottom-right: 10 agents, 2 busy / 2 idle / 6 offline. Offline is normal — fungible
+workers are created on demand.
+""")
+
+image_slide("03-life-of-a-task.png", """
+ONE TASK, END TO END. Ten steps, five lanes, time left to right.
+
+The thing to say out loud: every hand-off is a durable row, not a message. That is what makes
+"why is this stuck?" answerable months later.
+
+The two red dashed edges are the failure paths, and they matter more than the happy path — lease
+expiry reclaims work from a dead agent, and a merge-queue eviction discards everything tested
+behind the evicted entry because those results were green against a state that will never exist.
+
+Step 6 is changing: ADR 0016 was accepted today, making review agent-initiated rather than
+mandatory. The motivating measurement is on the slide — 52 reviews, zero findings.
+""")
+
+image_slide("02-inside-the-hub.png", """
+THE DEEP DIVE, and the slide to spend time on.
+
+Three daemon threads, each separate for a measured reason. mac-publication got its own thread
+because it used to run inside the tick AND on worker heartbeats — heartbeats were measured at
+250-315 seconds because the cost landed on the worker.
+
+The middle band is the tick, in order. The order IS the design: retention sits at position 7, ahead
+of the review sweep, because it used to sit behind it and was starved — zero retention events in 48
+minutes while 235,615 rows sat past the cutoff. That failure is invisible by construction, since
+retention is silent when idle.
+
+31 services grouped by purpose. Do not read the lists; use them to show the surface is organised
+rather than accreted.
+""")
+
+image_slide(
+    "04-console-fleet.png",
+    """
+The read-only observability console, on a live hub.
+
+Ten agents; the "status not believable" tile is the interesting one — it counts agents reporting
+idle or busy that have not been heard from in over 15 minutes. A fleet that trusts self-reported
+status has no way to notice that.
+
+Agent identity is cropped out deliberately: this repository's docs must read as generic for any
+fleet owner, and the roster names would fail that gate.
+""",
+    caption="The fleet, observed",
+    sub="/ui is read-only. The command-and-control dashboard was retired — the console cannot mutate the control plane.",
+)
+
+image_slide(
+    "05-console-live.png",
+    """
+The live view: task movement over a six-hour window, in-flight work by state, and a transition
+ticker of individual state changes.
+
+Point at the blocked bar — 465 of 644 in-flight tasks. That is the number ADR 0018 exists for: the
+console can say how many are blocked but not WHAT blocks them, because the hub does not ship the
+dependency edges.
+
+The ticker is the honest bit: you can watch claimed -> running -> needs_review -> reviewing happen
+without anyone driving it.
+""",
+    caption="Movement, not a snapshot",
+    sub="Task transitions over six hours on a live hub, with in-flight work by state.",
+)
+
+image_slide(
+    "06-console-merge-queue.png",
+    """
+The merge queue, and the most uncomfortable slide in the deck.
+
+Two queues, 4 waiting, 2 landed — and 211 evicted, for a 1% land rate. Every eviction reason is the
+same: "projected merge conflicts with the queue base".
+
+That is not a queue working; that is a queue thrashing against a trunk moving faster than entries
+can be tested. It is exactly the kind of thing a dashboard is for, and exactly the kind of thing
+prose in a README would never have surfaced.
+
+Repository names are visible and that is fine — the identity gate explicitly permits the repo-org
+slug, and forbids only operator and fleet identity.
+""",
+    caption="Where changes actually land — and where they do not",
+    sub="Two queues, a speculative window, and 211 evictions at a 1% land rate.",
+)
+
+slide = prs.slides.add_slide(BLANK)
+tf = textbox(slide, Inches(0.85), Inches(0.55), Inches(11.6), Inches(1.0))
+line(tf, "Scale at this commit", 34, INK, bold=True, first=True, space_after=4)
+line(tf, f"Counted in the tree at {COMMIT}, not estimated.", 15, GREY)
+rows = [
+    ("198,038", "lines of Python under src/", "205 modules"),
+    ("483", "test files", "plus fault-replay and contract suites"),
+    ("408", "HTTP routes", "generated from the live OpenAPI schema"),
+    ("124", "CLI verbs", "across project, task, agent and admin"),
+    ("31", "hub services", "grouped six ways on the deep-dive slide"),
+    ("24", "architecture decision records", "11 of them still Proposed"),
+]
+tf2 = textbox(slide, Inches(0.85), Inches(1.9), Inches(11.6), Inches(5.0))
+first = True
+for num, label, note_ in rows:
+    p = tf2.paragraphs[0] if first else tf2.add_paragraph()
+    p.space_after = Pt(13)
+    r1 = p.add_run(); r1.text = f"{num:>9}   "
+    r1.font.size, r1.font.bold, r1.font.color.rgb, r1.font.name = Pt(25), True, INK, FONT
+    r2 = p.add_run(); r2.text = label
+    r2.font.size, r2.font.color.rgb, r2.font.name = Pt(18), SLATE, FONT
+    r3 = p.add_run(); r3.text = f"   — {note_}"
+    r3.font.size, r3.font.color.rgb, r3.font.name = Pt(14), GREY, FONT
+    first = False
+notes(slide, """
+Do not read the table. One point: this is not a prototype, and the CLI and HTTP references are
+generated from the running system, so they cannot drift without failing CI.
+""")
+
+slide = prs.slides.add_slide(BLANK)
+tf = textbox(slide, Inches(0.85), Inches(0.55), Inches(11.6), Inches(1.0))
+line(tf, "What is decided but not yet true", 34, INK, bold=True, first=True, space_after=4)
+line(tf, "The easiest claims in this deck to falsify, stated up front.", 15, GREY)
+items = [
+    ("Eleven of twenty-four ADRs are still Proposed.",
+     "Including router-side token metering (0017) and the dependency graph (0018). A proposal is a decision the code has not caught up with."),
+    ("ADR 0016 was accepted the day this deck was built.",
+     "Agent-initiated review is decided, not deployed: the rollout is one project-level flag, and the mandatory path still runs everywhere else."),
+    ("A 1% merge-queue land rate is on a slide, not in a runbook.",
+     "211 evictions, all for projected conflicts with the queue base. Nobody has fixed it; the console is simply honest enough to show it."),
+    ("A third of blocked work may be permanently dead.",
+     "ADR 0018 found 165 of 355 blocked tasks waiting on dependencies that can never complete, and it took a hand-written query to find."),
+    ("The screenshots cannot be regenerated from this repository.",
+     "They come from a live hub. The diagrams are reproducible; the captures are evidence with a date on them."),
+]
+tf2 = textbox(slide, Inches(0.85), Inches(1.85), Inches(11.6), Inches(5.3))
+first = True
+for head, body in items:
+    line(tf2, head, 17.5, INK, bold=True, space_before=0 if first else 11, space_after=3, first=first)
+    line(tf2, body, 14, GREY, space_after=2)
+    first = False
+notes(slide, """
+Keep this slide. In front of engineers it is what earns the rest of the deck — and every item is
+something the system itself surfaced rather than something a reviewer had to dig out.
+""")
+
+slide = prs.slides.add_slide(BLANK)
+bg(slide, SLATE)
+tf = textbox(slide, Inches(0.9), Inches(0.7), Inches(11.5), Inches(1.0))
+line(tf, "Provenance", 34, WHITE, bold=True, first=True, space_after=4)
+line(tf, "A pinned artifact, not a living document.", 16, PALE)
+tf2 = textbox(slide, Inches(0.9), Inches(2.0), Inches(5.6), Inches(4.6))
+line(tf2, "How to read it", 19, SAND, bold=True, first=True, space_after=8)
+for t in [
+    f"It describes commit {COMMIT} and nothing later.",
+    "Figures carry the date they were measured.",
+    "AUDIT.md traces every claim to a file or commit.",
+    "Diagrams are SVG; PNGs render from them.",
+]:
+    line(tf2, "•  " + t, 14.5, PALE, space_after=8)
+tf3 = textbox(slide, Inches(7.0), Inches(2.0), Inches(5.5), Inches(4.6))
+line(tf3, "Making the next one", 19, SAND, bold=True, first=True, space_after=8)
+line(tf3, "Follow skills/cut-a-release/SKILL.md. Build a new sibling directory rather than editing this one:",
+     14.5, PALE, space_after=8)
+line(tf3, "docs/presentation/<UTC timestamp>-<short commit>/", 13.5, WHITE, space_after=10)
+line(tf3, "The timestamp sorts, the commit pins, and neither collides. An old deck keeps meaning what it meant when it was shown.",
+     14.5, PALE)
+notes(slide, """
+Close on the convention: decks are cheap, pinned to a commit, and nobody has to wonder whether a
+slide is still true — they can check the hash.
+""")
+
+prs.save(OUT)
+print(f"wrote {OUT.name} — {len(prs.slides._sldIdLst)} slides")

--- a/docs/presentation/20260820T182340Z-bac50778/images/01-hub-and-workers.svg
+++ b/docs/presentation/20260820T182340Z-bac50778/images/01-hub-and-workers.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="940" viewBox="0 0 1600 940" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#2E6F9E"/></marker>
+    <marker id="g" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#3E7C4F"/></marker>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#B5651D"/></marker>
+  </defs>
+  <rect width="1600" height="940" fill="#FFFFFF"/>
+
+  <text x="40" y="48" font-size="31" font-weight="700" fill="#1B2530">One hub, many workers</text>
+  <text x="40" y="78" font-size="16.5" fill="#5A6B7A">The hub owns durable truth and hands out leases. Workers hold the work. Nothing is assigned by a human.</text>
+
+  <!-- HUB -->
+  <rect x="60" y="120" width="400" height="440" rx="12" fill="#2F3A45"/>
+  <text x="84" y="156" font-size="22" font-weight="700" fill="#FFFFFF">HUB</text>
+  <text x="84" y="178" font-size="13" fill="#9FB0BE">one process · PostgreSQL is the authority</text>
+
+  <rect x="84" y="196" width="352" height="86" rx="8" fill="#3C4A57"/>
+  <text x="102" y="222" font-size="16" font-weight="700" fill="#FFFFFF">Task ledger</text>
+  <text x="102" y="245" font-size="13" fill="#C9D6E2">11 states · leases · evidence</text>
+  <text x="102" y="266" font-size="13" fill="#C9D6E2">dependencies · history · recovery</text>
+
+  <rect x="84" y="296" width="352" height="72" rx="8" fill="#3C4A57"/>
+  <text x="102" y="322" font-size="16" font-weight="700" fill="#FFFFFF">Capability registry</text>
+  <text x="102" y="345" font-size="13" fill="#C9D6E2">what each worker can do, and its health</text>
+
+  <rect x="84" y="382" width="352" height="72" rx="8" fill="#3C4A57"/>
+  <text x="102" y="408" font-size="16" font-weight="700" fill="#FFFFFF">Capacity</text>
+  <text x="102" y="431" font-size="13" fill="#C9D6E2">ask for more workers when saturated</text>
+
+  <rect x="84" y="472" width="352" height="66" rx="8" fill="#4A3B2A" stroke="#C08A4A"/>
+  <text x="102" y="497" font-size="14" font-weight="700" fill="#F2C48A">It does NOT decide</text>
+  <text x="102" y="520" font-size="13" fill="#EBD9C4">what a task needs — the agent that read the diff does</text>
+
+  <!-- WORKERS -->
+  <text x="640" y="146" font-size="14" font-weight="700" fill="#2E6F9E">WORKERS — heterogeneous by design</text>
+
+  <rect x="640" y="160" width="330" height="96" rx="10" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="662" y="190" font-size="17" font-weight="700" fill="#1B4E73">macOS node</text>
+  <text x="662" y="212" font-size="13" fill="#2F3A45">host install under launchd</text>
+  <text x="662" y="233" font-size="13" fill="#5A6B7A">native toolchains · Apple silicon</text>
+
+  <rect x="640" y="276" width="330" height="96" rx="10" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="662" y="306" font-size="17" font-weight="700" fill="#1B4E73">Linux node</text>
+  <text x="662" y="328" font-size="13" fill="#2F3A45">steward + containerized execution</text>
+  <text x="662" y="349" font-size="13" fill="#5A6B7A">OpenShell owns the isolation</text>
+
+  <rect x="640" y="392" width="330" height="96" rx="10" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="662" y="422" font-size="17" font-weight="700" fill="#1B4E73">Kubernetes / HGX</text>
+  <text x="662" y="444" font-size="13" fill="#2F3A45">pods under supervisord</text>
+  <text x="662" y="465" font-size="13" fill="#5A6B7A">elastic — grows under load</text>
+
+  <!-- hub <-> worker arrows -->
+  <path d="M470 250 L 628 200" stroke="#2E6F9E" stroke-width="2.5" fill="none" marker-end="url(#b)"/>
+  <text x="486" y="212" font-size="13" font-weight="700" fill="#1B4E73">lease + task</text>
+
+  <path d="M628 330 L 470 330" stroke="#3E7C4F" stroke-width="2.5" fill="none" marker-end="url(#g)"/>
+  <text x="492" y="322" font-size="13" font-weight="700" fill="#265536">register · heartbeat · claim</text>
+  <text x="492" y="352" font-size="13" font-weight="700" fill="#265536">evidence · request review</text>
+
+  <path d="M470 430 L 628 440" stroke="#2E6F9E" stroke-width="2.5" fill="none" marker-end="url(#b)"/>
+  <text x="486" y="470" font-size="13" font-weight="700" fill="#1B4E73">capacity provisioning</text>
+
+  <!-- MERGE QUEUE / MAIN -->
+  <rect x="1130" y="160" width="410" height="180" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M1130 170 a10 10 0 0 1 10 -10 h390 a10 10 0 0 1 10 10 v40 h-410 z" fill="#3E7C4F"/>
+  <text x="1152" y="196" font-size="17" font-weight="700" fill="#FFFFFF">Merge queue</text>
+  <text x="1152" y="234" font-size="13.5" fill="#2F3A45">Speculative train: entry N is tested on</text>
+  <text x="1152" y="255" font-size="13.5" fill="#2F3A45">top of 1..N-1. A failure evicts it and</text>
+  <text x="1152" y="276" font-size="13.5" fill="#2F3A45">discards everything behind it.</text>
+  <text x="1152" y="304" font-size="13" font-weight="700" fill="#265536">Invariant: never land an untested tree.</text>
+  <text x="1152" y="325" font-size="12.5" fill="#5A6B7A">window is TCP congestion control: floor 1, ceiling 4</text>
+
+  <rect x="1130" y="366" width="410" height="76" rx="10" fill="#2F3A45"/>
+  <text x="1152" y="396" font-size="18" font-weight="700" fill="#FFFFFF">main</text>
+  <text x="1152" y="420" font-size="13" fill="#B7C4D0">agents land through a PR they own — never a push</text>
+
+  <path d="M980 300 L 1118 250" stroke="#3E7C4F" stroke-width="2.5" fill="none" marker-end="url(#g)"/>
+  <text x="988" y="296" font-size="13" font-weight="700" fill="#265536">approved change</text>
+  <path d="M1335 348 L 1335 358" stroke="#3E7C4F" stroke-width="2.5" fill="none" marker-end="url(#g)"/>
+
+  <!-- AGENTBUS -->
+  <rect x="60" y="600" width="1480" height="70" rx="10" fill="#2E6F9E"/>
+  <text x="800" y="632" font-size="20" font-weight="700" fill="#FFFFFF" text-anchor="middle">AgentBus — every participant hears everything</text>
+  <text x="800" y="656" font-size="13.5" fill="#D6E6F2" text-anchor="middle">peer review requests · task.claimed / progress / released · git events · sandbox policy · lifecycle directives</text>
+
+  <line x1="260" y1="560" x2="260" y2="600" stroke="#2E6F9E" stroke-width="2"/>
+  <line x1="805" y1="488" x2="805" y2="600" stroke="#2E6F9E" stroke-width="2"/>
+  <line x1="1335" y1="442" x2="1335" y2="600" stroke="#2E6F9E" stroke-width="2"/>
+
+  <!-- HUMAN -->
+  <rect x="60" y="712" width="470" height="180" rx="10" fill="#FDF6EE" stroke="#C08A4A" stroke-width="1.5"/>
+  <text x="84" y="744" font-size="17" font-weight="700" fill="#7A430F">The human is on the bus, not above it</text>
+  <text x="84" y="772" font-size="13.5" fill="#2F3A45">The console never mutates the control plane.</text>
+  <text x="84" y="793" font-size="13.5" fill="#2F3A45">It speaks like any other participant.</text>
+  <rect x="84" y="810" width="118" height="34" rx="5" fill="#FFFFFF" stroke="#B5651D"/>
+  <text x="143" y="832" font-size="13" font-weight="700" fill="#7A430F" text-anchor="middle">stand_down</text>
+  <rect x="212" y="810" width="80" height="34" rx="5" fill="#FFFFFF" stroke="#B5651D"/>
+  <text x="252" y="832" font-size="13" font-weight="700" fill="#7A430F" text-anchor="middle">pause</text>
+  <rect x="302" y="810" width="88" height="34" rx="5" fill="#FFFFFF" stroke="#B5651D"/>
+  <text x="346" y="832" font-size="13" font-weight="700" fill="#7A430F" text-anchor="middle">resume</text>
+  <rect x="400" y="810" width="80" height="34" rx="5" fill="#FBE9E6" stroke="#C0392B"/>
+  <text x="440" y="832" font-size="13" font-weight="700" fill="#98291C" text-anchor="middle">abort</text>
+  <text x="84" y="872" font-size="12.5" fill="#8A6438">stand-down is not abort — one pauses, one destroys work in flight</text>
+  <line x1="295" y1="670" x2="295" y2="712" stroke="#B5651D" stroke-width="2"/>
+
+  <!-- LIVE -->
+  <rect x="560" y="712" width="980" height="180" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="584" y="744" font-size="17" font-weight="700" fill="#1B2530">This fleet, right now</text>
+  <text x="700" y="800" font-size="42" font-weight="700" fill="#1B2530" text-anchor="end">10</text>
+  <text x="716" y="790" font-size="14" fill="#2F3A45">agents registered</text>
+  <text x="716" y="812" font-size="13" fill="#5A6B7A">6 static · 4 fungible · 6 GPU-capable</text>
+
+  <text x="1010" y="800" font-size="42" font-weight="700" fill="#1B2530" text-anchor="end">2 / 2 / 6</text>
+  <text x="1026" y="790" font-size="14" fill="#2F3A45">busy / idle / offline</text>
+  <text x="1026" y="812" font-size="13" fill="#5A6B7A">offline is normal — fungible workers are created on demand</text>
+
+  <text x="584" y="866" font-size="13" fill="#5A6B7A">Measured live on 2026-08-20. Identity withheld: this repository's docs must read as generic for any fleet owner.</text>
+</svg>

--- a/docs/presentation/20260820T182340Z-bac50778/images/02-inside-the-hub.svg
+++ b/docs/presentation/20260820T182340Z-bac50778/images/02-inside-the-hub.svg
@@ -1,0 +1,143 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1010" viewBox="0 0 1600 1010" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="f" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#5A6B7A"/></marker>
+  </defs>
+  <rect width="1600" height="1010" fill="#FFFFFF"/>
+
+  <text x="40" y="48" font-size="31" font-weight="700" fill="#1B2530">Inside the hub</text>
+  <text x="40" y="78" font-size="16.5" fill="#5A6B7A">Three daemon threads and 31 services. The interesting part is not the list — it is the order, and why it was fought over.</text>
+
+  <!-- THREE THREADS -->
+  <text x="40" y="116" font-size="14" font-weight="700" fill="#2E6F9E">1 · THREE THREADS, DELIBERATELY SEPARATE</text>
+
+  <rect x="40" y="130" width="490" height="196" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 140 a10 10 0 0 1 10 -10 h470 a10 10 0 0 1 10 10 v40 h-490 z" fill="#2E6F9E"/>
+  <text x="62" y="166" font-size="16" font-weight="700" fill="#FFFFFF">mac-hub-tick</text>
+  <text x="508" y="166" font-size="12.5" fill="#BBD7EA" text-anchor="end">the self-driver</text>
+  <text x="62" y="204" font-size="13.5" fill="#2F3A45">Drives the whole loop on the hub's own clock.</text>
+  <text x="62" y="226" font-size="13.5" fill="#2F3A45">Before it existed, approved work parked forever</text>
+  <text x="62" y="248" font-size="13.5" fill="#2F3A45">waiting for someone to POST /dispatch/tick.</text>
+  <text x="62" y="278" font-size="12.5" fill="#5A6B7A">Off unless MAC_HUB_TICK_INTERVAL_SECONDS &gt; 0, so the</text>
+  <text x="62" y="298" font-size="12.5" fill="#5A6B7A">CLI, the tests and stateless replicas never compete.</text>
+
+  <rect x="555" y="130" width="490" height="196" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M555 140 a10 10 0 0 1 10 -10 h470 a10 10 0 0 1 10 10 v40 h-490 z" fill="#2E6F9E"/>
+  <text x="577" y="166" font-size="16" font-weight="700" fill="#FFFFFF">mac-publication</text>
+  <text x="1023" y="166" font-size="12.5" fill="#BBD7EA" text-anchor="end">the slow one, quarantined</text>
+  <text x="577" y="204" font-size="13.5" fill="#2F3A45">Clones a repository and runs a sandboxed contract</text>
+  <text x="577" y="226" font-size="13.5" fill="#2F3A45">gate. It got its own thread because it used to run</text>
+  <text x="577" y="248" font-size="13.5" fill="#2F3A45">inside the tick — and on worker heartbeats.</text>
+  <text x="577" y="278" font-size="12.5" fill="#8C3227">Heartbeats measured at 250–315s, lease renewals at 33s,</text>
+  <text x="577" y="298" font-size="12.5" fill="#8C3227">because the cost landed on the worker, not the hub.</text>
+
+  <rect x="1070" y="130" width="490" height="196" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M1070 140 a10 10 0 0 1 10 -10 h470 a10 10 0 0 1 10 10 v40 h-490 z" fill="#2E6F9E"/>
+  <text x="1092" y="166" font-size="16" font-weight="700" fill="#FFFFFF">mac-retention</text>
+  <text x="1538" y="166" font-size="12.5" fill="#BBD7EA" text-anchor="end">its own timer, on purpose</text>
+  <text x="1092" y="204" font-size="13.5" fill="#2F3A45">Prunes the observability and action-event stores.</text>
+  <text x="1092" y="226" font-size="13.5" fill="#2F3A45">It is silent when there is nothing to do — so</text>
+  <text x="1092" y="248" font-size="13.5" fill="#2F3A45">"alive and idle" and "never reached" look identical.</text>
+  <text x="1092" y="278" font-size="12.5" fill="#8C3227">That is how the store reached 16GB / 10.4M rows while</text>
+  <text x="1092" y="298" font-size="12.5" fill="#8C3227">retention was believed to be wired.</text>
+
+  <!-- THE TICK -->
+  <text x="40" y="368" font-size="14" font-weight="700" fill="#2E6F9E">2 · WHAT ONE TICK DOES, IN ORDER — THE ORDER IS THE DESIGN</text>
+
+  <rect x="40" y="382" width="1520" height="196" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+
+  <rect x="62" y="410" width="168" height="70" rx="7" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="146" y="436" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">1 · stale agents</text>
+  <text x="146" y="456" font-size="12" fill="#5A6B7A" text-anchor="middle">mark offline</text>
+  <text x="146" y="472" font-size="12" fill="#5A6B7A" text-anchor="middle">if unheard</text>
+  <path d="M234 445 L 252 445" stroke="#5A6B7A" stroke-width="2" marker-end="url(#f)"/>
+
+  <rect x="256" y="410" width="168" height="70" rx="7" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="340" y="436" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">2 · ephemerals</text>
+  <text x="340" y="456" font-size="12" fill="#5A6B7A" text-anchor="middle">expire fungible</text>
+  <text x="340" y="472" font-size="12" fill="#5A6B7A" text-anchor="middle">workers</text>
+  <path d="M428 445 L 446 445" stroke="#5A6B7A" stroke-width="2" marker-end="url(#f)"/>
+
+  <rect x="450" y="410" width="168" height="70" rx="7" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="534" y="436" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">3 · leases</text>
+  <text x="534" y="456" font-size="12" fill="#5A6B7A" text-anchor="middle">reclaim work from</text>
+  <text x="534" y="472" font-size="12" fill="#5A6B7A" text-anchor="middle">a dead agent</text>
+  <path d="M622 445 L 640 445" stroke="#5A6B7A" stroke-width="2" marker-end="url(#f)"/>
+
+  <rect x="644" y="410" width="168" height="70" rx="7" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="728" y="436" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">4 · workflows</text>
+  <text x="728" y="456" font-size="12" fill="#5A6B7A" text-anchor="middle">advance DAG runs</text>
+  <path d="M816 445 L 834 445" stroke="#5A6B7A" stroke-width="2" marker-end="url(#f)"/>
+
+  <rect x="838" y="410" width="168" height="70" rx="7" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="922" y="436" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">5 · service roles</text>
+  <text x="922" y="456" font-size="12" fill="#5A6B7A" text-anchor="middle">reap stale claims</text>
+  <path d="M1010 445 L 1028 445" stroke="#5A6B7A" stroke-width="2" marker-end="url(#f)"/>
+
+  <rect x="1032" y="410" width="168" height="70" rx="7" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="1116" y="436" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">6 · unblock</text>
+  <text x="1116" y="456" font-size="12" fill="#5A6B7A" text-anchor="middle">dependency-ready</text>
+  <text x="1116" y="472" font-size="12" fill="#5A6B7A" text-anchor="middle">+ auto-retry</text>
+  <path d="M1204 445 L 1222 445" stroke="#5A6B7A" stroke-width="2" marker-end="url(#f)"/>
+
+  <rect x="1226" y="410" width="150" height="70" rx="7" fill="#FDF6EE" stroke="#C08A4A" stroke-width="2"/>
+  <text x="1301" y="436" font-size="13.5" font-weight="700" fill="#7A430F" text-anchor="middle">7 · retention</text>
+  <text x="1301" y="456" font-size="12" fill="#8A6438" text-anchor="middle">prune, HERE</text>
+  <text x="1301" y="472" font-size="12" fill="#8A6438" text-anchor="middle">and not later</text>
+  <path d="M1380 445 L 1398 445" stroke="#5A6B7A" stroke-width="2" marker-end="url(#f)"/>
+
+  <rect x="1402" y="410" width="136" height="70" rx="7" fill="#E3F0E7" stroke="#3E7C4F" stroke-width="2"/>
+  <text x="1470" y="436" font-size="13.5" font-weight="700" fill="#265536" text-anchor="middle">8 · dispatch</text>
+  <text x="1470" y="456" font-size="12" fill="#3E7C4F" text-anchor="middle">match ready work</text>
+  <text x="1470" y="472" font-size="12" fill="#3E7C4F" text-anchor="middle">to capable agents</text>
+
+  <text x="62" y="516" font-size="13.5" fill="#2F3A45"><tspan font-weight="700" fill="#7A430F">Why retention sits at 7 and not at the end.</tspan> It used to run after the review sweep, which clones a repository and runs a test suite. Everything ordered</text>
+  <text x="62" y="538" font-size="13.5" fill="#2F3A45">behind that inherited its period. Measured live: <tspan font-weight="700">zero retention events in the 48 minutes after a restart</tspan>, while 235,615 observability rows and 5,576 action</text>
+  <text x="62" y="560" font-size="13.5" fill="#2F3A45">events sat past the 7-day cutoff. Retention is cheap and bounded, so running it first costs the sweep nothing — and the sweep moved to its own thread.</text>
+
+  <!-- SERVICES -->
+  <text x="40" y="620" font-size="14" font-weight="700" fill="#2E6F9E">3 · 31 SERVICES, BY WHAT THEY ARE FOR</text>
+
+  <rect x="40" y="634" width="490" height="164" rx="10" fill="#FFFFFF" stroke="#C9D2DA"/>
+  <text x="62" y="662" font-size="15.5" font-weight="700" fill="#1B2530">Work and review <tspan font-size="13" font-weight="400" fill="#5A6B7A">— 8</tspan></text>
+  <text x="62" y="688" font-size="13" fill="#2F3A45">task_transition · review · roles · workflow</text>
+  <text x="62" y="710" font-size="13" fill="#2F3A45">provisioning · project_repository</text>
+  <text x="62" y="732" font-size="13" fill="#2F3A45">source_convergence · ticketing</text>
+  <text x="62" y="762" font-size="12.5" fill="#5A6B7A">Everything between "a task exists" and "the change</text>
+  <text x="62" y="781" font-size="12.5" fill="#5A6B7A">is on main".</text>
+
+  <rect x="555" y="634" width="490" height="164" rx="10" fill="#FFFFFF" stroke="#C9D2DA"/>
+  <text x="577" y="662" font-size="15.5" font-weight="700" fill="#1B2530">Fleet and runtime <tspan font-size="13" font-weight="400" fill="#5A6B7A">— 6</tspan></text>
+  <text x="577" y="688" font-size="13" fill="#2F3A45">agent_state · deploy · fleet_release_epoch</text>
+  <text x="577" y="710" font-size="13" fill="#2F3A45">openshell · rollout · service_role</text>
+  <text x="577" y="740" font-size="12.5" fill="#5A6B7A">Who is alive, what image they run, and how a fleet</text>
+  <text x="577" y="759" font-size="12.5" fill="#5A6B7A">moves between qualified versions as a transaction.</text>
+
+  <rect x="1070" y="634" width="490" height="164" rx="10" fill="#FFFFFF" stroke="#C9D2DA"/>
+  <text x="1092" y="662" font-size="15.5" font-weight="700" fill="#1B2530">Communication <tspan font-size="13" font-weight="400" fill="#5A6B7A">— 6</tspan></text>
+  <text x="1092" y="688" font-size="13" fill="#2F3A45">agentbus · communication · directive</text>
+  <text x="1092" y="710" font-size="13" fill="#2F3A45">humans · messaging · notifier</text>
+  <text x="1092" y="740" font-size="12.5" fill="#5A6B7A">The bus, the typed payload contracts, and the path a</text>
+  <text x="1092" y="759" font-size="12.5" fill="#5A6B7A">human question takes to reach an agent.</text>
+
+  <rect x="40" y="812" width="490" height="164" rx="10" fill="#FFFFFF" stroke="#C9D2DA"/>
+  <text x="62" y="840" font-size="15.5" font-weight="700" fill="#1B2530">Knowledge <tspan font-size="13" font-weight="400" fill="#5A6B7A">— 4</tspan></text>
+  <text x="62" y="866" font-size="13" fill="#2F3A45">memory · vector_writer · curiosity · eval</text>
+  <text x="62" y="896" font-size="12.5" fill="#5A6B7A">Durable lessons, their embeddings, and the evaluation</text>
+  <text x="62" y="915" font-size="12.5" fill="#5A6B7A">contract a rollout can be gated on.</text>
+  <text x="62" y="945" font-size="12.5" fill="#5A6B7A">Memory must shrink to be promoted: a run whose output</text>
+  <text x="62" y="964" font-size="12.5" fill="#5A6B7A">exceeds 0.75× its input is quarantined.</text>
+
+  <rect x="555" y="812" width="490" height="164" rx="10" fill="#FFFFFF" stroke="#C9D2DA"/>
+  <text x="577" y="840" font-size="15.5" font-weight="700" fill="#1B2530">Operations <tspan font-size="13" font-weight="400" fill="#5A6B7A">— 5</tspan></text>
+  <text x="577" y="866" font-size="13" fill="#2F3A45">action_event · crash · observability</text>
+  <text x="577" y="888" font-size="13" fill="#2F3A45">retention · router</text>
+  <text x="577" y="918" font-size="12.5" fill="#5A6B7A">What happened, what broke, what it cost, and what</text>
+  <text x="577" y="937" font-size="12.5" fill="#5A6B7A">gets thrown away. The router meters model spend.</text>
+
+  <rect x="1070" y="812" width="490" height="164" rx="10" fill="#FFFFFF" stroke="#C9D2DA"/>
+  <text x="1092" y="840" font-size="15.5" font-weight="700" fill="#1B2530">Identity <tspan font-size="13" font-weight="400" fill="#5A6B7A">— 2</tspan></text>
+  <text x="1092" y="866" font-size="13" fill="#2F3A45">identity · secrets</text>
+  <text x="1092" y="896" font-size="12.5" fill="#5A6B7A">Secrets are handles, never values. API and CLI output</text>
+  <text x="1092" y="915" font-size="12.5" fill="#5A6B7A">is redacted, and runtime manifests check that no</text>
+  <text x="1092" y="934" font-size="12.5" fill="#5A6B7A">secret value was baked into an image.</text>
+</svg>

--- a/docs/presentation/20260820T182340Z-bac50778/images/03-life-of-a-task.svg
+++ b/docs/presentation/20260820T182340Z-bac50778/images/03-life-of-a-task.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="s" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#2E6F9E"/></marker>
+    <marker id="r" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#C0392B"/></marker>
+  </defs>
+  <rect width="1600" height="900" fill="#FFFFFF"/>
+
+  <text x="40" y="48" font-size="31" font-weight="700" fill="#1B2530">The life of one task</text>
+  <text x="40" y="78" font-size="16.5" fill="#5A6B7A">Time runs left to right. Every hand-off is a durable row, not a message someone hopes was read.</text>
+
+  <!-- lane bands -->
+  <rect x="200" y="112" width="1360" height="88" fill="#F7F9FA"/>
+  <rect x="200" y="288" width="1360" height="88" fill="#F7F9FA"/>
+  <rect x="200" y="464" width="1360" height="88" fill="#F7F9FA"/>
+
+  <text x="40" y="162" font-size="15" font-weight="700" fill="#5A6B7A">FILER</text>
+  <text x="40" y="182" font-size="12" fill="#8A98A6">human or agent</text>
+  <text x="40" y="250" font-size="15" font-weight="700" fill="#2E6F9E">HUB</text>
+  <text x="40" y="270" font-size="12" fill="#8A98A6">ledger + dispatch</text>
+  <text x="40" y="338" font-size="15" font-weight="700" fill="#5A6B7A">WORKER</text>
+  <text x="40" y="358" font-size="12" fill="#8A98A6">holds the work</text>
+  <text x="40" y="426" font-size="15" font-weight="700" fill="#5A6B7A">PEER</text>
+  <text x="40" y="446" font-size="12" fill="#8A98A6">a different agent</text>
+  <text x="40" y="514" font-size="15" font-weight="700" fill="#3E7C4F">LANDING</text>
+  <text x="40" y="534" font-size="12" fill="#8A98A6">queue then main</text>
+
+  <!-- 1 file -->
+  <rect x="220" y="128" width="140" height="58" rx="7" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="290" y="152" font-size="13.5" font-weight="700" fill="#1B2530" text-anchor="middle">1 · file task</text>
+  <text x="290" y="172" font-size="11.5" fill="#5A6B7A" text-anchor="middle">title + description</text>
+  <path d="M290 190 L 290 216" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 2 dispatch -->
+  <rect x="220" y="220" width="140" height="58" rx="7" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="290" y="244" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">2 · dispatch</text>
+  <text x="290" y="264" font-size="11.5" fill="#5A6B7A" text-anchor="middle">match capability</text>
+  <path d="M364 250 L 396 250" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 3 claim -->
+  <rect x="400" y="220" width="140" height="58" rx="7" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="470" y="244" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">3 · lease</text>
+  <text x="470" y="264" font-size="11.5" fill="#5A6B7A" text-anchor="middle">exact fence, not an id</text>
+  <path d="M470 282 L 470 304" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 4 run -->
+  <rect x="400" y="308" width="140" height="58" rx="7" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="470" y="332" font-size="13.5" font-weight="700" fill="#1B2530" text-anchor="middle">4 · run</text>
+  <text x="470" y="352" font-size="11.5" fill="#5A6B7A" text-anchor="middle">read · change · test</text>
+  <path d="M544 338 L 576 338" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 5 evidence -->
+  <rect x="580" y="308" width="150" height="58" rx="7" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="655" y="332" font-size="13.5" font-weight="700" fill="#1B2530" text-anchor="middle">5 · evidence</text>
+  <text x="655" y="352" font-size="11.5" fill="#5A6B7A" text-anchor="middle">typed, bound to attempt</text>
+  <path d="M655 304 L 655 282" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+  <text x="668" y="298" font-size="11" fill="#5A6B7A">recorded</text>
+  <path d="M655 370 L 655 392" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 6 review -->
+  <rect x="580" y="396" width="150" height="72" rx="7" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="655" y="420" font-size="13.5" font-weight="700" fill="#1B2530" text-anchor="middle">6 · review</text>
+  <text x="655" y="440" font-size="11.5" fill="#5A6B7A" text-anchor="middle">asked over AgentBus</text>
+  <text x="655" y="458" font-size="11.5" fill="#5A6B7A" text-anchor="middle">findings → the ledger</text>
+  <path d="M734 432 L 766 432" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 7 approve -->
+  <rect x="770" y="220" width="176" height="76" rx="7" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="858" y="244" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">7 · approve</text>
+  <text x="858" y="264" font-size="11.5" fill="#5A6B7A" text-anchor="middle">a different agent AND</text>
+  <text x="858" y="282" font-size="11.5" fill="#5A6B7A" text-anchor="middle">a different model</text>
+  <path d="M770 420 L 858 302" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <path d="M950 258 L 1000 258" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 8 PR -->
+  <rect x="1004" y="308" width="150" height="58" rx="7" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="1079" y="332" font-size="13.5" font-weight="700" fill="#1B2530" text-anchor="middle">8 · pull request</text>
+  <text x="1079" y="352" font-size="11.5" fill="#5A6B7A" text-anchor="middle">the agent owns it</text>
+  <path d="M1004 268 L 1079 304" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+  <path d="M1079 370 L 1079 476" stroke="#2E6F9E" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 9 queue -->
+  <rect x="1004" y="480" width="150" height="58" rx="7" fill="#E3F0E7" stroke="#3E7C4F" stroke-width="1.5"/>
+  <text x="1079" y="504" font-size="13.5" font-weight="700" fill="#265536" text-anchor="middle">9 · enqueued</text>
+  <text x="1079" y="524" font-size="11.5" fill="#3E7C4F" text-anchor="middle">tested on 1..N-1</text>
+  <path d="M1158 510 L 1196 510" stroke="#3E7C4F" stroke-width="2" marker-end="url(#s)"/>
+
+  <!-- 10 land -->
+  <rect x="1200" y="480" width="150" height="58" rx="7" fill="#3E7C4F"/>
+  <text x="1275" y="504" font-size="13.5" font-weight="700" fill="#FFFFFF" text-anchor="middle">10 · landed</text>
+  <text x="1275" y="524" font-size="11.5" fill="#CFE4D6" text-anchor="middle">on main</text>
+
+  <!-- failure edges -->
+  <path d="M470 366 C 400 620, 300 600, 292 288" stroke="#C0392B" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#r)"/>
+  <text x="330" y="600" font-size="12.5" font-weight="700" fill="#98291C">lease expires →</text>
+  <text x="330" y="618" font-size="12.5" fill="#8C3227">work reclaimed, task returns to open</text>
+
+  <path d="M1079 546 C 1000 640, 900 640, 870 302" stroke="#C0392B" stroke-width="2" fill="none" stroke-dasharray="6 4" marker-end="url(#r)"/>
+  <text x="900" y="640" font-size="12.5" font-weight="700" fill="#98291C">evicted →</text>
+  <text x="900" y="658" font-size="12.5" fill="#8C3227">everything behind it is discarded and re-planned</text>
+
+  <!-- invariants -->
+  <rect x="40" y="690" width="490" height="180" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="62" y="720" font-size="16" font-weight="700" fill="#1B2530">Nothing here is a message</text>
+  <text x="62" y="748" font-size="13.5" fill="#2F3A45">Every hand-off is a row with a state, an owner and a</text>
+  <text x="62" y="769" font-size="13.5" fill="#2F3A45">timestamp. That is what makes "why is this stuck?"</text>
+  <text x="62" y="790" font-size="13.5" fill="#2F3A45">answerable months later.</text>
+  <text x="62" y="820" font-size="13" fill="#5A6B7A">Lease expiry is the single liveness mechanism. A peer</text>
+  <text x="62" y="840" font-size="13" fill="#5A6B7A">review that goes unanswered by its deadline completes</text>
+  <text x="62" y="860" font-size="13" fill="#5A6B7A">without review rather than waiting forever.</text>
+
+  <rect x="555" y="690" width="490" height="180" rx="10" fill="#FDF6EE" stroke="#C08A4A"/>
+  <text x="577" y="720" font-size="16" font-weight="700" fill="#7A430F">Step 6 is about to change</text>
+  <text x="577" y="748" font-size="13.5" fill="#2F3A45">Review is mandatory today. ADR 0016 makes it agent-</text>
+  <text x="577" y="769" font-size="13.5" fill="#2F3A45">initiated, because the agent that read the diff knows</text>
+  <text x="577" y="790" font-size="13.5" fill="#2F3A45">whether it needs one and the hub does not.</text>
+  <text x="577" y="820" font-size="13" fill="#8A6438">The motivating measurement: 52 reviews across 38 tasks</text>
+  <text x="577" y="840" font-size="13" fill="#8A6438">produced four distinct reason strings and zero findings.</text>
+  <text x="577" y="860" font-size="13" fill="#8A6438">Accepted 2026-08-20; rollout is one project-level flag.</text>
+
+  <rect x="1070" y="690" width="490" height="180" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="1092" y="720" font-size="16" font-weight="700" fill="#1B2530">Recovery is a verb, not an incident</text>
+  <text x="1092" y="748" font-size="13.5" fill="#2F3A45">Stranded work, stalled finalizers and expired leases</text>
+  <text x="1092" y="769" font-size="13.5" fill="#2F3A45">each have a named recovery path.</text>
+  <text x="1092" y="799" font-size="13" fill="#5A6B7A">Break-glass override is grantable, listable and</text>
+  <text x="1092" y="819" font-size="13" fill="#5A6B7A">revocable — an emergency leaves a record instead of</text>
+  <text x="1092" y="839" font-size="13" fill="#5A6B7A">an ambient permission.</text>
+</svg>

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -54,7 +54,23 @@ need to know, the failure message names it when it fires.
 
 | Directory | Commit | Deck | Subject |
 |---|---|---|---|
+| [`20260820T182340Z-bac50778`](20260820T182340Z-bac50778/README.md) | `bac50778` | [Google Slides](https://docs.google.com/presentation/d/1vzkNL3_IM-ophzQWUpJl3JE5L-X3MnEva8m6edeEOQk/edit) | How the control plane is put together — hub↔workers, the life of a task, inside the hub, with live console captures |
 | [`20260820T011224Z-8b424c20`](20260820T011224Z-8b424c20/README.md) | `8b424c20` | [Google Slides](https://docs.google.com/presentation/d/1DXgpB-3fy4IDLynGloaAP349BWrwoVSw8T46VyPdT3M/edit) | What the control plane can do today — object model, task lifecycle, coordination, fleet, measurement |
+
+Newest first. The two entries above were cut nine hours apart and disagree about ADR 0016's status,
+which is the convention working as intended rather than a defect: each is true of its own commit.
+
+## Screenshots of a live fleet
+
+A deck may include console captures. Two rules, both learned the hard way:
+
+- **Crop or skip the `agents` view.** Its roster lists real agent names, several of which
+  `tests/test_docs_no_operator_identity.py` forbids in checked-in docs — and a deck is a shareable
+  artifact even when it is not committed. Repository names are fine; that test explicitly permits
+  the repo-org slug.
+- **Captures are evidence with a date, not a reproducible build step.** They cannot be regenerated
+  from the repository, so the deck states when they were taken and the diagrams carry the load that
+  has to survive.
 
 ## Build conventions
 


### PR DESCRIPTION
The previous deck answered *"what can mac do?"* in prose. This one answers **"how is it put together?"** in pictures — six of ten slides are diagrams or live console captures, and the text slides carry only what a picture cannot: counts, and what has not shipped.

**[MAC — How the control plane is put together (`bac50778`)](https://docs.google.com/presentation/d/1vzkNL3_IM-ophzQWUpJl3JE5L-X3MnEva8m6edeEOQk/edit)**

## Three diagrams, drawn from the source

**One hub, many workers.** The hub keeps the ledger, the capability registry and capacity, and hands out leases; workers hold the work. The amber box is the argument — the hub does *not* decide what a task needs, because `required_capabilities` is a guess made before anyone has read the diff. Worker classes are drawn as genuinely different (launchd host install, containerized execution under a steward, elastic pods) because mac does not pretend they are one server class. AgentBus runs underneath, and the human is *on* it.

**The life of one task.** Ten steps, five lanes, time left to right. The two red edges matter more than the happy path: lease expiry reclaims work from a dead agent, and a merge-queue eviction discards everything tested behind it, because those results were green against a state that will never exist.

**Inside the hub.** The deep-dive: three daemon threads each separate for a *measured* reason, the tick in order with retention at position 7 and the reason it is not last, and 31 services grouped by purpose. The order is the design, and the repository already argues that in its own comments.

## Three live captures

From a hub that was running while the deck was made. They say things no diagram would:

- **465 of 644** in-flight tasks blocked — the number ADR 0018 exists for.
- A **"status not believable"** tile counting agents whose self-reported status the hub does not trust.
- A merge queue at a **1% land rate with 211 evictions**, every one blaming *"projected merge conflicts with the queue base"*. Nobody wrote that down anywhere; the console simply shows it.

## Identity

The `agents` view lists real agent names, several of which `tests/test_docs_no_operator_identity.py` forbids in checked-in docs — and a deck is shareable even when it is not committed. That capture is **cropped to its stat tiles**, the crop rule is now written into `docs/presentation/README.md`, and no hostname appears anywhere. Repository names are left visible: that gate explicitly permits the repo-org slug and forbids only operator and fleet identity.

## Captures are not reproducible, and the deck says so

They come from a live fleet, so they are evidence with a date rather than a build step. Rebuilding without a fleet gives you the diagrams and blank screenshot slides. The diagrams carry everything that has to survive.

## Audited, not recalled

**ADR 0016 moved from Proposed to Accepted nine hours after the previous deck was cut.** The first draft of the task-lifecycle diagram still said Proposed — exactly the failure the audit step exists to catch. Both decks are now in the index and disagree about it, which is the pinning convention working as intended: each is true of its own commit.

## Verification

Everything staged **first**, per `skills/cut-a-release/SKILL.md` (the gate enumerates `git ls-files`, so an unstaged run scans nothing):

| Gate | Result |
|---|---|
| identity, guide-truth, release-skill gates | 14 pass |
| `scripts/check-docs-accessibility.py` | pass — 198 pages |
| `scripts/test-docs.py` | pass — 18 chapters, 20 shell blocks |
| `scripts/generate-docs-reference.py --check` | clean |
| `mkdocs build --strict` | succeeds |
| published deck | 10 slides, verified by round-tripping back out of Google |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
