### PR TITLE
A dead controller's cohort transaction blocks every deploy, and nothing reaps it (task_5d21d9055b8c4ba888eb676bbae11003)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -43,6 +43,8 @@ load_env_file_with_caller_precedence() {
     MAC_DEPLOY_CONTAINER_RUNTIME_PATHS
     MAC_DEPLOY_SSH_SESSION_MODE
     MAC_FLEET_COHORT_JOURNAL_DIR
+    MAC_FLEET_COHORT_JOURNAL_RETENTION_DAYS
+    MAC_FLEET_COHORT_JOURNAL_RETENTION_KEEP
     MAC_DEPLOY_HOLD_ADOPTIONS_FILE
     MAC_DEPLOY_REQUIRE_RELEASE_ALL_SELECTED
     MAC_DEPLOY_SUCCESSOR_HOLD_REASON
@@ -764,7 +766,14 @@ COHORT_JOURNAL_DIR="${MAC_FLEET_COHORT_JOURNAL_DIR:-$HOME/.mac/fleet-cohort-tran
 COHORT_JOURNAL_ACTIVE=0
 COHORT_JOURNAL_REVISION=0
 COHORT_RECOVERY_RUNNING=0
+# Terminal journals are finished-epoch evidence, not operating inputs. Nothing
+# used to expire them, so the directory grew without bound. Keep a window that
+# is generous enough to inspect the previous deployments and bounded enough
+# that it cannot become the next silent breakage.
+COHORT_JOURNAL_RETENTION_DAYS="${MAC_FLEET_COHORT_JOURNAL_RETENTION_DAYS:-14}"
+COHORT_JOURNAL_RETENTION_KEEP="${MAC_FLEET_COHORT_JOURNAL_RETENTION_KEEP:-32}"
 readonly COHORT_EPOCH_ID COHORT_JOURNAL_DIR COHORT_JOURNAL_HELPER
+readonly COHORT_JOURNAL_RETENTION_DAYS COHORT_JOURNAL_RETENTION_KEEP
 # Durable, owner-only failure evidence for bounded node phases. The EXIT trap
 # removes TMPDIR_LOCAL wholesale after fix-forward recovery, which previously
 # erased the reported per-agent phase log. Sanitized failure artifacts are
@@ -1552,6 +1561,8 @@ start_ssh_control_master() {
   while IFS= read -r -d '' item; do route_parts+=("$item"); done < <(fleet_ssh_route_args ssh "$agent")
   [ "${#route_parts[@]}" -gt 0 ] || {
     echo "ERROR: ${agent}: authoritative SSH route resolved empty" >&2
+    echo "  ${agent} has no route in the frozen fleet registry: ${FLEET_REGISTRY_SOURCE}" >&2
+    echo "  if this agent was not requested, it is being replayed from the pinned cohort of an incomplete cohort transaction in ${COHORT_JOURNAL_DIR}; reconcile that epoch rather than the agent" >&2
     return 1
   }
   if [ "$SSH_SESSION_MODE" = direct ]; then
@@ -14115,12 +14126,133 @@ PY
   echo "==> fleet: committed typed cohort finalization recovered"
 }
 
+reap_terminal_cohort_journals() {
+  # Age out finished-epoch journals before anything reads the directory. This
+  # is bookkeeping, not a gate: a retention failure must never block a deploy,
+  # so the outcome is reported and ignored.
+  local reaped removed
+  if ! reaped="$(cohort_journal reap \
+    --max-age-days "$COHORT_JOURNAL_RETENTION_DAYS" \
+    --keep "$COHORT_JOURNAL_RETENTION_KEEP" 2>/dev/null)"; then
+    echo "==> WARNING: fleet: cohort journal retention did not run; the journal directory was left untouched" >&2
+    return 0
+  fi
+  if ! removed="$(printf '%s' "$reaped" | "$PYTHON_BIN" -c '
+import json,sys
+payload=json.load(sys.stdin)
+print("%d %d" % (len(payload["removed_epochs"]), len(payload["removed_plans"])))
+' 2>/dev/null)"; then
+    return 0
+  fi
+  case "$removed" in
+    "0 0") ;;
+    *)
+      echo "==> fleet: cohort journal retention aged out ${removed% *} terminal epoch journal(s) and ${removed#* } orphan plan file(s) (window: ${COHORT_JOURNAL_RETENTION_DAYS}d / newest ${COHORT_JOURNAL_RETENTION_KEEP})"
+      ;;
+  esac
+  return 0
+}
+
+report_stuck_cohort_transaction() {
+  # Name the blocking transaction BY EPOCH before a single SSH is attempted.
+  #
+  # A non-terminal transaction whose controller is dead cannot progress and
+  # cannot release itself, so every later deploy replays its pinned cohort.
+  # When a pinned member has since been removed from the fleet registry the
+  # first visible failure is "authoritative SSH route resolved empty" for that
+  # agent -- a symptom that points at the agent instead of at the transaction.
+  # This prints the diagnostic, including which pinned members no longer exist
+  # in the frozen registry, before any of that can happen.
+  local discovered="$1"
+  local registry_ids="$TMPDIR_LOCAL/cohort-registry-stable-ids.txt"
+  local discovered_file="$TMPDIR_LOCAL/cohort-discover.json"
+  : > "$registry_ids"
+  chmod 0600 "$registry_ids"
+  fleet_config_query configured-agent-ids > "$registry_ids" 2>/dev/null || : > "$registry_ids"
+  printf '%s' "$discovered" > "$discovered_file" || return 0
+  chmod 0600 "$discovered_file"
+  "$PYTHON_BIN" - "$registry_ids" "$COHORT_JOURNAL_DIR" "$discovered_file" <<'PY' >&2 || return 0
+import json
+import sys
+from pathlib import Path
+
+registry_path, journal_dir, discovered_path = sys.argv[1:4]
+try:
+    payload = json.loads(Path(discovered_path).read_text(encoding="utf-8"))
+except (ValueError, OSError):
+    raise SystemExit(0)
+stuck = payload.get("stuck")
+if not stuck:
+    raise SystemExit(0)
+known = {
+    line.strip()
+    for line in Path(registry_path).read_text(encoding="utf-8").splitlines()
+    if line.strip()
+}
+age = stuck.get("age_days")
+age_text = "unknown age" if age is None else "%d day(s) old" % age
+print(
+    "ERROR: fleet: cohort epoch %s is incomplete and its controller is dead"
+    % stuck["epoch_id"]
+)
+print(
+    "  transaction: state=%s phase=%s hub_state=%s revision=%s (%s, last updated %s)"
+    % (
+        stuck["state"],
+        stuck["phase"],
+        stuck["hub_state"],
+        stuck["revision"],
+        age_text,
+        stuck["updated_at"],
+    )
+)
+print(
+    "  owner: pid %s (not running) acquired %s"
+    % (stuck["owner"]["pid"], stuck["owner"]["acquired_at"])
+)
+print(
+    "  pinned cohort (%d): %s"
+    % (stuck["cohort_size"], ", ".join(stuck["cohort_names"]) or "(none)")
+)
+if not stuck["mutated"]:
+    print("  no node or hub mutation was ever journalled for this epoch")
+elif stuck["mutated_nodes"]:
+    print("  mutated members: %s" % ", ".join(stuck["mutated_nodes"]))
+absent = [
+    node["name"]
+    for node in stuck["cohort"]
+    if known and node["stable_id"] not in known
+]
+if absent:
+    print(
+        "  pinned members absent from the frozen fleet registry: %s"
+        % ", ".join(absent)
+    )
+    print(
+        "  these members are replayed from the pinned cohort in the journal, not"
+        " from the registry or the task ledger, so removing or deleting the"
+        " agents cannot clear them"
+    )
+print(
+    "  this journal, not any agent, is what every deploy replays: %s"
+    % journal_dir
+)
+print(
+    "  resolve it by reconciling the epoch (recovery runs next); it is never"
+    " cleared by agent deletion, registry edits, or an explicit --agents list"
+)
+PY
+  return 0
+}
+
 recover_incomplete_cohort_transaction_before_deploy() {
   local discovered active_values epoch_id revision previous_nonce previous_pid alive adopted
   local -a active_fields=()
+  reap_terminal_cohort_journals
   if ! discovered="$(cohort_journal discover)"; then
     return 1
   fi
+  report_stuck_cohort_transaction "$discovered"
   if ! active_values="$(printf '%s' "$discovered" | "$PYTHON_BIN" -c '
 import json,sys
 active=json.load(sys.stdin).get("active")

--- a/deploy/fleet-cohort-transaction.py
+++ b/deploy/fleet-cohort-transaction.py
@@ -8,8 +8,13 @@ the single writer for that state.  It provides:
 * an immutable epoch/cohort binding;
 * compare-and-swap transitions with operation-id retry deduplication;
 * live-controller fencing and explicit dead-controller adoption;
-* durable atomic writes in an owner-private directory; and
-* deterministic recovery discovery in reverse deployment order.
+* durable atomic writes in an owner-private directory;
+* deterministic recovery discovery in reverse deployment order;
+* a named diagnostic for a non-terminal epoch whose controller is dead, so the
+  transaction that blocks every later deploy is reported by epoch instead of
+  as whatever downstream symptom its pinned cohort produces first; and
+* bounded retention (``reap``) for terminal journals, which are finished-epoch
+  evidence rather than operating inputs.
 
 Only deployment identities, adapter-typed endpoint authority, and evidence
 digests are retained.  Host targets, credentials, environment values, raw
@@ -101,6 +106,16 @@ MAX_HOLD_BYTES = 512
 JOURNAL_PREFIX = "transaction-"
 JOURNAL_SUFFIX = ".json"
 LOCK_NAME = ".cohort-transaction.lock"
+AUXILIARY_PREFIXES = ("release-plan-", "hub-open-plan-", "hub-prove-plan-")
+STUCK_SCHEMA = "mac.fleet_cohort_stuck_transaction.v1"
+REAP_SCHEMA = "mac.fleet_cohort_journal_reap.v1"
+# A terminal journal is evidence of a finished epoch, not an operating input.
+# Keep a bounded window so the directory cannot grow without limit, but keep
+# enough recent history that the previous deployment stays inspectable.
+DEFAULT_RETENTION_DAYS = 14
+DEFAULT_RETENTION_KEEP = 32
+MAX_RETENTION_DAYS = 3650
+MAX_RETENTION_KEEP = 4096
 SAFE_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+-]*$")
 HEX_COMMIT = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
 HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
@@ -1508,6 +1523,34 @@ class JournalDirectory:
                 names.append(name)
         return sorted(names)
 
+    def auxiliary_names(self) -> list[str]:
+        names = []
+        for name in os.listdir(self.directory_fd):
+            if name.endswith(JOURNAL_SUFFIX) and name.startswith(AUXILIARY_PREFIXES):
+                names.append(name)
+        return sorted(names)
+
+    def remove(self, name: str) -> None:
+        """Unlink one journal or auxiliary plan and fsync the directory.
+
+        Only names this module itself generates are accepted, so retention can
+        never be steered at an unrelated path by a crafted journal.
+        """
+
+        if name != os.path.basename(name) or not name.endswith(JOURNAL_SUFFIX):
+            raise JournalError("invalid_input", "retention target name is invalid")
+        if not name.startswith((JOURNAL_PREFIX,) + AUXILIARY_PREFIXES):
+            raise JournalError("invalid_input", "retention target name is invalid")
+        try:
+            os.unlink(name, dir_fd=self.directory_fd)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise JournalError(
+                "retention_failed", f"cannot remove {name}: {exc}"
+            ) from exc
+        os.fsync(self.directory_fd)
+
     def read_name(
         self, name: str, *, expected_epoch: str | None = None
     ) -> dict[str, Any]:
@@ -2656,6 +2699,102 @@ def _is_unmutated_pre_route(journal: dict[str, Any]) -> bool:
         if any(node[key] is not None for key in _NODE_MUTATION_EVIDENCE_KEYS):
             return False
     return True
+
+
+def _parse_timestamp(value: Any) -> dt.datetime | None:
+    """Parse a journal timestamp, returning None when it is unusable.
+
+    Age is a diagnostic and a retention input, never an authorization input,
+    so an unparseable timestamp degrades to "unknown age" instead of failing
+    a deployment.  Retention treats unknown age as "too young to reap".
+    """
+
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _age_seconds(value: Any, now: dt.datetime) -> int | None:
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return None
+    return max(0, int((now - parsed).total_seconds()))
+
+
+def _node_was_mutated(node: dict[str, Any]) -> bool:
+    return (
+        node["state"] != "planned"
+        or node["abort_kind"] is not None
+        or node["abort_from_state"] is not None
+        or any(node[key] is not None for key in _NODE_MUTATION_EVIDENCE_KEYS)
+    )
+
+
+def _stuck_report(journal: dict[str, Any], now: dt.datetime) -> dict[str, Any] | None:
+    """Describe a non-terminal transaction whose owning controller is dead.
+
+    A dead owner cannot make progress and cannot release the epoch, so the
+    journal blocks every later deployment until it is reconciled.  The report
+    names the epoch, the dead controller, and the pinned cohort so the
+    operator sees the transaction rather than the first downstream symptom
+    (typically an unresolvable SSH route for a cohort member that no longer
+    exists).  Returns None when the transaction is terminal or still owned by
+    a live controller.
+    """
+
+    if journal["state"] in TERMINAL_STATES:
+        return None
+    if _owner_alive(journal["owner"]):
+        return None
+    owner = journal["owner"]
+    cohort = [
+        {
+            "name": node["name"],
+            "stable_id": node["stable_id"],
+            "generation": node["generation"],
+            "state": node["state"],
+            "mutated": _node_was_mutated(node),
+        }
+        for node in journal["cohort"]
+    ]
+    age = _age_seconds(journal["updated_at"], now)
+    return {
+        "schema": STUCK_SCHEMA,
+        "epoch_id": journal["epoch_id"],
+        "fleet": journal["fleet"],
+        "hub_agent": journal["hub_agent"],
+        "source_commit": journal["source_commit"],
+        "state": journal["state"],
+        "phase": journal["phase"],
+        "hub_state": journal["hub_state"],
+        "revision": journal["revision"],
+        "owner": {
+            "nonce": owner["nonce"],
+            "pid": owner["pid"],
+            "acquired_at": owner["acquired_at"],
+            "alive": False,
+        },
+        "cohort": cohort,
+        "cohort_size": len(cohort),
+        "cohort_names": [node["name"] for node in cohort],
+        "cohort_stable_ids": [node["stable_id"] for node in cohort],
+        "mutated": not _is_unmutated_pre_route(journal),
+        "mutated_nodes": [node["name"] for node in cohort if node["mutated"]],
+        "created_at": journal["created_at"],
+        "updated_at": journal["updated_at"],
+        "age_seconds": age,
+        "age_days": None if age is None else age // 86400,
+        "blocks_new_epoch": True,
+    }
 
 
 def _summary(journal: dict[str, Any]) -> dict[str, Any]:
@@ -3868,10 +4007,140 @@ def command_discover(
         raise JournalError(
             "multiple_active_epochs", "more than one incomplete cohort epoch exists"
         )
+    now = dt.datetime.now(dt.timezone.utc)
     return {
         "active": _summary(active[0]) if active else None,
+        "stuck": _stuck_report(active[0], now) if active else None,
         "journals": [_summary(journal) for journal in journals],
     }, False
+
+
+def _reap_bound(value: Any, field: str, maximum: int) -> int:
+    if isinstance(value, bool):
+        raise JournalError("invalid_input", f"{field} must be an integer")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise JournalError("invalid_input", f"{field} must be an integer") from exc
+    if parsed < 0 or parsed > maximum:
+        raise JournalError("invalid_input", f"{field} is outside the supported range")
+    return parsed
+
+
+def command_reap(
+    directory: JournalDirectory, args: argparse.Namespace
+) -> tuple[Any, bool]:
+    """Age out terminal journals and report any stuck transaction by epoch.
+
+    Retention only ever removes *terminal* journals: a finished epoch is
+    evidence, and evidence past the bounded window is what quietly grew this
+    directory to hundreds of files.  A non-terminal transaction is never
+    deleted -- deleting one would discard the record of work that may have
+    reached a node.  It is reported instead, named by epoch, so the operator
+    sees the transaction that blocks the fleet rather than a downstream SSH
+    symptom.  A journal this build cannot parse is likewise retained and
+    counted, never silently removed.
+    """
+
+    max_age_days = _reap_bound(args.max_age_days, "max age days", MAX_RETENTION_DAYS)
+    keep = _reap_bound(args.keep, "keep", MAX_RETENTION_KEEP)
+    now = dt.datetime.now(dt.timezone.utc)
+    cutoff = max_age_days * 86400
+
+    journals: list[tuple[str, dict[str, Any]]] = []
+    unreadable: list[str] = []
+    for name in directory.names():
+        try:
+            journals.append((name, directory.read_name(name)))
+        except FileNotFoundError:
+            continue
+        except JournalError:
+            unreadable.append(name)
+
+    active = [
+        journal for _name, journal in journals if journal["state"] not in TERMINAL_STATES
+    ]
+    stuck = None
+    for journal in active:
+        report = _stuck_report(journal, now)
+        if report is not None:
+            stuck = report
+            break
+
+    terminal = [
+        (name, journal)
+        for name, journal in journals
+        if journal["state"] in TERMINAL_STATES
+    ]
+    # Newest first, so "keep the newest N" is a stable, timestamp-free rule
+    # when two journals share an updated_at.
+    terminal.sort(
+        key=lambda item: (
+            _parse_timestamp(item[1]["updated_at"]) or dt.datetime.max.replace(
+                tzinfo=dt.timezone.utc
+            ),
+            item[1]["epoch_id"],
+        ),
+        reverse=True,
+    )
+
+    expired: list[dict[str, Any]] = []
+    for index, (name, journal) in enumerate(terminal):
+        if index < keep:
+            continue
+        age = _age_seconds(journal["updated_at"], now)
+        if age is None or age <= cutoff:
+            continue
+        expired.append(
+            {
+                "epoch_id": journal["epoch_id"],
+                "state": journal["state"],
+                "updated_at": journal["updated_at"],
+                "age_seconds": age,
+                "journal": name,
+            }
+        )
+
+    expired_names = {item["journal"] for item in expired}
+    surviving_digests = {
+        name[len(JOURNAL_PREFIX) : -len(JOURNAL_SUFFIX)]
+        for name in directory.names()
+        if name not in expired_names
+    }
+    orphan_plans = [
+        name
+        for name in directory.auxiliary_names()
+        if name[: -len(JOURNAL_SUFFIX)].rsplit("-", 1)[-1] not in surviving_digests
+    ]
+
+    removed_plans: list[str] = []
+    removed_epochs: list[dict[str, Any]] = []
+    if not args.dry_run:
+        for name in orphan_plans:
+            directory.remove(name)
+            removed_plans.append(name)
+        for item in expired:
+            directory.remove(item["journal"])
+            removed_epochs.append(item)
+
+    payload = {
+        "schema": REAP_SCHEMA,
+        "max_age_days": max_age_days,
+        "keep": keep,
+        "dry_run": bool(args.dry_run),
+        "scanned": len(journals) + len(unreadable),
+        "terminal": len(terminal),
+        "active": len(active),
+        "unreadable": sorted(unreadable),
+        "expired": expired,
+        "expired_epochs": [item["epoch_id"] for item in expired],
+        "orphan_plans": orphan_plans,
+        "removed_epochs": [item["epoch_id"] for item in removed_epochs],
+        "removed_plans": removed_plans,
+        "retained": len(journals) + len(unreadable) - len(removed_epochs),
+        "stuck": stuck,
+    }
+    return payload, bool(removed_epochs or removed_plans)
 
 
 def command_recovery(
@@ -4183,6 +4452,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     discover = commands.add_parser("discover")
     discover.set_defaults(handler=command_discover)
+
+    reap = commands.add_parser("reap")
+    reap.add_argument("--max-age-days", default=DEFAULT_RETENTION_DAYS)
+    reap.add_argument("--keep", default=DEFAULT_RETENTION_KEEP)
+    reap.add_argument("--dry-run", action="store_true")
+    reap.set_defaults(handler=command_reap)
 
     recovery = commands.add_parser("recovery")
     _add_epoch(recovery, optional=True)

--- a/tests/test_deploy_stuck_cohort_transaction.py
+++ b/tests/test_deploy_stuck_cohort_transaction.py
@@ -1,0 +1,370 @@
+"""Regression coverage for the stuck cohort transaction that blocked deploys.
+
+A cohort transaction whose owning controller had died sat non-terminal in
+``~/.mac/fleet-cohort-transactions`` for nine days.  Every deploy replayed its
+pinned 8-member cohort, five of whose agents no longer existed, and the only
+error an operator saw was::
+
+    ERROR: jordanh-worker5: authoritative SSH route resolved empty
+
+That names an agent, so three remedies were aimed at agents -- deleting them,
+pruning the fleet registry, passing an explicit ``--agents`` list -- and none of
+them touched the journal the deploy actually reads.
+
+These tests drive the deploy script's own functions and assert that:
+
+* the blocking transaction is named BY EPOCH, before any SSH is attempted;
+* pinned cohort members absent from the frozen registry are named specifically,
+  together with the fact that agent deletion cannot clear them;
+* terminal journals age out to a bounded window, and the non-terminal one is
+  reported and retained rather than replayed or deleted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = ROOT / "deploy" / "deploy-mac-fleet.sh"
+HELPER = ROOT / "deploy" / "fleet-cohort-transaction.py"
+
+SOURCE_COMMIT = "a" * 40
+GHOST = "jordanh-worker5"
+LIVE = "rocky"
+
+
+def _extract(name: str, next_marker: str) -> str:
+    source = DEPLOY.read_text(encoding="utf-8")
+    start = source.index(f"{name}() {{")
+    body = source[start:]
+    return body[: body.index(next_marker)].rstrip()
+
+
+def _reap_source() -> str:
+    return _extract(
+        "reap_terminal_cohort_journals", "\nreport_stuck_cohort_transaction() {"
+    )
+
+
+def _report_source() -> str:
+    return _extract(
+        "report_stuck_cohort_transaction",
+        "\nrecover_incomplete_cohort_transaction_before_deploy() {",
+    )
+
+
+def _route_guard_source() -> str:
+    """The exact empty-route guard an operator hits on a ghost cohort member."""
+
+    source = DEPLOY.read_text(encoding="utf-8")
+    start = source.index('    echo "ERROR: ${agent}: authoritative SSH route resolved empty" >&2')
+    body = source[start:]
+    return body[: body.index("  }")]
+
+
+def _preamble(journal_dir: Path, tmpdir_local: Path, registry: list[str]) -> str:
+    stub = (
+        "fleet_config_query() {\n"
+        + "".join(f"  printf '%s\\n' {shlex.quote(name)}\n" for name in registry)
+        + "  return 0\n}\n"
+    )
+    return "\n".join(
+        [
+            "set -u",
+            f"PYTHON_BIN={shlex.quote(sys.executable)}",
+            f"COHORT_JOURNAL_HELPER={shlex.quote(str(HELPER))}",
+            f"COHORT_JOURNAL_DIR={shlex.quote(str(journal_dir))}",
+            f"TMPDIR_LOCAL={shlex.quote(str(tmpdir_local))}",
+            "COHORT_JOURNAL_RETENTION_DAYS=14",
+            "COHORT_JOURNAL_RETENTION_KEEP=2",
+            "cohort_journal() {",
+            '  "$PYTHON_BIN" "$COHORT_JOURNAL_HELPER" --directory "$COHORT_JOURNAL_DIR" "$@"',
+            "}",
+            stub,
+        ]
+    )
+
+
+def _helper(journal_dir: Path, *args: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(HELPER), "--directory", str(journal_dir), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    stream = result.stdout if result.returncode == 0 else result.stderr
+    payload = json.loads(stream)
+    assert result.returncode == 0, payload
+    return payload
+
+
+def _journal_file(journal_dir: Path, epoch: str) -> Path:
+    return journal_dir / (
+        "transaction-" + hashlib.sha256(epoch.encode()).hexdigest() + ".json"
+    )
+
+
+def _cohort(tmp_path: Path, names: list[str]) -> Path:
+    path = tmp_path / "cohort.json"
+    path.write_text(
+        json.dumps(
+            [
+                {
+                    "name": name,
+                    "stable_id": f"agent_{name.replace('-', '_')}",
+                    "generation": f"generation-{index}",
+                    "deployment_id": f"deployment-{index}",
+                    "os": "linux",
+                    "supervisor": "systemd",
+                }
+                for index, name in enumerate(names)
+            ]
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    return path
+
+
+def _init_epoch(
+    journal_dir: Path,
+    tmp_path: Path,
+    epoch: str,
+    names: list[str],
+    *,
+    owner_pid: int,
+    nonce: str = "dead-controller",
+) -> None:
+    _helper(
+        journal_dir,
+        "init",
+        "--epoch",
+        epoch,
+        "--source-commit",
+        SOURCE_COMMIT,
+        "--deploy-ts",
+        "20260811T211348Z",
+        "--fleet",
+        "mac",
+        "--hub-agent",
+        LIVE,
+        "--cohort-file",
+        str(_cohort(tmp_path, names)),
+        "--owner-nonce",
+        nonce,
+        "--owner-pid",
+        str(owner_pid),
+    )
+
+
+def _run(snippet: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", snippet], text=True, capture_output=True, check=False
+    )
+
+
+def _stuck_journal(tmp_path: Path) -> tuple[Path, str]:
+    journal_dir = tmp_path / "fleet-cohort-transactions"
+    epoch = f"{SOURCE_COMMIT}:20260811T211348Z:deadcontroller"
+    owner = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _init_epoch(
+            journal_dir,
+            tmp_path,
+            epoch,
+            [LIVE, "bullwinkle", GHOST],
+            owner_pid=owner.pid,
+        )
+    finally:
+        owner.terminate()
+        owner.wait(timeout=10)
+    # The journal now records a controller that no longer exists.
+    assert _helper(journal_dir, "discover")["active"]["owner"]["alive"] is False
+    return journal_dir, epoch
+
+
+def test_dead_owner_transaction_is_named_by_epoch_before_any_ssh(tmp_path) -> None:
+    journal_dir, epoch = _stuck_journal(tmp_path)
+    tmpdir_local = tmp_path / "tmpdir-local"
+    tmpdir_local.mkdir()
+
+    snippet = "\n".join(
+        [
+            # The registry still knows the live members but not the ghost.
+            _preamble(journal_dir, tmpdir_local, ["agent_rocky", "agent_bullwinkle"]),
+            _report_source(),
+            'report_stuck_cohort_transaction "$(cohort_journal discover)"',
+        ]
+    )
+    result = _run(snippet)
+    assert result.returncode == 0, result.stderr
+    diagnostic = result.stderr
+
+    # The epoch is the subject of the diagnostic, not an agent.
+    assert epoch in diagnostic
+    assert "cohort epoch" in diagnostic
+    assert "controller is dead" in diagnostic
+    assert "state=preparing" in diagnostic
+    assert "(not running)" in diagnostic
+    # The pinned cohort is enumerated, and the ghost member is named as absent
+    # from the registry rather than surfacing later as an empty SSH route.
+    assert f"pinned cohort (3): {LIVE}, bullwinkle, {GHOST}" in diagnostic
+    assert (
+        f"pinned members absent from the frozen fleet registry: {GHOST}" in diagnostic
+    )
+    # And the remedies that were tried and failed are ruled out explicitly.
+    assert "removing or deleting the" in diagnostic
+    assert "--agents" in diagnostic
+    assert str(journal_dir) in diagnostic
+    # Nothing was attempted against a node: no SSH, no mutation, no deletion.
+    assert "no node or hub mutation was ever journalled" in diagnostic
+    assert _journal_file(journal_dir, epoch).exists()
+
+
+def test_diagnostic_is_silent_when_the_owning_controller_is_alive(tmp_path) -> None:
+    journal_dir = tmp_path / "fleet-cohort-transactions"
+    epoch = f"{SOURCE_COMMIT}:20260820T000000Z:livecontroller"
+    _init_epoch(
+        journal_dir,
+        tmp_path,
+        epoch,
+        [LIVE],
+        owner_pid=os.getpid(),
+        nonce="live-controller",
+    )
+    tmpdir_local = tmp_path / "tmpdir-local"
+    tmpdir_local.mkdir()
+
+    result = _run(
+        "\n".join(
+            [
+                _preamble(journal_dir, tmpdir_local, ["agent_rocky"]),
+                _report_source(),
+                'report_stuck_cohort_transaction "$(cohort_journal discover)"',
+            ]
+        )
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stderr.strip() == ""
+
+
+def test_empty_ssh_route_points_at_the_journal_not_only_the_agent(tmp_path) -> None:
+    """The symptom message now carries its own cause."""
+
+    snippet = "\n".join(
+        [
+            "set -u",
+            "FLEET_REGISTRY_SOURCE=/home/operator/.mac/fleets.yaml",
+            "COHORT_JOURNAL_DIR=/home/operator/.mac/fleet-cohort-transactions",
+            "empty_route_guard() {",
+            '  local agent="$1"',
+            _route_guard_source(),
+            "}",
+            f"empty_route_guard {shlex.quote(GHOST)}",
+        ]
+    )
+    result = _run(snippet)
+    assert result.returncode == 1
+    assert f"{GHOST}: authoritative SSH route resolved empty" in result.stderr
+    assert "/home/operator/.mac/fleets.yaml" in result.stderr
+    assert "pinned cohort of an incomplete cohort transaction" in result.stderr
+    assert "/home/operator/.mac/fleet-cohort-transactions" in result.stderr
+
+
+def test_retention_bounds_terminal_journals_and_retains_the_stuck_one(
+    tmp_path,
+) -> None:
+    tmpdir_local = tmp_path / "tmpdir-local"
+    tmpdir_local.mkdir()
+    journal_dir = tmp_path / "fleet-cohort-transactions"
+
+    # An incomplete epoch blocks `init`, so the finished history is built
+    # first and the stuck transaction is layered on top -- the same order in
+    # which a real directory accumulated 638 files behind one blocked epoch.
+    aged = []
+    for index in range(4):
+        epoch = f"{SOURCE_COMMIT}:2026071{index}T000000Z:controller{index}"
+        _init_epoch(
+            journal_dir,
+            tmp_path,
+            epoch,
+            [LIVE],
+            owner_pid=os.getpid(),
+            nonce=f"controller{index}",
+        )
+        _helper(
+            journal_dir,
+            "abort",
+            "--epoch",
+            epoch,
+            "--expected-revision",
+            "0",
+            "--operation-id",
+            f"abort-{index}",
+            "--owner-nonce",
+            f"controller{index}",
+        )
+        path = _journal_file(journal_dir, epoch)
+        record = json.loads(path.read_text(encoding="utf-8"))
+        record["updated_at"] = f"2026-07-{19 + index:02d}T05:45:00Z"
+        path.write_text(json.dumps(record, sort_keys=True) + "\n", encoding="utf-8")
+        path.chmod(0o600)
+        aged.append(epoch)
+
+    _journal_dir, stuck_epoch = _stuck_journal(tmp_path)
+    assert _journal_dir == journal_dir
+
+    result = _run(
+        "\n".join(
+            [
+                _preamble(journal_dir, tmpdir_local, ["agent_rocky"]),
+                _reap_source(),
+                "reap_terminal_cohort_journals",
+            ]
+        )
+    )
+    assert result.returncode == 0, result.stderr
+    assert "cohort journal retention aged out 2 terminal epoch journal(s)" in (
+        result.stdout
+    )
+    # The two oldest terminal journals are gone; the newest two are the window.
+    assert not _journal_file(journal_dir, aged[0]).exists()
+    assert not _journal_file(journal_dir, aged[1]).exists()
+    assert _journal_file(journal_dir, aged[2]).exists()
+    assert _journal_file(journal_dir, aged[3]).exists()
+    # The non-terminal, dead-owner transaction is never a retention target.
+    assert _journal_file(journal_dir, stuck_epoch).exists()
+    assert _helper(journal_dir, "discover")["stuck"]["epoch_id"] == stuck_epoch
+
+
+def test_retention_failure_never_blocks_a_deploy(tmp_path) -> None:
+    """Retention is bookkeeping: an unusable journal directory is not a gate."""
+
+    tmpdir_local = tmp_path / "tmpdir-local"
+    tmpdir_local.mkdir()
+    unusable = tmp_path / "missing-parent" / "journal"
+
+    result = _run(
+        "\n".join(
+            [
+                _preamble(unusable, tmpdir_local, ["agent_rocky"]),
+                _reap_source(),
+                "reap_terminal_cohort_journals",
+                'echo "continued=$?"',
+            ]
+        )
+    )
+    assert result.returncode == 0, result.stderr
+    assert "continued=0" in result.stdout
+    assert "cohort journal retention did not run" in result.stderr

--- a/tests/test_fleet_cohort_transaction.py
+++ b/tests/test_fleet_cohort_transaction.py
@@ -1863,3 +1863,226 @@ def test_recovery_classifier_flags_orphan_recoverable_barrier(tmp_path: Path) ->
     resolved = recovery(scenario)
     assert resolved["hub_recovery"]["action"] == "none"
     assert resolved["hub_recovery"]["orphan_recoverable"] is False
+
+
+def journal_path(directory: Path, epoch: str) -> Path:
+    return directory / (
+        "transaction-" + hashlib.sha256(epoch.encode()).hexdigest() + ".json"
+    )
+
+
+def terminal_epoch(
+    directory: Path, tmp_path: Path, label: str, *, updated_at: str | None = None
+) -> str:
+    """Create one aborted (terminal) journal, optionally aged."""
+
+    epoch = f"{SOURCE_COMMIT}:{label}:controller"
+    cohort_file = write_json(tmp_path / f"cohort-{label}.json", cohort(1))
+    run_cli(
+        directory,
+        "init",
+        "--epoch",
+        epoch,
+        "--source-commit",
+        SOURCE_COMMIT,
+        "--deploy-ts",
+        "20260719T054500Z",
+        "--fleet",
+        "rocky",
+        "--hub-agent",
+        "rocky",
+        "--cohort-file",
+        str(cohort_file),
+        "--owner-nonce",
+        OWNER_NONCE,
+        "--owner-pid",
+        str(os.getpid()),
+    )
+    run_cli(
+        directory,
+        "abort",
+        "--epoch",
+        epoch,
+        "--expected-revision",
+        "0",
+        "--operation-id",
+        f"abort-{label}",
+        "--owner-nonce",
+        OWNER_NONCE,
+    )
+    if updated_at is not None:
+        path = journal_path(directory, epoch)
+        record = json.loads(path.read_text(encoding="utf-8"))
+        assert record["state"] == "aborted"
+        record["updated_at"] = updated_at
+        write_json(path, record)
+    return epoch
+
+
+def dead_owner_scenario(tmp_path: Path) -> Scenario:
+    """An epoch owned by a controller process that has since exited."""
+
+    owner = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(60)"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        scenario = Scenario(tmp_path, node_count=3, owner_pid=owner.pid)
+    finally:
+        owner.terminate()
+        owner.wait(timeout=10)
+    return scenario
+
+
+def test_stuck_transaction_with_dead_owner_is_reported_by_epoch_not_replayed(
+    tmp_path: Path,
+) -> None:
+    """A dead controller's incomplete epoch is named, never silently replayed.
+
+    This is the defect that made the fleet undeployable for nine days: the
+    journal pinned a cohort, its owner died, nothing surfaced the epoch, and
+    the only visible error named a cohort member instead.
+    """
+
+    scenario = dead_owner_scenario(tmp_path)
+
+    _result, discovered = run_cli(scenario.directory, "discover")
+    stuck = discovered["stuck"]
+    assert stuck is not None
+    assert stuck["schema"] == "mac.fleet_cohort_stuck_transaction.v1"
+    # The diagnostic names the transaction, not an agent.
+    assert stuck["epoch_id"] == EPOCH
+    assert stuck["blocks_new_epoch"] is True
+    assert stuck["owner"]["alive"] is False
+    assert stuck["state"] == "preparing"
+    assert stuck["mutated"] is False
+    assert stuck["mutated_nodes"] == []
+    # The pinned cohort is reported so the caller can name members that no
+    # longer exist in the registry instead of failing on an empty SSH route.
+    assert stuck["cohort_size"] == 3
+    assert stuck["cohort_names"] == [node["name"] for node in scenario.nodes]
+    assert stuck["cohort_stable_ids"] == [
+        node["stable_id"] for node in scenario.nodes
+    ]
+    assert stuck["age_seconds"] is not None
+
+    # Retention must never delete it: the epoch is reported and retained even
+    # under the most aggressive window a caller can ask for.
+    _result, reaped = run_cli(
+        scenario.directory, "reap", "--max-age-days", "0", "--keep", "0"
+    )
+    assert reaped["removed_epochs"] == []
+    assert reaped["active"] == 1
+    assert reaped["stuck"] is not None
+    assert reaped["stuck"]["epoch_id"] == EPOCH
+    assert journal_path(scenario.directory, EPOCH).exists()
+
+    # And it is still discoverable and adoptable afterwards.
+    _result, after = run_cli(scenario.directory, "discover")
+    assert after["active"]["epoch_id"] == EPOCH
+    assert after["stuck"]["epoch_id"] == EPOCH
+
+
+def test_live_owner_transaction_is_not_reported_as_stuck(tmp_path: Path) -> None:
+    scenario = Scenario(tmp_path)
+    _result, discovered = run_cli(scenario.directory, "discover")
+    assert discovered["active"]["epoch_id"] == EPOCH
+    assert discovered["stuck"] is None
+
+    _result, reaped = run_cli(scenario.directory, "reap")
+    assert reaped["stuck"] is None
+    assert reaped["removed_epochs"] == []
+
+
+def test_terminal_journals_age_out_but_keep_a_bounded_recent_window(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "journal"
+    epochs = [
+        terminal_epoch(
+            directory,
+            tmp_path,
+            f"aged{index}",
+            updated_at=f"2026-07-{19 + index:02d}T05:45:00Z",
+        )
+        for index in range(5)
+    ]
+
+    _result, preview = run_cli(
+        directory, "reap", "--max-age-days", "14", "--keep", "2", "--dry-run"
+    )
+    assert preview["dry_run"] is True
+    assert preview["terminal"] == 5
+    assert sorted(preview["expired_epochs"]) == sorted(epochs[:3])
+    assert preview["removed_epochs"] == []
+    assert all(journal_path(directory, epoch).exists() for epoch in epochs)
+
+    _result, reaped = run_cli(
+        directory, "reap", "--max-age-days", "14", "--keep", "2"
+    )
+    assert sorted(reaped["removed_epochs"]) == sorted(epochs[:3])
+    assert reaped["retained"] == 2
+    assert reaped["stuck"] is None
+    for epoch in epochs[:3]:
+        assert not journal_path(directory, epoch).exists()
+    for epoch in epochs[3:]:
+        assert journal_path(directory, epoch).exists()
+
+    # Retention is idempotent: a second pass finds nothing left to age out.
+    _result, again = run_cli(directory, "reap", "--max-age-days", "14", "--keep", "2")
+    assert again["removed_epochs"] == []
+    assert again["changed"] is False
+
+
+def test_recent_terminal_journals_survive_retention(tmp_path: Path) -> None:
+    directory = tmp_path / "journal"
+    epoch = terminal_epoch(directory, tmp_path, "fresh")
+    _result, reaped = run_cli(directory, "reap", "--max-age-days", "14", "--keep", "0")
+    assert reaped["removed_epochs"] == []
+    assert journal_path(directory, epoch).exists()
+
+
+def test_retention_prunes_orphan_plan_files_and_keeps_bound_ones(
+    tmp_path: Path,
+) -> None:
+    directory = tmp_path / "journal"
+    kept = terminal_epoch(directory, tmp_path, "kept")
+    bound_digest = hashlib.sha256(kept.encode()).hexdigest()
+    bound_plan = directory / f"release-plan-{bound_digest}.json"
+    write_json(bound_plan, {"schema": "mac.test_plan.v1"})
+    orphan_plan = directory / ("hub-open-plan-" + "a" * 64 + ".json")
+    write_json(orphan_plan, {"schema": "mac.test_plan.v1"})
+
+    _result, reaped = run_cli(directory, "reap", "--max-age-days", "14", "--keep", "8")
+    assert reaped["removed_plans"] == [orphan_plan.name]
+    assert not orphan_plan.exists()
+    assert bound_plan.exists()
+    assert journal_path(directory, kept).exists()
+
+
+def test_retention_retains_journals_this_build_cannot_parse(tmp_path: Path) -> None:
+    directory = tmp_path / "journal"
+    epoch = terminal_epoch(
+        directory, tmp_path, "aged", updated_at="2026-01-01T00:00:00Z"
+    )
+    corrupt = directory / ("transaction-" + "b" * 64 + ".json")
+    corrupt.write_text("{not json", encoding="utf-8")
+    corrupt.chmod(0o600)
+
+    _result, reaped = run_cli(directory, "reap", "--max-age-days", "1", "--keep", "0")
+    assert reaped["unreadable"] == [corrupt.name]
+    assert corrupt.exists()
+    assert reaped["removed_epochs"] == [epoch]
+
+
+def test_retention_rejects_out_of_range_windows(tmp_path: Path) -> None:
+    directory = tmp_path / "journal"
+    terminal_epoch(directory, tmp_path, "kept")
+    _result, rejected = run_cli(
+        directory, "reap", "--max-age-days", "-1", check=False
+    )
+    assert rejected["error"]["code"] == "invalid_input"
+    _result, rejected = run_cli(directory, "reap", "--keep", "notanumber", check=False)
+    assert rejected["error"]["code"] == "invalid_input"


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_5d21d9055b8c4ba888eb676bbae11003`
- head: `2a5a98d094e945f38be7dd9fbc08ec23263b809e`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
