### PR TITLE
QUICKDEMO: SSH route probe fails opaquely on untrusted host key (BatchMode swallows cause) (task_b0ec3816988d4ccd86b2b25eaca97fd0)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -1491,10 +1491,72 @@ ssh_pinned_route_file_for_agent() {
   printf '%s.route\n' "$(ssh_control_path_for_agent "$1")"
 }
 
+# OpenSSH failure modes are not distinguishable by exit status: a refused TCP
+# connection, a rejected key, and an untrusted host key all exit non-zero, and
+# the sentence naming the cause is the *last* thing written to the -vv
+# transcript.  Classify the transcript so the operator is told which of those
+# happened instead of a generic "could not establish" line.  Output is
+# ``reason|summary|remediation`` on one line.
+ssh_transcript_failure_reason() {
+  local log_path="$1" status="${2:-0}" transcript=""
+  if [ "$status" = 124 ]; then
+    printf '%s\n' 'timeout|SSH did not finish the handshake before the probe deadline|Confirm the target is reachable (overlay or VPN up, host awake, port open) and that any ProxyJump hop answers.'
+    return 0
+  fi
+  if [ -f "$log_path" ]; then
+    transcript="$(LC_ALL=C tr -d '\r' <"$log_path")"
+  fi
+  case "$transcript" in
+    *"REMOTE HOST IDENTIFICATION HAS CHANGED"*)
+      printf '%s\n' 'host-key-changed|the target presented a host key that conflicts with the pinned known_hosts entry|The host was rebuilt or this route now reaches a different machine. Reconcile the known_hosts entry deliberately; do not disable host-key checking to get past it.'
+      ;;
+    *"Host key verification failed"*|*"host key is known for"*|*"No matching host key"*|*"host key type "*" not in HostKeyAlgorithms"*)
+      printf '%s\n' 'host-key-untrusted|the target host key is not trusted by this client and BatchMode cannot prompt to accept it|Trust the key first (ssh-keyscan -H <host> >> ~/.ssh/known_hosts), or give the fleet an explicit ssh_known_hosts_file / ssh_host_key_fingerprint, or set ssh_host_key_policy: accept-new in ~/.mac/fleets.yaml for a host you control.'
+      ;;
+    *"Permission denied"*|*"Too many authentication failures"*|*"No supported authentication methods"*|*"Authentication failed"*)
+      printf '%s\n' 'auth-rejected|the target refused every offered credential|Check the identity_file/identity_ref for this agent and that its public key is installed for the route user on the target.'
+      ;;
+    *"Connection refused"*|*"Connection timed out"*|*"No route to host"*|*"Could not resolve hostname"*|*"Network is unreachable"*|*"Operation timed out"*|*"kex_exchange_identification"*)
+      printf '%s\n' 'unreachable|the client could not complete a TCP or protocol handshake with the target|Check the address, port, and that sshd is listening; if the route uses a jump host, verify that hop separately.'
+      ;;
+    "")
+      printf '%s\n' 'no-transcript|SSH produced no diagnostic transcript|Re-run the printed ssh command manually to reproduce the failure.'
+      ;;
+    *)
+      printf '%s\n' 'unknown|the transcript contains no recognized OpenSSH failure signature|Read the transcript below in full, or re-run the printed ssh command manually.'
+      ;;
+  esac
+}
+
+# Report a failed SSH route with its classified cause and the *end* of the
+# transcript.  The head of a -vv log only lists candidate identity files, so
+# printing it hid the one line that names the failure.
+report_ssh_route_failure() {
+  local agent="$1" log_path="$2" status="$3" headline="$4" target="${5:-}"
+  local diagnosis reason summary remediation rest
+  diagnosis="$(ssh_transcript_failure_reason "$log_path" "$status")"
+  reason="${diagnosis%%|*}"
+  rest="${diagnosis#*|}"
+  summary="${rest%%|*}"
+  remediation="${rest#*|}"
+  echo "ERROR: ${agent}: ${headline} (${reason}: ${summary})" >&2
+  if [ -n "$target" ]; then
+    echo "ERROR: ${agent}: route target: ${target}" >&2
+  fi
+  echo "ERROR: ${agent}: remediation: ${remediation}" >&2
+  if [ -f "$log_path" ]; then
+    echo "ERROR: ${agent}: last 40 transcript lines (${log_path}):" >&2
+    tail -n 40 "$log_path" >&2 || true
+  fi
+}
+
 probe_direct_ssh_route() {
-  local agent="$1" log_path="$2"
+  local agent="$1" log_path="$2" status=0 target=""
   shift 2
-  if ! "$PYTHON_BIN" - "$log_path" "$@" <<'PY'
+  if [ "$#" -gt 0 ]; then
+    target="${*: -1}"
+  fi
+  "$PYTHON_BIN" - "$log_path" "$@" <<'PY' || status=$?
 import os
 import signal
 import subprocess
@@ -1523,21 +1585,30 @@ with open(log_path, "wb") as log:
             except ProcessLookupError:
                 pass
             process.wait()
-        raise SystemExit("direct SSH route probe timed out")
+        print("direct SSH route probe timed out after 30s", file=sys.stderr)
+        # 124 is the conventional timeout status and lets the caller name the
+        # deadline as the cause instead of guessing from an empty transcript.
+        raise SystemExit(124)
 if returncode:
     raise SystemExit(returncode)
 PY
-  then
-    echo "ERROR: ${agent}: could not establish bounded direct SSH route" >&2
-    sed -n '1,20p' "$log_path" >&2 || true
+  # The transcript names the route and its host key, so lock it down on both
+  # the success and the failure path before anything else reads it.
+  if [ -f "$log_path" ]; then
+    chmod 0600 "$log_path"
+  fi
+  if [ "$status" -ne 0 ]; then
+    report_ssh_route_failure "$agent" "$log_path" "$status" \
+      "could not establish bounded direct SSH route (ssh exit ${status})" \
+      "$target"
     return 1
   fi
-  chmod 0600 "$log_path"
 }
 
 start_ssh_control_master() {
   local agent="$1" control_path route_path route_tmp log_path pid_path
   local route_parts=() route_args=() target item last_index attempt pid
+  local master_status
   control_path="$(ssh_control_path_for_agent "$agent")"
   route_path="$(ssh_pinned_route_file_for_agent "$agent")"
   log_path="${control_path}.log"
@@ -1590,17 +1661,24 @@ start_ssh_control_master() {
   pid=$!
   printf '%s\n' "$pid" > "$pid_path"
   chmod 0600 "$pid_path" "$log_path"
+  # 124 marks "the master never became usable while it was still running", so
+  # an exhausted wait is reported as a deadline rather than as an unclassified
+  # failure. A master that exited hands back its own status instead.
+  master_status=124
   for attempt in $(seq 1 100); do
     if ssh -n -S "$control_path" -O check "${route_args[@]}" "$target" >/dev/null 2>&1; then
       return 0
     fi
     if ! kill -0 "$pid" >/dev/null 2>&1; then
+      master_status=0
+      wait "$pid" 2>/dev/null || master_status=$?
       break
     fi
     sleep 0.1
   done
-  echo "ERROR: ${agent}: could not establish pinned SSH control master" >&2
-  sed -n '1,20p' "$log_path" >&2 || true
+  report_ssh_route_failure "$agent" "$log_path" "$master_status" \
+    "could not establish pinned SSH control master (ssh exit ${master_status})" \
+    "$target"
   return 1
 }
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -450,6 +450,22 @@ Re-run deployment for an existing hub:
 make deploy HUB=horde
 ```
 
+The deploy opens SSH with `BatchMode=yes`, so it can never prompt to accept an
+unknown host key. On a brand-new box (no `~/.ssh/known_hosts` entry for the
+target yet) the route probe therefore fails; it reports the classified cause —
+`host-key-untrusted` — with the tail of the OpenSSH transcript and the fix.
+Trust the key deliberately before deploying:
+
+```console
+ssh-keyscan -H <host> >> ~/.ssh/known_hosts
+```
+
+Alternatively, give the fleet an explicit `ssh_known_hosts_file` /
+`ssh_host_key_fingerprint`, or set `ssh_host_key_policy: accept-new` in
+`~/.mac/fleets.yaml` for a host you control. The other classified causes are
+`host-key-changed` (the target's key no longer matches the pinned entry — never
+paper over this one), `auth-rejected`, `unreachable`, and `timeout`.
+
 The Make targets pick a Python 3.11+ `.venv/bin/python`, `python3.11`, `python3`, or `python` automatically:
 
 ```console

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -2654,6 +2654,183 @@ def test_direct_ssh_mode_reuses_a_frozen_route_without_a_control_socket(tmp_path
     ]
 
 
+def _ssh_failure_report_functions():
+    deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    classify = (
+        "ssh_transcript_failure_reason() {"
+        + deploy.split("ssh_transcript_failure_reason() {", 1)[1].split(
+            "\n}\n\n# Report a failed SSH route", 1
+        )[0]
+        + "\n}"
+    )
+    report = (
+        "report_ssh_route_failure() {"
+        + deploy.split("report_ssh_route_failure() {", 1)[1].split(
+            "\n}\n\nprobe_direct_ssh_route() {", 1
+        )[0]
+        + "\n}"
+    )
+    return classify + "\n" + report
+
+
+UNTRUSTED_HOST_KEY_TRANSCRIPT = (
+    "debug1: Reading configuration data /dev/null\n"
+    + "debug1: identity file /root/.ssh/id_rsa type -1\n" * 24
+    + "debug1: Server host key: ssh-ed25519 SHA256:AAAA\n"
+    "No ED25519 host key is known for 127.0.0.1 and you have requested "
+    "strict checking.\n"
+    "Host key verification failed.\n"
+)
+
+
+@pytest.mark.parametrize(
+    "transcript,status,expected_reason",
+    [
+        (UNTRUSTED_HOST_KEY_TRANSCRIPT, 255, "host-key-untrusted"),
+        (
+            "debug1: connect\n@@@ WARNING @@@\n"
+            "REMOTE HOST IDENTIFICATION HAS CHANGED!\n"
+            "Host key verification failed.\n",
+            255,
+            "host-key-changed",
+        ),
+        (
+            "debug1: Server host key: ssh-ed25519 SHA256:AAAA\n"
+            "horde@127.0.0.1: Permission denied (publickey).\n",
+            255,
+            "auth-rejected",
+        ),
+        (
+            "debug1: Connecting to 127.0.0.1 port 22.\n"
+            "ssh: connect to host 127.0.0.1 port 22: Connection refused\n",
+            255,
+            "unreachable",
+        ),
+        ("", 124, "timeout"),
+        ("debug1: nothing interesting happened\n", 255, "unknown"),
+        ("", 255, "no-transcript"),
+    ],
+    ids=[
+        "host-key-untrusted",
+        "host-key-changed",
+        "auth-rejected",
+        "unreachable",
+        "timeout",
+        "unknown",
+        "no-transcript",
+    ],
+)
+def test_ssh_transcript_failure_reason_names_the_actual_cause(
+    tmp_path, transcript, status, expected_reason
+):
+    log_path = tmp_path / "probe.log"
+    log_path.write_text(transcript, encoding="utf-8")
+    snippet = (
+        "set -euo pipefail\n"
+        + _ssh_failure_report_functions()
+        + f"\nssh_transcript_failure_reason {shlex.quote(str(log_path))} {status}\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", snippet], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    reason, summary, remediation = result.stdout.strip().split("|")
+    assert reason == expected_reason
+    assert summary and remediation
+    if expected_reason == "host-key-untrusted":
+        assert "ssh-keyscan" in remediation
+
+
+def test_ssh_route_failure_report_prints_the_tail_that_names_the_cause(tmp_path):
+    log_path = tmp_path / "probe.log"
+    log_path.write_text(UNTRUSTED_HOST_KEY_TRANSCRIPT, encoding="utf-8")
+    snippet = (
+        "set -euo pipefail\n"
+        + _ssh_failure_report_functions()
+        + "\nreport_ssh_route_failure hazel "
+        + shlex.quote(str(log_path))
+        + " 255 'could not establish bounded direct SSH route (ssh exit 255)'"
+        + " horde@127.0.0.1\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", snippet], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == ""
+    # The generic headline stays, but it now carries the classified cause, the
+    # route it applies to, a remediation, and the end of the transcript where
+    # OpenSSH actually prints the failure.
+    assert "could not establish bounded direct SSH route" in result.stderr
+    assert "host-key-untrusted" in result.stderr
+    assert "route target: horde@127.0.0.1" in result.stderr
+    assert "ssh-keyscan" in result.stderr
+    assert "Host key verification failed." in result.stderr
+
+
+def _run_direct_ssh_probe(tmp_path, fake_ssh_body):
+    deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    probe = (
+        "probe_direct_ssh_route() {"
+        + deploy.split("probe_direct_ssh_route() {", 1)[1].split(
+            "\n}\n\nstart_ssh_control_master() {", 1
+        )[0]
+        + "\n}"
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_ssh = fake_bin / "ssh"
+    fake_ssh.write_text(fake_ssh_body, encoding="utf-8")
+    fake_ssh.chmod(0o700)
+    log_path = tmp_path / "probe.log"
+    snippet = (
+        "set -euo pipefail\n"
+        f"PYTHON_BIN={shlex.quote(sys.executable)}\n"
+        f"PATH={shlex.quote(str(fake_bin))}:/usr/bin:/bin\n"
+        + _ssh_failure_report_functions()
+        + "\n"
+        + probe
+        + f"\nprobe_direct_ssh_route hazel {shlex.quote(str(log_path))}"
+        " -F /dev/null -o StrictHostKeyChecking=yes horde@127.0.0.1\n"
+    )
+    result = subprocess.run(
+        ["bash", "-c", snippet], capture_output=True, text=True, check=False
+    )
+    return result, log_path
+
+
+def test_direct_ssh_probe_failure_reports_the_untrusted_host_key(tmp_path):
+    result, log_path = _run_direct_ssh_probe(
+        tmp_path,
+        "#!/usr/bin/env bash\n"
+        "for _ in $(seq 1 24); do\n"
+        "  echo 'debug1: identity file /root/.ssh/id_rsa type -1' >&2\n"
+        "done\n"
+        "echo 'No ED25519 host key is known for 127.0.0.1 and you have "
+        "requested strict checking.' >&2\n"
+        "echo 'Host key verification failed.' >&2\n"
+        "exit 255\n",
+    )
+    assert result.returncode == 1
+    assert "host-key-untrusted" in result.stderr
+    assert "ssh exit 255" in result.stderr
+    assert "ssh-keyscan" in result.stderr
+    # Regression: the old report printed only the first 20 lines, which on a
+    # -vv transcript are identity-file probes, so the real cause was invisible.
+    assert "Host key verification failed." in result.stderr
+    # The full transcript stays on disk; the host-key fingerprint parser reads it.
+    assert "identity file" in log_path.read_text(encoding="utf-8")
+
+
+def test_direct_ssh_probe_succeeds_quietly_and_locks_down_the_transcript(tmp_path):
+    result, log_path = _run_direct_ssh_probe(
+        tmp_path,
+        "#!/usr/bin/env bash\necho 'debug1: Authenticated to fixture' >&2\nexit 0\n",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ERROR:" not in result.stderr
+    assert log_path.stat().st_mode & 0o077 == 0
+
+
 def _run_live_ssh_host_key_parser(tmp_path, transcript):
     deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
     function = (


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_b0ec3816988d4ccd86b2b25eaca97fd0`
- head: `c561936a9634c29a124687c821134c4bc499f84a`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
