### PR TITLE
Feature: self-hosted Headscale key should land in the secrets vault, be CLI-fetchable by the provisioner, and A2A traffic should be mesh-enforced (task_310e9d31cec64e5087661fd68746a9e0)

### DIFF
--- a/deploy/headscale-key-vault.sh
+++ b/deploy/headscale-key-vault.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# headscale-key-vault.sh — move the hub's headscale pre-auth key between the
+# secrets vault and the nodes that need it.
+#
+#     deploy/headscale-key-vault.sh publish    # hub: vault <- generated key
+#     deploy/headscale-key-vault.sh fetch      # any node: vault -> stdout
+#
+# WHY. install-headscale.sh generates a reusable pre-auth key and writes it to
+# the hub's local env file. Every worker that joined the mesh so far got that
+# value because the deploy pipeline forwarded the env var over SSH during that
+# worker's own bootstrap — the key was never a SecretRecord, so nothing off the
+# deploy path could ask for it. An operator laptop, a provisioner host, or a
+# control node added months later had no way to fetch it, which is why the
+# first demo fleet ended up pasting a personal Tailscale auth key into
+# ~/.mac/.env instead. `publish` closes that; `fetch` is the other end of it.
+#
+# Publication is a separate step from generation because the two have different
+# preconditions: generation needs headscale, publication needs the mac hub to
+# answer, and on a fresh fleet the network layer is installed BEFORE the
+# control plane. install-headscale.sh therefore calls `publish` best-effort and
+# stamps the outcome into the env file; the deploy pipeline or an operator can
+# re-run it once the hub is up. `publish` is idempotent: an existing secret of
+# the same name is ROTATED in place, keeping its id, scopes and audit trail.
+#
+# Inputs (all optional; sensible defaults):
+#   FLEET_NAME                      fleet name, used in the default secret name
+#   ENV_FILE                        hub env file to read the key from / stamp
+#   HEADSCALE_PREAUTHKEY            the key itself; read from ENV_FILE if unset
+#   HEADSCALE_PREAUTHKEY_SECRET     secret name (default headscale-preauthkey-<fleet>)
+#   HEADSCALE_PREAUTHKEY_SCOPES     JSON scopes for the SecretRecord
+#   MAC_BIN                         path to the mac CLI
+#   HEADSCALE_VAULT_REQUIRED=1      make a failed publish fatal
+#
+# The key value is never echoed by `publish`, never passed as an argv word
+# (argv is world-readable in /proc), and never written to a log: it reaches the
+# CLI on stdin. `fetch` writes it to stdout and NOTHING else, so a caller can
+# capture it; every message goes to stderr.
+set -euo pipefail
+
+FLEET_NAME="${FLEET_NAME:-mac}"
+MAC_HOME="${MAC_HOME:-$HOME/.mac}"
+ENV_FILE="${ENV_FILE:-$MAC_HOME/mac.env}"
+SECRET_NAME="${HEADSCALE_PREAUTHKEY_SECRET:-headscale-preauthkey-${FLEET_NAME}}"
+# Scoped by capability, not by agent id: the set of nodes that may join the
+# mesh is open-ended (workers, an operator laptop, a provisioner added later),
+# and enumerating agent ids here would have to be edited on every join.
+DEFAULT_SECRET_SCOPES='{"capabilities": ["deploy", "mesh-join"]}'
+SECRET_SCOPES="${HEADSCALE_PREAUTHKEY_SCOPES:-$DEFAULT_SECRET_SCOPES}"
+CREATED_BY="${HEADSCALE_PREAUTHKEY_CREATED_BY:-install-headscale.sh}"
+VAULT_REQUIRED="${HEADSCALE_VAULT_REQUIRED:-0}"
+
+log() { echo "[headscale-key] $*" >&2; }
+
+resolve_mac_bin() {
+  if [ -n "${MAC_BIN:-}" ]; then
+    printf '%s\n' "$MAC_BIN"
+    return 0
+  fi
+  if [ -x "$MAC_HOME/venv/bin/mac" ]; then
+    printf '%s\n' "$MAC_HOME/venv/bin/mac"
+    return 0
+  fi
+  if command -v mac >/dev/null 2>&1; then
+    command -v mac
+    return 0
+  fi
+  return 1
+}
+
+read_env_key() {
+  # Value of KEY in ENV_FILE, without sourcing the file: it holds credentials
+  # for other subsystems and must not be executed.
+  local key="$1"
+  [ -f "$ENV_FILE" ] || return 0
+  sed -n "s|^${key}=||p" "$ENV_FILE" | tail -n 1
+}
+
+set_env_key() {
+  local file="$1" key="$2" value="$3"
+  mkdir -p "$(dirname "$file")"
+  if [ ! -f "$file" ]; then
+    : > "$file"
+    chmod 600 "$file"
+  fi
+  if grep -q "^${key}=" "$file" 2>/dev/null; then
+    # -i.bak + rm is the spelling that works on both GNU and BSD sed; the hub
+    # can be either.
+    sed -i.bak "s|^${key}=.*|${key}=${value}|" "$file" && rm -f "$file.bak"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$file"
+  fi
+}
+
+secret_exists() {
+  # `secret list` returns metadata only (no values), so this is a safe
+  # existence probe and it doubles as a hub-reachability check. Exit 0 present,
+  # 1 absent, 2 hub unreachable / unparseable.
+  local mac_bin="$1" name="$2" listed=""
+  listed="$("$mac_bin" admin secret list 2>/dev/null)" || return 2
+  printf '%s' "$listed" | python3 -c '
+import json, sys
+try:
+    records = json.load(sys.stdin)
+except ValueError:
+    sys.exit(2)
+if not isinstance(records, list):
+    sys.exit(2)
+sys.exit(0 if any(r.get("name") == sys.argv[1] for r in records) else 1)
+' "$name"
+}
+
+cmd_publish() {
+  stamp() {
+    # Record the outcome next to the key so a later deploy phase (or an
+    # operator reading the env file) can tell "published" from "hub was down".
+    set_env_key "$ENV_FILE" HEADSCALE_PREAUTHKEY_SECRET "$SECRET_NAME"
+    set_env_key "$ENV_FILE" HEADSCALE_PREAUTHKEY_VAULT "$1"
+  }
+  give_up() {
+    # Publication failed. Not fatal by default: the key is still in the hub env
+    # file and the deploy pipeline still forwards it, so the fleet comes up. It
+    # just comes up with the gap this script exists to close, and says so
+    # rather than reporting success.
+    log "ERROR: $1"
+    stamp deferred
+    if [ "$VAULT_REQUIRED" = "1" ]; then
+      exit 1
+    fi
+    log "key is NOT in the vault; re-run 'headscale-key-vault.sh publish' once the hub is up"
+    exit 0
+  }
+
+  local preauthkey="${HEADSCALE_PREAUTHKEY:-}"
+  if [ -z "$preauthkey" ]; then
+    preauthkey="$(read_env_key HEADSCALE_PREAUTHKEY)"
+  fi
+  [ -n "$preauthkey" ] || give_up "no HEADSCALE_PREAUTHKEY in the environment or ${ENV_FILE}"
+
+  local mac_bin=""
+  mac_bin="$(resolve_mac_bin)" || give_up "could not find the mac CLI (set MAC_BIN)"
+
+  local present=0
+  if secret_exists "$mac_bin" "$SECRET_NAME"; then
+    present=0
+  else
+    present=$?
+  fi
+  case "$present" in
+    0)
+      log "rotating existing secret ${SECRET_NAME}"
+      printf '%s' "$preauthkey" \
+        | "$mac_bin" admin secret rotate "$SECRET_NAME" --from-stdin --actor "$CREATED_BY" >/dev/null \
+        || give_up "could not rotate ${SECRET_NAME}"
+      ;;
+    1)
+      log "creating secret ${SECRET_NAME}"
+      printf '%s' "$preauthkey" \
+        | "$mac_bin" admin secret set "$SECRET_NAME" --from-stdin \
+            --scopes "$SECRET_SCOPES" --created-by "$CREATED_BY" >/dev/null \
+        || give_up "could not create ${SECRET_NAME}"
+      ;;
+    *)
+      give_up "the mac hub did not answer 'admin secret list'"
+      ;;
+  esac
+
+  stamp published
+  log "published to the vault as ${SECRET_NAME}"
+  log "fetch it with: mac admin secret get ${SECRET_NAME} --raw"
+}
+
+cmd_fetch() {
+  local mac_bin=""
+  if ! mac_bin="$(resolve_mac_bin)"; then
+    log "could not find the mac CLI (set MAC_BIN); cannot fetch ${SECRET_NAME}"
+    return 1
+  fi
+  local value=""
+  if ! value="$("$mac_bin" admin secret get "$SECRET_NAME" --raw --purpose mesh-join 2>/dev/null)"; then
+    log "vault has no usable ${SECRET_NAME} (hub unreachable, token lacks the 'secret' scope, or the key was never published)"
+    return 1
+  fi
+  value="${value%$'\n'}"
+  [ -n "$value" ] || { log "vault returned an empty ${SECRET_NAME}"; return 1; }
+  printf '%s\n' "$value"
+}
+
+case "${1:-}" in
+  publish) cmd_publish ;;
+  fetch) cmd_fetch ;;
+  *)
+    echo "usage: $(basename "$0") {publish|fetch}" >&2
+    exit 2
+    ;;
+esac

--- a/deploy/install-headscale.sh
+++ b/deploy/install-headscale.sh
@@ -7,6 +7,13 @@
 #   HEADSCALE_URL=http://localhost:<port>      (used by hub's own tailscale up)
 #   HEADSCALE_FLEET_URL=<login-server-url>     (used by worker tailscale up)
 #   HEADSCALE_PREAUTHKEY=<reusable-key>        (used by all agents)
+#   HEADSCALE_PREAUTHKEY_SECRET=<secret-name>  (its name in the secrets vault)
+#   HEADSCALE_PREAUTHKEY_VAULT=published|deferred
+#
+# The key is also registered in the mac secrets vault (see
+# headscale-key-vault.sh), which is what lets a node the deploy pipeline never
+# SSHes into — an operator laptop, a provisioner — join the same mesh with
+# `mac admin secret get`.
 set -euo pipefail
 
 AGENT_NAME="${AGENT:-$(hostname)}"
@@ -324,4 +331,21 @@ if [ "$SUPERVISOR_KIND" = launchd ]; then
 fi
 
 echo "[headscale] Wrote credentials to ${ENV_FILE}"
+
+# -- Register the key in the secrets vault --
+# The env file alone only serves nodes the deploy pipeline SSHes into. Putting
+# the key in the vault is what lets anything else — an operator laptop, a
+# provisioner host, a control node added months later — fetch it with
+# `mac admin secret get`. Best-effort: on a fresh fleet the network layer is
+# installed before the hub, so publication is expected to be deferred on the
+# first pass and re-run afterwards. publish-headscale-key.sh stamps the outcome
+# into ENV_FILE either way. Set HEADSCALE_VAULT_REQUIRED=1 to make it fatal.
+key_vault_script="$(CDPATH= cd -P -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/headscale-key-vault.sh"
+if [ -x "$key_vault_script" ]; then
+  FLEET_NAME="$FLEET_NAME" ENV_FILE="$ENV_FILE" HEADSCALE_PREAUTHKEY="$preauthkey" \
+    "$key_vault_script" publish || echo "[headscale] WARNING: vault publication failed" >&2
+else
+  echo "[headscale] WARNING: ${key_vault_script} is missing; key not published to the vault" >&2
+fi
+
 echo "[headscale] Fleet URL (for workers): ${HEADSCALE_FLEET_URL}"

--- a/deploy/install-tailscale.sh
+++ b/deploy/install-tailscale.sh
@@ -5,9 +5,11 @@
 #   tailscale cloud — Tailscale SaaS (requires TAILSCALE_AUTH_KEY)
 #   headscale       — self-hosted control plane (requires explicit HEADSCALE_URL)
 #
-# In headscale mode HEADSCALE_URL and HEADSCALE_PREAUTHKEY must be set.
-# For the hub, these are written by install-headscale.sh. For workers they
-# are read from the hub's mac.env during deploy.
+# In headscale mode HEADSCALE_URL must be set. HEADSCALE_PREAUTHKEY is read
+# from the environment when the deploy pipeline forwarded it (the hub gets it
+# from install-headscale.sh; workers get it from the hub's mac.env during
+# deploy) and otherwise from the secrets vault via headscale-key-vault.sh —
+# the route for a node deploy never touched, such as a provisioner.
 set -euo pipefail
 
 AGENT_NAME="${AGENT:-$(hostname)}"
@@ -150,7 +152,22 @@ wait_for_tailscale_ip() {
 # -- Validate credentials --
 if [ -n "$HEADSCALE_URL" ]; then
   if [ -z "$HEADSCALE_PREAUTHKEY" ]; then
-    echo "[tailscale] ERROR: HEADSCALE_URL is set but HEADSCALE_PREAUTHKEY is empty" >&2
+    # No key in the environment. Before failing, ask the vault: the hub
+    # publishes its generated pre-auth key there, and that is the only route
+    # for a node the deploy pipeline did not SSH into and hand the value to —
+    # an operator's laptop, a provisioner, a control node added later. Needs a
+    # `secret`-scoped hub token, not a registered fleet-agent identity.
+    key_vault_script="$(CDPATH= cd -P -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/headscale-key-vault.sh"
+    if [ -x "$key_vault_script" ]; then
+      echo "[tailscale] No HEADSCALE_PREAUTHKEY in the environment; trying the secrets vault" >&2
+      HEADSCALE_PREAUTHKEY="$(FLEET_NAME="$FLEET_NAME" "$key_vault_script" fetch || true)"
+    fi
+  fi
+  if [ -z "$HEADSCALE_PREAUTHKEY" ]; then
+    echo "[tailscale] ERROR: HEADSCALE_URL is set but no pre-auth key is available:" >&2
+    echo "[tailscale]   HEADSCALE_PREAUTHKEY is empty and the vault has no usable" >&2
+    echo "[tailscale]   headscale-preauthkey-${FLEET_NAME}. On the hub, run" >&2
+    echo "[tailscale]   deploy/headscale-key-vault.sh publish to register it." >&2
     exit 1
   fi
   control_mode="headscale"

--- a/docs/adr/0025-mesh-membership-is-the-network-boundary.md
+++ b/docs/adr/0025-mesh-membership-is-the-network-boundary.md
@@ -1,0 +1,192 @@
+# ADR 0025 - Mesh membership is the network boundary, and the vault is how you get in
+
+- Status: **Partially accepted** — the enrollment-key half is implemented; the
+  binding half is proposed and deliberately not yet built (see *Status of each
+  decision*)
+- Date: 2026-08-20
+- Decision owner: MAC fleet owner
+- Related: ADR 0013 (the hub allocator is authoritative), ADR 0019 (privilege
+  is an ACL on a resource tree), ADR 0022 (a gate returns a named decision)
+
+## Context
+
+A fleet that should not ride on anyone's personal Tailscale tailnet — a demo
+fleet, a customer fleet, an air-gapped one — runs its own coordination server.
+`deploy/install-headscale.sh` already does the hard part: it installs
+headscale, writes `server_url`, starts it under the node's supervisor, waits
+for `/health`, creates a user, and generates a reusable one-year pre-auth key.
+
+Three things were missing around it, and they are different in kind.
+
+**The key had exactly one distribution channel: SSH.** The generated key was
+written to `HEADSCALE_PREAUTHKEY` in the hub's env file and nowhere else. Every
+worker that joined got it because the deploy pipeline forwarded that env var
+over SSH during that worker's own bootstrap. Nothing that the pipeline does not
+SSH into could obtain it — an operator's laptop, a CI runner, the provisioner
+host itself. The observable cost: the first QUICKDEMO fleet gave up and pasted
+a *personal* Tailscale auth key into `~/.mac/.env`, creating a
+`tailscale-auth-<fleet>` secret as a workaround, which is the exact coupling to
+a personal tailnet the self-hosted control plane exists to avoid.
+
+**No CLI could reveal a secret.** `SecretsService` is a real vault, but its
+access flow is `request_secret()` → `SecretHandle` → `reveal_secret()`, and
+`reveal_secret` matches `accessor_agent_id` against a registered `Agent` row on
+a trusted `Machine`. The CLI's `secret` subtree had `set/list/delete/rotate/
+access/audits` and no reveal at all. Even for a registered agent there was no
+terminal path to a value; for a machine that is not a fleet agent the handle
+flow is not merely missing, it is *circular* — it would require fleet-agent
+registration in order to fetch the enrollment key that lets you join the fleet.
+
+**Nothing ties API traffic to the mesh.** The hub control plane binds
+`0.0.0.0` by default (`deploy/deploy-mac-fleet.sh:1352`,
+`src/mac/fleet_setup.py:528`, and the hub entry in `deploy/fleet/config.yaml`),
+and `hub_url` is whatever was configured at setup time — a mesh IP, a cluster
+DNS name, or loopback — with no cross-check against `network.provider`. A2A
+delegation (`POST /a2a`) is scope-gated like every other route but is not
+network-confined. So "all agent-to-agent traffic goes over the mesh" is at
+present a description of how the fleet happens to be addressed, not a property
+anything enforces.
+
+## Decision
+
+### 1. The vault is the distribution channel for the enrollment key; the env file is a cache
+
+`install-headscale.sh` keeps writing `HEADSCALE_PREAUTHKEY` to the hub env file
+— the deploy pipeline reads it there and that path is fine — but the key's
+authoritative home is a `SecretRecord` named `headscale-preauthkey-<fleet>`,
+scoped by capability (`deploy`, `mesh-join`) rather than by agent id, because
+the set of nodes that may join is open-ended by definition.
+
+Publication is a **separate step** from generation, in
+`deploy/headscale-key-vault.sh`, because the two have different preconditions:
+generation needs headscale, publication needs the hub to answer, and on a fresh
+fleet the network layer is installed *before* the control plane. So the first
+publish attempt is expected to be deferred, and the outcome is stamped into the
+env file (`HEADSCALE_PREAUTHKEY_VAULT=published|deferred`) so that "the hub was
+not up yet" never looks like success. Re-running is idempotent: an existing
+secret of that name is rotated in place, keeping its id, scopes and audit
+trail, which is what a regenerated key actually is.
+
+### 2. Reveal-by-name is the non-agent path, and the `secret` token scope is its credential
+
+`POST /secrets/{name}/resolve` already existed for in-fleet consumers (the
+Slack and forge fetchers). It is the right mechanism for this too, and a second
+reveal endpoint would have been a mistake. What it needed was a CLI
+(`mac admin secret get <name> [--raw]`) and an explicit answer to "who may
+call it".
+
+That answer is the **`secret` token scope**, which a hub token may carry
+without being bound to any agent. It is a real credential with real limits, not
+a bypass: tenant isolation (closed on this route as part of this work — it was
+the one `/secrets/*` route that skipped `_assert_secret_tenant`), the existing
+per-principal rate limit, an audit row per call naming the principal and the
+declared purpose, and a 404 rather than an empty string for a
+missing-or-disabled secret.
+
+The handle flow remains preferred wherever the caller *is* a registered agent:
+it is single-use and time-limited, and reveal-by-name is neither.
+
+### 3. The mesh address is derived from the provider, not hand-configured (proposed)
+
+`control_bind_host` is already a per-agent config field; it simply never
+consults `network.provider`. The proposal is that when `network.provider` is
+`tailscale` or `headscale`, the hub's bind address is **derived** from the
+node's mesh interface (`tailscale ip -4`, within the fleet's `ip_prefix`,
+default `100.64.0.0/10`) rather than defaulting to `0.0.0.0`, with:
+
+- an explicit escape hatch (`control_bind_host` set literally in the fleet
+  config always wins, including back to `0.0.0.0`);
+- a named decision at deploy time, per ADR 0022 — `mesh-bound`,
+  `explicitly-unbound`, `no-provider`, or `mesh-address-unavailable` — recorded
+  in the deploy manifest, so an operator can see which one happened rather than
+  inferring it from a port scan;
+- a **fail-closed refusal** when the provider is a mesh and the mesh address
+  cannot be determined, because silently falling back to `0.0.0.0` in that case
+  would turn an enforcement mechanism into a coin flip;
+- a `hub_url` / provider cross-check that warns when `hub_url` names an address
+  outside the mesh prefix while the provider is a mesh, since that combination
+  means agents are reaching the hub off-mesh no matter what the bind says.
+
+Precedent for derivation over configuration already exists in
+`canonicalize_mesh_ssh_target(target, provider=network_provider)`: SSH targets
+are already normalized against the provider, and the control-plane address is
+the same question asked about a different port.
+
+### 4. Binding is the enforcement layer; firewall rules are an addition, not the mechanism
+
+Bind-address enforcement is chosen over `iptables`/`pf` rules as the primary
+mechanism because it is portable across the platforms mac deploys to (linux,
+darwin, wsl2), needs no root at runtime, cannot drift out of sync with the
+service it protects, and fails in the safe direction: a socket that was never
+opened on a public interface cannot be reached by a rule that was never
+applied. Packet filtering may be layered on for defence in depth, but a fleet
+whose only mesh guarantee is a firewall rule has its guarantee in a different
+subsystem from its listener.
+
+### 5. Authentication is not replaced by network confinement
+
+Mesh binding narrows *reachability*; it does not authorize anything. Token
+scopes, tenant isolation, and `mac-853j`'s refusal to fail open on a
+non-loopback bind all continue to apply unchanged. A node on the mesh is still
+an unauthenticated stranger to the control plane until it presents a token.
+This is worth stating because "it's on the private network" is the oldest way
+an authorization gate quietly stops being enforced.
+
+## Status of each decision
+
+| # | Decision | Status |
+|---|----------|--------|
+| 1 | Key lands in the vault, publication separate and idempotent | **Implemented** |
+| 2 | `mac admin secret get` + `secret` scope as the operator credential | **Implemented** |
+| 3 | Mesh-derived `control_bind_host` | **Proposed — not built** |
+| 4 | Binding over firewall as the mechanism | **Proposed — not built** |
+| 5 | Auth still applies | Already true; stated so it is not eroded |
+
+Decisions 3 and 4 change the network security model and can, if wrong, make a
+hub unreachable from the operator's own machine — the failure mode is
+"locked out of the fleet", and it lands on whoever is least able to recover it.
+They are recorded here so the enrollment-key work has a stated boundary rather
+than an implied one, and are left for a change that can be reviewed on its own
+terms with a rollback path.
+
+## Consequences
+
+- A control node that the deploy pipeline never touches can join the fleet's
+  mesh: fetch the key from the vault, `tailscale up --login-server`, done. That
+  is the case that previously forced a personal auth key into the fleet.
+- The hub's own generated key becomes rotatable and auditable like any other
+  credential, instead of living only in a file on one host.
+- `mac admin secret get` puts plaintext on stdout by design. That is the point
+  of the command, and the audit row records that it happened — but it means the
+  `secret` scope should be minted deliberately and not folded into a
+  general-purpose operator token out of convenience.
+- Until decision 3 lands, "A2A traffic goes over the mesh" remains a
+  description of the addressing, not an enforced property. Anything that claims
+  otherwise is claiming more than the code does.
+
+## Alternatives considered
+
+**Have workers keep taking the key over SSH only, and skip the vault.** Rejected:
+it works for exactly the nodes the pipeline SSHes into, and the whole ask is
+about the nodes it does not. It also leaves the key unrotatable and unaudited.
+
+**Add a second, operator-specific reveal endpoint.** Rejected: `/secrets/{name}
+/resolve` already is an audited, scope-gated, rate-limited reveal-by-name. A
+parallel endpoint would have meant two authorization boundaries to keep in
+agreement, and they would eventually disagree.
+
+**Let the operator use the existing handle flow by registering their laptop as a
+fleet agent.** Rejected as circular for the mesh case — registration requires
+reaching the hub, which is what the mesh key is for — and wrong in general: a
+person is not an agent, and giving an operator an Agent row to borrow its
+authorization confuses identity with role (ADR 0019).
+
+**Make publication to the vault fatal on failure.** Rejected: on a fresh fleet
+the hub is not up when the network layer installs, so this would fail every
+first deploy. Deferred-and-stamped, with `HEADSCALE_VAULT_REQUIRED=1` available
+for fleets that want the strict behavior, keeps the failure visible without
+making the ordering a landmine.
+
+**Bind the hub to the mesh address now, as part of this change.** Rejected: see
+*Status of each decision*. The blast radius is an unreachable hub, and it does
+not share a review with a key-distribution change.

--- a/docs/secrets-management-guide.md
+++ b/docs/secrets-management-guide.md
@@ -363,6 +363,52 @@ still emits an audit record but skips the request/reveal two-step.
 
 ---
 
+## Fetching a Secret as an Operator or a Control Node
+
+The handle flow above is the **agent** path. `reveal_secret` matches
+`accessor_agent_id` against a registered `Agent` row on a trusted `Machine`, so
+it is unavailable to a caller that is not part of the fleet: an operator's
+laptop, a CI runner, or the provisioner host that is about to join the fleet's
+mesh. For the mesh case the handle flow is also circular — it would require
+fleet-agent registration in order to fetch the enrollment key that lets you
+join the fleet.
+
+Reveal-by-name is that other path:
+
+```bash
+# JSON: {"name": "...", "value": "..."}
+mac admin secret get headscale-preauthkey-demo
+
+# Just the value, for shell capture
+key="$(mac admin secret get headscale-preauthkey-demo --raw --purpose mesh-join)"
+```
+
+Over a hub this is `POST /secrets/{name}/resolve`. Its credential is the
+**`secret` token scope**, which does not have to be bound to an agent — mint an
+operator token by adding it to the hub's `MAC_API_TOKENS` registry:
+
+```json
+{
+  "<operator-token>": {"scopes": ["secret"]}
+}
+```
+
+What still applies to that token, so a `secret` scope is not a skeleton key:
+
+- **Tenant isolation.** A tenant-bound token can only resolve secrets scoped to
+  its own tenant; fleet-global (untenanted) secrets are reachable only by an
+  untenanted token.
+- **Rate limiting.** Non-admin principals get 30 resolve calls per minute, so a
+  leaked token cannot enumerate the vault at line rate.
+- **Audit.** Every resolve writes a `secret_access_audit` row naming the
+  principal and the `--purpose` the caller declared. Pass a meaningful purpose.
+- **`enabled`.** A disabled secret resolves to a 404, not an empty value.
+
+Prefer the handle flow whenever the caller *is* a registered agent: it is
+single-use and time-limited, and this one is neither.
+
+---
+
 ## Disabling and Deleting Secrets
 
 Disable a secret (leaves audit trail intact):

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1837,6 +1837,12 @@ class SecretRotate(BaseModel):
     actor: str = "operator"
 
 
+class SecretResolve(BaseModel):
+    #: Why this reveal happened, recorded on the access-audit row. Optional so
+    #: existing callers that POST an empty body keep working.
+    purpose: str = "fleet-fetch"
+
+
 class ArtifactRegister(BaseModel):
     kind: str
     digest: str
@@ -8923,6 +8929,7 @@ def create_app(
     @app.post("/secrets/{name}/resolve")
     def resolve_secret(
         name: str,
+        body: Optional[SecretResolve] = None,
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
         # th-merge-07: audited admin reveal-by-name for in-fleet consumers — the
@@ -8930,12 +8937,24 @@ def create_app(
         # retired. Requires the `secret` scope (admin inherits it); decrypt-at-use
         # and access-audited via SecretsService.resolve_secret_value. Distinct from
         # the request/reveal handle flow (which is for per-agent scoped access).
+        #
+        # It is ALSO the operator/provisioner path (`mac admin secret get`): a
+        # control node that is not a registered Agent cannot use the handle flow,
+        # because reveal_secret matches accessor_agent_id against an Agent row.
+        # A `secret`-scoped bearer token is the credential here, and it does not
+        # have to be bound to an agent.
         _enforce_secret_rate_limit(principal, "resolve")  # mac-xc8u
         secrets = getattr(cp, "secrets", None)
         if secrets is None:
             raise NotFoundError("secret store unavailable")
+        # mac-01g0: reveal-by-name is a /secrets/* operation like every other,
+        # so it takes the same tenant isolation. Without this a tenant-bound
+        # `secret` token could name any secret in the fleet and read it back —
+        # the one route in the family that skipped the check.
+        _assert_secret_tenant(principal, name)
         accessor = getattr(principal, "agent_id", None) or "fleet-fetch"
-        value = secrets.resolve_secret_value(name, purpose="fleet-fetch", accessor=accessor)
+        purpose = (body.purpose if body is not None else "") or "fleet-fetch"
+        value = secrets.resolve_secret_value(name, purpose=purpose, accessor=accessor)
         if value is None:
             raise NotFoundError("secret not found or disabled: %s" % name)
         return {"name": name, "value": value}

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -6081,6 +6081,31 @@ def cmd_secret_rotate(args: argparse.Namespace) -> None:
     _print(_plane(args).rotate_secret(args.name, value, actor=args.actor))
 
 
+def cmd_secret_get(args: argparse.Namespace) -> None:
+    """Reveal a secret's plaintext by name, for a caller that is not an agent.
+
+    `secret access` starts the per-agent handle flow, which needs a registered
+    Agent row on a trusted Machine. An operator laptop or a provisioner host
+    has neither -- and needing fleet-agent registration to fetch the mesh key
+    that lets you JOIN the fleet is circular. This is the audited
+    reveal-by-name path instead; over a hub it is authorized by the `secret`
+    token scope, which need not be bound to an agent.
+
+    `--raw` prints the value alone so it can be captured in a shell
+    (`key="$(mac admin secret get ... --raw)"`) without a JSON parse. The value
+    is still written to stdout in both modes: this command exists to hand a
+    plaintext credential to its caller, and the audit row records that it did.
+    """
+    resolved = _plane(args).resolve_secret(
+        args.name, purpose=args.purpose, accessor=args.accessor
+    )
+    if args.raw:
+        payload = resolved.to_dict() if hasattr(resolved, "to_dict") else resolved
+        sys.stdout.write("%s\n" % payload.get("value", ""))
+        return
+    _print(resolved)
+
+
 def cmd_secret_access(args: argparse.Namespace) -> None:
     _print(_plane(args).request_secret(args.secret, args.agent_id, args.purpose))
 
@@ -10807,6 +10832,30 @@ def build_parser() -> argparse.ArgumentParser:
     secret_rotate.add_argument("--from-file", help="read the new value from a file path")
     secret_rotate.add_argument("--actor", default="operator")
     _set(cmd_secret_rotate, secret_rotate)
+    secret_get = secret.add_parser(
+        "get",
+        help="reveal a secret's value by name (audited; for operators and control nodes)",
+    )
+    secret_get.add_argument("name", help="secret id or name")
+    secret_get.add_argument(
+        "--purpose",
+        default="operator-fetch",
+        help="recorded on the access-audit row (default: operator-fetch)",
+    )
+    secret_get.add_argument(
+        "--accessor",
+        default="operator",
+        help=(
+            "audit accessor for --db mode; over a hub the accessor is derived "
+            "from the bearer token and this is ignored"
+        ),
+    )
+    secret_get.add_argument(
+        "--raw",
+        action="store_true",
+        help="print the value alone, for shell capture",
+    )
+    _set(cmd_secret_get, secret_get)
     secret_access = secret.add_parser("access")
     secret_access.add_argument("secret")
     secret_access.add_argument("agent_id")

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -786,6 +786,7 @@
     "name": "MAC_BIN",
     "retired": false,
     "sources": [
+      "deploy/headscale-key-vault.sh",
       "src/mac/client_login.py"
     ],
     "type": "str"
@@ -5889,6 +5890,7 @@
       "deploy/fleet-node-install.sh",
       "deploy/fleet-node-phase1-quiesce.sh",
       "deploy/fleet-node-substrate-adopt.py",
+      "deploy/headscale-key-vault.sh",
       "deploy/install-firecrawl-gateway.sh",
       "deploy/install-headscale.sh",
       "deploy/install-qdrant-service.sh",

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -1936,6 +1936,24 @@ class RemoteDispatch:
     def list_secret_audits(self, secret_id: str) -> List[_Dictish]:
         return _wrap_list(self._get("/secret-audits", secret_id=secret_id))
 
+    def resolve_secret(
+        self,
+        name: str,
+        *,
+        purpose: str = "operator-fetch",
+        accessor: str = "operator",
+    ) -> _Dictish:
+        # Audited reveal-by-name. ``accessor`` is accepted for signature parity
+        # with ControlPlane.resolve_secret but deliberately NOT sent: over HTTP
+        # the hub derives the accessor from the bearer token, and a
+        # caller-supplied identity in the audit row would be a claim, not a fact.
+        return _Dictish(
+            self._post(
+                "/secrets/%s/resolve" % quote(name, safe=""),
+                {"purpose": purpose},
+            )
+        )
+
     # -- Runtime / Artifact / Environment / Deployment ----------------------
 
     def create_runtime(self, name: str, manifest: Dict[str, Any], created_by: str) -> _Dictish:

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -23233,6 +23233,35 @@ class ControlPlane:
     def reveal_secret(self, *args: Any, **kwargs: Any) -> str:
         return self.secrets.reveal_secret(*args, **kwargs)
 
+    def resolve_secret(
+        self,
+        name: str,
+        *,
+        purpose: str = "operator-fetch",
+        accessor: str = "operator",
+    ) -> Dict[str, Any]:
+        """Audited reveal-by-name for a caller that is not a registered agent.
+
+        ``request_secret``/``reveal_secret`` are the *agent* path: they need an
+        Agent row, a trusted Machine, and a single-use handle. An operator
+        laptop or a provisioner host joining the mesh has none of those, and
+        requiring fleet-agent registration to fetch the key that lets you join
+        the fleet is circular. This is the same audited decrypt-at-use that
+        ``resolve_secret_value`` already gives in-process consumers, surfaced as
+        an operator-shaped result and raising ``NotFoundError`` instead of
+        returning ``None`` so a missing secret cannot read as an empty value.
+
+        Authorization lives one layer up: over HTTP this is the ``secret``
+        scope (see ``mac.api._required_scope``), which an operator token can
+        carry without being bound to any agent.
+        """
+        value = self.secrets.resolve_secret_value(
+            name, purpose=purpose, accessor=accessor
+        )
+        if value is None:
+            raise NotFoundError("secret not found or disabled: %s" % name)
+        return {"name": name, "value": value}
+
     # Artifact registry
 
     # Artifacts + environments + deployments + runtimes: thin facade over

--- a/tests/api/test_secret_operator_reveal.py
+++ b/tests/api/test_secret_operator_reveal.py
@@ -1,0 +1,202 @@
+"""Reveal-by-name is the path for a caller that is not a registered agent.
+
+`POST /secrets/{id}/access` + `/reveal` is the AGENT path: `reveal_secret`
+matches ``accessor_agent_id`` against an Agent row on a trusted Machine. An
+operator's laptop, or the provisioner host that is about to join the fleet's
+mesh, is neither -- and requiring fleet-agent registration in order to fetch
+the enrollment key that lets you JOIN the fleet is circular.
+
+`POST /secrets/{name}/resolve` is that other path, and `mac admin secret get`
+is its CLI. The credential is the ``secret`` token scope, which need not be
+bound to any agent. These tests pin both halves: that an unbound operator token
+works, and that the ordinary authorization boundaries (scope, tenant, rate
+limit) still apply to it -- resolve was the one route in the /secrets/* family
+that skipped the tenant check.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from mac.api import create_app
+from mac.services import ControlPlane
+
+
+def _fleet():
+    cp = ControlPlane.in_memory()
+    cp.create_secret(
+        "headscale-preauthkey-demo",
+        "hskey-abc123",
+        {"capabilities": ["deploy", "mesh-join"]},
+        created_by="install-headscale.sh",
+    )
+    return cp
+
+
+def test_operator_token_reveals_by_name_without_being_an_agent():
+    cp = _fleet()
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                # No agent_id, no tenant: an operator/provisioner credential.
+                "operator": {"scopes": ["secret"]},
+            },
+        )
+    )
+
+    resolved = client.post(
+        "/secrets/headscale-preauthkey-demo/resolve",
+        headers={"Authorization": "Bearer operator"},
+        json={"purpose": "mesh-join"},
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert resolved.json() == {
+        "name": "headscale-preauthkey-demo",
+        "value": "hskey-abc123",
+    }
+
+    # The declared purpose lands on the audit row: "who fetched the mesh key,
+    # and why" is the whole point of routing this through the vault.
+    audits = cp.list_secret_audits()
+    assert [a.purpose for a in audits] == ["mesh-join"]
+    assert audits[0].result == "granted"
+
+
+def test_resolve_defaults_the_purpose_for_callers_that_send_no_body():
+    """The Slack/forge fetchers POST with no body at all; that must keep working."""
+    cp = _fleet()
+    client = TestClient(
+        create_app(control_plane=cp, auth_tokens={"operator": {"scopes": ["secret"]}})
+    )
+    resolved = client.post(
+        "/secrets/headscale-preauthkey-demo/resolve",
+        headers={"Authorization": "Bearer operator"},
+    )
+    assert resolved.status_code == 200, resolved.text
+    assert resolved.json()["value"] == "hskey-abc123"
+    assert [a.purpose for a in cp.list_secret_audits()] == ["fleet-fetch"]
+
+
+def test_resolve_still_requires_the_secret_scope():
+    cp = _fleet()
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "writer": {"scopes": ["write"]},
+                "operator": {"scopes": ["secret"]},
+            },
+        )
+    )
+    refused = client.post(
+        "/secrets/headscale-preauthkey-demo/resolve",
+        headers={"Authorization": "Bearer writer"},
+    )
+    assert refused.status_code == 403, refused.text
+    assert "hskey-abc123" not in refused.text
+
+
+def test_resolve_is_tenant_isolated_like_every_other_secret_route():
+    """mac-01g0 applies here too.
+
+    `_assert_secret_tenant` guards access/reveal, but resolve-by-name skipped
+    it -- so a tenant-bound `secret` token could name any secret in the fleet
+    and read it back, which is exactly the boundary the other routes exist to
+    hold. Promoting resolve to the operator-facing fetch path makes that gap
+    reachable from the CLI, so it is closed here.
+    """
+    cp = ControlPlane.in_memory()
+    cp.create_secret(
+        "tenant-a-key", "a-value", {"capabilities": ["deploy"], "tenant_id": "tenant-a"}, "human"
+    )
+    cp.create_secret("global-key", "g-value", {"capabilities": ["deploy"]}, "human")
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "tok-a": {"scopes": ["secret"], "tenant_id": "tenant-a"},
+                "tok-b": {"scopes": ["secret"], "tenant_id": "tenant-b"},
+                "operator": {"scopes": ["secret"]},
+            },
+        )
+    )
+
+    own = client.post(
+        "/secrets/tenant-a-key/resolve", headers={"Authorization": "Bearer tok-a"}
+    )
+    assert own.status_code == 200, own.text
+    assert own.json()["value"] == "a-value"
+
+    cross = client.post(
+        "/secrets/tenant-a-key/resolve", headers={"Authorization": "Bearer tok-b"}
+    )
+    assert cross.status_code == 403, cross.text
+    assert "a-value" not in cross.text
+
+    # An unscoped (fleet-global) secret is off limits to a tenant-bound token,
+    # and reachable by the untenanted operator credential.
+    globalled = client.post(
+        "/secrets/global-key/resolve", headers={"Authorization": "Bearer tok-a"}
+    )
+    assert globalled.status_code == 403, globalled.text
+    ok = client.post(
+        "/secrets/global-key/resolve", headers={"Authorization": "Bearer operator"}
+    )
+    assert ok.status_code == 200, ok.text
+
+
+def test_resolve_of_a_missing_secret_is_a_not_found_not_an_empty_value():
+    cp = _fleet()
+    client = TestClient(
+        create_app(control_plane=cp, auth_tokens={"operator": {"scopes": ["secret"]}})
+    )
+    missing = client.post(
+        "/secrets/no-such-secret/resolve", headers={"Authorization": "Bearer operator"}
+    )
+    assert missing.status_code == 404, missing.text
+
+
+def test_remote_dispatch_sends_the_purpose_and_never_the_accessor():
+    """The CLI's hub-mode seam.
+
+    `resolve_secret` takes an `accessor` for signature parity with the
+    ControlPlane method that `--db` mode calls, but must not put it on the
+    wire: over HTTP the hub derives the accessor from the bearer token, and a
+    caller-supplied identity on an audit row is a claim, not a fact.
+    """
+    from mac.dispatch import RemoteDispatch
+
+    class _Recording:
+        def __init__(self):
+            self.calls = []
+
+        def request(self, method, path, body=None):
+            self.calls.append((method, path, body))
+            return {"name": "headscale-preauthkey-demo", "value": "hskey-abc123"}
+
+    client = _Recording()
+    resolved = RemoteDispatch(client).resolve_secret(
+        "headscale-preauthkey-demo", purpose="mesh-join", accessor="laptop"
+    )
+
+    assert resolved.to_dict()["value"] == "hskey-abc123"
+    assert client.calls == [
+        ("POST", "/secrets/headscale-preauthkey-demo/resolve", {"purpose": "mesh-join"})
+    ]
+
+
+def test_resolve_is_rate_limited_for_non_admin_tokens():
+    """mac-xc8u: a leaked `secret` token must not enumerate the vault at line rate."""
+    cp = _fleet()
+    client = TestClient(
+        create_app(control_plane=cp, auth_tokens={"operator": {"scopes": ["secret"]}})
+    )
+    statuses = [
+        client.post(
+            "/secrets/headscale-preauthkey-demo/resolve",
+            headers={"Authorization": "Bearer operator"},
+        ).status_code
+        for _ in range(32)
+    ]
+    assert 403 in statuses

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -801,6 +801,84 @@ def test_mac_cli_secret_set_and_list_redacts_value(tmp_path):
         assert s.get("value", "***REDACTED***") != "never-reveal-this"
 
 
+def test_mac_cli_secret_get_reveals_plaintext_without_an_agent_identity(tmp_path):
+    """`secret get` is the path for a caller that is not a registered agent.
+
+    `secret access` needs an Agent row on a trusted Machine, so a provisioner
+    or an operator laptop cannot use it -- and requiring fleet-agent
+    registration to fetch the mesh key that lets you JOIN the fleet is
+    circular. This is the case the headscale pre-auth key hits.
+    """
+    rc, _ = _run(
+        tmp_path,
+        "admin", "secret", "set",
+        "headscale-preauthkey-demo",
+        "hskey-abc123",
+        "--scopes", '{"capabilities": ["deploy", "mesh-join"]}',
+        "--created-by", "install-headscale.sh",
+    )
+    assert rc == 0
+
+    rc, resolved = _run(tmp_path, "admin", "secret", "get", "headscale-preauthkey-demo")
+    assert rc == 0
+    assert resolved == {"name": "headscale-preauthkey-demo", "value": "hskey-abc123"}
+
+    # Every reveal is audited, with the purpose the caller declared.
+    rc, audits = _run(tmp_path, "admin", "secret", "audits")
+    assert rc == 0
+    purposes = [a["purpose"] for a in audits if a["result"] == "granted"]
+    assert "operator-fetch" in purposes
+
+
+def test_mac_cli_secret_get_raw_prints_only_the_value(tmp_path):
+    """--raw exists so a deploy script can capture the key in a shell.
+
+    JSON here would force every caller to shell out to python just to unwrap
+    one string, which is how keys end up in `ps` output and log lines.
+    """
+    rc, _ = _run(
+        tmp_path,
+        "admin", "secret", "set",
+        "mesh-key",
+        "hskey-raw-value",
+        "--scopes", '{"capabilities": ["mesh-join"]}',
+        "--created-by", "test",
+    )
+    assert rc == 0
+
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "admin", "secret", "get", "mesh-key", "--raw"])
+    finally:
+        sys.stdout = old
+    assert rc == 0
+    assert out.getvalue() == "hskey-raw-value\n"
+
+
+def test_mac_cli_secret_get_refuses_a_missing_secret_instead_of_printing_nothing(tmp_path):
+    """A missing secret must not read as an empty value.
+
+    `resolve_secret_value` returns None so in-process consumers can fall back;
+    an operator capturing `--raw` into a shell variable would then join the
+    mesh with an empty key and get a confusing failure two layers away.
+    """
+    rc, _ = _run(tmp_path, "admin", "init")
+    assert rc == 0
+
+    out, err = io.StringIO(), io.StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = out, err
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "admin", "secret", "get", "no-such-secret", "--raw"])
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+    assert rc != 0
+    assert out.getvalue() == ""
+    assert "no-such-secret" in err.getvalue()
+
+
 def test_task_ask_parks_the_task_on_a_stated_question(tmp_path):
     """`mac task ask` parks work on a human question instead of failing it."""
     rc, task = _run(tmp_path, "task", "create", "Ambiguous work")

--- a/tests/test_headscale_key_vault.py
+++ b/tests/test_headscale_key_vault.py
@@ -1,0 +1,234 @@
+"""The headscale pre-auth key must reach the secrets vault, and come back out.
+
+install-headscale.sh has generated a reusable pre-auth key for a while, but it
+only ever wrote it to the hub's local env file. Workers got the value because
+the deploy pipeline forwarded that env var over SSH during their own bootstrap;
+nothing else could ask for it. A node the pipeline never touches -- an
+operator's laptop, a provisioner host joining the mesh it is about to provision
+-- had no route to the key at all, which is how the first demo fleet ended up
+pasting a personal Tailscale auth key into ~/.mac/.env instead.
+
+deploy/headscale-key-vault.sh is both ends of the fix. These tests drive it
+against a FAKE `mac` CLI (a recording shim on PATH) rather than a live hub, so
+they pin the contract that matters here: which CLI verbs run, in which order,
+and -- the part a live-hub test would not show -- that the key value never
+appears in argv or in anything the script prints.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "deploy" / "headscale-key-vault.sh"
+
+KEY = "hskey-super-secret-value"
+
+
+def _fake_mac(bin_dir: Path, *, listed: str = "[]", behavior: str = "ok") -> Path:
+    """A stand-in `mac` that records its argv+stdin and answers `secret list`.
+
+    ``behavior``: ``ok`` (all calls succeed), ``unreachable`` (every call
+    fails, as when the hub is not up yet), or ``no-secret`` (list works, `get`
+    fails, as when nothing was ever published).
+    """
+    calls = bin_dir / "calls.log"
+    script = bin_dir / "mac"
+    template = """#!/usr/bin/env bash
+printf 'ARGV:%s\\n' "$*" >> @CALLS@
+stdin_value=''
+if [ ! -t 0 ]; then stdin_value="$(cat)"; fi
+printf 'STDIN:%s\\n' "$stdin_value" >> @CALLS@
+behavior='@BEHAVIOR@'
+if [ "$behavior" = unreachable ]; then exit 1; fi
+case "$*" in
+  *'secret list'*) printf '%s\\n' '@LISTED@' ;;
+  *'secret get'*)
+    if [ "$behavior" = no-secret ]; then exit 1; fi
+    printf '%s\\n' '@KEY@' ;;
+  *) printf '{}\\n' ;;
+esac
+"""
+    rendered = (
+        template.replace("@CALLS@", str(calls))
+        .replace("@BEHAVIOR@", behavior)
+        .replace("@LISTED@", listed)
+        .replace("@KEY@", KEY)
+    )
+    script.write_text(rendered, encoding="utf-8")
+    script.chmod(0o755)
+    return calls
+
+
+def _run(tmp_path, argument, *, env_extra=None, listed="[]", behavior="ok"):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    calls = _fake_mac(bin_dir, listed=listed, behavior=behavior)
+    env = dict(os.environ)
+    env.update(
+        {
+            "PATH": "%s:%s" % (bin_dir, env.get("PATH", "")),
+            "MAC_BIN": str(bin_dir / "mac"),
+            "FLEET_NAME": "demo",
+            "ENV_FILE": str(tmp_path / "mac.env"),
+            "HOME": str(tmp_path),
+        }
+    )
+    env.update(env_extra or {})
+    completed = subprocess.run(
+        ["bash", str(SCRIPT), argument],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    recorded = calls.read_text(encoding="utf-8") if calls.exists() else ""
+    return completed, recorded
+
+
+def _env_file(tmp_path) -> dict:
+    path = tmp_path / "mac.env"
+    if not path.exists():
+        return {}
+    values = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            values[key] = value
+    return values
+
+
+def test_publish_creates_the_secret_when_the_vault_does_not_have_it(tmp_path):
+    completed, recorded = _run(
+        tmp_path, "publish", env_extra={"HEADSCALE_PREAUTHKEY": KEY}
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    assert "admin secret set headscale-preauthkey-demo --from-stdin" in recorded
+    assert "--created-by install-headscale.sh" in recorded
+    # The value is handed over on stdin, never as an argv word: argv is world
+    # readable in /proc, so a key passed there leaks to every user on the host.
+    assert "STDIN:%s" % KEY in recorded
+    argv_lines = [l for l in recorded.splitlines() if l.startswith("ARGV:")]
+    assert argv_lines and all(KEY not in line for line in argv_lines)
+    assert KEY not in completed.stdout
+    assert KEY not in completed.stderr
+
+    env = _env_file(tmp_path)
+    assert env["HEADSCALE_PREAUTHKEY_SECRET"] == "headscale-preauthkey-demo"
+    assert env["HEADSCALE_PREAUTHKEY_VAULT"] == "published"
+
+
+def test_publish_rotates_rather_than_duplicating_an_existing_secret(tmp_path):
+    """Re-running install-headscale.sh generates a NEW key.
+
+    `secrets.name` is UNIQUE, so a second create would simply fail; rotating
+    keeps the record's id, scopes and audit trail while swapping the value,
+    which is what a regenerated key actually is.
+    """
+    listed = '[{"name": "headscale-preauthkey-demo", "id": "secret_1"}]'
+    completed, recorded = _run(
+        tmp_path,
+        "publish",
+        env_extra={"HEADSCALE_PREAUTHKEY": KEY},
+        listed=listed,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+    assert "admin secret rotate headscale-preauthkey-demo --from-stdin" in recorded
+    assert "secret set" not in recorded
+    assert _env_file(tmp_path)["HEADSCALE_PREAUTHKEY_VAULT"] == "published"
+
+
+def test_publish_reads_the_key_from_the_env_file_when_not_in_the_environment(tmp_path):
+    """`publish` is re-runnable by hand after the hub comes up.
+
+    On a fresh fleet the network layer is installed BEFORE the control plane,
+    so the first publish attempt is expected to be deferred. The re-run has no
+    HEADSCALE_PREAUTHKEY in its environment -- only the env file the earlier
+    install wrote.
+    """
+    (tmp_path / "mac.env").write_text(
+        "HEADSCALE_URL=http://127.0.0.1:8080\nHEADSCALE_PREAUTHKEY=%s\n" % KEY,
+        encoding="utf-8",
+    )
+    completed, recorded = _run(tmp_path, "publish")
+    assert completed.returncode == 0, completed.stderr
+    assert "STDIN:%s" % KEY in recorded
+    assert _env_file(tmp_path)["HEADSCALE_PREAUTHKEY_VAULT"] == "published"
+
+
+def test_publish_defers_instead_of_failing_the_deploy_when_the_hub_is_down(tmp_path):
+    """A hub that is not up yet must not fail the network install.
+
+    But it must not look like success either: the env file records `deferred`
+    so a later phase -- or an operator reading it -- can tell "published" from
+    "nobody ever managed to".
+    """
+    completed, _ = _run(
+        tmp_path,
+        "publish",
+        env_extra={"HEADSCALE_PREAUTHKEY": KEY},
+        behavior="unreachable",
+    )
+    assert completed.returncode == 0
+    assert "did not answer" in completed.stderr
+    assert _env_file(tmp_path)["HEADSCALE_PREAUTHKEY_VAULT"] == "deferred"
+
+
+def test_publish_is_fatal_when_the_caller_demands_the_vault(tmp_path):
+    completed, _ = _run(
+        tmp_path,
+        "publish",
+        env_extra={"HEADSCALE_PREAUTHKEY": KEY, "HEADSCALE_VAULT_REQUIRED": "1"},
+        behavior="unreachable",
+    )
+    assert completed.returncode == 1
+    assert _env_file(tmp_path)["HEADSCALE_PREAUTHKEY_VAULT"] == "deferred"
+
+
+def test_fetch_prints_the_key_and_nothing_else(tmp_path):
+    """`fetch` is captured in a shell, so stdout carries the key alone.
+
+    Anything else on stdout -- a progress line, a JSON envelope -- ends up
+    inside the value install-tailscale.sh passes to `tailscale up`.
+    """
+    completed, recorded = _run(tmp_path, "fetch")
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "%s\n" % KEY
+    assert "admin secret get headscale-preauthkey-demo --raw --purpose mesh-join" in recorded
+
+
+def test_fetch_fails_loudly_rather_than_returning_an_empty_key(tmp_path):
+    completed, _ = _run(tmp_path, "fetch", behavior="no-secret")
+    assert completed.returncode == 1
+    assert completed.stdout == ""
+    assert "headscale-preauthkey-demo" in completed.stderr
+
+
+def test_installers_are_wired_to_the_vault_helper():
+    """The scripts that generate and consume the key must actually call it.
+
+    A helper nothing invokes is the same gap with more files in it.
+    """
+    install_headscale = (ROOT / "deploy" / "install-headscale.sh").read_text(encoding="utf-8")
+    assert "headscale-key-vault.sh" in install_headscale
+    assert '"$key_vault_script" publish' in install_headscale
+
+    install_tailscale = (ROOT / "deploy" / "install-tailscale.sh").read_text(encoding="utf-8")
+    assert "headscale-key-vault.sh" in install_tailscale
+    assert '"$key_vault_script" fetch' in install_tailscale
+
+
+@pytest.mark.parametrize(
+    "script_name", ("headscale-key-vault.sh", "install-headscale.sh", "install-tailscale.sh")
+)
+def test_scripts_are_syntactically_valid_and_executable(script_name):
+    script = ROOT / "deploy" / script_name
+    assert os.access(script, os.X_OK), "%s must be executable on a node" % script_name
+    subprocess.run(["bash", "-n", str(script)], check=True, timeout=60)


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_310e9d31cec64e5087661fd68746a9e0`
- head: `30975c526eae611d8037a1834c0164d0cf9472d6`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
