### PR TITLE
A dead controller's cohort transaction blocks every deploy, and nothing reaps it (task_5d21d9055b8c4ba888eb676bbae11003)

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -764,6 +764,10 @@ COHORT_JOURNAL_DIR="${MAC_FLEET_COHORT_JOURNAL_DIR:-$HOME/.mac/fleet-cohort-tran
 COHORT_JOURNAL_ACTIVE=0
 COHORT_JOURNAL_REVISION=0
 COHORT_RECOVERY_RUNNING=0
+# Set to the adopted epoch while a prior controller's incomplete transaction is
+# being replayed. A node failure during replay belongs to that epoch, not to
+# the fresh COHORT_EPOCH_ID this invocation would otherwise name.
+COHORT_REPLAY_EPOCH_ID=""
 readonly COHORT_EPOCH_ID COHORT_JOURNAL_DIR COHORT_JOURNAL_HELPER
 # Durable, owner-only failure evidence for bounded node phases. The EXIT trap
 # removes TMPDIR_LOCAL wholesale after fix-forward recovery, which previously
@@ -1481,6 +1485,40 @@ fleet_ssh_route_args() {
   PYTHONPATH="$ROOT/src${PYTHONPATH:+:$PYTHONPATH}" "${cmd[@]}"
 }
 
+cohort_pinned_epoch_id() {
+  if [ -n "${COHORT_REPLAY_EPOCH_ID:-}" ]; then
+    printf '%s\n' "$COHORT_REPLAY_EPOCH_ID"
+  elif [ "${COHORT_JOURNAL_ACTIVE:-0}" = 1 ]; then
+    printf '%s\n' "$COHORT_EPOCH_ID"
+  fi
+}
+
+# A cohort member that no longer exists in the frozen fleet registry resolves to
+# no SSH route at all, and "authoritative SSH route resolved empty" reads as an
+# agent problem. It is not: the name is either absent from the registry (say so,
+# by name) or present and misconfigured. When the name was pinned by a replayed
+# cohort transaction, the epoch is the subject, so name that too -- deleting the
+# agent, pruning the registry, or passing an explicit agent list cannot help.
+report_absent_ssh_route() {
+  local agent="$1" agent_id pinned_epoch
+  # This runs on an already-failing path; never let the diagnostic itself abort.
+  agent_id="$(stable_worker_agent_id "$agent" 2>/dev/null || printf 'unresolved')"
+  pinned_epoch="$(cohort_pinned_epoch_id || true)"
+  if fleet_config_query configured-agent-ids 2>/dev/null | grep -Fxq "$agent_id"; then
+    echo "ERROR: ${agent}: authoritative SSH route resolved empty" >&2
+    echo "  ${agent} (${agent_id}) IS an enabled agent in ${FLEET_REGISTRY_SOURCE};" \
+      "its target/ssh settings resolve no route" >&2
+  else
+    echo "ERROR: ${agent}: no SSH route exists because ${agent_id} is not an enabled agent in the frozen fleet registry" >&2
+    echo "  Fleet registry: ${FLEET_REGISTRY_SOURCE}" >&2
+  fi
+  if [ -n "$pinned_epoch" ]; then
+    echo "  ${agent} is pinned by cohort epoch ${pinned_epoch}, which every deploy replays until it reaches a terminal state." >&2
+    echo "  Inspect the epoch, not the agent:" >&2
+    echo "    ${PYTHON_BIN} ${COHORT_JOURNAL_HELPER} --directory ${COHORT_JOURNAL_DIR} status --epoch ${pinned_epoch}" >&2
+  fi
+}
+
 ssh_control_path_for_agent() {
   local digest
   digest="$("$PYTHON_BIN" -c 'import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest()[:20])' "$1")"
@@ -1551,7 +1589,7 @@ start_ssh_control_master() {
   fi
   while IFS= read -r -d '' item; do route_parts+=("$item"); done < <(fleet_ssh_route_args ssh "$agent")
   [ "${#route_parts[@]}" -gt 0 ] || {
-    echo "ERROR: ${agent}: authoritative SSH route resolved empty" >&2
+    report_absent_ssh_route "$agent"
     return 1
   }
   if [ "$SSH_SESSION_MODE" = direct ]; then
@@ -14115,9 +14153,164 @@ PY
   echo "==> fleet: committed typed cohort finalization recovered"
 }
 
+# Name every non-terminal cohort epoch whose owning controller is gone, BY
+# EPOCH, before a single SSH is attempted. Without this the first thing an
+# operator sees is a per-agent route failure from a cohort pinned days earlier
+# by a controller that no longer exists, and nothing anywhere connects the two.
+# Purely diagnostic: it never mutates a journal and never fails the deploy.
+report_stuck_cohort_transactions() {
+  local diagnosis registry_ids="" payload status=0
+  if ! diagnosis="$(cohort_journal diagnose 2>/dev/null)"; then
+    return 0
+  fi
+  registry_ids="$(fleet_config_query configured-agent-ids 2>/dev/null || true)"
+  # The reader below arrives on stdin as a heredoc, so the diagnosis travels by
+  # owner-only file rather than by pipe or argv (a directory holding hundreds of
+  # journals produces more than one argv can carry on every platform).
+  payload="$(mktemp "${TMPDIR:-/tmp}/mac-cohort-diagnosis.XXXXXX")" || return 0
+  chmod 0600 "$payload"
+  printf '%s' "$diagnosis" > "$payload"
+  "$PYTHON_BIN" - "$payload" \
+    "$registry_ids" "$COHORT_JOURNAL_DIR" "$COHORT_JOURNAL_HELPER" \
+    "$FLEET_REGISTRY_SOURCE" "$PYTHON_BIN" >&2 <<'PY' || status=$?
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+source, registry_raw, journal_dir, helper, registry_source, python_bin = sys.argv[1:7]
+registry = {line.strip() for line in registry_raw.splitlines() if line.strip()}
+try:
+    payload = json.loads(Path(source).read_text(encoding="utf-8"))
+except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+    raise SystemExit(0)
+
+for entry in payload.get("unreadable") or []:
+    print(
+        "WARNING: cohort journal %s is unreadable (%s: %s); it is retained, not reaped"
+        % (entry.get("file"), entry.get("code"), entry.get("message"))
+    )
+
+stuck = payload.get("stuck") or []
+if not stuck:
+    raise SystemExit(0)
+
+
+def days(seconds):
+    if not isinstance(seconds, int):
+        return "unknown"
+    return "%.1fd" % (seconds / 86400.0)
+
+
+unresolvable = False
+for epoch in stuck:
+    epoch_id = epoch["epoch_id"]
+    owner = epoch.get("owner") or {}
+    digest = hashlib.sha256(epoch_id.encode()).hexdigest()
+    print(
+        "ERROR: cohort epoch %s is stuck: state=%s phase=%s revision=%s, and its owning "
+        "controller is gone" % (epoch_id, epoch["state"], epoch["phase"], epoch["revision"])
+    )
+    print(
+        "  owner pid %s is not running; last journal write %s (%s ago)"
+        % (owner.get("pid"), epoch.get("updated_at"), days(epoch.get("age_seconds")))
+    )
+    print("  journal: %s/transaction-%s.json" % (journal_dir, digest))
+    cohort = epoch.get("cohort") or []
+    print(
+        "  pinned cohort (%d): %s"
+        % (len(cohort), ", ".join(node["name"] for node in cohort) or "(none)")
+    )
+    if registry:
+        missing = [
+            node for node in cohort if node.get("stable_id") not in registry
+        ]
+        if missing:
+            unresolvable = True
+            print(
+                "  pinned but NOT an enabled agent in %s (%d): %s"
+                % (
+                    registry_source,
+                    len(missing),
+                    ", ".join(
+                        "%s (%s)" % (node["name"], node.get("stable_id"))
+                        for node in missing
+                    ),
+                )
+            )
+            print(
+                "  Every deploy re-enumerates this pinned cohort, so deleting those agents,"
+            )
+            print(
+                "  pruning the fleet registry, or passing an explicit agent list cannot clear it."
+            )
+    if not epoch.get("applied_node_count") and not epoch.get("hub_committed"):
+        print(
+            "  nothing was ever applied to a cohort node or committed on the hub:"
+            " this epoch is blocking no completed work"
+        )
+    print("  Resolve it by epoch:")
+    print(
+        "    %s %s --directory %s status --epoch %s"
+        % (python_bin, helper, journal_dir, epoch_id)
+    )
+    print(
+        "    %s %s --directory %s recovery --epoch %s"
+        % (python_bin, helper, journal_dir, epoch_id)
+    )
+
+# Replaying a cohort that names agents the registry no longer has cannot
+# succeed: route resolution returns nothing for them, every time. Say so here
+# instead of discovering it one empty SSH route at a time.
+raise SystemExit(3 if unresolvable else 0)
+PY
+  rm -f "$payload"
+  # Only the explicit unresolvable verdict blocks; a diagnostic that itself
+  # misbehaves must never be what stops a deploy.
+  if [ "$status" = 3 ]; then
+    return 1
+  fi
+  return 0
+}
+
+# Terminal journals are evidence, not live state. Nothing aged them out, so the
+# directory accumulated hundreds of files spanning months. This pass keeps a
+# bounded window and can never remove a non-terminal or unparseable journal.
+reap_cohort_transaction_journals() {
+  local result
+  if ! result="$(cohort_journal reap 2>/dev/null)"; then
+    echo "WARNING: cohort journal retention pass failed; terminal journals were left in place" >&2
+    return 0
+  fi
+  printf '%s' "$result" | "$PYTHON_BIN" -c '
+import json, sys
+try:
+    payload = json.load(sys.stdin)
+except json.JSONDecodeError:
+    raise SystemExit(0)
+removed = len(payload.get("removed") or [])
+plans = len(payload.get("removed_plans") or [])
+if removed or plans:
+    print(
+        "==> fleet: reaped %d terminal cohort journal(s) and %d orphan plan file(s) "
+        "older than %s days" % (removed, plans, payload.get("max_age_days"))
+    )
+' || true
+}
+
 recover_incomplete_cohort_transaction_before_deploy() {
   local discovered active_values epoch_id revision previous_nonce previous_pid alive adopted
   local -a active_fields=()
+  # The diagnostic runs first and unconditionally: `discover` itself refuses a
+  # directory holding more than one live epoch, and that refusal names no epoch.
+  # It returns non-zero only when a stuck epoch pins a name the frozen registry
+  # no longer has -- replaying that cohort resolves an empty SSH route on every
+  # attempt, so stop here rather than proving it one ghost agent at a time.
+  if ! report_stuck_cohort_transactions; then
+    echo "ERROR: refusing to replay a stuck cohort epoch whose pinned cohort the frozen fleet registry can no longer resolve" >&2
+    echo "  Resolve the epoch named above; the deploy cannot proceed past it." >&2
+    return 1
+  fi
   if ! discovered="$(cohort_journal discover)"; then
     return 1
   fi
@@ -14157,8 +14350,12 @@ if active:
   fi
   COHORT_JOURNAL_ACTIVE=1
   COHORT_RECOVERY_RUNNING=1
+  # Any node failure from here on belongs to the adopted epoch, so failures name
+  # it rather than the fresh epoch this invocation has not created yet.
+  COHORT_REPLAY_EPOCH_ID="$epoch_id"
   if recover_active_cohort_transaction_v2 "$epoch_id" "$DEPLOY_CONTROLLER_NONCE"; then
     COHORT_RECOVERY_RUNNING=0
+    COHORT_REPLAY_EPOCH_ID=""
     return 0
   fi
   # Leave this set so the EXIT trap does not launch a second concurrent retry.
@@ -15298,6 +15495,9 @@ main() {
       && [ "$LEGACY_HUB_BOOTSTRAP" != 1 ] \
       && [ "$PREPARE_FUNGIBLE_ONBOARDING" != 1 ]; then
     recover_incomplete_cohort_transaction_before_deploy
+    # Bounded retention, after reconciliation so a just-resolved epoch is
+    # inside the keep window. Only terminal journals are eligible.
+    reap_cohort_transaction_journals
   fi
   assert_frozen_deployment_source
   if [ "$PREFLIGHT_ONLY" != 1 ]; then

--- a/deploy/fleet-cohort-transaction.py
+++ b/deploy/fleet-cohort-transaction.py
@@ -101,6 +101,16 @@ MAX_HOLD_BYTES = 512
 JOURNAL_PREFIX = "transaction-"
 JOURNAL_SUFFIX = ".json"
 LOCK_NAME = ".cohort-transaction.lock"
+AUXILIARY_PREFIXES = ("release-plan-", "hub-open-plan-", "hub-prove-plan-")
+# Terminal journals are evidence, not live state.  Nothing used to age them
+# out, so the directory grew to hundreds of files spanning months.  Reaping
+# keeps a bounded window and never touches a journal that is still live.
+DEFAULT_RETENTION_DAYS = 14
+MAX_RETENTION_DAYS = 3650
+DEFAULT_RETENTION_KEEP = 5
+MAX_RETENTION_KEEP = 4096
+DIAGNOSIS_SCHEMA = "mac.fleet_cohort_transaction_diagnosis.v1"
+REAP_SCHEMA = "mac.fleet_cohort_transaction_reap.v1"
 SAFE_TOKEN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:+-]*$")
 HEX_COMMIT = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
 HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
@@ -306,6 +316,28 @@ class JournalError(Exception):
 
 def _utc_now() -> str:
     return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: Any) -> dt.datetime | None:
+    """Parse a journal timestamp, returning ``None`` for anything unusable."""
+    if not isinstance(value, str) or not value:
+        return None
+    text = f"{value[:-1]}+00:00" if value.endswith("Z") else value
+    try:
+        parsed = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _age_seconds(value: Any) -> int | None:
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return None
+    delta = dt.datetime.now(dt.timezone.utc) - parsed
+    return max(0, int(delta.total_seconds()))
 
 
 def _canonical(value: Any) -> bytes:
@@ -1508,6 +1540,31 @@ class JournalDirectory:
                 names.append(name)
         return sorted(names)
 
+    def auxiliary_names(self) -> list[str]:
+        names = []
+        for name in os.listdir(self.directory_fd):
+            if not name.endswith(JOURNAL_SUFFIX):
+                continue
+            if name.startswith(AUXILIARY_PREFIXES):
+                names.append(name)
+        return sorted(names)
+
+    def remove(self, name: str) -> None:
+        """Unlink one retention-eligible file inside the locked directory."""
+        if name != os.path.basename(name) or not name.endswith(JOURNAL_SUFFIX):
+            raise JournalError("invalid_schema", "retention filename is invalid")
+        if not name.startswith((JOURNAL_PREFIX, *AUXILIARY_PREFIXES)):
+            raise JournalError("invalid_schema", "retention filename is invalid")
+        try:
+            os.unlink(name, dir_fd=self.directory_fd)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            raise JournalError(
+                "write_failed", f"cannot remove {name}: {exc}"
+            ) from exc
+        os.fsync(self.directory_fd)
+
     def read_name(
         self, name: str, *, expected_epoch: str | None = None
     ) -> dict[str, Any]:
@@ -2681,6 +2738,234 @@ def _summary(journal: dict[str, Any]) -> dict[str, Any]:
         "hub_orphan_evidence": journal["hub_orphan_evidence"],
         "updated_at": journal["updated_at"],
     }
+
+
+_NODE_APPLIED_EVIDENCE_KEYS = (
+    "phase2_arm_evidence",
+    "prepared_evidence",
+    "finalize_evidence",
+)
+
+
+def _diagnosis(journal: dict[str, Any]) -> dict[str, Any]:
+    """Describe one journal well enough to act on it without touching a node.
+
+    A stuck transaction used to present itself as an agent problem: the first
+    thing an operator saw was an SSH route error naming a cohort member, with
+    nothing anywhere naming the epoch that pinned that member.  This projection
+    is the diagnostic instead of the symptom -- it names the epoch, how long it
+    has been parked, whether its owning controller is still alive, and whether
+    the transaction ever applied anything to a node (that is, whether blocking
+    on it is protecting any work at all).
+    """
+
+    owner = journal["owner"]
+    alive = _owner_alive(owner)
+    terminal = journal["state"] in TERMINAL_STATES
+    cohort = journal["cohort"]
+    return {
+        "schema": DIAGNOSIS_SCHEMA,
+        "epoch_id": journal["epoch_id"],
+        "source_commit": journal["source_commit"],
+        "deploy_ts": journal["deploy_ts"],
+        "fleet": journal["fleet"],
+        "hub_agent": journal["hub_agent"],
+        "state": journal["state"],
+        "phase": journal["phase"],
+        "hub_state": journal["hub_state"],
+        "revision": journal["revision"],
+        "terminal": terminal,
+        "owner": {**owner, "alive": alive},
+        # The exact condition nothing used to reap: not terminal, and the
+        # controller that owns it is provably gone.
+        "stuck_dead_owner": (not terminal) and not alive,
+        "created_at": journal["created_at"],
+        "updated_at": journal["updated_at"],
+        "age_seconds": _age_seconds(journal["updated_at"]),
+        "cohort_size": len(cohort),
+        "cohort": [
+            {
+                "ordinal": node["ordinal"],
+                "name": node["name"],
+                "stable_id": node["stable_id"],
+                "generation": node["generation"],
+                "state": node["state"],
+                "mutated": any(
+                    node[key] is not None for key in _NODE_MUTATION_EVIDENCE_KEYS
+                ),
+                "applied": any(
+                    node[key] is not None for key in _NODE_APPLIED_EVIDENCE_KEYS
+                ),
+            }
+            for node in cohort
+        ],
+        "applied_node_count": sum(
+            1
+            for node in cohort
+            if any(node[key] is not None for key in _NODE_APPLIED_EVIDENCE_KEYS)
+        ),
+        "hub_committed": journal["hub_commit_evidence"] is not None,
+    }
+
+
+def _diagnose_directory(directory: JournalDirectory) -> dict[str, Any]:
+    """Read every journal defensively; one bad file must not hide the rest.
+
+    ``discover`` refuses a directory with more than one live epoch and fails on
+    the first unparseable journal.  Diagnosis has the opposite obligation: it
+    runs when something is already wrong, so an unreadable or contradictory
+    directory is a thing to report, never a reason to report nothing.
+    """
+
+    diagnoses: list[dict[str, Any]] = []
+    unreadable: list[dict[str, Any]] = []
+    for name in directory.names():
+        try:
+            journal = directory.read_name(name)
+        except FileNotFoundError:
+            continue
+        except JournalError as exc:
+            unreadable.append({"file": name, "code": exc.code, "message": str(exc)})
+            continue
+        diagnoses.append(_diagnosis(journal))
+    diagnoses.sort(key=lambda item: (item["updated_at"], item["epoch_id"]))
+    active = [item for item in diagnoses if not item["terminal"]]
+    return {
+        "journals": diagnoses,
+        "active": active,
+        "stuck": [item for item in active if item["stuck_dead_owner"]],
+        "unreadable": unreadable,
+    }
+
+
+def command_diagnose(
+    directory: JournalDirectory, args: argparse.Namespace
+) -> tuple[Any, bool]:
+    if args.epoch_id:
+        journal = directory.read_epoch(_epoch(args.epoch_id))
+        diagnosis = _diagnosis(journal)
+        return {
+            "journals": [diagnosis],
+            "active": [] if diagnosis["terminal"] else [diagnosis],
+            "stuck": [diagnosis] if diagnosis["stuck_dead_owner"] else [],
+            "unreadable": [],
+        }, False
+    return _diagnose_directory(directory), False
+
+
+def _retention_days(value: Any) -> int:
+    try:
+        days = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise JournalError(
+            "invalid_input", "retention window must be a whole number of days"
+        ) from exc
+    if not 0 <= days <= MAX_RETENTION_DAYS:
+        raise JournalError(
+            "invalid_input",
+            f"retention window must be between 0 and {MAX_RETENTION_DAYS} days",
+        )
+    return days
+
+
+def _retention_keep(value: Any) -> int:
+    try:
+        keep = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise JournalError(
+            "invalid_input", "retention keep count must be a whole number"
+        ) from exc
+    if not 0 <= keep <= MAX_RETENTION_KEEP:
+        raise JournalError(
+            "invalid_input",
+            f"retention keep count must be between 0 and {MAX_RETENTION_KEEP}",
+        )
+    return keep
+
+
+def command_reap(
+    directory: JournalDirectory, args: argparse.Namespace
+) -> tuple[Any, bool]:
+    """Age out terminal journals and orphan plans; never a live transaction.
+
+    Three invariants make this safe to run unattended on every deploy:
+    a non-terminal journal is never removed no matter how old it is, an
+    unparseable file is reported rather than deleted (it may be the only
+    remaining evidence of a failure), and the newest ``--keep`` terminal
+    journals are retained regardless of age so a fresh directory keeps its
+    recent history.
+    """
+
+    max_age_days = _retention_days(args.max_age_days)
+    keep = _retention_keep(args.keep)
+    cutoff = max_age_days * 86400
+    removed: list[dict[str, Any]] = []
+    retained: list[dict[str, Any]] = []
+    live: list[dict[str, Any]] = []
+    unreadable: list[dict[str, Any]] = []
+    terminal: list[tuple[str, str, dict[str, Any]]] = []
+
+    for name in directory.names():
+        try:
+            journal = directory.read_name(name)
+        except FileNotFoundError:
+            continue
+        except JournalError as exc:
+            # Never delete a file we could not prove is terminal.
+            unreadable.append({"file": name, "code": exc.code, "message": str(exc)})
+            continue
+        record = {
+            "file": name,
+            "epoch_id": journal["epoch_id"],
+            "state": journal["state"],
+            "updated_at": journal["updated_at"],
+            "age_seconds": _age_seconds(journal["updated_at"]),
+        }
+        if journal["state"] not in TERMINAL_STATES:
+            live.append(record)
+            continue
+        terminal.append((journal["updated_at"], name, record))
+
+    # Newest terminal journals first, so ``keep`` protects recent history.
+    terminal.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    for index, (_updated_at, name, record) in enumerate(terminal):
+        age = record["age_seconds"]
+        if index < keep or age is None or age < cutoff:
+            retained.append(record)
+            continue
+        if not args.dry_run:
+            directory.remove(name)
+        removed.append(record)
+
+    # Subtract the reaped names explicitly so a dry run previews exactly the
+    # orphan plans a real run would collect.
+    reaped_names = {record["file"] for record in removed}
+    surviving = {
+        name[len(JOURNAL_PREFIX) : -len(JOURNAL_SUFFIX)]
+        for name in directory.names()
+        if name not in reaped_names
+    }
+    removed_plans: list[str] = []
+    for name in sorted(directory.auxiliary_names()):
+        prefix = next(item for item in AUXILIARY_PREFIXES if name.startswith(item))
+        digest = name[len(prefix) : -len(JOURNAL_SUFFIX)]
+        if digest in surviving:
+            continue
+        if not args.dry_run:
+            directory.remove(name)
+        removed_plans.append(name)
+
+    return {
+        "schema": REAP_SCHEMA,
+        "max_age_days": max_age_days,
+        "keep": keep,
+        "dry_run": bool(args.dry_run),
+        "removed": removed,
+        "removed_plans": removed_plans,
+        "retained": retained,
+        "retained_non_terminal": live,
+        "unreadable": unreadable,
+    }, bool(removed or removed_plans) and not args.dry_run
 
 
 def command_init(
@@ -4183,6 +4468,26 @@ def build_parser() -> argparse.ArgumentParser:
 
     discover = commands.add_parser("discover")
     discover.set_defaults(handler=command_discover)
+
+    diagnose = commands.add_parser("diagnose")
+    _add_epoch(diagnose, optional=True)
+    diagnose.set_defaults(handler=command_diagnose)
+
+    reap = commands.add_parser("reap")
+    reap.add_argument(
+        "--max-age-days",
+        default=os.environ.get(
+            "MAC_FLEET_COHORT_JOURNAL_RETENTION_DAYS", DEFAULT_RETENTION_DAYS
+        ),
+    )
+    reap.add_argument(
+        "--keep",
+        default=os.environ.get(
+            "MAC_FLEET_COHORT_JOURNAL_RETENTION_KEEP_COUNT", DEFAULT_RETENTION_KEEP
+        ),
+    )
+    reap.add_argument("--dry-run", action="store_true")
+    reap.set_defaults(handler=command_reap)
 
     recovery = commands.add_parser("recovery")
     _add_epoch(recovery, optional=True)

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -433,6 +433,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_FLEET` | str | consumer-defined | core | Core setting: fleet. |
 | `MAC_FLEETS_CONFIG` | str | consumer-defined | core | Core setting: fleets config. |
 | `MAC_FLEET_COHORT_JOURNAL_DIR` | str | consumer-defined | core | Core setting: fleet cohort journal dir. |
+| `MAC_FLEET_COHORT_JOURNAL_RETENTION_DAYS` | str | consumer-defined | core | Core setting: fleet cohort journal retention days. |
+| `MAC_FLEET_COHORT_JOURNAL_RETENTION_KEEP_COUNT` | int | consumer-defined | core | Core setting: fleet cohort journal retention keep count. |
 | `MAC_FLEET_NAME` | str | consumer-defined | core | Core setting: fleet name. |
 | `MAC_FLEET_PHASE_FAILURE_EVIDENCE_DIR` | str | consumer-defined | core | Core setting: fleet phase failure evidence dir. |
 | `MAC_FLEET_TENANT_ID` | str | consumer-defined | core | Core setting: fleet tenant id. |

--- a/docs/fleet-cutover-transaction-protocol.md
+++ b/docs/fleet-cutover-transaction-protocol.md
@@ -229,6 +229,58 @@ Journal ownership binds controller nonce, boot identity, PID, and process start
 time. PID liveness alone is insufficient because PID reuse after reboot can
 impersonate the previous owner.
 
+## Stuck-transaction diagnosis
+
+A journal that is not terminal and whose owning controller is provably gone is
+a *stuck* transaction. It is not self-clearing: the cohort it pinned is
+re-enumerated by every subsequent deploy, so a cohort member that has since
+left the fleet registry fails route resolution on every attempt.
+
+That failure used to be reported per agent, which named the wrong subject. An
+operator seeing only `authoritative SSH route resolved empty` has no way to
+reach the epoch that pinned the name, and the obvious remedies — deleting the
+agent, pruning the fleet registry, or passing an explicit agent list — cannot
+work, because none of them touch the journal the deploy actually reads.
+
+`diagnose` is therefore the first thing a deploy runs, before any node is
+contacted:
+
+- it reports every non-terminal epoch whose owner is dead, **by epoch id**,
+  with its state, phase, age, and pinned cohort;
+- it names each pinned member that is no longer an enabled agent in the frozen
+  fleet registry, rather than letting it surface later as an empty route;
+- it reports whether anything was ever applied to a node or committed on the
+  hub, so an operator can tell whether the block is protecting real work;
+- unlike `discover`, it never refuses a directory. More than one live epoch, or
+  an unparseable journal, is a fact to report — it is the exact situation in
+  which reporting nothing is worst.
+
+Diagnosis is read-only. It never adopts, mutates, or removes a journal.
+
+A dead owner by itself is not a refusal — adopting the journal and recovering
+is the correct response to a crashed controller. The deploy stops before
+contacting any node in exactly one case: a stuck epoch pins a name the frozen
+registry no longer has. Route resolution returns nothing for that name on every
+attempt, so replaying the cohort cannot succeed, and the deploy says so by
+epoch instead of proving it one empty SSH route at a time.
+
+## Journal retention
+
+Terminal journals are evidence, not live state, and nothing used to age them
+out. `reap` keeps a bounded window under three invariants:
+
+- a non-terminal journal is never removed, at any age — it is state, and the
+  stuck epoch above is exactly the case that must survive;
+- an unparseable journal is reported, never deleted — it may be the only
+  surviving evidence of a failure;
+- the newest `--keep` terminal journals are retained regardless of age.
+
+Auxiliary plan files (`release-plan-*`, `hub-open-plan-*`, `hub-prove-plan-*`)
+are removed only when their epoch's journal is gone. `--dry-run` previews the
+exact set a real pass would remove. The window defaults to 14 days and 5 kept
+journals, overridable with `MAC_FLEET_COHORT_JOURNAL_RETENTION_DAYS` and
+`MAC_FLEET_COHORT_JOURNAL_RETENTION_KEEP_COUNT`.
+
 ## Orphan-authority recovery
 
 Hub HA failover (or any authority loss) can leave the controller holding a

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -5091,6 +5091,28 @@
   },
   {
     "default": null,
+    "description": "Core setting: fleet cohort journal retention days.",
+    "family": "core",
+    "name": "MAC_FLEET_COHORT_JOURNAL_RETENTION_DAYS",
+    "retired": false,
+    "sources": [
+      "deploy/fleet-cohort-transaction.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: fleet cohort journal retention keep count.",
+    "family": "core",
+    "name": "MAC_FLEET_COHORT_JOURNAL_RETENTION_KEEP_COUNT",
+    "retired": false,
+    "sources": [
+      "deploy/fleet-cohort-transaction.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Core setting: fleet name.",
     "family": "core",
     "name": "MAC_FLEET_NAME",

--- a/tests/test_deploy_stuck_cohort_transaction.py
+++ b/tests/test_deploy_stuck_cohort_transaction.py
@@ -1,0 +1,482 @@
+"""The deploy script must name a stuck cohort epoch before it touches a node.
+
+A transaction stuck in ``preparing`` since 2026-08-11, owned by a controller
+that no longer existed, made the fleet undeployable for nine days. It presented
+as an agent problem -- ``ERROR: jordanh-worker5: authoritative SSH route
+resolved empty`` -- so three remedies were aimed at the agents (deleting them,
+pruning the fleet registry, passing an explicit agent list) and none of them
+could work, because the deploy replays the cohort pinned in the journal.
+
+These tests drive the deploy script's own functions against a real dead-owner
+journal and assert the diagnostic names the epoch, before any SSH is attempted.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEPLOY = ROOT / "deploy" / "deploy-mac-fleet.sh"
+HELPER = ROOT / "deploy" / "fleet-cohort-transaction.py"
+SOURCE = DEPLOY.read_text(encoding="utf-8")
+SOURCE_COMMIT = "a" * 40
+STUCK_EPOCH = f"{SOURCE_COMMIT}:20260811T211348Z:0123456789abcdef"
+FRESH_EPOCH = f"{SOURCE_COMMIT}:20260820T000000Z:fedcba9876543210"
+COHORT_NAMES = ("natasha", "bullwinkle", "jordanh-worker5")
+# Only the first two survive in the frozen fleet registry.
+REGISTRY_IDS = ("agent_natasha", "agent_bullwinkle")
+
+
+def extract(name: str, next_marker: str) -> str:
+    start = SOURCE.index(f"{name}() {{")
+    body = SOURCE[start:]
+    return body[: body.index(next_marker)].rstrip()
+
+
+def diagnostics_source() -> str:
+    # report_stuck_cohort_transactions and reap_cohort_transaction_journals sit
+    # together, immediately before the pre-deploy recovery entry point.
+    return extract(
+        "report_stuck_cohort_transactions",
+        "\nrecover_incomplete_cohort_transaction_before_deploy() {",
+    )
+
+
+def route_report_source() -> str:
+    # cohort_pinned_epoch_id and report_absent_ssh_route are adjacent.
+    return extract("cohort_pinned_epoch_id", "\nssh_control_path_for_agent() {")
+
+
+def cohort_journal_source() -> str:
+    return extract("cohort_journal", "\ncohort_journal_revision() {")
+
+
+def stable_id_source() -> str:
+    return extract(
+        "stable_worker_agent_id", "\npersist_bounded_phase_failure_evidence() {"
+    )
+
+
+def run_journal(directory: Path, *args: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, str(HELPER), "--directory", str(directory), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def dead_pid() -> int:
+    process = subprocess.Popen([sys.executable, "-c", "pass"])
+    process.wait()
+    return process.pid
+
+
+def journal_file(directory: Path, epoch: str) -> Path:
+    import hashlib
+
+    return directory / f"transaction-{hashlib.sha256(epoch.encode()).hexdigest()}.json"
+
+
+def make_stuck_journal(tmp_path: Path, epoch: str = STUCK_EPOCH) -> tuple[Path, int]:
+    """A real journal, pinned to a real cohort, owned by a dead controller."""
+    directory = tmp_path / "fleet-cohort-transactions"
+    cohort_file = tmp_path / "cohort.json"
+    cohort_file.write_text(
+        json.dumps(
+            [
+                {
+                    "name": name,
+                    "stable_id": f"agent_{name.replace('-', '-')}",
+                    "generation": f"generation-{index}",
+                    "deployment_id": f"deployment-{index}",
+                    "os": "linux",
+                    "supervisor": "systemd",
+                }
+                for index, name in enumerate(COHORT_NAMES)
+            ],
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    cohort_file.chmod(0o600)
+    run_journal(
+        directory,
+        "init",
+        "--epoch",
+        epoch,
+        "--source-commit",
+        SOURCE_COMMIT,
+        "--deploy-ts",
+        "20260811T211348Z",
+        "--fleet",
+        "rocky",
+        "--hub-agent",
+        "rocky",
+        "--cohort-file",
+        str(cohort_file),
+        "--owner-nonce",
+        "dead-controller",
+        "--owner-pid",
+        str(os.getpid()),
+    )
+    pid = dead_pid()
+    path = journal_file(directory, epoch)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["owner"]["pid"] = pid
+    payload["owner"]["process_start_sha256"] = "0" * 64
+    payload["updated_at"] = "2026-08-11T21:13:48Z"
+    path.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    return directory, pid
+
+
+def preamble(
+    journal_dir: Path,
+    *,
+    registry_ids: tuple[str, ...] = REGISTRY_IDS,
+    active: int = 0,
+    replay_epoch: str = "",
+) -> str:
+    registry = "\n".join(registry_ids)
+    return "\n".join(
+        [
+            "set -euo pipefail",
+            f"PYTHON_BIN={shlex.quote(sys.executable)}",
+            f"COHORT_JOURNAL_HELPER={shlex.quote(str(HELPER))}",
+            f"COHORT_JOURNAL_DIR={shlex.quote(str(journal_dir))}",
+            f"COHORT_EPOCH_ID={shlex.quote(FRESH_EPOCH)}",
+            f"COHORT_JOURNAL_ACTIVE={active}",
+            f"COHORT_REPLAY_EPOCH_ID={shlex.quote(replay_epoch)}",
+            "FLEET_REGISTRY_SOURCE=/frozen/fleets.yaml",
+            "fleet_config_query() {",
+            f"  printf '%s' {shlex.quote(registry)}",
+            "  [ -n " + shlex.quote(registry) + " ] && printf '\\n'",
+            "  return 0",
+            "}",
+            cohort_journal_source(),
+            stable_id_source(),
+        ]
+    )
+
+
+def run_snippet(snippet: str, *, path_prefix: Path | None = None):
+    environment = dict(os.environ)
+    if path_prefix is not None:
+        environment["PATH"] = f"{path_prefix}{os.pathsep}{environment['PATH']}"
+    return subprocess.run(
+        ["bash", "-c", snippet],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+    )
+
+
+@pytest.fixture
+def ssh_tripwire(tmp_path: Path) -> Path:
+    """An `ssh` on PATH that records any invocation and fails."""
+    binary_dir = tmp_path / "tripwire-bin"
+    binary_dir.mkdir()
+    marker = binary_dir / "ssh-was-called"
+    for name in ("ssh", "scp"):
+        stub = binary_dir / name
+        stub.write_text(
+            f'#!/bin/sh\necho "$@" >> {shlex.quote(str(marker))}\nexit 1\n',
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+    return binary_dir
+
+
+def test_stuck_epoch_is_reported_by_epoch_before_any_ssh(
+    tmp_path: Path, ssh_tripwire: Path
+) -> None:
+    directory, pid = make_stuck_journal(tmp_path)
+    snippet = (
+        preamble(directory)
+        + "\n"
+        + diagnostics_source()
+        + "\nreport_stuck_cohort_transactions\n"
+    )
+    result = run_snippet(snippet, path_prefix=ssh_tripwire)
+    # A cohort pinning a name the registry no longer has cannot be replayed, so
+    # the diagnostic returns the refusal verdict instead of proceeding.
+    assert result.returncode == 1
+    report = result.stderr
+
+    # The diagnostic, not the symptom: the epoch is the subject.
+    assert STUCK_EPOCH in report
+    assert "is stuck" in report
+    assert "state=preparing" in report
+    assert f"owner pid {pid}" in report
+    assert "2026-08-11T21:13:48Z" in report
+    # The pinned cohort is named, so the SSH failure has an explanation.
+    for name in COHORT_NAMES:
+        assert name in report
+    # Nothing reached a node, so blocking on this epoch protects nothing.
+    assert "blocking no completed work" in report
+    # And the operator is told how to act on the epoch.
+    assert f"status --epoch {STUCK_EPOCH}" in report
+    assert f"recovery --epoch {STUCK_EPOCH}" in report
+
+    # Nothing in the diagnostic path touched a node.
+    assert not (ssh_tripwire / "ssh-was-called").exists()
+
+
+def test_cohort_members_absent_from_the_registry_are_named(tmp_path: Path) -> None:
+    directory, _pid = make_stuck_journal(tmp_path)
+    snippet = (
+        preamble(directory)
+        + "\n"
+        + diagnostics_source()
+        + "\nreport_stuck_cohort_transactions\n"
+    )
+    result = run_snippet(snippet)
+    assert result.returncode == 1
+    report = result.stderr
+
+    assert "NOT an enabled agent in /frozen/fleets.yaml (1)" in report
+    assert "jordanh-worker5 (agent_jordanh-worker5)" in report
+    # The two surviving members are not accused of being missing.
+    absent_line = next(
+        line for line in report.splitlines() if "NOT an enabled agent" in line
+    )
+    assert "natasha" not in absent_line
+    assert "bullwinkle" not in absent_line
+    # The three failed remedies are named so they are not attempted again.
+    assert "deleting those agents" in report
+    assert "passing an explicit agent list cannot clear it" in report
+
+
+def test_a_resolvable_stuck_epoch_is_reported_but_still_recoverable(
+    tmp_path: Path,
+) -> None:
+    """A dead owner alone is a diagnosis, not a refusal.
+
+    Recovery is the normal, correct response to a crashed controller. Only a
+    cohort the registry can no longer resolve makes the replay futile, so only
+    that case blocks.
+    """
+    directory, _pid = make_stuck_journal(tmp_path)
+    registry = tuple(f"agent_{name}" for name in COHORT_NAMES)
+    snippet = (
+        preamble(directory, registry_ids=registry)
+        + "\n"
+        + diagnostics_source()
+        + "\nreport_stuck_cohort_transactions\n"
+    )
+    result = run_snippet(snippet)
+    assert result.returncode == 0, result.stderr
+    assert STUCK_EPOCH in result.stderr
+    assert "is stuck" in result.stderr
+    assert "NOT an enabled agent" not in result.stderr
+
+
+def test_a_live_or_terminal_epoch_produces_no_stuck_report(tmp_path: Path) -> None:
+    directory = tmp_path / "fleet-cohort-transactions"
+    cohort_file = tmp_path / "cohort.json"
+    cohort_file.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "natasha",
+                    "stable_id": "agent_natasha",
+                    "generation": "generation-0",
+                    "deployment_id": "deployment-0",
+                    "os": "linux",
+                    "supervisor": "systemd",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cohort_file.chmod(0o600)
+    run_journal(
+        directory,
+        "init",
+        "--epoch",
+        FRESH_EPOCH,
+        "--source-commit",
+        SOURCE_COMMIT,
+        "--deploy-ts",
+        "20260820T000000Z",
+        "--fleet",
+        "rocky",
+        "--hub-agent",
+        "rocky",
+        "--cohort-file",
+        str(cohort_file),
+        "--owner-nonce",
+        "live-controller",
+        "--owner-pid",
+        str(os.getpid()),
+    )
+    snippet = (
+        preamble(directory)
+        + "\n"
+        + diagnostics_source()
+        + "\nreport_stuck_cohort_transactions\n"
+    )
+    result = run_snippet(snippet)
+    assert result.returncode == 0, result.stderr
+    assert result.stderr.strip() == ""
+
+
+def test_empty_ssh_route_names_the_absent_agent_and_the_pinning_epoch(
+    tmp_path: Path,
+) -> None:
+    directory, _pid = make_stuck_journal(tmp_path)
+    snippet = (
+        preamble(directory, replay_epoch=STUCK_EPOCH)
+        + "\n"
+        + route_report_source()
+        + "\nreport_absent_ssh_route jordanh-worker5\n"
+    )
+    result = run_snippet(snippet)
+    assert result.returncode == 0, result.stderr
+    report = result.stderr
+
+    # The old message blamed the agent for an empty route and stopped there.
+    assert "no SSH route exists because agent_jordanh-worker5 is not an enabled agent" in report
+    assert "/frozen/fleets.yaml" in report
+    # The replayed epoch is named, not the fresh one this invocation would use.
+    assert STUCK_EPOCH in report
+    assert FRESH_EPOCH not in report
+    assert "every deploy replays until it reaches a terminal state" in report
+    assert f"status --epoch {STUCK_EPOCH}" in report
+
+
+def test_registered_agent_with_no_route_is_not_blamed_on_the_registry(
+    tmp_path: Path,
+) -> None:
+    directory, _pid = make_stuck_journal(tmp_path)
+    snippet = (
+        preamble(directory)
+        + "\n"
+        + route_report_source()
+        + "\nreport_absent_ssh_route natasha\n"
+    )
+    result = run_snippet(snippet)
+    assert result.returncode == 0, result.stderr
+    report = result.stderr
+    assert "authoritative SSH route resolved empty" in report
+    assert "IS an enabled agent in /frozen/fleets.yaml" in report
+    assert "not an enabled agent" not in report
+    # No transaction is active here, so no epoch is asserted.
+    assert STUCK_EPOCH not in report
+
+
+def test_retention_pass_reaps_aged_terminal_journals_but_not_the_stuck_one(
+    tmp_path: Path,
+) -> None:
+    directory, _pid = make_stuck_journal(tmp_path)
+    # A finished epoch from a month ago, which nothing used to remove.
+    terminal_epoch = f"{SOURCE_COMMIT}:20260701T000000Z:terminal"
+    cohort_file = tmp_path / "cohort-terminal.json"
+    cohort_file.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "natasha",
+                    "stable_id": "agent_natasha",
+                    "generation": "generation-0",
+                    "deployment_id": "deployment-0",
+                    "os": "linux",
+                    "supervisor": "systemd",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    cohort_file.chmod(0o600)
+    # `init` refuses a second live epoch, so fork the terminal one durably.
+    scratch = tmp_path / "scratch-journal"
+    run_journal(
+        scratch,
+        "init",
+        "--epoch",
+        terminal_epoch,
+        "--source-commit",
+        SOURCE_COMMIT,
+        "--deploy-ts",
+        "20260701T000000Z",
+        "--fleet",
+        "rocky",
+        "--hub-agent",
+        "rocky",
+        "--cohort-file",
+        str(cohort_file),
+        "--owner-nonce",
+        "old-controller",
+        "--owner-pid",
+        str(os.getpid()),
+    )
+    run_journal(
+        scratch,
+        "abort",
+        "--epoch",
+        terminal_epoch,
+        "--expected-revision",
+        "0",
+        "--operation-id",
+        "abort-old",
+        "--owner-nonce",
+        "old-controller",
+    )
+    source = journal_file(scratch, terminal_epoch)
+    payload = json.loads(source.read_text(encoding="utf-8"))
+    payload["updated_at"] = "2026-07-01T00:00:00Z"
+    target = journal_file(directory, terminal_epoch)
+    target.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    target.chmod(0o600)
+
+    snippet = (
+        preamble(directory)
+        # Retention knobs reach the helper through the environment.
+        + "\nexport MAC_FLEET_COHORT_JOURNAL_RETENTION_DAYS=14"
+        + "\nexport MAC_FLEET_COHORT_JOURNAL_RETENTION_KEEP_COUNT=0\n"
+        + diagnostics_source()
+        + "\nreap_cohort_transaction_journals\n"
+    )
+    result = run_snippet(snippet)
+    assert result.returncode == 0, result.stderr
+    assert "reaped 1 terminal cohort journal(s)" in result.stdout
+    assert "older than 14 days" in result.stdout
+    assert not target.exists()
+    # The stuck, non-terminal journal is state, not evidence: it survives.
+    assert journal_file(directory, STUCK_EPOCH).exists()
+
+
+def test_deploy_reports_and_reaps_before_it_replays_a_pinned_cohort() -> None:
+    """Order matters: the diagnostic must precede discover/adopt/recover."""
+    entry = SOURCE.index("recover_incomplete_cohort_transaction_before_deploy() {")
+    body = SOURCE[entry : SOURCE.index("\ncommit_fleet_release_epoch() {", entry)]
+    assert body.index("report_stuck_cohort_transactions") < body.index(
+        "cohort_journal discover"
+    )
+    # And the refusal short-circuits before adopt/recover, never after.
+    assert body.index("refusing to replay a stuck cohort epoch") < body.index(
+        "cohort_journal adopt"
+    )
+    # main() reconciles first, then applies bounded retention.
+    main_body = SOURCE[SOURCE.index("\nmain() {") :]
+    assert main_body.index("recover_incomplete_cohort_transaction_before_deploy\n") < (
+        main_body.index("reap_cohort_transaction_journals\n")
+    )

--- a/tests/test_fleet_cohort_transaction_reaping.py
+++ b/tests/test_fleet_cohort_transaction_reaping.py
@@ -1,0 +1,392 @@
+"""Diagnosis and bounded retention for the cohort transaction journal.
+
+Two defects made a single cohort transaction block every deploy for nine days:
+
+A. A non-terminal transaction whose owning controller is dead was never
+   reaped and never surfaced. The journal knew the owner was gone
+   (``owner.alive`` is computed, not stored), but no command reported it, so
+   the only symptom an operator saw was a per-agent SSH route failure from a
+   cohort pinned days earlier.
+
+B. Nothing aged out terminal journals. The directory reached 638 files
+   spanning three months.
+
+``diagnose`` answers A by naming the epoch, and ``reap`` answers B with a
+bounded window that can never remove a live or unparseable journal.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "deploy" / "fleet-cohort-transaction.py"
+SOURCE_COMMIT = "a" * 40
+
+
+@pytest.fixture
+def journal_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "mac_fleet_cohort_transaction_reaping", SCRIPT
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_cli(
+    directory: Path, *args: str, check: bool = True
+) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--directory", str(directory), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    payload = json.loads(result.stdout if result.returncode == 0 else result.stderr)
+    if check:
+        assert result.returncode == 0, payload
+        assert payload["ok"] is True
+    return payload
+
+
+def dead_pid() -> int:
+    """A pid that has exited, so ``os.kill(pid, 0)`` raises."""
+    process = subprocess.Popen([sys.executable, "-c", "pass"])
+    process.wait()
+    return process.pid
+
+
+def cohort(names: list[str]) -> list[dict[str, str]]:
+    return [
+        {
+            "name": name,
+            "stable_id": f"agent_{name}",
+            "generation": f"generation-{index}",
+            "deployment_id": f"deployment-{index}",
+            "os": "linux",
+            "supervisor": "systemd",
+        }
+        for index, name in enumerate(names)
+    ]
+
+
+def create(
+    tmp_path: Path,
+    directory: Path,
+    epoch: str,
+    *,
+    names: list[str] | None = None,
+) -> dict[str, Any]:
+    cohort_file = tmp_path / f"cohort-{abs(hash(epoch))}.json"
+    cohort_file.write_text(
+        json.dumps(cohort(names or ["node-a"]), sort_keys=True), encoding="utf-8"
+    )
+    cohort_file.chmod(0o600)
+    return run_cli(
+        directory,
+        "init",
+        "--epoch",
+        epoch,
+        "--source-commit",
+        SOURCE_COMMIT,
+        "--deploy-ts",
+        "20260719T054500Z",
+        "--fleet",
+        "rocky",
+        "--hub-agent",
+        "rocky",
+        "--cohort-file",
+        str(cohort_file),
+        "--owner-nonce",
+        "controller-nonce",
+        "--owner-pid",
+        str(os.getpid()),
+    )["journal"]
+
+
+def abort(directory: Path, epoch: str, revision: int) -> dict[str, Any]:
+    return run_cli(
+        directory,
+        "abort",
+        "--epoch",
+        epoch,
+        "--expected-revision",
+        str(revision),
+        "--operation-id",
+        f"abort-{revision}",
+        "--owner-nonce",
+        "controller-nonce",
+    )["journal"]
+
+
+def journal_path(module: Any, directory: Path, epoch: str) -> Path:
+    return directory / module._journal_name(epoch)
+
+
+def patch(path: Path, **fields: Any) -> dict[str, Any]:
+    """Rewrite journal fields the binding digest deliberately does not cover.
+
+    ``owner`` and ``updated_at`` sit outside ``_binding_projection``, so a
+    controller can die and a journal can age without invalidating the file.
+    That is exactly the state under test.
+    """
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    for key, value in fields.items():
+        if key == "owner":
+            payload["owner"].update(value)
+        else:
+            payload[key] = value
+    path.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o600)
+    return payload
+
+
+def clone_journal(module: Any, directory: Path, source: str, epoch: str) -> Path:
+    """Durably fork a journal onto a second epoch id.
+
+    ``init`` refuses to open a second incomplete epoch, which is precisely why
+    a directory holding two live epochs is a state only a crash can produce --
+    and the state diagnosis has to survive.
+    """
+    payload = json.loads(
+        journal_path(module, directory, source).read_text(encoding="utf-8")
+    )
+    payload["epoch_id"] = epoch
+    payload["binding_sha256"] = module._sha256(module._binding_projection(payload))
+    target = journal_path(module, directory, epoch)
+    target.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    target.chmod(0o600)
+    return target
+
+
+def make_dead_owner(module: Any, directory: Path, epoch: str) -> int:
+    """Mark the owning controller gone the way a crash does."""
+    pid = dead_pid()
+    patch(
+        journal_path(module, directory, epoch),
+        owner={
+            "pid": pid,
+            # Even if the pid is recycled, the recorded start identity no
+            # longer matches, so the owner is still provably not this process.
+            "process_start_sha256": "0" * 64,
+        },
+    )
+    return pid
+
+
+def age(module: Any, directory: Path, epoch: str, iso: str) -> None:
+    patch(journal_path(module, directory, epoch), updated_at=iso)
+
+
+def test_stuck_transaction_with_dead_owner_is_reported_by_epoch(
+    journal_module: Any, tmp_path: Path
+) -> None:
+    """The nine-day outage, reduced: report the epoch instead of replaying it."""
+    directory = tmp_path / "journal"
+    epoch = f"{SOURCE_COMMIT}:20260811T211348Z:controller"
+    create(tmp_path, directory, epoch, names=["natasha", "ghost-worker5"])
+    pid = make_dead_owner(journal_module, directory, epoch)
+    age(journal_module, directory, epoch, "2026-08-11T21:13:48Z")
+
+    payload = run_cli(directory, "diagnose")
+    assert [item["epoch_id"] for item in payload["stuck"]] == [epoch]
+    stuck = payload["stuck"][0]
+    assert stuck["schema"] == "mac.fleet_cohort_transaction_diagnosis.v1"
+    assert stuck["terminal"] is False
+    assert stuck["stuck_dead_owner"] is True
+    assert stuck["owner"]["pid"] == pid
+    assert stuck["owner"]["alive"] is False
+    assert stuck["state"] == "preparing"
+    # The pinned cohort is named, which is what connects the SSH symptom to
+    # the epoch that is actually blocking the deploy.
+    assert [node["name"] for node in stuck["cohort"]] == ["natasha", "ghost-worker5"]
+    assert stuck["cohort_size"] == 2
+    # Nothing was applied, so blocking on this epoch protects no work.
+    assert stuck["applied_node_count"] == 0
+    assert stuck["hub_committed"] is False
+    assert stuck["age_seconds"] > 86400
+
+    # `discover` still reports the same epoch as active; diagnosis adds the
+    # dead-owner verdict rather than replacing the existing view.
+    assert run_cli(directory, "discover")["active"]["epoch_id"] == epoch
+
+
+def test_live_owner_and_terminal_epochs_are_never_called_stuck(
+    journal_module: Any, tmp_path: Path
+) -> None:
+    directory = tmp_path / "journal"
+    live = f"{SOURCE_COMMIT}:20260820T000000Z:live"
+    journal = create(tmp_path, directory, live)
+    payload = run_cli(directory, "diagnose")
+    assert payload["stuck"] == []
+    assert [item["epoch_id"] for item in payload["active"]] == [live]
+    assert payload["journals"][0]["owner"]["alive"] is True
+
+    # A terminal epoch owned by a dead controller is finished, not stuck.
+    abort(directory, live, journal["revision"])
+    make_dead_owner(journal_module, directory, live)
+    payload = run_cli(directory, "diagnose")
+    assert payload["stuck"] == []
+    assert payload["active"] == []
+    assert payload["journals"][0]["terminal"] is True
+
+
+def test_diagnose_survives_an_unreadable_journal_and_multiple_live_epochs(
+    journal_module: Any, tmp_path: Path
+) -> None:
+    """Diagnosis runs when things are already wrong, so it must not fail closed."""
+    directory = tmp_path / "journal"
+    first = f"{SOURCE_COMMIT}:20260811T000000Z:one"
+    second = f"{SOURCE_COMMIT}:20260812T000000Z:two"
+    create(tmp_path, directory, first)
+    make_dead_owner(journal_module, directory, first)
+    clone_journal(journal_module, directory, first, second)
+    corrupt = directory / journal_module._journal_name(f"{SOURCE_COMMIT}:x:corrupt")
+    corrupt.write_text("{not json", encoding="utf-8")
+    corrupt.chmod(0o600)
+
+    # `discover` refuses this directory outright, and its refusal names no epoch.
+    failed = run_cli(directory, "discover", check=False)
+    assert failed["ok"] is False
+
+    payload = run_cli(directory, "diagnose")
+    assert sorted(item["epoch_id"] for item in payload["stuck"]) == sorted(
+        [first, second]
+    )
+    assert [entry["file"] for entry in payload["unreadable"]] == [corrupt.name]
+    assert payload["unreadable"][0]["code"] == "invalid_schema"
+
+
+def test_reap_ages_out_terminal_journals_and_keeps_recent_history(
+    journal_module: Any, tmp_path: Path
+) -> None:
+    directory = tmp_path / "journal"
+    old = []
+    for index in range(4):
+        epoch = f"{SOURCE_COMMIT}:2026071{index}T000000Z:old{index}"
+        journal = create(tmp_path, directory, epoch)
+        abort(directory, epoch, journal["revision"])
+        age(journal_module, directory, epoch, f"2026-07-1{index}T00:00:00Z")
+        old.append(epoch)
+    recent = f"{SOURCE_COMMIT}:20260820T000000Z:recent"
+    journal = create(tmp_path, directory, recent)
+    abort(directory, recent, journal["revision"])
+
+    payload = run_cli(directory, "reap", "--max-age-days", "14", "--keep", "1")
+    assert payload["schema"] == "mac.fleet_cohort_transaction_reap.v1"
+    assert payload["changed"] is True
+    # The newest terminal journal is kept by --keep; the four aged ones go.
+    assert sorted(item["epoch_id"] for item in payload["removed"]) == sorted(old)
+    assert [item["epoch_id"] for item in payload["retained"]] == [recent]
+    for epoch in old:
+        assert not journal_path(journal_module, directory, epoch).exists()
+    assert journal_path(journal_module, directory, recent).exists()
+
+    # Reaping is idempotent: a second pass has nothing left to do.
+    again = run_cli(directory, "reap", "--max-age-days", "14", "--keep", "1")
+    assert again["removed"] == []
+    assert again["changed"] is False
+
+
+def test_reap_never_removes_a_live_or_unparseable_journal(
+    journal_module: Any, tmp_path: Path
+) -> None:
+    """The stuck epoch itself must survive reaping -- it is state, not evidence."""
+    directory = tmp_path / "journal"
+    stuck = f"{SOURCE_COMMIT}:20260811T211348Z:stuck"
+    create(tmp_path, directory, stuck)
+    make_dead_owner(journal_module, directory, stuck)
+    age(journal_module, directory, stuck, "2020-01-01T00:00:00Z")
+    corrupt = directory / journal_module._journal_name(f"{SOURCE_COMMIT}:x:corrupt")
+    corrupt.write_text("{not json", encoding="utf-8")
+    corrupt.chmod(0o600)
+
+    payload = run_cli(directory, "reap", "--max-age-days", "0", "--keep", "0")
+    assert payload["removed"] == []
+    assert [item["epoch_id"] for item in payload["retained_non_terminal"]] == [stuck]
+    assert [entry["file"] for entry in payload["unreadable"]] == [corrupt.name]
+    assert journal_path(journal_module, directory, stuck).exists()
+    assert corrupt.exists()
+
+
+def test_reap_dry_run_removes_nothing_and_orphan_plans_are_collected(
+    journal_module: Any, tmp_path: Path
+) -> None:
+    directory = tmp_path / "journal"
+    epoch = f"{SOURCE_COMMIT}:20260701T000000Z:old"
+    journal = create(tmp_path, directory, epoch)
+    abort(directory, epoch, journal["revision"])
+    age(journal_module, directory, epoch, "2026-07-01T00:00:00Z")
+    # A plan file left behind by a crashed controller, keyed to this epoch.
+    plan = directory / journal_module._release_plan_name(epoch)
+    plan.write_text('{"schema":"mac.test_plan.v1"}\n', encoding="utf-8")
+    plan.chmod(0o600)
+
+    preview = run_cli(
+        directory, "reap", "--max-age-days", "14", "--keep", "0", "--dry-run"
+    )
+    assert [item["epoch_id"] for item in preview["removed"]] == [epoch]
+    assert preview["removed_plans"] == [plan.name]
+    assert preview["dry_run"] is True
+    assert preview["changed"] is False
+    assert journal_path(journal_module, directory, epoch).exists()
+    assert plan.exists()
+
+    payload = run_cli(directory, "reap", "--max-age-days", "14", "--keep", "0")
+    assert [item["epoch_id"] for item in payload["removed"]] == [epoch]
+    assert payload["removed_plans"] == [plan.name]
+    assert not journal_path(journal_module, directory, epoch).exists()
+    assert not plan.exists()
+    # The lock is directory machinery, not retention state.
+    assert (directory / journal_module.LOCK_NAME).exists()
+    assert stat.S_IMODE(directory.stat().st_mode) == 0o700
+
+
+def test_reap_rejects_an_out_of_range_retention_window(tmp_path: Path) -> None:
+    directory = tmp_path / "journal"
+    for argument in ("--max-age-days", "--keep"):
+        payload = run_cli(directory, "reap", argument, "-1", check=False)
+        assert payload["ok"] is False
+        assert payload["error"]["code"] == "invalid_input"
+    payload = run_cli(directory, "reap", "--max-age-days", "nonsense", check=False)
+    assert payload["error"]["code"] == "invalid_input"
+
+
+def test_retention_window_defaults_come_from_the_environment(
+    journal_module: Any, tmp_path: Path
+) -> None:
+    directory = tmp_path / "journal"
+    environment = dict(os.environ)
+    environment["MAC_FLEET_COHORT_JOURNAL_RETENTION_DAYS"] = "3"
+    environment["MAC_FLEET_COHORT_JOURNAL_RETENTION_KEEP_COUNT"] = "2"
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--directory", str(directory), "reap"],
+        text=True,
+        capture_output=True,
+        check=False,
+        env=environment,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["max_age_days"] == 3
+    assert payload["keep"] == 2
+    assert journal_module.DEFAULT_RETENTION_DAYS == 14
+    assert journal_module.DEFAULT_RETENTION_KEEP == 5


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_5d21d9055b8c4ba888eb676bbae11003`
- head: `db1b0a4d62d710742f3738ed714a061f5d095525`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
