### PR TITLE
Make deploy-mac-fleet.sh OpenShell gating OS-aware for darwin host installs (task_160c848b5efa4920a61353744361f5da)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -1352,6 +1352,37 @@ for name in selected:
     control_bind_host = text_field(agent.get("control_bind_host"))
     if not control_bind_host:
         control_bind_host = "0.0.0.0" if name == hub_agent else "127.0.0.1"
+    # Pure workers are code executors and therefore require the confined
+    # OpenShell runtime by default.  Conversational nodes remain opt-in,
+    # while an explicit worker.openshell_required value wins for either
+    # role.  Carry this in the deploy spec so a fresh/ephemeral node cannot
+    # inherit an enabled policy but miss the CLI and gateway binaries.
+    openshell_required = bool_field(
+        worker.get("openshell_required"),
+        text_field(hermes.get("gateway_impl") or "hermes") == "none",
+    )
+    # ADR 0015: the managed OpenShell runtime is a Linux container runtime and a
+    # darwin node is a plain host install with no container runtime at all, so
+    # OpenShell is never required there.  Resolve that here, at the one place
+    # the frozen spec is built, rather than leaving the contradiction in the
+    # spec for every OS-blind consumer to re-derive.
+    #
+    # A darwin agent that sets worker.openshell_required: true on its own entry
+    # is asserting the contradiction directly, so reject it and keep it
+    # unexpressible.  A fleet-wide defaults.worker value, or the implicit
+    # pure-worker default above, is a default rather than a claim about this
+    # node: normalize those to "0" instead of failing a mixed-OS fleet.
+    if os_kind.strip().lower() == "darwin":
+        own_worker = agent.get("worker") if isinstance(agent.get("worker"), dict) else {}
+        if bool_field(own_worker.get("openshell_required"), False) == "1":
+            print(
+                "ERROR: agent %s runs on darwin, which is a host install with no "
+                "OpenShell runtime (ADR 0015); remove worker.openshell_required "
+                "or set it to false" % name,
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        openshell_required = "0"
     fields = [
         name,
         target,
@@ -1406,15 +1437,7 @@ for name in selected:
         text_field(webdav.get("root")),
         webdav_public_path,
         hermes_surface_payload(hermes),
-        # Pure workers are code executors and therefore require the confined
-        # OpenShell runtime by default.  Conversational nodes remain opt-in,
-        # while an explicit worker.openshell_required value wins for either
-        # role.  Carry this in the deploy spec so a fresh/ephemeral node cannot
-        # inherit an enabled policy but miss the CLI and gateway binaries.
-        bool_field(
-            worker.get("openshell_required"),
-            text_field(hermes.get("gateway_impl") or "hermes") == "none",
-        ),
+        openshell_required,
         # Pure workers must be able to fetch and publish repository work from a
         # fresh host.  Make that fail closed by default while preserving an
         # explicit opt-out for intentionally public/read-only executors.
@@ -10114,14 +10137,21 @@ worker_can_reach_hub_url() {
 }
 
 spec_requires_report_repository_executor() {
-  # Report repository execution is meaningful only for a loop worker whose
-  # frozen deployment enables OpenShell. The same calculation is used by the
-  # image preflight and remote installer, so selected launchd/systemd targets
-  # and SSH-managed K8s pods cannot disagree about the release requirement.
-  local spec="$1" fields=() worker_mode openshell_required request required
+  # Report repository execution is meaningful only for a loop worker. On Linux
+  # the discriminator is the frozen OpenShell deployment, because the managed
+  # container runtime is what confines the executor. On darwin there is no
+  # managed OpenShell runtime to enable (ADR 0015): the node is a host install
+  # that attests the macos_host isolation posture, so a darwin loop worker
+  # qualifies on the strength of that attestation and an OpenShell flag can
+  # never be the discriminator there. The same calculation is used by the image
+  # preflight and remote installer, so selected launchd/systemd targets and
+  # SSH-managed K8s pods cannot disagree about the release requirement.
+  local spec="$1" fields=() worker_mode os_kind openshell_required request required
   IFS='|' read -r -a fields <<<"$spec"
   worker_mode="${fields[9]:-heartbeat}"
   [ "$worker_mode" = loop ] || return 1
+  os_kind="$(printf '%s' "${fields[2]:-}" | tr '[:upper:]' '[:lower:]')"
+  [ "$os_kind" != darwin ] || return 0
   openshell_required="${fields[53]:-0}"
   request="$(normalize_boolean_token "${MAC_DEPLOY_OPENSHELL:-}")"
   required="$(normalize_boolean_token "$openshell_required")"
@@ -10464,6 +10494,15 @@ venv_python = mac_home / "venv" / "bin" / "python"
 hermes_root = mac_home / "src" / "mac" / "src" / "mac" / "_hermes"
 mac_env = mac_home / "mac.env"
 truthy = lambda value: value.strip().lower() in {"1", "true", "yes", "on"}
+# The managed OpenShell runtime is a Linux container runtime (ADR 0015). A
+# darwin node is a host install with no container runtime, so it never requires
+# OpenShell and must never be marked unready for a missing Docker engine. The
+# flag reaching this probe is shell-interpolated from the frozen host spec,
+# which can still carry openshell_required=1 from the container era, so decide
+# it here against the configured OS rather than trusting the flag alone.
+openshell_runtime_required = (
+    truthy(openshell_required) and expected_os.strip().lower() != "darwin"
+)
 installed_python_ready = venv_python.is_file() and os.access(venv_python, os.X_OK)
 installed_python_311 = False
 if installed_python_ready:
@@ -10494,7 +10533,7 @@ docker_cli = next(
     None,
 )
 docker_engine_ready = False
-if truthy(openshell_required) and docker_cli is not None:
+if openshell_runtime_required and docker_cli is not None:
     try:
         docker_probe = subprocess.run(
             [docker_cli, "info", "--format", "{{json .ServerVersion}}"],
@@ -10599,7 +10638,7 @@ checks = {
     "installed_python_runtime": installed_python_ready,
     "installed_hermes_runtime": hermes_root.is_dir() and not hermes_root.is_symlink(),
     "route_configuration": mac_env.is_file() and not mac_env.is_symlink(),
-    "openshell_container_runtime_if_required": (not truthy(openshell_required)) or docker_engine_ready,
+    "openshell_container_runtime_if_required": (not openshell_runtime_required) or docker_engine_ready,
     "qdrant_if_required": service_ready(qdrant_url, qdrant_required),
     "firecrawl_if_required": service_ready(firecrawl_url, firecrawl_required),
     "webdav_if_required": service_ready(webdav_url, webdav_required),
@@ -11561,6 +11600,7 @@ import urllib.request
 from mac.models import (
     REPORT_REPOSITORY_EXECUTOR_ATTESTATION_KEY,
     agent_has_read_only_report_repository_executor,
+    report_repository_executor_attestation_is_host_install,
     valid_read_only_report_repository_executor_attestation,
 )
 
@@ -11620,7 +11660,15 @@ try:
     if not valid_read_only_report_repository_executor_attestation(attestation):
         raise RuntimeError("worker lacks a valid current report executor attestation")
     if not (
-        resources.get("openshell_required") is True
+        (
+            resources.get("openshell_required") is True
+            # A darwin host install has no OpenShell runtime for the flag to
+            # assert, and qualifies on its honest macos_host attestation
+            # instead (ADR 0015). Same rule the hub applies in services.py, so
+            # this local pre-check cannot be stricter than the approval it is
+            # about to request.
+            or report_repository_executor_attestation_is_host_install(attestation)
+        )
         and isinstance(startup, dict)
         # One definition, shared with the hub (mac.agent_health). These four
         # lines were spelled out identically in three places in this file and

--- a/docs/adr/0015-macos-nodes-are-host-installs.md
+++ b/docs/adr/0015-macos-nodes-are-host-installs.md
@@ -150,6 +150,18 @@ isolation and is recorded here as one.
 - `deploy/openshell/bootstrap-openshell.sh` — the entire `bootstrap_darwin()`
   Docker-Desktop path is removed. macOS exits successfully with an explanation;
   a macOS node with no OpenShell is correctly provisioned, not broken.
+- `deploy/deploy-mac-fleet.sh` — the deploy orchestration is OS-aware in the
+  same way. The frozen spec never carries `openshell_required` on darwin, and a
+  darwin agent that writes `worker.openshell_required: true` on its own entry is
+  rejected when the spec is built, so the contradiction cannot be expressed. A
+  fleet-wide `defaults.worker` value, or the implicit pure-worker default, is a
+  default rather than a claim about that node and is normalized to false.
+  `spec_requires_report_repository_executor` treats a darwin *loop* worker as a
+  report-repository executor on the strength of its `macos_host` attestation,
+  since no OpenShell flag can be the discriminator there, and the node readiness
+  probe decides `openshell_container_runtime_if_required` against the configured
+  OS rather than the interpolated flag, so a container-era value left in a fleet
+  config cannot mark a mac unready for missing Docker.
 - `deploy/fleet-node-install.sh` — darwin always takes the "optional OpenShell
   runtime disabled" path, records `MAC_OPENSHELL_SANDBOX=0`,
   `MAC_OPENSHELL_REQUIRED=0`, `MAC_ALLOW_UNSANDBOXED_YOLO=1` in `mac.env`, and

--- a/docs/fleet-registry-schema.md
+++ b/docs/fleet-registry-schema.md
@@ -106,6 +106,17 @@ agents:
       openshell_required: true
 ```
 
+`os: darwin` is the exception. A macOS node is a host install with no container
+runtime at all ([ADR 0015](adr/0015-macos-nodes-are-host-installs.md)), so
+OpenShell is never required there. Writing `worker.openshell_required: true` on
+a darwin agent is rejected when the deploy spec is built, rather than carried
+into the fleet as a contradiction; remove the field or set it to `false`. A
+fleet-wide `defaults.worker.openshell_required` and the pure-worker default are
+defaults rather than claims about that node, so they are normalized to `false`
+for darwin agents and a mixed-OS fleet still deploys. A darwin loop worker is
+still a report-repository executor — it qualifies on its `macos_host`
+attestation instead of on this flag.
+
 Required nodes automatically run the idempotent OpenShell bootstrap with
 enforcement and fail-closed execution during every deploy. This is deliberate
 for ephemeral pods: `~/.mac` may survive while `~/.local/bin/openshell` does

--- a/tests/test_deploy_openshell_os_aware_gating.py
+++ b/tests/test_deploy_openshell_os_aware_gating.py
@@ -1,0 +1,283 @@
+"""Deploy-side OpenShell gating must be OS-aware (ADR 0015).
+
+A darwin fleet node is a host install: there is no managed OpenShell container
+runtime on it at all. Two deploy-orchestration decisions used to read "OpenShell
+enabled" as if it meant the same thing on every OS, which made a macOS loop
+worker both invisible to report-repository execution and permanently unready for
+a Docker engine it will never have.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY_SCRIPT = ROOT / "deploy" / "deploy-mac-fleet.sh"
+BASE_CONFIG = ROOT / "deploy" / "fleet" / "config.yaml"
+
+OS_FIELD = 2
+WORKER_MODE_FIELD = 9
+OPENSHELL_REQUIRED_FIELD = 53
+
+
+def _script() -> str:
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+def _function(name: str) -> str:
+    match = re.search(
+        r"^%s\(\) \{\n.*?^}$" % re.escape(name),
+        _script(),
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, name
+    return match.group(0)
+
+
+def _heredoc_source(name: str) -> str:
+    match = re.search(
+        r"%s\(\) \{.*?<<'PY'\n(?P<source>.*?)\nPY\n\}" % re.escape(name),
+        _script(),
+        re.DOTALL,
+    )
+    assert match is not None, name
+    return match.group("source")
+
+
+def _spec(*, os_kind: str, worker_mode: str, openshell_required: str) -> str:
+    fields = [""] * (OPENSHELL_REQUIRED_FIELD + 1)
+    fields[0] = "node"
+    fields[1] = "operator@node.example.internal"
+    fields[OS_FIELD] = os_kind
+    fields[WORKER_MODE_FIELD] = worker_mode
+    fields[OPENSHELL_REQUIRED_FIELD] = openshell_required
+    return "|".join(fields)
+
+
+def _requires_report_executor(spec: str, *, deploy_openshell: str = "") -> bool:
+    snippet = "\n".join(
+        [
+            _function("normalize_boolean_token"),
+            _function("spec_requires_report_repository_executor"),
+            'MAC_DEPLOY_OPENSHELL="$2"',
+            'spec_requires_report_repository_executor "$1"',
+        ]
+    )
+    result = subprocess.run(
+        ["bash", "-c", snippet, "gating", spec, deploy_openshell],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode in {0, 1}, result.stderr
+    return result.returncode == 0
+
+
+def test_darwin_loop_worker_is_a_report_repository_executor() -> None:
+    """The macos_host attestation qualifies it, not an OpenShell flag.
+
+    On darwin OpenShell is always disabled, so gating on the flag benched every
+    macOS loop worker from report-repository execution.
+    """
+
+    assert _requires_report_executor(
+        _spec(os_kind="darwin", worker_mode="loop", openshell_required="0")
+    )
+    assert _requires_report_executor(
+        _spec(os_kind="Darwin", worker_mode="loop", openshell_required="0")
+    )
+
+
+def test_darwin_non_loop_worker_is_still_not_a_report_executor() -> None:
+    assert not _requires_report_executor(
+        _spec(os_kind="darwin", worker_mode="heartbeat", openshell_required="0")
+    )
+
+
+def test_linux_gating_still_follows_the_frozen_openshell_deployment() -> None:
+    assert not _requires_report_executor(
+        _spec(os_kind="linux", worker_mode="loop", openshell_required="0")
+    )
+    assert _requires_report_executor(
+        _spec(os_kind="linux", worker_mode="loop", openshell_required="1")
+    )
+    assert _requires_report_executor(
+        _spec(os_kind="linux", worker_mode="loop", openshell_required="0"),
+        deploy_openshell="1",
+    )
+    assert not _requires_report_executor(
+        _spec(os_kind="linux", worker_mode="heartbeat", openshell_required="1")
+    )
+
+
+def _probe_openshell_runtime_required(*, expected_os: str, flag: str) -> bool:
+    source = _heredoc_source("preflight_probe_helper_source")
+    match = re.search(
+        r"^openshell_runtime_required = \(\n.*?^\)$",
+        source,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, "probe no longer derives openshell_runtime_required"
+    namespace = {
+        "truthy": lambda value: value.strip().lower() in {"1", "true", "yes", "on"},
+        "expected_os": expected_os,
+        "openshell_required": flag,
+    }
+    exec(match.group(0), namespace)  # noqa: S102 - the probe's own expression
+    return bool(namespace["openshell_runtime_required"])
+
+
+def test_darwin_node_never_requires_the_openshell_container_runtime() -> None:
+    """A stale openshell_required=1 in the frozen spec must not bench a mac.
+
+    The readiness probe used the shell-interpolated flag directly, so a darwin
+    node whose fleet config still carried the container-era value failed
+    ``openshell_container_runtime_if_required`` for missing Docker.
+    """
+
+    assert not _probe_openshell_runtime_required(expected_os="darwin", flag="1")
+    assert not _probe_openshell_runtime_required(expected_os="Darwin", flag="true")
+    assert _probe_openshell_runtime_required(expected_os="linux", flag="1")
+    assert not _probe_openshell_runtime_required(expected_os="linux", flag="0")
+
+
+def test_probe_readiness_check_uses_the_os_aware_value() -> None:
+    source = _heredoc_source("preflight_probe_helper_source")
+    assert (
+        '"openshell_container_runtime_if_required": (not openshell_runtime_required)'
+        " or docker_engine_ready," in source
+    )
+    assert "if openshell_runtime_required and docker_cli is not None:" in source
+    # The OS-blind expression must not come back anywhere in the probe.
+    assert "not truthy(openshell_required)" not in source
+    assert source.count("truthy(openshell_required)") == 1
+
+
+def _report_executor_approval_body() -> str:
+    """The approval helper is a subshell function wrapping an SSH heredoc."""
+
+    text = _script()
+    start = text.index("reconcile_report_repository_executor_approval() (")
+    end = text.index("\nREMOTE_REPORT_EXECUTOR_APPROVAL\n", start)
+    return text[start:end]
+
+
+def test_report_executor_approval_accepts_a_host_install_attestation() -> None:
+    """The local pre-check must not be stricter than the hub approval it asks for."""
+
+    function = _report_executor_approval_body()
+    assert "report_repository_executor_attestation_is_host_install," in function
+    assert (
+        "or report_repository_executor_attestation_is_host_install(attestation)"
+        in function
+    )
+
+
+def _fleet_config_query_source() -> str:
+    return _heredoc_source("fleet_config_query")
+
+
+def _specs(registry: Path, agent: str = "node") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-",
+            "specs",
+            str(BASE_CONFIG),
+            str(registry),
+            "hub",
+            agent,
+        ],
+        input=_fleet_config_query_source(),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _registry(tmp_path: Path, *, os_kind: str, worker_block: str, defaults: str = "") -> Path:
+    registry = tmp_path / "fleets.yaml"
+    registry.write_text(
+        """
+fleets:
+  hub:
+    sample: false
+    fleet_name: default
+    hub_agent: hub
+    control_port: 8789
+{defaults}    agents:
+      hub:
+        target: operator@hub.example.internal
+        os: linux
+      node:
+        target: operator@node.example.internal
+        os: {os_kind}
+{worker_block}
+""".lstrip().format(os_kind=os_kind, worker_block=worker_block, defaults=defaults),
+        encoding="utf-8",
+    )
+    return registry
+
+
+PURE_WORKER = """        hermes:
+          gateway_impl: none
+        worker:
+          mode: loop
+"""
+
+
+def test_darwin_spec_never_freezes_openshell_required(tmp_path: Path) -> None:
+    """A darwin pure worker would otherwise inherit the container-era default."""
+
+    result = _specs(_registry(tmp_path, os_kind="darwin", worker_block=PURE_WORKER))
+    assert result.returncode == 0, result.stderr
+    fields = result.stdout.strip().split("|")
+    assert fields[OS_FIELD] == "darwin"
+    assert fields[WORKER_MODE_FIELD] == "loop"
+    assert fields[OPENSHELL_REQUIRED_FIELD] == "0"
+
+
+def test_linux_pure_worker_still_freezes_openshell_required(tmp_path: Path) -> None:
+    result = _specs(_registry(tmp_path, os_kind="linux", worker_block=PURE_WORKER))
+    assert result.returncode == 0, result.stderr
+    fields = result.stdout.strip().split("|")
+    assert fields[OPENSHELL_REQUIRED_FIELD] == "1"
+
+
+@pytest.mark.parametrize("value", ["true", "yes", "on", "1"])
+def test_darwin_agent_cannot_declare_openshell_required(tmp_path: Path, value: str) -> None:
+    """The contradiction is rejected where it is written, not carried in a spec."""
+
+    worker_block = "        worker:\n          openshell_required: %s\n" % value
+    result = _specs(_registry(tmp_path, os_kind="darwin", worker_block=worker_block))
+    assert result.returncode == 2
+    assert "host install" in result.stderr
+    assert "ADR 0015" in result.stderr
+
+
+def test_fleet_wide_openshell_default_does_not_fail_a_darwin_node(tmp_path: Path) -> None:
+    """A defaults.worker value is a fleet default, not a claim about this node."""
+
+    defaults = """    defaults:
+      worker:
+        openshell_required: true
+"""
+    registry = _registry(
+        tmp_path, os_kind="darwin", worker_block="", defaults=defaults
+    )
+    result = _specs(registry)
+    assert result.returncode == 0, result.stderr
+    fields = result.stdout.strip().split("|")
+    assert fields[OPENSHELL_REQUIRED_FIELD] == "0"
+
+    linux = _specs(
+        _registry(tmp_path, os_kind="linux", worker_block="", defaults=defaults)
+    )
+    assert linux.returncode == 0, linux.stderr
+    assert linux.stdout.strip().split("|")[OPENSHELL_REQUIRED_FIELD] == "1"


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_160c848b5efa4920a61353744361f5da`
- head: `d226fb48d6ffb30d781c88545f253bcf4f451dd8`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
