### PR TITLE
Phase 2: repoint the gateway home under MAC_HOME, off the evicted .hermes

### DIFF
--- a/src/mac/mac_paths.py
+++ b/src/mac/mac_paths.py
@@ -63,14 +63,18 @@ def mac_home() -> Path:
 
 
 def gateway_home() -> Path:
-    """The gateway / agent-personal home (legacy name ``.hermes``).
+    """The gateway / agent-personal home.
 
-    ``HERMES_HOME`` overrides; default ``~/.hermes``. This is the same value
-    every runtime resolves today (``journal.hermes_home()`` et al.); Phase 2 of
-    the consolidation plan repoints this default under ``mac_home()`` without
-    changing any caller.
+    ``HERMES_HOME`` still overrides, for a host that has not been migrated yet.
+    The DEFAULT is now ``$MAC_HOME/openclaw`` -- this is the Phase 2 repoint the
+    previous docstring promised, done without changing a single caller, which is
+    the whole reason this module is the one place allowed to name a home.
+
+    ``~/.hermes`` is not a fallback. The fleet migrated hard to OpenClaw and the
+    directory was evicted from every host on 2026-08-21 (4.9GB across three),
+    so defaulting there would resolve to something that no longer exists.
     """
-    return _env_path("HERMES_HOME") or (Path.home() / ".hermes")
+    return _env_path("HERMES_HOME") or (mac_home() / "openclaw")
 
 
 # --- Control-plane files (under mac_home) ----------------------------------

--- a/tests/test_mac_paths.py
+++ b/tests/test_mac_paths.py
@@ -26,14 +26,14 @@ def clean_home(tmp_path, monkeypatch):
 def test_defaults_match_legacy_literals(clean_home):
     home = clean_home
     assert mac_paths.mac_home() == home / ".mac"
-    assert mac_paths.gateway_home() == home / ".hermes"
+    assert mac_paths.gateway_home() == home / ".mac" / "openclaw"
     assert mac_paths.mac_env_file() == home / ".mac" / "mac.env"
     assert mac_paths.deploy_env_file() == home / ".mac" / ".env"
     assert mac_paths.fleets_config() == home / ".mac" / "fleets.yaml"
     assert mac_paths.ledger_db() == home / ".mac" / "mac.db"
     assert mac_paths.journal_dir() == home / ".mac" / "journal"
-    assert mac_paths.gateway_env_file() == home / ".hermes" / ".env"
-    assert mac_paths.dream_logs_dir() == home / ".hermes" / "dream_logs"
+    assert mac_paths.gateway_env_file() == home / ".mac" / "openclaw" / ".env"
+    assert mac_paths.dream_logs_dir() == home / ".mac" / "openclaw" / "dream_logs"
     assert mac_paths.openclaw_home() == home / ".mac" / "openclaw"
 
 
@@ -45,8 +45,10 @@ def test_mac_home_relocates_all_derived_paths_together(clean_home, monkeypatch):
     assert mac_paths.journal_dir() == root / "journal"
     assert mac_paths.fleets_config() == root / "fleets.yaml"
     assert mac_paths.openclaw_home() == root / "openclaw"
-    # gateway home is independent of MAC_HOME until Phase 2 repoints it.
-    assert mac_paths.gateway_home() == clean_home / ".hermes"
+    # Phase 2 (2026-08-21): the gateway home now relocates WITH MAC_HOME, which
+    # is what "all derived paths together" was always supposed to mean. It used
+    # to sit outside at ~/.hermes, so moving MAC_HOME left it behind.
+    assert mac_paths.gateway_home() == root / "openclaw"
 
 
 def test_hermes_home_relocates_gateway_paths(clean_home, monkeypatch):


### PR DESCRIPTION
`mac_paths.gateway_home()` defaulted to `~/.hermes`. Its own docstring promised
this change:

> Phase 2 of the consolidation plan repoints this default under `mac_home()`
> **without changing any caller**.

This is that. No caller changes — which is the whole reason this module is the
one place allowed to name a home.

## Why it became urgent rather than tidy

`~/.hermes` was **evicted from every fleet host** on 2026-08-21 — 4.9 GB across
three — after the hard migration to OpenClaw. A resolver defaulting there now
resolves to a directory that does not exist, and eight call sites route through
it: `worker.py` ×3, `journal.py`, `hermes_runtime.py`, `hermes_chat_config.py`,
plus `gateway_env_file()` and `dream_logs_dir()`.

## Behaviour

| | before | after |
|---|---|---|
| default | `~/.hermes` | `$MAC_HOME/openclaw` |
| `HERMES_HOME` override | honoured | **still honoured** (a host not yet migrated) |
| fallback to `~/.hermes` | — | **none** — the fleet is not going back |

## The test that had to invert

`test_mac_home_relocates_all_derived_paths_together` carried:

```python
# gateway home is independent of MAC_HOME until Phase 2 repoints it.
assert mac_paths.gateway_home() == clean_home / ".hermes"
```

Phase 2 is this, so it now asserts the gateway home relocates **with** `MAC_HOME`
— which is what "all derived paths together" was always supposed to mean.

754 tests pass across the hermes/path/journal/dream/gateway selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)