### PR TITLE
QUICKDEMO: tailscaled can't start in gke-newhouse pods -- no /dev/net/tun, no NET_ADMIN (task_4ca2519c980f47e0a5f8bc050037475f)

### DIFF
--- a/QUICKDEMO.md
+++ b/QUICKDEMO.md
@@ -31,6 +31,14 @@ mac task stats                 # existing hub reachable
 `--cluster dgxc-az27`, which was 387/464 used at last check; `gke-newhouse` was
 0/372. Taking the default is how this demo fails at step 1.
 
+**`gke-newhouse` pods have no `/dev/net/tun` and no `NET_ADMIN`.** An
+`hgx`-provisioned pod there cannot open a TUN device — `tailscaled` dies with
+`CreateTUN("tailscale0") failed; /dev/net/tun does not exist`, and every
+`iptables` call it makes is denied even though it runs as root. `hgx create`
+exposes no flag to request that capability, so it is a property of the
+cluster/profile you pick, not something this demo can ask for. Step 1 below
+shows how to check, and what the fallback costs.
+
 ---
 
 ## 1. Provision three nodes
@@ -76,6 +84,30 @@ hgx ssh Fiver -- hostname
 hgx ssh Bigwig -- hostname
 ```
 
+Then check, on Hazel especially, whether the mesh can use the kernel:
+
+```bash
+for rabbit in Hazel Fiver Bigwig; do
+  echo -n "$rabbit: "; hgx ssh "$rabbit" -- 'ls /dev/net/tun 2>/dev/null || echo NO-TUN'
+done
+```
+
+`NO-TUN` is the normal answer on `gke-newhouse`. `deploy/install-tailscale.sh`
+detects it and falls back to Tailscale's **userspace networking** mode rather
+than hard-failing: `tailscaled` runs the network stack in-process, needs
+neither TUN nor netfilter, and publishes SOCKS5 and HTTP proxies on
+`localhost:1055`. The node joins the mesh and gets a Tailscale IP, and the
+resolved mode lands in `~/.mac/mac.env` as `MAC_TAILSCALE_NETWORKING_MODE`.
+Set `MAC_DEPLOY_TAILSCALE_NETWORKING=kernel|userspace` on the node to pin the
+choice instead of probing for it.
+
+**What userspace mode costs:** the host does not route into the mesh. Outbound
+mesh traffic has to be dialled through the local proxy, and other nodes can
+only reach ports published explicitly with `tailscale serve`. A node in that
+mode is fine as a *worker* that talks outward to the hub through the proxy; it
+is a poor hub. If `Hazel` reports `NO-TUN`, expect step 3's mesh hub URL not to
+be directly dialable and plan to reach the hub over a non-mesh route.
+
 ---
 
 ## 2. Bootstrap the mac stack on Hazel
@@ -106,6 +138,16 @@ grep MAC_API_TOKEN ~/.mac/.env            # print the bearer token for the opera
 ```
 
 Open the URL in a browser and print the token to the terminal.
+
+This step assumes Hazel is on kernel networking. Confirm it rather than
+discovering otherwise in front of an audience:
+
+```bash
+hgx ssh Hazel -- 'grep MAC_TAILSCALE_NETWORKING_MODE ~/.mac/mac.env'
+```
+
+`userspace` means that Tailscale IP is not directly dialable — see the
+`NO-TUN` note in step 1.
 
 ---
 

--- a/deploy/fleet-scripts/README.md
+++ b/deploy/fleet-scripts/README.md
@@ -78,6 +78,16 @@ plane modes:
 - **headscale** — self-hosted control plane (requires `HEADSCALE_AUTH_KEY`
   and `HEADSCALE_CONTROL_URL`).
 
+It also picks a data plane. Nodes with `/dev/net/tun` get the normal
+kernel-TUN daemon; container nodes that were never granted `NET_ADMIN` (GKE
+pods, for example) cannot open a TUN device or program netfilter, so the
+script falls back to Tailscale's userspace networking stack and publishes
+SOCKS5/HTTP proxies on `localhost:1055` instead. Such a node joins the mesh
+but does not route into it, so it makes a usable worker and a poor hub. Set
+`MAC_DEPLOY_TAILSCALE_NETWORKING` to `kernel` or `userspace` to pin the choice
+and `MAC_DEPLOY_TAILSCALE_PROXY_PORT` to move the proxies; the resolved mode is
+written back to `mac.env` as `MAC_TAILSCALE_NETWORKING_MODE`.
+
 ### install-webdav-server.sh
 
 Installs a lightweight WebDAV server that agents and operators use for

--- a/deploy/install-tailscale.sh
+++ b/deploy/install-tailscale.sh
@@ -8,6 +8,14 @@
 # In headscale mode HEADSCALE_URL and HEADSCALE_PREAUTHKEY must be set.
 # For the hub, these are written by install-headscale.sh. For workers they
 # are read from the hub's mac.env during deploy.
+#
+# Supports two data plane modes:
+#   kernel    — tailscaled owns a TUN device and programs netfilter (default
+#               on any node that has /dev/net/tun and NET_ADMIN)
+#   userspace — tailscaled runs its network stack in-process and needs
+#               neither TUN nor netfilter, at the cost of the host not
+#               routing into the mesh implicitly
+# The mode is probed automatically; MAC_DEPLOY_TAILSCALE_NETWORKING pins it.
 set -euo pipefail
 
 AGENT_NAME="${AGENT:-$(hostname)}"
@@ -32,6 +40,15 @@ TAILSCALE_HOSTNAME="${TAILSCALE_HOSTNAME_PREFIX}${AGENT_NAME}"
 # All tailscale(1) client commands must point at the same socket; we compute
 # it once after detect_supervisor() so every helper reads the same value.
 TAILSCALE_SOCKET=""  # filled by compute_tailscale_socket() after supervisor detection
+
+# Data plane selection: auto (probe for TUN), kernel (force TUN), or
+# userspace (force Tailscale's in-process network stack).
+MAC_DEPLOY_TAILSCALE_NETWORKING="${MAC_DEPLOY_TAILSCALE_NETWORKING:-auto}"
+# In userspace mode nothing on the node routes into the mesh implicitly, so
+# tailscaled publishes SOCKS5 and HTTP proxies on this loopback port instead.
+# tailscaled multiplexes both protocols on a single listener.
+MAC_DEPLOY_TAILSCALE_PROXY_PORT="${MAC_DEPLOY_TAILSCALE_PROXY_PORT:-1055}"
+TAILSCALE_NETWORKING_MODE=""  # filled by detect_networking_mode()
 
 set_env_key() {
   local file="$1" key="$2" value="$3"
@@ -85,6 +102,64 @@ compute_tailscale_socket() {
       printf '%s\n' ""
       ;;
   esac
+}
+
+# Can tailscaled get a kernel TUN device on this node?
+#
+# A container that is not granted NET_ADMIN has no /dev/net/tun and cannot
+# modprobe one, which is exactly how tailscaled fails on an hgx-provisioned
+# GKE pod: "CreateTUN(\"tailscale0\") failed; /dev/net/tun does not exist".
+# The same missing capability also makes tailscaled's iptables calls fail with
+# "Permission denied (you must be root)" despite running as root, so one probe
+# answers both questions.
+tun_device_available() {
+  # Only Linux exposes TUN as /dev/net/tun. macOS synthesises utun interfaces
+  # on demand and never has that path, so a probe there would wrongly force
+  # every Mac node into userspace mode.
+  [ "$(uname -s)" = "Linux" ] || return 0
+  [ -c /dev/net/tun ] && return 0
+  # The node may simply not have the module loaded yet. Loading it needs the
+  # capability we are testing for, so a failure here is the signal we want.
+  if sudo -n modprobe tun >/dev/null 2>&1 || modprobe tun >/dev/null 2>&1; then
+    [ -c /dev/net/tun ] && return 0
+  fi
+  return 1
+}
+
+detect_networking_mode() {
+  case "$MAC_DEPLOY_TAILSCALE_NETWORKING" in
+    kernel|userspace) printf '%s\n' "$MAC_DEPLOY_TAILSCALE_NETWORKING"; return ;;
+    auto|"") ;;
+    *)
+      echo "[tailscale] ERROR: unsupported MAC_DEPLOY_TAILSCALE_NETWORKING:" \
+        "$MAC_DEPLOY_TAILSCALE_NETWORKING (want auto, kernel, or userspace)" >&2
+      exit 1
+      ;;
+  esac
+  if tun_device_available; then
+    printf '%s\n' "kernel"
+  else
+    printf '%s\n' "userspace"
+  fi
+}
+
+# Extra tailscaled(8) flags for the resolved mode. Empty in kernel mode so the
+# stock daemon invocation is unchanged on nodes that do have TUN.
+tailscaled_networking_args() {
+  if [ "$TAILSCALE_NETWORKING_MODE" = "userspace" ]; then
+    printf '%s\n' "--tun=userspace-networking --socks5-server=localhost:${MAC_DEPLOY_TAILSCALE_PROXY_PORT} --outbound-http-proxy-listen=localhost:${MAC_DEPLOY_TAILSCALE_PROXY_PORT}"
+  fi
+}
+
+# Extra join flags for the resolved mode. Userspace mode has no
+# kernel routing table entry and no netfilter rules to program, so asking for
+# either is what produces the permission-denied storm we are avoiding.
+tailscale_up_networking_flags() {
+  if [ "$TAILSCALE_NETWORKING_MODE" = "userspace" ]; then
+    printf '%s\n' "--netfilter-mode=off --accept-dns=false"
+  else
+    printf '%s\n' "--accept-routes --accept-dns=true"
+  fi
 }
 
 # Build --socket flag (empty string -> no flag, so systemd/launchd are unaffected)
@@ -203,20 +278,44 @@ fi
 # -- Start tailscaled under the detected supervisor --
 SUPERVISOR_KIND="$(detect_supervisor)"
 TAILSCALE_SOCKET="$(compute_tailscale_socket "$SUPERVISOR_KIND")"
-echo "[tailscale] Starting tailscaled under ${SUPERVISOR_KIND}"
+TAILSCALE_NETWORKING_MODE="$(detect_networking_mode)"
+if [ "$TAILSCALE_NETWORKING_MODE" = "userspace" ]; then
+  echo "[tailscale] No usable /dev/net/tun (container without NET_ADMIN?);" \
+    "falling back to Tailscale userspace networking"
+  echo "[tailscale] NOTE: this node joins the mesh but the host does not route" \
+    "into it — mesh traffic must go through the local SOCKS5/HTTP proxy on" \
+    "localhost:${MAC_DEPLOY_TAILSCALE_PROXY_PORT}, and only ports published" \
+    "with 'tailscale serve' are reachable from other nodes."
+fi
+echo "[tailscale] Starting tailscaled under ${SUPERVISOR_KIND} (${TAILSCALE_NETWORKING_MODE} networking)"
 mkdir -p "$LOG_DIR"
 
 case "$SUPERVISOR_KIND" in
   systemd)
-    sudo -n systemctl enable tailscaled >/dev/null 2>&1 || true
-    sudo -n systemctl start tailscaled
+    if [ "$TAILSCALE_NETWORKING_MODE" = "userspace" ]; then
+      # The packaged tailscaled.service appends $FLAGS from this file to its
+      # ExecStart, so it is the supported way to add daemon flags without
+      # editing a package-owned unit. Rewrite then restart, because a daemon
+      # that is already up would ignore `systemctl start`.
+      sudo -n install -d -m 0755 /etc/default
+      sudo -n tee /etc/default/tailscaled >/dev/null <<EOF
+# Managed by mac deploy/install-tailscale.sh
+PORT="41641"
+FLAGS="$(tailscaled_networking_args)"
+EOF
+      sudo -n systemctl enable tailscaled >/dev/null 2>&1 || true
+      sudo -n systemctl restart tailscaled
+    else
+      sudo -n systemctl enable tailscaled >/dev/null 2>&1 || true
+      sudo -n systemctl start tailscaled
+    fi
     ;;
   supervisord)
     conf_dir="$(supervisord_conf_dir)"
     sudo -n install -d -m 0755 "$conf_dir"
     sudo -n tee "$conf_dir/${FLEET_NAME}-tailscaled.conf" >/dev/null <<EOF
 [program:${FLEET_NAME}-tailscaled]
-command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641
+command=/usr/sbin/tailscaled --state=/var/lib/${FLEET_NAME}/tailscale/tailscaled.state --socket=/run/tailscale/${FLEET_NAME}.sock --port=41641 $(tailscaled_networking_args)
 directory=/var/lib/${FLEET_NAME}/tailscale
 user=root
 autostart=true
@@ -257,8 +356,7 @@ if [ "$control_mode" = "headscale" ]; then
     --login-server="$HEADSCALE_URL" \
     --auth-key="$HEADSCALE_PREAUTHKEY" \
     --hostname="$TAILSCALE_HOSTNAME" \
-    --accept-routes \
-    --accept-dns=true >/dev/null 2>&1 || {
+    $(tailscale_up_networking_flags) >/dev/null 2>&1 || {
       echo "[tailscale] ERROR: headscale join failed (credential-bearing output suppressed)" >&2
       exit 1
     }
@@ -267,8 +365,7 @@ else
   run_tailscale $(tailscale_socket_flag) up \
     --auth-key="$TAILSCALE_AUTH_KEY" \
     --hostname="$TAILSCALE_HOSTNAME" \
-    --accept-routes \
-    --accept-dns=true >/dev/null 2>&1 || {
+    $(tailscale_up_networking_flags) >/dev/null 2>&1 || {
       echo "[tailscale] ERROR: tailscale join failed (credential-bearing output suppressed)" >&2
       exit 1
     }
@@ -283,7 +380,14 @@ if [ -z "$ts_ip" ]; then
   exit 1
 fi
 
-echo "[tailscale] Connected — hostname=${TAILSCALE_HOSTNAME} IP=${ts_ip}"
+echo "[tailscale] Connected — hostname=${TAILSCALE_HOSTNAME} IP=${ts_ip} networking=${TAILSCALE_NETWORKING_MODE}"
 
 set_env_key "$ENV_FILE" MAC_TAILSCALE_IP "$ts_ip"
 set_env_key "$ENV_FILE" MAC_TAILSCALE_HOSTNAME "$TAILSCALE_HOSTNAME"
+# Record the data plane so anything reading mac.env can tell a node that routes
+# into the mesh from one that can only reach it through the local proxy.
+set_env_key "$ENV_FILE" MAC_TAILSCALE_NETWORKING_MODE "$TAILSCALE_NETWORKING_MODE"
+if [ "$TAILSCALE_NETWORKING_MODE" = "userspace" ]; then
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_SOCKS5_PROXY "socks5://localhost:${MAC_DEPLOY_TAILSCALE_PROXY_PORT}"
+  set_env_key "$ENV_FILE" MAC_TAILSCALE_HTTP_PROXY "http://localhost:${MAC_DEPLOY_TAILSCALE_PROXY_PORT}"
+fi

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -364,6 +364,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_SUPERVISOR_CONF_DIR` | str | consumer-defined | deployment | Deployment setting: deploy supervisor conf dir. |
 | `MAC_DEPLOY_TAILSCALE_AUTH_KEY` | str | consumer-defined | deployment | Deployment setting: deploy tailscale auth key. |
 | `MAC_DEPLOY_TAILSCALE_AUTH_KEY_ENV` | str | consumer-defined | deployment | Deployment setting: deploy tailscale auth key env. |
+| `MAC_DEPLOY_TAILSCALE_NETWORKING` | str | consumer-defined | deployment | Deployment setting: deploy tailscale networking. |
+| `MAC_DEPLOY_TAILSCALE_PROXY_PORT` | int | consumer-defined | deployment | Deployment setting: deploy tailscale proxy port. |
 | `MAC_DEPLOY_TAKEOVER_STALE_LOCK` | str | consumer-defined | deployment | Deployment setting: deploy takeover stale lock. |
 | `MAC_DEPLOY_TARGET` | str | consumer-defined | deployment | Deployment setting: deploy target. |
 | `MAC_DEPLOY_TEST_INJECT_OPENCLAW_SNAPSHOT_FAILURE` | str | consumer-defined | deployment | Deployment setting: deploy test inject openclaw snapshot failure. |
@@ -1042,7 +1044,10 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_SUPPRESS_VERSION_WARNING` | str | consumer-defined | core | Core setting: suppress version warning. |
 | `MAC_SYSTEMD_COMMAND_TIMEOUT_SECONDS` | int | consumer-defined | core | Core setting: systemd command timeout seconds. |
 | `MAC_TAILSCALE_HOSTNAME` | str | consumer-defined | core | Core setting: tailscale hostname. |
+| `MAC_TAILSCALE_HTTP_PROXY` | str | consumer-defined | core | Core setting: tailscale http proxy. |
 | `MAC_TAILSCALE_IP` | str | consumer-defined | core | Core setting: tailscale ip. |
+| `MAC_TAILSCALE_NETWORKING_MODE` | str | consumer-defined | core | Core setting: tailscale networking mode. |
+| `MAC_TAILSCALE_SOCKS5_PROXY` | str | consumer-defined | core | Core setting: tailscale socks5 proxy. |
 | `MAC_TASK_CANONICAL_REMOTE` | str | consumer-defined | task-execution | Task Execution setting: task canonical remote. |
 | `MAC_TASK_EVIDENCE_MANIFEST_PATH` | str | consumer-defined | task-execution | Task Execution setting: task evidence manifest path. |
 | `MAC_TASK_EXECUTOR_COMMAND` | str | consumer-defined | task-execution | Task Execution setting: task executor command. |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -4280,6 +4280,28 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy tailscale networking.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_TAILSCALE_NETWORKING",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy tailscale proxy port.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_TAILSCALE_PROXY_PORT",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy takeover stale lock.",
     "family": "deployment",
     "name": "MAC_DEPLOY_TAKEOVER_STALE_LOCK",
@@ -12289,12 +12311,45 @@
   },
   {
     "default": null,
+    "description": "Core setting: tailscale http proxy.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_HTTP_PROXY",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: tailscale ip.",
     "family": "core",
     "name": "MAC_TAILSCALE_IP",
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: tailscale networking mode.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_NETWORKING_MODE",
+    "retired": false,
+    "sources": [
+      "deploy/install-tailscale.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: tailscale socks5 proxy.",
+    "family": "core",
+    "name": "MAC_TAILSCALE_SOCKS5_PROXY",
+    "retired": false,
+    "sources": [
       "deploy/install-tailscale.sh"
     ],
     "type": "str"

--- a/tests/test_tailscale_userspace_fallback.py
+++ b/tests/test_tailscale_userspace_fallback.py
@@ -1,0 +1,285 @@
+"""Tests for the install-tailscale.sh userspace-networking fallback.
+
+Acceptance criteria (task: tailscaled cannot start in gke-newhouse pods --
+no /dev/net/tun, no NET_ADMIN):
+
+- tun_device_available reports failure when /dev/net/tun is absent and the
+  node cannot modprobe one -- the exact state of an hgx-provisioned GKE pod
+  that was never granted NET_ADMIN.
+- tun_device_available reports success on macOS, which synthesises utun
+  interfaces on demand and legitimately has no /dev/net/tun.
+- detect_networking_mode picks 'userspace' from that probe, 'kernel' when a
+  TUN device is usable, and honours an explicit
+  MAC_DEPLOY_TAILSCALE_NETWORKING pin (rejecting unknown values).
+- userspace mode adds --tun=userspace-networking plus the loopback
+  SOCKS5/HTTP proxies to tailscaled, and turns netfilter off for
+  `tailscale up`; kernel mode keeps the stock flags exactly as before.
+- Both supervisor branches that own a daemon invocation apply those flags,
+  and the resolved mode is recorded in mac.env.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = (ROOT / "deploy" / "install-tailscale.sh").read_text(encoding="utf-8")
+
+
+def _extract(func: str) -> str:
+    m = re.search(
+        r"^%s\(\) \{\n.*?^}$" % re.escape(func),
+        SCRIPT,
+        re.S | re.M,
+    )
+    assert m, "could not extract function %s from install-tailscale.sh" % func
+    return m.group(0)
+
+
+def _run_bash(snippet: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["bash", "-c", snippet], capture_output=True, text=True)
+
+
+# ---------------------------------------------------------------------------
+# TUN probe
+# ---------------------------------------------------------------------------
+
+def _probe_snippet(
+    *,
+    tun_present: bool,
+    modprobe_body: str = "exit 1",
+    uname: str = "Linux",
+    tail: str = "tun_device_available && echo kernel || echo userspace",
+) -> str:
+    """Drive tun_device_available against fake uname/sudo/modprobe.
+
+    The device path is rewritten to a test-owned one so the outcome does not
+    depend on whether the host happens to have /dev/net/tun -- CI runners do,
+    the target pods do not.  ``/dev/null`` stands in for a present TUN device
+    because it is a character device on every supported platform and needs no
+    privileges to conjure, unlike ``mknod``.
+    """
+    probe = _extract("tun_device_available").replace(
+        "/dev/net/tun", '"$TUN_DEVICE_PATH"'
+    )
+    return r"""
+set -u
+FAKE_BIN="$(mktemp -d)"
+{ echo '#!/bin/sh'; echo 'echo %(uname)s'; } > "$FAKE_BIN/uname"
+# A pod without NET_ADMIN has no passwordless sudo path to modprobe either.
+{ echo '#!/bin/sh'; echo 'exit 1'; } > "$FAKE_BIN/sudo"
+{ echo '#!/bin/sh'; echo '%(modprobe_body)s'; } > "$FAKE_BIN/modprobe"
+chmod +x "$FAKE_BIN/uname" "$FAKE_BIN/sudo" "$FAKE_BIN/modprobe"
+# Prepended, not replaced: the fakes shadow the real uname/sudo/modprobe
+# while ordinary utilities stay reachable for the fake bodies.
+PATH="$FAKE_BIN:$PATH"
+export TUN_DEVICE_PATH="%(tun_path)s"
+
+%(probe)s
+
+%(tail)s
+""" % {
+        "uname": uname,
+        "modprobe_body": modprobe_body,
+        "tun_path": "/dev/null" if tun_present else "$FAKE_BIN/absent-tun",
+        "probe": probe,
+        "tail": tail,
+    }
+
+
+def test_tun_probe_fails_without_device_and_without_modprobe() -> None:
+    """The gke-newhouse pod case: no device node, no capability to load one."""
+    result = _run_bash(_probe_snippet(tun_present=False))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "userspace"
+
+
+def test_tun_probe_succeeds_on_darwin_without_dev_net_tun() -> None:
+    """macOS has no /dev/net/tun and still does kernel networking via utun."""
+    result = _run_bash(_probe_snippet(tun_present=False, uname="Darwin"))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "kernel", (
+        "a missing /dev/net/tun on macOS must not force userspace networking"
+    )
+
+
+def test_tun_probe_only_consults_dev_net_tun_on_linux() -> None:
+    probe = _extract("tun_device_available")
+    assert '[ "$(uname -s)" = "Linux" ] || return 0' in probe
+
+
+# ---------------------------------------------------------------------------
+# Mode resolution
+# ---------------------------------------------------------------------------
+
+def _mode_snippet(pin: str, *, tun_present: bool, modprobe_body: str = "exit 1") -> str:
+    resolve = _extract("detect_networking_mode")
+    return _probe_snippet(
+        tun_present=tun_present,
+        modprobe_body=modprobe_body,
+        tail="MAC_DEPLOY_TAILSCALE_NETWORKING=%s\n%s\ndetect_networking_mode"
+        % (pin, resolve),
+    )
+
+
+def test_auto_resolves_to_userspace_when_tun_is_unavailable() -> None:
+    result = _run_bash(_mode_snippet("auto", tun_present=False))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "userspace"
+
+
+def test_auto_resolves_to_kernel_when_tun_is_available() -> None:
+    result = _run_bash(_mode_snippet("auto", tun_present=True))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "kernel"
+
+
+def test_auto_resolves_to_kernel_when_modprobe_can_load_the_module() -> None:
+    """Device absent but loadable: a privileged node must stay on kernel TUN."""
+    result = _run_bash(
+        _mode_snippet(
+            "auto",
+            tun_present=False,
+            # A successful modprobe is only believed if the device node then
+            # appears, so the fake has to produce one.
+            modprobe_body='ln -s /dev/null "$TUN_DEVICE_PATH"',
+        )
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "kernel"
+
+
+def test_successful_modprobe_without_a_device_still_falls_back() -> None:
+    """A modprobe that reports success but leaves no device is not enough."""
+    result = _run_bash(_mode_snippet("auto", tun_present=False, modprobe_body="exit 0"))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "userspace"
+
+
+def test_explicit_userspace_pin_skips_the_probe() -> None:
+    result = _run_bash(_mode_snippet("userspace", tun_present=True))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "userspace"
+
+
+def test_explicit_kernel_pin_skips_the_probe() -> None:
+    result = _run_bash(_mode_snippet("kernel", tun_present=False))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "kernel"
+
+
+def test_unknown_networking_pin_is_rejected() -> None:
+    result = _run_bash(_mode_snippet("socks", tun_present=True))
+    assert result.returncode != 0
+    assert "unsupported MAC_DEPLOY_TAILSCALE_NETWORKING" in result.stderr
+
+
+def test_networking_mode_defaults_to_auto() -> None:
+    assert 'MAC_DEPLOY_TAILSCALE_NETWORKING="${MAC_DEPLOY_TAILSCALE_NETWORKING:-auto}"' in SCRIPT
+
+
+# ---------------------------------------------------------------------------
+# Daemon flags
+# ---------------------------------------------------------------------------
+
+def _flags(func: str, mode: str, *, port: str = "1055") -> subprocess.CompletedProcess:
+    return _run_bash(
+        'TAILSCALE_NETWORKING_MODE=%s\nMAC_DEPLOY_TAILSCALE_PROXY_PORT=%s\n%s\n%s'
+        % (mode, port, _extract(func), func)
+    )
+
+
+def test_userspace_daemon_flags_drop_tun_and_publish_proxies() -> None:
+    result = _flags("tailscaled_networking_args", "userspace")
+    assert result.returncode == 0, result.stderr
+    flags = result.stdout.strip()
+    assert "--tun=userspace-networking" in flags
+    assert "--socks5-server=localhost:1055" in flags
+    assert "--outbound-http-proxy-listen=localhost:1055" in flags
+
+
+def test_userspace_proxy_port_is_configurable() -> None:
+    result = _flags("tailscaled_networking_args", "userspace", port="1080")
+    assert result.returncode == 0, result.stderr
+    assert "--socks5-server=localhost:1080" in result.stdout
+    assert "--outbound-http-proxy-listen=localhost:1080" in result.stdout
+
+
+def test_kernel_daemon_flags_are_empty() -> None:
+    """Nodes with TUN must keep the stock tailscaled invocation."""
+    result = _flags("tailscaled_networking_args", "kernel")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
+def test_userspace_up_flags_turn_netfilter_off() -> None:
+    """The iptables 'Permission denied' storm is what netfilter-mode=off ends."""
+    result = _flags("tailscale_up_networking_flags", "userspace")
+    assert result.returncode == 0, result.stderr
+    flags = result.stdout.strip()
+    assert "--netfilter-mode=off" in flags
+    assert "--accept-dns=false" in flags
+    assert "--accept-routes" not in flags, (
+        "userspace networking has no kernel routing table to accept routes into"
+    )
+
+
+def test_kernel_up_flags_are_unchanged() -> None:
+    result = _flags("tailscale_up_networking_flags", "kernel")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.split() == ["--accept-routes", "--accept-dns=true"]
+
+
+# ---------------------------------------------------------------------------
+# Wiring: both daemon-owning branches and the join
+# ---------------------------------------------------------------------------
+
+def test_supervisord_conf_applies_the_networking_flags() -> None:
+    command_line = next(
+        line for line in SCRIPT.splitlines() if line.startswith("command=/usr/sbin/tailscaled")
+    )
+    assert "$(tailscaled_networking_args)" in command_line, (
+        "the supervisord tailscaled stanza is the one that runs on GKE pods; "
+        "it must carry the resolved networking flags"
+    )
+
+
+def test_systemd_userspace_branch_writes_flags_and_restarts() -> None:
+    """/etc/default/tailscaled is the packaged unit's supported flag hook."""
+    assert 'sudo -n tee /etc/default/tailscaled' in SCRIPT
+    assert 'FLAGS="$(tailscaled_networking_args)"' in SCRIPT
+    assert "sudo -n systemctl restart tailscaled" in SCRIPT
+    # The kernel path must still use plain `start`, unchanged from before.
+    assert "sudo -n systemctl start tailscaled" in SCRIPT
+
+
+def test_both_join_paths_use_the_mode_specific_flags() -> None:
+    assert SCRIPT.count("$(tailscale_up_networking_flags)") == 2, (
+        "cloud and headscale joins must both honour the resolved mode"
+    )
+    assert "--accept-routes \\" not in SCRIPT, (
+        "kernel-only flags must come from tailscale_up_networking_flags, "
+        "not be hard-coded into the up invocations"
+    )
+
+
+def test_resolved_mode_is_recorded_in_mac_env() -> None:
+    assert 'set_env_key "$ENV_FILE" MAC_TAILSCALE_NETWORKING_MODE' in SCRIPT
+    assert 'set_env_key "$ENV_FILE" MAC_TAILSCALE_SOCKS5_PROXY' in SCRIPT
+    assert 'set_env_key "$ENV_FILE" MAC_TAILSCALE_HTTP_PROXY' in SCRIPT
+
+
+def test_userspace_fallback_warns_about_reduced_reachability() -> None:
+    """Silently degrading reachability would be worse than the hard failure."""
+    assert "falling back to Tailscale userspace networking" in SCRIPT
+    assert "the host does not route" in SCRIPT
+
+
+def test_script_parses() -> None:
+    result = subprocess.run(
+        ["bash", "-n", str(ROOT / "deploy" / "install-tailscale.sh")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_4ca2519c980f47e0a5f8bc050037475f`
- head: `692b38d3a87d4526f6747bd01600fe85b1f4802c`
- base at push: `c2e6ff4acc1ee58a494fdfd3e8d44ae3edf24046`
