### PR TITLE
PR #551 follow-up: --first-hub-bootstrap still sets MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE=1, crashing on a receipt file the from-scratch path never creates (task_dd1d404a33bc48b6877fe911e100b95f)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -254,6 +254,22 @@ normalize_boolean_token() {
     | tr '[:upper:]' '[:lower:]'
 }
 
+# Phase-1 cohort quiescence is a statement about a *prior* generation: the node
+# install refuses to proceed unless this generation's phase-1 receipt proves the
+# previously running worker and gateways were drained and can be restored.  A
+# from-scratch first-hub bootstrap has no prior generation -- no dispatch hold
+# to take, no worker to drain, no phase-1 topology to restore -- so it runs no
+# phase-1 transaction and writes no receipt.  Demanding the receipt there turns
+# the documented from-scratch path into a guaranteed remote failure, so the
+# requirement is reported honestly per invocation instead of hardcoded.  Every
+# other install action still requires it.
+phase1_quiescence_remote_flag() {
+  case "$(normalize_boolean_token "${FIRST_HUB_BOOTSTRAP:-0}")" in
+    1|true|yes|on) printf '0' ;;
+    *) printf '1' ;;
+  esac
+}
+
 resolve_python_bin() {
   local candidate
   for candidate in "${PYTHON:-}" "${MAC_PYTHON:-}" "$ROOT/.venv/bin/python" python3.11 python3 python; do
@@ -2258,13 +2274,24 @@ reconcile_remote_deploy() {
       sleep "$_sleep_interval"
     fi
     if ssh -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=30 -o ServerAliveCountMax=6 "${ssh_args[@]}" "$ssh_target" \
-      "MAC_DEPLOY_AGENT=$(shell_quote "$agent") MAC_DEPLOY_TS=$(shell_quote "$TS") MAC_DEPLOY_GIT_REV=$(shell_quote "$GIT_REV") MAC_DEPLOY_GENERATION_EXPECTED=$(shell_quote "$deployment_id") MAC_DEPLOY_CLEAR_REPO_UPDATE_BLOCKER=$(shell_quote "$clear_repo_update_blocker") $fence_exec" <<'REMOTE'
+      "MAC_DEPLOY_AGENT=$(shell_quote "$agent") MAC_DEPLOY_TS=$(shell_quote "$TS") MAC_DEPLOY_GIT_REV=$(shell_quote "$GIT_REV") MAC_DEPLOY_GENERATION_EXPECTED=$(shell_quote "$deployment_id") MAC_DEPLOY_CLEAR_REPO_UPDATE_BLOCKER=$(shell_quote "$clear_repo_update_blocker") MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE=$(shell_quote "$(phase1_quiescence_remote_flag)") $fence_exec" <<'REMOTE'
 set -euo pipefail
 agent="${MAC_DEPLOY_AGENT:?}"
 deploy_ts="${MAC_DEPLOY_TS:?}"
 expected_rev="${MAC_DEPLOY_GIT_REV:?}"
 expected_generation="${MAC_DEPLOY_GENERATION_EXPECTED:?}"
 clear_repo_update_blocker="${MAC_DEPLOY_CLEAR_REPO_UPDATE_BLOCKER:-0}"
+# The same requirement the install itself was given.  An install that ran no
+# phase-1 cohort transaction cannot publish phase-1 or media evidence, and
+# demanding it here would fail every from-scratch node after a clean install.
+expected_require_phase1="${MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE:-1}"
+case "$expected_require_phase1" in
+  0|1) ;;
+  *)
+    echo "remote reconciliation failed: phase-1 requirement is not 0 or 1" >&2
+    exit 1
+    ;;
+esac
 mac_home="${MAC_HOME:-$HOME/.mac}"
 log_dir="$mac_home/logs"
 manifest="$log_dir/deploy-manifest-${deploy_ts}-post.json"
@@ -2317,7 +2344,7 @@ if [ -e "$mac_home/src/mac/.git" ]; then
     exit 1
   fi
 fi
-"$python_bin" - "$manifest" "$latest" "$agent" "$deploy_ts" "$expected_rev" "$expected_generation" <<'PY'
+"$python_bin" - "$manifest" "$latest" "$agent" "$deploy_ts" "$expected_rev" "$expected_generation" "$expected_require_phase1" <<'PY'
 import json
 import sys
 (
@@ -2327,11 +2354,41 @@ import sys
     expected_ts,
     expected_rev,
     expected_generation,
+    raw_require_phase1,
 ) = sys.argv[1:]
+require_phase1 = raw_require_phase1 == "1"
 quiescence_summaries = []
 gateway_summaries = []
 phase1_summaries = []
 media_summaries = []
+
+
+def proved_gateway_readiness(data, label):
+    # Gateway readiness is proved by the install itself and does not depend on a
+    # prior generation, so every install action must publish it.
+    gateway = data.get("gateway_readiness")
+    if (
+        not isinstance(gateway, dict)
+        or gateway.get("schema") != "mac.gateway_readiness_manifest.v1"
+        or gateway.get("status") != "proved"
+        or gateway.get("generation") != expected_generation
+        or gateway.get("revision") != expected_rev
+        or gateway.get("stable_observations") != 2
+        or gateway.get("implementation")
+        not in {"hermes", "openclaw", "nemoclaw", "none"}
+        or gateway.get("supervisor")
+        not in {"systemd", "launchd", "supervisord"}
+        or not isinstance(gateway.get("sha256"), str)
+        or len(gateway["sha256"]) != 64
+        or not isinstance(gateway.get("identities"), dict)
+        or not isinstance(gateway.get("state"), dict)
+    ):
+        raise SystemExit(
+            "remote reconciliation failed: %s has invalid gateway readiness" % label
+        )
+    return gateway
+
+
 for label, path in (("post manifest", manifest_path), ("latest manifest", latest_path)):
     with open(path, encoding="utf-8") as handle:
         data = json.load(handle)
@@ -2381,6 +2438,36 @@ for label, path in (("post manifest", manifest_path), ("latest manifest", latest
         if isinstance(phase1, dict)
         else None
     )
+    if not require_phase1:
+        # A from-scratch install has no prior generation to quiesce, so the node
+        # reports the phase-1 and media lifecycles as not required rather than
+        # proving receipts it never wrote.  Accept exactly that shape -- a node
+        # that claims a proof here did not run the install we asked for.
+        if (
+            not isinstance(phase1, dict)
+            or phase1.get("schema")
+            != "mac.phase1_cohort_quiescence_manifest.v1"
+            or phase1.get("status") != "not_required"
+        ):
+            raise SystemExit(
+                "remote reconciliation failed: %s has invalid phase-1 evidence" % label
+            )
+        phase1_summaries.append(phase1)
+        media = data.get("media_runtime_readiness")
+        if (
+            not isinstance(media, dict)
+            or media.get("schema")
+            != "mac.media_runtime_readiness_manifest.v1"
+            or media.get("status") != "not_required"
+            or media.get("resources")
+        ):
+            raise SystemExit(
+                "remote reconciliation failed: %s has invalid media runtime readiness"
+                % label
+            )
+        media_summaries.append(media)
+        gateway_summaries.append(proved_gateway_readiness(data, label))
+        continue
     if (
         not isinstance(phase1, dict)
         or phase1.get("schema")
@@ -2446,27 +2533,7 @@ for label, path in (("post manifest", manifest_path), ("latest manifest", latest
             % label
         )
     media_summaries.append(media)
-    gateway = data.get("gateway_readiness")
-    if (
-        not isinstance(gateway, dict)
-        or gateway.get("schema") != "mac.gateway_readiness_manifest.v1"
-        or gateway.get("status") != "proved"
-        or gateway.get("generation") != expected_generation
-        or gateway.get("revision") != expected_rev
-        or gateway.get("stable_observations") != 2
-        or gateway.get("implementation")
-        not in {"hermes", "openclaw", "nemoclaw", "none"}
-        or gateway.get("supervisor")
-        not in {"systemd", "launchd", "supervisord"}
-        or not isinstance(gateway.get("sha256"), str)
-        or len(gateway["sha256"]) != 64
-        or not isinstance(gateway.get("identities"), dict)
-        or not isinstance(gateway.get("state"), dict)
-    ):
-        raise SystemExit(
-            "remote reconciliation failed: %s has invalid gateway readiness" % label
-        )
-    gateway_summaries.append(gateway)
+    gateway_summaries.append(proved_gateway_readiness(data, label))
 if quiescence_summaries[0] != quiescence_summaries[1]:
     raise SystemExit("remote reconciliation failed: manifest quiescence evidence diverged")
 if phase1_summaries[0] != phase1_summaries[1]:
@@ -8365,7 +8432,7 @@ PY
   add_remote_env MAC_DEPLOY_TS "$TS"
   add_remote_env MAC_DEPLOY_GIT_REV "$GIT_REV"
   add_remote_env MAC_DEPLOY_GENERATION "$deploy_generation"
-  add_remote_env MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE 1
+  add_remote_env MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE "$(phase1_quiescence_remote_flag)"
   add_remote_env MAC_DEPLOY_GIT_URL "$GIT_URL"
   add_remote_env MAC_DEPLOY_GIT_BRANCH "$GIT_BRANCH"
   add_remote_env MAC_DEPLOY_HERMES_SLACK_HOME_CHANNEL_NAME "$home_channel"

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -5808,12 +5808,18 @@ capture_darwin_launchd_prestate() {
   # Recover that fact only from the generation-bound phase-1 receipt.  A
   # system-domain gateway/worker would be a topology this installer cannot
   # faithfully restore (the canonical definitions are LaunchAgents), so fail
-  # closed instead of silently moving it to another domain.
-  phase1_states="$("$PY" - \
-    "$MAC_HOME/phase1-cohort-quiescence-${DEPLOY_GENERATION}.json" \
-    "$AGENT" "$FLEET_NAME" "$DEPLOY_REV" "$DEPLOY_GENERATION" "$uid" \
-    "$HERMES_LAUNCHD_LABEL" "$OPENCLAW_LAUNCHD_LABEL" \
-    "$NEMOCLAW_LAUNCHD_LABEL" "$MAC_AGENT_LAUNCHD_LABEL" <<'PY'
+  # closed instead of silently moving it to another domain.  An install that
+  # requires no phase-1 quiescence ran no cohort transaction and has no receipt:
+  # a node with no prior generation has no prior gateway or worker, which is
+  # what the DARWIN_*_LAUNCHD_ACTIVE defaults already describe.
+  if ! truthy "${MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE:-0}"; then
+    log "phase-1 cohort quiescence is not required; assuming no prior launchd gateway or worker"
+  else
+    phase1_states="$("$PY" - \
+      "$MAC_HOME/phase1-cohort-quiescence-${DEPLOY_GENERATION}.json" \
+      "$AGENT" "$FLEET_NAME" "$DEPLOY_REV" "$DEPLOY_GENERATION" "$uid" \
+      "$HERMES_LAUNCHD_LABEL" "$OPENCLAW_LAUNCHD_LABEL" \
+      "$NEMOCLAW_LAUNCHD_LABEL" "$MAC_AGENT_LAUNCHD_LABEL" <<'PY'
 import json
 import os
 import stat
@@ -5896,24 +5902,25 @@ print(
 )
 PY
 )" || return $?
-  read -r \
-    DARWIN_HERMES_LAUNCHD_ACTIVE \
-    DARWIN_OPENCLAW_LAUNCHD_ACTIVE \
-    DARWIN_NEMOCLAW_LAUNCHD_ACTIVE \
-    DARWIN_AGENT_LAUNCHD_ACTIVE <<<"$phase1_states"
-  case "${DARWIN_HERMES_LAUNCHD_ACTIVE}${DARWIN_OPENCLAW_LAUNCHD_ACTIVE}${DARWIN_NEMOCLAW_LAUNCHD_ACTIVE}${DARWIN_AGENT_LAUNCHD_ACTIVE}" in
-    ""|*[!01]*|?????*|???|??|?)
-      log "ERROR: phase-1 launchd prestate result is malformed"
+    read -r \
+      DARWIN_HERMES_LAUNCHD_ACTIVE \
+      DARWIN_OPENCLAW_LAUNCHD_ACTIVE \
+      DARWIN_NEMOCLAW_LAUNCHD_ACTIVE \
+      DARWIN_AGENT_LAUNCHD_ACTIVE <<<"$phase1_states"
+    case "${DARWIN_HERMES_LAUNCHD_ACTIVE}${DARWIN_OPENCLAW_LAUNCHD_ACTIVE}${DARWIN_NEMOCLAW_LAUNCHD_ACTIVE}${DARWIN_AGENT_LAUNCHD_ACTIVE}" in
+      ""|*[!01]*|?????*|???|??|?)
+        log "ERROR: phase-1 launchd prestate result is malformed"
+        return 1
+        ;;
+    esac
+    if [ $((
+      DARWIN_HERMES_LAUNCHD_ACTIVE
+      + DARWIN_OPENCLAW_LAUNCHD_ACTIVE
+      + DARWIN_NEMOCLAW_LAUNCHD_ACTIVE
+    )) -gt 1 ]; then
+      log "ERROR: phase-1 found multiple active launchd gateway owners"
       return 1
-      ;;
-  esac
-  if [ $((
-    DARWIN_HERMES_LAUNCHD_ACTIVE
-    + DARWIN_OPENCLAW_LAUNCHD_ACTIVE
-    + DARWIN_NEMOCLAW_LAUNCHD_ACTIVE
-  )) -gt 1 ]; then
-    log "ERROR: phase-1 found multiple active launchd gateway owners"
-    return 1
+    fi
   fi
 
   if sudo -n test -f "$system_plist"; then
@@ -5946,6 +5953,18 @@ PY
 
 capture_phase1_prior_worker_topology() {
   local topology=""
+  if ! truthy "${MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE:-0}"; then
+    # No phase-1 cohort transaction ran for this generation, so no receipt was
+    # written and there is no prior gateway/worker topology to restore.  That is
+    # the from-scratch first-hub bootstrap: its faithful rollback target is a
+    # node with nothing deploy-managed on it.  Reading the receipt anyway would
+    # abort every such install on a missing file.
+    ROLLBACK_ACTIVE_GATEWAY=none
+    ROLLBACK_AGENT_PRIOR_STATE=absent
+    log "phase-1 cohort quiescence is not required; recording an empty prior topology"
+    write_rollback_script
+    return 0
+  fi
   topology="$("$PY" - \
     "$MAC_HOME/phase1-cohort-quiescence-${DEPLOY_GENERATION}.json" \
     "$AGENT" "$FLEET_NAME" "$DEPLOY_REV" "$DEPLOY_GENERATION" \

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -54,6 +54,10 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
     ".github/workflows/ci.yml": ("tests/test_deployment_image_artifact.py",),
     "deploy/deploy-mac-fleet.sh": (
         "tests/test_deploy_fleet_drain.py",
+        # Owns the phase-1 quiescence requirement this script hands the node:
+        # a from-scratch first-hub bootstrap must not be told to prove a
+        # receipt that only an upgrade of a prior generation can produce.
+        "tests/test_first_hub_bootstrap_phase1_quiescence.py",
         "tests/test_fleet_node_machine_onboard.py",
         "tests/test_reviewed_openshell_cli.py",
     ),
@@ -77,6 +81,7 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         "tests/test_deploy_fleet_drain.py",
         "tests/test_deploy_fleet_parallel_staging.py",
         "tests/test_deploy_github_https_credentials.py",
+        "tests/test_first_hub_bootstrap_phase1_quiescence.py",
         "tests/test_fleet_node_capability_truthfulness.py",
         "tests/test_fleet_node_daemon_quiescence.py",
         "tests/test_fleet_node_gateway_readiness.py",

--- a/tests/test_first_hub_bootstrap_phase1_quiescence.py
+++ b/tests/test_first_hub_bootstrap_phase1_quiescence.py
@@ -1,0 +1,258 @@
+"""A from-scratch first-hub bootstrap must not demand phase-1 cohort quiescence.
+
+Phase-1 quiescence is evidence about a *prior* generation: the cohort was
+drained, its topology recorded, and it can be restored.  A first-hub bootstrap
+installs onto a node with no prior generation, so it runs no phase-1
+transaction and writes no receipt.  Every layer that consumes the requirement
+has to agree about that, or the documented from-scratch path fails on a file it
+never creates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = ROOT / "deploy" / "deploy-mac-fleet.sh"
+NODE_INSTALL = ROOT / "deploy" / "fleet-node-install.sh"
+
+AGENT = "hub"
+TS = "20260820T000000Z"
+REV = "a" * 40
+GENERATION = "deployment_0123456789abcdef"
+DIGEST = hashlib.sha256(b"receipt").hexdigest()
+
+
+def _function(source: str, name: str) -> str:
+    """Return the body text of a top-level shell function."""
+    return source.split("%s() {" % name, 1)[1].split("\n}\n", 1)[0]
+
+
+def _run_bash(script: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin", **(env or {})},
+    )
+
+
+@pytest.mark.parametrize(
+    ("first_hub_bootstrap", "expected"),
+    [
+        (None, "1"),
+        ("", "1"),
+        ("0", "1"),
+        ("false", "1"),
+        ("1", "0"),
+        ("true", "0"),
+        ("TRUE", "0"),
+        ("yes", "0"),
+        ("on", "0"),
+    ],
+)
+def test_remote_quiescence_flag_follows_first_hub_bootstrap(first_hub_bootstrap, expected) -> None:
+    source = DEPLOY.read_text(encoding="utf-8")
+    harness = "\n".join(
+        [
+            "set -euo pipefail",
+            "normalize_boolean_token() {%s\n}" % _function(source, "normalize_boolean_token"),
+            "phase1_quiescence_remote_flag() {%s\n}" % _function(source, "phase1_quiescence_remote_flag"),
+            "phase1_quiescence_remote_flag",
+        ]
+    )
+    env = {} if first_hub_bootstrap is None else {"FIRST_HUB_BOOTSTRAP": first_hub_bootstrap}
+    result = _run_bash(harness, env)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == expected
+
+
+def test_deploy_never_hardcodes_the_phase1_requirement() -> None:
+    source = DEPLOY.read_text(encoding="utf-8")
+    # The bug this guards: one unconditional `1` in the shared remote-env path
+    # made every install action -- including the from-scratch bootstrap --
+    # promise the node a phase-1 receipt that only an upgrade can produce.
+    assert "add_remote_env MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE 1" not in source
+    assert (
+        'add_remote_env MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE "$(phase1_quiescence_remote_flag)"'
+        in source
+    )
+    # Reconciliation validates the manifest the install was actually asked to
+    # produce, so it must be told the same thing the install was told.
+    assert (
+        'MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE=$(shell_quote "$(phase1_quiescence_remote_flag)")'
+        in source
+    )
+
+
+def test_node_install_skips_prior_topology_when_quiescence_is_not_required(tmp_path) -> None:
+    source = NODE_INSTALL.read_text(encoding="utf-8")
+    body = source.split("capture_phase1_prior_worker_topology() {", 1)[1]
+    guard = body.split('topology="$("$PY" -', 1)[0]
+    # The receipt-reading remainder of the function is represented by a sentinel
+    # return: this asserts *whether* the strict path is entered, without running
+    # the embedded receipt validator.
+    harness = "\n".join(
+        [
+            "set -uo pipefail",
+            "truthy() {%s\n}" % _function(source, "truthy"),
+            'log() { printf "LOG %s\\n" "$*"; }',
+            'write_rollback_script() { printf "ROLLBACK_WRITTEN\\n"; }',
+            "capture_phase1_prior_worker_topology() {",
+            guard,
+            "  return 9",
+            "}",
+            "capture_phase1_prior_worker_topology",
+            "rc=$?",
+            'printf "GATEWAY=%s AGENT_PRIOR=%s\\n" "${ROLLBACK_ACTIVE_GATEWAY:-unset}" "${ROLLBACK_AGENT_PRIOR_STATE:-unset}"',
+            "exit $rc",
+        ]
+    )
+
+    for env in ({}, {"MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE": "0"}):
+        result = _run_bash(harness, env)
+        assert result.returncode == 0, result.stderr
+        assert "ROLLBACK_WRITTEN" in result.stdout
+        assert "GATEWAY=none AGENT_PRIOR=absent" in result.stdout
+
+    required = _run_bash(harness, {"MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE": "1"})
+    assert required.returncode == 9, required.stdout
+    assert "ROLLBACK_WRITTEN" not in required.stdout
+
+
+def test_node_install_launchd_prestate_is_gated_on_the_same_requirement() -> None:
+    source = NODE_INSTALL.read_text(encoding="utf-8")
+    body = source.split("capture_darwin_launchd_prestate() {", 1)[1]
+    guard = body.split('if ! truthy "${MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE:-0}"; then', 1)
+    assert len(guard) == 2, "launchd prestate no longer honours the phase-1 requirement"
+    skipped, remainder = guard[1].split("\n  else\n", 1)
+    assert "assuming no prior launchd gateway or worker" in skipped
+    assert 'phase1-cohort-quiescence-${DEPLOY_GENERATION}.json' not in skipped
+    assert 'phase1-cohort-quiescence-${DEPLOY_GENERATION}.json' in remainder
+
+
+def _reconcile_validator() -> str:
+    source = DEPLOY.read_text(encoding="utf-8")
+    start = source.index('"$python_bin" - "$manifest" "$latest"')
+    body = source[source.index("<<'PY'\n", start) + len("<<'PY'\n"):]
+    return body[: body.index("\nPY\n")]
+
+
+def _manifest(*, phase1: dict, media: dict) -> dict:
+    return {
+        "stage": "post",
+        "agent": AGENT,
+        "deploy": {"timestamp": TS, "mac_git_rev": REV},
+        "daemon_resource_quiescence": {
+            "schema": "mac.daemon_resource_quiescence_manifest.v1",
+            "status": "proved",
+            "generation": GENERATION,
+            "revision": REV,
+            "sha256": DIGEST,
+            "required_phases": ["pre_source", "pre_install", "post_install"],
+            "proved_phases": ["pre_source", "pre_install", "post_install"],
+            "container_runtimes": [],
+        },
+        "phase1_cohort_quiescence": phase1,
+        "media_runtime_readiness": media,
+        "gateway_readiness": {
+            "schema": "mac.gateway_readiness_manifest.v1",
+            "status": "proved",
+            "generation": GENERATION,
+            "revision": REV,
+            "stable_observations": 2,
+            "implementation": "openclaw",
+            "supervisor": "launchd",
+            "sha256": DIGEST,
+            "identities": {},
+            "state": {},
+        },
+    }
+
+
+_NOT_REQUIRED_PHASE1 = {
+    "schema": "mac.phase1_cohort_quiescence_manifest.v1",
+    "status": "not_required",
+}
+_NOT_REQUIRED_MEDIA = {
+    "schema": "mac.media_runtime_readiness_manifest.v1",
+    "status": "not_required",
+}
+_PROVED_PHASE1 = {
+    "schema": "mac.phase1_cohort_quiescence_manifest.v1",
+    "status": "proved",
+    "path": "/home/agent/.mac/phase1-cohort-quiescence-%s.json" % GENERATION,
+    "generation": GENERATION,
+    "revision": REV,
+    "sha256": DIGEST,
+    "supervisor": {"manager": "launchd"},
+    "daemon_resource_receipt": {
+        "schema": "mac.daemon_resource_quiescence.v1",
+        "proof_phase": "pre_source",
+        "sha256": DIGEST,
+        "function_block_sha256": DIGEST,
+    },
+}
+_PROVED_MEDIA = {
+    "schema": "mac.media_runtime_readiness_manifest.v1",
+    "status": "not_applicable",
+    "manager": "launchd",
+    "sha256": DIGEST,
+    "source_contract_sha256": DIGEST,
+    "resources": [],
+}
+
+
+def _reconcile(tmp_path: Path, manifest: dict, require_phase1: str) -> subprocess.CompletedProcess:
+    post = tmp_path / "deploy-manifest-post.json"
+    latest = tmp_path / "deploy-manifest-latest.json"
+    for path in (post, latest):
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _reconcile_validator(),
+            str(post),
+            str(latest),
+            AGENT,
+            TS,
+            REV,
+            GENERATION,
+            require_phase1,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_reconciliation_accepts_a_from_scratch_manifest(tmp_path) -> None:
+    manifest = _manifest(phase1=_NOT_REQUIRED_PHASE1, media=_NOT_REQUIRED_MEDIA)
+    result = _reconcile(tmp_path, manifest, "0")
+    assert result.returncode == 0, result.stderr
+
+
+def test_reconciliation_still_requires_phase1_proof_for_normal_installs(tmp_path) -> None:
+    manifest = _manifest(phase1=_NOT_REQUIRED_PHASE1, media=_NOT_REQUIRED_MEDIA)
+    result = _reconcile(tmp_path, manifest, "1")
+    assert result.returncode != 0
+    assert "invalid phase-1 evidence" in result.stderr
+
+    proved = _manifest(phase1=_PROVED_PHASE1, media=_PROVED_MEDIA)
+    assert _reconcile(tmp_path, proved, "1").returncode == 0
+
+
+def test_reconciliation_rejects_an_unexpected_phase1_proof(tmp_path) -> None:
+    # A node that proves phase-1 for a from-scratch install ran something other
+    # than the install we asked for; that divergence stays fail-closed.
+    manifest = _manifest(phase1=_PROVED_PHASE1, media=_PROVED_MEDIA)
+    result = _reconcile(tmp_path, manifest, "0")
+    assert result.returncode != 0
+    assert "invalid phase-1 evidence" in result.stderr

--- a/tests/test_fleet_node_launchd_prestate.py
+++ b/tests/test_fleet_node_launchd_prestate.py
@@ -114,6 +114,11 @@ DARWIN_HERMES_LAUNCHD_ACTIVE=0
 DARWIN_OPENCLAW_LAUNCHD_ACTIVE=0
 DARWIN_NEMOCLAW_LAUNCHD_ACTIVE=0
 DARWIN_AGENT_LAUNCHD_ACTIVE=0
+# The launchd prestate comes from the phase-1 receipt only when the deployment
+# required cohort quiescence.  A from-scratch install has no prior generation and
+# is covered by test_first_hub_bootstrap_phase1_quiescence.
+MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE=1
+truthy() {{ case "${{1:-}}" in 1|true|TRUE|yes|YES|on|ON) return 0 ;; *) return 1 ;; esac; }}
 log() {{ printf '%s\n' "$*" >&2; }}
 sudo() {{
   if [ "${{1:-}}" = -n ]; then shift; fi

--- a/tests/test_fleet_node_prior_topology.py
+++ b/tests/test_fleet_node_prior_topology.py
@@ -157,6 +157,10 @@ def _run(
 
     values = {
         "PY": sys.executable,
+        # Prior topology is only recovered from a receipt when the deployment
+        # required phase-1 cohort quiescence; a from-scratch install has no prior
+        # generation and is covered by test_first_hub_bootstrap_phase1_quiescence.
+        "MAC_DEPLOY_REQUIRE_PHASE1_QUIESCENCE": "1",
         "MAC_HOME": str(mac_home),
         "AGENT": "rocky",
         "FLEET_NAME": "mac",
@@ -181,6 +185,8 @@ def _run(
         "#!/usr/bin/env bash\nset -euo pipefail\n"
         + "\n".join(f"{key}={shlex.quote(value)}" for key, value in values.items())
         + "\nwrite_rollback_script() { :; }\n"
+        + "log() { printf '%s\\n' \"$*\" >&2; }\n"
+        + "truthy() { case \"${1:-}\" in 1|true|TRUE|yes|YES|on|ON) return 0 ;; *) return 1 ;; esac; }\n"
         + "die() { printf '%s\\n' \"$*\" >&2; return 1; }\n"
         + _function_source()
         + "capture_phase1_prior_worker_topology\n"


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_dd1d404a33bc48b6877fe911e100b95f`
- head: `3ef057018baca7adfe5840b979944396c0013912`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
