### PR TITLE
QUICKDEMO: tailscaled can't start in gke-newhouse pods -- no /dev/net/tun, no NET_ADMIN (task_4ca2519c980f47e0a5f8bc050037475f)

### DIFF
--- a/QUICKDEMO.md
+++ b/QUICKDEMO.md
@@ -76,6 +76,28 @@ hgx ssh Fiver -- hostname
 hgx ssh Bigwig -- hostname
 ```
 
+**These pods cannot run kernel-mode Tailscale.** An hgx session on
+`gke-newhouse` (checked on the `standard` and `lightweight` profiles) has
+neither `/dev/net/tun` nor `CAP_NET_ADMIN` in its capability bounding set, and
+`hgx create` exposes no flag to request either — no `--cap-add`, no privileged
+profile. Confirm on any node before assuming otherwise:
+
+```bash
+hgx ssh Hazel -- 'ls -l /dev/net/tun; grep CapBnd /proc/self/status'
+```
+
+A missing device node plus a `CapBnd` value with bit 12 clear means kernel-mode
+`tailscaled` cannot start there at all: it dies on
+`CreateTUN("tailscale0") failed`, and every `iptables` call it makes returns
+`Permission denied (you must be root)` even as root. No auth key, restart, or
+deploy-script retry changes that.
+
+`deploy/install-tailscale.sh` detects exactly this and joins the mesh in
+Tailscale's **userspace networking** mode instead of failing the deploy. Force
+the choice with `MAC_DEPLOY_TAILSCALE_NETWORK_MODE=kernel|userspace` when you
+want to test one path deliberately. See step 3 for what userspace mode changes
+about the hub URL.
+
 ---
 
 ## 2. Bootstrap the mac stack on Hazel
@@ -106,6 +128,24 @@ grep MAC_API_TOKEN ~/.mac/.env            # print the bearer token for the opera
 ```
 
 Open the URL in a browser and print the token to the terminal.
+
+**If the nodes joined in userspace mode** (step 1), that hub URL still resolves
+for anyone whose own machine is on the tailnet with a real interface —
+`tailscaled` forwards inbound mesh TCP to local listeners, so Hazel answers on
+port 8789 at its mesh IP. What changes is *outbound* traffic from the pods:
+Fiver and Bigwig have no `tailscale0` to route through, so they reach Hazel
+only through the proxy `tailscaled` listens on. `install-tailscale.sh` records
+its address in `~/.mac/mac.env`:
+
+```bash
+hgx ssh Fiver -- grep MAC_TAILSCALE_ ~/.mac/mac.env
+```
+
+`MAC_TAILSCALE_NETWORK_MODE=userspace` there means the worker's fleet processes
+need `ALL_PROXY=$MAC_TAILSCALE_SOCKS5_PROXY` (or
+`HTTPS_PROXY=$MAC_TAILSCALE_HTTP_PROXY`) in their environment before they can
+dial the hub's mesh IP. A worker that can `hgx ssh` fine but cannot reach the
+hub URL is almost always this.
 
 ---
 

--- a/deploy/install-tailscale.sh
+++ b/deploy/install-tailscale.sh
@@ -8,6 +8,25 @@
 # In headscale mode HEADSCALE_URL and HEADSCALE_PREAUTHKEY must be set.
 # For the hub, these are written by install-headscale.sh. For workers they
 # are read from the hub's mac.env during deploy.
+#
+# Supports two data plane modes:
+#   kernel    — tailscaled owns a real tailscale0 TUN interface (the default
+#               everywhere the node actually has one)
+#   userspace — tailscaled runs its networking stack in userspace and exposes
+#               a SOCKS5 / HTTP CONNECT proxy instead of an interface
+#
+# The userspace mode exists for containerized nodes. A GKE pod created without
+# an explicit capability grant has neither /dev/net/tun nor CAP_NET_ADMIN in
+# its bounding set, so the kernel engine cannot start at all:
+#
+#   tun module not loaded nor found on disk
+#   CreateTUN("tailscale0") failed; /dev/net/tun does not exist
+#   ... every iptables/ip6tables call: Permission denied (you must be root)
+#
+# Both symptoms are the same missing capability, and no auth key or restart
+# fixes them. Rather than hard-fail such a node out of the mesh, detect the
+# condition up front and start tailscaled in userspace-relay mode, which
+# needs neither the TUN device nor netfilter access.
 set -euo pipefail
 
 AGENT_NAME="${AGENT:-$(hostname)}"
@@ -32,6 +51,13 @@ TAILSCALE_HOSTNAME="${TAILSCALE_HOSTNAME_PREFIX}${AGENT_NAME}"
 # All tailscale(1) client commands must point at the same socket; we compute
 # it once after detect_supervisor() so every helper reads the same value.
 TAILSCALE_SOCKET=""  # filled by compute_tailscale_socket() after supervisor detection
+
+# Data plane mode: auto (detect), kernel (force TUN), userspace (force relay).
+NETWORK_MODE_REQUEST="${MAC_DEPLOY_TAILSCALE_NETWORK_MODE:-auto}"
+# Single listen address serving both SOCKS5 and HTTP CONNECT, as tailscaled
+# multiplexes the two protocols on one listener in userspace mode.
+USERSPACE_PROXY_ADDR="${MAC_DEPLOY_TAILSCALE_PROXY_ADDR:-localhost:1055}"
+NETWORK_MODE=""  # filled by select_network_mode() before the daemon is started
 
 set_env_key() {
   local file="$1" key="$2" value="$3"
@@ -68,6 +94,69 @@ detect_supervisor() {
   fi
   echo "[tailscale] ERROR: could not detect systemd, launchd, or supervisord" >&2
   exit 1
+}
+
+# True when CAP_NET_ADMIN is reachable at all in this process tree.
+#
+# The bounding set is the right thing to read, not the effective set: this
+# script runs unprivileged and escalates through `sudo -n`, so an empty
+# effective set says nothing.  A capability absent from the bounding set can
+# never be regained by any process in the container, including root, which is
+# exactly the pod-spec case we are detecting.  A kernel without the file (any
+# non-Linux host) is reported capable and left to the kernel-mode path.
+net_admin_capable() {
+  local bounding
+  bounding="$(sed -n 's/^CapBnd:[[:space:]]*//p' /proc/self/status 2>/dev/null | head -1)"
+  [ -n "$bounding" ] || return 0
+  # CAP_NET_ADMIN is capability number 12.
+  python3 -c 'import sys; sys.exit(0 if int(sys.argv[1], 16) & (1 << 12) else 1)' \
+    "$bounding" 2>/dev/null
+}
+
+# Resolve the data plane mode: kernel when this node can really own a TUN
+# interface, userspace otherwise.
+select_network_mode() {
+  case "$NETWORK_MODE_REQUEST" in
+    kernel|userspace) printf '%s\n' "$NETWORK_MODE_REQUEST"; return ;;
+    auto|"") ;;
+    *) echo "[tailscale] ERROR: unsupported network mode: $NETWORK_MODE_REQUEST" >&2; exit 1 ;;
+  esac
+  # Only Linux has /dev/net/tun; macOS tailscaled creates a utun device with
+  # no such node, so probing for it there would wrongly force userspace mode.
+  if [ "$(uname -s)" != "Linux" ]; then
+    printf '%s\n' "kernel"; return
+  fi
+  if [ ! -c /dev/net/tun ]; then
+    echo "[tailscale] /dev/net/tun is absent — using userspace networking" >&2
+    printf '%s\n' "userspace"; return
+  fi
+  if ! net_admin_capable; then
+    echo "[tailscale] CAP_NET_ADMIN is outside this container's bounding set — using userspace networking" >&2
+    printf '%s\n' "userspace"; return
+  fi
+  printf '%s\n' "kernel"
+}
+
+# Extra tailscaled flags for the resolved mode (empty in kernel mode, so the
+# daemon command line on a normal host is byte-for-byte what it always was).
+tailscaled_mode_flags() {
+  if [ "$1" = "userspace" ]; then
+    printf '%s\n' "--tun=userspace-networking --socks5-server=${USERSPACE_PROXY_ADDR} --outbound-http-proxy-listen=${USERSPACE_PROXY_ADDR}"
+  fi
+}
+
+# Join flags that differ by mode.
+#
+# Kernel mode keeps the historical behavior.  Userspace mode has no interface
+# to install subnet routes on and no netfilter access to program, and letting
+# tailscaled rewrite /etc/resolv.conf on a node that cannot route to the
+# MagicDNS address would break name resolution rather than extend it.
+tailscale_up_mode_flags() {
+  if [ "$1" = "userspace" ]; then
+    printf '%s\n' "--netfilter-mode=off --accept-dns=false"
+  else
+    printf '%s\n' "--accept-routes --accept-dns=true"
+  fi
 }
 
 # Compute the tailscaled unix socket path for this fleet.
@@ -203,20 +292,35 @@ fi
 # -- Start tailscaled under the detected supervisor --
 SUPERVISOR_KIND="$(detect_supervisor)"
 TAILSCALE_SOCKET="$(compute_tailscale_socket "$SUPERVISOR_KIND")"
-echo "[tailscale] Starting tailscaled under ${SUPERVISOR_KIND}"
+NETWORK_MODE="$(select_network_mode)"
+tailscaled_extra_flags="$(tailscaled_mode_flags "$NETWORK_MODE")"
+echo "[tailscale] Starting tailscaled under ${SUPERVISOR_KIND} (networking: ${NETWORK_MODE})"
 mkdir -p "$LOG_DIR"
 
 case "$SUPERVISOR_KIND" in
   systemd)
+    # The packaged unit reads its flags from /etc/default/tailscaled, so that
+    # is where userspace mode has to be recorded for it to survive a restart.
     sudo -n systemctl enable tailscaled >/dev/null 2>&1 || true
-    sudo -n systemctl start tailscaled
+    if [ -n "$tailscaled_extra_flags" ]; then
+      sudo -n install -d -m 0755 /etc/default
+      sudo -n tee /etc/default/tailscaled >/dev/null <<EOF
+# Written by mac install-tailscale.sh: this node has no usable TUN device.
+FLAGS="--state=/var/lib/tailscale/tailscaled.state --port=41641 ${tailscaled_extra_flags}"
+EOF
+      # The daemon may already be up with kernel-mode flags from the package
+      # default, so the new FLAGS only take effect after a restart.
+      sudo -n systemctl restart tailscaled
+    else
+      sudo -n systemctl start tailscaled
+    fi
     ;;
   supervisord)
     conf_dir="$(supervisord_conf_dir)"
     sudo -n install -d -m 0755 "$conf_dir"
     sudo -n tee "$conf_dir/${FLEET_NAME}-tailscaled.conf" >/dev/null <<EOF
 [program:${FLEET_NAME}-tailscaled]
-command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641
+command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641 ${tailscaled_extra_flags}
 directory=/var/lib/${FLEET_NAME}/tailscale
 user=root
 autostart=true
@@ -233,6 +337,13 @@ EOF
       || run_supervisorctl start "${FLEET_NAME}-tailscaled" >/dev/null
     ;;
   launchd)
+    if [ -n "$tailscaled_extra_flags" ]; then
+      # The system LaunchDaemon plist is owned by the Tailscale package; there
+      # is no supported flag channel here, so refuse rather than join in a
+      # mode the operator did not ask for.
+      echo "[tailscale] ERROR: userspace networking is not supported under launchd" >&2
+      exit 1
+    fi
     sudo -n launchctl enable system/com.tailscale.tailscaled 2>/dev/null || true
     sudo -n launchctl bootstrap system /Library/LaunchDaemons/com.tailscale.tailscaled.plist 2>/dev/null || true
     sudo -n launchctl kickstart -k system/com.tailscale.tailscaled 2>/dev/null || true
@@ -250,6 +361,7 @@ done
 
 # -- Join the network --
 echo "[tailscale] Joining as hostname='${TAILSCALE_HOSTNAME}'"
+up_mode_flags="$(tailscale_up_mode_flags "$NETWORK_MODE")"
 
 if [ "$control_mode" = "headscale" ]; then
   # shellcheck disable=SC2046
@@ -257,8 +369,7 @@ if [ "$control_mode" = "headscale" ]; then
     --login-server="$HEADSCALE_URL" \
     --auth-key="$HEADSCALE_PREAUTHKEY" \
     --hostname="$TAILSCALE_HOSTNAME" \
-    --accept-routes \
-    --accept-dns=true >/dev/null 2>&1 || {
+    $up_mode_flags >/dev/null 2>&1 || {
       echo "[tailscale] ERROR: headscale join failed (credential-bearing output suppressed)" >&2
       exit 1
     }
@@ -267,8 +378,7 @@ else
   run_tailscale $(tailscale_socket_flag) up \
     --auth-key="$TAILSCALE_AUTH_KEY" \
     --hostname="$TAILSCALE_HOSTNAME" \
-    --accept-routes \
-    --accept-dns=true >/dev/null 2>&1 || {
+    $up_mode_flags >/dev/null 2>&1 || {
       echo "[tailscale] ERROR: tailscale join failed (credential-bearing output suppressed)" >&2
       exit 1
     }
@@ -283,7 +393,20 @@ if [ -z "$ts_ip" ]; then
   exit 1
 fi
 
-echo "[tailscale] Connected — hostname=${TAILSCALE_HOSTNAME} IP=${ts_ip}"
+echo "[tailscale] Connected — hostname=${TAILSCALE_HOSTNAME} IP=${ts_ip} networking=${NETWORK_MODE}"
 
 set_env_key "$ENV_FILE" MAC_TAILSCALE_IP "$ts_ip"
 set_env_key "$ENV_FILE" MAC_TAILSCALE_HOSTNAME "$TAILSCALE_HOSTNAME"
+set_env_key "$ENV_FILE" MAC_TAILSCALE_NETWORK_MODE "$NETWORK_MODE"
+
+if [ "$NETWORK_MODE" = "userspace" ]; then
+  # In this mode the node has no tailscale0 interface. Inbound mesh TCP is
+  # still delivered to local listeners by tailscaled, so the hub stays
+  # reachable at its mesh IP, but outbound mesh traffic from this node must
+  # go through the proxy — record its address so fleet processes that dial a
+  # mesh IP (e.g. a worker reaching the hub URL) can point ALL_PROXY /
+  # HTTPS_PROXY at it.
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_SOCKS5_PROXY "socks5://${USERSPACE_PROXY_ADDR}"
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_HTTP_PROXY "http://${USERSPACE_PROXY_ADDR}"
+  echo "[tailscale] Userspace mode: outbound mesh traffic must use socks5://${USERSPACE_PROXY_ADDR}"
+fi

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -364,6 +364,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_SUPERVISOR_CONF_DIR` | str | consumer-defined | deployment | Deployment setting: deploy supervisor conf dir. |
 | `MAC_DEPLOY_TAILSCALE_AUTH_KEY` | str | consumer-defined | deployment | Deployment setting: deploy tailscale auth key. |
 | `MAC_DEPLOY_TAILSCALE_AUTH_KEY_ENV` | str | consumer-defined | deployment | Deployment setting: deploy tailscale auth key env. |
+| `MAC_DEPLOY_TAILSCALE_NETWORK_MODE` | str | consumer-defined | deployment | Deployment setting: deploy tailscale network mode. |
+| `MAC_DEPLOY_TAILSCALE_PROXY_ADDR` | str | consumer-defined | deployment | Deployment setting: deploy tailscale proxy addr. |
 | `MAC_DEPLOY_TAKEOVER_STALE_LOCK` | str | consumer-defined | deployment | Deployment setting: deploy takeover stale lock. |
 | `MAC_DEPLOY_TARGET` | str | consumer-defined | deployment | Deployment setting: deploy target. |
 | `MAC_DEPLOY_TEST_INJECT_OPENCLAW_SNAPSHOT_FAILURE` | str | consumer-defined | deployment | Deployment setting: deploy test inject openclaw snapshot failure. |
@@ -1042,7 +1044,10 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_SUPPRESS_VERSION_WARNING` | str | consumer-defined | core | Core setting: suppress version warning. |
 | `MAC_SYSTEMD_COMMAND_TIMEOUT_SECONDS` | int | consumer-defined | core | Core setting: systemd command timeout seconds. |
 | `MAC_TAILSCALE_HOSTNAME` | str | consumer-defined | core | Core setting: tailscale hostname. |
+| `MAC_TAILSCALE_HTTP_PROXY` | str | consumer-defined | core | Core setting: tailscale http proxy. |
 | `MAC_TAILSCALE_IP` | str | consumer-defined | core | Core setting: tailscale ip. |
+| `MAC_TAILSCALE_NETWORK_MODE` | str | consumer-defined | core | Core setting: tailscale network mode. |
+| `MAC_TAILSCALE_SOCKS5_PROXY` | str | consumer-defined | core | Core setting: tailscale socks5 proxy. |
 | `MAC_TASK_CANONICAL_REMOTE` | str | consumer-defined | task-execution | Task Execution setting: task canonical remote. |
 | `MAC_TASK_EVIDENCE_MANIFEST_PATH` | str | consumer-defined | task-execution | Task Execution setting: task evidence manifest path. |
 | `MAC_TASK_EXECUTOR_COMMAND` | str | consumer-defined | task-execution | Task Execution setting: task executor command. |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -4280,6 +4280,28 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy tailscale network mode.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_TAILSCALE_NETWORK_MODE",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy tailscale proxy addr.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_TAILSCALE_PROXY_ADDR",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy takeover stale lock.",
     "family": "deployment",
     "name": "MAC_DEPLOY_TAKEOVER_STALE_LOCK",
@@ -12289,12 +12311,45 @@
   },
   {
     "default": null,
+    "description": "Core setting: tailscale http proxy.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_HTTP_PROXY",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: tailscale ip.",
     "family": "core",
     "name": "MAC_TAILSCALE_IP",
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: tailscale network mode.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_NETWORK_MODE",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: tailscale socks5 proxy.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_SOCKS5_PROXY",
+    "retired": false,
+    "sources": [
       "deploy/install-tailscale.sh"
     ],
     "type": "str"

--- a/tests/test_tailscale_userspace_fallback.py
+++ b/tests/test_tailscale_userspace_fallback.py
@@ -1,0 +1,394 @@
+"""Tests for install-tailscale.sh userspace-networking fallback.
+
+Acceptance criteria (task: tailscaled cannot start in gke-newhouse pods):
+- A node with no /dev/net/tun selects userspace networking instead of letting
+  tailscaled fail with CreateTUN("tailscale0").
+- A node whose capability bounding set excludes CAP_NET_ADMIN selects
+  userspace networking, which is the same pod-spec defect seen as
+  "iptables: Permission denied (you must be root)" under a root daemon.
+- net_admin_capable reads the *bounding* set, so an unprivileged caller that
+  escalates via sudo is judged by what the container permits, not by what
+  this shell currently holds.
+- macOS is never pushed into userspace mode by the absence of /dev/net/tun,
+  because tailscaled uses utun there and no such device node exists.
+- An explicit MAC_DEPLOY_TAILSCALE_NETWORK_MODE wins over detection, and an
+  unknown value is rejected rather than silently treated as "auto".
+- Userspace mode adds the daemon flags that make the mesh usable without a
+  TUN device, and drops the `tailscale up` flags that need one.
+- Kernel mode is byte-for-byte unchanged: no extra daemon flags, and the
+  historical --accept-routes/--accept-dns=true join flags.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (ROOT / "deploy" / "install-tailscale.sh").read_text(encoding="utf-8")
+
+# A capability bounding set with every bit set below 38 -- CAP_NET_ADMIN (12)
+# is present. This is what an ordinary privileged Linux host reports.
+FULL_BOUNDING_SET = "0000003fffffffff"
+# Capabilities 0..8 only: CAP_NET_ADMIN is absent. This is the shape a
+# restricted container (the gke-newhouse pod) reports.
+RESTRICTED_BOUNDING_SET = "00000000000001ff"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _extract(func: str) -> str:
+    m = re.search(
+        r"^%s\(\) \{\n.*?^}$" % re.escape(func),
+        SCRIPT,
+        re.S | re.M,
+    )
+    assert m, "could not extract function %s from install-tailscale.sh" % func
+    return m.group(0)
+
+
+def _run_bash(snippet: str, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", snippet],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd else None,
+    )
+
+
+def _net_admin_capable(status_file: str) -> str:
+    """net_admin_capable with its /proc path redirected at a fixture.
+
+    The production literal stays asserted by
+    test_net_admin_capable_reads_the_bounding_set_from_proc, so the rewrite
+    cannot hide a change of source.
+    """
+    fn = _extract("net_admin_capable")
+    assert "/proc/self/status" in fn
+    return fn.replace("/proc/self/status", status_file, 1)
+
+
+def _select_network_mode(*, tun_path: str, uname_dir: str | None = None) -> str:
+    """select_network_mode with the TUN device path redirected at a fixture."""
+    fn = _extract("select_network_mode")
+    assert "/dev/net/tun" in fn
+    fn = fn.replace("/dev/net/tun", tun_path)
+    if uname_dir:
+        fn = "PATH=%s:$PATH\n" % uname_dir + fn
+    return fn
+
+
+def _fake_uname(tmp_path: Path, kernel_name: str) -> str:
+    directory = tmp_path / ("uname-%s" % kernel_name)
+    directory.mkdir()
+    script = directory / "uname"
+    script.write_text("#!/bin/sh\nprintf '%s\\n'\n" % kernel_name, encoding="utf-8")
+    script.chmod(0o755)
+    return str(directory)
+
+
+def _status_file(tmp_path: Path, name: str, bounding: str | None) -> str:
+    path = tmp_path / name
+    if bounding is None:
+        return str(path)  # deliberately absent
+    path.write_text(
+        "Name:\ttailscaled\nCapBnd:\t%s\nCapEff:\t0000000000000000\n" % bounding,
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# net_admin_capable
+# ---------------------------------------------------------------------------
+
+def test_net_admin_capable_true_when_bounding_set_has_the_bit(tmp_path: Path) -> None:
+    status = _status_file(tmp_path, "full", FULL_BOUNDING_SET)
+    result = _run_bash(_net_admin_capable(status) + "\nnet_admin_capable")
+    assert result.returncode == 0, result.stderr
+
+
+def test_net_admin_capable_false_when_bounding_set_lacks_the_bit(tmp_path: Path) -> None:
+    """The gke-newhouse pod case: root, but CAP_NET_ADMIN is not grantable."""
+    status = _status_file(tmp_path, "restricted", RESTRICTED_BOUNDING_SET)
+    result = _run_bash(_net_admin_capable(status) + "\nnet_admin_capable")
+    assert result.returncode != 0
+
+
+def test_net_admin_capable_false_for_an_empty_bounding_set(tmp_path: Path) -> None:
+    status = _status_file(tmp_path, "empty", "0000000000000000")
+    result = _run_bash(_net_admin_capable(status) + "\nnet_admin_capable")
+    assert result.returncode != 0
+
+
+def test_net_admin_capable_true_when_the_status_file_is_absent(tmp_path: Path) -> None:
+    """No /proc/self/status (any non-Linux host) must not force userspace."""
+    status = _status_file(tmp_path, "missing", None)
+    result = _run_bash(_net_admin_capable(status) + "\nnet_admin_capable")
+    assert result.returncode == 0, result.stderr
+
+
+def test_net_admin_capable_reads_the_bounding_set_from_proc() -> None:
+    """The effective set is meaningless here: this script runs unprivileged
+    and escalates with `sudo -n`, so only the bounding set says what the
+    container will ever permit.
+    """
+    fn = _extract("net_admin_capable")
+    assert "CapBnd" in fn, "net_admin_capable must read the capability bounding set"
+    assert "/proc/self/status" in fn
+    assert "CapEff" not in fn, (
+        "reading CapEff would report 'incapable' on every unprivileged node "
+        "that can still escalate through sudo"
+    )
+
+
+# ---------------------------------------------------------------------------
+# select_network_mode: detection
+# ---------------------------------------------------------------------------
+
+def test_select_network_mode_picks_kernel_when_tun_and_cap_are_present(tmp_path: Path) -> None:
+    # /dev/null is a character device, so `[ -c ... ]` sees a usable node.
+    fn = _select_network_mode(tun_path="/dev/null", uname_dir=_fake_uname(tmp_path, "Linux"))
+    status = _status_file(tmp_path, "full-kernel", FULL_BOUNDING_SET)
+    snippet = "NETWORK_MODE_REQUEST=auto\n%s\n%s\nselect_network_mode" % (
+        _net_admin_capable(status),
+        fn,
+    )
+    result = _run_bash(snippet)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "kernel"
+
+
+def test_select_network_mode_picks_userspace_when_tun_device_is_missing(tmp_path: Path) -> None:
+    """The reported failure: /dev/net/tun does not exist in the pod."""
+    missing = str(tmp_path / "no-such-tun")
+    fn = _select_network_mode(tun_path=missing, uname_dir=_fake_uname(tmp_path, "Linux"))
+    status = _status_file(tmp_path, "full-notun", FULL_BOUNDING_SET)
+    snippet = "NETWORK_MODE_REQUEST=auto\n%s\n%s\nselect_network_mode" % (
+        _net_admin_capable(status),
+        fn,
+    )
+    result = _run_bash(snippet)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "userspace"
+    # The probed path is rewritten to the fixture, so match the explanation.
+    assert "is absent — using userspace networking" in result.stderr
+
+
+def test_select_network_mode_picks_userspace_without_net_admin(tmp_path: Path) -> None:
+    """A TUN node can exist while the pod still cannot program netfilter."""
+    fn = _select_network_mode(tun_path="/dev/null", uname_dir=_fake_uname(tmp_path, "Linux"))
+    status = _status_file(tmp_path, "restricted-tun", RESTRICTED_BOUNDING_SET)
+    snippet = "NETWORK_MODE_REQUEST=auto\n%s\n%s\nselect_network_mode" % (
+        _net_admin_capable(status),
+        fn,
+    )
+    result = _run_bash(snippet)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "userspace"
+    assert "CAP_NET_ADMIN" in result.stderr
+
+
+def test_select_network_mode_keeps_kernel_on_non_linux(tmp_path: Path) -> None:
+    """macOS has no /dev/net/tun and needs none; probing for it must not
+    demote every Mac in the fleet to userspace relaying.
+    """
+    missing = str(tmp_path / "no-such-tun-darwin")
+    fn = _select_network_mode(tun_path=missing, uname_dir=_fake_uname(tmp_path, "Darwin"))
+    snippet = "NETWORK_MODE_REQUEST=auto\n%s\nselect_network_mode" % fn
+    result = _run_bash(snippet)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "kernel"
+
+
+def test_select_network_mode_probes_the_real_device_path() -> None:
+    fn = _extract("select_network_mode")
+    assert "[ ! -c /dev/net/tun ]" in fn, (
+        "detection must test the actual TUN device node, not merely whether "
+        "the tun module is listed"
+    )
+    assert 'uname -s' in fn
+
+
+# ---------------------------------------------------------------------------
+# select_network_mode: explicit override
+# ---------------------------------------------------------------------------
+
+def test_select_network_mode_honors_an_explicit_userspace_request() -> None:
+    fn = _extract("select_network_mode")
+    result = _run_bash("NETWORK_MODE_REQUEST=userspace\n" + fn + "\nselect_network_mode")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "userspace"
+
+
+def test_select_network_mode_honors_an_explicit_kernel_request(tmp_path: Path) -> None:
+    """Forcing kernel mode must skip detection entirely, even on a node that
+    auto-detection would have demoted.
+    """
+    missing = str(tmp_path / "no-such-tun-forced")
+    fn = _select_network_mode(tun_path=missing, uname_dir=_fake_uname(tmp_path, "Linux"))
+    result = _run_bash("NETWORK_MODE_REQUEST=kernel\n" + fn + "\nselect_network_mode")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "kernel"
+
+
+def test_select_network_mode_rejects_an_unknown_request() -> None:
+    fn = _extract("select_network_mode")
+    result = _run_bash("NETWORK_MODE_REQUEST=proxy-only\n" + fn + "\nselect_network_mode")
+    assert result.returncode != 0
+    assert "unsupported network mode" in result.stderr
+
+
+def test_network_mode_request_comes_from_the_deploy_variable() -> None:
+    assert 'NETWORK_MODE_REQUEST="${MAC_DEPLOY_TAILSCALE_NETWORK_MODE:-auto}"' in SCRIPT
+    assert 'USERSPACE_PROXY_ADDR="${MAC_DEPLOY_TAILSCALE_PROXY_ADDR:-localhost:1055}"' in SCRIPT
+
+
+# ---------------------------------------------------------------------------
+# Mode flags
+# ---------------------------------------------------------------------------
+
+def test_tailscaled_mode_flags_are_empty_in_kernel_mode() -> None:
+    fn = _extract("tailscaled_mode_flags")
+    result = _run_bash(
+        "USERSPACE_PROXY_ADDR=localhost:1055\n" + fn + "\ntailscaled_mode_flags kernel"
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "", (
+        "kernel-mode nodes must keep their historical tailscaled command line"
+    )
+
+
+def test_tailscaled_mode_flags_select_userspace_networking() -> None:
+    fn = _extract("tailscaled_mode_flags")
+    result = _run_bash(
+        "USERSPACE_PROXY_ADDR=localhost:1055\n" + fn + "\ntailscaled_mode_flags userspace"
+    )
+    assert result.returncode == 0, result.stderr
+    flags = result.stdout.split()
+    assert "--tun=userspace-networking" in flags, (
+        "without this flag tailscaled still tries to CreateTUN and dies"
+    )
+    assert "--socks5-server=localhost:1055" in flags
+    assert "--outbound-http-proxy-listen=localhost:1055" in flags
+
+
+def test_tailscaled_mode_flags_honor_a_custom_proxy_address() -> None:
+    fn = _extract("tailscaled_mode_flags")
+    result = _run_bash(
+        "USERSPACE_PROXY_ADDR=127.0.0.1:9055\n" + fn + "\ntailscaled_mode_flags userspace"
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--socks5-server=127.0.0.1:9055" in result.stdout
+    assert "--outbound-http-proxy-listen=127.0.0.1:9055" in result.stdout
+
+
+def test_tailscale_up_mode_flags_keep_the_historical_kernel_flags() -> None:
+    fn = _extract("tailscale_up_mode_flags")
+    result = _run_bash(fn + "\ntailscale_up_mode_flags kernel")
+    assert result.returncode == 0, result.stderr
+    flags = result.stdout.split()
+    assert flags == ["--accept-routes", "--accept-dns=true"]
+
+
+def test_tailscale_up_mode_flags_drop_netfilter_and_dns_in_userspace() -> None:
+    fn = _extract("tailscale_up_mode_flags")
+    result = _run_bash(fn + "\ntailscale_up_mode_flags userspace")
+    assert result.returncode == 0, result.stderr
+    flags = result.stdout.split()
+    assert "--netfilter-mode=off" in flags, (
+        "a pod without CAP_NET_ADMIN cannot program iptables; asking tailscale "
+        "to try is the 'Permission denied (you must be root)' log"
+    )
+    assert "--accept-dns=false" in flags
+    assert "--accept-routes" not in flags, (
+        "there is no interface to install subnet routes on in userspace mode"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the resolved mode must actually reach the daemon and the join
+# ---------------------------------------------------------------------------
+
+def test_mode_is_resolved_before_the_daemon_is_started() -> None:
+    mode_pos = SCRIPT.index('NETWORK_MODE="$(select_network_mode)"')
+    flags_pos = SCRIPT.index('tailscaled_extra_flags="$(tailscaled_mode_flags')
+    start_pos = SCRIPT.index("case \"$SUPERVISOR_KIND\" in\n  systemd)")
+    assert mode_pos < flags_pos < start_pos
+
+
+def test_supervisord_daemon_command_carries_the_mode_flags() -> None:
+    """The supervisord stanza is the branch the containerized nodes take."""
+    assert (
+        "command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/"
+        "tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641 "
+        "${tailscaled_extra_flags}" in SCRIPT
+    )
+
+
+def test_systemd_records_the_mode_flags_where_the_unit_reads_them() -> None:
+    """A systemd node in userspace mode needs the flags in /etc/default so the
+    setting survives the restart and every later one.
+    """
+    assert "sudo -n tee /etc/default/tailscaled" in SCRIPT
+    assert 'FLAGS="--state=/var/lib/tailscale/tailscaled.state --port=41641 ${tailscaled_extra_flags}"' in SCRIPT
+    assert "sudo -n systemctl restart tailscaled" in SCRIPT
+
+
+def test_launchd_refuses_userspace_rather_than_ignoring_it() -> None:
+    assert "userspace networking is not supported under launchd" in SCRIPT
+
+
+def test_both_join_paths_use_the_mode_flags() -> None:
+    """Neither control-plane branch may keep hard-coded --accept-routes."""
+    assert 'up_mode_flags="$(tailscale_up_mode_flags "$NETWORK_MODE")"' in SCRIPT
+    assert SCRIPT.count("$up_mode_flags >/dev/null 2>&1") == 2
+    join_section = SCRIPT.split("# -- Join the network --", 1)[1]
+    assert "--accept-routes" not in join_section, (
+        "route acceptance is mode-dependent and must come from "
+        "tailscale_up_mode_flags"
+    )
+
+
+def test_the_resolved_mode_is_recorded_in_the_env_file() -> None:
+    assert 'set_env_key "$ENV_FILE" MAC_TAILSCALE_NETWORK_MODE "$NETWORK_MODE"' in SCRIPT
+
+
+def test_userspace_mode_publishes_its_outbound_proxy() -> None:
+    """A userspace node has no interface, so anything of ours that dials a
+    mesh IP -- a worker reaching the hub URL -- has to go via the proxy.
+    """
+    assert (
+        'set_env_key "$ENV_FILE" MAC_TAILSCALE_SOCKS5_PROXY "socks5://${USERSPACE_PROXY_ADDR}"'
+        in SCRIPT
+    )
+    assert (
+        'set_env_key "$ENV_FILE" MAC_TAILSCALE_HTTP_PROXY "http://${USERSPACE_PROXY_ADDR}"'
+        in SCRIPT
+    )
+    proxy_block = SCRIPT.split('if [ "$NETWORK_MODE" = "userspace" ]; then', 1)[1]
+    assert "MAC_TAILSCALE_SOCKS5_PROXY" in proxy_block, (
+        "the proxy keys must be written only for userspace nodes"
+    )
+
+
+def test_new_env_keys_are_registered() -> None:
+    """New MAC_* names must be in the generated registry, or the contract
+    preflight rejects the change as a stale registry.
+    """
+    import json
+
+    registry = json.loads(
+        (ROOT / "src/mac/data/env_config_registry.json").read_text(encoding="utf-8")
+    )
+    names = {record["name"] for record in registry}
+    for name in (
+        "MAC_DEPLOY_TAILSCALE_NETWORK_MODE",
+        "MAC_DEPLOY_TAILSCALE_PROXY_ADDR",
+        "MAC_TAILSCALE_NETWORK_MODE",
+        "MAC_TAILSCALE_SOCKS5_PROXY",
+        "MAC_TAILSCALE_HTTP_PROXY",
+    ):
+        assert name in names, "%s is missing from the generated env registry" % name


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_4ca2519c980f47e0a5f8bc050037475f`
- head: `e33d3fc5b78950a1808b6419d88d31c5fdaad8a6`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
