### PR TITLE
Task lifecycle is not on AgentBus, and a CLI agent never reads what is addressed to it (task_7faf8e5695864ea48d12e13389426180)

### DIFF
--- a/docs/in-flight-agent-messages.md
+++ b/docs/in-flight-agent-messages.md
@@ -88,6 +88,89 @@ mac agentbus open  <sender> <recipient> --stream-id correction-1
 mac agentbus append correction-1 <sender> --payload '{"text":"stop, wrong file"}'
 ```
 
+## Not every consumer has a background slot
+
+`wait` assumes a harness that can run a task in the background and surface it
+between steps. An interactive CLI session registered as an agent has no such
+slot, and the consequence was measured on 2026-08-21: two
+`mac.repo.update.result.v1` replies were addressed to a registered session at
+03:15Z and 03:21Z, opened and closed within ~20ms, and nothing ever surfaced
+them. That session published to the bus all day and received nothing from it.
+
+Two things were wrong at once, and both are fixed:
+
+- **`wait` did not work in hub mode at all.** `RemoteDispatch` wrapped the
+  entire agentbus surface *except* the inbox, so `mac admin agentbus wait`
+  answered `not yet supported in hub mode` — for every agent in the fleet,
+  because hub mode is the only mode a fleet agent runs in.
+- **Blocking was the only shape offered.** So the inbox gained a non-blocking
+  half:
+
+```console
+# How much is waiting? Returns at once.
+mac agentbus pending agent_1234
+
+# Take it. Also returns at once, whether or not anything was waiting.
+mac agentbus drain agent_1234
+
+# Look without consuming.
+mac agentbus drain agent_1234 --peek
+```
+
+`drain` keeps the consumed position **at the hub**
+(`agentbus_consumer_cursors`, topic `agentbus.inbox`), which is the difference
+that matters for a session that exits between turns: `wait --after-cursor`
+requires the caller to carry its own bookmark, and a session with nowhere to
+keep one either re-reads everything or misses messages. Both spell the same
+cursor, so the two can be interleaved.
+
+Draining does **not** close the streams it read. On this bus, closing is the
+sender's statement that a conversation is over, and it is what `agentbus
+request` waits on to collect its reply; a recipient that closed an incoming
+stream would destroy the channel it is supposed to answer on.
+
+The count is cheap enough to hang off ordinary output, which is the point —
+`mac agent show <id>` carries `pending_inbox`, `mac agent list --inbox` carries
+`pending_inbox_count`, and `mac task show <id>` carries the owner's. An operator
+who never learns the bus exists still sees that someone answered them.
+
+## Task lifecycle is on the bus
+
+A topic census on 2026-08-21 found eleven live topics fleet-wide — reflect
+requests, peer messages, repo updates, human directives — and no `task.*` among
+them. The fleet's entire subject matter was missing from its own bus, so nothing
+could subscribe to it and every observer polled, including the operator: eleven
+tasks were filed and claimed within an hour and the operator learned it only by
+re-running `mac task stats`.
+
+Every task transition now publishes an addressed record:
+
+- **Topic** — `task.<state>`, derived from `TaskState` rather than hand-mapped,
+  so a new state cannot ship without a topic.
+- **Payload** — `mac.task.lifecycle.v1`, validated at publish time like every
+  other registered schema. It carries the true `actor` of the transition.
+- **Addressed to** — the task's owner, plus any agent id listed under the task's
+  `metadata["watchers"]`. An operator that files a task and wants to hear about
+  it adds itself there.
+- **Sender** — the hub's existing virtual operator persona. The hub has no agent
+  row of its own, and most transitions are performed by actors (`human`,
+  `allocator`, `outbox`) that have none either.
+
+The publication hook is the transition outbox, which already enqueued a
+`task.lifecycle` row for every transition and then dropped it. That seam matters:
+the row is written inside the transition's transaction and processed after it
+commits, so a published record can never describe a state the database does not
+hold. Publication is best-effort in the other direction too — a bus failure
+never fails a transition that already committed, and never stalls the outbox
+rows queued behind it.
+
+One subtlety worth knowing if you touch this: a terminal or blocked transition
+*releases the owner*, and the outbox is drained after that commits. A publisher
+reading the owner off the task would find `None` on exactly the events an
+operator most needs — "your task failed", "your task was blocked". So the
+audience is resolved inside the transition's own transaction, where the outgoing
+owner is still on the row, and travels with the outbox row.
+
 ## What this does not do
 
 It does not interrupt the current step. The message surfaces at the harness's

--- a/src/mac/agentbus_schemas.py
+++ b/src/mac/agentbus_schemas.py
@@ -143,6 +143,30 @@ AGENTBUS_SCHEMA_REGISTRY: Dict[str, SchemaSpec] = {
             "to_agent_id": str,
         },
     },
+    # Task lifecycle (task_7faf8e56). The fleet's own subject matter, absent
+    # from the bus until now: a topic census found eleven live topics and no
+    # ``task.*`` among them, so every observer polled for state changes.
+    # ``actor`` is required and is the true origin of the transition -- the
+    # stream's sender is the hub's virtual persona, because most transitions
+    # are performed by actors (``human``, ``allocator``, ``outbox``) that have
+    # no agent row to send from.
+    "mac.task.lifecycle.v1": {
+        "required": ["schema", "task_id", "topic", "to_state", "actor"],
+        "fields": {
+            "schema": str,
+            "task_id": str,
+            "topic": str,
+            "from_state": str,
+            "to_state": str,
+            "actor": str,
+            "owner_agent_id": str,
+            "recipients": list,
+            "project": str,
+            "title": str,
+            "detail": dict,
+            "at": str,
+        },
+    },
     "mac.directive.activation.v1": {
         "required": [
             "schema",

--- a/src/mac/agentbus_service.py
+++ b/src/mac/agentbus_service.py
@@ -807,6 +807,151 @@ class AgentBusService:
             if self._stream_addresses_agent(agent_id, chunk.stream_id)
         ]
 
+    # Non-blocking inbox consumption (task_7faf8e56).
+    #
+    # ``read_inbox`` answers "what is addressed to me", but the only consumer
+    # the fleet shipped was ``mac admin agentbus wait``, which BLOCKS. That is
+    # the right shape for a working agent whose harness can run a watcher in
+    # the background, and the wrong shape for an interactive CLI session, which
+    # has no background loop to put it in. The observed consequence: two
+    # ``mac.repo.update.result.v1`` replies were addressed to a registered CLI
+    # session on 2026-08-21 (03:15Z and 03:21Z), opened and closed within
+    # ~20ms, and nothing ever surfaced them. The session published to the bus
+    # and never received from it.
+    #
+    # So the inbox gets the other half: ask how much is waiting, and take it,
+    # both returning immediately.
+
+    #: Consumer-cursor topic under which an agent's durable inbox position is
+    #: kept. One row per agent in ``agentbus_consumer_cursors``, so "already
+    #: drained" survives a process restart -- the caller does not have to hold
+    #: the cursor itself the way ``wait --after-cursor`` requires.
+    INBOX_CURSOR_TOPIC = "agentbus.inbox"
+
+    #: Ceiling on a pending count. The number exists to make a CLI line say
+    #: "you have messages", not to be exact at the tail; an unbounded COUNT over
+    #: the busiest table on the bus would be the wrong price for that.
+    PENDING_INBOX_COUNT_CAP = 500
+
+    def durable_inbox_cursor(self, agent_id: str) -> str:
+        """This agent's stored inbox position, or ``""`` if it has never drained."""
+        record = self.get_consumer_cursor(agent_id, self.INBOX_CURSOR_TOPIC)
+        if not record:
+            return ""
+        position = record.get("position")
+        if isinstance(position, dict):
+            return str(position.get("cursor") or "")
+        return str(position or "")
+
+    def pending_inbox_count(
+        self,
+        agent_id: str,
+        after_cursor: Optional[str] = None,
+        *,
+        limit: Optional[int] = None,
+    ) -> JsonDict:
+        """How many messages are waiting for ``agent_id``, right now.
+
+        Cheap enough to hang off ordinary CLI output (``mac agent show``,
+        ``mac task show``): that is the point. An operator who can see "3
+        pending" on a command they were already running does not need to know
+        the bus exists to discover that someone answered them.
+
+        ``after_cursor`` defaults to the agent's durable position, so the count
+        means "new since you last drained" rather than "since the beginning of
+        time".
+        """
+        self._require_agent(agent_id)
+        cursor = (
+            self.durable_inbox_cursor(agent_id) if after_cursor is None else str(after_cursor)
+        )
+        cap = max(1, min(int(limit or self.PENDING_INBOX_COUNT_CAP), self.PENDING_INBOX_COUNT_CAP))
+        chunks = self.read_inbox(agent_id, cursor, limit=cap)
+        return {
+            "agent_id": agent_id,
+            "count": len(chunks),
+            # True when the real backlog may be larger than ``count``. A caller
+            # rendering this should say "500+", not "500".
+            "capped": len(chunks) >= cap,
+            "cursor": cursor,
+            "oldest_at": chunks[0].created_at if chunks else None,
+            "newest_at": chunks[-1].created_at if chunks else None,
+        }
+
+    def drain_inbox(
+        self,
+        agent_id: str,
+        after_cursor: Optional[str] = None,
+        *,
+        limit: int = 100,
+        commit: bool = True,
+    ) -> JsonDict:
+        """Take everything addressed to ``agent_id`` and advance its position.
+
+        Returns immediately whether or not anything was waiting -- this is the
+        surface an interactive session can call between turns, where blocking
+        is not an option.
+
+        **Draining does not close the streams it read.** On this bus, closing is
+        the SENDER's statement that a conversation is finished, and it is what
+        ``agentbus_request`` waits on to collect a reply; a recipient that
+        closed an incoming stream would destroy the channel it is supposed to
+        answer on. ``close_stream`` enforces this (only the sender may close),
+        and this method does not work around it. "Consumed" is expressed the
+        way a bus expresses it: the durable read position moves, so the same
+        message is not delivered twice.
+
+        ``commit=False`` reads without advancing -- a peek, for a caller that
+        wants to look before it can promise to act.
+        """
+        self._require_agent(agent_id)
+        cursor = (
+            self.durable_inbox_cursor(agent_id) if after_cursor is None else str(after_cursor)
+        )
+        chunks = self.read_inbox(agent_id, cursor, limit=limit)
+        messages: List[JsonDict] = []
+        next_cursor = cursor
+        for chunk in chunks:
+            next_cursor = self.inbox_cursor(chunk)
+            entry = chunk.to_dict()
+            entry["inbox_cursor"] = next_cursor
+            messages.append(entry)
+        committed = False
+        if commit and chunks:
+            self.set_consumer_cursor(
+                agent_id,
+                self.INBOX_CURSOR_TOPIC,
+                {"cursor": next_cursor, "updated_at": utcnow()},
+            )
+            committed = True
+        # Agent health tracks an UNCONSUMED control stream (see
+        # ``_agent_unconsumed_control_stream_age_from_row``). Stamping on every
+        # drain would clear that signal whenever an agent read any unrelated
+        # chatter, so only a genuine control stream counts as consumed.
+        if any(
+            is_control_stream(stream.topic, stream.content_type)
+            for stream in self._streams_for_chunks(chunks)
+        ):
+            self._stamp_control_stream_consumed(agent_id)
+        return {
+            "agent_id": agent_id,
+            "count": len(messages),
+            "cursor": cursor,
+            "next_cursor": next_cursor,
+            "committed": committed,
+            "messages": messages,
+        }
+
+    def _streams_for_chunks(self, chunks: List[AgentBusChunk]) -> List[AgentBusStream]:
+        """Hydrate the distinct streams behind ``chunks``, skipping any that vanished."""
+        streams: List[AgentBusStream] = []
+        for stream_id in dict.fromkeys(chunk.stream_id for chunk in chunks):
+            try:
+                streams.append(self.get_stream(stream_id))
+            except NotFoundError:
+                continue
+        return streams
+
     def read_bus_traffic(
         self,
         agent_id: str,

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -2242,6 +2242,15 @@ def _required_scope(method: str, path: str) -> Optional[str]:
         or "/directive-activations/" in path
         or path.endswith("/openshell/policy")
         or path.endswith("/agentbus/inbox")
+        # The non-blocking half of the inbox (task_7faf8e56). Same self-only
+        # worker read, and it must land here explicitly: without these two the
+        # path suffix rules would hand `pending` the generic `read` scope and
+        # `drain` the generic `write` scope, so any read token in the fleet
+        # could count another agent's messages and any write token could
+        # advance another agent's consumed position -- silently costing that
+        # agent the messages it had not seen yet.
+        or path.endswith("/agentbus/inbox/pending")
+        or path.endswith("/agentbus/inbox/drain")
         # The broadcast feed, the bus traffic view and roll call are the same
         # self-only worker read as the inbox: an agent connects to the bus as
         # itself, with agent credentials, and the route binds the path agent
@@ -8637,6 +8646,45 @@ def create_app(
                 await asyncio.sleep(poll_interval)
 
         return StreamingResponse(iter_events(), media_type="application/x-ndjson")
+
+    @app.get("/agents/{agent_id}/agentbus/inbox/pending")
+    def agentbus_inbox_pending(
+        agent_id: str,
+        after_cursor: Optional[str] = Query(default=None),
+        limit: Optional[int] = Query(default=None, ge=1, le=500),
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        """How many messages are waiting for this agent. Returns immediately.
+
+        The sibling of ``/inbox``, which BLOCKS. That one is right for a worker
+        whose harness can run a watcher in a background slot; an interactive
+        CLI session has no such slot, which is how two replies addressed to a
+        registered session on 2026-08-21 were never read by it. This is the
+        question such a session can afford to ask between turns, and the number
+        ordinary CLI output can carry.
+        """
+        principal.assert_actor(agent_id)
+        return cp.pending_agentbus_inbox_count(agent_id, after_cursor, limit=limit)
+
+    @app.post("/agents/{agent_id}/agentbus/inbox/drain")
+    def agentbus_inbox_drain(
+        agent_id: str,
+        after_cursor: Optional[str] = Query(default=None),
+        limit: int = Query(default=100, ge=1, le=500),
+        commit: bool = Query(default=True),
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        """Take everything addressed to this agent, without blocking.
+
+        ``after_cursor`` defaults to the agent's hub-durable inbox position, so
+        a caller that holds no cursor of its own still gets each message once.
+        Draining advances that position; it does not close the streams it read
+        (closing belongs to the sender, and is what a request/reply waits on).
+        """
+        principal.assert_actor(agent_id)
+        return cp.drain_agentbus_inbox(
+            agent_id, after_cursor, limit=limit, commit=commit
+        )
 
     @app.post("/agentbus/broadcast")
     def publish_agentbus_broadcast(

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -2487,7 +2487,22 @@ def cmd_task_show(args: argparse.Namespace) -> None:
     global _LIVE_TASK_STATE
     _LIVE_TASK_STATE = lambda dep_id: _task_state(cp, dep_id)
     try:
-        _print(cp.task_detail(args.task_id))
+        detail = cp.task_detail(args.task_id)
+        payload = detail.to_dict() if hasattr(detail, "to_dict") else detail
+        if isinstance(payload, dict):
+            # Transitions on this task are now published to the bus addressed
+            # at its owner (task_7faf8e56). Saying how many of the owner's
+            # messages are unread is what turns that from a write into a
+            # delivery someone notices.
+            owner = payload.get("owner_agent_id") or (
+                (payload.get("task") or {}).get("owner_agent_id")
+                if isinstance(payload.get("task"), dict)
+                else None
+            )
+            pending = _pending_inbox_summary(cp, str(owner or ""))
+            if pending is not None:
+                payload["owner_pending_inbox"] = pending
+        _print(payload)
     finally:
         _LIVE_TASK_STATE = None
 
@@ -4409,12 +4424,27 @@ def cmd_agent_show(args: argparse.Namespace) -> None:
     question. This is the plain read that makes the object's vocabulary
     uniform: create, list, show, update, delete.
     """
-    _print(_plane(args).get_agent(args.agent_id))
+    cp = _plane(args)
+    agent = cp.get_agent(args.agent_id)
+    row = agent.to_dict() if hasattr(agent, "to_dict") else dict(agent)
+    # The bus is only useful if you can tell it has something for you without
+    # already knowing to ask (task_7faf8e56). This is the cheapest place to
+    # say so: a command an operator was running anyway.
+    pending = _pending_inbox_summary(cp, str(row.get("id") or args.agent_id))
+    if pending is not None:
+        row["pending_inbox"] = pending
+    _print(row)
 
 
 def cmd_agent_list(args: argparse.Namespace) -> None:
     cp = _plane(args)
     rows = [agent.to_dict() if hasattr(agent, "to_dict") else dict(agent) for agent in cp.list_agents()]
+    if getattr(args, "inbox", False):
+        # Opt-in: one hub round-trip per agent. `show` carries it for free
+        # because it is already reading exactly one agent.
+        for row in rows:
+            pending = _pending_inbox_summary(cp, str(row.get("id") or ""))
+            row["pending_inbox_count"] = (pending or {}).get("count")
     if getattr(args, "health", False):
         age_helper = getattr(cp, "unconsumed_control_stream_age_seconds", None)
         for row in rows:
@@ -5881,7 +5911,7 @@ def cmd_agentbus_wait(args: argparse.Namespace) -> None:
     while True:
         chunks = cp.read_agentbus_inbox(args.agent_id, cursor, limit=args.limit)
         if chunks:
-            cursor = cp.agentbus_inbox_cursor(chunks[-1])
+            cursor = _inbox_cursor(cp, chunks[-1])
             _print(
                 {
                     "status": "message",
@@ -5895,6 +5925,83 @@ def cmd_agentbus_wait(args: argparse.Namespace) -> None:
             _print({"status": "timeout", "count": 0, "next_cursor": cursor})
             return
         _time.sleep(interval)
+
+
+def _inbox_cursor(cp: Any, chunk: Any) -> str:
+    """The resume cursor for an inbox chunk, in either transport.
+
+    Against a hub the chunk arrives as a plain document that already carries
+    its ``inbox_cursor``; against a local control plane it is an
+    ``AgentBusChunk`` and the control plane composes one. Both spell the same
+    cursor, so `wait` and `drain` can be interleaved on one bookmark.
+    """
+    existing = chunk.get("inbox_cursor") if hasattr(chunk, "get") else None
+    if existing:
+        return str(existing)
+    return str(cp.agentbus_inbox_cursor(chunk))
+
+
+def cmd_agentbus_drain(args: argparse.Namespace) -> None:
+    """Print everything addressed to this agent and mark it consumed. Never blocks.
+
+    ``wait`` is the watcher a WORKING agent runs in a background slot of its
+    harness. An interactive session has no such slot, so for it the bus was
+    write-only: two replies addressed to a registered CLI session on
+    2026-08-21 were opened and closed within ~20ms and nothing surfaced them.
+    This is the read that fits between turns -- it returns at once whether or
+    not anything was waiting.
+
+    The consumed position is kept at the hub, so a session that holds no cursor
+    of its own still sees each message exactly once. Draining does NOT close
+    the streams it read: on this bus the sender closes, and a request waiting
+    for its reply would lose the channel it is waiting on.
+    """
+    _print(
+        _plane(args).drain_agentbus_inbox(
+            args.agent_id,
+            args.after_cursor,
+            limit=args.limit,
+            commit=not args.peek,
+        )
+    )
+
+
+def cmd_agentbus_pending(args: argparse.Namespace) -> None:
+    """How many messages are waiting for this agent. Returns immediately."""
+    _print(
+        _plane(args).pending_agentbus_inbox_count(
+            args.agent_id,
+            args.after_cursor,
+            limit=args.limit,
+        )
+    )
+
+
+def _pending_inbox_summary(cp: Any, agent_id: str) -> Optional[Dict[str, Any]]:
+    """Best-effort pending-message count for ordinary CLI output.
+
+    Swallows every failure: a hub that predates the endpoint, or an agent id
+    that no longer resolves, must not turn `mac agent show` into an error. The
+    count is an additional courtesy on someone else's command, so its failure
+    mode is silence.
+    """
+    if not agent_id:
+        return None
+    reader = getattr(cp, "pending_agentbus_inbox_count", None)
+    if not callable(reader):
+        return None
+    try:
+        result = reader(agent_id)
+    except Exception:  # noqa: BLE001 - decoration must never break the command.
+        return None
+    payload = result.to_dict() if hasattr(result, "to_dict") else result
+    if not isinstance(payload, dict):
+        return None
+    return {
+        "count": payload.get("count"),
+        "capped": bool(payload.get("capped")),
+        "oldest_at": payload.get("oldest_at"),
+    }
 
 
 def cmd_agentbus_read(args: argparse.Namespace) -> None:
@@ -9527,9 +9634,14 @@ def build_parser() -> argparse.ArgumentParser:
     _set(cmd_agent_show, agent_show)
 
     agent_list = agent.add_parser(
-        "list", help="list agents (--health adds liveness)"
+        "list", help="list agents (--health adds liveness, --inbox adds pending bus messages)"
     )
     agent_list.add_argument("--health", action="store_true")
+    agent_list.add_argument(
+        "--inbox",
+        action="store_true",
+        help="add each agent's pending AgentBus message count (one call per agent)",
+    )
     agent_list.add_argument(
         "--selector",
         help="filter by attributes, e.g. 'state!=cancelled' or "
@@ -10721,6 +10833,43 @@ def build_parser() -> argparse.ArgumentParser:
     bus_wait.add_argument("--poll-interval-seconds", type=float, default=1.0)
     bus_wait.add_argument("--limit", type=int, default=100)
     _set(cmd_agentbus_wait, bus_wait)
+
+    bus_drain = agentbus.add_parser(
+        "drain",
+        help="print what is addressed to this agent and mark it consumed (never blocks)",
+        description=(
+            "The non-blocking counterpart to `wait`. `wait` is for a working "
+            "agent whose harness can run a watcher in a background slot; an "
+            "interactive session has none, so for it the bus was write-only. "
+            "This returns at once whether or not anything was waiting, and the "
+            "consumed position is kept at the hub, so a session that holds no "
+            "cursor still sees each message exactly once. It does not close "
+            "the streams it reads -- the sender closes, and a request awaiting "
+            "its reply would lose the channel it is waiting on."
+        ),
+    )
+    bus_drain.add_argument("agent_id")
+    bus_drain.add_argument(
+        "--after-cursor",
+        default=None,
+        help="override the hub-durable position; omit to resume from it",
+    )
+    bus_drain.add_argument("--limit", type=int, default=100)
+    bus_drain.add_argument(
+        "--peek",
+        action="store_true",
+        help="read without advancing the consumed position",
+    )
+    _set(cmd_agentbus_drain, bus_drain)
+
+    bus_pending = agentbus.add_parser(
+        "pending",
+        help="how many messages are waiting for this agent (never blocks)",
+    )
+    bus_pending.add_argument("agent_id")
+    bus_pending.add_argument("--after-cursor", default=None)
+    bus_pending.add_argument("--limit", type=int, default=None)
+    _set(cmd_agentbus_pending, bus_pending)
 
     bus_read = agentbus.add_parser("read")
     bus_read.add_argument("stream_id")

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -1792,6 +1792,77 @@ class RemoteDispatch:
             )
         )
 
+    # -- Inbox (task_7faf8e56) ----------------------------------------------
+    #
+    # RemoteDispatch wrapped the entire agentbus surface EXCEPT the inbox, and
+    # every fleet agent runs in hub mode. So ``mac admin agentbus wait`` -- the
+    # one consumer the bus shipped -- raised "not yet supported in hub mode"
+    # for every agent that could have used it, which is the mechanical reason
+    # messages addressed to a registered CLI session were never read. These
+    # three methods close that gap.
+
+    def pending_agentbus_inbox_count(
+        self,
+        agent_id: str,
+        after_cursor: Optional[str] = None,
+        *,
+        limit: Optional[int] = None,
+    ) -> _Dictish:
+        return _Dictish(
+            self._get(
+                "/agents/%s/agentbus/inbox/pending" % quote(agent_id, safe=""),
+                after_cursor=after_cursor,
+                limit=limit,
+            )
+        )
+
+    def drain_agentbus_inbox(
+        self,
+        agent_id: str,
+        after_cursor: Optional[str] = None,
+        *,
+        limit: int = 100,
+        commit: bool = True,
+    ) -> _Dictish:
+        path = "/agents/%s/agentbus/inbox/drain" % quote(agent_id, safe="")
+        return _Dictish(
+            self._post(
+                path
+                + _query(
+                    {
+                        "after_cursor": after_cursor,
+                        "limit": limit,
+                        "commit": commit,
+                    }
+                )
+            )
+        )
+
+    def read_agentbus_inbox(
+        self,
+        agent_id: str,
+        after_cursor: str = "",
+        limit: int = 100,
+    ) -> List[_Dictish]:
+        """Peek at what is addressed to this agent, without consuming it.
+
+        ``commit=False``: this is the read the local control plane offers, and
+        the polling loop in ``cmd_agentbus_wait`` is built on it advancing its
+        own cursor between rounds. Committing here would additionally move the
+        hub-durable position and quietly change what ``drain`` returns to a
+        different caller for the same agent.
+        """
+        response = self.drain_agentbus_inbox(
+            agent_id, after_cursor, limit=limit, commit=False
+        )
+        return _wrap_list(response.get("messages") or [])
+
+    # No ``agentbus_inbox_cursor`` here on purpose: composing a cursor is pure
+    # local arithmetic over a chunk, and every public method on this class owes
+    # the caller a hub request. Each drained message carries its own
+    # ``inbox_cursor``, and ``cli._inbox_cursor`` prefers that field, so the
+    # CLI reads one cursor in both transports without a round trip for it.
+
     def publish_agentbus_content(self, **kw: Any) -> _Dictish:
         return _Dictish(self._post("/agentbus", _drop_none(kw)))
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -276,6 +276,7 @@ from mac.sandbox_rollout import (
     validate_image_ref,
 )
 from mac.task_lifecycle import DispatchService, TaskLedgerService
+from mac.task_lifecycle_bus import TaskLifecycleBusPublisher, lifecycle_outbox_detail
 from mac.task_transition_service import TaskTransitionService
 from mac.workflow_runtime import WorkflowRuntime
 from mac.workflow_service import WorkflowService
@@ -2198,6 +2199,9 @@ class ControlPlane:
             derive_ledger_fact=self._derive_broadcast_ledger_fact,
             list_agents=self.list_agents,
         )
+        # Task lifecycle -> addressed bus traffic. Fed by the transition
+        # outbox, so it publishes only what committed (task_7faf8e56).
+        self.task_lifecycle_bus = TaskLifecycleBusPublisher(self)
         self.source_convergence = SourceConvergenceService(self)
         self.provisioning = ProvisioningService(self.store, self.observability)
         self.service_roles = ServiceRoleService(self.store, self.observability)
@@ -11802,7 +11806,9 @@ class ControlPlane:
                 actor=actor,
                 from_state=task.state,
                 to_state=TaskState.COMPLETED.value,
-                detail=detail,
+                # Pre-transition row: force-completion releases the owner too,
+                # so the audience is captured before it is cleared.
+                detail=lifecycle_outbox_detail(detail, task),
                 created_at=now,
             )
         self.drain_task_transition_outbox(task_id=task_id, limit=20)
@@ -19144,6 +19150,31 @@ class ControlPlane:
 
     def agentbus_inbox_cursor(self, chunk: AgentBusChunk) -> str:
         return self.agentbus.inbox_cursor(chunk)
+
+    def pending_agentbus_inbox_count(self, *args: Any, **kwargs: Any) -> JsonDict:
+        """How many bus messages are waiting for an agent (task_7faf8e56).
+
+        Cheap by design so ordinary CLI output can carry it: an operator who
+        never learns the bus exists still sees "3 pending" on the command they
+        were already running.
+        """
+        return self.agentbus.pending_inbox_count(*args, **kwargs)
+
+    def drain_agentbus_inbox(self, *args: Any, **kwargs: Any) -> JsonDict:
+        """Take everything addressed to an agent, without blocking.
+
+        The counterpart to ``mac admin agentbus wait``, which only a harness
+        with a background slot can use. See ``AgentBusService.drain_inbox``.
+        """
+        return self.agentbus.drain_inbox(*args, **kwargs)
+
+    def publish_task_lifecycle_event(self, **kwargs: Any) -> JsonDict:
+        """Publish one committed task transition as addressed ``task.*`` traffic.
+
+        Called from the transition outbox drain. Never raises: see
+        ``TaskLifecycleBusPublisher``.
+        """
+        return self.task_lifecycle_bus.publish(**kwargs)
 
     def read_agentbus_traffic(self, *args: Any, **kwargs: Any) -> List[JsonDict]:
         return self.agentbus.read_bus_traffic(*args, **kwargs)

--- a/src/mac/task_lifecycle_bus.py
+++ b/src/mac/task_lifecycle_bus.py
@@ -1,0 +1,470 @@
+"""Task lifecycle as bus traffic (task_7faf8e56).
+
+The fleet exists to move tasks between states, and until now that was the one
+thing the bus never carried. A topic census taken 2026-08-21 found eleven
+distinct topics in fleet-wide traffic -- reflect requests, peer messages, repo
+updates, human directives -- and no ``task.*`` topic at all. Nothing published
+claimed / running / completed / failed / needs_review, so nothing could
+subscribe to it, so every observer polled. An operator session registered as an
+agent spent a working session re-running ``mac task stats`` and ``mac agent
+list``; eleven tasks were filed and claimed within the hour and the operator
+learned it only by asking again.
+
+This module is the publisher side of the fix. Every task transition already
+enqueues a ``task.lifecycle`` row on the transition outbox
+(``TaskTransitionService._transition_task_impl``), which until now was drained
+and dropped. That row is the seam: it is written inside the transition's
+transaction, so it exists if and only if the transition committed, and it is
+processed after commit, so a notification can never describe a state the
+database does not hold.
+
+Three decisions worth stating, because each had a plausible alternative:
+
+**The topic is derived, not mapped.** ``task.<state>`` for every
+:class:`~mac.models.TaskState`. A hand-written map (``running`` ->
+``task.started``) reads better in prose and drifts the first time a state is
+added, at which point a consumer subscribes to a topic that is never published.
+Derivation makes the vocabulary closed by construction:
+:data:`TASK_LIFECYCLE_TOPICS` is exactly the set of states.
+
+**The sender is the operator persona, not the actor.** The hub has no agent
+identity of its own -- ``agentbus_streams.sender_agent_id`` is a NOT NULL
+foreign key into ``agents`` -- and most transitions are performed by actors that
+are not agents at all (``human``, ``allocator``, ``outbox``, the host
+finalizer). ``ControlPlane._ensure_operator_persona`` already exists for exactly
+this problem and is already used to address directive activations from the hub,
+so lifecycle records reuse it rather than mint a second virtual identity. The
+true actor is never lost: it is a required field of the payload.
+
+**Delivery is addressed, not broadcast.** The broadcast channel
+(:mod:`mac.agentbus_broadcast`) is fleet-readable observation, retained on the
+observability table and rate-limited. "Your task was cancelled" is not
+observation -- it is addressed at someone who has to act, and the thing that
+makes it retrievable by :meth:`AgentBusService.read_inbox` is a stream whose
+recipient is that someone. So this opens a real stream toward the task's owner
+and any watcher.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from mac.models import (
+    JsonDict,
+    NotFoundError,
+    TaskState,
+    ValidationError,
+    ensure_json_object,
+    json_dumps,
+    utcnow,
+)
+
+#: Payload contract, registered in :mod:`mac.agentbus_schemas` so a malformed
+#: lifecycle record is refused at publish time rather than discovered by a
+#: consumer.
+TASK_LIFECYCLE_SCHEMA = "mac.task.lifecycle.v1"
+
+#: Content type carried by every lifecycle stream. Distinct from plain
+#: ``application/json`` so a consumer can filter on the envelope alone.
+TASK_LIFECYCLE_CONTENT_TYPE = "application/vnd.mac.task-lifecycle+json"
+
+#: Topic prefix. Every lifecycle topic starts with this, so a subscriber can
+#: match the whole family with one prefix test.
+TASK_LIFECYCLE_TOPIC_PREFIX = "task."
+
+#: The closed lifecycle vocabulary: one topic per task state, derived from the
+#: state enum so the two cannot drift.
+TASK_LIFECYCLE_TOPICS: Dict[str, str] = {
+    state.value: TASK_LIFECYCLE_TOPIC_PREFIX + state.value for state in TaskState
+}
+
+TASK_LIFECYCLE_TOPIC_SET = frozenset(TASK_LIFECYCLE_TOPICS.values())
+
+#: Task metadata key holding additional agent ids to notify.
+#:
+#: "Watcher" had no prior representation in this repository. It is defined here
+#: as the smallest thing that answers the operator's complaint: a list of agent
+#: ids under ``metadata["watchers"]``. An operator session that files a task and
+#: wants to hear about it adds itself; nothing else in the system reads or
+#: writes the key, so an unknown or stale entry costs one skipped recipient and
+#: never an error.
+TASK_WATCHERS_METADATA_KEY = "watchers"
+
+#: Cap on notified recipients per transition. ``open_stream`` refuses group
+#: streams above 32 participants, and the sender occupies one slot.
+MAX_LIFECYCLE_RECIPIENTS = 31
+
+#: Stream-id prefix. The id is derived from the outbox row so redelivery of the
+#: same row collides on the primary key instead of publishing a duplicate.
+LIFECYCLE_STREAM_ID_PREFIX = "tasklc."
+
+#: Payload budget, deliberately well under the bus's 256 KB chunk ceiling.
+#: Stated locally rather than imported so this module keeps depending on
+#: ``mac.models`` alone, and so the margin is visible: the point is to trim the
+#: detail bag long before the serializer would refuse the whole notification.
+MAX_LIFECYCLE_PAYLOAD_BYTES = 64 * 1024
+
+#: Outbox-detail key carrying who to notify, captured at ENQUEUE time.
+#:
+#: This exists because of the transitions that matter most. A terminal or
+#: blocked transition clears ``tasks.owner_agent_id`` as part of releasing the
+#: agent, and the outbox row is processed AFTER that commit -- so a publisher
+#: that read the owner from the task would find None on exactly the events an
+#: operator needs ("your task failed", "your task was blocked") and correctly
+#: conclude there was nobody to tell. The audience is therefore resolved inside
+#: the transition's own transaction, where the outgoing owner is still on the
+#: row, and travels with the outbox row.
+LIFECYCLE_AUDIENCE_KEY = "_lifecycle_audience"
+
+
+def lifecycle_topic(state: Any) -> str:
+    """The ``task.*`` topic for a destination state.
+
+    Raises rather than inventing a topic for an unknown state: a consumer
+    subscribes to a closed vocabulary, and silently minting ``task.<typo>``
+    would produce traffic nothing is listening for.
+    """
+    value = state.value if hasattr(state, "value") else str(state or "")
+    topic = TASK_LIFECYCLE_TOPICS.get(value)
+    if topic is None:
+        raise ValidationError("unknown task lifecycle state: %r" % (state,))
+    return topic
+
+
+def lifecycle_stream_id(outbox_id: str) -> str:
+    """The deterministic stream id for one outbox row.
+
+    The transition outbox is at-least-once: a row that fails mid-processing is
+    retried, and ``drain`` can be called concurrently from more than one place.
+    Deriving the stream id from the row id turns "publish twice" into a primary
+    key collision the publisher can recognise and skip, which is cheaper and
+    more honest than a dedupe table.
+    """
+    value = str(outbox_id or "").strip()
+    if not value:
+        raise ValidationError("task lifecycle stream id requires an outbox id")
+    return LIFECYCLE_STREAM_ID_PREFIX + value
+
+
+def task_watchers(metadata: Any) -> List[str]:
+    """Agent ids listed under ``metadata["watchers"]``, order-stable and deduped.
+
+    Tolerant by construction: task metadata is caller-supplied and a malformed
+    watcher list must cost a missing notification, never a failed transition.
+    """
+    bag = ensure_json_object(metadata)
+    raw = bag.get(TASK_WATCHERS_METADATA_KEY)
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple)):
+        return []
+    seen: Dict[str, None] = {}
+    for item in raw:
+        candidate = str(item or "").strip()
+        if candidate:
+            seen.setdefault(candidate, None)
+    return list(seen)
+
+
+def lifecycle_recipients(
+    owner_agent_id: Optional[str],
+    watchers: Iterable[str],
+    *,
+    exclude: Iterable[str] = (),
+) -> List[str]:
+    """Who to address, owner first, deduped, minus ``exclude``.
+
+    Owner first because a pair stream keeps ``recipient_agent_id`` as the
+    primary addressee and that should be the agent whose work moved, not
+    whichever watcher happened to register first.
+    """
+    excluded = {str(item or "").strip() for item in exclude}
+    ordered: Dict[str, None] = {}
+    for candidate in [owner_agent_id, *watchers]:
+        value = str(candidate or "").strip()
+        if value and value not in excluded:
+            ordered.setdefault(value, None)
+    return list(ordered)[:MAX_LIFECYCLE_RECIPIENTS]
+
+
+def lifecycle_outbox_detail(detail: Optional[Dict[str, Any]], task: Any) -> JsonDict:
+    """Stamp the notification audience onto an outgoing outbox detail bag.
+
+    Called from inside the transition's transaction, with the task row as it
+    stood BEFORE the transition, so a transition that releases the owner still
+    knows who to tell. See :data:`LIFECYCLE_AUDIENCE_KEY`.
+    """
+    stamped = dict(ensure_json_object(detail))
+    owner = str(getattr(task, "owner_agent_id", "") or "")
+    watchers = task_watchers(getattr(task, "metadata", None))
+    if owner or watchers:
+        stamped[LIFECYCLE_AUDIENCE_KEY] = {
+            "owner_agent_id": owner,
+            "watchers": watchers,
+        }
+    return stamped
+
+
+def pop_lifecycle_audience(detail: Any) -> Tuple[Optional[JsonDict], JsonDict]:
+    """Split a stamped detail bag into ``(audience, detail_without_audience)``.
+
+    The audience is plumbing, not part of the published record: the payload
+    already states ``owner_agent_id`` and ``recipients`` in their own fields,
+    and echoing an internal key into every consumer's copy would make it look
+    like contract.
+    """
+    bag = dict(ensure_json_object(detail))
+    audience = bag.pop(LIFECYCLE_AUDIENCE_KEY, None)
+    if not isinstance(audience, dict):
+        return None, bag
+    owner = str(audience.get("owner_agent_id") or "") or None
+    raw_watchers = audience.get("watchers")
+    watchers = [
+        str(item).strip()
+        for item in (raw_watchers if isinstance(raw_watchers, (list, tuple)) else [])
+        if str(item or "").strip()
+    ]
+    return {"owner_agent_id": owner, "watchers": watchers}, bag
+
+
+def lifecycle_payload(
+    *,
+    task_id: str,
+    topic: str,
+    from_state: Optional[str],
+    to_state: Optional[str],
+    actor: str,
+    owner_agent_id: Optional[str],
+    recipients: List[str],
+    project: Optional[str] = None,
+    title: Optional[str] = None,
+    detail: Optional[Dict[str, Any]] = None,
+    at: Optional[str] = None,
+) -> JsonDict:
+    """Build the ``mac.task.lifecycle.v1`` payload.
+
+    ``detail`` is the transition's own detail bag, copied through unbounded in
+    shape but not in size. The chunk serializer refuses a payload over 256 KB,
+    and ``publish`` swallows that refusal -- so an oversized detail bag would
+    cost the notification ENTIRELY rather than costing the bag. Detail is the
+    least load-bearing field here (state, actor and task id carry the meaning),
+    so it is the one that gets dropped when it does not fit.
+    """
+    payload: JsonDict = {
+        "schema": TASK_LIFECYCLE_SCHEMA,
+        "task_id": str(task_id),
+        "topic": topic,
+        "from_state": str(from_state or ""),
+        "to_state": str(to_state or ""),
+        "actor": str(actor or "unknown"),
+        "owner_agent_id": str(owner_agent_id or ""),
+        "recipients": list(recipients),
+        "at": at or utcnow(),
+    }
+    if project:
+        payload["project"] = str(project)
+    if title:
+        payload["title"] = str(title)[:500]
+    detail_obj = ensure_json_object(detail)
+    if detail_obj:
+        payload["detail"] = detail_obj
+        if len(json_dumps(payload).encode("utf-8")) > MAX_LIFECYCLE_PAYLOAD_BYTES:
+            payload["detail"] = {
+                "omitted": "transition detail exceeded the lifecycle payload budget",
+                "keys": sorted(str(key) for key in detail_obj)[:50],
+            }
+    return payload
+
+
+class TaskLifecycleBusPublisher:
+    """Turns a drained ``task.lifecycle`` outbox row into addressed bus traffic.
+
+    Best-effort by contract. The outbox drain also advances dependency
+    resolution and workflow runs; a bus write that fails must not take those
+    down with it, and a transition that committed must not be re-run because
+    nobody could be told about it. Every failure is recorded to observability
+    and swallowed, and :meth:`publish` reports what it did rather than raising.
+    """
+
+    def __init__(self, control_plane: Any) -> None:
+        self.control_plane = control_plane
+
+    # -- public ---------------------------------------------------------
+
+    def publish(
+        self,
+        *,
+        outbox_id: str,
+        task: Any,
+        actor: str,
+        from_state: Optional[str],
+        to_state: Optional[str],
+        detail: Optional[Dict[str, Any]] = None,
+    ) -> JsonDict:
+        """Publish one transition. Returns a status document, never raises."""
+        try:
+            return self._publish(
+                outbox_id=outbox_id,
+                task=task,
+                actor=actor,
+                from_state=from_state,
+                to_state=to_state,
+                detail=detail,
+            )
+        except Exception as exc:  # noqa: BLE001 - notification must not fail a transition.
+            self._record(
+                "task.lifecycle.publish_failed",
+                level="warning",
+                task_id=getattr(task, "id", ""),
+                detail={"error": str(exc), "outbox_id": str(outbox_id)},
+            )
+            return {"status": "error", "error": str(exc)}
+
+    # -- internals ------------------------------------------------------
+
+    def _publish(
+        self,
+        *,
+        outbox_id: str,
+        task: Any,
+        actor: str,
+        from_state: Optional[str],
+        to_state: Optional[str],
+        detail: Optional[Dict[str, Any]],
+    ) -> JsonDict:
+        if from_state and to_state and from_state == to_state:
+            # A lifecycle record says work MOVED. The same row is also enqueued
+            # to backfill a cancelled task's repository-ref disposition, where
+            # nothing transitioned; publishing "task.cancelled" again for a
+            # metadata correction would teach consumers to distrust the topic.
+            return {"status": "skipped", "reason": "no_transition"}
+        topic = lifecycle_topic(to_state or getattr(task, "state", ""))
+        audience, detail = pop_lifecycle_audience(detail)
+        if audience is None:
+            # No stamp: an outbox row enqueued before this shipped, or by a
+            # path that does not stamp. The live task is the best available
+            # answer and is correct for every non-releasing transition.
+            audience = {
+                "owner_agent_id": getattr(task, "owner_agent_id", None),
+                "watchers": task_watchers(getattr(task, "metadata", None)),
+            }
+        owner = audience.get("owner_agent_id")
+        watchers = audience.get("watchers") or []
+        sender = self._sender_agent_id()
+        recipients = [
+            agent_id
+            for agent_id in lifecycle_recipients(owner, watchers, exclude=[sender])
+            if self._is_live_agent(agent_id)
+        ]
+        if not recipients:
+            # An unowned, unwatched task moving is real traffic with no
+            # audience. Opening a stream nobody can read would spend a row per
+            # transition on the busiest table the bus has.
+            return {"status": "skipped", "reason": "no_recipients", "topic": topic}
+
+        stream_id = lifecycle_stream_id(outbox_id)
+        payload = lifecycle_payload(
+            task_id=getattr(task, "id", ""),
+            topic=topic,
+            from_state=from_state,
+            to_state=to_state,
+            actor=actor,
+            owner_agent_id=owner,
+            recipients=recipients,
+            project=getattr(task, "project", None),
+            title=getattr(task, "title", None),
+            detail=detail,
+        )
+        agentbus = self.control_plane.agentbus
+        try:
+            agentbus.open_stream(
+                sender_agent_id=sender,
+                recipient_agent_id=recipients[0],
+                content_type=TASK_LIFECYCLE_CONTENT_TYPE,
+                topic=topic,
+                task_id=getattr(task, "id", None),
+                stream_id=stream_id,
+                participant_agent_ids=recipients[1:] or None,
+                headers={
+                    "task_id": str(getattr(task, "id", "")),
+                    "to_state": str(to_state or ""),
+                    "actor": str(actor or ""),
+                },
+            )
+        except ValidationError as exc:
+            if "already exists" not in str(exc):
+                raise
+            # Redelivered outbox row. Usually the record is already on the bus
+            # and saying so is the correct outcome -- but not always: opening
+            # the stream and appending its chunk are two writes, and a failure
+            # between them leaves an EMPTY stream. Reporting that as a
+            # duplicate would strand the notification forever behind an id
+            # that can never be re-opened. So the empty case falls through and
+            # finishes the job.
+            if agentbus.read_chunks(
+                sender, stream_id, 0, 1, record_observation=False
+            ):
+                return {
+                    "status": "duplicate",
+                    "stream_id": stream_id,
+                    "topic": topic,
+                    "recipients": recipients,
+                }
+        chunk = agentbus.append_chunk(
+            stream_id,
+            sender,
+            payload=payload,
+            content_type=TASK_LIFECYCLE_CONTENT_TYPE,
+            final=True,
+        )
+        self._record(
+            "task.lifecycle.published",
+            level="info",
+            task_id=str(getattr(task, "id", "")),
+            detail={
+                "stream_id": stream_id,
+                "topic": topic,
+                "recipients": recipients,
+                "to_state": str(to_state or ""),
+            },
+        )
+        return {
+            "status": "published",
+            "stream_id": stream_id,
+            "chunk_id": chunk.id,
+            "topic": topic,
+            "recipients": recipients,
+        }
+
+    def _sender_agent_id(self) -> str:
+        """The hub's virtual identity, materialized on first use."""
+        persona = self.control_plane._ensure_operator_persona()
+        return str(persona.id)
+
+    def _is_live_agent(self, agent_id: str) -> bool:
+        try:
+            agent = self.control_plane.get_agent(agent_id)
+        except NotFoundError:
+            return False
+        return not getattr(agent, "deleted_at", None)
+
+    def _record(
+        self,
+        name: str,
+        *,
+        level: str,
+        task_id: str,
+        detail: Dict[str, Any],
+    ) -> None:
+        try:
+            self.control_plane.record_log(
+                name,
+                layer="agentbus",
+                source="task-lifecycle",
+                level=level,
+                subject_type="task" if task_id else None,
+                subject_id=task_id or None,
+                detail=detail,
+            )
+        except Exception:  # noqa: BLE001 - telemetry may be down; the caller still proceeds.
+            pass

--- a/src/mac/task_transition_service.py
+++ b/src/mac/task_transition_service.py
@@ -50,6 +50,7 @@ from mac.repository_hygiene import (
     repository_ref_lifecycle_for_transition,
     validate_replacement_target,
 )
+from mac.task_lifecycle_bus import lifecycle_outbox_detail
 
 
 def _state_value(state: Any) -> str:
@@ -501,7 +502,12 @@ class TaskTransitionService:
                 actor=actor,
                 from_state=task.state,
                 to_state=target,
-                detail=detail or {},
+                # ``task`` is the PRE-transition row, which is the only place
+                # the outgoing owner still exists: a terminal or blocked
+                # transition releases the agent, and the outbox is drained
+                # after that commits. Stamping here is what lets "your task
+                # failed" reach the agent it was taken from.
+                detail=lifecycle_outbox_detail(detail, task),
                 created_at=now,
             )
             if target in TERMINAL_TASK_STATES.union({TaskState.BLOCKED.value}):
@@ -947,6 +953,26 @@ class TaskTransitionService:
                         "replacement_task_id": lifecycle.get("replacement_task_id"),
                     },
                 )
+            # ...and put the transition itself on the bus (task_7faf8e56).
+            #
+            # This row was already being written for EVERY transition and then
+            # dropped, which is why no ``task.*`` topic existed fleet-wide and
+            # why every observer -- including the operator -- discovered fleet
+            # state by polling. The row is enqueued inside the transition's
+            # transaction and processed after it commits, so a published record
+            # can never describe a state the database does not hold.
+            #
+            # Best-effort: ``publish`` never raises. A notification that cannot
+            # be delivered must not fail a transition that already committed,
+            # nor stall the outbox rows queued behind it.
+            self.control_plane.publish_task_lifecycle_event(
+                outbox_id=item.id,
+                task=task,
+                actor=item.actor,
+                from_state=item.from_state,
+                to_state=item.to_state,
+                detail=item.detail,
+            )
             return
         task = self.control_plane.get_task(item.task_id)
         if item.event_type == "workflow.advance":

--- a/tests/cli/test_cli_agentbus_drain.py
+++ b/tests/cli/test_cli_agentbus_drain.py
@@ -1,0 +1,141 @@
+"""`mac agentbus drain` / `mac agentbus pending` — the inbox for a session.
+
+``wait`` blocks, and that is right for a working agent whose harness can run a
+watcher in a background slot. An interactive CLI session registered as an agent
+has no such slot, so for it the bus was write-only: two replies addressed to
+such a session on 2026-08-21 were opened and closed within ~20ms and nothing
+ever surfaced them.
+
+These two verbs are the read that fits between turns. Three properties make
+them usable that way and are asserted here:
+
+* they **return at once** whether or not anything was waiting;
+* the consumed position is **kept at the hub**, so a session that exits between
+  turns and holds no cursor still sees each message exactly once; and
+* draining **does not close** the streams it read, because on this bus the
+  sender closes, and a request awaiting its reply would lose the channel it is
+  waiting on.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+import pytest
+
+from mac.cli import main
+from mac.test_support import control_plane_on, dsn_for
+
+
+def _run(db, *args):
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        main(["--db", dsn_for(db), "--json", *args])
+    finally:
+        sys.stdout = old
+    raw = out.getvalue().strip()
+    return json.loads(raw) if raw else None
+
+
+@pytest.fixture
+def fleet(tmp_path, monkeypatch):
+    monkeypatch.setenv("MAC_SECRET_KEY", "test-key-with-at-least-32-characters-x")
+    cp = control_plane_on(dsn_for(tmp_path))
+    machine = cp.register_machine("host")
+    session = cp.register_agent(machine.id, "operator-session")
+    peer = cp.register_agent(machine.id, "worker-1")
+    return tmp_path, cp, session, peer
+
+
+def _say(cp, sender, recipient, text, stream_id):
+    stream = cp.agentbus.open_stream(sender.id, recipient.id, stream_id=stream_id)
+    cp.agentbus.append_chunk(stream.id, sender.id, {"text": text})
+    return stream
+
+
+def test_pending_reports_the_backlog_without_reading_it(fleet):
+    tmp, cp, session, peer = fleet
+    assert _run(tmp, "admin", "agentbus", "pending", session.id)["count"] == 0
+
+    _say(cp, peer, session, "your refresh-source finished", "s1")
+    _say(cp, peer, session, "and so did the second one", "s2")
+
+    result = _run(tmp, "admin", "agentbus", "pending", session.id)
+    assert result["count"] == 2
+    assert result["capped"] is False
+    # Counting is not consuming: the messages are still there to be taken.
+    assert _run(tmp, "admin", "agentbus", "pending", session.id)["count"] == 2
+
+
+def test_drain_prints_what_was_addressed_and_consumes_it(fleet):
+    tmp, cp, session, peer = fleet
+    _say(cp, peer, session, "your refresh-source finished", "s1")
+
+    drained = _run(tmp, "admin", "agentbus", "drain", session.id)
+
+    assert drained["count"] == 1
+    assert drained["committed"] is True
+    assert drained["messages"][0]["payload"]["text"] == "your refresh-source finished"
+    # The position lives at the hub, so the next invocation -- a different
+    # process, holding no cursor -- does not replay it.
+    assert _run(tmp, "admin", "agentbus", "drain", session.id)["count"] == 0
+    assert _run(tmp, "admin", "agentbus", "pending", session.id)["count"] == 0
+
+
+def test_drain_returns_immediately_when_nothing_is_waiting(fleet):
+    """The whole point: no timeout to pick, no channel held open."""
+    tmp, _cp, session, _peer = fleet
+    empty = _run(tmp, "admin", "agentbus", "drain", session.id)
+    assert empty["count"] == 0
+    assert empty["messages"] == []
+    assert empty["committed"] is False
+
+
+def test_peek_reads_without_consuming(fleet):
+    tmp, cp, session, peer = fleet
+    _say(cp, peer, session, "look but do not take", "s1")
+
+    peeked = _run(tmp, "admin", "agentbus", "drain", session.id, "--peek")
+    assert peeked["count"] == 1
+    assert peeked["committed"] is False
+
+    assert _run(tmp, "admin", "agentbus", "drain", session.id)["count"] == 1
+
+
+def test_draining_leaves_the_stream_open_for_a_reply(fleet):
+    """A recipient must not destroy the channel it is expected to answer on."""
+    tmp, cp, session, peer = fleet
+    stream = _say(cp, peer, session, "are you on this branch?", "ask-1")
+
+    assert _run(tmp, "admin", "agentbus", "drain", session.id)["count"] == 1
+
+    assert cp.get_agentbus_stream(stream.id).status == "open"
+    cp.agentbus.append_chunk(stream.id, peer.id, {"text": "still there?"})
+    assert _run(tmp, "admin", "agentbus", "drain", session.id)["count"] == 1
+
+
+def test_an_explicit_cursor_overrides_the_stored_position(fleet):
+    tmp, cp, session, peer = fleet
+    _say(cp, peer, session, "first", "s1")
+    assert _run(tmp, "admin", "agentbus", "drain", session.id)["count"] == 1
+
+    # A caller that keeps its own bookmark -- as `wait --after-cursor` does --
+    # can still drive the read itself. Both verbs spell one cursor, so the two
+    # can be interleaved.
+    replayed = _run(tmp, "admin", "agentbus", "drain", session.id, "--after-cursor", "", "--peek")
+    assert replayed["count"] == 1
+    assert replayed["messages"][0]["payload"]["text"] == "first"
+
+
+def test_drain_ignores_conversations_it_was_not_part_of(fleet):
+    """An inbox is "who spoke to me", not "what is being said"."""
+    tmp, cp, session, peer = fleet
+    machine = cp.list_machines()[0]
+    third = cp.register_agent(machine.id, "worker-2")
+    _say(cp, peer, third, "not for the session", "elsewhere")
+
+    assert _run(tmp, "admin", "agentbus", "drain", session.id)["count"] == 0

--- a/tests/test_task_lifecycle_bus.py
+++ b/tests/test_task_lifecycle_bus.py
@@ -1,0 +1,531 @@
+"""Task lifecycle reaches the bus, and a CLI agent can take it without blocking.
+
+Two defects, one session, opposite directions (task_7faf8e56).
+
+**Nothing published.** A topic census on 2026-08-21 found eleven live topics
+fleet-wide -- reflect requests, peer messages, repo updates, human directives --
+and no ``task.*`` among them. The fleet's entire subject matter was absent from
+its own bus, so nothing could subscribe to it and every observer polled. An
+operator session discovered eleven tasks being filed and claimed within the hour
+only by re-running ``mac task stats``.
+
+**Nothing consumed.** Two ``mac.repo.update.result.v1`` replies WERE addressed
+to a registered CLI session (03:15Z and 03:21Z), opened and closed within ~20ms,
+and were never read -- the only consumer the bus shipped was ``agentbus wait``,
+which blocks, and an interactive session has no background slot to block in.
+
+So the assertions here are the two halves of one delivery: a committed
+transition produces a bus record addressed to the task's owner, and that owner
+can retrieve it with a call that returns immediately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.agentbus_service import AgentBusService
+from mac.models import TaskState
+from mac.services import ControlPlane
+from mac.task_lifecycle_bus import (
+    TASK_LIFECYCLE_SCHEMA,
+    TASK_LIFECYCLE_TOPIC_PREFIX,
+    TASK_LIFECYCLE_TOPICS,
+    TASK_WATCHERS_METADATA_KEY,
+    lifecycle_recipients,
+    lifecycle_stream_id,
+    lifecycle_topic,
+    task_watchers,
+)
+
+
+@pytest.fixture
+def fleet():
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host")
+    owner = cp.register_agent(machine.id, "worker-1")
+    watcher = cp.register_agent(machine.id, "operator-session")
+    bystander = cp.register_agent(machine.id, "worker-2")
+    return cp, owner, watcher, bystander
+
+
+def _owned_task(cp, owner, *, watchers=None, title="ship the thing"):
+    """A claimed task plus the lease fence every public transition requires."""
+    metadata = {TASK_WATCHERS_METADATA_KEY: list(watchers)} if watchers else None
+    task = cp.create_task(title, project="mac", metadata=metadata)
+    _claimed, lease = cp.claim_task(task.id, owner.id)
+    return cp.get_task(task.id), lease.id
+
+
+def _move(cp, task_id, state, *, actor, lease_id=None, detail=None):
+    """Transition a task the way the fleet does.
+
+    Worker-authored transitions go through the public, lease-fenced path (the
+    actor must hold the current lease, which is why these pass ``owner.id``
+    rather than a prose actor name); hub-authored ones use the trusted internal
+    path, because ``human``/``allocator`` hold no lease and are exactly the
+    transitions an operator has no other way to hear about.
+    """
+    if lease_id:
+        return cp.transition_task(task_id, state, actor, detail, lease_id=lease_id)
+    return cp._transition_task_internal(task_id, state, actor, detail)
+
+
+def _lifecycle(cp, agent_id):
+    """Lifecycle payloads sitting in ``agent_id``'s inbox, oldest first."""
+    return [
+        chunk.payload
+        for chunk in cp.read_agentbus_inbox(agent_id, "", limit=100)
+        if isinstance(chunk.payload, dict)
+        and chunk.payload.get("schema") == TASK_LIFECYCLE_SCHEMA
+    ]
+
+
+# --- the vocabulary -------------------------------------------------------
+
+
+def test_every_task_state_has_a_topic_and_no_state_is_missed():
+    """Derived, not hand-mapped: a new state cannot ship without a topic.
+
+    A map maintained by hand drifts the first time a state is added, and the
+    failure is silent -- consumers subscribe to a topic that is never published.
+    """
+    assert set(TASK_LIFECYCLE_TOPICS) == {state.value for state in TaskState}
+    assert all(
+        topic.startswith(TASK_LIFECYCLE_TOPIC_PREFIX)
+        for topic in TASK_LIFECYCLE_TOPICS.values()
+    )
+    assert lifecycle_topic(TaskState.COMPLETED) == "task.completed"
+    assert lifecycle_topic("needs_review") == "task.needs_review"
+
+
+def test_an_unknown_state_is_refused_rather_than_minting_a_topic():
+    from mac.models import ValidationError
+
+    with pytest.raises(ValidationError):
+        lifecycle_topic("definitely_not_a_state")
+
+
+def test_watchers_are_read_leniently_and_recipients_are_owner_first():
+    assert task_watchers({TASK_WATCHERS_METADATA_KEY: ["a", "a", " b ", ""]}) == ["a", "b"]
+    assert task_watchers({TASK_WATCHERS_METADATA_KEY: "solo"}) == ["solo"]
+    # Malformed metadata costs a missed notification, never an exception --
+    # this runs inside a transition that has already committed.
+    assert task_watchers({TASK_WATCHERS_METADATA_KEY: 17}) == []
+    assert task_watchers(None) == []
+    assert lifecycle_recipients("owner", ["w1", "owner"]) == ["owner", "w1"]
+    assert lifecycle_recipients("owner", ["w1"], exclude=["owner"]) == ["w1"]
+
+
+# --- publication ----------------------------------------------------------
+
+
+def test_a_transition_puts_a_record_on_the_bus_addressed_to_the_owner(fleet):
+    """The headline assertion: work moved, and the owner was told."""
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+
+    payloads = _lifecycle(cp, owner.id)
+    assert [item["to_state"] for item in payloads] == ["running"]
+    record = payloads[0]
+    assert record["task_id"] == task.id
+    assert record["topic"] == "task.running"
+    assert record["owner_agent_id"] == owner.id
+    assert record["actor"] == owner.id
+    assert record["project"] == "mac"
+    assert record["title"] == "ship the thing"
+
+
+def test_the_record_is_a_real_stream_on_a_task_topic(fleet):
+    """Addressed traffic, not a log line: topic, recipient and task binding."""
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+    _move(
+        cp,
+        task.id,
+        TaskState.FAILED.value,
+        actor=owner.id,
+        lease_id=lease,
+        detail={"error": "the build fell over"},
+    )
+
+    streams = [
+        stream
+        for stream in cp.list_agentbus_streams(agent_id=owner.id, limit=100)
+        if str(stream.topic).startswith(TASK_LIFECYCLE_TOPIC_PREFIX)
+    ]
+    # ``list_agentbus_streams`` is newest-first; the set is what matters here.
+    assert {stream.topic for stream in streams} == {"task.running", "task.failed"}
+    stream = next(item for item in streams if item.topic == "task.failed")
+    assert stream.recipient_agent_id == owner.id
+    assert stream.task_id == task.id
+    # One-shot: nothing is expected to reply to a lifecycle notification, so
+    # the sender finalizes it rather than leaving an open channel per
+    # transition on the busiest table the bus has.
+    assert stream.status == "closed"
+
+
+def test_watchers_are_addressed_alongside_the_owner(fleet):
+    """The operator's half: file a task, name yourself, hear about it."""
+    cp, owner, watcher, bystander = fleet
+    task, lease = _owned_task(cp, owner, watchers=[watcher.id])
+
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+
+    assert [item["to_state"] for item in _lifecycle(cp, watcher.id)] == ["running"]
+    assert [item["to_state"] for item in _lifecycle(cp, owner.id)] == ["running"]
+    # An inbox is "who spoke to me". A fleet where every agent is woken by
+    # every transition is worse than one that polls.
+    assert _lifecycle(cp, bystander.id) == []
+
+
+def test_an_unknown_watcher_costs_one_recipient_and_not_the_notification(fleet):
+    cp, owner, watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner, watchers=["agent_does_not_exist", watcher.id])
+
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+    _move(
+        cp,
+        task.id,
+        TaskState.FAILED.value,
+        actor=owner.id,
+        lease_id=lease,
+        detail={"error": "the build fell over"},
+    )
+
+    assert [item["to_state"] for item in _lifecycle(cp, owner.id)] == ["running", "failed"]
+    assert [item["to_state"] for item in _lifecycle(cp, watcher.id)] == ["running", "failed"]
+
+
+def test_an_unowned_unwatched_task_publishes_nothing(fleet):
+    """No audience, no stream: a row per transition nobody can read is a leak."""
+    cp, owner, _watcher, _bystander = fleet
+    task = cp.create_task("nobody's task", project="mac")
+
+    _move(cp, task.id, TaskState.BLOCKED.value, actor="human", detail={"reason": "no capacity"})
+
+    assert _lifecycle(cp, owner.id) == []
+    assert [
+        stream
+        for stream in cp.list_agentbus_streams(limit=100)
+        if str(stream.topic).startswith(TASK_LIFECYCLE_TOPIC_PREFIX)
+    ] == []
+
+
+def test_redelivering_the_outbox_row_does_not_duplicate_the_record(fleet):
+    """The outbox is at-least-once; the stream id is derived so a retry collides."""
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+    before = _lifecycle(cp, owner.id)
+    assert len(before) == 1
+
+    rows = cp.task_ledger.list_outbox(status="delivered", task_id=task.id, limit=10)
+    lifecycle_rows = [row for row in rows if row.event_type == "task.lifecycle"]
+    assert lifecycle_rows, "the transition should have enqueued a task.lifecycle row"
+    result = cp.publish_task_lifecycle_event(
+        outbox_id=lifecycle_rows[0].id,
+        task=cp.get_task(task.id),
+        actor=owner.id,
+        from_state=lifecycle_rows[0].from_state,
+        to_state=lifecycle_rows[0].to_state,
+        detail=lifecycle_rows[0].detail,
+    )
+
+    assert result["status"] == "duplicate"
+    assert _lifecycle(cp, owner.id) == before
+
+
+def test_an_empty_stream_from_a_half_written_publish_is_finished_not_skipped(fleet):
+    """Opening the stream and appending its chunk are two writes.
+
+    A failure between them leaves an EMPTY stream under an id derived from the
+    outbox row -- an id that can never be re-opened. Reporting that as a
+    duplicate would strand the notification forever, so the retry finishes it.
+    """
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+    rows = cp.task_ledger.list_outbox(status="delivered", task_id=task.id, limit=10)
+    row = next(item for item in rows if item.event_type == "task.lifecycle")
+
+    # Simulate the half-written state: same derived id, no chunk.
+    orphan_id = lifecycle_stream_id("tout_orphan_%s" % row.id)
+    persona = cp._ensure_operator_persona()
+    cp.agentbus.open_stream(
+        persona.id, owner.id, stream_id=orphan_id, topic="task.running"
+    )
+    before = len(_lifecycle(cp, owner.id))
+
+    result = cp.publish_task_lifecycle_event(
+        outbox_id="tout_orphan_%s" % row.id,
+        task=cp.get_task(task.id),
+        actor=owner.id,
+        from_state="claimed",
+        to_state="running",
+        detail=row.detail,
+    )
+
+    assert result["status"] == "published"
+    assert len(_lifecycle(cp, owner.id)) == before + 1
+
+
+def test_an_oversized_detail_bag_costs_the_bag_and_not_the_notification(fleet):
+    """``publish`` swallows failures, so a payload the bus would refuse is silent.
+
+    Detail is the least load-bearing field -- state, actor and task id carry
+    the meaning -- so it is what gets trimmed.
+    """
+    cp, owner, _watcher, _bystander = fleet
+    task, _lease = _owned_task(cp, owner)
+
+    result = cp.publish_task_lifecycle_event(
+        outbox_id="tout_big_%s" % task.id,
+        task=cp.get_task(task.id),
+        actor=owner.id,
+        from_state="claimed",
+        to_state="running",
+        detail={"stdout": "x" * (256 * 1024), "error": "boom"},
+    )
+
+    assert result["status"] == "published"
+    record = _lifecycle(cp, owner.id)[-1]
+    assert record["to_state"] == "running"
+    assert record["detail"]["omitted"]
+    assert record["detail"]["keys"] == ["error", "stdout"]
+
+
+def test_a_bus_failure_does_not_fail_a_committed_transition(fleet, monkeypatch):
+    """A transition that committed must not be undone by a notification.
+
+    The transition outbox also advances dependency resolution and workflow
+    runs; an exception escaping the publisher would stall every row behind it.
+    """
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+
+    def explode(*_args, **_kwargs):
+        raise RuntimeError("bus is down")
+
+    monkeypatch.setattr(cp.agentbus, "open_stream", explode)
+    moved = _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+
+    assert moved.state == "running"
+    assert cp.get_task(task.id).state == "running"
+    assert _lifecycle(cp, owner.id) == []
+
+
+# --- non-blocking retrieval ----------------------------------------------
+
+
+def test_the_owner_retrieves_the_record_without_blocking(fleet):
+    """The other half of the defect: addressed IS NOT delivered until read.
+
+    ``drain`` is the call an interactive session can afford between turns. It
+    returns whether or not anything was waiting -- there is no timeout
+    argument to get wrong and no channel held open.
+    """
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+
+    drained = cp.drain_agentbus_inbox(owner.id)
+
+    assert drained["count"] == 1
+    assert drained["committed"] is True
+    message = drained["messages"][0]
+    assert message["payload"]["task_id"] == task.id
+    assert message["payload"]["to_state"] == "running"
+    assert message["inbox_cursor"] == drained["next_cursor"]
+
+
+def test_drain_is_not_repeated_and_needs_no_caller_held_cursor(fleet):
+    """The consumed position lives at the hub, which is what ``wait`` lacked.
+
+    ``agentbus wait --after-cursor`` requires the caller to carry its own
+    bookmark between invocations. A session that exits between turns has
+    nowhere to keep one, so it either re-reads everything or misses messages.
+    """
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+
+    assert cp.drain_agentbus_inbox(owner.id)["count"] == 1
+    assert cp.drain_agentbus_inbox(owner.id)["count"] == 0
+
+    _move(
+        cp,
+        task.id,
+        TaskState.FAILED.value,
+        actor=owner.id,
+        lease_id=lease,
+        detail={"error": "the build fell over"},
+    )
+    second = cp.drain_agentbus_inbox(owner.id)
+    assert second["count"] == 1
+    assert second["messages"][0]["payload"]["to_state"] == "failed"
+
+
+def test_a_peek_reads_without_consuming(fleet):
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+
+    peeked = cp.drain_agentbus_inbox(owner.id, commit=False)
+    assert peeked["count"] == 1
+    assert peeked["committed"] is False
+    assert cp.drain_agentbus_inbox(owner.id)["count"] == 1
+
+
+def test_the_pending_count_answers_without_reading_the_messages(fleet):
+    """What ordinary CLI output carries, so an operator never has to ask."""
+    cp, owner, _watcher, _bystander = fleet
+    task, lease = _owned_task(cp, owner)
+
+    assert cp.pending_agentbus_inbox_count(owner.id)["count"] == 0
+
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+    _move(
+        cp,
+        task.id,
+        TaskState.FAILED.value,
+        actor=owner.id,
+        lease_id=lease,
+        detail={"error": "the build fell over"},
+    )
+
+    pending = cp.pending_agentbus_inbox_count(owner.id)
+    assert pending["count"] == 2
+    assert pending["capped"] is False
+    assert pending["oldest_at"] and pending["newest_at"]
+
+    cp.drain_agentbus_inbox(owner.id)
+    assert cp.pending_agentbus_inbox_count(owner.id)["count"] == 0
+
+
+def test_draining_leaves_the_stream_intact_for_a_reply(fleet):
+    """A recipient must not destroy the channel it is expected to answer on.
+
+    ``agentbus_request`` waits on the SENDER closing the stream. Had drain
+    closed what it read, the first agent to use it would have broken every
+    request/reply exchange addressed to it.
+    """
+    cp, owner, _watcher, bystander = fleet
+    stream = cp.agentbus.open_stream(bystander.id, owner.id, stream_id="ask-1")
+    cp.agentbus.append_chunk(stream.id, bystander.id, {"text": "are you on this branch?"})
+
+    assert cp.drain_agentbus_inbox(owner.id)["count"] == 1
+
+    assert cp.get_agentbus_stream(stream.id).status == "open"
+    cp.agentbus.append_chunk(stream.id, bystander.id, {"text": "still there?"})
+    assert cp.drain_agentbus_inbox(owner.id)["count"] == 1
+
+
+def test_the_durable_cursor_matches_the_wait_cursor_format(fleet):
+    """``drain`` and ``wait`` share one cursor, so the two can be interleaved."""
+    cp, owner, _watcher, bystander = fleet
+    stream = cp.agentbus.open_stream(bystander.id, owner.id, stream_id="s-fmt")
+    cp.agentbus.append_chunk(stream.id, bystander.id, {"text": "hello"})
+
+    chunk = cp.read_agentbus_inbox(owner.id, "", limit=1)[0]
+    drained = cp.drain_agentbus_inbox(owner.id)
+
+    assert drained["next_cursor"] == cp.agentbus_inbox_cursor(chunk)
+    assert cp.agentbus.durable_inbox_cursor(owner.id) == drained["next_cursor"]
+    assert AgentBusService.INBOX_CURSOR_SEPARATOR in drained["next_cursor"]
+    # A caller that already holds a cursor may still drive it explicitly.
+    assert cp.drain_agentbus_inbox(owner.id, "")["count"] == 1
+
+
+# --- the HTTP surface a hub-mode agent actually reaches -------------------
+
+
+def test_the_non_blocking_routes_are_self_only():
+    """Both halves carry the agent scope, not the generic read/write scopes.
+
+    Left to the suffix rules, ``pending`` would have been an ordinary GET
+    (``read``) and ``drain`` an ordinary POST (``write``). Any read token in
+    the fleet could then count another agent's messages, and any write token
+    could advance another agent's consumed position -- which does not just
+    disclose, it CONSUMES: the victim never sees what was taken.
+    """
+    from mac.api import _required_scope
+
+    assert _required_scope("GET", "/agents/a1/agentbus/inbox/pending") == "agent"
+    assert _required_scope("POST", "/agents/a1/agentbus/inbox/drain") == "agent"
+
+
+def test_an_agent_drains_its_own_inbox_over_http_and_nobody_elses(fleet):
+    from fastapi.testclient import TestClient
+
+    from mac.api import create_app
+
+    cp, owner, _watcher, bystander = fleet
+    task, lease = _owned_task(cp, owner)
+    _move(cp, task.id, TaskState.RUNNING.value, actor=owner.id, lease_id=lease)
+
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={
+                "mine": {"scopes": ["agent"], "agent_id": owner.id},
+                "other": {"scopes": ["agent"], "agent_id": bystander.id},
+                "reader": {"scopes": ["read"], "client_id": "dash"},
+            },
+        )
+    )
+    pending_url = "/agents/%s/agentbus/inbox/pending" % owner.id
+    drain_url = "/agents/%s/agentbus/inbox/drain" % owner.id
+
+    for token in ("other", "reader"):
+        headers = {"Authorization": "Bearer %s" % token}
+        assert client.get(pending_url, headers=headers).status_code == 403
+        assert client.post(drain_url, headers=headers).status_code == 403
+
+    mine = {"Authorization": "Bearer mine"}
+    pending = client.get(pending_url, headers=mine)
+    assert pending.status_code == 200
+    assert pending.json()["count"] == 1
+
+    drained = client.post(drain_url, headers=mine)
+    assert drained.status_code == 200
+    body = drained.json()
+    assert body["count"] == 1
+    assert body["messages"][0]["payload"]["to_state"] == "running"
+    # Consumed: the hub remembers, so the caller does not have to.
+    assert client.get(pending_url, headers=mine).json()["count"] == 0
+
+
+def test_hub_mode_can_read_an_inbox_at_all(fleet):
+    """The defect that made every other fix unreachable.
+
+    ``RemoteDispatch`` wrapped the whole agentbus surface except the inbox, so
+    ``mac admin agentbus wait`` -- the only consumer the bus shipped -- answered
+    "not yet supported in hub mode" for every agent in the fleet, because hub
+    mode is the only mode a fleet agent runs in.
+    """
+    from mac.dispatch import RemoteDispatch
+
+    for name in (
+        "read_agentbus_inbox",
+        "drain_agentbus_inbox",
+        "pending_agentbus_inbox_count",
+    ):
+        assert callable(getattr(RemoteDispatch, name, None)), name
+
+
+def test_the_cli_reads_one_cursor_in_either_transport(fleet):
+    """`wait` and `drain` must agree, or interleaving them loses messages."""
+    from mac.cli import _inbox_cursor
+
+    cp, owner, _watcher, bystander = fleet
+    stream = cp.agentbus.open_stream(bystander.id, owner.id, stream_id="s-cli")
+    cp.agentbus.append_chunk(stream.id, bystander.id, {"text": "hello"})
+
+    local_chunk = cp.read_agentbus_inbox(owner.id, "", limit=1)[0]
+    hub_shaped = cp.drain_agentbus_inbox(owner.id, "", commit=False)["messages"][0]
+
+    assert _inbox_cursor(cp, local_chunk) == _inbox_cursor(cp, hub_shaped)


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_7faf8e5695864ea48d12e13389426180`
- head: `512b863837ec61520e2f98367d7fba0d7fb3c128`
- base at push: `4434ccd1379bc9d44d0c2b24e14ab9141405617d`
