### PR TITLE
QUICKDEMO: tailscaled can't start in gke-newhouse pods -- no /dev/net/tun, no NET_ADMIN (task_4ca2519c980f47e0a5f8bc050037475f)

### DIFF
--- a/QUICKDEMO.md
+++ b/QUICKDEMO.md
@@ -100,8 +100,38 @@ Then run `setup.sh` again per worker, answering **worker**, pointing at Hazel.
 
 ## 3. Hand over the URL and token
 
+**Check the node's network mode first.** An `hgx`-provisioned `gke-newhouse`
+pod does not get `/dev/net/tun` or `CAP_NET_ADMIN`, and Tailscale's stock data
+plane needs both: `tailscaled` fails at `CreateTUN("tailscale0")`, and every
+`iptables` call it makes is denied even though the daemon runs as root.
+`deploy/install-tailscale.sh` detects that and joins in userspace-networking
+mode instead of failing, which changes what a mesh IP means:
+
 ```bash
-hgx ssh Hazel -- tailscale ip -4          # hub URL is http://<tailscale-ip>:8789
+hgx ssh Hazel -- 'grep MAC_TAILSCALE_NETWORK_MODE ~/.mac/mac.env'
+```
+
+- `tun` — the node's tailnet address is on the host stack. Use it:
+
+  ```bash
+  hgx ssh Hazel -- tailscale ip -4        # hub URL is http://<tailscale-ip>:8789
+  ```
+
+- `userspace` — the node joined the tailnet, but its address is served by
+  tailscaled's userspace engine, not by the host stack. Inbound connections are
+  forwarded to localhost, and outbound tailnet traffic must go through the
+  proxy recorded next to it (`MAC_TAILSCALE_SOCKS5_PROXY`,
+  `MAC_TAILSCALE_HTTP_PROXY`). MAC's own HTTP clients do not read those
+  variables, so **a mesh-IP hub URL is not a working hub URL for the workers**
+  in this mode. Give the fleet a hub address the workers can reach directly
+  (the pod's own routable address, or an SSH-forwarded port), or provision the
+  nodes on a cluster/profile that grants the capability — see
+  `docs/hgx-elastic-capacity.md`, "Network capabilities on created sessions",
+  which also documents `--create-extra-arg` for requesting it at create time.
+
+Then hand over the token:
+
+```bash
 grep MAC_API_TOKEN ~/.mac/.env            # print the bearer token for the operator
 ```
 

--- a/deploy/fleet-scripts/README.md
+++ b/deploy/fleet-scripts/README.md
@@ -78,6 +78,22 @@ plane modes:
 - **headscale** — self-hosted control plane (requires `HEADSCALE_AUTH_KEY`
   and `HEADSCALE_CONTROL_URL`).
 
+It also picks a data plane mode by probing the node, because a container is
+not guaranteed the privileges the stock engine needs:
+
+- **tun** — `/dev/net/tun` exists and `CAP_NET_ADMIN` is in the capability
+  bounding set; stock behavior.
+- **userspace** — either is missing, so `tailscaled` runs
+  `--tun=userspace-networking` with a local SOCKS5/HTTP proxy instead of
+  failing at `CreateTUN`. The node's tailnet address is then reachable only
+  through that proxy, which is recorded in `mac.env` as
+  `MAC_TAILSCALE_NETWORK_MODE`, `MAC_TAILSCALE_SOCKS5_PROXY`, and
+  `MAC_TAILSCALE_HTTP_PROXY`.
+
+`TAILSCALE_NETWORK_MODE=tun|userspace` overrides the probe.
+`deploy/install-tailscale.sh --print-network-capability` classifies a node as
+`mac.node_network_capability.v1` JSON without installing or changing anything.
+
 ### install-webdav-server.sh
 
 Installs a lightweight WebDAV server that agents and operators use for

--- a/deploy/install-tailscale.sh
+++ b/deploy/install-tailscale.sh
@@ -8,6 +8,14 @@
 # In headscale mode HEADSCALE_URL and HEADSCALE_PREAUTHKEY must be set.
 # For the hub, these are written by install-headscale.sh. For workers they
 # are read from the hub's mac.env during deploy.
+#
+# It also supports two data plane modes, selected by probing the node instead
+# of by assuming a privileged host:
+#   tun       — the stock kernel TUN engine (needs /dev/net/tun + CAP_NET_ADMIN)
+#   userspace — Tailscale's userspace-networking engine, which needs neither
+#
+# Run with MAC_TAILSCALE_PROBE_ONLY=1 (or --print-network-capability) to print
+# the capability classification as JSON and exit without installing anything.
 set -euo pipefail
 
 AGENT_NAME="${AGENT:-$(hostname)}"
@@ -32,6 +40,27 @@ TAILSCALE_HOSTNAME="${TAILSCALE_HOSTNAME_PREFIX}${AGENT_NAME}"
 # All tailscale(1) client commands must point at the same socket; we compute
 # it once after detect_supervisor() so every helper reads the same value.
 TAILSCALE_SOCKET=""  # filled by compute_tailscale_socket() after supervisor detection
+
+# Data plane mode: auto (probe the node), tun, or userspace.
+TAILSCALE_NETWORK_MODE="${TAILSCALE_NETWORK_MODE:-auto}"
+# Where the userspace engine publishes its outbound proxy. Both the SOCKS5 and
+# the HTTP CONNECT listener share one address, which is what tailscaled's own
+# userspace-networking documentation does.
+TAILSCALE_USERSPACE_PROXY_HOST="${TAILSCALE_USERSPACE_PROXY_HOST:-127.0.0.1}"
+TAILSCALE_USERSPACE_PROXY_PORT="${TAILSCALE_USERSPACE_PROXY_PORT:-1055}"
+# Test/override seams for the capability probe. Production values are the
+# real paths; the tests point them at fixtures so the probe is checkable on a
+# host whose own capabilities differ from the node being modelled.
+TAILSCALE_TUN_DEVICE="${TAILSCALE_TUN_DEVICE:-/dev/net/tun}"
+TAILSCALE_PROC_STATUS="${TAILSCALE_PROC_STATUS:-/proc/self/status}"
+
+# Filled in by select_network_mode(); empty means "stock TUN behavior".
+TAILSCALED_EXTRA_FLAGS=""
+TAILSCALE_UP_EXTRA_FLAGS=""
+# MagicDNS is installed into the host resolver through the TUN interface. A
+# userspace node has no such interface, so accepting DNS there would point the
+# host resolver at a nameserver nothing can route to.
+TAILSCALE_ACCEPT_DNS="true"
 
 set_env_key() {
   local file="$1" key="$2" value="$3"
@@ -94,6 +123,129 @@ tailscale_socket_flag() {
   fi
 }
 
+# -- Node network capability probe ----------------------------------------
+#
+# tailscaled's default engine needs two things a container is not guaranteed:
+# a TUN device (/dev/net/tun, or a loadable tun module) and CAP_NET_ADMIN to
+# program netfilter. A pod created without an explicit capability request has
+# neither, and reports it twice: CreateTUN fails because /dev/net/tun does not
+# exist, and every iptables call fails with "Permission denied (you must be
+# root)" even for uid 0 — because the capability is missing from the container
+# bounding set, not from the process. Probing both up front lets such a node
+# join the mesh in userspace-networking mode instead of hard-failing.
+
+node_has_tun_device() {
+  [ -c "$TAILSCALE_TUN_DEVICE" ] && return 0
+  # tailscaled tries this itself before giving up; a node that can load the
+  # module is a TUN node.
+  if command -v modprobe >/dev/null 2>&1; then
+    sudo -n modprobe tun >/dev/null 2>&1 || true
+  fi
+  [ -c "$TAILSCALE_TUN_DEVICE" ]
+}
+
+node_has_net_admin() {
+  # The bounding set is the honest check: a root process cannot acquire a
+  # capability the container's bounding set does not contain, so an effective
+  # set can look adequate on a node that still cannot program netfilter.
+  [ -r "$TAILSCALE_PROC_STATUS" ] || return 1
+  python3 - "$TAILSCALE_PROC_STATUS" <<'PY'
+import sys
+
+CAP_NET_ADMIN = 12
+try:
+    with open(sys.argv[1], encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if line.startswith("CapBnd:"):
+                mask = int(line.split()[1], 16)
+                sys.exit(0 if (mask >> CAP_NET_ADMIN) & 1 else 1)
+except (OSError, ValueError, IndexError):
+    pass
+sys.exit(1)
+PY
+}
+
+# Classify the node and print 'tun' or 'userspace'.
+classify_network_mode() {
+  case "$TAILSCALE_NETWORK_MODE" in
+    tun|userspace) printf '%s\n' "$TAILSCALE_NETWORK_MODE"; return ;;
+    auto|"") ;;
+    *)
+      # Return rather than exit: this function is called through command
+      # substitution, where an exit would only kill the subshell and leave the
+      # caller with an empty mode.
+      echo "[tailscale] ERROR: unsupported TAILSCALE_NETWORK_MODE: $TAILSCALE_NETWORK_MODE" >&2
+      return 1
+      ;;
+  esac
+  # The /dev/net/tun + CAP_NET_ADMIN contract is Linux-specific. macOS reaches
+  # the network through utun and never needs the fallback.
+  if [ "$(uname -s)" != "Linux" ]; then
+    printf '%s\n' "tun"
+    return
+  fi
+  if node_has_tun_device && node_has_net_admin; then
+    printf '%s\n' "tun"
+  else
+    printf '%s\n' "userspace"
+  fi
+}
+
+# Emit the classification as JSON without mutating the node.
+print_network_capability() {
+  local tun="false" net_admin="false" mode
+  mode="$(classify_network_mode)" || return 1
+  node_has_tun_device && tun="true"
+  node_has_net_admin && net_admin="true"
+  printf '{"schema":"mac.node_network_capability.v1","os":"%s","tun_device":%s,"net_admin":%s,"mode":"%s"}\n' \
+    "$(uname -s)" "$tun" "$net_admin" "$mode"
+}
+
+userspace_proxy_address() {
+  printf '%s:%s\n' "$TAILSCALE_USERSPACE_PROXY_HOST" "$TAILSCALE_USERSPACE_PROXY_PORT"
+}
+
+# Resolve the data plane mode once and derive every flag that depends on it.
+select_network_mode() {
+  TAILSCALE_NETWORK_MODE="$(classify_network_mode)" || exit 1
+  if [ "$TAILSCALE_NETWORK_MODE" != "userspace" ]; then
+    return
+  fi
+  local proxy
+  proxy="$(userspace_proxy_address)"
+  TAILSCALED_EXTRA_FLAGS="--tun=userspace-networking --socks5-server=${proxy} --outbound-http-proxy-listen=${proxy}"
+  # The userspace engine never touches netfilter; saying so explicitly keeps
+  # `up` from attempting the iptables setup that this node cannot perform.
+  TAILSCALE_UP_EXTRA_FLAGS="--netfilter-mode=off"
+  TAILSCALE_ACCEPT_DNS="false"
+  echo "[tailscale] Node has no usable TUN device or CAP_NET_ADMIN; joining in userspace-networking mode"
+  echo "[tailscale] Tailnet traffic from this node must go through the local proxy at ${proxy}"
+}
+
+# Record the resolved mode so that everything reading mac.env knows whether
+# this node's tailnet address is bound to the host stack (tun) or reachable
+# only through the local proxy (userspace).
+record_network_mode_env() {
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_NETWORK_MODE "$TAILSCALE_NETWORK_MODE"
+  if [ "$TAILSCALE_NETWORK_MODE" = "userspace" ]; then
+    set_env_key "$ENV_FILE" MAC_TAILSCALE_SOCKS5_PROXY "$(userspace_proxy_address)"
+    set_env_key "$ENV_FILE" MAC_TAILSCALE_HTTP_PROXY "http://$(userspace_proxy_address)"
+  fi
+}
+
+# The Debian/RPM tailscaled unit reads flags from /etc/default/tailscaled, so
+# that is where a systemd node's userspace flags belong.
+configure_systemd_daemon_flags() {
+  local file="${TAILSCALED_DEFAULTS_FILE:-/etc/default/tailscaled}" rendered
+  rendered="$(
+    if [ -f "$file" ]; then
+      grep -v '^FLAGS=' "$file" || true
+    fi
+    printf 'FLAGS="%s"\n' "$TAILSCALED_EXTRA_FLAGS"
+  )"
+  printf '%s\n' "$rendered" | sudo -n tee "$file" >/dev/null
+}
+
 run_tailscale() {
   # supervisord owns a root-scoped fleet socket. Use non-interactive privilege
   # for every client operation in that topology so a failed `up` cannot print
@@ -147,6 +299,12 @@ wait_for_tailscale_ip() {
   return 1
 }
 
+# -- Capability probe only: classify and exit before touching the node --
+if [ "${MAC_TAILSCALE_PROBE_ONLY:-0}" = "1" ] || [ "${1:-}" = "--print-network-capability" ]; then
+  print_network_capability || exit 1
+  exit 0
+fi
+
 # -- Validate credentials --
 if [ -n "$HEADSCALE_URL" ]; then
   if [ -z "$HEADSCALE_PREAUTHKEY" ]; then
@@ -163,6 +321,11 @@ else
   exit 1
 fi
 
+# -- Resolve the data plane mode before anything reads it --
+# This runs ahead of the already-connected check so that mac.env records the
+# node's real mode on every path, not only on a fresh join.
+select_network_mode
+
 # -- Already connected? --
 # Note: TAILSCALE_SOCKET is empty at this point (set after detect_supervisor below),
 # so tailscale_connected uses the default socket path for the early idempotency check.
@@ -175,6 +338,7 @@ if tailscale_connected; then
   if [ -n "$ts_ip" ]; then
     set_env_key "$ENV_FILE" MAC_TAILSCALE_IP "$ts_ip"
     set_env_key "$ENV_FILE" MAC_TAILSCALE_HOSTNAME "$TAILSCALE_HOSTNAME"
+    record_network_mode_env
   fi
   exit 0
 fi
@@ -208,15 +372,19 @@ mkdir -p "$LOG_DIR"
 
 case "$SUPERVISOR_KIND" in
   systemd)
+    if [ -n "$TAILSCALED_EXTRA_FLAGS" ]; then
+      configure_systemd_daemon_flags
+      sudo -n systemctl daemon-reload >/dev/null 2>&1 || true
+    fi
     sudo -n systemctl enable tailscaled >/dev/null 2>&1 || true
-    sudo -n systemctl start tailscaled
+    sudo -n systemctl restart tailscaled 2>/dev/null || sudo -n systemctl start tailscaled
     ;;
   supervisord)
     conf_dir="$(supervisord_conf_dir)"
     sudo -n install -d -m 0755 "$conf_dir"
     sudo -n tee "$conf_dir/${FLEET_NAME}-tailscaled.conf" >/dev/null <<EOF
 [program:${FLEET_NAME}-tailscaled]
-command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641
+command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641 ${TAILSCALED_EXTRA_FLAGS}
 directory=/var/lib/${FLEET_NAME}/tailscale
 user=root
 autostart=true
@@ -252,23 +420,25 @@ done
 echo "[tailscale] Joining as hostname='${TAILSCALE_HOSTNAME}'"
 
 if [ "$control_mode" = "headscale" ]; then
-  # shellcheck disable=SC2046
+  # shellcheck disable=SC2046,SC2086
   run_tailscale $(tailscale_socket_flag) up \
     --login-server="$HEADSCALE_URL" \
     --auth-key="$HEADSCALE_PREAUTHKEY" \
     --hostname="$TAILSCALE_HOSTNAME" \
     --accept-routes \
-    --accept-dns=true >/dev/null 2>&1 || {
+    --accept-dns="$TAILSCALE_ACCEPT_DNS" \
+    $TAILSCALE_UP_EXTRA_FLAGS >/dev/null 2>&1 || {
       echo "[tailscale] ERROR: headscale join failed (credential-bearing output suppressed)" >&2
       exit 1
     }
 else
-  # shellcheck disable=SC2046
+  # shellcheck disable=SC2046,SC2086
   run_tailscale $(tailscale_socket_flag) up \
     --auth-key="$TAILSCALE_AUTH_KEY" \
     --hostname="$TAILSCALE_HOSTNAME" \
     --accept-routes \
-    --accept-dns=true >/dev/null 2>&1 || {
+    --accept-dns="$TAILSCALE_ACCEPT_DNS" \
+    $TAILSCALE_UP_EXTRA_FLAGS >/dev/null 2>&1 || {
       echo "[tailscale] ERROR: tailscale join failed (credential-bearing output suppressed)" >&2
       exit 1
     }
@@ -277,13 +447,26 @@ fi
 # -- Wait for Tailscale IP --
 ts_ip="$(wait_for_tailscale_ip || true)"
 if [ -z "$ts_ip" ]; then
-  echo "[tailscale] ERROR: did not get a Tailscale IP after joining" >&2
+  echo "[tailscale] ERROR: did not get a Tailscale IP after joining (mode=${TAILSCALE_NETWORK_MODE})" >&2
   # shellcheck disable=SC2046
   run_tailscale $(tailscale_socket_flag) status >&2 || true
   exit 1
 fi
 
-echo "[tailscale] Connected — hostname=${TAILSCALE_HOSTNAME} IP=${ts_ip}"
+echo "[tailscale] Connected — hostname=${TAILSCALE_HOSTNAME} IP=${ts_ip} mode=${TAILSCALE_NETWORK_MODE}"
 
 set_env_key "$ENV_FILE" MAC_TAILSCALE_IP "$ts_ip"
 set_env_key "$ENV_FILE" MAC_TAILSCALE_HOSTNAME "$TAILSCALE_HOSTNAME"
+record_network_mode_env
+
+if [ "$TAILSCALE_NETWORK_MODE" = "userspace" ]; then
+  cat >&2 <<EOF
+[tailscale] This node joined in userspace-networking mode. Its tailnet address
+[tailscale] is not bound to the host network stack, so:
+[tailscale]   - inbound tailnet connections are forwarded to localhost by tailscaled;
+[tailscale]   - outbound tailnet connections must use the proxy recorded in
+[tailscale]     ${ENV_FILE} as MAC_TAILSCALE_SOCKS5_PROXY / MAC_TAILSCALE_HTTP_PROXY;
+[tailscale]   - subnet routes and MagicDNS are not installed on this host.
+[tailscale] Grant the pod CAP_NET_ADMIN and /dev/net/tun for full TUN networking.
+EOF
+fi

--- a/docs/hgx-elastic-capacity.md
+++ b/docs/hgx-elastic-capacity.md
@@ -61,6 +61,61 @@ Before a session is reported as attested capacity, the controller:
 An SSH failure is recorded by failure class without raw provider output. A
 failed session never counts toward `min-ready`.
 
+## Network capabilities on created sessions
+
+A created session is a container, and a container only has the Linux
+capabilities its pod spec asked for. On an observed `gke-newhouse` `standard`
+pod it has neither of the two things a stock Tailscale data plane needs:
+
+- `/dev/net/tun` does not exist and `modprobe tun` cannot create it, so
+  `tstun.New("tailscale0")` fails at `CreateTUN`; and
+- `CAP_NET_ADMIN` is absent from the container's capability *bounding set*, so
+  every `iptables`/`ip6tables` call fails with `Permission denied (you must be
+  root)` even for a process already running as uid 0.
+
+MAC cannot grant a capability it was not given: whether a session gets one is
+decided by the provider's cluster and profile, and by the flags the local `hgx`
+build exposes. Two consequences follow, and they are handled separately.
+
+**Asking for the capability.** `--create-extra-arg` (repeatable) appends argv
+items to every `hgx create`, so an operator can request capabilities with the
+spelling their `hgx` build supports without MAC inventing a flag name it cannot
+verify:
+
+```console
+$ mac admin hgx capacity execute --pending-requests 1 \
+    --create-extra-arg=--cap-add --create-extra-arg NET_ADMIN
+```
+
+A value that starts with `-` needs the `=` form, or argparse reads it as the
+next option. The background autoscaler takes the same list from
+`MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS` as a whitespace-separated string. Entries
+are bounded to at most 16 flag-shaped tokens of 128 characters drawn from
+letters, digits and `-_=:,./+@`; anything else is a configuration error that
+never reaches the provider. MAC does not verify that the provider honoured the
+request — a session that comes back without the capability is still classified
+correctly by the node-side probe below.
+
+**Working without the capability.** `deploy/install-tailscale.sh` probes both
+facts before starting `tailscaled` and, when either is missing, joins the mesh
+with Tailscale's userspace-networking engine instead of failing. Run the probe
+on its own to classify a node:
+
+```console
+$ deploy/install-tailscale.sh --print-network-capability
+{"schema":"mac.node_network_capability.v1","os":"Linux","tun_device":false,"net_admin":false,"mode":"userspace"}
+```
+
+A userspace node joins the tailnet and gets an address, but that address is not
+bound to the host network stack: outbound tailnet traffic has to go through the
+local SOCKS5/HTTP proxy the daemon publishes, recorded in `mac.env` as
+`MAC_TAILSCALE_NETWORK_MODE`, `MAC_TAILSCALE_SOCKS5_PROXY`, and
+`MAC_TAILSCALE_HTTP_PROXY`. Subnet routes and MagicDNS are not installed on the
+host. Plan hub URLs accordingly: a mesh-IP hub URL is reachable from a
+userspace node only through that proxy, so a node that must reach the hub
+directly still needs a capability-bearing pod or a routable non-mesh hub
+address.
+
 ## Bounds and cooldown
 
 The desired ready count is:

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -7155,6 +7155,7 @@ def _hgx_capacity_controller(args: argparse.Namespace) -> Any:
         cooldown_seconds=args.cooldown_seconds,
         wait_timeout_seconds=args.wait_timeout_seconds,
         poll_interval_seconds=args.poll_interval_seconds,
+        create_extra_args=tuple(getattr(args, "create_extra_arg", None) or ()),
     )
     provider = HgxProvider(
         binary=args.hgx_binary,
@@ -7259,6 +7260,20 @@ def _add_hgx_capacity_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=1,
         help="maximum sessions created by one execute invocation (default: 1)",
+    )
+    parser.add_argument(
+        "--create-extra-arg",
+        action="append",
+        default=None,
+        metavar="ARG",
+        help=(
+            "extra argv item appended to every 'hgx create' (repeatable); use "
+            "it to request provider capabilities such as NET_ADMIN/TUN with the "
+            "spelling the local hgx build supports. Values starting with '-' "
+            "need the '=' form (--create-extra-arg=--cap-add). MAC does not "
+            "grant capabilities itself; a session without them still joins the "
+            "mesh in Tailscale userspace-networking mode"
+        ),
     )
     parser.add_argument("--cooldown-seconds", type=float, default=300.0)
     parser.add_argument("--wait-timeout-seconds", type=float, default=300.0)

--- a/src/mac/hgx_autoscaler.py
+++ b/src/mac/hgx_autoscaler.py
@@ -80,6 +80,11 @@ class HgxAutoscalerConfig:
     state_path: str = DEFAULT_STATE_PATH
     registered_agents_file: str = ""
     name_prefix: str = "mac-fungible"
+    # Whitespace-separated argv items appended to every ``hgx create``; the
+    # seam for requesting provider capabilities (NET_ADMIN / TUN) that MAC
+    # itself cannot grant. Invalid entries surface as a configuration_error
+    # rather than reaching the provider.
+    create_extra_args: str = ""
     configuration_error: str = ""
 
     @property
@@ -102,6 +107,7 @@ class HgxAutoscalerConfig:
             cooldown_seconds=self.cooldown_seconds,
             wait_timeout_seconds=self.wait_timeout_seconds,
             poll_interval_seconds=self.poll_interval_seconds,
+            create_extra_args=tuple(self.create_extra_args.split()),
         )
 
     @classmethod
@@ -242,6 +248,9 @@ class HgxAutoscalerConfig:
             ),
             name_prefix=env_str(
                 "MAC_HGX_AUTOSCALE_NAME_PREFIX", "mac-fungible", environ=env
+            ),
+            create_extra_args=env_str(
+                "MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS", "", environ=env
             ),
         )
         error = ""

--- a/src/mac/hgx_elastic_capacity.py
+++ b/src/mac/hgx_elastic_capacity.py
@@ -36,6 +36,8 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
+    Sequence,
+    Tuple,
 )
 
 from mac.hgx_provider import (
@@ -74,6 +76,52 @@ class _Provider(Protocol):
     def delete(self, session_id: str) -> str: ...
 
 
+_MAX_CREATE_EXTRA_ARGS = 16
+_MAX_CREATE_EXTRA_ARG_LENGTH = 128
+_CREATE_EXTRA_ARG_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "-_=:,./+@"
+)
+
+
+def _validated_create_extra_args(value: Any) -> Tuple[str, ...]:
+    """Bound operator-supplied ``hgx create`` arguments to a safe argv shape.
+
+    These are passed to the provider as separate argv items, never through a
+    shell, but they still reach an external binary: keep them to explicit,
+    bounded, flag-shaped tokens so a policy record can never smuggle a
+    whitespace-split surprise or an unreviewed payload into a create call.
+    """
+
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValidationError("create_extra_args must be a sequence of strings")
+    items: List[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValidationError("create_extra_args entries must be strings")
+        token = item.strip()
+        if not token or len(token) > _MAX_CREATE_EXTRA_ARG_LENGTH:
+            raise ValidationError(
+                "create_extra_args entries must be 1..%d characters"
+                % _MAX_CREATE_EXTRA_ARG_LENGTH
+            )
+        if any(ch not in _CREATE_EXTRA_ARG_CHARS for ch in token):
+            raise ValidationError(
+                "create_extra_args entries may only contain letters, digits, "
+                "and the characters -_=:,./+@"
+            )
+        items.append(token)
+    if len(items) > _MAX_CREATE_EXTRA_ARGS:
+        raise ValidationError(
+            "create_extra_args must contain at most %d entries" % _MAX_CREATE_EXTRA_ARGS
+        )
+    return tuple(items)
+
+
 @dataclass(frozen=True)
 class HgxCapacityPolicy:
     """Explicit bounds for one controller invocation."""
@@ -89,6 +137,15 @@ class HgxCapacityPolicy:
     cooldown_seconds: float = 300.0
     wait_timeout_seconds: float = 300.0
     poll_interval_seconds: float = 5.0
+    # Operator-supplied provider arguments appended to every ``hgx create``.
+    # MAC cannot grant a pod a Linux capability itself: whether a session gets
+    # /dev/net/tun and CAP_NET_ADMIN is decided by the provider's cluster and
+    # profile. This is the seam for asking for one, spelled the way the local
+    # hgx build spells it, without MAC inventing a flag name it cannot verify.
+    # A session that is not granted those capabilities still joins the mesh:
+    # deploy/install-tailscale.sh classifies it and falls back to Tailscale's
+    # userspace-networking engine.
+    create_extra_args: Tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         for name in ("min_ready", "max_sessions", "headroom", "max_create_per_run"):
@@ -144,6 +201,9 @@ class HgxCapacityPolicy:
             raise ValidationError("wait_timeout_seconds must be greater than zero")
         if self.poll_interval_seconds <= 0:
             raise ValidationError("poll_interval_seconds must be greater than zero")
+        object.__setattr__(
+            self, "create_extra_args", _validated_create_extra_args(self.create_extra_args)
+        )
 
     def desired_ready(self, pending_request_count: int) -> int:
         pending = _pending_count(pending_request_count)
@@ -165,6 +225,7 @@ class HgxCapacityPolicy:
             "cooldown_seconds": self.cooldown_seconds,
             "wait_timeout_seconds": self.wait_timeout_seconds,
             "poll_interval_seconds": self.poll_interval_seconds,
+            "create_extra_args": list(self.create_extra_args),
         }
 
 
@@ -666,6 +727,10 @@ class HgxElasticCapacityController:
                             "%dGi" % self.policy.memory_gib,
                             "--cpu",
                             str(self.policy.cpu_count),
+                            # Operator-supplied placement/capability arguments
+                            # come last so they cannot rewrite the bounded
+                            # resource request above.
+                            *self.policy.create_extra_args,
                         ],
                     )
                 except HgxCommandError as exc:

--- a/tests/test_hgx_autoscaler.py
+++ b/tests/test_hgx_autoscaler.py
@@ -218,3 +218,27 @@ def test_config_from_env_builds_bounded_step_policy() -> None:
     assert config.max_sessions == 7
     assert config.scale_up_stabilization_seconds == 180
     assert config.capacity_policy().max_create_per_run == 2
+
+
+def test_config_from_env_passes_capability_args_to_the_capacity_policy() -> None:
+    config = HgxAutoscalerConfig.from_env(
+        {
+            "MAC_HGX_AUTOSCALE_ENABLED": "1",
+            "MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS": "--cap-add NET_ADMIN",
+        }
+    )
+
+    assert config.active is True
+    assert config.capacity_policy().create_extra_args == ("--cap-add", "NET_ADMIN")
+
+
+def test_config_from_env_reports_invalid_capability_args_instead_of_creating() -> None:
+    config = HgxAutoscalerConfig.from_env(
+        {
+            "MAC_HGX_AUTOSCALE_ENABLED": "1",
+            "MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS": "--name=$(whoami)",
+        }
+    )
+
+    assert config.active is False
+    assert "create_extra_args" in config.configuration_error

--- a/tests/test_hgx_elastic_capacity.py
+++ b/tests/test_hgx_elastic_capacity.py
@@ -916,3 +916,96 @@ def test_cli_accepts_registered_agents_file_for_capacity_commands() -> None:
     assert parser.parse_args(
         ["admin", "hgx", "capacity", "status"]
     ).registered_agents_file is None
+
+
+def test_create_extra_args_are_appended_after_the_bounded_resource_request(
+    tmp_path: Path,
+) -> None:
+    """MAC cannot grant a pod NET_ADMIN/TUN itself; it can only ask hgx for it.
+
+    The operator supplies the flag spelling their hgx build supports, and it
+    lands *after* the bounded placement/resource arguments so it can extend the
+    request without rewriting the bounds.
+    """
+    provider = FakeProvider()
+    clock = FakeClock()
+    controller = _controller(
+        tmp_path,
+        provider,
+        clock,
+        policy=HgxCapacityPolicy(
+            min_ready=1,
+            max_sessions=1,
+            wait_timeout_seconds=10,
+            poll_interval_seconds=1,
+            create_extra_args=("--cap-add", "NET_ADMIN", "--device=/dev/net/tun"),
+        ),
+    )
+
+    controller.execute()
+
+    assert provider.created[0][2] == [
+        "--cluster",
+        "gke-newhouse",
+        "--gpu",
+        "1",
+        "--memory",
+        "64Gi",
+        "--cpu",
+        "8",
+        "--cap-add",
+        "NET_ADMIN",
+        "--device=/dev/net/tun",
+    ]
+
+
+def test_create_extra_args_default_to_nothing() -> None:
+    policy = HgxCapacityPolicy()
+
+    assert policy.create_extra_args == ()
+    assert policy.to_dict()["create_extra_args"] == []
+
+
+def test_create_extra_args_are_normalized_and_reported() -> None:
+    policy = HgxCapacityPolicy(create_extra_args=["  --cap-add ", "NET_ADMIN"])
+
+    assert policy.create_extra_args == ("--cap-add", "NET_ADMIN")
+    assert policy.to_dict()["create_extra_args"] == ["--cap-add", "NET_ADMIN"]
+
+
+def test_create_extra_args_reject_unsafe_or_unbounded_input() -> None:
+    with pytest.raises(ValidationError):
+        # A single string is a whitespace-splitting hazard, not one argv item.
+        HgxCapacityPolicy(create_extra_args="--cap-add NET_ADMIN")
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=["--cap-add NET_ADMIN"])
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=["--name=$(whoami)"])
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=[""])
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=[123])
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=["--x=%d" % index for index in range(17)])
+
+
+def test_cli_accepts_repeatable_create_extra_arg() -> None:
+    parser = build_parser()
+
+    execute = parser.parse_args(
+        [
+            "admin", "hgx",
+            "capacity",
+            "execute",
+            # A value that itself starts with '-' needs the '=' form; argparse
+            # would otherwise read it as the next option.
+            "--create-extra-arg=--cap-add",
+            "--create-extra-arg",
+            "NET_ADMIN",
+        ]
+    )
+
+    assert execute.create_extra_arg == ["--cap-add", "NET_ADMIN"]
+    assert parser.parse_args(
+        ["admin", "hgx", "capacity", "execute"]
+    ).create_extra_arg is None

--- a/tests/test_tailscale_userspace_fallback.py
+++ b/tests/test_tailscale_userspace_fallback.py
@@ -1,0 +1,373 @@
+"""Tests for the install-tailscale.sh userspace-networking fallback.
+
+Acceptance criteria (task: tailscaled cannot start in a pod without
+/dev/net/tun or CAP_NET_ADMIN):
+
+- The capability probe classifies a node from two independent facts: whether a
+  TUN character device exists and whether CAP_NET_ADMIN is in the capability
+  *bounding* set (the set a root process cannot exceed).
+- A node missing either fact classifies as 'userspace'; only a node with both
+  classifies as 'tun'.
+- Non-Linux nodes always classify as 'tun' -- macOS reaches the network through
+  utun and has no /dev/net/tun contract to fail.
+- An explicit TAILSCALE_NETWORK_MODE overrides the probe; an unknown value
+  fails loudly instead of silently picking a mode.
+- Userspace mode selects the flags that make tailscaled work without TUN or
+  netfilter: --tun=userspace-networking, a SOCKS5 + outbound HTTP proxy
+  listener, --netfilter-mode=off on `up`, and no MagicDNS takeover.
+- The resolved mode reaches both supervisors (the supervisord program command
+  line and the systemd /etc/default/tailscaled FLAGS) and is recorded in
+  mac.env so callers know a userspace node's address is reachable only through
+  its local proxy.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "deploy" / "install-tailscale.sh"
+SCRIPT = SCRIPT_PATH.read_text(encoding="utf-8")
+
+# CapBnd masks as the kernel prints them in /proc/<pid>/status.
+CAP_BND_WITH_NET_ADMIN = "000001ffffffffff"
+# Docker's default bounding set: root, but deliberately without CAP_NET_ADMIN.
+CAP_BND_WITHOUT_NET_ADMIN = "00000000a80425fb"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _extract(func: str) -> str:
+    m = re.search(r"^%s\(\) \{\n.*?^}$" % re.escape(func), SCRIPT, re.S | re.M)
+    assert m, "could not extract function %s from install-tailscale.sh" % func
+    return m.group(0)
+
+
+def _functions(*names: str) -> str:
+    return "\n\n".join(_extract(name) for name in names)
+
+
+def _run_bash(snippet: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True,
+        text=True,
+        env={**os.environ, **(env or {})},
+    )
+
+
+def _status_file(tmp_path: Path, cap_bnd: str) -> Path:
+    path = tmp_path / ("status-%s" % cap_bnd)
+    path.write_text("Name:\tbash\nCapBnd:\t%s\nCapEff:\t%s\n" % (cap_bnd, cap_bnd), encoding="utf-8")
+    return path
+
+
+def _probe(tmp_path: Path, *, tun: bool, net_admin: bool, **extra: str) -> subprocess.CompletedProcess:
+    """Run the script's probe-only path against fixture capabilities."""
+    # /dev/null is a character device, so it models "a TUN device exists"
+    # without needing a privileged host to create one.
+    device = "/dev/null" if tun else str(tmp_path / "no-such-tun")
+    cap = CAP_BND_WITH_NET_ADMIN if net_admin else CAP_BND_WITHOUT_NET_ADMIN
+    env = {
+        "MAC_TAILSCALE_PROBE_ONLY": "1",
+        "TAILSCALE_TUN_DEVICE": device,
+        "TAILSCALE_PROC_STATUS": str(_status_file(tmp_path, cap)),
+        **extra,
+    }
+    return _run_bash("bash %s" % SCRIPT_PATH, env=env)
+
+
+# ---------------------------------------------------------------------------
+# Capability probe
+# ---------------------------------------------------------------------------
+
+def test_probe_reports_tun_mode_when_device_and_capability_are_present(tmp_path):
+    result = _probe(tmp_path, tun=True, net_admin=True)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["schema"] == "mac.node_network_capability.v1"
+    assert payload["tun_device"] is True
+    assert payload["net_admin"] is True
+    assert payload["mode"] == "tun"
+
+
+def test_probe_falls_back_to_userspace_without_tun_device(tmp_path):
+    """The gke-newhouse pod case: CreateTUN fails because /dev/net/tun is absent."""
+    result = _probe(tmp_path, tun=False, net_admin=True)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["tun_device"] is False
+    assert payload["mode"] == "userspace"
+
+
+def test_probe_falls_back_to_userspace_without_net_admin(tmp_path):
+    """The other half of the same pod: iptables is denied even for uid 0.
+
+    A TUN device alone is not enough, so a node that cannot program netfilter
+    must not be sent down the stock path.
+    """
+    result = _probe(tmp_path, tun=True, net_admin=False)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["net_admin"] is False
+    assert payload["mode"] == "userspace"
+
+
+def test_probe_reads_the_bounding_set_not_the_effective_set(tmp_path):
+    """CapEff can look complete on a node that still cannot program netfilter.
+
+    tailscaled's stanza already runs as root, so the effective set is not the
+    discriminating fact; the bounding set is.
+    """
+    status = tmp_path / "root-in-restricted-container.status"
+    status.write_text(
+        "Name:\tbash\nCapBnd:\t%s\nCapEff:\t%s\n"
+        % (CAP_BND_WITHOUT_NET_ADMIN, CAP_BND_WITH_NET_ADMIN),
+        encoding="utf-8",
+    )
+    result = _run_bash(
+        "bash %s" % SCRIPT_PATH,
+        env={
+            "MAC_TAILSCALE_PROBE_ONLY": "1",
+            "TAILSCALE_TUN_DEVICE": "/dev/null",
+            "TAILSCALE_PROC_STATUS": str(status),
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["net_admin"] is False
+    assert payload["mode"] == "userspace"
+
+
+def test_probe_needs_no_credentials(tmp_path):
+    """Classification must not require an auth key: it is a read-only probe."""
+    result = _probe(
+        tmp_path,
+        tun=False,
+        net_admin=False,
+        MAC_DEPLOY_TAILSCALE_AUTH_KEY="",
+        HEADSCALE_URL="",
+        HEADSCALE_PREAUTHKEY="",
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["mode"] == "userspace"
+
+
+def test_probe_flag_form_matches_env_form(tmp_path):
+    env = {
+        "TAILSCALE_TUN_DEVICE": str(tmp_path / "absent"),
+        "TAILSCALE_PROC_STATUS": str(_status_file(tmp_path, CAP_BND_WITHOUT_NET_ADMIN)),
+    }
+    flagged = _run_bash("bash %s --print-network-capability" % SCRIPT_PATH, env=env)
+    assert flagged.returncode == 0, flagged.stderr
+    assert json.loads(flagged.stdout)["mode"] == "userspace"
+
+
+def test_explicit_mode_overrides_the_probe(tmp_path):
+    result = _probe(tmp_path, tun=False, net_admin=False, TAILSCALE_NETWORK_MODE="tun")
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["mode"] == "tun"
+
+
+def test_unknown_mode_fails_loudly(tmp_path):
+    result = _probe(tmp_path, tun=True, net_admin=True, TAILSCALE_NETWORK_MODE="bogus")
+    assert result.returncode != 0
+    assert "unsupported TAILSCALE_NETWORK_MODE" in result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_non_linux_nodes_keep_the_tun_path(tmp_path):
+    """macOS has no /dev/net/tun and never needs (or supports) this fallback."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uname = fake_bin / "uname"
+    uname.write_text("#!/bin/sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
+    uname.chmod(0o755)
+    result = _probe(
+        tmp_path,
+        tun=False,
+        net_admin=False,
+        PATH="%s:%s" % (fake_bin, os.environ["PATH"]),
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["mode"] == "tun"
+
+
+# ---------------------------------------------------------------------------
+# Mode selection: the flags that make a TUN-less node work
+# ---------------------------------------------------------------------------
+
+def _select_mode_snippet(mode: str) -> str:
+    return r"""
+TAILSCALE_NETWORK_MODE=%(mode)s
+TAILSCALE_USERSPACE_PROXY_HOST=127.0.0.1
+TAILSCALE_USERSPACE_PROXY_PORT=1055
+TAILSCALED_EXTRA_FLAGS=""
+TAILSCALE_UP_EXTRA_FLAGS=""
+TAILSCALE_ACCEPT_DNS="true"
+
+%(functions)s
+
+select_network_mode >/dev/null
+printf 'mode=%%s\n' "$TAILSCALE_NETWORK_MODE"
+printf 'daemon=%%s\n' "$TAILSCALED_EXTRA_FLAGS"
+printf 'up=%%s\n' "$TAILSCALE_UP_EXTRA_FLAGS"
+printf 'dns=%%s\n' "$TAILSCALE_ACCEPT_DNS"
+""" % {
+        "mode": mode,
+        "functions": _functions(
+            "classify_network_mode",
+            "userspace_proxy_address",
+            "select_network_mode",
+        ),
+    }
+
+
+def _selected(mode: str) -> dict:
+    result = _run_bash(_select_mode_snippet(mode))
+    assert result.returncode == 0, result.stderr
+    return dict(line.split("=", 1) for line in result.stdout.strip().splitlines())
+
+
+def test_userspace_mode_selects_the_userspace_engine_and_proxy():
+    selected = _selected("userspace")
+    assert selected["mode"] == "userspace"
+    assert "--tun=userspace-networking" in selected["daemon"]
+    assert "--socks5-server=127.0.0.1:1055" in selected["daemon"]
+    assert "--outbound-http-proxy-listen=127.0.0.1:1055" in selected["daemon"]
+
+
+def test_userspace_mode_disables_netfilter_and_magicdns():
+    selected = _selected("userspace")
+    assert selected["up"] == "--netfilter-mode=off"
+    # There is no TUN interface to route MagicDNS answers through, so taking
+    # over the host resolver would break name resolution rather than extend it.
+    assert selected["dns"] == "false"
+
+
+def test_tun_mode_changes_nothing():
+    selected = _selected("tun")
+    assert selected["mode"] == "tun"
+    assert selected["daemon"] == ""
+    assert selected["up"] == ""
+    assert selected["dns"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# The resolved mode must reach the daemon under both supervisors
+# ---------------------------------------------------------------------------
+
+def test_supervisord_program_command_carries_the_daemon_flags():
+    stanza = SCRIPT.split("[program:${FLEET_NAME}-tailscaled]", 1)[1]
+    command = next(
+        line for line in stanza.splitlines() if line.startswith("command=")
+    )
+    assert "${TAILSCALED_EXTRA_FLAGS}" in command
+
+
+def test_systemd_flags_file_replaces_only_the_flags_line(tmp_path):
+    defaults = tmp_path / "tailscaled"
+    defaults.write_text('PORT="41641"\nFLAGS="--stale"\n', encoding="utf-8")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    sudo = fake_bin / "sudo"
+    # The real call is `sudo -n tee`; this stand-in drops the -n and execs so
+    # the rendering can be checked without privilege.
+    sudo.write_text('#!/bin/sh\n[ "$1" = "-n" ] && shift\nexec "$@"\n', encoding="utf-8")
+    sudo.chmod(0o755)
+    snippet = r"""
+TAILSCALED_EXTRA_FLAGS="--tun=userspace-networking --socks5-server=127.0.0.1:1055"
+TAILSCALED_DEFAULTS_FILE=%(file)s
+
+%(functions)s
+
+configure_systemd_daemon_flags
+""" % {"file": defaults, "functions": _functions("configure_systemd_daemon_flags")}
+    result = _run_bash(snippet, env={"PATH": "%s:%s" % (fake_bin, os.environ["PATH"])})
+    assert result.returncode == 0, result.stderr
+    rendered = defaults.read_text(encoding="utf-8")
+    assert 'PORT="41641"' in rendered
+    assert "--stale" not in rendered
+    assert rendered.count("FLAGS=") == 1
+    assert '--tun=userspace-networking' in rendered
+
+
+def test_systemd_branch_writes_flags_before_starting_the_daemon():
+    branch = SCRIPT.split("  systemd)", 1)[1].split(";;", 1)[0]
+    assert "configure_systemd_daemon_flags" in branch
+    assert branch.index("configure_systemd_daemon_flags") < branch.index("systemctl start")
+    # A daemon already running with stock flags must be restarted, or the
+    # userspace flags never take effect on a re-run.
+    assert "systemctl restart tailscaled" in branch
+
+
+def test_up_calls_carry_the_mode_dependent_flags():
+    up_calls = [
+        block
+        for block in SCRIPT.split("run_tailscale $(tailscale_socket_flag) up")[1:]
+    ]
+    assert len(up_calls) == 2, "expected the headscale and cloud join branches"
+    for call in up_calls:
+        command = call.split("}", 1)[0]
+        assert '--accept-dns="$TAILSCALE_ACCEPT_DNS"' in command
+        assert "$TAILSCALE_UP_EXTRA_FLAGS" in command
+
+
+# ---------------------------------------------------------------------------
+# mac.env must record what a userspace node's address actually means
+# ---------------------------------------------------------------------------
+
+def _record_env(tmp_path: Path, mode: str) -> str:
+    env_file = tmp_path / ("mac-%s.env" % mode)
+    snippet = r"""
+ENV_FILE=%(env_file)s
+TAILSCALE_NETWORK_MODE=%(mode)s
+TAILSCALE_USERSPACE_PROXY_HOST=127.0.0.1
+TAILSCALE_USERSPACE_PROXY_PORT=1055
+
+%(functions)s
+
+record_network_mode_env
+""" % {
+        "env_file": env_file,
+        "mode": mode,
+        "functions": _functions(
+            "set_env_key", "userspace_proxy_address", "record_network_mode_env"
+        ),
+    }
+    result = _run_bash(snippet)
+    assert result.returncode == 0, result.stderr
+    return env_file.read_text(encoding="utf-8")
+
+
+def test_userspace_mode_records_mode_and_proxy_in_mac_env(tmp_path):
+    rendered = _record_env(tmp_path, "userspace")
+    assert "MAC_TAILSCALE_NETWORK_MODE=userspace" in rendered
+    assert "MAC_TAILSCALE_SOCKS5_PROXY=127.0.0.1:1055" in rendered
+    assert "MAC_TAILSCALE_HTTP_PROXY=http://127.0.0.1:1055" in rendered
+
+
+def test_tun_mode_records_the_mode_without_proxy_keys(tmp_path):
+    rendered = _record_env(tmp_path, "tun")
+    assert "MAC_TAILSCALE_NETWORK_MODE=tun" in rendered
+    assert "PROXY" not in rendered
+
+
+def test_mode_is_recorded_on_the_already_connected_path():
+    """A node that is already up must still publish its mode."""
+    block = SCRIPT.split("if tailscale_connected; then", 1)[1].split("\nfi\n", 1)[0]
+    assert "record_network_mode_env" in block
+    # Classification has to happen before that check, or the recorded mode
+    # would be whatever the default was.
+    assert SCRIPT.index("select_network_mode\n") < SCRIPT.index("if tailscale_connected; then")
+
+
+def test_userspace_join_explains_the_reachability_consequence():
+    assert "userspace-networking mode" in SCRIPT
+    assert "MAC_TAILSCALE_SOCKS5_PROXY" in SCRIPT
+    assert "CAP_NET_ADMIN" in SCRIPT


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_4ca2519c980f47e0a5f8bc050037475f`
- head: `024f876c1faf53fbac7031207011af9db9d613b1`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
