### PR TITLE
QUICKDEMO: tailscaled can't start in gke-newhouse pods -- no /dev/net/tun, no NET_ADMIN (task_4ca2519c980f47e0a5f8bc050037475f)

### DIFF
--- a/QUICKDEMO.md
+++ b/QUICKDEMO.md
@@ -107,6 +107,37 @@ grep MAC_API_TOKEN ~/.mac/.env            # print the bearer token for the opera
 
 Open the URL in a browser and print the token to the terminal.
 
+### If the node is an hgx container session
+
+An `hgx`-provisioned pod (e.g. a gke-newhouse `standard` session) has no
+`/dev/net/tun` and no `CAP_NET_ADMIN`, so tailscaled cannot create a
+`tailscale0` interface or program netfilter — `user=root` does not help,
+because the capability was never in the pod's bounding set. `deploy/install-tailscale.sh`
+detects this and joins the mesh with Tailscale's **userspace networking**
+engine instead of failing. Check which datapath a node ended up on:
+
+```bash
+hgx ssh Hazel -- grep MAC_TAILSCALE_TUN_MODE ~/.mac/mac.env
+```
+
+`kernel` means this chapter works as written. `userspace` means the node is
+on the mesh but has **no local route to it**: there is no `tailscale0`, so a
+bare `curl http://<tailscale-ip>:8789` from inside that pod does not connect.
+Traffic has to go through the local proxy the userspace engine publishes:
+
+```bash
+hgx ssh Hazel -- 'set -a; . ~/.mac/mac.env; set +a; ALL_PROXY="$MAC_TAILSCALE_SOCKS5_PROXY" curl -sS http://127.0.0.1:8789/health'
+```
+
+Peers reaching *this* node over the mesh still work normally, and `tailscale ip -4`
+still reports the node's mesh address, so the hub URL handed to the operator is
+unchanged. Only outbound traffic originating on a userspace node needs the proxy.
+
+To get a real kernel datapath instead, the session must be created with the
+capability — `hgx create` has no first-class flag for it, so pass whatever the
+provider does expose through `mac admin hgx capacity ... --create-extra-arg=...`
+(see `docs/hgx-elastic-capacity.md`).
+
 ---
 
 ## 4. Staff the warren

--- a/deploy/install-tailscale.sh
+++ b/deploy/install-tailscale.sh
@@ -17,6 +17,36 @@ ENV_FILE="${ENV_FILE:-$MAC_HOME/mac.env}"
 SUPERVISOR_KIND="${TAILSCALE_SUPERVISOR:-${MAC_SUPERVISOR_KIND:-auto}}"
 FLEET_NAME="${FLEET_NAME:-mac}"
 
+# Datapath engine selection.
+#
+# tailscaled's default engine needs a kernel TUN device: /dev/net/tun must
+# exist AND the process must hold CAP_NET_ADMIN so it can create tailscale0 and
+# program netfilter.  An hgx-provisioned container node (e.g. a gke-newhouse
+# `standard` pod) is granted neither, and tailscaled hard-fails:
+#
+#   is CONFIG_TUN enabled in your kernel? `modprobe tun` failed
+#   tstun.New("tailscale0"): CreateTUN("tailscale0") failed;
+#     /dev/net/tun does not exist
+#
+# The same missing capability makes every iptables/ip6tables call fail with
+# "Permission denied (you must be root)" even under user=root, because netlink
+# rejects the unprivileged netns.  No auth key and no supervisor change can fix
+# that: it is the pod spec, not the deploy.  Tailscale ships a userspace
+# networking engine for exactly this topology, so detect the missing capability
+# and select it instead of failing the node.
+#
+#   auto      probe /dev/net/tun + CAP_NET_ADMIN and pick kernel or userspace
+#   kernel    force the default TUN engine (fail loudly if it is unavailable)
+#   userspace force userspace networking even where TUN would work
+TAILSCALE_TUN_MODE="${MAC_DEPLOY_TAILSCALE_TUN_MODE:-auto}"
+# Local proxy endpoints published by the userspace engine.  In userspace mode
+# the node has no tailscale0 interface, so host traffic reaches the mesh only
+# through these listeners.
+TAILSCALE_USERSPACE_SOCKS5_PORT="${MAC_DEPLOY_TAILSCALE_SOCKS5_PORT:-1055}"
+TAILSCALE_USERSPACE_HTTP_PROXY_PORT="${MAC_DEPLOY_TAILSCALE_HTTP_PROXY_PORT:-1055}"
+TAILSCALE_TUN_MODE_RESOLVED=""   # filled by resolve_tun_mode()
+TAILSCALE_TUN_MODE_REASON=""     # why resolve_tun_mode() chose what it chose
+
 # Headscale mode (preferred): point tailscale at a self-hosted control plane
 HEADSCALE_URL="${HEADSCALE_URL:-}"
 HEADSCALE_PREAUTHKEY="${HEADSCALE_PREAUTHKEY:-}"
@@ -91,6 +121,82 @@ compute_tailscale_socket() {
 tailscale_socket_flag() {
   if [ -n "$TAILSCALE_SOCKET" ]; then
     printf '%s\n' "--socket=$TAILSCALE_SOCKET"
+  fi
+}
+
+# -- Datapath capability probes --------------------------------------------
+# Both probes are read-only and never modprobe: on a container node the module
+# load is exactly what is denied, so attempting it only produces noise.
+
+have_tun_device() {
+  [ -c /dev/net/tun ]
+}
+
+# CAP_NET_ADMIN (capability bit 12) in this process's bounding set.  The
+# bounding set is the right question: a pod that was never granted NET_ADMIN
+# cannot regain it by becoming root, which is precisely why `user=root` in the
+# supervisord stanza did not help.  Reading /proc/self/status works without
+# capsh(1), which container images routinely omit.
+have_net_admin() {
+  local bounding
+  bounding="$(awk '/^CapBnd:/ { print $2; exit }' /proc/self/status 2>/dev/null || true)"
+  # No /proc/self/status (macOS, or a hardened procfs) means "unknown", not
+  # "missing".  Fail open so a Mac node keeps its stock kernel datapath; the
+  # /dev/net/tun probe still guards the container case.
+  [ -n "$bounding" ] || return 0
+  python3 -c 'import sys
+try:
+    mask = int(sys.argv[1], 16)
+except ValueError:
+    sys.exit(0)
+sys.exit(0 if mask & (1 << 12) else 1)' "$bounding"
+}
+
+# Resolve kernel vs userspace once; echoes "<mode> <reason>".
+resolve_tun_mode() {
+  case "$TAILSCALE_TUN_MODE" in
+    kernel)    printf '%s %s\n' "kernel" "forced_by_operator"; return ;;
+    userspace) printf '%s %s\n' "userspace" "forced_by_operator"; return ;;
+    auto|"") ;;
+    *)
+      echo "[tailscale] ERROR: unsupported MAC_DEPLOY_TAILSCALE_TUN_MODE: $TAILSCALE_TUN_MODE (expected auto, kernel, or userspace)" >&2
+      exit 1
+      ;;
+  esac
+  # The probe is Linux-specific.  macOS has no /dev/net/tun (tailscaled uses
+  # utun there) and no CapBnd, so probing would misread a healthy Mac node as
+  # capability-starved and quietly downgrade it to userspace networking.
+  if [ "$(uname -s 2>/dev/null || echo unknown)" != "Linux" ]; then
+    printf '%s %s\n' "kernel" "non_linux_host"
+    return
+  fi
+  if ! have_tun_device; then
+    printf '%s %s\n' "userspace" "no_dev_net_tun"
+    return
+  fi
+  if ! have_net_admin; then
+    printf '%s %s\n' "userspace" "no_cap_net_admin"
+    return
+  fi
+  printf '%s %s\n' "kernel" "tun_and_net_admin_present"
+}
+
+# Flags tailscaled itself needs for the resolved mode.
+tailscaled_mode_flags() {
+  if [ "$TAILSCALE_TUN_MODE_RESOLVED" = "userspace" ]; then
+    printf '%s\n' "--tun=userspace-networking --socks5-server=localhost:${TAILSCALE_USERSPACE_SOCKS5_PORT} --outbound-http-proxy-listen=localhost:${TAILSCALE_USERSPACE_HTTP_PROXY_PORT}"
+  fi
+}
+
+# Extra join flags handed to tailscale(1) up for the resolved mode.  Userspace networking has
+# no tailscale0 interface: there is nothing to install routes into and no
+# netfilter access, so asking for either only produces the permission-denied
+# spam that made the original failure hard to read.
+tailscale_up_mode_flags() {
+  if [ "$TAILSCALE_TUN_MODE_RESOLVED" = "userspace" ]; then
+    printf '%s\n' "--netfilter-mode=off --accept-routes=false --accept-dns=false"
+  else
+    printf '%s\n' "--accept-routes --accept-dns=true"
   fi
 }
 
@@ -179,6 +285,9 @@ if tailscale_connected; then
   exit 0
 fi
 
+# Everything past this point provisions the daemon, so the datapath the node is
+# capable of has to be known before the supervisor stanza is written.
+
 # -- Install tailscale package if missing --
 if ! command -v tailscale >/dev/null 2>&1; then
   echo "[tailscale] Installing Tailscale"
@@ -203,11 +312,28 @@ fi
 # -- Start tailscaled under the detected supervisor --
 SUPERVISOR_KIND="$(detect_supervisor)"
 TAILSCALE_SOCKET="$(compute_tailscale_socket "$SUPERVISOR_KIND")"
+read -r TAILSCALE_TUN_MODE_RESOLVED TAILSCALE_TUN_MODE_REASON <<EOF
+$(resolve_tun_mode)
+EOF
+if [ "$TAILSCALE_TUN_MODE_RESOLVED" = "userspace" ]; then
+  echo "[tailscale] datapath=userspace-networking (reason: ${TAILSCALE_TUN_MODE_REASON}) — this node joins the mesh in relay mode; outbound host traffic must use the local SOCKS5/HTTP proxy on port ${TAILSCALE_USERSPACE_SOCKS5_PORT}"
+else
+  echo "[tailscale] datapath=kernel-tun (reason: ${TAILSCALE_TUN_MODE_REASON})"
+fi
 echo "[tailscale] Starting tailscaled under ${SUPERVISOR_KIND}"
 mkdir -p "$LOG_DIR"
 
 case "$SUPERVISOR_KIND" in
   systemd)
+    # The packaged unit runs `tailscaled ... $FLAGS` with an EnvironmentFile,
+    # so the datapath choice belongs there rather than in a unit override.
+    if [ -n "$(tailscaled_mode_flags)" ]; then
+      sudo -n tee /etc/default/tailscaled >/dev/null <<EOF
+# Written by mac install-tailscale.sh: $TAILSCALE_TUN_MODE_REASON
+FLAGS="$(tailscaled_mode_flags)"
+EOF
+      sudo -n systemctl daemon-reload >/dev/null 2>&1 || true
+    fi
     sudo -n systemctl enable tailscaled >/dev/null 2>&1 || true
     sudo -n systemctl start tailscaled
     ;;
@@ -216,7 +342,7 @@ case "$SUPERVISOR_KIND" in
     sudo -n install -d -m 0755 "$conf_dir"
     sudo -n tee "$conf_dir/${FLEET_NAME}-tailscaled.conf" >/dev/null <<EOF
 [program:${FLEET_NAME}-tailscaled]
-command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641
+command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641 $(tailscaled_mode_flags)
 directory=/var/lib/${FLEET_NAME}/tailscale
 user=root
 autostart=true
@@ -257,8 +383,7 @@ if [ "$control_mode" = "headscale" ]; then
     --login-server="$HEADSCALE_URL" \
     --auth-key="$HEADSCALE_PREAUTHKEY" \
     --hostname="$TAILSCALE_HOSTNAME" \
-    --accept-routes \
-    --accept-dns=true >/dev/null 2>&1 || {
+    $(tailscale_up_mode_flags) >/dev/null 2>&1 || {
       echo "[tailscale] ERROR: headscale join failed (credential-bearing output suppressed)" >&2
       exit 1
     }
@@ -267,8 +392,7 @@ else
   run_tailscale $(tailscale_socket_flag) up \
     --auth-key="$TAILSCALE_AUTH_KEY" \
     --hostname="$TAILSCALE_HOSTNAME" \
-    --accept-routes \
-    --accept-dns=true >/dev/null 2>&1 || {
+    $(tailscale_up_mode_flags) >/dev/null 2>&1 || {
       echo "[tailscale] ERROR: tailscale join failed (credential-bearing output suppressed)" >&2
       exit 1
     }
@@ -283,7 +407,18 @@ if [ -z "$ts_ip" ]; then
   exit 1
 fi
 
-echo "[tailscale] Connected — hostname=${TAILSCALE_HOSTNAME} IP=${ts_ip}"
+echo "[tailscale] Connected — hostname=${TAILSCALE_HOSTNAME} IP=${ts_ip} datapath=${TAILSCALE_TUN_MODE_RESOLVED}"
 
 set_env_key "$ENV_FILE" MAC_TAILSCALE_IP "$ts_ip"
 set_env_key "$ENV_FILE" MAC_TAILSCALE_HOSTNAME "$TAILSCALE_HOSTNAME"
+# Downstream deploy steps must be able to tell a kernel-datapath node from a
+# userspace-relay one: on the latter, a bare `curl http://100.x.y.z:8789` does
+# not route, and callers have to go through the proxy recorded below.
+set_env_key "$ENV_FILE" MAC_TAILSCALE_TUN_MODE "$TAILSCALE_TUN_MODE_RESOLVED"
+if [ "$TAILSCALE_TUN_MODE_RESOLVED" = "userspace" ]; then
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_SOCKS5_PROXY "socks5://localhost:${TAILSCALE_USERSPACE_SOCKS5_PORT}"
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_HTTP_PROXY "http://localhost:${TAILSCALE_USERSPACE_HTTP_PROXY_PORT}"
+else
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_SOCKS5_PROXY ""
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_HTTP_PROXY ""
+fi

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -364,6 +364,9 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_SUPERVISOR_CONF_DIR` | str | consumer-defined | deployment | Deployment setting: deploy supervisor conf dir. |
 | `MAC_DEPLOY_TAILSCALE_AUTH_KEY` | str | consumer-defined | deployment | Deployment setting: deploy tailscale auth key. |
 | `MAC_DEPLOY_TAILSCALE_AUTH_KEY_ENV` | str | consumer-defined | deployment | Deployment setting: deploy tailscale auth key env. |
+| `MAC_DEPLOY_TAILSCALE_HTTP_PROXY_PORT` | int | consumer-defined | deployment | Deployment setting: deploy tailscale http proxy port. |
+| `MAC_DEPLOY_TAILSCALE_SOCKS5_PORT` | int | consumer-defined | deployment | Deployment setting: deploy tailscale socks5 port. |
+| `MAC_DEPLOY_TAILSCALE_TUN_MODE` | str | consumer-defined | deployment | Deployment setting: deploy tailscale tun mode. |
 | `MAC_DEPLOY_TAKEOVER_STALE_LOCK` | str | consumer-defined | deployment | Deployment setting: deploy takeover stale lock. |
 | `MAC_DEPLOY_TARGET` | str | consumer-defined | deployment | Deployment setting: deploy target. |
 | `MAC_DEPLOY_TEST_INJECT_OPENCLAW_SNAPSHOT_FAILURE` | str | consumer-defined | deployment | Deployment setting: deploy test inject openclaw snapshot failure. |
@@ -478,6 +481,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HGX_AUTOSCALE_CLUSTER` | str | consumer-defined | core | Core setting: hgx autoscale cluster. |
 | `MAC_HGX_AUTOSCALE_COOLDOWN_SECONDS` | int | consumer-defined | core | Core setting: hgx autoscale cooldown seconds. |
 | `MAC_HGX_AUTOSCALE_CPU` | str | consumer-defined | core | Core setting: hgx autoscale cpu. |
+| `MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS` | str | consumer-defined | core | Core setting: hgx autoscale create extra args. |
 | `MAC_HGX_AUTOSCALE_ENABLED` | bool | consumer-defined | core | Core setting: hgx autoscale enabled. |
 | `MAC_HGX_AUTOSCALE_GPU` | str | consumer-defined | core | Core setting: hgx autoscale gpu. |
 | `MAC_HGX_AUTOSCALE_HEADROOM` | str | consumer-defined | core | Core setting: hgx autoscale headroom. |
@@ -1042,7 +1046,10 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_SUPPRESS_VERSION_WARNING` | str | consumer-defined | core | Core setting: suppress version warning. |
 | `MAC_SYSTEMD_COMMAND_TIMEOUT_SECONDS` | int | consumer-defined | core | Core setting: systemd command timeout seconds. |
 | `MAC_TAILSCALE_HOSTNAME` | str | consumer-defined | core | Core setting: tailscale hostname. |
+| `MAC_TAILSCALE_HTTP_PROXY` | str | consumer-defined | core | Core setting: tailscale http proxy. |
 | `MAC_TAILSCALE_IP` | str | consumer-defined | core | Core setting: tailscale ip. |
+| `MAC_TAILSCALE_SOCKS5_PROXY` | str | consumer-defined | core | Core setting: tailscale socks5 proxy. |
+| `MAC_TAILSCALE_TUN_MODE` | str | consumer-defined | core | Core setting: tailscale tun mode. |
 | `MAC_TASK_CANONICAL_REMOTE` | str | consumer-defined | task-execution | Task Execution setting: task canonical remote. |
 | `MAC_TASK_EVIDENCE_MANIFEST_PATH` | str | consumer-defined | task-execution | Task Execution setting: task evidence manifest path. |
 | `MAC_TASK_EXECUTOR_COMMAND` | str | consumer-defined | task-execution | Task Execution setting: task executor command. |

--- a/docs/hgx-elastic-capacity.md
+++ b/docs/hgx-elastic-capacity.md
@@ -35,6 +35,48 @@ non-interactively with a valid owner credential. Enabling the service without
 that credential is observable as a provider error and never falls back to
 unverified capacity.
 
+## Session capabilities that MAC does not model
+
+A created session is a container. It gets no `/dev/net/tun` and no
+`CAP_NET_ADMIN`, and no amount of running as root inside the pod recovers a
+capability the pod spec never granted. That is why tailscaled cannot bring up
+`tailscale0` on a stock gke-newhouse `standard` session, and why every
+`iptables` call in the same log fails with "Permission denied (you must be
+root)": both symptoms are the one missing capability.
+
+`hgx create` exposes no first-class flag for either facility today, so the
+controller does not invent one. It carries a bounded verbatim pass-through
+instead:
+
+```console
+$ mac admin hgx capacity execute --pending-requests 1 \
+    --create-extra-arg=--cap-add=NET_ADMIN \
+    --create-extra-arg=--device=/dev/net/tun
+```
+
+The attached (`--flag=value`) form is required, because the values are
+themselves flags. The autoscaler takes the same list as one shell-quoted
+variable:
+
+```text
+MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS=--cap-add=NET_ADMIN --device=/dev/net/tun
+```
+
+Arguments are appended after the shape flags the controller owns and are
+validated first: at most 16 entries of at most 128 characters, restricted to
+letters, digits and `-_=.,:/+@`, and never `--cluster`, `--gpu`, `--memory`,
+`--cpu`, `--name`, `--flavor` or `--json` — overriding one of those would
+silently contradict the declared policy. An invalid list is a configuration
+error that disables the autoscaler rather than an exception that kills the hub.
+
+This is a pass-through, not a promise: if the provider rejects the flags, the
+session is still created without the capability. That case is not fatal to the
+fleet, because `deploy/install-tailscale.sh` probes for `/dev/net/tun` and
+`CAP_NET_ADMIN` and falls back to Tailscale's userspace networking engine,
+recording `MAC_TAILSCALE_TUN_MODE=userspace` plus the local SOCKS5/HTTP proxy
+endpoints in `mac.env`. A userspace node is on the mesh and reachable from
+peers, but its own outbound traffic must use that proxy — see `QUICKDEMO.md`.
+
 ## Readiness contract
 
 Every created session uses the current HGX CLI contract for an explicit

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -7155,6 +7155,7 @@ def _hgx_capacity_controller(args: argparse.Namespace) -> Any:
         cooldown_seconds=args.cooldown_seconds,
         wait_timeout_seconds=args.wait_timeout_seconds,
         poll_interval_seconds=args.poll_interval_seconds,
+        create_extra_args=tuple(args.create_extra_arg or ()),
     )
     provider = HgxProvider(
         binary=args.hgx_binary,
@@ -7263,6 +7264,21 @@ def _add_hgx_capacity_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--cooldown-seconds", type=float, default=300.0)
     parser.add_argument("--wait-timeout-seconds", type=float, default=300.0)
     parser.add_argument("--poll-interval-seconds", type=float, default=5.0)
+    parser.add_argument(
+        "--create-extra-arg",
+        action="append",
+        default=None,
+        metavar="ARG",
+        help=(
+            "extra argument appended verbatim to hgx create; repeatable. Use "
+            "this to request provider capabilities mac does not model, such as "
+            "the /dev/net/tun + NET_ADMIN a session needs to run a kernel-mode "
+            "tailscale datapath. Values that themselves begin with '-' must use "
+            "the attached form (--create-extra-arg=--cap-add=NET_ADMIN). Flags "
+            "the controller already supplies "
+            "(--cluster/--gpu/--memory/--cpu/--name) are refused"
+        ),
+    )
     parser.add_argument(
         "--state-file",
         default=DEFAULT_STATE_PATH,

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -4280,6 +4280,39 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy tailscale http proxy port.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_TAILSCALE_HTTP_PROXY_PORT",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy tailscale socks5 port.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_TAILSCALE_SOCKS5_PORT",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy tailscale tun mode.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_TAILSCALE_TUN_MODE",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy takeover stale lock.",
     "family": "deployment",
     "name": "MAC_DEPLOY_TAKEOVER_STALE_LOCK",
@@ -5651,6 +5684,17 @@
     "description": "Core setting: hgx autoscale cpu.",
     "family": "core",
     "name": "MAC_HGX_AUTOSCALE_CPU",
+    "retired": false,
+    "sources": [
+      "src/mac/hgx_autoscaler.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: hgx autoscale create extra args.",
+    "family": "core",
+    "name": "MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS",
     "retired": false,
     "sources": [
       "src/mac/hgx_autoscaler.py"
@@ -12289,12 +12333,45 @@
   },
   {
     "default": null,
+    "description": "Core setting: tailscale http proxy.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_HTTP_PROXY",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: tailscale ip.",
     "family": "core",
     "name": "MAC_TAILSCALE_IP",
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: tailscale socks5 proxy.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_SOCKS5_PROXY",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: tailscale tun mode.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_TUN_MODE",
+    "retired": false,
+    "sources": [
       "deploy/install-tailscale.sh"
     ],
     "type": "str"

--- a/src/mac/hgx_autoscaler.py
+++ b/src/mac/hgx_autoscaler.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import shlex
 import threading
 import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from mac.env_config import env_bool, env_float, env_int, env_str
 from mac.hgx_elastic_capacity import (
@@ -80,6 +81,9 @@ class HgxAutoscalerConfig:
     state_path: str = DEFAULT_STATE_PATH
     registered_agents_file: str = ""
     name_prefix: str = "mac-fungible"
+    # Bounded verbatim pass-through to ``hgx create``; see
+    # HgxCapacityPolicy.create_extra_args.
+    create_extra_args: Tuple[str, ...] = ()
     configuration_error: str = ""
 
     @property
@@ -102,6 +106,7 @@ class HgxAutoscalerConfig:
             cooldown_seconds=self.cooldown_seconds,
             wait_timeout_seconds=self.wait_timeout_seconds,
             poll_interval_seconds=self.poll_interval_seconds,
+            create_extra_args=self.create_extra_args,
         )
 
     @classmethod
@@ -242,6 +247,15 @@ class HgxAutoscalerConfig:
             ),
             name_prefix=env_str(
                 "MAC_HGX_AUTOSCALE_NAME_PREFIX", "mac-fungible", environ=env
+            ),
+            # Shell-style splitting so an operator can express a multi-token
+            # provider request in one variable; the policy validates every
+            # token and rejects anything that would contradict the shape flags
+            # the controller owns.
+            create_extra_args=tuple(
+                shlex.split(
+                    env_str("MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS", "", environ=env)
+                )
             ),
         )
         error = ""

--- a/src/mac/hgx_elastic_capacity.py
+++ b/src/mac/hgx_elastic_capacity.py
@@ -36,6 +36,8 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
+    Sequence,
+    Tuple,
 )
 
 from mac.hgx_provider import (
@@ -89,6 +91,18 @@ class HgxCapacityPolicy:
     cooldown_seconds: float = 300.0
     wait_timeout_seconds: float = 300.0
     poll_interval_seconds: float = 5.0
+    # Verbatim extra ``hgx create`` arguments, appended after the shape flags
+    # this controller owns.
+    #
+    # A container session that has to run real networking (tailscale, a VPN)
+    # needs /dev/net/tun and CAP_NET_ADMIN, and ``hgx create`` exposes no
+    # first-class flag for either today.  Rather than guess at a provider flag
+    # name that may not exist, the controller carries a bounded, explicit
+    # pass-through so an operator can request whatever the provider does
+    # expose without waiting for a mac release.  When the provider grants
+    # nothing, ``deploy/install-tailscale.sh`` still joins the mesh in
+    # userspace-relay mode, so this is an upgrade path and not a prerequisite.
+    create_extra_args: Tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         for name in ("min_ready", "max_sessions", "headroom", "max_create_per_run"):
@@ -144,6 +158,9 @@ class HgxCapacityPolicy:
             raise ValidationError("wait_timeout_seconds must be greater than zero")
         if self.poll_interval_seconds <= 0:
             raise ValidationError("poll_interval_seconds must be greater than zero")
+        object.__setattr__(
+            self, "create_extra_args", _validated_create_extra_args(self.create_extra_args)
+        )
 
     def desired_ready(self, pending_request_count: int) -> int:
         pending = _pending_count(pending_request_count)
@@ -165,7 +182,64 @@ class HgxCapacityPolicy:
             "cooldown_seconds": self.cooldown_seconds,
             "wait_timeout_seconds": self.wait_timeout_seconds,
             "poll_interval_seconds": self.poll_interval_seconds,
+            "create_extra_args": list(self.create_extra_args),
         }
+
+
+# Shape flags the controller supplies itself. An operator override for one of
+# these would silently contradict the declared policy — the provider would see
+# the flag twice and pick one — so they are refused rather than merged.
+_CONTROLLER_OWNED_CREATE_FLAGS = frozenset(
+    {"--cluster", "--gpu", "--memory", "--cpu", "--name", "--flavor", "--json"}
+)
+_CREATE_EXTRA_ARG_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "-_=.,:/+@"
+)
+_MAX_CREATE_EXTRA_ARGS = 16
+_MAX_CREATE_EXTRA_ARG_LENGTH = 128
+
+
+def _validated_create_extra_args(value: Any) -> Tuple[str, ...]:
+    """Bound the verbatim ``hgx create`` pass-through.
+
+    These strings become argv for a provider subprocess, so there is no shell
+    to quote for; the bounds exist so a typo cannot turn into an unbounded or
+    unreadable provider command, and so the flags the controller owns cannot be
+    contradicted from the outside.
+    """
+
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValidationError("create_extra_args must be a sequence of strings")
+    items = list(value)
+    if len(items) > _MAX_CREATE_EXTRA_ARGS:
+        raise ValidationError(
+            "create_extra_args must contain at most %d arguments" % _MAX_CREATE_EXTRA_ARGS
+        )
+    validated: List[str] = []
+    for item in items:
+        if not isinstance(item, str) or not item:
+            raise ValidationError("create_extra_args entries must be non-empty strings")
+        if len(item) > _MAX_CREATE_EXTRA_ARG_LENGTH:
+            raise ValidationError(
+                "create_extra_args entries must be at most %d characters"
+                % _MAX_CREATE_EXTRA_ARG_LENGTH
+            )
+        if any(ch not in _CREATE_EXTRA_ARG_CHARS for ch in item):
+            raise ValidationError(
+                "create_extra_args entries may only contain letters, digits and -_=.,:/+@"
+            )
+        if item.split("=", 1)[0] in _CONTROLLER_OWNED_CREATE_FLAGS:
+            raise ValidationError(
+                "create_extra_args must not override the controller-owned flag %r"
+                % item.split("=", 1)[0]
+            )
+        validated.append(item)
+    return tuple(validated)
 
 
 def count_pending_provisioning_requests(requests: Iterable[Any]) -> int:
@@ -666,6 +740,7 @@ class HgxElasticCapacityController:
                             "%dGi" % self.policy.memory_gib,
                             "--cpu",
                             str(self.policy.cpu_count),
+                            *self.policy.create_extra_args,
                         ],
                     )
                 except HgxCommandError as exc:

--- a/tests/test_hgx_autoscaler.py
+++ b/tests/test_hgx_autoscaler.py
@@ -218,3 +218,43 @@ def test_config_from_env_builds_bounded_step_policy() -> None:
     assert config.max_sessions == 7
     assert config.scale_up_stabilization_seconds == 180
     assert config.capacity_policy().max_create_per_run == 2
+
+
+def test_create_extra_args_reach_the_capacity_policy_from_the_environment() -> None:
+    config = HgxAutoscalerConfig.from_env(
+        {
+            "MAC_HGX_AUTOSCALE_ENABLED": "1",
+            "MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS": "--cap-add=NET_ADMIN --device=/dev/net/tun",
+        }
+    )
+
+    assert config.configuration_error == ""
+    assert config.create_extra_args == ("--cap-add=NET_ADMIN", "--device=/dev/net/tun")
+    assert config.capacity_policy().create_extra_args == (
+        "--cap-add=NET_ADMIN",
+        "--device=/dev/net/tun",
+    )
+    assert config.to_dict()["create_extra_args"] == (
+        "--cap-add=NET_ADMIN",
+        "--device=/dev/net/tun",
+    )
+
+
+def test_unset_create_extra_args_changes_nothing() -> None:
+    config = HgxAutoscalerConfig.from_env({"MAC_HGX_AUTOSCALE_ENABLED": "1"})
+
+    assert config.create_extra_args == ()
+    assert config.capacity_policy().create_extra_args == ()
+
+
+def test_invalid_create_extra_args_surface_as_configuration_error_not_a_crash() -> None:
+    """A bad provider request must disable the autoscaler, not kill the app."""
+    config = HgxAutoscalerConfig.from_env(
+        {
+            "MAC_HGX_AUTOSCALE_ENABLED": "1",
+            "MAC_HGX_AUTOSCALE_CREATE_EXTRA_ARGS": "--cluster=other",
+        }
+    )
+
+    assert config.active is False
+    assert "create_extra_args" in config.configuration_error

--- a/tests/test_hgx_elastic_capacity.py
+++ b/tests/test_hgx_elastic_capacity.py
@@ -916,3 +916,116 @@ def test_cli_accepts_registered_agents_file_for_capacity_commands() -> None:
     assert parser.parse_args(
         ["admin", "hgx", "capacity", "status"]
     ).registered_agents_file is None
+
+
+# ---------------------------------------------------------------------------
+# Bounded `hgx create` pass-through
+#
+# A session that has to run a kernel-mode tailscale datapath needs
+# /dev/net/tun and CAP_NET_ADMIN, and `hgx create` models neither. The
+# controller therefore carries an explicit, bounded pass-through instead of
+# guessing at a provider flag name, and refuses anything that would contradict
+# the shape flags it supplies itself.
+# ---------------------------------------------------------------------------
+
+def test_create_extra_args_are_appended_after_controller_owned_shape_flags(
+    tmp_path: Path,
+) -> None:
+    provider = FakeProvider()
+    clock = FakeClock()
+    controller = _controller(
+        tmp_path,
+        provider,
+        clock,
+        policy=HgxCapacityPolicy(
+            min_ready=1,
+            max_sessions=1,
+            create_extra_args=("--cap-add=NET_ADMIN", "--device=/dev/net/tun"),
+        ),
+    )
+
+    controller.execute(pending_request_count=1)
+
+    _flavor, _name, extra_args = provider.created[0]
+    assert extra_args[-2:] == ["--cap-add=NET_ADMIN", "--device=/dev/net/tun"]
+    # The declared shape still leads, so the pass-through cannot reorder it.
+    assert extra_args[:8] == [
+        "--cluster",
+        "gke-newhouse",
+        "--gpu",
+        "1",
+        "--memory",
+        "64Gi",
+        "--cpu",
+        "8",
+    ]
+
+
+def test_create_extra_args_default_to_nothing(tmp_path: Path) -> None:
+    provider = FakeProvider()
+    clock = FakeClock()
+    controller = _controller(
+        tmp_path,
+        provider,
+        clock,
+        policy=HgxCapacityPolicy(min_ready=1, max_sessions=1),
+    )
+
+    controller.execute(pending_request_count=1)
+
+    _flavor, _name, extra_args = provider.created[0]
+    assert extra_args == [
+        "--cluster",
+        "gke-newhouse",
+        "--gpu",
+        "1",
+        "--memory",
+        "64Gi",
+        "--cpu",
+        "8",
+    ]
+    assert HgxCapacityPolicy().to_dict()["create_extra_args"] == []
+
+
+def test_create_extra_args_refuse_controller_owned_flags() -> None:
+    for flag in ("--cluster", "--gpu=4", "--memory", "--cpu=2", "--name", "--flavor"):
+        with pytest.raises(ValidationError):
+            HgxCapacityPolicy(create_extra_args=(flag,))
+
+
+def test_create_extra_args_are_bounded_and_typed() -> None:
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args="--cap-add=NET_ADMIN")
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=("",))
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=(17,))
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=("--x=" + "a" * 200,))
+    with pytest.raises(ValidationError):
+        HgxCapacityPolicy(create_extra_args=tuple("--flag%d" % i for i in range(17)))
+    # Whitespace and shell metacharacters never reach a provider argv.
+    for hostile in ("--priv ileged", "--x=$(id)", "--x=a;b", "--x=`id`"):
+        with pytest.raises(ValidationError):
+            HgxCapacityPolicy(create_extra_args=(hostile,))
+    assert HgxCapacityPolicy(
+        create_extra_args=["--cap-add=NET_ADMIN"]
+    ).create_extra_args == ("--cap-add=NET_ADMIN",)
+
+
+def test_cli_exposes_repeatable_create_extra_arg() -> None:
+    parser = build_parser()
+
+    # The values are themselves flags, so the attached form is the usable one;
+    # this is the spelling the help text documents.
+    execute = parser.parse_args(
+        [
+            "admin", "hgx",
+            "capacity",
+            "execute",
+            "--create-extra-arg=--cap-add=NET_ADMIN",
+            "--create-extra-arg=--device=/dev/net/tun",
+        ]
+    )
+    assert execute.create_extra_arg == ["--cap-add=NET_ADMIN", "--device=/dev/net/tun"]
+    assert parser.parse_args(["admin", "hgx", "capacity", "plan"]).create_extra_arg is None

--- a/tests/test_tailscale_userspace_fallback.py
+++ b/tests/test_tailscale_userspace_fallback.py
@@ -1,0 +1,277 @@
+"""Tests for install-tailscale.sh datapath selection (kernel TUN vs userspace).
+
+Acceptance criteria (task: tailscaled cannot start in gke-newhouse pods --
+no /dev/net/tun, no NET_ADMIN):
+
+- On Linux, a missing /dev/net/tun selects Tailscale's userspace networking
+  engine instead of letting tailscaled hard-fail on CreateTUN.
+- A present /dev/net/tun but absent CAP_NET_ADMIN in the bounding set also
+  selects userspace: the pod that cannot open the TUN device is the same pod
+  whose iptables calls fail with "Permission denied (you must be root)", and
+  `user=root` in the supervisord stanza cannot recover a capability the pod
+  spec never granted.
+- A capable Linux node keeps the stock kernel datapath, and a non-Linux node
+  is never probed at all (macOS has no /dev/net/tun and no CapBnd, so probing
+  would silently downgrade a healthy Mac).
+- MAC_DEPLOY_TAILSCALE_TUN_MODE lets an operator force either mode, and an
+  unrecognized value fails loudly rather than defaulting.
+- The userspace daemon flags reach both the supervisord program line and the
+  systemd EnvironmentFile, and `tailscale up` stops asking for routes and
+  netfilter it provably cannot install.
+- The resolved datapath and its proxy endpoints are recorded in mac.env,
+  because a userspace-relay node is not reachable the same way a kernel-TUN
+  node is and downstream steps must be able to tell them apart.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "deploy" / "install-tailscale.sh"
+SCRIPT = SCRIPT_PATH.read_text(encoding="utf-8")
+
+# Functions the datapath decision is built from, in dependency order.
+_DATAPATH_FUNCS = (
+    "have_tun_device",
+    "have_net_admin",
+    "resolve_tun_mode",
+    "tailscaled_mode_flags",
+    "tailscale_up_mode_flags",
+)
+
+
+def _extract(func: str) -> str:
+    m = re.search(r"^%s\(\) \{\n.*?^}$" % re.escape(func), SCRIPT, re.S | re.M)
+    assert m, "could not extract function %s from install-tailscale.sh" % func
+    return m.group(0)
+
+
+def _harness(*, overrides: str = "", env: str = "", call: str) -> subprocess.CompletedProcess:
+    """Run the real datapath functions with explicit stubs for the probes.
+
+    ``overrides`` is appended *after* the extracted definitions so a test can
+    replace a probe (or ``uname``/``awk``) without editing the script.
+    """
+    body = "\n".join(
+        [
+            "set -uo pipefail",
+            'TAILSCALE_TUN_MODE="${MAC_DEPLOY_TAILSCALE_TUN_MODE:-auto}"',
+            'TAILSCALE_USERSPACE_SOCKS5_PORT="${MAC_DEPLOY_TAILSCALE_SOCKS5_PORT:-1055}"',
+            'TAILSCALE_USERSPACE_HTTP_PROXY_PORT="${MAC_DEPLOY_TAILSCALE_HTTP_PROXY_PORT:-1055}"',
+            'TAILSCALE_TUN_MODE_RESOLVED="${TAILSCALE_TUN_MODE_RESOLVED:-}"',
+            *(_extract(name) for name in _DATAPATH_FUNCS),
+            overrides,
+            call,
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", (env + "\n" if env else "") + body],
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_tun_mode
+# ---------------------------------------------------------------------------
+
+def test_missing_dev_net_tun_selects_userspace() -> None:
+    result = _harness(
+        overrides="\n".join(
+            [
+                'uname() { printf "Linux\\n"; }',
+                "have_tun_device() { return 1; }",
+                "have_net_admin() { return 0; }",
+            ]
+        ),
+        call="resolve_tun_mode",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["userspace", "no_dev_net_tun"]
+
+
+def test_missing_net_admin_selects_userspace_even_with_tun_device() -> None:
+    result = _harness(
+        overrides="\n".join(
+            [
+                'uname() { printf "Linux\\n"; }',
+                "have_tun_device() { return 0; }",
+                "have_net_admin() { return 1; }",
+            ]
+        ),
+        call="resolve_tun_mode",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["userspace", "no_cap_net_admin"]
+
+
+def test_capable_linux_node_keeps_kernel_datapath() -> None:
+    result = _harness(
+        overrides="\n".join(
+            [
+                'uname() { printf "Linux\\n"; }',
+                "have_tun_device() { return 0; }",
+                "have_net_admin() { return 0; }",
+            ]
+        ),
+        call="resolve_tun_mode",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["kernel", "tun_and_net_admin_present"]
+
+
+def test_non_linux_host_is_never_probed() -> None:
+    """macOS has no /dev/net/tun; probing it would downgrade a healthy Mac."""
+    result = _harness(
+        overrides="\n".join(
+            [
+                'uname() { printf "Darwin\\n"; }',
+                'have_tun_device() { echo "probed" >&2; return 1; }',
+                "have_net_admin() { return 1; }",
+            ]
+        ),
+        call="resolve_tun_mode",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["kernel", "non_linux_host"]
+    assert "probed" not in result.stderr
+
+
+def test_operator_can_force_either_mode() -> None:
+    for forced in ("kernel", "userspace"):
+        result = _harness(
+            env='export MAC_DEPLOY_TAILSCALE_TUN_MODE=%s' % forced,
+            overrides="\n".join(
+                [
+                    'uname() { printf "Linux\\n"; }',
+                    'have_tun_device() { echo "probed" >&2; return 1; }',
+                    "have_net_admin() { return 1; }",
+                ]
+            ),
+            call="resolve_tun_mode",
+        )
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.split() == [forced, "forced_by_operator"]
+        assert "probed" not in result.stderr
+
+
+def test_unrecognized_forced_mode_fails_loudly() -> None:
+    result = _harness(
+        env="export MAC_DEPLOY_TAILSCALE_TUN_MODE=maybe",
+        overrides='uname() { printf "Linux\\n"; }',
+        call="resolve_tun_mode",
+    )
+    assert result.returncode != 0
+    assert "MAC_DEPLOY_TAILSCALE_TUN_MODE" in result.stderr
+    assert result.stdout.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# have_net_admin: CAP_NET_ADMIN is capability bit 12 of CapBnd
+# ---------------------------------------------------------------------------
+
+def _net_admin_with_capbnd(capbnd: str) -> int:
+    return _harness(
+        overrides='awk() { printf "%s\\n"; }' % capbnd,
+        call="have_net_admin",
+    ).returncode
+
+
+def test_net_admin_reads_bit_twelve_of_the_bounding_set() -> None:
+    # 0x...1000 has bit 12 set; 0x...0fff covers bits 0..11 only.
+    assert _net_admin_with_capbnd("0000000000001000") == 0
+    assert _net_admin_with_capbnd("0000003fffffffff") == 0
+    assert _net_admin_with_capbnd("0000000000000fff") == 1
+    assert _net_admin_with_capbnd("0000000000000000") == 1
+    # The default container bounding set: NET_RAW (bit 13, 0x2000) is granted
+    # but NET_ADMIN (bit 12) is not -- which is why a pod can hold a plausible
+    # capability set, run as root, and still not be able to open a TUN device.
+    assert _net_admin_with_capbnd("00000000a80425fb") == 1
+
+
+def test_net_admin_fails_open_when_the_bounding_set_is_unreadable() -> None:
+    """No CapBnd means "unknown", not "missing" -- do not downgrade blindly."""
+    assert _net_admin_with_capbnd("") == 0
+    assert _net_admin_with_capbnd("not-hex") == 0
+
+
+# ---------------------------------------------------------------------------
+# Flag construction
+# ---------------------------------------------------------------------------
+
+def test_userspace_daemon_flags_publish_local_proxies() -> None:
+    result = _harness(
+        env="export MAC_DEPLOY_TAILSCALE_SOCKS5_PORT=1080 MAC_DEPLOY_TAILSCALE_HTTP_PROXY_PORT=1081",
+        overrides='TAILSCALE_TUN_MODE_RESOLVED="userspace"',
+        call="tailscaled_mode_flags",
+    )
+    assert result.returncode == 0, result.stderr
+    flags = result.stdout.split()
+    assert "--tun=userspace-networking" in flags
+    assert "--socks5-server=localhost:1080" in flags
+    assert "--outbound-http-proxy-listen=localhost:1081" in flags
+
+
+def test_kernel_mode_adds_no_daemon_flags() -> None:
+    result = _harness(
+        overrides='TAILSCALE_TUN_MODE_RESOLVED="kernel"',
+        call="tailscaled_mode_flags",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_userspace_join_stops_requesting_routes_and_netfilter() -> None:
+    userspace = _harness(
+        overrides='TAILSCALE_TUN_MODE_RESOLVED="userspace"',
+        call="tailscale_up_mode_flags",
+    )
+    assert userspace.returncode == 0, userspace.stderr
+    flags = userspace.stdout.split()
+    assert "--netfilter-mode=off" in flags
+    assert "--accept-routes=false" in flags
+    assert "--accept-dns=false" in flags
+
+    kernel = _harness(
+        overrides='TAILSCALE_TUN_MODE_RESOLVED="kernel"',
+        call="tailscale_up_mode_flags",
+    )
+    assert kernel.returncode == 0, kernel.stderr
+    assert kernel.stdout.split() == ["--accept-routes", "--accept-dns=true"]
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the resolved flags have to reach the daemon and mac.env
+# ---------------------------------------------------------------------------
+
+def test_supervisord_program_line_carries_the_datapath_flags() -> None:
+    command_line = next(
+        line for line in SCRIPT.splitlines() if line.startswith("command=/usr/sbin/tailscaled")
+    )
+    assert "$(tailscaled_mode_flags)" in command_line
+
+
+def test_systemd_branch_writes_the_flags_to_the_environment_file() -> None:
+    systemd_branch = SCRIPT.split("  systemd)\n", 1)[1].split("    ;;", 1)[0]
+    assert "/etc/default/tailscaled" in systemd_branch
+    assert 'FLAGS="$(tailscaled_mode_flags)"' in systemd_branch
+
+
+def test_join_uses_the_mode_flags_for_both_control_planes() -> None:
+    assert SCRIPT.count("$(tailscale_up_mode_flags)") == 2
+    for marker in ('--auth-key="$TAILSCALE_AUTH_KEY"', '--auth-key="$HEADSCALE_PREAUTHKEY"'):
+        command = SCRIPT.split(marker, 1)[1].split("}", 1)[0]
+        assert "$(tailscale_up_mode_flags)" in command
+
+
+def test_resolved_datapath_is_recorded_in_mac_env() -> None:
+    assert 'set_env_key "$ENV_FILE" MAC_TAILSCALE_TUN_MODE "$TAILSCALE_TUN_MODE_RESOLVED"' in SCRIPT
+    assert "MAC_TAILSCALE_SOCKS5_PROXY" in SCRIPT
+    assert "MAC_TAILSCALE_HTTP_PROXY" in SCRIPT
+
+
+def test_probe_never_attempts_a_module_load() -> None:
+    """modprobe is exactly what the pod is denied; retrying it only adds noise."""
+    assert "modprobe" not in "\n".join(_extract(name) for name in _DATAPATH_FUNCS)


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_4ca2519c980f47e0a5f8bc050037475f`
- head: `58846ede8c58e2b047fd10aab980dd7720ce5d2b`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
