### PR TITLE
QUICKDEMO: first-time self-hosted hub deploy can never pass its own hub-reachability precondition (provider=none) (task_3ea880112c2b44c49cf7a4ef641a1b81)

### DIFF
--- a/QUICKDEMO.md
+++ b/QUICKDEMO.md
@@ -233,3 +233,16 @@ hgx list
 2. **Worker bootstrap (step 2)** — the wizard is interactive; a fully scripted
    run needs its answers pre-seeded.
 3. **#537 (step 6)** — must be in Hazel's build, or the pipeline stage strands.
+4. **Tailscale enrollment credential (steps 2–3)** — an unstated prerequisite of
+   the whole demo. The default `--network-provider tailscale` is the only
+   provider the deploy can *repair*: it enrolls a node by reading a fleet-scoped
+   auth key, `MAC_DEPLOY_TAILSCALE_AUTH_KEY__WATERSHIP_DOWN`, from
+   `~/.mac/.env`. Without one, `deploy/deploy-mac-fleet.sh
+   --prepare-network-prerequisites` fails with "tailscale credential source
+   MAC_DEPLOY_TAILSCALE_AUTH_KEY is unavailable", and step 3's `tailscale ip -4`
+   has no mesh IP to print — the hub URL has to come from somewhere else (an SSH
+   port-forward of `127.0.0.1:8789`, or the pod's in-cluster DNS name).
+   Deploying `--network-provider none` no longer deadlocks on the hub's own
+   unreachable endpoint, but it also gives the operator no mesh address, so
+   decide which of the two you are demoing *before* provisioning: get an auth key
+   from the tailnet admin, or plan the non-mesh hand-over for step 3.

--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -186,6 +186,16 @@ PREPARE_NETWORK_PREREQUISITES=0
 PREPARE_FUNGIBLE_ONBOARDING=0
 PREFLIGHT_ONLY=0
 QUALIFICATION_RECEIPT=""
+# Names the one node whose hub route this run is allowed to prove after the
+# deploy instead of before it: the fleet's own hub agent, on a machine that has
+# never been deployed. Empty for every other run. Set only by
+# classify_network_prerequisites, read by the phase-1 prerequisite bundle and by
+# the post-start re-proof, so the deferral is one classified decision rather than
+# an assumption repeated at each gate.
+DEFERRED_HUB_ROUTE_AGENT=""
+# Last verdict from probe_remote_first_deploy_state, so a refusal can name the
+# cause it classified instead of re-probing an already-failing node.
+LAST_FIRST_DEPLOY_STATE="unknown"
 
 if [ -n "${MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE:-}" ]; then
   [[ "$MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE" =~ ^ghcr\.io/jordanhubbard/mac-openshell-runtime@sha256:[0-9a-f]{64}$ ]] || {
@@ -5751,9 +5761,55 @@ with socket.create_connection((sys.argv[1],int(sys.argv[2])),5): pass'
     >/dev/null 2>&1
 }
 
+# Classify whether a node has ever carried a deployed revision. ``~/.mac/mac.env``
+# is this repository's existing marker of the first-deploy cycle: fleet-node-install.sh
+# is the component that writes it, which is why the typed prerequisite bundle
+# already refuses to require it (see the route-tunnel checks below).
+#
+# Fail closed. The only answer that ever relaxes a prerequisite is an explicit
+# ``fresh``; a transport failure, a non-zero exit, or any output this function
+# does not recognise classifies as ``unknown`` and is treated as "may already be
+# deployed", so an unreachable or lying node can never talk its way past a gate.
+probe_remote_first_deploy_state() {
+  local agent="$1" ssh_parts=() ssh_args=() ssh_target item last_index answer probe
+  while IFS= read -r -d '' item; do ssh_parts+=("$item"); done < <(ssh_target_args "$agent")
+  last_index=$((${#ssh_parts[@]} - 1))
+  ssh_target="${ssh_parts[$last_index]}"; ssh_args=("${ssh_parts[@]:0:$last_index}")
+  probe='if [ -e "$HOME/.mac/mac.env" ]; then echo deployed; else echo fresh; fi'
+  answer="$(ssh -n -o BatchMode=yes -o ConnectTimeout=10 \
+    "${ssh_args[@]}" "$ssh_target" "$probe" 2>/dev/null)" || {
+    printf 'unknown\n'
+    return 0
+  }
+  case "$answer" in
+    deployed) printf 'deployed\n' ;;
+    fresh) printf 'fresh\n' ;;
+    *) printf 'unknown\n' ;;
+  esac
+}
+
+# The hub endpoint is not a precondition of the hub's own first deploy -- it is
+# that deploy's product. Requiring it beforehand asks this operation to have
+# already happened, which no provider can repair (the repair action is
+# tailscale-only, and provider=none has none at all), so a fresh self-hosted hub
+# could never pass its own gate. Defer the route for exactly that node and never
+# for anything else: a worker still has to reach an already-running hub, and a
+# hub that has been deployed before still has to answer on its own endpoint.
+#
+# Publishes the classification it used in LAST_FIRST_DEPLOY_STATE so a caller can
+# name the cause in its refusal without paying for a second round trip.
+hub_route_prerequisite_is_deferrable() {
+  local agent="$1" hub_agent="$2"
+  LAST_FIRST_DEPLOY_STATE="$(probe_remote_first_deploy_state "$agent")"
+  [ -n "$hub_agent" ] && [ "$agent" = "$hub_agent" ] || return 1
+  [ "$LAST_FIRST_DEPLOY_STATE" = fresh ] || return 1
+}
+
 classify_network_prerequisites() {
-  local selected_specs_file="$1" spec fields=() agent hub_url provider install failed=0
+  local selected_specs_file="$1" hub_agent="${2:-}" spec fields=() agent hub_url
+  local provider install failed=0
   echo "==> fleet: proving selected hub routes before typed mutation"
+  DEFERRED_HUB_ROUTE_AGENT=""
   while IFS= read -r spec; do
     [ -n "$spec" ] || continue
     IFS='|' read -r -a fields <<<"$spec"
@@ -5763,14 +5819,52 @@ classify_network_prerequisites() {
       echo "==> ${agent}: hub route prerequisite ready"
       continue
     fi
-    echo "ERROR: ${agent}: hub route prerequisite is unreachable (provider=${provider}, install=${install})" >&2
+    if hub_route_prerequisite_is_deferrable "$agent" "$hub_agent"; then
+      DEFERRED_HUB_ROUTE_AGENT="$agent"
+      echo "==> ${agent}: hub route prerequisite deferred to this first hub deploy"
+      continue
+    fi
+    echo "ERROR: ${agent}: hub route prerequisite is unreachable (provider=${provider}, install=${install}, first-deploy state: ${LAST_FIRST_DEPLOY_STATE})" >&2
     failed=1
   done < "$selected_specs_file"
   if [ "$failed" = 1 ]; then
+    DEFERRED_HUB_ROUTE_AGENT=""
     echo "ERROR: run this separate network prerequisite operation before cutover:" >&2
     echo "  deploy/deploy-mac-fleet.sh --hub $(shell_quote "$HUB_SELECTOR") --prepare-network-prerequisites [agent ...]" >&2
     return 1
   fi
+}
+
+# Deferred, not deleted. The gate above let the first hub deploy proceed on the
+# promise that the deploy itself would make the hub endpoint reachable; this is
+# where that promise is collected, after the hub's service has been started and
+# committed. The wait is bounded and the verdict is fail-closed: a hub that never
+# answers on its own endpoint is a failed deploy, not a quiet success.
+reprove_deferred_hub_route() {
+  local selected_specs_file="$1" agent="$DEFERRED_HUB_ROUTE_AGENT" spec fields=()
+  local hub_url="" attempt attempts="${MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS:-6}"
+  [ -n "$agent" ] || return 0
+  while IFS= read -r spec; do
+    [ -n "$spec" ] || continue
+    IFS='|' read -r -a fields <<<"$spec"
+    [ "${fields[0]}" = "$agent" ] || continue
+    hub_url="${fields[7]:-}"
+    break
+  done < "$selected_specs_file"
+  echo "==> ${agent}: re-proving the hub route deferred by this first hub deploy"
+  attempt=1
+  while [ "$attempt" -le "$attempts" ]; do
+    if probe_remote_hub_tcp "$agent" "$hub_url"; then
+      DEFERRED_HUB_ROUTE_AGENT=""
+      echo "==> ${agent}: hub route prerequisite proved after first hub deploy"
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    [ "$attempt" -le "$attempts" ] || break
+    sleep "${MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS:-5}"
+  done
+  echo "ERROR: ${agent}: deferred hub route is still unreachable after this deploy started the hub service" >&2
+  return 1
 }
 
 prepare_remote_tailscale_prerequisite() {
@@ -5787,7 +5881,8 @@ prepare_remote_tailscale_prerequisite() {
 }
 
 prepare_network_prerequisites() {
-  local selected_specs_file="$1" spec fields=() agent hub_url supervisor fleet_name
+  local selected_specs_file="$1" hub_agent="${2:-}" spec fields=() agent hub_url
+  local supervisor fleet_name
   local provider install hostname_prefix auth_key_env credential blocked=0
   echo "==> fleet: classifying every network prerequisite before repair"
   while IFS= read -r spec; do
@@ -5797,8 +5892,15 @@ prepare_network_prerequisites() {
     fleet_name="${fields[23]:-mac}"; provider="${fields[31]:-none}"
     install="${fields[32]:-none}"; auth_key_env="${fields[34]:-MAC_DEPLOY_TAILSCALE_AUTH_KEY}"
     probe_remote_hub_tcp "$agent" "$hub_url" && continue
+    # Nothing to repair, rather than nothing that can repair it: this endpoint is
+    # what the pending first hub deploy will create, so preparation is complete
+    # for this node the moment it is classified.
+    if hub_route_prerequisite_is_deferrable "$agent" "$hub_agent"; then
+      echo "==> ${agent}: hub route needs no repair; it is created by this node's first hub deploy" >&2
+      continue
+    fi
     if [ "$provider" != tailscale ] || [[ "$install" != auto && "$install" != true && "$install" != 1 ]]; then
-      echo "ERROR: ${agent}: network preparation cannot repair provider=${provider}, install=${install}" >&2
+      echo "ERROR: ${agent}: hub route is unreachable and network preparation has no repair action for provider=${provider}, install=${install} (first-deploy state: ${LAST_FIRST_DEPLOY_STATE}; only a fleet's own hub agent on a node that has never been deployed may defer this route)" >&2
       blocked=1
       continue
     fi
@@ -5826,6 +5928,7 @@ prepare_network_prerequisites() {
     fleet_name="${fields[23]:-mac}"; hostname_prefix="${fields[33]:-}"
     auth_key_env="${fields[34]:-MAC_DEPLOY_TAILSCALE_AUTH_KEY}"
     probe_remote_hub_tcp "$agent" "$hub_url" && continue
+    hub_route_prerequisite_is_deferrable "$agent" "$hub_agent" && continue
     credential="$(fleet_scoped_env "$auth_key_env" "$fleet_name")"
     prepare_remote_tailscale_prerequisite \
       "$agent" "$fleet_name" "$supervisor" "$hostname_prefix" "$credential"
@@ -5833,7 +5936,7 @@ prepare_network_prerequisites() {
   done < "$selected_specs_file"
 
   echo "==> fleet: re-proving every selected hub route"
-  classify_network_prerequisites "$selected_specs_file"
+  classify_network_prerequisites "$selected_specs_file" "$hub_agent"
 }
 
 classify_fungible_machine_onboarding() {
@@ -6391,7 +6494,7 @@ PY
 prepare_remote_prerequisite_bundle() {
   local spec="$1" fields=() agent supervisor os_kind qdrant_url qdrant_required
   local hub_url firecrawl_url firecrawl_required webdav_url webdav_enabled openshell_required
-  local network_provider
+  local network_provider route_hub_required
   local deployment_id agent_id identity_sha remote_helper remote_root command
   local bundle expectations ssh_parts=() ssh_args=() ssh_target item last_index
   IFS='|' read -r -a fields <<<"$spec"
@@ -6407,6 +6510,15 @@ prepare_remote_prerequisite_bundle() {
   network_provider="${fields[31]:-none}"
   supervisor="${fields[14]:-auto}"
   openshell_required="${fields[53]:-0}"
+  # This bundle is proved in the phase announced as running "before hub or
+  # service mutation", so for a first hub deploy it would dial an endpoint this
+  # deploy has not created yet -- the same circularity as the network gate, one
+  # phase later. classify_network_prerequisites already classified that node, so
+  # honour its single verdict here rather than re-deciding it per node.
+  route_hub_required=1
+  if [ -n "${DEFERRED_HUB_ROUTE_AGENT:-}" ] && [ "$agent" = "$DEFERRED_HUB_ROUTE_AGENT" ]; then
+    route_hub_required=0
+  fi
   deployment_id="$(deployment_id_for_agent "$agent")"
   agent_id="$(stable_worker_agent_id "$agent")"
   identity_sha="$(node_route_identity_sha256 "$agent")"
@@ -6421,7 +6533,7 @@ prepare_remote_prerequisite_bundle() {
   ssh_target="${ssh_parts[$last_index]}"
   ssh_args=("${ssh_parts[@]:0:$last_index}")
   command="$(remote_deployment_fenced_exec "$deployment_id" 0 sh -c \
-    "set -e; umask 077; rm -rf $(shell_quote "$remote_root"); mkdir -m 0700 $(shell_quote "$remote_root"); MAC_PREREQ_AGENT=$(shell_quote "$agent") MAC_PREREQ_AGENT_ID=$(shell_quote "$agent_id") MAC_PREREQ_IDENTITY=$(shell_quote "$identity_sha") MAC_PREREQ_HELPER=$(shell_quote "$remote_helper") MAC_PREREQ_ROOT=$(shell_quote "$remote_root") MAC_PREREQ_HUB_URL=$(shell_quote "$hub_url") MAC_PREREQ_QDRANT_URL=$(shell_quote "$qdrant_url") MAC_PREREQ_QDRANT_REQUIRED=$(shell_quote "$qdrant_required") MAC_PREREQ_FIRECRAWL_URL=$(shell_quote "$firecrawl_url") MAC_PREREQ_FIRECRAWL_REQUIRED=$(shell_quote "$firecrawl_required") MAC_PREREQ_WEBDAV_URL=$(shell_quote "$webdav_url") MAC_PREREQ_WEBDAV_ENABLED=$(shell_quote "$webdav_enabled") MAC_PREREQ_OPENSHELL_REQUIRED=$(shell_quote "$openshell_required") MAC_PREREQ_SUPERVISOR=$(shell_quote "$supervisor") MAC_PREREQ_OS=$(shell_quote "$os_kind") MAC_PREREQ_NETWORK_PROVIDER=$(shell_quote "$network_provider") MAC_PREREQ_CODEGRAPH_VERSION=$(shell_quote "$MAC_REVIEWED_CODEGRAPH_VERSION") python3 -")"
+    "set -e; umask 077; rm -rf $(shell_quote "$remote_root"); mkdir -m 0700 $(shell_quote "$remote_root"); MAC_PREREQ_AGENT=$(shell_quote "$agent") MAC_PREREQ_AGENT_ID=$(shell_quote "$agent_id") MAC_PREREQ_IDENTITY=$(shell_quote "$identity_sha") MAC_PREREQ_HELPER=$(shell_quote "$remote_helper") MAC_PREREQ_ROOT=$(shell_quote "$remote_root") MAC_PREREQ_HUB_URL=$(shell_quote "$hub_url") MAC_PREREQ_ROUTE_HUB_REQUIRED=$(shell_quote "$route_hub_required") MAC_PREREQ_QDRANT_URL=$(shell_quote "$qdrant_url") MAC_PREREQ_QDRANT_REQUIRED=$(shell_quote "$qdrant_required") MAC_PREREQ_FIRECRAWL_URL=$(shell_quote "$firecrawl_url") MAC_PREREQ_FIRECRAWL_REQUIRED=$(shell_quote "$firecrawl_required") MAC_PREREQ_WEBDAV_URL=$(shell_quote "$webdav_url") MAC_PREREQ_WEBDAV_ENABLED=$(shell_quote "$webdav_enabled") MAC_PREREQ_OPENSHELL_REQUIRED=$(shell_quote "$openshell_required") MAC_PREREQ_SUPERVISOR=$(shell_quote "$supervisor") MAC_PREREQ_OS=$(shell_quote "$os_kind") MAC_PREREQ_NETWORK_PROVIDER=$(shell_quote "$network_provider") MAC_PREREQ_CODEGRAPH_VERSION=$(shell_quote "$MAC_REVIEWED_CODEGRAPH_VERSION") python3 -")"
   if ! ssh -o BatchMode=yes -o ConnectTimeout=10 \
     "${ssh_args[@]}" "$ssh_target" "$command" <<'PY'
 import hashlib
@@ -6637,8 +6749,19 @@ checks = {
     # the contract. Prove the other half of the route by dialing the selected
     # hub endpoint. Requiring mac.env here creates a first-deploy cycle because
     # fleet-node-install.sh is the component that creates that file.
+    #
+    # The controller lowers MAC_PREREQ_ROUTE_HUB_REQUIRED for exactly one node --
+    # a fleet's own hub agent on a machine that has never been deployed, whose
+    # hub endpoint this deploy is what creates. That node seals its MAC state
+    # root instead, the same way a disabled optional participant does, and the
+    # controller re-proves the real route once the hub service is running.
     "route-tunnel": [
-        service_check("route-hub", os.environ["MAC_PREREQ_HUB_URL"], True, mac_home)
+        service_check(
+            "route-hub",
+            os.environ["MAC_PREREQ_HUB_URL"],
+            os.environ["MAC_PREREQ_ROUTE_HUB_REQUIRED"],
+            mac_home,
+        )
     ],
     "openshell": openshell_checks,
     "qdrant": [service_check("qdrant", os.environ["MAC_PREREQ_QDRANT_URL"], os.environ["MAC_PREREQ_QDRANT_REQUIRED"], mac_home)],
@@ -15418,7 +15541,7 @@ PY
     # for the duration of preparation. Neither value is placed in SSH argv;
     # the resolved mesh key still crosses only on the target session's stdin.
     MAC_URL="$hub_url_field" MAC_API_TOKEN="$hub_token" \
-      prepare_network_prerequisites "$selected_specs_file"
+      prepare_network_prerequisites "$selected_specs_file" "$hub_agent"
     echo "==> network prerequisites prepared; no cohort transaction was opened"
     rm -rf "$TMPDIR_LOCAL"
     return 0
@@ -15445,7 +15568,7 @@ PY
     return 0
   fi
 
-  classify_network_prerequisites "$selected_specs_file"
+  classify_network_prerequisites "$selected_specs_file" "$hub_agent"
 
   github_review_key_b64="$(ensure_local_github_review_key)"
   if [ -z "$hub_tunnel_pubkey" ]; then
@@ -15470,6 +15593,9 @@ PY
 
   run_typed_cohort "$selected_specs_file" "$hub_agent" "$hub_token" \
     "$hub_tunnel_pubkey" "$github_review_key_b64" "$hold_adoption_plan"
+  # Collect the promise the first-deploy gate was allowed to defer, now that the
+  # hub's own service is started and committed.
+  reprove_deferred_hub_route "$selected_specs_file"
   ide_handoff_file="$(write_ide_handoff_file \
     "http://127.0.0.1:8789" "$hub_token" "$hub_agent" "$cohort_fleet_name")"
   echo "==> ${hub_agent}: hub UI access:"

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -853,10 +853,16 @@ def test_typed_route_receipt_proves_hub_reachability_without_prior_mac_env():
 
     assert 'hub_url="${fields[7]:-}"' in builder
     assert "MAC_PREREQ_HUB_URL=" in builder
-    assert (
-        'service_check("route-hub", os.environ["MAC_PREREQ_HUB_URL"], True, mac_home)'
-        in builder
-    )
+    # The route is proved by dialling the hub, never by requiring the installer's
+    # own output. Whether it is required is the controller's classified verdict
+    # (see tests/test_deploy_fleet_first_deploy_hub_route.py): every node defaults
+    # to a live proof, and only a fresh hub deploying itself defers it.
+    route_check = builder.split('"route-tunnel": [', 1)[1].split("\n    ],", 1)[0]
+    assert 'service_check(' in route_check
+    assert '"route-hub",' in route_check
+    assert 'os.environ["MAC_PREREQ_HUB_URL"]' in route_check
+    assert 'os.environ["MAC_PREREQ_ROUTE_HUB_REQUIRED"]' in route_check
+    assert "route_hub_required=1" in builder
     assert '"route-tunnel": [path_check("route-config", mac_env)]' not in builder
 
 

--- a/tests/test_deploy_fleet_first_deploy_hub_route.py
+++ b/tests/test_deploy_fleet_first_deploy_hub_route.py
@@ -1,0 +1,413 @@
+"""A fleet's own hub cannot be required to answer on its hub endpoint before the
+deploy that starts the hub service has run.
+
+The gate that used to enforce that made a first self-hosted hub deploy
+impossible: ``classify_network_prerequisites`` dialled ``http://<hub>:8789``
+as a *precondition* of the operation responsible for making it reachable, and
+``provider=none`` has no repair action, so the only advice the failure could
+offer ("run --prepare-network-prerequisites") led to the same wall.
+
+These tests pin the narrow exemption that resolves it -- hub agent, fresh node,
+route deferred and then re-proved -- and, just as importantly, pin that it stays
+narrow: a worker, a redeployed hub, and a node whose state could not be
+classified are all still refused.
+"""
+
+import os
+from pathlib import Path
+import shlex
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY_SCRIPT = ROOT / "deploy" / "deploy-mac-fleet.sh"
+
+HARNESS_FUNCTIONS = (
+    "probe_remote_first_deploy_state",
+    "hub_route_prerequisite_is_deferrable",
+    "classify_network_prerequisites",
+    "reprove_deferred_hub_route",
+    "prepare_network_prerequisites",
+)
+
+
+def deploy_text():
+    return DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+
+def extract_function(name):
+    """Slice one top-level ``name() { ... }`` block out of the deploy script."""
+    text = deploy_text()
+    opening = "\n%s() {\n" % name
+    start = text.index(opening)
+    end = text.index("\n}\n", start)
+    return text[start + 1 : end + 2]
+
+
+def spec(agent, hub_url="http://hazel.example:8789", provider="none", install="auto"):
+    fields = [""] * 56
+    fields[0] = agent
+    fields[7] = hub_url
+    fields[23] = "watership-down"
+    fields[31] = provider
+    fields[32] = install
+    fields[34] = "MAC_DEPLOY_TAILSCALE_AUTH_KEY"
+    return "|".join(fields)
+
+
+def run_harness(tmp_path, body, first_deploy_mode, *, stubs="", specs=None, env=None):
+    """Execute the real deploy-script functions against stubbed SSH and probes.
+
+    Only the transport is faked. ``probe_remote_first_deploy_state`` runs for
+    real against a fake ``ssh`` so its fail-closed classification is exercised
+    rather than described.
+    """
+    case = tmp_path / first_deploy_mode / str(abs(hash(body)) % 100000)
+    fake_bin = case / "bin"
+    fake_bin.mkdir(parents=True)
+    mode_file = case / "mode"
+    mode_file.write_text(first_deploy_mode + "\n", encoding="utf-8")
+
+    ssh = fake_bin / "ssh"
+    ssh.write_text(
+        """#!/bin/sh
+IFS= read -r mode < "$FAKE_SSH_MODE"
+case "$mode" in
+  fresh) echo fresh ;;
+  deployed) echo deployed ;;
+  garbage) echo 'maybe?' ;;
+  multiline) echo fresh; echo deployed ;;
+  empty) : ;;
+  transport) echo 'ssh: connect to host port 22: Connection refused' >&2; exit 255 ;;
+  *) echo "unhandled fake ssh mode: $mode" >&2; exit 2 ;;
+esac
+exit 0
+""",
+        encoding="utf-8",
+    )
+    ssh.chmod(0o755)
+
+    specs_file = case / "specs"
+    specs_file.write_text(
+        "".join(line + "\n" for line in (specs or [spec("hazel")])), encoding="utf-8"
+    )
+
+    script = case / "harness.sh"
+    script.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                "set -euo pipefail",
+                'PATH="%s:$PATH"' % fake_bin,
+                "HUB_SELECTOR=watership-down",
+                'DEFERRED_HUB_ROUTE_AGENT=""',
+                'LAST_FIRST_DEPLOY_STATE="unknown"',
+                'shell_quote() { printf "\'%s\'" "$1"; }',
+                # NUL-delimited, target last -- the contract the real helper honours.
+                "ssh_target_args() { printf '%s\\0' -o BatchMode=yes \"user@$1\"; }",
+                "",
+                *(extract_function(name) for name in HARNESS_FUNCTIONS),
+                "",
+                stubs,
+                "",
+                'SPECS=%s' % shlex.quote(str(specs_file)),
+                body,
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+    environment = dict(os.environ)
+    environment["FAKE_SSH_MODE"] = str(mode_file)
+    environment.update(env or {})
+    return subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env=environment,
+        cwd=str(case),
+    )
+
+
+UNREACHABLE_HUB = 'probe_remote_hub_tcp() { return 1; }'
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("fresh", "fresh"),
+        ("deployed", "deployed"),
+        # Everything that is not an unambiguous answer is "may already be
+        # deployed", never "fresh".
+        ("transport", "unknown"),
+        ("garbage", "unknown"),
+        ("multiline", "unknown"),
+        ("empty", "unknown"),
+    ],
+)
+def test_first_deploy_state_is_classified_fail_closed(tmp_path, mode, expected):
+    result = run_harness(
+        tmp_path, 'probe_remote_first_deploy_state hazel', mode
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == expected
+
+
+def test_first_deploy_marker_is_the_installer_written_mac_env():
+    probe = extract_function("probe_remote_first_deploy_state")
+
+    assert '$HOME/.mac/mac.env' in probe
+    assert "echo deployed" in probe and "echo fresh" in probe
+
+
+@pytest.mark.parametrize(
+    ("agent", "hub_agent", "mode", "deferrable"),
+    [
+        ("hazel", "hazel", "fresh", True),
+        # A worker must still reach a hub that is supposed to already be up.
+        ("fiver", "hazel", "fresh", False),
+        # A hub that has been deployed before owes a live endpoint.
+        ("hazel", "hazel", "deployed", False),
+        ("hazel", "hazel", "transport", False),
+        # No hub agent named: nothing is exempt.
+        ("hazel", "", "fresh", False),
+    ],
+)
+def test_only_a_fresh_hub_agent_may_defer_its_own_route(
+    tmp_path, agent, hub_agent, mode, deferrable
+):
+    result = run_harness(
+        tmp_path,
+        'if hub_route_prerequisite_is_deferrable %s %s; then echo defer; else echo refuse; fi'
+        % (shlex.quote(agent), shlex.quote(hub_agent)),
+        mode,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ("defer" if deferrable else "refuse")
+
+
+def test_fresh_hub_passes_its_own_unreachable_route_gate(tmp_path):
+    result = run_harness(
+        tmp_path,
+        'classify_network_prerequisites "$SPECS" hazel; echo "deferred=$DEFERRED_HUB_ROUTE_AGENT"',
+        "fresh",
+        stubs=UNREACHABLE_HUB,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "hub route prerequisite deferred to this first hub deploy" in result.stdout
+    assert "deferred=hazel" in result.stdout
+
+
+@pytest.mark.parametrize("mode", ["deployed", "transport"])
+def test_gate_still_refuses_a_hub_that_is_not_on_a_fresh_node(tmp_path, mode):
+    result = run_harness(
+        tmp_path,
+        'if classify_network_prerequisites "$SPECS" hazel; then echo passed; else'
+        ' echo "refused deferred=$DEFERRED_HUB_ROUTE_AGENT"; fi',
+        mode,
+        stubs=UNREACHABLE_HUB,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "refused deferred=" in result.stdout
+    assert "passed" not in result.stdout
+    assert "hub route prerequisite is unreachable" in result.stderr
+    assert "first-deploy state: %s" % ("deployed" if mode == "deployed" else "unknown") in result.stderr
+
+
+def test_gate_still_refuses_an_unreachable_worker_on_a_fresh_node(tmp_path):
+    result = run_harness(
+        tmp_path,
+        'if classify_network_prerequisites "$SPECS" hazel; then echo passed; else echo refused; fi',
+        "fresh",
+        stubs=UNREACHABLE_HUB,
+        specs=[spec("fiver")],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("refused")
+    assert "fiver: hub route prerequisite is unreachable" in result.stderr
+
+
+def test_one_unreachable_worker_clears_the_hub_deferral(tmp_path):
+    """A refused cohort must not leave a deferral armed for the next phase."""
+    result = run_harness(
+        tmp_path,
+        'if classify_network_prerequisites "$SPECS" hazel; then echo passed; else'
+        ' echo "refused deferred=[$DEFERRED_HUB_ROUTE_AGENT]"; fi',
+        "fresh",
+        stubs=UNREACHABLE_HUB,
+        specs=[spec("hazel"), spec("fiver")],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "refused deferred=[]" in result.stdout
+
+
+def test_reachable_route_is_never_deferred(tmp_path):
+    result = run_harness(
+        tmp_path,
+        'classify_network_prerequisites "$SPECS" hazel;'
+        ' echo "deferred=[$DEFERRED_HUB_ROUTE_AGENT]"',
+        "fresh",
+        stubs='probe_remote_hub_tcp() { return 0; }',
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "hub route prerequisite ready" in result.stdout
+    assert "deferred=[]" in result.stdout
+    assert "deferred to this first hub deploy" not in result.stdout
+
+
+def test_deferred_route_is_re_proved_after_the_hub_service_starts(tmp_path):
+    """Deferred, not deleted: the promise is collected once the hub is running."""
+    result = run_harness(
+        tmp_path,
+        'DEFERRED_HUB_ROUTE_AGENT=hazel;'
+        ' reprove_deferred_hub_route "$SPECS";'
+        ' echo "attempts=$(cat attempts)";'
+        ' echo "deferred=[$DEFERRED_HUB_ROUTE_AGENT]"',
+        "fresh",
+        stubs=(
+            'echo 0 > attempts\n'
+            'probe_remote_hub_tcp() {\n'
+            '  local n; IFS= read -r n < attempts; n=$((n + 1));\n'
+            '  printf "%s\\n" "$n" > attempts\n'
+            '  [ "$n" -ge 3 ]\n'
+            '}'
+        ),
+        env={
+            "MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS": "6",
+            "MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS": "0",
+        },
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "hub route prerequisite proved after first hub deploy" in result.stdout
+    assert "attempts=3" in result.stdout
+    assert "deferred=[]" in result.stdout
+
+
+def test_a_hub_that_never_answers_is_a_failed_deploy(tmp_path):
+    result = run_harness(
+        tmp_path,
+        'DEFERRED_HUB_ROUTE_AGENT=hazel;'
+        ' if reprove_deferred_hub_route "$SPECS"; then echo passed; else echo failed; fi',
+        "fresh",
+        stubs=UNREACHABLE_HUB,
+        env={
+            "MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS": "2",
+            "MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS": "0",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("failed")
+    assert "deferred hub route is still unreachable" in result.stderr
+
+
+def test_re_proof_is_a_no_op_when_nothing_was_deferred(tmp_path):
+    result = run_harness(
+        tmp_path,
+        'reprove_deferred_hub_route "$SPECS"; echo done',
+        "fresh",
+        stubs='probe_remote_hub_tcp() { echo "probe must not run" >&2; return 1; }',
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "done"
+    assert "probe must not run" not in result.stderr
+
+
+def test_preparation_reports_nothing_to_repair_for_a_fresh_hub(tmp_path):
+    """provider=none on a fresh hub is complete, not unrepairable."""
+    result = run_harness(
+        tmp_path,
+        'prepare_network_prerequisites "$SPECS" hazel',
+        "fresh",
+        stubs=UNREACHABLE_HUB + '\nprepare_remote_tailscale_prerequisite() { echo "must not repair" >&2; return 1; }',
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "needs no repair" in result.stderr
+    assert "cannot repair provider=" not in result.stderr
+    assert "must not repair" not in result.stderr
+
+
+def test_unrepairable_verdict_names_the_classified_cause(tmp_path):
+    result = run_harness(
+        tmp_path,
+        'if prepare_network_prerequisites "$SPECS" hazel; then echo passed; else echo blocked; fi',
+        "deployed",
+        stubs=UNREACHABLE_HUB,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().endswith("blocked")
+    assert "no repair action for provider=none, install=auto" in result.stderr
+    assert "first-deploy state: deployed" in result.stderr
+    assert "refusing every network mutation" in result.stderr
+
+
+def test_phase1_route_tunnel_check_honours_the_single_deferral_verdict():
+    """The phase-1 bundle is the same circularity one phase later.
+
+    It runs "before hub or service mutation" and dials the hub URL, so a first
+    hub deploy would fail there even after the network gate let it through. It
+    must consume the gate's verdict rather than re-deciding it.
+    """
+    deploy = deploy_text()
+    builder = deploy.split("prepare_remote_prerequisite_bundle() {", 1)[1].split(
+        "\n}\n\nprerequisite_bundle_digests", 1
+    )[0]
+
+    assert "route_hub_required=1" in builder
+    assert '[ "$agent" = "$DEFERRED_HUB_ROUTE_AGENT" ]' in builder
+    assert "route_hub_required=0" in builder
+    assert 'MAC_PREREQ_ROUTE_HUB_REQUIRED=$(shell_quote "$route_hub_required")' in builder
+    assert 'os.environ["MAC_PREREQ_ROUTE_HUB_REQUIRED"]' in builder
+    # Still a real TCP proof for every node the gate did not exempt.
+    assert 'service_check(' in builder
+    assert '"route-hub",' in builder
+    assert 'os.environ["MAC_PREREQ_HUB_URL"]' in builder
+
+
+def test_deferral_is_armed_by_the_gate_and_defaults_to_disarmed():
+    deploy = deploy_text()
+    preamble = deploy.split("\nmain() {", 1)[0]
+    classify = extract_function("classify_network_prerequisites")
+
+    assert 'DEFERRED_HUB_ROUTE_AGENT=""' in preamble
+    # The gate owns both arming and disarming.
+    assert classify.index('DEFERRED_HUB_ROUTE_AGENT=""') < classify.index(
+        'DEFERRED_HUB_ROUTE_AGENT="$agent"'
+    )
+
+
+def test_both_gates_receive_the_hub_agent_and_the_route_is_re_proved_after_cutover():
+    deploy = deploy_text()
+    main = deploy.split("\nmain() {", 1)[1]
+
+    assert 'classify_network_prerequisites "$selected_specs_file" "$hub_agent"' in main
+    assert (
+        'prepare_network_prerequisites "$selected_specs_file" "$hub_agent"' in main
+    )
+    assert main.index("run_typed_cohort ") < main.index(
+        'reprove_deferred_hub_route "$selected_specs_file"'
+    )
+
+
+def test_quickdemo_documents_the_tailscale_enrollment_credential_prerequisite():
+    quickdemo = (ROOT / "QUICKDEMO.md").read_text(encoding="utf-8")
+    gaps = quickdemo.split("## Known gaps in this script", 1)[1]
+
+    assert "MAC_DEPLOY_TAILSCALE_AUTH_KEY__WATERSHIP_DOWN" in gaps
+    assert "4. **" in gaps
+    assert "tailscale ip -4" in gaps


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_3ea880112c2b44c49cf7a4ef641a1b81`
- head: `3d36b29fb1799bc76c5e5d6c277561b21436d8f4`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
