### PR TITLE
Feature: self-hosted Headscale key should land in the secrets vault, be CLI-fetchable by the provisioner, and A2A traffic should be mesh-enforced (task_310e9d31cec64e5087661fd68746a9e0)

### DIFF
--- a/deploy/headscale-key-vault.sh
+++ b/deploy/headscale-key-vault.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# headscale-key-vault.sh — publish/fetch the headscale pre-auth key via the
+# mac secrets vault.
+#
+# WHY THIS EXISTS. install-headscale.sh generates a reusable pre-auth key on the
+# hub and writes it to the hub's local env file. Every consumer of that key --
+# each worker, and any control node an operator later wants on the mesh -- had
+# to receive it by having the deploy pipeline forward the env value over ssh.
+# That works for nodes the pipeline touches and for nobody else, and it means
+# the key that admits a machine to the fleet network is the one credential the
+# fleet's own vault never held.
+#
+# So: after generation, the key is written to SecretsService under a
+# fleet-scoped name, and any authorized caller fetches it with
+# `mac admin secret get <name> --raw`.
+#
+# SOURCE IT, don't exec it:
+#
+#     . "$(dirname "$0")/headscale-key-vault.sh"
+#     printf '%s' "$key" | headscale_vault_publish "$(headscale_vault_secret_name)"
+#
+# The key never appears in argv (it would be world-readable in `ps`) and never
+# on stdout. Publication reads it from stdin; the CLI is invoked with
+# --from-stdin for the same reason.
+
+# Fleet scope for the secret name. Two fleets sharing a vault must not share a
+# mesh key, so the fleet name is part of the name rather than a convention.
+FLEET_NAME="${FLEET_NAME:-mac}"
+
+# auto     — publish when a hub is reachable; warn and continue when it is not.
+# required — a publication failure fails the caller.
+# off      — skip publication entirely.
+#
+# `auto` is the default because install-headscale.sh runs during hub bring-up,
+# where the control plane it would publish to may not be listening yet. A fleet
+# that sources worker keys from the vault should set `required` so a silent
+# no-op cannot masquerade as a working install.
+HEADSCALE_VAULT_PUBLISH="${HEADSCALE_VAULT_PUBLISH:-auto}"
+
+headscale_vault_secret_name() {
+  printf '%s\n' "${HEADSCALE_PREAUTHKEY_SECRET_NAME:-headscale-preauthkey-${FLEET_NAME}}"
+}
+
+# Scopes are what SecretsService checks when a *registered agent* asks through
+# the handle flow: any agent carrying the `mesh` capability, plus any agent
+# explicitly listed via HEADSCALE_VAULT_SCOPE_AGENTS. Operator and provisioner
+# fetches do not go through this gate at all -- they authorize on the token's
+# `secret` scope (see `mac admin secret get`), because a node that is not yet on the
+# mesh cannot be a registered agent on a trusted machine.
+headscale_vault_scopes() {
+  local agents="${HEADSCALE_VAULT_SCOPE_AGENTS:-}"
+  local agents_json="[]"
+  if [ -n "$agents" ]; then
+    agents_json="$(printf '%s' "$agents" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+items = [item.strip() for item in raw.replace(",", " ").split() if item.strip()]
+print(json.dumps(items))
+')"
+  fi
+  printf '{"capabilities": ["mesh"], "agents": %s}\n' "$agents_json"
+}
+
+# Resolve the mac CLI. On a deployed node it lives in the fleet venv; in a
+# development checkout it is whatever is on PATH.
+headscale_vault_cli() {
+  if [ -n "${MAC_DEPLOY_VAULT_CLI:-}" ]; then
+    printf '%s\n' "$MAC_DEPLOY_VAULT_CLI"
+    return 0
+  fi
+  local venv_cli="${MAC_HOME:-$HOME/.mac}/venv/bin/mac"
+  if [ -x "$venv_cli" ]; then
+    printf '%s\n' "$venv_cli"
+    return 0
+  fi
+  command -v mac 2>/dev/null || return 1
+}
+
+# headscale_vault_publish <secret-name> [actor]
+#
+# Reads the key from stdin. Rotates first and creates on failure, rather than
+# the other way round: rotation is the common case on redeploy, it preserves
+# the secret's id and scopes, and it is recorded in the audit trail as a
+# rotation rather than as a second secret with the same purpose.
+#
+# Prints the disposition (created|rotated) on stdout. Never prints the key.
+headscale_vault_publish() {
+  local name="$1" actor="${2:-install-headscale}" cli key
+  key="$(cat)"
+  if [ -z "$key" ]; then
+    echo "[headscale-vault] ERROR: refusing to publish an empty key" >&2
+    return 1
+  fi
+  cli="$(headscale_vault_cli)" || {
+    echo "[headscale-vault] ERROR: mac CLI not found (set MAC_DEPLOY_VAULT_CLI)" >&2
+    return 1
+  }
+  if printf '%s' "$key" \
+    | "$cli" admin secret rotate "$name" --from-stdin --actor "$actor" >/dev/null 2>&1; then
+    printf 'rotated\n'
+    return 0
+  fi
+  if printf '%s' "$key" \
+    | "$cli" admin secret set "$name" --from-stdin \
+        --scopes "$(headscale_vault_scopes)" --created-by "$actor" >/dev/null 2>&1; then
+    printf 'created\n'
+    return 0
+  fi
+  echo "[headscale-vault] ERROR: could not publish ${name} to the secrets vault" >&2
+  return 1
+}
+
+# headscale_vault_fetch <secret-name>
+#
+# Prints the plaintext key on stdout and nothing else, so a caller can do
+#   HEADSCALE_PREAUTHKEY="$(headscale_vault_fetch "$name")"
+# This is the provisioner path: it needs a token with the `secret` scope and
+# does NOT need the caller to be a registered fleet agent.
+headscale_vault_fetch() {
+  local name="$1" cli
+  cli="$(headscale_vault_cli)" || {
+    echo "[headscale-vault] ERROR: mac CLI not found (set MAC_DEPLOY_VAULT_CLI)" >&2
+    return 1
+  }
+  "$cli" admin secret get "$name" --raw --purpose "headscale-enrollment" 2>/dev/null
+}
+
+# headscale_vault_publish_guarded <secret-name> [actor]
+#
+# The policy wrapper install-headscale.sh calls: applies HEADSCALE_VAULT_PUBLISH
+# and turns a failure into a warning or an error accordingly. Reads the key from
+# stdin like headscale_vault_publish.
+headscale_vault_publish_guarded() {
+  local name="$1" actor="${2:-install-headscale}" disposition
+  case "$HEADSCALE_VAULT_PUBLISH" in
+    off|0|false|no)
+      echo "[headscale-vault] publication disabled (HEADSCALE_VAULT_PUBLISH=off)"
+      cat >/dev/null
+      return 0
+      ;;
+    auto|required|1|true|yes) ;;
+    *)
+      echo "[headscale-vault] ERROR: unsupported HEADSCALE_VAULT_PUBLISH: ${HEADSCALE_VAULT_PUBLISH}" >&2
+      cat >/dev/null
+      return 1
+      ;;
+  esac
+  if disposition="$(headscale_vault_publish "$name" "$actor")"; then
+    echo "[headscale-vault] ${disposition} secret ${name}"
+    return 0
+  fi
+  if [ "$HEADSCALE_VAULT_PUBLISH" = "required" ]; then
+    echo "[headscale-vault] ERROR: HEADSCALE_VAULT_PUBLISH=required and publication failed" >&2
+    return 1
+  fi
+  echo "[headscale-vault] WARNING: key not published to the vault; workers and control" >&2
+  echo "[headscale-vault] nodes will have to receive it over the deploy pipeline instead." >&2
+  return 0
+}

--- a/deploy/install-headscale.sh
+++ b/deploy/install-headscale.sh
@@ -7,6 +7,13 @@
 #   HEADSCALE_URL=http://localhost:<port>      (used by hub's own tailscale up)
 #   HEADSCALE_FLEET_URL=<login-server-url>     (used by worker tailscale up)
 #   HEADSCALE_PREAUTHKEY=<reusable-key>        (used by all agents)
+#   HEADSCALE_PREAUTHKEY_SECRET_NAME=<name>    (vault name for the same key)
+#
+# The pre-auth key is also published to the mac secrets vault under that name,
+# so a worker or a control node can fetch it with `mac admin secret get <name> --raw`
+# instead of depending on the deploy pipeline to forward the env value. See
+# headscale-key-vault.sh; HEADSCALE_VAULT_PUBLISH controls how hard that is
+# tried.
 set -euo pipefail
 
 AGENT_NAME="${AGENT:-$(hostname)}"
@@ -313,10 +320,27 @@ fi
 
 echo "[headscale] Pre-auth key generated (reusable, 1 year expiry)"
 
+# -- Publish the key to the secrets vault --
+# The env file below is the hub's own copy. The vault copy is what makes the
+# key reachable by anything the deploy pipeline does not ssh into: a worker
+# re-enrolling, or the operator's provisioner joining the same mesh.
+vault_script_dir="$(CDPATH= cd -P -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=headscale-key-vault.sh
+if [ -r "$vault_script_dir/headscale-key-vault.sh" ]; then
+  . "$vault_script_dir/headscale-key-vault.sh"
+  preauthkey_secret_name="$(headscale_vault_secret_name)"
+  printf '%s' "$preauthkey" \
+    | headscale_vault_publish_guarded "$preauthkey_secret_name" "install-headscale"
+else
+  echo "[headscale] ERROR: headscale-key-vault.sh is missing beside this script" >&2
+  exit 1
+fi
+
 # Write to mac.env for use by tailscale install and worker deploys
 set_env_key "$ENV_FILE" HEADSCALE_URL "$HEADSCALE_LOCAL_URL"
 set_env_key "$ENV_FILE" HEADSCALE_FLEET_URL "$HEADSCALE_FLEET_URL"
 set_env_key "$ENV_FILE" HEADSCALE_PREAUTHKEY "$preauthkey"
+set_env_key "$ENV_FILE" HEADSCALE_PREAUTHKEY_SECRET_NAME "$preauthkey_secret_name"
 set_env_key "$ENV_FILE" HEADSCALE_PORT "$HEADSCALE_PORT"
 
 if [ "$SUPERVISOR_KIND" = launchd ]; then

--- a/deploy/install-tailscale.sh
+++ b/deploy/install-tailscale.sh
@@ -5,9 +5,12 @@
 #   tailscale cloud — Tailscale SaaS (requires TAILSCALE_AUTH_KEY)
 #   headscale       — self-hosted control plane (requires explicit HEADSCALE_URL)
 #
-# In headscale mode HEADSCALE_URL and HEADSCALE_PREAUTHKEY must be set.
-# For the hub, these are written by install-headscale.sh. For workers they
-# are read from the hub's mac.env during deploy.
+# In headscale mode HEADSCALE_URL must be set and a pre-auth key must be
+# resolvable. For the hub, install-headscale.sh writes both. For workers the
+# deploy pipeline forwards them from the hub's mac.env. For anything the
+# pipeline does not touch -- a provisioner, an operator's control node -- an
+# empty HEADSCALE_PREAUTHKEY falls back to the mac secrets vault, which needs a
+# token with the `secret` scope and no fleet-agent registration.
 set -euo pipefail
 
 AGENT_NAME="${AGENT:-$(hostname)}"
@@ -147,10 +150,41 @@ wait_for_tailscale_ip() {
   return 1
 }
 
+# -- Resolve the headscale pre-auth key --
+# Preference order is env first, vault second. Env stays first because the
+# deploy pipeline still forwards the key that way and a caller who passed one
+# explicitly meant it. The vault fallback is what lets a machine the pipeline
+# never ssh'd into -- a provisioner, an operator's laptop -- join the same mesh:
+# it needs a mac token with the `secret` scope and nothing else. See
+# headscale-key-vault.sh.
+headscale_vault_library() {
+  local script_dir
+  script_dir="$(CDPATH= cd -P -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  printf '%s\n' "$script_dir/headscale-key-vault.sh"
+}
+
+headscale_preauthkey_secret_name=""
+if [ -r "$(headscale_vault_library)" ]; then
+  # shellcheck source=headscale-key-vault.sh
+  . "$(headscale_vault_library)"
+  headscale_preauthkey_secret_name="$(headscale_vault_secret_name)"
+fi
+
+if [ -n "$HEADSCALE_URL" ] && [ -z "$HEADSCALE_PREAUTHKEY" ] \
+  && [ -n "$headscale_preauthkey_secret_name" ]; then
+  echo "[tailscale] No HEADSCALE_PREAUTHKEY in the environment; trying the secrets vault"
+  HEADSCALE_PREAUTHKEY="$(headscale_vault_fetch "$headscale_preauthkey_secret_name" || true)"
+  if [ -n "$HEADSCALE_PREAUTHKEY" ]; then
+    echo "[tailscale] Fetched the headscale pre-auth key from the secrets vault"
+  fi
+fi
+
 # -- Validate credentials --
 if [ -n "$HEADSCALE_URL" ]; then
   if [ -z "$HEADSCALE_PREAUTHKEY" ]; then
-    echo "[tailscale] ERROR: HEADSCALE_URL is set but HEADSCALE_PREAUTHKEY is empty" >&2
+    echo "[tailscale] ERROR: HEADSCALE_URL is set but no pre-auth key is available:" >&2
+    echo "[tailscale]   HEADSCALE_PREAUTHKEY is empty and the secrets vault has no" >&2
+    echo "[tailscale]   readable ${headscale_preauthkey_secret_name:-headscale-preauthkey-${FLEET_NAME}} entry for this token." >&2
     exit 1
   fi
   control_mode="headscale"

--- a/docs/adr/0025-mesh-membership-is-the-network-boundary.md
+++ b/docs/adr/0025-mesh-membership-is-the-network-boundary.md
@@ -1,0 +1,163 @@
+# ADR 0025 - Mesh membership is the network boundary for the hub API
+
+- Status: **Proposed** — design only. Nothing in this ADR is implemented.
+- Date: 2026-08-20
+- Decision owner: MAC fleet owner
+- Related: ADR 0019 (privilege is an ACL on a resource tree), ADR 0013
+  (authoritative hub allocator)
+
+## Context
+
+The operator's stated goal is that all agent-to-agent traffic ride the fleet
+mesh "for security". Two of the three gaps behind that goal were wiring gaps
+and are closed: the self-hosted headscale pre-auth key now lands in the secrets
+vault, and `mac admin secret get` gives a non-agent caller an audited way to
+fetch it. This third one is not a wiring gap. It is a change to the network
+security model, and this ADR is the design pass it needs before anyone writes
+the code.
+
+### What the boundary actually is today
+
+The hub's bind address is chosen at fleet-config time and threaded through the
+deploy pipeline unchanged:
+
+    deploy/deploy-mac-fleet.sh:1352   control_bind_host defaults to
+                                      "0.0.0.0" for the hub agent and
+                                      "127.0.0.1" for every other node
+    deploy/deploy-mac-fleet.sh:8382   -> MAC_DEPLOY_CONTROL_BIND_HOST
+    deploy/fleet-node-install.sh:287  -> CONTROL_BIND_HOST
+    src/mac/deploy_env.py:359         -> MAC_BIND_HOST in mac.env
+    deploy/fleet-node-install.sh:11038 -> uvicorn --host "$MAC_BIND_HOST"
+
+So a hub listens on every interface the host has. Whether that is the mesh, the
+office LAN, or a public NIC is a property of the machine, not of anything the
+fleet configuration states or checks.
+
+`hub_url` is independently configured — a mesh IP, a cluster DNS name, or
+loopback, whatever was typed at setup. Nothing compares it to
+`network.provider`. A fleet can be configured `provider: headscale`, stand up a
+mesh, and still have every agent talking to the hub over its LAN address, and
+no part of the system would notice or say so.
+
+### What is already protecting it
+
+Not nothing, which matters for judging urgency. `mac-853j`
+(`src/mac/api.py:4419`) refuses to start a non-loopback hub with no tokens
+configured, precisely so that `/secrets/{id}/reveal` is not reachable
+unauthenticated from the network. Every route carries a scope requirement, and
+`/secrets/*` is rate-limited per principal.
+
+The current posture is therefore: **reachable from anywhere the host's NICs
+reach, authenticated by bearer token**. The gap this ADR addresses is that the
+network layer contributes nothing — a stolen token works equally well from the
+mesh and from a coffee shop.
+
+## Decision
+
+*Proposed.* Make mesh membership a **precondition for reaching the control
+plane at all**, so that a token is the second gate rather than the only one.
+Concretely, three changes that must land in this order:
+
+### 1. A `mesh` sentinel for `control_bind_host`
+
+`control_bind_host` gains one new accepted value, `mesh`, alongside the literal
+addresses it takes today. At node bring-up it resolves to the node's own mesh
+address:
+
+    tailscale ip -4        # the client is tailscale(1) under headscale too
+
+and the resolved address, not the sentinel, is what reaches
+`MAC_BIND_HOST`. Resolution is **fail-closed**: if the node is not on the mesh,
+the service does not start with a wider bind than was asked for. Falling back
+to `0.0.0.0` on a mesh that has not come up yet is precisely the failure this
+is meant to prevent, and it would be invisible.
+
+This is a sentinel rather than a new default. `0.0.0.0` stays the default for
+the hub agent; a fleet opts in.
+
+### 2. A configuration check that names the mismatch
+
+`fleet_setup` validation gains a check with the same shape as the existing
+`network.provider` one (`src/mac/fleet_setup.py:395`): when
+`network.provider != none` and the hub's `control_bind_host` is `0.0.0.0`, and
+when `hub_url`'s host does not fall inside the configured
+`headscale.ip_prefix`, say so. A **warning, not a failure** — plenty of real
+topologies legitimately front the hub with a proxy or a cluster service — but
+stated, because today the mismatch is silent.
+
+### 3. Host firewall rules as the second layer, separately
+
+Binding to the mesh address stops the socket from accepting off-mesh
+connections. It does not stop a local process, and it does not cover the
+sidecar services (qdrant, firecrawl, webdav) that have their own bind
+addresses. Per-platform firewall rules are the belt to the bind's braces, and
+they are a distinct change with distinct rollback characteristics — `nft` on
+Linux and `pf` on macOS share no implementation.
+
+## Why this is not implemented in the change that carries this ADR
+
+Every other part of this task was a wiring gap: something the system already
+computed but failed to hand to the next component. This one changes what the
+fleet is reachable from, and its failure mode is asymmetric in a way the others
+are not.
+
+If the vault publication breaks, a deploy warns and the key still travels the
+old path. If `mac admin secret get` breaks, a command fails and prints why. If
+the bind is wrong, **the hub becomes unreachable by the API you would use to
+fix it** — every remaining repair is an ssh to each host, which is exactly the
+situation `docs/break-glass-host-recovery.md` exists for. Shipping that in the
+same change as two credential-plumbing fixes would mean the review that clears
+the plumbing also clears the outage risk.
+
+It also needs things this change cannot supply on its own:
+
+- A **staged rollout**: one node, then the hub, with a verified route between
+  each step, rather than a fleet-wide config flip.
+- A **pre-flight**: prove the node's mesh address is up and the hub is
+  reachable at it *before* narrowing the bind, not after.
+- A **documented reversal**: the one-line edit and restart that puts a
+  locked-out hub back on `0.0.0.0`, written down before it is needed.
+- An answer for **non-mesh consumers**: the observability dashboard, any
+  operator browser, and the k8s manifest (`deploy/k8s/mac-api/deployment.yaml`
+  sets `MAC_BIND_HOST` on its own terms and does not go through
+  fleet-node-install at all).
+
+Filing it as its own task with its own review is the point, not a deferral of
+work — the operator's third ask is a security-model change and should be
+reviewed as one.
+
+## Consequences
+
+- Mesh membership becomes a real gate rather than a description of how traffic
+  happens to flow. A stolen worker token is worth much less off-mesh.
+- Enrollment becomes load-bearing: a node that cannot join the mesh cannot
+  reach the hub at all. That raises the stakes on the key-provisioning path
+  this change just finished — which is the correct order to build them in, and
+  the reason this ADR follows rather than precedes it.
+- Anything that reached the hub over a LAN address stops working at cutover.
+  That set has to be enumerated per fleet before the flip, not discovered
+  after.
+
+## Alternatives considered
+
+**Leave the bind at `0.0.0.0` and rely on tokens.** This is today. It is not
+unreasonable — the scope model and `mac-853j` are real — but it makes the
+credential the only boundary, and a credential is the thing most likely to
+leak. The operator asked for defense in depth; this provides one layer.
+
+**Enforce in application middleware: reject requests whose source address is
+outside the mesh prefix.** Rejected as the primary mechanism. It accepts the
+connection before refusing it, so the surface is still exposed to anything that
+can reach the port, and a source address is a weak thing to authorize on when a
+proxy sits anywhere in the path. It is a reasonable *additional* check once the
+bind is narrow, and a poor substitute for one.
+
+**Make `mesh` the default whenever `provider != none`.** Rejected for now. It
+would silently narrow the bind for every existing headscale and tailscale
+fleet on the next deploy, which is the fleet-wide outage described above with
+no opt-in step. A sentinel first, a default later once fleets have run on it.
+
+**Tie the bind to `hub_url` instead of adding a sentinel.** Rejected: `hub_url`
+is what *clients* dial, which is legitimately a proxy, a DNS name, or a
+published service address. Deriving the listen address from it conflates two
+things that are allowed to differ.

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -31,6 +31,7 @@ their retained sources.
 - [ADR 0022 - A gate returns a named decision, not a boolean](../adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md) — `adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md`
 - [ADR 0023 - One skill source, thin plugins per coding harness](../adr/0023-one-skill-source-many-harness-plugins.md) — `adr/0023-one-skill-source-many-harness-plugins.md`
 - [ADR 0024 - The dashboard streams the bus, not just its counts](../adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md) — `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md`
+- [ADR 0025 - Mesh membership is the network boundary for the hub API](../adr/0025-mesh-membership-is-the-network-boundary.md) — `adr/0025-mesh-membership-is-the-network-boundary.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -374,6 +374,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_TOKENHUB_REF` | str | consumer-defined | deployment | Deployment setting: deploy tokenhub ref. |
 | `MAC_DEPLOY_TOKENHUB_URL` | str | consumer-defined | deployment | Deployment setting: deploy tokenhub url. |
 | `MAC_DEPLOY_TS` | str | consumer-defined | deployment | Deployment setting: deploy ts. |
+| `MAC_DEPLOY_VAULT_CLI` | str | consumer-defined | deployment | Deployment setting: deploy vault cli. |
 | `MAC_DEPLOY_WEBDAV_BIND_ADDR` | str | consumer-defined | deployment | Deployment setting: deploy webdav bind addr. |
 | `MAC_DEPLOY_WEBDAV_ENABLED` | bool | consumer-defined | deployment | Deployment setting: deploy webdav enabled. |
 | `MAC_DEPLOY_WEBDAV_INSTALL` | bool | consumer-defined | deployment | Deployment setting: deploy webdav install. |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -36,6 +36,7 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md` | ADR 0022 - A gate returns a named decision, not a boolean |
 | architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | ADR 0023 - One skill source, thin plugins per coding harness |
 | architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | ADR 0024 - The dashboard streams the bus, not just its counts |
+| architecture decision | `adr/0025-mesh-membership-is-the-network-boundary.md` | ADR 0025 - Mesh membership is the network boundary for the hub API |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/docs/secrets-management-guide.md
+++ b/docs/secrets-management-guide.md
@@ -363,6 +363,79 @@ still emits an audit record but skips the request/reveal two-step.
 
 ---
 
+## Fetching a Secret From an Operator or Provisioner Machine
+
+The handle flow above is the *agent* path: `request_secret` checks that the
+accessor is a registered `Agent`, on a `Machine` marked trusted, whose
+capabilities satisfy the secret's scopes.
+
+There is a class of caller that path cannot serve. The machine that most needs
+the fleet's mesh enrollment key is the one that is not on the mesh yet — a
+provisioner, an operator's laptop, a worker being re-enrolled. None of them are
+registered agents, and they cannot become registered agents until they can
+reach the hub, which is what the key is for. Gating that fetch on fleet-agent
+registration would mean the only way to join the mesh is to already be on it.
+
+`mac admin secret get` is that path. It authorizes on the **token's `secret`
+scope**, not on an agent identity:
+
+```console
+$ mac --hub-url https://hub.example --token "$MAC_API_TOKEN" \
+    admin secret get headscale-preauthkey-demo
+{
+  "name": "headscale-preauthkey-demo",
+  "value": "<plaintext>"
+}
+```
+
+`--raw` prints only the value, with no trailing newline, so a shell can capture
+it directly:
+
+```console
+$ HEADSCALE_PREAUTHKEY="$(mac admin secret get headscale-preauthkey-demo --raw)"
+```
+
+What it is and is not:
+
+- **Audited.** Every fetch writes a `secret_access_audit` row. `--purpose` is
+  the label recorded against it; use it to distinguish an operator pull from
+  the router's own upstream-key lookups, which share the underlying route.
+- **Not self-asserted.** The *accessor* in the audit row is derived by the hub
+  from the authenticated principal. A client cannot write someone else's name
+  into the trail.
+- **Not scope-checked against agent capabilities.** The secret's `scopes` gate
+  the handle flow; they do not gate this one. A token carrying the `secret`
+  scope can read any secret its tenant binding permits, so issue those tokens
+  as narrowly as you issue admin tokens.
+- **Rate limited.** Non-admin principals get 30 resolve calls per minute, so a
+  leaked token cannot enumerate the vault at line rate.
+- **Explicit about absence.** A missing or disabled secret fails the command
+  rather than printing an empty value — otherwise `KEY="$(... --raw)"` would
+  silently yield `""` and the failure would surface far from its cause.
+
+### Worked example: the headscale mesh enrollment key
+
+`deploy/install-headscale.sh` generates the fleet's reusable pre-auth key and
+publishes it to the vault as `headscale-preauthkey-<fleet>` (see
+`deploy/headscale-key-vault.sh`; `HEADSCALE_VAULT_PUBLISH=required` makes a
+publication failure fail the install). Anything that then needs to join that
+mesh fetches it:
+
+```console
+$ HEADSCALE_URL=http://hub.example:8080 \
+    FLEET_NAME=demo \
+    deploy/install-tailscale.sh
+[tailscale] No HEADSCALE_PREAUTHKEY in the environment; trying the secrets vault
+[tailscale] Fetched the headscale pre-auth key from the secrets vault
+```
+
+An explicit `HEADSCALE_PREAUTHKEY` still wins; the vault is the fallback, not
+an override. The key is passed to the CLI over stdin at every step, never as a
+positional argument, because `ps` is world-readable on every platform the fleet
+deploys to.
+
+---
+
 ## Disabling and Deleting Secrets
 
 Disable a secret (leaves audit trail intact):

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -8923,6 +8923,7 @@ def create_app(
     @app.post("/secrets/{name}/resolve")
     def resolve_secret(
         name: str,
+        purpose: Optional[str] = Query(default=None),
         principal: TokenPrincipal = Depends(_get_principal),
     ) -> Dict[str, Any]:
         # th-merge-07: audited admin reveal-by-name for in-fleet consumers — the
@@ -8930,12 +8931,21 @@ def create_app(
         # retired. Requires the `secret` scope (admin inherits it); decrypt-at-use
         # and access-audited via SecretsService.resolve_secret_value. Distinct from
         # the request/reveal handle flow (which is for per-agent scoped access).
+        #
+        # This is also the operator/provisioner fetch path behind `mac secret
+        # get`. The token scope is the whole gate: a control node joining the
+        # mesh is not a registered Agent and cannot satisfy reveal_secret's
+        # identity check, so requiring one would be circular. `purpose` is a
+        # caller-supplied audit label; the *accessor* stays server-derived from
+        # the authenticated principal so it cannot be self-asserted.
         _enforce_secret_rate_limit(principal, "resolve")  # mac-xc8u
         secrets = getattr(cp, "secrets", None)
         if secrets is None:
             raise NotFoundError("secret store unavailable")
         accessor = getattr(principal, "agent_id", None) or "fleet-fetch"
-        value = secrets.resolve_secret_value(name, purpose="fleet-fetch", accessor=accessor)
+        value = secrets.resolve_secret_value(
+            name, purpose=(purpose or "fleet-fetch"), accessor=accessor
+        )
         if value is None:
             raise NotFoundError("secret not found or disabled: %s" % name)
         return {"name": name, "value": value}

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -6072,6 +6072,29 @@ def cmd_secret_list(args: argparse.Namespace) -> None:
     _print([secret.to_dict() for secret in _plane(args).list_secrets()])
 
 
+def cmd_secret_get(args: argparse.Namespace) -> None:
+    """Reveal a secret's plaintext by name, audited, for an operator or a
+    provisioning control node.
+
+    ``secret access`` + reveal is the *agent* path: it needs a registered Agent
+    row on a trusted machine. The node being provisioned onto the mesh is
+    neither, and requiring fleet registration in order to fetch the key that
+    joins the mesh is circular. So this path authorizes on the token's
+    ``secret`` scope instead, and the hub audits the fetch against the
+    authenticated principal.
+
+    ``--raw`` writes only the value, with no trailing newline, so a shell can
+    capture it without stripping: ``KEY="$(mac secret get name --raw)"``.
+    """
+    value = _plane(args).resolve_secret_value(args.name, purpose=args.purpose)
+    if value is None:
+        raise MACError("secret not found or disabled: %s" % args.name)
+    if args.raw:
+        sys.stdout.write(value)
+        return
+    _print({"name": args.name, "value": value})
+
+
 def cmd_secret_delete(args: argparse.Namespace) -> None:
     _print(_plane(args).delete_secret(args.secret, actor=args.actor))
 
@@ -10796,6 +10819,21 @@ def build_parser() -> argparse.ArgumentParser:
     _set(cmd_secret_set, secret_set)
     secret_list = secret.add_parser("list")
     _set(cmd_secret_list, secret_list)
+    secret_get = secret.add_parser(
+        "get", help="reveal a secret's value by name (audited; needs the `secret` token scope)"
+    )
+    secret_get.add_argument("name", help="secret id or name")
+    secret_get.add_argument(
+        "--raw",
+        action="store_true",
+        help="print only the value, with no trailing newline, for shell capture",
+    )
+    secret_get.add_argument(
+        "--purpose",
+        default="operator-fetch",
+        help="audit label recorded against this fetch",
+    )
+    _set(cmd_secret_get, secret_get)
     secret_delete = secret.add_parser("delete", help="hard-delete a secret (scrub its value)")
     secret_delete.add_argument("secret", help="secret id or name")
     secret_delete.add_argument("--actor", default="operator")

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -4393,6 +4393,17 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy vault cli.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_VAULT_CLI",
+    "retired": false,
+    "sources": [
+      "deploy/headscale-key-vault.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy webdav bind addr.",
     "family": "deployment",
     "name": "MAC_DEPLOY_WEBDAV_BIND_ADDR",
@@ -5889,6 +5900,7 @@
       "deploy/fleet-node-install.sh",
       "deploy/fleet-node-phase1-quiesce.sh",
       "deploy/fleet-node-substrate-adopt.py",
+      "deploy/headscale-key-vault.sh",
       "deploy/install-firecrawl-gateway.sh",
       "deploy/install-headscale.sh",
       "deploy/install-qdrant-service.sh",

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -60,7 +60,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 from urllib.parse import quote, urlencode
 
 from mac.fleet_env import resolve as resolve_env_var
-from mac.http_client import HubClient
+from mac.http_client import HubClient, HubClientError
 from mac.models import MACError
 
 
@@ -1935,6 +1935,40 @@ class RemoteDispatch:
 
     def list_secret_audits(self, secret_id: str) -> List[_Dictish]:
         return _wrap_list(self._get("/secret-audits", secret_id=secret_id))
+
+    def resolve_secret_value(
+        self,
+        name: str,
+        *,
+        purpose: str = "operator-fetch",
+        accessor: str = "operator",
+    ) -> Optional[str]:
+        """Audited reveal-by-name over the hub (`mac secret get`).
+
+        Mirrors ``ControlPlane.resolve_secret_value`` including its ``None``
+        (rather than raise) answer for an absent or disabled secret, so the CLI
+        handler is transport-agnostic. The hub says 404 for that case, which
+        arrives as a ``HubClientError``; only that status is swallowed, so a
+        403 from a token without the ``secret`` scope still surfaces.
+
+        ``accessor`` is accepted for signature parity with the local plane and
+        deliberately not sent: the hub derives the audited accessor from the
+        authenticated principal, so a client cannot name someone else in the
+        audit trail.
+        """
+        try:
+            payload = self._post(
+                "/secrets/%s/resolve%s"
+                % (quote(name, safe=""), _query({"purpose": purpose}))
+            )
+        except HubClientError as exc:
+            if "HTTP 404" in str(exc):
+                return None
+            raise
+        if not isinstance(payload, dict):
+            return None
+        value = payload.get("value")
+        return None if value is None else str(value)
 
     # -- Runtime / Artifact / Environment / Deployment ----------------------
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -23233,6 +23233,17 @@ class ControlPlane:
     def reveal_secret(self, *args: Any, **kwargs: Any) -> str:
         return self.secrets.reveal_secret(*args, **kwargs)
 
+    def resolve_secret_value(self, *args: Any, **kwargs: Any) -> Optional[str]:
+        """Audited reveal-by-name for a caller that is not a registered Agent.
+
+        The facade exists so ``LocalDispatch`` (which forwards by attribute)
+        exposes the same method name the remote transport does, which is what
+        lets ``mac secret get`` work against ``--db`` and against a hub. See
+        ``SecretsService.resolve_secret_value`` for the contract: ``None``
+        rather than a raise when the secret is absent or disabled.
+        """
+        return self.secrets.resolve_secret_value(*args, **kwargs)
+
     # Artifact registry
 
     # Artifacts + environments + deployments + runtimes: thin facade over

--- a/tests/api/test_secret_operator_reveal.py
+++ b/tests/api/test_secret_operator_reveal.py
@@ -1,0 +1,148 @@
+"""The operator/provisioner path to a secret's plaintext.
+
+There are two ways to get a secret out of the vault and they authorize on
+different things:
+
+  * ``/secrets/{id}/access`` + ``/secrets/{id}/reveal`` -- the AGENT path. The
+    accessor must be a registered ``Agent`` row on a trusted ``Machine`` whose
+    capabilities satisfy the secret's scopes, and the handle it issues is
+    single-use and time-limited.
+
+  * ``/secrets/{name}/resolve`` -- the OPERATOR path, which these tests cover.
+    It authorizes on the token's ``secret`` scope alone.
+
+The second exists because of a circularity in the first. The machine that most
+needs the headscale pre-auth key is the one that is not on the mesh yet: a
+provisioner, an operator's laptop, a worker being re-enrolled. None of them are
+registered agents, and they cannot become registered agents until they can
+reach the hub, which is what the key is for. Gating that fetch on fleet-agent
+registration would mean the only way to join the mesh is to already be on it.
+
+So the tests below assert the property that makes the operator path useful --
+that it works with NO agent registered anywhere -- alongside the properties
+that keep it from being a hole: the scope is still required, the accessor in
+the audit trail is server-derived rather than self-asserted, and a disabled or
+absent secret is a refusal rather than an empty answer.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from mac.api import TokenPrincipal, create_app
+from mac.services import ControlPlane
+
+
+OPERATOR = TokenPrincipal(scopes=frozenset({"secret"}))
+READ_ONLY = TokenPrincipal(scopes=frozenset({"task"}))
+
+
+def _fixture():
+    cp = ControlPlane.in_memory()
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={"operator-token": OPERATOR, "task-token": READ_ONLY},
+        )
+    )
+    cp.create_secret(
+        "headscale-preauthkey-demo",
+        "hskey-abcdef",
+        {"capabilities": ["mesh"]},
+        "install-headscale",
+    )
+    return cp, client
+
+
+def _auth(token):
+    return {"Authorization": "Bearer %s" % token}
+
+
+def test_resolve_reveals_plaintext_without_any_registered_agent():
+    cp, client = _fixture()
+    assert cp.list_agents() == []
+
+    response = client.post(
+        "/secrets/headscale-preauthkey-demo/resolve", headers=_auth("operator-token")
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "name": "headscale-preauthkey-demo",
+        "value": "hskey-abcdef",
+    }
+
+
+def test_resolve_refuses_a_token_without_the_secret_scope():
+    _cp, client = _fixture()
+    response = client.post(
+        "/secrets/headscale-preauthkey-demo/resolve", headers=_auth("task-token")
+    )
+    assert response.status_code in (401, 403), response.text
+    assert "hskey-abcdef" not in response.text
+
+
+def test_resolve_refuses_an_unauthenticated_caller():
+    _cp, client = _fixture()
+    response = client.post("/secrets/headscale-preauthkey-demo/resolve")
+    assert response.status_code in (401, 403), response.text
+    assert "hskey-abcdef" not in response.text
+
+
+def test_resolve_records_the_caller_supplied_purpose_in_the_audit_trail():
+    """`purpose` is a caller-supplied label so an operator pull is
+    distinguishable from the model router's own upstream-key lookups, which
+    share this route."""
+    cp, client = _fixture()
+    response = client.post(
+        "/secrets/headscale-preauthkey-demo/resolve",
+        params={"purpose": "headscale-enrollment"},
+        headers=_auth("operator-token"),
+    )
+    assert response.status_code == 200, response.text
+
+    purposes = [audit.purpose for audit in cp.list_secret_audits()]
+    assert "headscale-enrollment" in purposes
+
+
+def test_resolve_audits_a_server_derived_accessor():
+    """The accessor is taken from the authenticated principal, never from the
+    request, so a client cannot write someone else's name into the audit."""
+    cp, client = _fixture()
+    assert (
+        client.post(
+            "/secrets/headscale-preauthkey-demo/resolve",
+            params={"purpose": "headscale-enrollment"},
+            headers=_auth("operator-token"),
+        ).status_code
+        == 200
+    )
+
+    fetches = [
+        audit
+        for audit in cp.list_secret_audits()
+        if audit.purpose == "headscale-enrollment"
+    ]
+    assert len(fetches) == 1
+    # An unbound operator token carries no agent_id, so the hub labels it
+    # "fleet-fetch" rather than accepting a name from the caller.
+    assert fetches[0].accessor_agent_id == "fleet-fetch"
+
+
+def test_resolve_defaults_the_purpose_when_none_is_supplied():
+    cp, client = _fixture()
+    assert (
+        client.post(
+            "/secrets/headscale-preauthkey-demo/resolve",
+            headers=_auth("operator-token"),
+        ).status_code
+        == 200
+    )
+    assert [audit.purpose for audit in cp.list_secret_audits()] == ["fleet-fetch"]
+
+
+def test_resolve_refuses_an_absent_secret():
+    _cp, client = _fixture()
+    response = client.post(
+        "/secrets/no-such-secret/resolve", headers=_auth("operator-token")
+    )
+    assert response.status_code == 404, response.text

--- a/tests/cli/test_mac_cli.py
+++ b/tests/cli/test_mac_cli.py
@@ -801,6 +801,101 @@ def test_mac_cli_secret_set_and_list_redacts_value(tmp_path):
         assert s.get("value", "***REDACTED***") != "never-reveal-this"
 
 
+def test_mac_cli_secret_get_reveals_plaintext_for_a_non_agent_caller(tmp_path):
+    """`secret get` is the operator/provisioner fetch path.
+
+    `secret access` needs a registered Agent row on a trusted machine. A control
+    node being joined to the mesh is neither, and the key it is fetching is the
+    one that would make it a fleet member -- so requiring registration first is
+    circular. `secret get` therefore reveals by name with no agent identity in
+    play at all, which is exactly what this asserts: no agent is registered
+    anywhere in this test.
+    """
+    rc, _ = _run(
+        tmp_path,
+        "admin", "secret", "set",
+        "headscale-preauthkey-demo",
+        "hskey-abcdef",
+        "--scopes", '{"capabilities": ["mesh"]}',
+        "--created-by", "install-headscale",
+    )
+    assert rc == 0
+
+    rc, revealed = _run(tmp_path, "admin", "secret", "get", "headscale-preauthkey-demo")
+    assert rc == 0
+    assert revealed == {"name": "headscale-preauthkey-demo", "value": "hskey-abcdef"}
+
+
+def test_mac_cli_secret_get_raw_emits_only_the_value(tmp_path):
+    """--raw exists so a shell can capture the key without stripping anything.
+
+    `HEADSCALE_PREAUTHKEY="$(mac secret get <name> --raw)"` has to yield the key
+    and nothing else; a JSON envelope or a stray newline would be baked into the
+    credential and the mesh join would fail with an opaque auth error.
+    """
+    rc, _ = _run(
+        tmp_path,
+        "admin", "secret", "set",
+        "headscale-preauthkey-raw",
+        "hskey-raw-value",
+        "--scopes", '{"capabilities": ["mesh"]}',
+        "--created-by", "install-headscale",
+    )
+    assert rc == 0
+
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(
+            ["--db", dsn_for(tmp_path), "admin", "secret", "get",
+             "headscale-preauthkey-raw", "--raw"]
+        )
+    finally:
+        sys.stdout = old
+    assert rc == 0
+    assert out.getvalue() == "hskey-raw-value"
+
+
+def test_mac_cli_secret_get_reports_a_missing_secret(tmp_path, capsys):
+    """An absent secret fails the command rather than printing an empty value.
+
+    `KEY="$(mac secret get x --raw)"` on a missing secret must not silently
+    yield "" -- the caller would go on to join a mesh with an empty credential
+    and get an auth error far from the cause."""
+    rc, _ = _run(tmp_path, "admin", "init")
+    assert rc == 0
+    rc = main(["--db", dsn_for(tmp_path), "admin", "secret", "get", "absent-key"])
+    assert rc == 1
+    assert "secret not found or disabled: absent-key" in capsys.readouterr().err
+
+
+def test_mac_cli_secret_get_records_an_audit_row_with_its_purpose(tmp_path):
+    """The fetch is audited, and --purpose is the label that makes the audit
+    trail able to distinguish an operator pull from the router's own lookups."""
+    rc, _ = _run(
+        tmp_path,
+        "admin", "secret", "set",
+        "headscale-preauthkey-audit",
+        "hskey-audited",
+        "--scopes", '{"capabilities": ["mesh"]}',
+        "--created-by", "install-headscale",
+    )
+    assert rc == 0
+
+    rc, _ = _run(
+        tmp_path,
+        "admin", "secret", "get", "headscale-preauthkey-audit",
+        "--purpose", "headscale-enrollment",
+    )
+    assert rc == 0
+
+    rc, audits = _run(tmp_path, "admin", "secret", "audits")
+    assert rc == 0
+    purposes = [row["purpose"] for row in audits]
+    assert "headscale-enrollment" in purposes
+
+
 def test_task_ask_parks_the_task_on_a_stated_question(tmp_path):
     """`mac task ask` parks work on a human question instead of failing it."""
     rc, task = _run(tmp_path, "task", "create", "Ambiguous work")

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -21,6 +21,7 @@ from mac.dispatch import (
     _wrap_list,
     resolve_dispatch,
 )
+from mac.http_client import HubClientError
 
 
 @pytest.fixture(autouse=True)
@@ -206,6 +207,53 @@ def test_remote_dispatch_repository_ref_reconciler_calls():
             {"mode": "prune", "actor": "operator"},
         ),
     ]
+
+
+def test_remote_dispatch_resolve_secret_value_posts_the_purpose_and_unwraps():
+    class _ValueClient(_FakeHttpClient):
+        def request(self, method, path, body=None):
+            self.calls.append((method, path, body))
+            return {"name": "headscale-preauthkey-demo", "value": "hskey-abcdef"}
+
+    client = _ValueClient()
+    dispatch = RemoteDispatch(client)  # type: ignore[arg-type]
+
+    assert (
+        dispatch.resolve_secret_value(
+            "headscale-preauthkey-demo", purpose="headscale-enrollment"
+        )
+        == "hskey-abcdef"
+    )
+    method, path, _body = client.calls[0]
+    assert method == "POST"
+    assert path == "/secrets/headscale-preauthkey-demo/resolve?purpose=headscale-enrollment"
+
+
+def test_remote_dispatch_resolve_secret_value_returns_none_for_a_missing_secret():
+    """The local plane answers None for an absent or disabled secret; the hub
+    answers 404. Both transports have to look the same to the CLI handler, or
+    `mac admin secret get` behaves differently against --db than against a hub."""
+
+    class _MissingClient(_FakeHttpClient):
+        def request(self, method, path, body=None):
+            raise HubClientError("HTTP 404 Not Found: secret not found")
+
+    dispatch = RemoteDispatch(_MissingClient())  # type: ignore[arg-type]
+    assert dispatch.resolve_secret_value("absent-key") is None
+
+
+def test_remote_dispatch_resolve_secret_value_propagates_a_refusal():
+    """Only 404 is swallowed. A 403 means the token lacks the `secret` scope,
+    and turning that into "no such secret" would send the operator looking for
+    a missing key instead of a missing scope."""
+
+    class _ForbiddenClient(_FakeHttpClient):
+        def request(self, method, path, body=None):
+            raise HubClientError("HTTP 403 Forbidden: scope 'secret' required")
+
+    dispatch = RemoteDispatch(_ForbiddenClient())  # type: ignore[arg-type]
+    with pytest.raises(HubClientError, match="403"):
+        dispatch.resolve_secret_value("headscale-preauthkey-demo")
 
 
 def test_remote_dispatch_project_crud_and_registration_calls():

--- a/tests/test_headscale_key_vault.py
+++ b/tests/test_headscale_key_vault.py
@@ -1,0 +1,372 @@
+"""The headscale pre-auth key reaches the secrets vault, and comes back out.
+
+install-headscale.sh has always generated a reusable pre-auth key and written it
+to the hub's own env file. Every other machine got it because the deploy
+pipeline forwarded that env value over ssh during the node's bootstrap -- which
+covers exactly the machines the pipeline ssh'es into, and nothing else. The key
+that admits a machine to the fleet network was the one credential the fleet's
+own vault never held, so an operator wanting to join a provisioner to the same
+mesh had no supported way to obtain it.
+
+These tests cover both halves of closing that:
+
+  * PUBLICATION -- install-headscale.sh writes the generated key to the vault
+    under a fleet-scoped name, without ever putting it in argv.
+  * CONSUMPTION -- install-tailscale.sh falls back to the vault when no
+    HEADSCALE_PREAUTHKEY was handed to it.
+
+The bash is exercised for real against a stub `mac` CLI rather than asserted
+against as text wherever behavior is what matters: rotate-then-create, the
+HEADSCALE_VAULT_PUBLISH policy, and the argv-hygiene claim are all things a
+grep would happily agree with while the script did something else.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Resolved once, absolutely: several tests below blank PATH to simulate a node
+# with no mac CLI, and a relative "bash" would then fail to spawn at all.
+BASH = shutil.which("bash") or "/bin/bash"
+
+ROOT = Path(__file__).resolve().parents[1]
+LIBRARY = ROOT / "deploy" / "headscale-key-vault.sh"
+INSTALL_HEADSCALE = (ROOT / "deploy" / "install-headscale.sh").read_text(encoding="utf-8")
+INSTALL_TAILSCALE = (ROOT / "deploy" / "install-tailscale.sh").read_text(encoding="utf-8")
+
+# A stub `mac` that records exactly how it was called and simulates the one
+# behavior the library depends on: `secret rotate` fails for a name that has
+# never been set, and succeeds afterwards.
+STUB_CLI = """#!/usr/bin/env bash
+store="$STUB_STORE"
+printf '%s\\n' "$*" >> "$store/argv.log"
+# drop the leading `admin` so the cases below read like the CLI's own spelling
+[ "$1" = admin ] && shift
+case "$1 $2" in
+  "secret rotate")
+    name="$3"
+    grep -qx "$name" "$store/names" 2>/dev/null || exit 1
+    cat > "$store/$name.value"
+    echo '{"rotated": true}'
+    ;;
+  "secret set")
+    name="$3"
+    cat > "$store/$name.value"
+    printf '%s\\n' "$name" >> "$store/names"
+    echo '{"created": true}'
+    ;;
+  "secret get")
+    name="$3"
+    [ -f "$store/$name.value" ] || { echo "secret not found" >&2; exit 1; }
+    printf '%s' "$(cat "$store/$name.value")"
+    ;;
+  *) echo "unexpected: $*" >&2; exit 2 ;;
+esac
+"""
+
+
+@pytest.fixture
+def vault(tmp_path):
+    """A stub-CLI sandbox plus a `run` helper that sources the library."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    cli = bin_dir / "mac"
+    cli.write_text(STUB_CLI, encoding="utf-8")
+    cli.chmod(0o755)
+    store = tmp_path / "store"
+    store.mkdir()
+
+    def run(script: str, **env_overrides):
+        env = dict(os.environ)
+        env.update(
+            {
+                "PATH": "%s:%s" % (bin_dir, env.get("PATH", "")),
+                "STUB_STORE": str(store),
+                "MAC_DEPLOY_VAULT_CLI": str(cli),
+                "FLEET_NAME": "demo",
+                "HOME": str(tmp_path),
+            }
+        )
+        env.update({key: str(value) for key, value in env_overrides.items()})
+        return subprocess.run(
+            [BASH, "-c", ". %s\n%s" % (LIBRARY, script)],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(ROOT),
+        )
+
+    run.store = store  # type: ignore[attr-defined]
+    return run
+
+
+def _argv_log(vault) -> str:
+    path = vault.store / "argv.log"
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+# ---------------------------------------------------------------------------
+# Naming and scoping
+# ---------------------------------------------------------------------------
+
+
+def test_secret_name_is_fleet_scoped(vault):
+    """Two fleets sharing a hub must not share a mesh key, so the fleet name is
+    part of the secret name rather than a convention someone has to remember."""
+    result = vault("headscale_vault_secret_name")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "headscale-preauthkey-demo"
+
+
+def test_secret_name_is_overridable(vault):
+    result = vault(
+        "headscale_vault_secret_name", HEADSCALE_PREAUTHKEY_SECRET_NAME="mesh-key"
+    )
+    assert result.stdout.strip() == "mesh-key"
+
+
+def test_scopes_are_valid_json_naming_the_mesh_capability(vault):
+    result = vault("headscale_vault_scopes")
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {"capabilities": ["mesh"], "agents": []}
+
+
+def test_scopes_accept_an_explicit_agent_list(vault):
+    result = vault(
+        "headscale_vault_scopes", HEADSCALE_VAULT_SCOPE_AGENTS="agent_a, agent_b"
+    )
+    assert json.loads(result.stdout) == {
+        "capabilities": ["mesh"],
+        "agents": ["agent_a", "agent_b"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Publication
+# ---------------------------------------------------------------------------
+
+
+def test_publish_creates_a_secret_that_does_not_exist_yet(vault):
+    result = vault('printf %s "hskey-first" | headscale_vault_publish mesh-key')
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "created"
+    assert (vault.store / "mesh-key.value").read_text(encoding="utf-8") == "hskey-first"
+
+
+def test_publish_rotates_an_existing_secret_rather_than_duplicating_it(vault):
+    """Rotation preserves the secret's id and scopes and lands in the audit
+    trail as a rotation. Creating a second secret for the same purpose would
+    lose both, and a redeploy is the common case -- so rotate is tried first."""
+    first = vault('printf %s "hskey-first" | headscale_vault_publish mesh-key')
+    assert first.stdout.strip() == "created"
+
+    second = vault(
+        'printf %s "hskey-first" | headscale_vault_publish mesh-key >/dev/null\n'
+        'printf %s "hskey-second" | headscale_vault_publish mesh-key'
+    )
+    assert second.returncode == 0, second.stderr
+    assert second.stdout.strip() == "rotated"
+    assert (vault.store / "mesh-key.value").read_text(encoding="utf-8") == "hskey-second"
+
+
+def test_publish_never_puts_the_key_in_argv(vault):
+    """`ps` is world-readable on every platform the fleet deploys to. A key
+    passed as a positional argument is visible to every local user for as long
+    as the process lives, so the CLI is driven with --from-stdin."""
+    result = vault('printf %s "hskey-supersecret" | headscale_vault_publish mesh-key')
+    assert result.returncode == 0, result.stderr
+
+    log = _argv_log(vault)
+    assert log, "the stub CLI was never invoked"
+    assert "hskey-supersecret" not in log
+    assert "--from-stdin" in log
+
+
+def test_publish_does_not_echo_the_key(vault):
+    result = vault('printf %s "hskey-supersecret" | headscale_vault_publish mesh-key')
+    assert "hskey-supersecret" not in result.stdout
+    assert "hskey-supersecret" not in result.stderr
+
+
+def test_publish_refuses_an_empty_key(vault):
+    """An empty key would be stored, fetched, and then fail the mesh join with
+    an opaque auth error far from the cause."""
+    result = vault('printf "" | headscale_vault_publish mesh-key')
+    assert result.returncode != 0
+    assert "refusing to publish an empty key" in result.stderr
+    assert not (vault.store / "mesh-key.value").exists()
+
+
+def test_publish_fails_when_the_cli_is_missing(vault):
+    result = vault(
+        'printf %s "hskey" | headscale_vault_publish mesh-key',
+        MAC_DEPLOY_VAULT_CLI="/nonexistent/mac",
+        PATH="/nonexistent",
+    )
+    assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Publication policy
+# ---------------------------------------------------------------------------
+
+
+def test_guarded_publish_reports_the_disposition(vault):
+    result = vault(
+        'printf %s "hskey" | headscale_vault_publish_guarded headscale-preauthkey-demo'
+    )
+    assert result.returncode == 0, result.stderr
+    assert "created secret headscale-preauthkey-demo" in result.stdout
+
+
+def test_guarded_publish_off_skips_without_calling_the_cli(vault):
+    result = vault(
+        'printf %s "hskey" | headscale_vault_publish_guarded mesh-key',
+        HEADSCALE_VAULT_PUBLISH="off",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "publication disabled" in result.stdout
+    assert _argv_log(vault) == ""
+
+
+def test_guarded_publish_auto_warns_but_succeeds_when_the_hub_is_absent(vault):
+    """install-headscale.sh runs during hub bring-up, where the control plane it
+    would publish to may not be listening yet. Failing the headscale install
+    over that would make the vault copy a hard dependency of the thing that
+    produces it."""
+    result = vault(
+        'printf %s "hskey" | headscale_vault_publish_guarded mesh-key',
+        MAC_DEPLOY_VAULT_CLI="/nonexistent/mac",
+        PATH="/nonexistent",
+    )
+    assert result.returncode == 0, result.stderr
+    assert "WARNING" in result.stderr
+
+
+def test_guarded_publish_required_fails_when_the_hub_is_absent(vault):
+    """A fleet whose workers source the key from the vault must not treat a
+    silent no-op as a working install."""
+    result = vault(
+        'printf %s "hskey" | headscale_vault_publish_guarded mesh-key',
+        HEADSCALE_VAULT_PUBLISH="required",
+        MAC_DEPLOY_VAULT_CLI="/nonexistent/mac",
+        PATH="/nonexistent",
+    )
+    assert result.returncode != 0
+    assert "HEADSCALE_VAULT_PUBLISH=required" in result.stderr
+
+
+def test_guarded_publish_rejects_an_unknown_policy(vault):
+    result = vault(
+        'printf %s "hskey" | headscale_vault_publish_guarded mesh-key',
+        HEADSCALE_VAULT_PUBLISH="maybe",
+    )
+    assert result.returncode != 0
+    assert "unsupported HEADSCALE_VAULT_PUBLISH" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Consumption
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_returns_only_the_key(vault):
+    """The caller does `KEY="$(headscale_vault_fetch "$name")"`, so anything
+    else on stdout is baked into the credential."""
+    result = vault(
+        'printf %s "hskey-fetchme" | headscale_vault_publish mesh-key >/dev/null\n'
+        "headscale_vault_fetch mesh-key"
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "hskey-fetchme"
+
+
+def test_fetch_asks_for_raw_output_with_an_audit_purpose(vault):
+    vault('printf %s "hskey" | headscale_vault_publish mesh-key >/dev/null\nheadscale_vault_fetch mesh-key')
+    log = _argv_log(vault)
+    assert "admin secret get mesh-key --raw --purpose headscale-enrollment" in log
+
+
+def test_fetch_is_empty_for_an_absent_secret(vault):
+    result = vault("headscale_vault_fetch absent-key || true")
+    assert result.stdout == ""
+
+
+# ---------------------------------------------------------------------------
+# Wiring into the deploy scripts
+# ---------------------------------------------------------------------------
+
+
+def test_install_headscale_publishes_before_writing_the_env_file():
+    """Ordering matters for the `required` policy: the env write is what makes
+    the install look successful, so a required publication that failed must
+    abort before it."""
+    publish = INSTALL_HEADSCALE.index("headscale_vault_publish_guarded")
+    env_write = INSTALL_HEADSCALE.index("set_env_key \"$ENV_FILE\" HEADSCALE_PREAUTHKEY ")
+    assert publish < env_write
+
+
+def test_install_headscale_pipes_the_key_rather_than_passing_it(vault):
+    call = re.search(
+        r"printf '%s' \"\$preauthkey\"[^\n]*\n\s*\| headscale_vault_publish_guarded",
+        INSTALL_HEADSCALE,
+    )
+    assert call, "the key must reach the publisher over stdin, not as an argument"
+
+
+def test_install_headscale_records_the_vault_name_in_the_env_file():
+    """The env file is how a later worker deploy learns which vault entry holds
+    this fleet's key."""
+    assert (
+        'set_env_key "$ENV_FILE" HEADSCALE_PREAUTHKEY_SECRET_NAME "$preauthkey_secret_name"'
+        in INSTALL_HEADSCALE
+    )
+
+
+def test_install_headscale_fails_when_the_vault_library_is_missing():
+    assert "headscale-key-vault.sh is missing beside this script" in INSTALL_HEADSCALE
+
+
+def test_install_tailscale_prefers_an_explicit_key_over_the_vault():
+    """A caller who passed HEADSCALE_PREAUTHKEY meant it; the vault is the
+    fallback, not an override."""
+    assert '[ -n "$HEADSCALE_URL" ] && [ -z "$HEADSCALE_PREAUTHKEY" ]' in INSTALL_TAILSCALE
+
+
+def test_install_tailscale_tries_the_vault_before_validating_credentials():
+    fetch = INSTALL_TAILSCALE.index("headscale_vault_fetch")
+    validate = INSTALL_TAILSCALE.index("# -- Validate credentials --")
+    assert fetch < validate
+
+
+def test_install_tailscale_names_the_vault_in_its_failure_message():
+    """The old message said only that HEADSCALE_PREAUTHKEY was empty, which
+    sends the reader to the env file when the fix may be a token scope."""
+    assert "the secrets vault has no" in INSTALL_TAILSCALE
+
+
+def test_install_tailscale_tolerates_the_vault_library_being_absent():
+    """deploy-mac-fleet.sh uploads install-tailscale.sh to a remote host BY
+    ITSELF (`prepare_remote_tailscale_prerequisite`), so the library is not
+    beside it on that path. That path is the tailscale-cloud repair route and
+    never needed the vault -- but an unguarded `source` would abort it under
+    `set -e` before it got to say so."""
+    assert 'if [ -r "$(headscale_vault_library)" ]; then' in INSTALL_TAILSCALE
+    # ...and the fetch is skipped rather than attempted when the name is unset.
+    assert 'headscale_preauthkey_secret_name=""' in INSTALL_TAILSCALE
+    assert '&& [ -n "$headscale_preauthkey_secret_name" ]' in INSTALL_TAILSCALE
+
+
+def test_install_tailscale_does_not_abort_when_the_vault_lookup_fails(vault):
+    """The script runs under `set -e`; an unguarded failing command substitution
+    would kill it before the error message that explains what to do."""
+    assert 'headscale_vault_fetch "$headscale_preauthkey_secret_name" || true' in (
+        INSTALL_TAILSCALE
+    )


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_310e9d31cec64e5087661fd68746a9e0`
- head: `605ed3dcb54a371b428dfb047f172231b8d34091`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
