### PR TITLE
Fleet feature idea: hub generates its own SSH key and self-registers to worker authorized_keys for independent repair (task_4f0230b992914feb8e9e1e1e200a5472)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -8466,6 +8466,7 @@ PY
   # it has reconciled the post manifest.
   add_remote_env MAC_DEPLOY_DEFER_AGENT_RESTART 1
   add_remote_env MAC_DEPLOY_HUB_TUNNEL_PUBKEY "$hub_tunnel_pubkey"
+  add_remote_env MAC_DEPLOY_HUB_REPAIR_PUBKEY "${MAC_DEPLOY_HUB_REPAIR_PUBKEY:-}"
   add_remote_env MAC_DEPLOY_ALLOW_DEGRADED_SERVICES "${allow_degraded_services:-0}"
   add_remote_env MAC_DEPLOY_DIRECT_HUB "${direct_mesh_hub_flag:-0}"
   add_remote_secret_env MAC_DEPLOY_GITHUB_REVIEW_KEY_B64 "$github_review_key_b64"
@@ -8799,6 +8800,22 @@ read_hub_tunnel_pubkey() {
   ssh_args=("${ssh_parts[@]:0:$last_index}")
   ssh -n -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=30 -o ServerAliveCountMax=6 "${ssh_args[@]}" "$ssh_target" \
     "cat \"\$HOME/.ssh/mac_tunnel_id.pub\" 2>/dev/null || true"
+}
+
+# hubrepair-01: read the hub's own repair public key so each worker can
+# authorize it (restricted to a forced command) during its bootstrap. Read-only
+# on purpose -- the hub generates this key during its own deploy, so a fleet
+# whose hub predates that revision simply reports nothing here and keeps
+# today's behavior instead of failing the whole cohort.
+read_hub_repair_pubkey() {
+  local hub_agent ssh_parts=() ssh_args=() ssh_target item last_index
+  hub_agent="$(fleet_hub_agent)"
+  while IFS= read -r -d '' item; do ssh_parts+=("$item"); done < <(ssh_target_args "$hub_agent")
+  last_index=$((${#ssh_parts[@]} - 1))
+  ssh_target="${ssh_parts[$last_index]}"
+  ssh_args=("${ssh_parts[@]:0:$last_index}")
+  ssh -n -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=30 -o ServerAliveCountMax=6 "${ssh_args[@]}" "$ssh_target" \
+    "cat \"\${MAC_HOME:-\$HOME/.mac}/keys/mac-hub-repair-id.pub\" 2>/dev/null || true"
 }
 
 ensure_local_github_review_key() {
@@ -15450,6 +15467,12 @@ PY
   github_review_key_b64="$(ensure_local_github_review_key)"
   if [ -z "$hub_tunnel_pubkey" ]; then
     hub_tunnel_pubkey="$(read_hub_tunnel_pubkey 2>/dev/null || true)"
+  fi
+  # hubrepair-01: resolve the hub's repair public key once per cohort so every
+  # worker in it authorizes the same hub identity in the same deploy.
+  if [ -z "${MAC_DEPLOY_HUB_REPAIR_PUBKEY:-}" ]; then
+    MAC_DEPLOY_HUB_REPAIR_PUBKEY="$(read_hub_repair_pubkey 2>/dev/null || true)"
+    export MAC_DEPLOY_HUB_REPAIR_PUBKEY
   fi
   if [ -z "$hub_token" ]; then
     hub_token="$(read_hub_token)"

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -356,6 +356,7 @@ HEADSCALE_DNS="${MAC_DEPLOY_HEADSCALE_DNS:-magicdns}"
 HEADSCALE_IP_PREFIX="${MAC_DEPLOY_HEADSCALE_IP_PREFIX:-100.64.0.0/10}"
 QDRANT_DATA_DIR_CONFIGURED="${MAC_DEPLOY_QDRANT_DATA_DIR:-}"
 HUB_TUNNEL_PUBKEY="${MAC_DEPLOY_HUB_TUNNEL_PUBKEY:-}"
+HUB_REPAIR_PUBKEY="${MAC_DEPLOY_HUB_REPAIR_PUBKEY:-}"
 GITHUB_REVIEW_KEY_B64="${MAC_DEPLOY_GITHUB_REVIEW_KEY_B64:-}"
 MAC_DEPLOY_TARGET="${MAC_DEPLOY_TARGET:-}"
 DRAIN_MODE="${MAC_DEPLOY_DRAIN_MODE:-wait}"
@@ -676,7 +677,7 @@ PY="$(python_bin)"
 PYTHON_BIN="$PY"
 HERMES_PY="$(hermes_python_bin "$PY")"
 SUPERVISOR_KIND=""
-export AGENT FLEET_NAME OS_KIND DEPLOY_TS DEPLOY_REV DEPLOY_GENERATION DEPLOY_GIT_URL DEPLOY_GIT_BRANCH DEPLOY_STARTED_ISO HERMES_SLACK_HOME_CHANNEL_NAME HERMES_GATEWAY_MODEL HERMES_GATEWAY_PROVIDER HERMES_GATEWAY_BASE_URL MAC_CHAT_GATEWAY_IMPL HERMES_SURFACE_B64 OPENCLAW_PUBLIC_IDENTITY OPENCLAW_REPRESENTED_BY OPENCLAW_REPRESENTATION_MODE OPENCLAW_SLACK_ACCOUNT_ID OPENCLAW_TELEGRAM_ACCOUNT_ID HUB_URL HUB_TUNNEL_PUBKEY CONTROL_BIND_HOST WORKER_MODE WORKER_CAPABILITIES WORKER_ALLOWED_PROJECTS WORKER_REQUIRED_METADATA WORKER_CLAIM_ONLY_CANARY_TASKS SUPERVISOR_REQUESTED SUPERVISOR_KIND SHARED_SERVICES_MANAGER_AGENT QDRANT_URL_CONFIGURED QDRANT_INSTALL QDRANT_REQUIRE QDRANT_BIND_ADDR_CONFIGURED QDRANT_PORT_CONFIGURED QDRANT_IMAGE_CONFIGURED QDRANT_MEMORY_LIMIT_CONFIGURED QDRANT_DATA_DIR_CONFIGURED FIRECRAWL_URL_CONFIGURED FIRECRAWL_INSTALL FIRECRAWL_REQUIRE FIRECRAWL_BIND_ADDR_CONFIGURED FIRECRAWL_PORT_CONFIGURED WEBDAV_ENABLED WEBDAV_URL_CONFIGURED WEBDAV_INSTALL WEBDAV_BIND_ADDR_CONFIGURED WEBDAV_PORT_CONFIGURED WEBDAV_ROOT_CONFIGURED WEBDAV_PUBLIC_PATH_CONFIGURED WEBDAV_MAX_UPLOAD_BYTES_CONFIGURED DRAIN_MODE DRAIN_TIMEOUT_SECONDS DRAIN_POLL_SECONDS CONFIGURED_AGENT_IDS OPENSHELL_DEPLOY_ENABLED OPENSHELL_EFFECTIVE_ARGS OPENSHELL_RUNTIME_IMAGE OPENSHELL_LOCAL_IMAGE_BUILD MAC_HOME MAC_PORT MAC_SERVICE_NAME HERMES_SERVICE_NAME OPENCLAW_SERVICE_NAME NEMOCLAW_SERVICE_NAME MAC_AGENT_SERVICE_NAME MAC_LAUNCHD_LABEL HERMES_LAUNCHD_LABEL OPENCLAW_LAUNCHD_LABEL NEMOCLAW_LAUNCHD_LABEL MAC_AGENT_LAUNCHD_LABEL MAC_SUPERVISORD_PROG HERMES_SUPERVISORD_PROG OPENCLAW_SUPERVISORD_PROG NEMOCLAW_SUPERVISORD_PROG AGENT_SUPERVISORD_PROG MAC_SUPERVISORD_CONF_NAME SRC_DIR VENV HERMES_DIR ENV_FILE LOG_DIR DEPLOY_LOG PY HERMES_PY PYTHON_BIN NODE_ACTION RECOVERY_POLICY NODE_IDENTITY_SHA256 PREREQUISITE_SUMMARY PREREQUISITE_BUNDLE_SHA256 PREREQUISITE_EXPECTATIONS_SHA256
+export AGENT FLEET_NAME OS_KIND DEPLOY_TS DEPLOY_REV DEPLOY_GENERATION DEPLOY_GIT_URL DEPLOY_GIT_BRANCH DEPLOY_STARTED_ISO HERMES_SLACK_HOME_CHANNEL_NAME HERMES_GATEWAY_MODEL HERMES_GATEWAY_PROVIDER HERMES_GATEWAY_BASE_URL MAC_CHAT_GATEWAY_IMPL HERMES_SURFACE_B64 OPENCLAW_PUBLIC_IDENTITY OPENCLAW_REPRESENTED_BY OPENCLAW_REPRESENTATION_MODE OPENCLAW_SLACK_ACCOUNT_ID OPENCLAW_TELEGRAM_ACCOUNT_ID HUB_URL HUB_TUNNEL_PUBKEY HUB_REPAIR_PUBKEY CONTROL_BIND_HOST WORKER_MODE WORKER_CAPABILITIES WORKER_ALLOWED_PROJECTS WORKER_REQUIRED_METADATA WORKER_CLAIM_ONLY_CANARY_TASKS SUPERVISOR_REQUESTED SUPERVISOR_KIND SHARED_SERVICES_MANAGER_AGENT QDRANT_URL_CONFIGURED QDRANT_INSTALL QDRANT_REQUIRE QDRANT_BIND_ADDR_CONFIGURED QDRANT_PORT_CONFIGURED QDRANT_IMAGE_CONFIGURED QDRANT_MEMORY_LIMIT_CONFIGURED QDRANT_DATA_DIR_CONFIGURED FIRECRAWL_URL_CONFIGURED FIRECRAWL_INSTALL FIRECRAWL_REQUIRE FIRECRAWL_BIND_ADDR_CONFIGURED FIRECRAWL_PORT_CONFIGURED WEBDAV_ENABLED WEBDAV_URL_CONFIGURED WEBDAV_INSTALL WEBDAV_BIND_ADDR_CONFIGURED WEBDAV_PORT_CONFIGURED WEBDAV_ROOT_CONFIGURED WEBDAV_PUBLIC_PATH_CONFIGURED WEBDAV_MAX_UPLOAD_BYTES_CONFIGURED DRAIN_MODE DRAIN_TIMEOUT_SECONDS DRAIN_POLL_SECONDS CONFIGURED_AGENT_IDS OPENSHELL_DEPLOY_ENABLED OPENSHELL_EFFECTIVE_ARGS OPENSHELL_RUNTIME_IMAGE OPENSHELL_LOCAL_IMAGE_BUILD MAC_HOME MAC_PORT MAC_SERVICE_NAME HERMES_SERVICE_NAME OPENCLAW_SERVICE_NAME NEMOCLAW_SERVICE_NAME MAC_AGENT_SERVICE_NAME MAC_LAUNCHD_LABEL HERMES_LAUNCHD_LABEL OPENCLAW_LAUNCHD_LABEL NEMOCLAW_LAUNCHD_LABEL MAC_AGENT_LAUNCHD_LABEL MAC_SUPERVISORD_PROG HERMES_SUPERVISORD_PROG OPENCLAW_SUPERVISORD_PROG NEMOCLAW_SUPERVISORD_PROG AGENT_SUPERVISORD_PROG MAC_SUPERVISORD_CONF_NAME SRC_DIR VENV HERMES_DIR ENV_FILE LOG_DIR DEPLOY_LOG PY HERMES_PY PYTHON_BIN NODE_ACTION RECOVERY_POLICY NODE_IDENTITY_SHA256 PREREQUISITE_SUMMARY PREREQUISITE_BUNDLE_SHA256 PREREQUISITE_EXPECTATIONS_SHA256
 
 disk_hygiene_report() {
   local stage="$1" path="$2"
@@ -1060,6 +1061,79 @@ install_hub_tunnel_pubkey() {
     log "adding hub tunnel public key to authorized_keys"
     printf '%s\n' "$HUB_TUNNEL_PUBKEY" >> "$auth_keys"
   fi
+}
+
+# hubrepair-01: the tunnel key above is not a repair path. It moves forwarded
+# ports, and every route that can actually FIX a worker still belongs to the
+# human who provisioned it -- their key, their laptop, their continued access.
+# A hub that talks to a wedged worker over HTTP all day still cannot restart its
+# supervisor once that operator is gone, rotated, or replaced. So the hub owns a
+# second keypair of its own, and every worker authorizes it during bootstrap
+# ALONGSIDE the provisioner's key, never instead of it.
+#
+# The private half lives under $MAC_HOME (node state a deploy preserves and
+# never packs into a release archive), not in the source tree a deploy replaces.
+# It is created if absent and NOT rotated per deploy: a key that rotates every
+# deploy is stale on exactly the workers that missed that deploy, which is the
+# population you need to reach. Rotation stays safe because the authorized_keys
+# merge below replaces the previous hub entry rather than appending beside it.
+ensure_hub_repair_key() {
+  local key_dir="$MAC_HOME/keys"
+  local key_file="$key_dir/mac-hub-repair-id"
+  mkdir -p "$key_dir"
+  chmod 700 "$key_dir"
+  if [ ! -f "$key_file" ]; then
+    log "generating hub repair keypair at $key_file"
+    ssh-keygen -t ed25519 -f "$key_file" -N "" -C "mac-hub-repair" -q
+  fi
+  chmod 600 "$key_file"
+  log "hub repair public key: $(cat "${key_file}.pub")"
+}
+
+# Authorize the hub's repair key on this worker with `restrict,command=`, so the
+# key can only run the generated shim and its closed verb set -- never a shell.
+# mac.hub_repair_key renders both the shim and the authorized_keys entry, so the
+# grammar the node enforces and the grammar the hub validates against cannot
+# drift; the shim it writes is dependency-free POSIX sh, because the repair path
+# has to outlive the venv it exists to repair.
+install_hub_repair_access() {
+  [ -n "$HUB_REPAIR_PUBKEY" ] || return 0
+  local -a services=()
+  case "$SUPERVISOR_KIND" in
+    systemd)
+      services=(
+        --service "mac=$MAC_SERVICE_NAME"
+        --service "hermes=$HERMES_SERVICE_NAME"
+        --service "agent=$MAC_AGENT_SERVICE_NAME"
+      )
+      ;;
+    launchd)
+      services=(
+        --service "mac=$MAC_LAUNCHD_LABEL"
+        --service "hermes=$HERMES_LAUNCHD_LABEL"
+        --service "agent=$MAC_AGENT_LAUNCHD_LABEL"
+      )
+      ;;
+    supervisord)
+      services=(
+        --service "mac=$MAC_SUPERVISORD_PROG"
+        --service "hermes=$HERMES_SUPERVISORD_PROG"
+        --service "agent=$AGENT_SUPERVISORD_PROG"
+      )
+      ;;
+    *)
+      die "cannot authorize the hub repair key for supervisor '${SUPERVISOR_KIND:-unset}'"
+      ;;
+  esac
+  log "authorizing hub repair key (restrict + forced command) for $SUPERVISOR_KIND"
+  "${PY:-python3}" -m mac.hub_repair_key install \
+    --supervisor "$SUPERVISOR_KIND" \
+    --agent "$AGENT" \
+    "${services[@]}" \
+    --public-key "$HUB_REPAIR_PUBKEY" \
+    --shim "$MAC_HOME/bin/mac-hub-repair" \
+    --authorized-keys "$HOME/.ssh/authorized_keys" \
+    || die "could not authorize the hub repair key"
 }
 
 # gketun-02: a spoke reaches the hub control plane (127.0.0.1:18789) and the
@@ -10787,11 +10861,15 @@ if [ "$NODE_ACTION" = legacy-one-shot ]; then
   # `ssh -R` reverse tunnel can connect. Decide by role, not worker mode.
   if [ "$AGENT" = "$SHARED_SERVICES_MANAGER_AGENT" ]; then
     ensure_hub_tunnel_key
+    # hubrepair-01: the hub owns the repair keypair; deploying the hub is what
+    # brings it into existence, and the next worker deploy authorizes it.
+    ensure_hub_repair_key
   else
     if [ "$WORKER_MODE" = "loop" ]; then
       ensure_hub_tunnel_key
     fi
     install_hub_tunnel_pubkey
+    install_hub_repair_access
     wait_for_hub_reverse_tunnel
   fi
   install_or_validate_shared_services

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -252,6 +252,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_HERMES_SURFACE_B64` | str | consumer-defined | deployment | Deployment setting: deploy hermes surface b64. |
 | `MAC_DEPLOY_HOLD_ADOPTIONS_FILE` | str | consumer-defined | deployment | Deployment setting: deploy hold adoptions file. |
 | `MAC_DEPLOY_HUB_AGENT` | str | consumer-defined | deployment | Deployment setting: deploy hub agent. |
+| `MAC_DEPLOY_HUB_REPAIR_PUBKEY` | str | consumer-defined | deployment | Deployment setting: deploy hub repair pubkey. |
 | `MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub tick interval seconds. |
 | `MAC_DEPLOY_HUB_TOKEN` | str | consumer-defined | deployment | Deployment setting: deploy hub token. |
 | `MAC_DEPLOY_HUB_TUNNEL_PUBKEY` | str | consumer-defined | deployment | Deployment setting: deploy hub tunnel pubkey. |
@@ -513,6 +514,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HUB_MAX_CONCURRENT_TASKS` | str | consumer-defined | hub | Hub setting: hub max concurrent tasks. |
 | `MAC_HUB_MAX_TEST_JOBS` | str | consumer-defined | hub | Hub setting: hub max test jobs. |
 | `MAC_HUB_MIN_TEST_JOBS` | str | consumer-defined | hub | Hub setting: hub min test jobs. |
+| `MAC_HUB_REPAIR_KEY` | str | consumer-defined | hub | Hub setting: hub repair key. |
 | `MAC_HUB_REVIEWER_AGENT_ID` | str | consumer-defined | hub | Hub setting: hub reviewer agent id. |
 | `MAC_HUB_REVIEWER_AGENT_NAME` | str | consumer-defined | hub | Hub setting: hub reviewer agent name. |
 | `MAC_HUB_REVIEWER_AUTO_REGISTER` | bool | consumer-defined | hub | Hub setting: hub reviewer auto register. |

--- a/docs/hub-repair-key.md
+++ b/docs/hub-repair-key.md
@@ -1,0 +1,177 @@
+# Hub repair key
+
+The hub generates an SSH keypair of its own and every worker authorizes it
+during bootstrap, so a wedged worker stays reachable when the operator who
+provisioned it is not.
+
+## The gap this closes
+
+A bootstrapped fleet has two kinds of hub-to-worker connectivity, and neither
+one can repair anything:
+
+* **The control plane.** The hub and the worker talk continuously over HTTP.
+  That link carries tasks, leases, and heartbeats. It runs *inside* the agent,
+  so when the agent is the thing that is wedged, the link is exactly as wedged.
+* **The reverse tunnel.** The hub already owns `~/.ssh/mac_tunnel_id` and
+  spokes already authorize it (`install_hub_tunnel_pubkey` in
+  `deploy/fleet-node-install.sh`). But that key exists to move forwarded ports —
+  the hub uses it as `ssh -N -R …` and never runs a command with it.
+
+Everything that can actually fix a node — restart a supervisor, look at a
+deploy log, find out which revision is deployed — went through the person who
+provisioned it, over their point-to-point SSH access. That is a single point of
+failure with a human in it: rotated or expired credentials, a laptop that is
+offline, a different operator running the fleet six months later.
+
+The hub therefore gets a key of its own. It is added **alongside** the
+provisioner's key in each worker's `authorized_keys`, never instead of it; the
+operator path is unchanged and remains the way to do anything outside the repair
+verb set.
+
+## What the key may do
+
+Not open a shell. The worker's entry looks like this:
+
+```text
+restrict,command="/home/mac/.mac/bin/mac-hub-repair" ssh-ed25519 AAAA… mac-hub-repair
+```
+
+`restrict` withdraws pty allocation, agent forwarding, port forwarding, X11 and
+user rc in one option, so the entry cannot be accidentally widened later by
+forgetting a new `no-*` flag when OpenSSH grows a new capability. The forced
+`command=` then narrows the single remaining capability to a generated shim,
+which accepts one verb from a closed allowlist and refuses everything else —
+including an empty request, which is what an attempt at an interactive shell
+looks like from the far side.
+
+| Verb | Arguments | What it does |
+| --- | --- | --- |
+| `status` | — | agent, host, supervisor, deployed revision, service states |
+| `services` | — | supervisor state of each mac-managed service |
+| `restart` | `<service>` | restart one allowlisted service (`mac`, `hermes`, `agent`) |
+| `logs` | — | list the log files available under `~/.mac/logs` |
+| `tail` | `<log> [lines]` | tail one of those files, bounded to 500 lines |
+| `deploy-info` | — | deployed source revision and deploy generation |
+
+Requests are tokenized with globbing off and every token is checked against
+`[A-Za-z0-9._:@-]` before anything is dispatched. The alphabet has no `/`, no
+quotes, and no shell metacharacters, so path traversal and command chaining are
+absent from the grammar rather than filtered out of it afterwards. Every
+request — allowed or denied — is appended to `~/.mac/logs/hub-repair.log` with
+the peer address, and a denial is recorded as denied even when the verb itself
+was valid but its argument was not.
+
+A denied request exits `78` (`EX_CONFIG`), so "the hub was refused" never reads
+as "the repair ran and failed".
+
+The shim is dependency-free POSIX `sh`: no Python, no venv, no deployed source
+tree. That is deliberate. The repair path has to keep working on the node whose
+venv is half-installed or whose source was rolled back, because that is the node
+someone needs to reach. Everything variable — the supervisor kind and the
+service allowlist — is baked in at install time by the deploy, which already
+knows those values.
+
+## Where the private key lives
+
+`~/.mac/keys/mac-hub-repair-id` on the hub node, mode `0600` in a `0700`
+directory.
+
+`~/.mac` is node state that a deploy preserves: a deploy replaces `~/.mac/src`
+and `~/.mac/venv` (backing up the previous ones) and leaves the rest alone. It
+is also never read into a release archive, so the key survives redeploys without
+ever becoming a deploy artifact. A key under the deployed source tree would fail
+both ways at once — destroyed by the next deploy, and shipped by the one after.
+
+## Rotation
+
+The key is created if absent and **not** rotated on redeploy.
+
+Rotating on every deploy sounds safer and is not: a hub key that changed last
+Tuesday is stale on precisely the workers that missed last Tuesday's deploy,
+which is the population you need to reach. Generation is create-if-absent;
+rotation is an explicit operator act (remove the keypair, deploy the hub, then
+deploy the workers).
+
+What makes rotation safe is the merge. `mac.hub_repair_key.merge_authorized_keys`
+replaces the previous hub entry instead of appending next to it: an entry is
+recognized as the hub's by its `mac-hub-repair` comment marker or by carrying
+the same key material under any other comment. Everything else in the file — the
+provisioner's key above all — is copied through byte for byte and keeps its
+position. Contrast the older `grep -qF … || printf >>` pattern used for the
+tunnel key, under which a rotated key leaves its predecessor authorized forever.
+
+## ProxyJump and the `ssh_jump` bastion
+
+Unchanged and reused. A deploy installs the fleet registry at
+`~/.mac/fleets.yaml` on every node, so the hub resolves a worker route through
+`mac.fleet_ssh` exactly as an operator's client does, inheriting the fleet's
+`ssh_jump` bastion, port, and host-key policy. For an in-cluster pod that means
+the hub reaches the worker through the same bastion the deploy uses. The hub
+needs its own *key*, not its own *transport*:
+
+```bash
+python3 -m mac.hub_repair_key ssh-argv --agent gke-worker-1 restart mac
+```
+
+resolves the registry route, swaps in the hub's repair identity, and prints the
+`ssh` argv — `ProxyJump` and all.
+
+## Rollout
+
+The two halves land in separate deploys, and that is fine:
+
+1. **Deploy the hub.** `ensure_hub_repair_key` creates the keypair.
+2. **Deploy the workers.** The cohort reads the hub's public key once
+   (`read_hub_repair_pubkey`), ships it as `MAC_DEPLOY_HUB_REPAIR_PUBKEY`, and
+   each worker installs the shim and authorizes the key.
+
+A fleet whose hub predates this revision reports no key, so
+`install_hub_repair_access` returns immediately and the cohort deploys exactly
+as it does today. Absence degrades to current behavior; it is not a failure.
+
+Both steps run on the legacy one-shot node path only. A typed phase-2 deploy
+consumes infrastructure receipts and is forbidden from mutating tunnel and
+authorization state, so it does not touch `authorized_keys` — same rule the
+reverse-tunnel key already follows.
+
+## Operating it
+
+```bash
+# On the hub: what is this worker doing?
+ssh -i ~/.mac/keys/mac-hub-repair-id worker-1 status
+
+# Restart a wedged agent.
+ssh -i ~/.mac/keys/mac-hub-repair-id worker-1 restart agent
+
+# Read the last 200 lines of a deploy log.
+ssh -i ~/.mac/keys/mac-hub-repair-id worker-1 logs
+ssh -i ~/.mac/keys/mac-hub-repair-id worker-1 tail deploy-20260820T000000Z.log
+```
+
+For a fleet that needs the bastion, let the module build the argv rather than
+reconstructing the route by hand:
+
+```bash
+python3 -m mac.hub_repair_key ssh-argv --agent worker-1 status
+```
+
+To narrow the entry further on a fleet with a stable hub address, add source
+restrictions at install time — `--allow-from 100.64.0.0/10` becomes a
+`from="…"` option on the authorized_keys entry.
+
+## Scope
+
+Deliberately outside this feature:
+
+* **No configuration writes.** Every verb is diagnosis or a restart of something
+  the deploy already manages. Re-pulling a deploy or rolling back a revision is
+  a deploy operation with its own receipts and cohort semantics; exposing it
+  behind a repair key would create a second, unjournaled path to the same state.
+* **No hub-side automation.** Nothing calls these verbs automatically. The key
+  is a path a human or an agent can use when the control plane cannot help;
+  making the hub self-heal over it is a separate decision about what a hub may
+  do unattended.
+* **The tunnel key is untouched.** It keeps its current unrestricted entry
+  because a reverse tunnel needs port forwarding, which is the first thing
+  `restrict` takes away. Merging the two roles into one key would mean giving
+  the repair role back the forwarding it should not have.

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -167,6 +167,7 @@ for provenance and is not a current operating contract.
 | supplemental reference | `home-consolidation.md` | Home-Directory Consolidation: Analysis & Plan |
 | runbook | `hub-availability.md` | Hub Availability |
 | supplemental reference | `hub-host-saturation-remediation.md` | Hub-Host Saturation Remediation |
+| supplemental reference | `hub-repair-key.md` | Hub repair key |
 | supplemental reference | `human-interface-selector.md` | The human interface: support both, activate one |
 | supplemental reference | `image-publication-and-qualification.md` | Image Publication and Pre-Publication Qualification |
 | supplemental reference | `in-flight-agent-messages.md` | Reaching an agent that is already working |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,7 @@ nav:
       - Fleet node onboarding: fleet-node-onboarding-checklist.md
       - Synchronized cutover: synchronized-fleet-cutover.md
       - Hub availability: hub-availability.md
+      - Hub repair key: hub-repair-key.md
       - Break-glass recovery: break-glass-host-recovery.md
   - Architecture:
       - Hermes boundary: hermes-boundary.md

--- a/skills/setup-mac-fleet/SKILL.md
+++ b/skills/setup-mac-fleet/SKILL.md
@@ -136,6 +136,19 @@ in-cluster pod) instead registers through a hub-managed **reverse tunnel**
 URL …; skipping reverse tunnel" or "restarted mac-agent with tunnel now
 available".
 
+**Repairing a worker without the original provisioner.** The reverse tunnel
+moves forwarded ports; it is not a way to *fix* a node. So the hub also
+generates a keypair of its own (`~/.mac/keys/mac-hub-repair-id`) and every
+worker authorizes it during bootstrap **alongside** the provisioner's key —
+restricted with `restrict,command=` to a generated shim that accepts a closed
+verb set (`status`, `services`, `restart <service>`, `logs`,
+`tail <log> [lines]`, `deploy-info`) and never a shell. That keeps a wedged
+worker reachable when the operator who provisioned it is not: rotated
+credentials, a laptop that is offline, a different operator running the fleet
+later. The hub resolves the route through the fleet registry it receives at
+`~/.mac/fleets.yaml`, so it inherits the fleet's `ssh_jump` bastion unchanged.
+See `docs/hub-repair-key.md`.
+
 ### Bare-metal agents
 
 - A physical host with a full init system.

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -2967,6 +2967,18 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy hub repair pubkey.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_REPAIR_PUBKEY",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh",
+      "deploy/fleet-node-install.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy hub tick interval seconds.",
     "family": "deployment",
     "name": "MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS",
@@ -5903,6 +5915,7 @@
       "src/mac/api.py",
       "src/mac/curiosity_service.py",
       "src/mac/hermes_runtime.py",
+      "src/mac/hub_repair_key.py",
       "src/mac/mac_paths.py",
       "src/mac/model_selection.py",
       "src/mac/models_catalog.py",
@@ -6065,6 +6078,17 @@
     "retired": false,
     "sources": [
       "src/mac/hub_load_shed.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Hub setting: hub repair key.",
+    "family": "hub",
+    "name": "MAC_HUB_REPAIR_KEY",
+    "retired": false,
+    "sources": [
+      "src/mac/hub_repair_key.py"
     ],
     "type": "str"
   },

--- a/src/mac/hub_repair_key.py
+++ b/src/mac/hub_repair_key.py
@@ -1,0 +1,889 @@
+"""Hub-owned repair key: hub-to-worker SSH that does not depend on the operator.
+
+Once a fleet is bootstrapped, every remaining path into a worker belongs to the
+human who provisioned it.  If that operator's key is rotated, their laptop is
+offline, or a different operator inherits the fleet, nothing can reach a wedged
+worker even though the hub is healthy and talks to it constantly over HTTP.
+The hub therefore owns a keypair of its own and each worker authorizes it
+during bootstrap, *in addition to* the provisioner's key -- never instead of it.
+
+The four decisions that make that safe, and where they live:
+
+``where the private key lives``
+    ``~/.mac/keys/mac-hub-repair-id`` on the hub node.  ``~/.mac`` is node state
+    that a deploy preserves (a deploy replaces ``~/.mac/src`` and
+    ``~/.mac/venv`` and backs the old ones up), and it is never read into a
+    release archive, so the key survives redeploys without ever becoming a
+    deploy artifact.  Contrast ``~/.ssh/mac_tunnel_id``, the *reverse tunnel*
+    key: that one is deliberately left alone here, because a tunnel key needs
+    port forwarding and a repair key must not have it.
+
+``rotation``
+    Not on redeploy.  A key that rotates every deploy is a key that is stale on
+    every worker that missed that deploy, which is exactly the population you
+    need to reach.  Generation is create-if-absent; rotation is an explicit act.
+    What makes rotation safe is :func:`merge_authorized_keys`, which replaces
+    the previous hub entry instead of appending next to it, so a rotated key
+    does not leave its predecessor authorized forever.
+
+``what the key may do``
+    Not a shell.  The authorized_keys entry is ``restrict`` plus a forced
+    ``command=``, so the key can only run the generated shim
+    (:func:`repair_shim_script`), which accepts the closed verb set in
+    :data:`VERBS` and nothing else.  The shim is plain POSIX ``sh`` with no
+    Python and no venv dependency on purpose: the repair path must survive the
+    thing it exists to repair.
+
+``ProxyJump``
+    Unchanged and reused.  A deploy installs the fleet registry at
+    ``~/.mac/fleets.yaml`` on every node, so the hub resolves a worker route
+    through :mod:`mac.fleet_ssh` exactly like an operator does, inheriting the
+    fleet's ``ssh_jump`` bastion for in-cluster pods.  The hub needs its own
+    key, not its own transport.
+
+The module is the single source of truth for all of it: the deploy installs
+what this module renders rather than hand-rolling authorized_keys text in
+shell, so the on-node grammar and the grammar this module validates cannot
+drift apart.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import sys
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+SCHEMA = "mac.hub_repair_key.v1"
+
+#: Comment stamped into the hub's public key and used as the authorized_keys
+#: marker.  Entry identity lives in this comment so a rotated key replaces its
+#: predecessor rather than accumulating beside it.
+KEY_COMMENT = "mac-hub-repair"
+
+#: Default on-node locations.  Both sit under ``~/.mac`` (node state a deploy
+#: preserves), not under the deployed source tree (which a deploy replaces).
+DEFAULT_KEY_RELPATH = "keys/mac-hub-repair-id"
+DEFAULT_SHIM_RELPATH = "bin/mac-hub-repair"
+
+#: ``EX_CONFIG``.  Distinguishable from a repair command's own exit status, so
+#: "the hub was refused" never reads as "the repair ran and failed".
+EXIT_DENIED = 78
+
+DEFAULT_TAIL_LINES = 200
+MAX_TAIL_LINES = 500
+
+#: Key algorithms accepted in an authorized_keys line.  Narrow on purpose: this
+#: is the parser that decides which existing entries are ours, so it must
+#: recognize real entries, and it is also the validator for the key the hub
+#: presents.
+KEY_ALGORITHMS = frozenset(
+    {
+        "ssh-ed25519",
+        "sk-ssh-ed25519@openssh.com",
+        "ecdsa-sha2-nistp256",
+        "ecdsa-sha2-nistp384",
+        "ecdsa-sha2-nistp521",
+        "sk-ecdsa-sha2-nistp256@openssh.com",
+        "ssh-rsa",
+        "rsa-sha2-256",
+        "rsa-sha2-512",
+    }
+)
+
+#: The alphabet a repair request may use.  ``/`` is absent deliberately: no
+#: repair argument is a path, so excluding the separator removes directory
+#: traversal from the grammar rather than filtering for it afterwards.
+_REQUEST_TOKEN_RE = re.compile(r"^[A-Za-z0-9._:@-]+$")
+_BASE64_RE = re.compile(r"^[A-Za-z0-9+/]+={0,3}$")
+_SERVICE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_UNIT_NAME_RE = re.compile(r"^[A-Za-z0-9._:@-]+$")
+
+SUPERVISORS = ("systemd", "launchd", "supervisord")
+
+
+class HubRepairKeyError(ValueError):
+    """Raised for an unusable key, an unparseable file, or a denied request."""
+
+
+@dataclass(frozen=True)
+class VerbSpec:
+    """One allowlisted repair verb and its arity."""
+
+    name: str
+    min_args: int
+    max_args: int
+    summary: str
+
+
+#: The closed set of things the hub's key may ask a worker to do.  Every verb
+#: is diagnosis or a restart of something the deploy already manages; nothing
+#: here writes node configuration, and nothing takes a free-form command.
+VERBS: Dict[str, VerbSpec] = {
+    spec.name: spec
+    for spec in (
+        VerbSpec("status", 0, 0, "node identity, deployed revision, service states"),
+        VerbSpec("services", 0, 0, "supervisor state of each mac-managed service"),
+        VerbSpec("restart", 1, 1, "restart one allowlisted service"),
+        VerbSpec("logs", 0, 0, "list the log files available to tail"),
+        VerbSpec("tail", 1, 2, "tail one log file, bounded to %d lines" % MAX_TAIL_LINES),
+        VerbSpec("deploy-info", 0, 0, "deployed source revision and deploy generation"),
+    )
+}
+
+
+@dataclass(frozen=True)
+class RepairRequest:
+    """A validated repair request: a known verb and checked arguments."""
+
+    verb: str
+    args: Tuple[str, ...]
+
+    @property
+    def command(self) -> str:
+        """Return the canonical wire form sent as ``SSH_ORIGINAL_COMMAND``."""
+
+        return " ".join((self.verb,) + self.args)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"schema": SCHEMA, "verb": self.verb, "args": list(self.args)}
+
+
+@dataclass(frozen=True)
+class PublicKey:
+    """A parsed SSH public key, with the hub marker applied to the comment."""
+
+    algorithm: str
+    blob: str
+    comment: str
+
+    def text(self) -> str:
+        return "%s %s %s" % (self.algorithm, self.blob, self.comment)
+
+
+# ---------------------------------------------------------------------------
+# Locations
+# ---------------------------------------------------------------------------
+
+def mac_home(home: Optional[str] = None) -> Path:
+    """Return the node's MAC state directory (``$MAC_HOME`` or ``~/.mac``)."""
+
+    if home:
+        return Path(home).expanduser()
+    configured = os.environ.get("MAC_HOME")
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".mac"
+
+
+def hub_repair_key_path(home: Optional[str] = None) -> Path:
+    """Return the hub's private repair key path."""
+
+    override = os.environ.get("MAC_HUB_REPAIR_KEY")
+    if override and home is None:
+        return Path(override).expanduser()
+    return mac_home(home) / DEFAULT_KEY_RELPATH
+
+
+def hub_repair_shim_path(home: Optional[str] = None) -> Path:
+    """Return the worker-side forced-command shim path."""
+
+    return mac_home(home) / DEFAULT_SHIM_RELPATH
+
+
+# ---------------------------------------------------------------------------
+# Public key + authorized_keys grammar
+# ---------------------------------------------------------------------------
+
+def parse_public_key(text: str) -> PublicKey:
+    """Parse one SSH public key and stamp it with the hub marker comment.
+
+    The comment is normalized rather than preserved: it is the identity
+    :func:`merge_authorized_keys` matches on, so it must be ours regardless of
+    what ``ssh-keygen -C`` happened to write.
+    """
+
+    candidate = (text or "").strip()
+    if not candidate:
+        raise HubRepairKeyError("public key is empty")
+    if "\n" in candidate or "\r" in candidate:
+        raise HubRepairKeyError("public key must be a single line")
+    fields = candidate.split()
+    if len(fields) < 2:
+        raise HubRepairKeyError("public key must be '<algorithm> <base64> [comment]'")
+    algorithm, blob = fields[0], fields[1]
+    if algorithm not in KEY_ALGORITHMS:
+        raise HubRepairKeyError("unsupported key algorithm %r" % algorithm)
+    if not _BASE64_RE.match(blob):
+        raise HubRepairKeyError("public key body is not base64")
+    return PublicKey(algorithm=algorithm, blob=blob, comment=KEY_COMMENT)
+
+
+def authorized_keys_options(
+    forced_command: str,
+    *,
+    from_patterns: Sequence[str] = (),
+) -> str:
+    """Return the option string for the hub's entry.
+
+    ``restrict`` is the whole point: it withdraws pty allocation, agent, port,
+    X11 forwarding and user rc, so the entry cannot be widened later by
+    forgetting to add a new ``no-*`` option when OpenSSH grows a new capability.
+    The forced ``command=`` then narrows the one remaining capability -- running
+    a program -- to the generated shim.
+    """
+
+    command = (forced_command or "").strip()
+    if not command:
+        raise HubRepairKeyError("a forced command is required; an unrestricted hub key is not installable")
+    if '"' in command or "\\" in command or "\n" in command:
+        raise HubRepairKeyError("forced command must not contain quotes, backslashes, or newlines")
+    options = ['restrict', 'command="%s"' % command]
+    patterns = [str(item).strip() for item in from_patterns if str(item).strip()]
+    if patterns:
+        for pattern in patterns:
+            if any(char in pattern for char in '", \\\n'):
+                raise HubRepairKeyError("from pattern %r contains an unusable character" % pattern)
+        options.append('from="%s"' % ",".join(patterns))
+    return ",".join(options)
+
+
+def authorized_keys_line(
+    public_key: str,
+    *,
+    forced_command: str,
+    from_patterns: Sequence[str] = (),
+) -> str:
+    """Return the complete, restricted authorized_keys line for the hub key."""
+
+    parsed = parse_public_key(public_key)
+    options = authorized_keys_options(forced_command, from_patterns=from_patterns)
+    return "%s %s" % (options, parsed.text())
+
+
+def _end_of_options(line: str) -> Optional[int]:
+    """Return the index just past the option field, honoring quoted values.
+
+    An authorized_keys option list is one whitespace-free field *except* inside
+    double quotes, which is where forced commands live.  Splitting on
+    whitespace without tracking quotes is the classic way to mangle exactly the
+    entries this module writes.
+    """
+
+    in_quote = False
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if char == "\\" and in_quote:
+            index += 2
+            continue
+        if char == '"':
+            in_quote = not in_quote
+        elif not in_quote and char.isspace():
+            return index
+        index += 1
+    return None
+
+
+def _parse_authorized_keys_line(line: str) -> Optional[Tuple[str, str, str, str]]:
+    """Return ``(options, algorithm, blob, comment)`` or ``None`` if not a key."""
+
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    head = stripped.split(None, 1)[0]
+    if head in KEY_ALGORITHMS:
+        options, rest = "", stripped
+    else:
+        cut = _end_of_options(stripped)
+        if cut is None:
+            return None
+        options, rest = stripped[:cut], stripped[cut:].lstrip()
+    fields = rest.split()
+    if len(fields) < 2 or fields[0] not in KEY_ALGORITHMS:
+        return None
+    return options, fields[0], fields[1], " ".join(fields[2:])
+
+
+def merge_authorized_keys(existing: str, line: str) -> Tuple[str, bool]:
+    """Merge the hub entry into *existing*, replacing any earlier hub entry.
+
+    Returns ``(text, changed)``.  Two entries are considered the hub's: one
+    whose comment is :data:`KEY_COMMENT` (a previous, possibly rotated hub key)
+    and one carrying the same key material (the same key installed under a
+    different comment).  Everything else -- the provisioner's key above all --
+    is copied through byte for byte and keeps its position.
+    """
+
+    parsed = _parse_authorized_keys_line(line)
+    if parsed is None:
+        raise HubRepairKeyError("refusing to install an unparseable authorized_keys line")
+    _, _, new_blob, new_comment = parsed
+    if new_comment != KEY_COMMENT:
+        raise HubRepairKeyError(
+            "hub entry must carry the %r comment marker" % KEY_COMMENT
+        )
+
+    kept: List[str] = []
+    for raw in (existing or "").splitlines():
+        entry = _parse_authorized_keys_line(raw)
+        if entry is not None:
+            _, _, blob, comment = entry
+            if comment == KEY_COMMENT or blob == new_blob:
+                continue
+        kept.append(raw.rstrip("\n"))
+    while kept and not kept[-1].strip():
+        kept.pop()
+    kept.append(line.strip())
+    text = "\n".join(kept) + "\n"
+    return text, text != (existing or "")
+
+
+def install_authorized_key(path: Path, line: str) -> bool:
+    """Write the merged authorized_keys file at *path*; return whether it changed.
+
+    The write is atomic and mode 0600 from creation: a partially written or
+    briefly world-readable authorized_keys file is a live authorization bug,
+    not a cleanup task.
+    """
+
+    path = Path(path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(path.parent, stat.S_IRWXU)
+    existing = path.read_text(encoding="utf-8") if path.is_file() else ""
+    merged, changed = merge_authorized_keys(existing, line)
+    if not changed:
+        return False
+    temp = path.with_name(path.name + ".mac-hub-repair.tmp")
+    fd = os.open(str(temp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(merged)
+    os.replace(str(temp), str(path))
+    os.chmod(path, 0o600)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Request grammar
+# ---------------------------------------------------------------------------
+
+def parse_repair_request(
+    command: Optional[str],
+    *,
+    services: Optional[Iterable[str]] = None,
+) -> RepairRequest:
+    """Validate one repair request and return it, or raise :class:`HubRepairKeyError`.
+
+    This mirrors, in Python, the check the generated shim performs on the node.
+    It exists so the grammar can be tested directly and so hub-side callers
+    refuse a bad request before spending an SSH connection on it.
+    """
+
+    request = (command or "").strip()
+    if not request:
+        raise HubRepairKeyError(
+            "interactive shells are not permitted on the hub repair key; send one repair verb"
+        )
+    tokens = request.split()
+    for token in tokens:
+        if not _REQUEST_TOKEN_RE.match(token) or ".." in token:
+            raise HubRepairKeyError("request token %r is outside the repair alphabet" % token)
+    verb, args = tokens[0], tuple(tokens[1:])
+    spec = VERBS.get(verb)
+    if spec is None:
+        raise HubRepairKeyError(
+            "verb %r is not in the repair allowlist (%s)" % (verb, ", ".join(sorted(VERBS)))
+        )
+    if not spec.min_args <= len(args) <= spec.max_args:
+        raise HubRepairKeyError(
+            "%s takes %d..%d arguments, got %d" % (verb, spec.min_args, spec.max_args, len(args))
+        )
+    if verb == "restart" and services is not None and args[0] not in set(services):
+        raise HubRepairKeyError(
+            "service %r is not in the repair allowlist (%s)"
+            % (args[0], ", ".join(sorted(services)))
+        )
+    if verb == "tail" and len(args) == 2:
+        if not args[1].isdigit() or not 1 <= int(args[1]) <= MAX_TAIL_LINES:
+            raise HubRepairKeyError(
+                "tail line count must be an integer in 1..%d" % MAX_TAIL_LINES
+            )
+    return RepairRequest(verb=verb, args=args)
+
+
+def parse_service_map(values: Iterable[str]) -> Dict[str, str]:
+    """Parse ``name=unit`` pairs into the shim's service allowlist."""
+
+    services: Dict[str, str] = {}
+    for value in values:
+        name, sep, unit = str(value).partition("=")
+        name, unit = name.strip(), unit.strip()
+        if not sep or not name or not unit:
+            raise HubRepairKeyError("service mapping %r must be name=unit" % value)
+        if not _SERVICE_NAME_RE.match(name):
+            raise HubRepairKeyError("service name %r must be lowercase alphanumeric" % name)
+        if not _UNIT_NAME_RE.match(unit):
+            raise HubRepairKeyError("service unit %r is outside the repair alphabet" % unit)
+        services[name] = unit
+    return services
+
+
+# ---------------------------------------------------------------------------
+# Shim
+# ---------------------------------------------------------------------------
+
+def repair_shim_script(
+    *,
+    supervisor: str,
+    services: Mapping[str, str],
+    agent: str = "",
+) -> str:
+    """Render the worker-side forced command as self-contained POSIX ``sh``.
+
+    No Python, no venv, no repository checkout: the shim must still run on a
+    node whose venv is half-installed or whose deployed source was rolled back,
+    because that is when someone needs it.  Everything variable -- the
+    supervisor kind and the service allowlist -- is baked in at install time by
+    the deploy that already knows those values.
+    """
+
+    if supervisor not in SUPERVISORS:
+        raise HubRepairKeyError(
+            "supervisor must be one of: %s" % ", ".join(SUPERVISORS)
+        )
+    if not services:
+        raise HubRepairKeyError("at least one allowlisted service is required")
+    for name, unit in services.items():
+        if not _SERVICE_NAME_RE.match(name) or not _UNIT_NAME_RE.match(unit):
+            raise HubRepairKeyError("service mapping %r=%r is not installable" % (name, unit))
+    if agent and not _UNIT_NAME_RE.match(agent):
+        raise HubRepairKeyError("agent name %r is outside the repair alphabet" % agent)
+
+    ordered = sorted(services.items())
+    case_arms = "\n".join(
+        "    %s) printf '%%s\\n' '%s' ;;" % (name, unit) for name, unit in ordered
+    )
+    service_names = " ".join(name for name, _ in ordered)
+    verb_help = "\n".join(
+        "#   %-12s %s" % (spec.name, spec.summary) for spec in VERBS.values()
+    )
+
+    return """#!/bin/sh
+# Generated by mac.hub_repair_key ({schema}). Do not edit on the node.
+#
+# Forced command for the hub's self-registered repair key. The hub's
+# authorized_keys entry is `restrict,command="<this file>"`, so this script --
+# not a shell -- is everything that key can do. It accepts one verb from a
+# closed allowlist and refuses everything else, including an empty request
+# (which is what an attempt at an interactive shell looks like from here).
+#
+{verb_help}
+#
+# Deliberately dependency-free: no Python, no venv, no deployed source tree.
+# The repair path must outlive the thing it repairs.
+set -u
+
+SCHEMA='{schema}'
+SUPERVISOR='{supervisor}'
+AGENT_NAME='{agent}'
+SERVICE_NAMES='{service_names}'
+MAC_HOME="${{MAC_HOME:-$HOME/.mac}}"
+LOG_DIR="$MAC_HOME/logs"
+AUDIT_LOG="$LOG_DIR/hub-repair.log"
+MAX_TAIL_LINES={max_tail}
+DEFAULT_TAIL_LINES={default_tail}
+EXIT_DENIED={exit_denied}
+
+request="${{SSH_ORIGINAL_COMMAND-}}"
+
+audit() {{
+  [ -d "$LOG_DIR" ] || mkdir -p "$LOG_DIR" 2>/dev/null || return 0
+  printf '%s %s peer=%s request=%s\\n' \\
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)" \\
+    "$1" "${{SSH_CONNECTION:-unknown}}" "$2" >>"$AUDIT_LOG" 2>/dev/null || true
+}}
+
+deny() {{
+  audit denied "$request"
+  printf 'mac-hub-repair: denied: %s\\n' "$*" >&2
+  exit "$EXIT_DENIED"
+}}
+
+# Run privileged helpers the way the deploy does: directly as root, otherwise
+# through non-interactive sudo. A node without either simply cannot be repaired
+# over this path, and says so instead of appearing to succeed.
+priv() {{
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo -n "$@"
+  else
+    printf 'mac-hub-repair: no root and no non-interactive sudo\\n' >&2
+    return 127
+  fi
+}}
+
+service_unit() {{
+  case "$1" in
+{case_arms}
+    *) return 1 ;;
+  esac
+}}
+
+service_state() {{
+  unit="$1"
+  case "$SUPERVISOR" in
+    supervisord) priv supervisorctl status "$unit" 2>&1 || true ;;
+    systemd)
+      if systemctl --user cat "$unit" >/dev/null 2>&1; then
+        systemctl --user is-active "$unit" 2>&1 || true
+      else
+        priv systemctl is-active "$unit" 2>&1 || true
+      fi
+      ;;
+    launchd) launchctl list "$unit" >/dev/null 2>&1 && echo loaded || echo not-loaded ;;
+    *) echo "unsupported-supervisor" ;;
+  esac
+}}
+
+do_restart() {{
+  unit="$(service_unit "$1")" || deny "service '$1' is not in the repair allowlist ($SERVICE_NAMES)"
+  audit allowed "$request"
+  case "$SUPERVISOR" in
+    supervisord) priv supervisorctl restart "$unit" ;;
+    systemd)
+      if systemctl --user cat "$unit" >/dev/null 2>&1; then
+        systemctl --user restart "$unit"
+      else
+        priv systemctl restart "$unit"
+      fi
+      ;;
+    launchd) launchctl kickstart -k "gui/$(id -u)/$unit" ;;
+    *) deny "unsupported supervisor '$SUPERVISOR'" ;;
+  esac
+}}
+
+do_services() {{
+  for name in $SERVICE_NAMES; do
+    unit="$(service_unit "$name")" || continue
+    printf 'service %s unit=%s state=%s\\n' "$name" "$unit" "$(service_state "$unit" | tr '\\n' ' ')"
+  done
+}}
+
+do_deploy_info() {{
+  if [ -f "$MAC_HOME/deployed-source-revision" ]; then
+    printf 'deployed_source_revision=%s\\n' "$(cat "$MAC_HOME/deployed-source-revision")"
+  else
+    printf 'deployed_source_revision=unknown\\n'
+  fi
+  if [ -f "$MAC_HOME/deploy-start-barrier" ]; then
+    printf 'deploy_start_barrier=%s\\n' "$(cat "$MAC_HOME/deploy-start-barrier")"
+  fi
+}}
+
+do_status() {{
+  printf 'schema=%s\\n' "$SCHEMA"
+  printf 'agent=%s\\n' "$AGENT_NAME"
+  printf 'host=%s\\n' "$(uname -n 2>/dev/null || echo unknown)"
+  printf 'supervisor=%s\\n' "$SUPERVISOR"
+  do_deploy_info
+  do_services
+}}
+
+do_logs() {{
+  [ -d "$LOG_DIR" ] || {{ printf 'no log directory at %s\\n' "$LOG_DIR"; return 0; }}
+  ls -1 "$LOG_DIR" 2>/dev/null || true
+}}
+
+do_tail() {{
+  name="$1"
+  lines="${{2:-$DEFAULT_TAIL_LINES}}"
+  case "$lines" in
+    ''|*[!0-9]*) deny "tail line count must be a positive integer" ;;
+  esac
+  [ "$lines" -ge 1 ] || deny "tail line count must be at least 1"
+  [ "$lines" -le "$MAX_TAIL_LINES" ] || deny "tail line count exceeds $MAX_TAIL_LINES"
+  [ -f "$LOG_DIR/$name" ] || deny "no such log file: $name"
+  audit allowed "$request"
+  tail -n "$lines" "$LOG_DIR/$name"
+}}
+
+[ -n "$request" ] || deny "interactive shells are not permitted; send one repair verb"
+
+# Split with globbing off, then vet every token before dispatching on any of
+# them. The alphabet has no '/', no quotes, and no shell metacharacters, so
+# nothing below can be talked into traversing a path or starting a second
+# command. Word-splitting an expansion never re-parses operators, so a ';' in
+# the request is only ever a rejected character.
+set -f
+# shellcheck disable=SC2086
+set -- $request
+[ $# -ge 1 ] || deny "interactive shells are not permitted; send one repair verb"
+for token in "$@"; do
+  case "$token" in
+    *[!A-Za-z0-9._:@-]*) deny "request token '$token' is outside the repair alphabet" ;;
+    *..*) deny "request contains a path traversal" ;;
+  esac
+done
+verb="$1"
+shift
+
+case "$verb" in
+  status) [ $# -eq 0 ] || deny "status takes no arguments"; audit allowed "$request"; do_status ;;
+  services) [ $# -eq 0 ] || deny "services takes no arguments"; audit allowed "$request"; do_services ;;
+  deploy-info) [ $# -eq 0 ] || deny "deploy-info takes no arguments"; audit allowed "$request"; do_deploy_info ;;
+  logs) [ $# -eq 0 ] || deny "logs takes no arguments"; audit allowed "$request"; do_logs ;;
+  restart) [ $# -eq 1 ] || deny "restart takes exactly one service"; do_restart "$1" ;;
+  tail)
+    [ $# -ge 1 ] && [ $# -le 2 ] || deny "tail takes a log name and an optional line count"
+    do_tail "$@"
+    ;;
+  *) deny "verb '$verb' is not in the repair allowlist" ;;
+esac
+""".format(
+        schema=SCHEMA,
+        supervisor=supervisor,
+        agent=agent,
+        service_names=service_names,
+        case_arms=case_arms,
+        verb_help=verb_help,
+        max_tail=MAX_TAIL_LINES,
+        default_tail=DEFAULT_TAIL_LINES,
+        exit_denied=EXIT_DENIED,
+    )
+
+
+def install_repair_shim(path: Path, script: str) -> bool:
+    """Write the shim at *path* mode 0700; return whether it changed."""
+
+    path = Path(path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(path.parent, stat.S_IRWXU)
+    if path.is_file() and path.read_text(encoding="utf-8") == script:
+        os.chmod(path, 0o700)
+        return False
+    temp = path.with_name(path.name + ".tmp")
+    fd = os.open(str(temp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o700)
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(script)
+    os.replace(str(temp), str(path))
+    os.chmod(path, 0o700)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Hub side
+# ---------------------------------------------------------------------------
+
+def repair_ssh_argv(
+    config: Mapping[str, Any],
+    agent: str,
+    request: RepairRequest,
+    *,
+    fleet: Optional[str] = None,
+    identity_file: Optional[str] = None,
+    connect_timeout: int = 10,
+) -> List[str]:
+    """Build the hub's ``ssh`` argv for one repair request against *agent*.
+
+    The route comes from the fleet registry the deploy installs on every node,
+    so the hub inherits the fleet's ``ssh_jump`` bastion and host-key policy
+    unchanged; only the identity is swapped to the hub's own repair key.  The
+    remote command is still sent even though the entry forces its own: the
+    worker reads it from ``SSH_ORIGINAL_COMMAND``.
+    """
+
+    from mac.fleet_ssh import FleetSshError, resolve_fleet_ssh, ssh_argv
+
+    try:
+        spec = resolve_fleet_ssh(config, fleet, agent)
+    except FleetSshError as exc:
+        raise HubRepairKeyError(str(exc)) from exc
+    key = Path(identity_file).expanduser() if identity_file else hub_repair_key_path()
+    if not key.is_file():
+        raise HubRepairKeyError(
+            "hub repair key %s is absent; deploy the hub to generate it" % key
+        )
+    routed = replace(spec, identity_file=str(key), identity_ref=None)
+    return ssh_argv(routed, request.command, connect_timeout=connect_timeout)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _read_public_key(args: argparse.Namespace) -> str:
+    if getattr(args, "public_key", None):
+        return str(args.public_key)
+    path = Path(str(args.public_key_file)).expanduser()
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise HubRepairKeyError("cannot read public key %s: %s" % (path, exc)) from exc
+
+
+def _cmd_emit_shim(args: argparse.Namespace) -> int:
+    script = repair_shim_script(
+        supervisor=args.supervisor,
+        services=parse_service_map(args.service),
+        agent=args.agent or "",
+    )
+    sys.stdout.write(script)
+    return 0
+
+
+def _cmd_authorized_keys_line(args: argparse.Namespace) -> int:
+    line = authorized_keys_line(
+        _read_public_key(args),
+        forced_command=args.shim or str(hub_repair_shim_path()),
+        from_patterns=args.allow_from,
+    )
+    sys.stdout.write(line + "\n")
+    return 0
+
+
+def _cmd_install(args: argparse.Namespace) -> int:
+    """Install the shim and authorize the hub key, in that order.
+
+    Order matters: authorizing a key whose forced command does not exist yet
+    turns every hub connection into an obscure exec failure for as long as the
+    window lasts.
+    """
+
+    shim_path = Path(args.shim or str(hub_repair_shim_path())).expanduser()
+    script = repair_shim_script(
+        supervisor=args.supervisor,
+        services=parse_service_map(args.service),
+        agent=args.agent or "",
+    )
+    shim_changed = install_repair_shim(shim_path, script)
+    line = authorized_keys_line(
+        _read_public_key(args),
+        forced_command=str(shim_path),
+        from_patterns=args.allow_from,
+    )
+    authorized = Path(args.authorized_keys).expanduser()
+    key_changed = install_authorized_key(authorized, line)
+    sys.stdout.write(
+        json.dumps(
+            {
+                "schema": SCHEMA,
+                "shim": str(shim_path),
+                "shim_changed": shim_changed,
+                "authorized_keys": str(authorized),
+                "authorized_keys_changed": key_changed,
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    return 0
+
+
+def _cmd_check_command(args: argparse.Namespace) -> int:
+    request = " ".join(args.request) if args.request else os.environ.get("SSH_ORIGINAL_COMMAND", "")
+    parsed = parse_repair_request(request, services=args.service or None)
+    sys.stdout.write(json.dumps(parsed.to_dict(), sort_keys=True) + "\n")
+    return 0
+
+
+def _cmd_ssh_argv(args: argparse.Namespace) -> int:
+    from mac.fleet_ssh import FleetSshError, load_fleet_config
+
+    parsed = parse_repair_request(" ".join(args.request))
+    try:
+        config = load_fleet_config(args.fleets_config)
+    except FleetSshError as exc:
+        raise HubRepairKeyError(str(exc)) from exc
+    argv = repair_ssh_argv(
+        config,
+        args.agent,
+        parsed,
+        fleet=args.fleet,
+        identity_file=args.identity_file,
+    )
+    sys.stdout.write(json.dumps(argv) + "\n")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="mac.hub_repair_key",
+        description="hub-owned, forced-command SSH access to a worker for repair",
+    )
+    sub = parser.add_subparsers(dest="command")
+    sub.required = True
+
+    def _add_shim_args(target: argparse.ArgumentParser) -> None:
+        target.add_argument("--supervisor", required=True, choices=SUPERVISORS)
+        target.add_argument(
+            "--service",
+            action="append",
+            default=[],
+            metavar="NAME=UNIT",
+            help="allowlisted service (repeatable)",
+        )
+        target.add_argument("--agent", default="", help="agent name recorded in status output")
+
+    def _add_key_args(target: argparse.ArgumentParser) -> None:
+        source = target.add_mutually_exclusive_group(required=True)
+        source.add_argument("--public-key", help="the hub's public key, verbatim")
+        source.add_argument("--public-key-file", help="file holding the hub's public key")
+        target.add_argument(
+            "--allow-from",
+            action="append",
+            default=[],
+            metavar="PATTERN",
+            help="restrict the entry to these source patterns (repeatable)",
+        )
+        target.add_argument("--shim", help="forced-command path (default: ~/.mac/bin/mac-hub-repair)")
+
+    emit = sub.add_parser("emit-shim", help="print the worker-side forced command")
+    _add_shim_args(emit)
+    emit.set_defaults(handler=_cmd_emit_shim)
+
+    line = sub.add_parser("authorized-keys-line", help="print the restricted authorized_keys entry")
+    _add_key_args(line)
+    line.set_defaults(handler=_cmd_authorized_keys_line)
+
+    install = sub.add_parser("install", help="install the shim and authorize the hub key")
+    _add_shim_args(install)
+    _add_key_args(install)
+    install.add_argument(
+        "--authorized-keys",
+        default=str(Path.home() / ".ssh" / "authorized_keys"),
+    )
+    install.set_defaults(handler=_cmd_install)
+
+    check = sub.add_parser("check-command", help="validate a repair request (defaults to $SSH_ORIGINAL_COMMAND)")
+    check.add_argument("--service", action="append", default=[], help="allowlisted service name (repeatable)")
+    check.add_argument("request", nargs="*")
+    check.set_defaults(handler=_cmd_check_command)
+
+    argv = sub.add_parser("ssh-argv", help="print the hub's ssh argv for one repair request")
+    argv.add_argument("--agent", required=True)
+    argv.add_argument("--fleet")
+    argv.add_argument("--fleets-config")
+    argv.add_argument("--identity-file")
+    argv.add_argument("request", nargs="+")
+    argv.set_defaults(handler=_cmd_ssh_argv)
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Run the hub-repair-key command-line interface."""
+
+    args = _build_parser().parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except HubRepairKeyError as exc:
+        print("mac hub repair key: %s" % exc, file=sys.stderr)
+        return EXIT_DENIED if args.command == "check-command" else 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_hub_repair_key.py
+++ b/tests/test_hub_repair_key.py
@@ -1,0 +1,466 @@
+"""The hub's own SSH key: restricted authorization and a closed repair grammar.
+
+The feature exists so a wedged worker is reachable when the operator who
+provisioned it is not.  That only holds if three things are true, and each
+section below pins one of them: the hub's authorization is a forced command
+rather than a shell, rotating the hub key retires the old one instead of
+stacking beside it, and the on-node shim enforces the same grammar this module
+validates -- so the tests run the generated shell, not a Python imitation of it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from mac.hub_repair_key import (  # noqa: E402
+    EXIT_DENIED,
+    KEY_COMMENT,
+    MAX_TAIL_LINES,
+    SCHEMA,
+    VERBS,
+    HubRepairKeyError,
+    authorized_keys_line,
+    authorized_keys_options,
+    hub_repair_key_path,
+    install_authorized_key,
+    main,
+    merge_authorized_keys,
+    parse_public_key,
+    parse_repair_request,
+    parse_service_map,
+    repair_shim_script,
+)
+
+HUB_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHubRepairKeyBodyAAAAAAAAAAAAAAAAAAAAAAAA"
+ROTATED_HUB_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIRotatedHubKeyBodyAAAAAAAAAAAAAAAAAAAAA"
+OPERATOR_KEY = (
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOperatorProvisionerKeyAAAAAAAAAAAAAAA"
+    " jkh@laptop"
+)
+SHIM = "/home/mac/.mac/bin/mac-hub-repair"
+SERVICES = {"mac": "mac", "agent": "mac-agent", "hermes": "hermes"}
+
+
+# ---------------------------------------------------------------------------
+# Authorization shape
+# ---------------------------------------------------------------------------
+
+def test_hub_entry_is_restricted_and_forced_to_the_shim():
+    line = authorized_keys_line(HUB_KEY, forced_command=SHIM)
+    options = line.split(" ", 1)[0]
+    assert options.startswith("restrict,")
+    assert 'command="%s"' % SHIM in options
+    assert line.endswith(" " + KEY_COMMENT)
+
+
+def test_an_unrestricted_hub_entry_is_not_installable():
+    # The whole security argument is the forced command; refusing to emit an
+    # entry without one keeps "temporarily give the hub a shell" from being a
+    # one-flag operation.
+    with pytest.raises(HubRepairKeyError):
+        authorized_keys_options("")
+
+
+def test_from_patterns_narrow_the_entry_further():
+    options = authorized_keys_options(SHIM, from_patterns=["100.64.0.0/10", "10.1.2.3"])
+    assert 'from="100.64.0.0/10,10.1.2.3"' in options
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['/bin/sh -c "id"', "/bin/sh\nrm -rf /", "/bin/sh\\x"],
+)
+def test_forced_command_rejects_quote_and_newline_smuggling(command):
+    with pytest.raises(HubRepairKeyError):
+        authorized_keys_options(command)
+
+
+def test_public_key_comment_is_normalized_to_the_marker():
+    parsed = parse_public_key("%s mac-hub-tunnel@somewhere" % HUB_KEY)
+    assert parsed.comment == KEY_COMMENT
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "ssh-ed25519", "not-a-key AAAA", "ssh-ed25519 not+base64!", "ssh-ed25519 AAAA\nssh-ed25519 AAAA"],
+)
+def test_unusable_public_keys_are_rejected(value):
+    with pytest.raises(HubRepairKeyError):
+        parse_public_key(value)
+
+
+# ---------------------------------------------------------------------------
+# Rotation and coexistence with the provisioner's key
+# ---------------------------------------------------------------------------
+
+def test_merge_preserves_the_provisioner_key_verbatim():
+    existing = "# operator keys\n%s\n" % OPERATOR_KEY
+    line = authorized_keys_line(HUB_KEY, forced_command=SHIM)
+    merged, changed = merge_authorized_keys(existing, line)
+    assert changed is True
+    assert merged.splitlines()[:2] == ["# operator keys", OPERATOR_KEY]
+    assert merged.splitlines()[-1] == line
+
+
+def test_merge_is_idempotent():
+    line = authorized_keys_line(HUB_KEY, forced_command=SHIM)
+    once, _ = merge_authorized_keys(OPERATOR_KEY + "\n", line)
+    twice, changed = merge_authorized_keys(once, line)
+    assert twice == once
+    assert changed is False
+
+
+def test_rotating_the_hub_key_retires_the_previous_entry():
+    # Appending without pruning is the failure this replaces: a rotated hub key
+    # would leave its predecessor authorized on every worker forever.
+    old = authorized_keys_line(HUB_KEY, forced_command=SHIM)
+    new = authorized_keys_line(ROTATED_HUB_KEY, forced_command=SHIM)
+    first, _ = merge_authorized_keys(OPERATOR_KEY + "\n", old)
+    second, changed = merge_authorized_keys(first, new)
+    assert changed is True
+    assert HUB_KEY.split()[1] not in second
+    assert ROTATED_HUB_KEY.split()[1] in second
+    assert OPERATOR_KEY in second
+
+
+def test_merge_replaces_the_same_key_installed_unrestricted():
+    # An earlier install (or a hand edit) may have authorized the same key with
+    # a full shell and a different comment. Re-installing must narrow it, not
+    # leave the unrestricted line in place next to the restricted one.
+    existing = "%s %s\n" % (HUB_KEY, "mac-hub-tunnel")
+    line = authorized_keys_line(HUB_KEY, forced_command=SHIM)
+    merged, changed = merge_authorized_keys(existing, line)
+    assert changed is True
+    assert merged.strip().splitlines() == [line]
+
+
+def test_merge_survives_quoted_commands_in_neighbouring_entries():
+    # Splitting an authorized_keys line on whitespace mangles exactly the kind
+    # of entry this module writes; the parser has to honour the quoting.
+    neighbour = 'command="/usr/bin/backup --to /srv, now",no-pty %s borg' % ROTATED_HUB_KEY
+    line = authorized_keys_line(HUB_KEY, forced_command=SHIM)
+    merged, _ = merge_authorized_keys(neighbour + "\n", line)
+    assert neighbour in merged
+    assert merged.strip().endswith(line)
+
+
+def test_install_authorized_key_is_owner_only_and_reports_change(tmp_path):
+    path = tmp_path / ".ssh" / "authorized_keys"
+    line = authorized_keys_line(HUB_KEY, forced_command=SHIM)
+    assert install_authorized_key(path, line) is True
+    assert install_authorized_key(path, line) is False
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    assert path.read_text(encoding="utf-8").strip() == line
+
+
+def test_install_refuses_a_line_that_is_not_ours(tmp_path):
+    with pytest.raises(HubRepairKeyError):
+        install_authorized_key(tmp_path / "authorized_keys", OPERATOR_KEY)
+
+
+# ---------------------------------------------------------------------------
+# Request grammar (Python side)
+# ---------------------------------------------------------------------------
+
+def test_every_verb_round_trips_through_the_parser():
+    samples = {
+        "status": "status",
+        "services": "services",
+        "restart": "restart mac",
+        "logs": "logs",
+        "tail": "tail deploy.log 50",
+        "deploy-info": "deploy-info",
+    }
+    assert set(samples) == set(VERBS)
+    for verb, request in samples.items():
+        assert parse_repair_request(request).verb == verb
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "",
+        "   ",
+        "bash",
+        "status; rm -rf /",
+        "status && id",
+        "restart mac extra",
+        "tail ../../etc/passwd",
+        "tail deploy.log 0",
+        "tail deploy.log %d" % (MAX_TAIL_LINES + 1),
+        "tail deploy.log notanumber",
+        "restart $(id)",
+        "tail /etc/passwd",
+    ],
+)
+def test_denied_requests(request_text):
+    with pytest.raises(HubRepairKeyError):
+        parse_repair_request(request_text)
+
+
+def test_service_allowlist_is_enforced_when_supplied():
+    assert parse_repair_request("restart mac", services=SERVICES).args == ("mac",)
+    with pytest.raises(HubRepairKeyError):
+        parse_repair_request("restart sshd", services=SERVICES)
+
+
+def test_parse_service_map_rejects_unusable_pairs():
+    assert parse_service_map(["mac=mac", "agent=mac-agent"]) == {
+        "mac": "mac",
+        "agent": "mac-agent",
+    }
+    for bad in (["mac"], ["=mac"], ["mac="], ["MAC=mac"], ["mac=a b"]):
+        with pytest.raises(HubRepairKeyError):
+            parse_service_map(bad)
+
+
+# ---------------------------------------------------------------------------
+# The generated shim, executed
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def shim(tmp_path):
+    """Render the shim, make it executable, and give it a node-like MAC_HOME."""
+
+    script = repair_shim_script(supervisor="supervisord", services=SERVICES, agent="worker-1")
+    path = tmp_path / "mac-hub-repair"
+    path.write_text(script, encoding="utf-8")
+    path.chmod(0o700)
+    home = tmp_path / "machome"
+    (home / "logs").mkdir(parents=True)
+    (home / "logs" / "deploy.log").write_text("one\ntwo\nthree\n", encoding="utf-8")
+    (home / "deployed-source-revision").write_text("abc123\n", encoding="utf-8")
+    return path, home
+
+
+def _run_shim(shim_path: Path, home: Path, request: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ, MAC_HOME=str(home), SSH_ORIGINAL_COMMAND=request)
+    # /bin/sh, not bash: the shim runs on nodes whose login shell is whatever
+    # the image ships, so POSIX sh is the contract.
+    return subprocess.run(
+        ["/bin/sh", str(shim_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_shim_is_posix_sh_clean(shim):
+    shim_path, _ = shim
+    assert subprocess.run(["/bin/sh", "-n", str(shim_path)]).returncode == 0
+
+
+def test_shim_denies_an_interactive_shell(shim):
+    shim_path, home = shim
+    result = _run_shim(shim_path, home, "")
+    assert result.returncode == EXIT_DENIED
+    assert "interactive shells are not permitted" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "request_text",
+    [
+        "bash",
+        "status; id",
+        "status && id",
+        "restart mac; id",
+        "tail ../../etc/passwd",
+        "tail deploy.log %d" % (MAX_TAIL_LINES + 1),
+        "tail deploy.log 0",
+        "restart sshd",
+        "restart",
+        "status extra",
+        "`id`",
+        "$(id)",
+    ],
+)
+def test_shim_denies_what_the_parser_denies(shim, request_text):
+    shim_path, home = shim
+    result = _run_shim(shim_path, home, request_text)
+    assert result.returncode == EXIT_DENIED, result.stdout
+    assert "denied" in result.stderr
+
+
+def test_shim_serves_deploy_info_and_tail(shim):
+    shim_path, home = shim
+    info = _run_shim(shim_path, home, "deploy-info")
+    assert info.returncode == 0
+    assert "deployed_source_revision=abc123" in info.stdout
+
+    tail = _run_shim(shim_path, home, "tail deploy.log 2")
+    assert tail.returncode == 0
+    assert tail.stdout.splitlines() == ["two", "three"]
+
+    logs = _run_shim(shim_path, home, "logs")
+    assert "deploy.log" in logs.stdout
+
+
+def test_shim_audits_allowed_and_denied_requests(shim):
+    shim_path, home = shim
+    _run_shim(shim_path, home, "deploy-info")
+    _run_shim(shim_path, home, "restart sshd")
+    audit = (home / "logs" / "hub-repair.log").read_text(encoding="utf-8")
+    assert "allowed" in audit and "request=deploy-info" in audit
+    # A request that fails the allowlist must not be recorded as allowed --
+    # otherwise the audit trail says the hub restarted something it never
+    # touched.
+    denied = [line for line in audit.splitlines() if "restart sshd" in line]
+    assert denied and all(" denied " in line for line in denied)
+
+
+def test_shim_refuses_an_unsupported_supervisor():
+    with pytest.raises(HubRepairKeyError):
+        repair_shim_script(supervisor="runit", services=SERVICES)
+
+
+def test_shim_requires_at_least_one_service():
+    with pytest.raises(HubRepairKeyError):
+        repair_shim_script(supervisor="systemd", services={})
+
+
+# ---------------------------------------------------------------------------
+# CLI, as the deploy calls it
+# ---------------------------------------------------------------------------
+
+def test_install_subcommand_writes_shim_and_authorizes_key(tmp_path, capsys):
+    authorized = tmp_path / ".ssh" / "authorized_keys"
+    authorized.parent.mkdir(parents=True)
+    authorized.write_text(OPERATOR_KEY + "\n", encoding="utf-8")
+    shim_path = tmp_path / ".mac" / "bin" / "mac-hub-repair"
+
+    rc = main(
+        [
+            "install",
+            "--supervisor", "systemd",
+            "--service", "mac=mac",
+            "--service", "agent=mac-agent",
+            "--agent", "worker-1",
+            "--public-key", HUB_KEY,
+            "--shim", str(shim_path),
+            "--authorized-keys", str(authorized),
+        ]
+    )
+    assert rc == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["schema"] == SCHEMA
+    assert report["shim_changed"] is True and report["authorized_keys_changed"] is True
+    assert oct(shim_path.stat().st_mode & 0o777) == "0o700"
+
+    body = authorized.read_text(encoding="utf-8")
+    assert OPERATOR_KEY in body
+    assert 'command="%s"' % shim_path in body
+
+
+def test_check_command_exits_denied_for_a_bad_request(capsys):
+    assert main(["check-command", "status"]) == 0
+    assert json.loads(capsys.readouterr().out)["verb"] == "status"
+    assert main(["check-command", "bash"]) == EXIT_DENIED
+
+
+def test_repair_ssh_argv_inherits_the_fleet_bastion(tmp_path, monkeypatch):
+    # The hub needs its own key, not its own transport: an in-cluster worker is
+    # only reachable through the fleet's declared ProxyJump, and the hub reads
+    # the same registry the deploy installs on every node.
+    from mac.hub_repair_key import repair_ssh_argv
+
+    key = tmp_path / "mac-hub-repair-id"
+    key.write_text("private", encoding="utf-8")
+    config = {
+        "fleets": {
+            "gke": {
+                "fleet_name": "gke",
+                "hub_agent": "gke-hub",
+                "defaults": {
+                    "ssh_jump": "ops@bastion.example:2222",
+                    "ssh_host_key_policy": "accept-new",
+                },
+                "agents": {
+                    "gke-worker-1": {"target": "horde@gke-worker-1", "os": "linux"},
+                },
+            }
+        }
+    }
+    argv = repair_ssh_argv(
+        config,
+        "gke-worker-1",
+        parse_repair_request("restart mac"),
+        identity_file=str(key),
+    )
+    assert "ProxyJump=ops@bastion.example:2222" in argv
+    assert argv[argv.index("-i") + 1] == str(key)
+    assert argv[-2:] == ["horde@gke-worker-1", "restart mac"]
+
+
+def test_repair_ssh_argv_reports_an_absent_hub_key(tmp_path):
+    from mac.hub_repair_key import repair_ssh_argv
+
+    config = {
+        "fleets": {
+            "f": {"hub_agent": "h", "agents": {"h": {"target": "u@h"}}},
+        }
+    }
+    with pytest.raises(HubRepairKeyError, match="is absent"):
+        repair_ssh_argv(
+            config, "h", parse_repair_request("status"),
+            identity_file=str(tmp_path / "missing"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deploy wiring
+# ---------------------------------------------------------------------------
+
+NODE_INSTALL = (ROOT / "deploy" / "fleet-node-install.sh").read_text(encoding="utf-8")
+FLEET_DEPLOY = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")
+
+
+def test_hub_generates_the_repair_key_and_workers_authorize_it():
+    assert "ensure_hub_repair_key" in NODE_INSTALL
+    assert "install_hub_repair_access" in NODE_INSTALL
+    # The node delegates both artifacts to this module rather than hand-rolling
+    # the authorized_keys grammar in shell, so the entry a worker ends up with
+    # and the entry this module's parser recognizes cannot drift apart.
+    block = NODE_INSTALL.split("install_hub_repair_access() {", 1)[1].split("\n}", 1)[0]
+    assert "-m mac.hub_repair_key install" in block
+    assert "--shim " in block and "--authorized-keys " in block
+    assert "--public-key " in block
+
+
+def test_repair_key_is_created_if_absent_not_rotated_per_deploy():
+    block = NODE_INSTALL.split("ensure_hub_repair_key() {", 1)[1].split("\n}", 1)[0]
+    assert 'if [ ! -f "$key_file" ]; then' in block
+    assert "ssh-keygen" in block
+    assert "rm -f" not in block
+
+
+def test_deploy_reads_the_hub_repair_pubkey_and_ships_it_to_workers():
+    assert "read_hub_repair_pubkey" in FLEET_DEPLOY
+    assert "keys/mac-hub-repair-id.pub" in FLEET_DEPLOY
+    assert 'add_remote_env MAC_DEPLOY_HUB_REPAIR_PUBKEY' in FLEET_DEPLOY
+    assert 'HUB_REPAIR_PUBKEY="${MAC_DEPLOY_HUB_REPAIR_PUBKEY:-}"' in NODE_INSTALL
+
+
+def test_authorizing_the_hub_key_is_skipped_when_the_hub_has_none():
+    # A fleet whose hub predates this feature must keep deploying, not fail its
+    # whole cohort on a key that does not exist yet.
+    block = NODE_INSTALL.split("install_hub_repair_access() {", 1)[1].split("\n}", 1)[0]
+    assert '[ -n "$HUB_REPAIR_PUBKEY" ] || return 0' in block
+
+
+def test_default_key_path_lives_in_node_state_not_the_source_tree(monkeypatch, tmp_path):
+    # ~/.mac survives a deploy (which replaces ~/.mac/src and ~/.mac/venv) and
+    # is never packed into a release archive. A key under the source tree would
+    # be destroyed by the next deploy and shipped by the one after it.
+    monkeypatch.delenv("MAC_HUB_REPAIR_KEY", raising=False)
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / ".mac"))
+    path = hub_repair_key_path()
+    assert path == tmp_path / ".mac" / "keys" / "mac-hub-repair-id"


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_4f0230b992914feb8e9e1e1e200a5472`
- head: `6a8d8f47c91cd7f283a111d8773f8f14d763508e`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
