### PR TITLE
Hub verify discarded the reason it failed before classifying it (task_68ed61db520d438ca8304979e58ac755)

### DIFF
--- a/src/mac/contract_failure.py
+++ b/src/mac/contract_failure.py
@@ -28,12 +28,14 @@ failure text rather than only through a live task.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional, Sequence, Tuple
 
 __all__ = [
     "ContractFailureCause",
     "ContractFailure",
     "classify_contract_failure",
+    "CONTRACT_FAILURE_ANCHORS",
+    "capture_failure_window",
 ]
 
 
@@ -158,3 +160,121 @@ def classify_contract_failure(
             "should be rare enough to notice."
         ),
     )
+
+
+#: Generic text that ANNOUNCES a failure, used to decide which bytes of a huge
+#: contract-test log are worth keeping. These are a *capture* heuristic, never
+#: a verdict: a wrong entry costs one wasted window, not a misclassification,
+#: because whatever survives is still handed to a classifier that decides what
+#: it means. That is the opposite of the discipline governing the hub's verdict
+#: signatures, where a wrong entry signs a rejection nobody judged — so this
+#: list can afford to be generous where that one must not be.
+CONTRACT_FAILURE_ANCHORS: Tuple[str, ...] = (
+    "= failures =",                       # pytest's section banner
+    "= errors =",
+    "short test summary info",            # pytest's own answer to "what failed"
+    "traceback (most recent call last)",
+    "returned non-zero exit status",
+    "timed out after",
+    "fatal:",
+    "command not found",
+    "no such file or directory",
+    "permission denied",
+)
+
+
+def _merge_spans(spans: Sequence[Tuple[int, int]]) -> List[Tuple[int, int]]:
+    merged: List[Tuple[int, int]] = []
+    for start, end in sorted(span for span in spans if span[1] > span[0]):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _spans_length(spans: Sequence[Tuple[int, int]]) -> int:
+    return sum(end - start for start, end in spans)
+
+
+def _render_spans(body: str, spans: Sequence[Tuple[int, int]]) -> str:
+    parts: List[str] = []
+    cursor = 0
+    for start, end in spans:
+        if start > cursor:
+            parts.append("... [%d chars omitted] ..." % (start - cursor))
+        parts.append(body[start:end])
+        cursor = end
+    if cursor < len(body):
+        parts.append("... [%d chars omitted] ..." % (len(body) - cursor))
+    return "\n".join(parts)
+
+
+def capture_failure_window(
+    text: str,
+    *,
+    anchors: Sequence[str] = (),
+    limit: int = 12000,
+    head: int = 1200,
+    tail: int = 1200,
+    before: int = 700,
+    after: int = 2200,
+) -> str:
+    """Keep the part of a contract-test log that says WHY it failed.
+
+    Position is the wrong selector for this repository's gate.
+    ``run-contract-tests.sh`` prints the pytest failure FIRST, then an
+    unconditional whole-repo ``coverage report`` — one row per source file,
+    tens of kilobytes — then a coverage summary whose floors both PASSED, and
+    only then exits with the saved pytest status. A blind ``out[-2000:]``
+    therefore keeps the coverage table's tail, a passing coverage line, and the
+    transport's generic "ssh exited with status 1", and drops every string a
+    classifier could act on.
+
+    Head-and-tail is not sufficient either: the failure sits between several
+    hundred lines of pytest progress and the coverage table, out of reach of
+    both ends. So this keeps the head, the tail, AND a window around the LAST
+    occurrence of each anchor, merged and rendered with explicit omission
+    markers so the reader knows what is missing.
+
+    ``anchors`` are tried before :data:`CONTRACT_FAILURE_ANCHORS` and are how a
+    caller keeps its own classifier fed: pass the exact strings that classifier
+    keys on. The FIRST anchor that matches is admitted whether or not it fits
+    ``limit`` — the reason is the one thing this function exists to preserve,
+    so it outranks the byte budget, and the result stays bounded by
+    ``head + tail + before + after`` plus the anchor. Lower-priority anchors
+    are admitted only while they fit, in that order.
+
+    Returns ``text`` unchanged when it already fits in ``limit``: most gate
+    failures are small, and eliding them would add noise for nothing.
+    """
+
+    body = text or ""
+    if len(body) <= limit:
+        return body
+    head = max(0, min(head, limit))
+    tail = max(0, min(tail, max(0, limit - head)))
+    kept = _merge_spans([(0, head), (len(body) - tail, len(body))])
+    lowered = body.lower()
+    admitted = False
+    seen = set()
+    for anchor in list(anchors) + list(CONTRACT_FAILURE_ANCHORS):
+        needle = (anchor or "").strip().lower()
+        if not needle or needle in seen:
+            continue
+        seen.add(needle)
+        index = lowered.rfind(needle)
+        if index < 0:
+            continue
+        window = (
+            max(0, index - before),
+            min(len(body), index + len(needle) + after),
+        )
+        candidate = _merge_spans(list(kept) + [window])
+        if admitted and _spans_length(candidate) > limit:
+            # Budget spent. Keep going rather than breaking: a later, cheaper
+            # anchor may still fit in a gap this one could not.
+            continue
+        kept = candidate
+        admitted = True
+    return _render_spans(body, kept)

--- a/src/mac/merge_queue.py
+++ b/src/mac/merge_queue.py
@@ -56,6 +56,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
+from mac.contract_failure import capture_failure_window
+
 GitRunner = Callable[[Sequence[str]], "subprocess.CompletedProcess"]
 ContractTestRunner = Callable[[str, str, str, str], Tuple[int, str]]
 
@@ -264,7 +266,14 @@ def validate_projected_merge_contract(
             projected_sha=projected_sha,
             test_command=command,
             test_returncode=returncode,
-            output_tail=output_tail[-2000:],
+            # NOT a blind tail. The control plane's runner already spends a
+            # relevance-selected excerpt getting the reason out of the middle
+            # of a ~90KB contract log; chopping 2000 bytes off the end of that
+            # excerpt puts the reason straight back in the discarded part,
+            # because the anchored window sits between the kept head and the
+            # kept tail. Bound it the same way the capture did, so the
+            # publication gate's evidence still names what failed.
+            output_tail=capture_failure_window(output_tail),
             error=error,
         )
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -60,6 +60,7 @@ from mac.agentbus_control import (
 if TYPE_CHECKING:
     from mac.executor_directive import TaskOwnershipVerdict
 from mac.attempt_failure_classifier import classify_attempt_failure
+from mac.contract_failure import capture_failure_window
 from mac.dispatch_advisor import DISPATCH_ASSIGNMENT_ADVISOR_VERSION
 from mac.gitops import validate_git_ref
 from mac.repository_contract import (
@@ -1153,35 +1154,25 @@ def _hub_verify_output_excerpt(
     failure and keep a window around its LAST occurrence, so the excerpt still
     carries a verdict signature after truncation and a rejection stays
     classifiable as a rejection.
+
+    The selection itself lives in :func:`~mac.contract_failure.
+    capture_failure_window`, because this is not the only place a contract
+    log gets reduced before something classifies it: the publication gate
+    reduces the excerpt AGAIN on its way into merge-queue evidence, and a
+    second, independently-written reducer there is how the reason got thrown
+    away a second time. One implementation, two callers, each supplying the
+    anchors its own classifier keys on.
     """
 
-    text = (output or "").strip()
-    if len(text) <= head + window + tail:
-        return text
-
-    spans = [(0, head), (len(text) - tail, len(text))]
-    lowered = text.lower()
-    found = [lowered.rfind(a) for a in _HUB_VERIFY_FAILURE_ANCHORS]
-    anchor_at = max(found)
-    if anchor_at >= 0:
-        start = max(0, anchor_at - window // 4)
-        spans.append((start, min(len(text), start + window)))
-
-    merged: List[Tuple[int, int]] = []
-    for start, end in sorted(spans):
-        if merged and start <= merged[-1][1]:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-        else:
-            merged.append((start, end))
-
-    parts: List[str] = []
-    previous = 0
-    for start, end in merged:
-        if start > previous:
-            parts.append("... [%d chars omitted] ..." % (start - previous))
-        parts.append(text[start:end])
-        previous = end
-    return "\n".join(parts)
+    return capture_failure_window(
+        (output or "").strip(),
+        anchors=_HUB_VERIFY_FAILURE_ANCHORS,
+        limit=head + window + tail,
+        head=head,
+        tail=tail,
+        before=window // 4,
+        after=window - window // 4,
+    )
 
 
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"

--- a/tests/test_contract_failure_window.py
+++ b/tests/test_contract_failure_window.py
@@ -1,0 +1,137 @@
+"""One reducer, two callers, and the reason survives both.
+
+`_hub_verify_output_excerpt` replaced the hub's blind `out[-2000:]` with an
+anchored window, and that fixed the capture site. It did not fix the second
+reduction: `validate_projected_merge_contract` took `output_tail[-2000:]` off
+the excerpt on its way into publication evidence. An excerpt whose MIDDLE is
+the answer does not survive a tail, so the publication gate reproduced the
+original bug one layer down -- a genuine rejection reading as a dead harness.
+
+These tests pin the shared selection (`capture_failure_window`) and the
+end-to-end property that matters: run a realistic failing
+`scripts/run-contract-tests.sh` transcript through the capture site and then
+through the publication gate's reduction, and the classifier must still call
+it a rejection.
+"""
+from __future__ import annotations
+
+from mac.contract_failure import CONTRACT_FAILURE_ANCHORS, capture_failure_window
+from mac.services import _hub_verify_output_excerpt, hub_verification_unavailable_reason
+
+# The shape run-contract-tests.sh produces, and the reason it defeats a tail:
+# the failure is announced FIRST, then an unconditional whole-repo coverage
+# report, then a coverage summary whose floors both PASSED, then the exit.
+PYTEST_PROGRESS = "\n".join(
+    "tests/test_module_%03d.py ....................... [ %2d%%]" % (i, i % 100)
+    for i in range(400)
+)
+FAILED_TEST = "FAILED tests/cli/test_cli_version_flag.py::test_it_prints_the_version"
+PYTEST_FAILURE = (
+    "=================================== FAILURES ===================================\n"
+    "E   AssertionError: expected 1 got 0\n"
+    "=========================== short test summary info ===========================\n"
+    "%s\n"
+    "= 7 failed, 10992 passed, 3 skipped, 1 xfailed in 737.45s =\n" % FAILED_TEST
+)
+COVERAGE_TABLE = "\n".join(
+    "src/mac/module_%03d.py%s500     40    92%%" % (i, " " * 8) for i in range(235)
+)
+FAILING_RUN = (
+    "============================= test session starts ==============================\n"
+    "collected 11003 items\n"
+    + PYTEST_PROGRESS
+    + "\n"
+    + PYTEST_FAILURE
+    + COVERAGE_TABLE
+    + "\ncoverage safety: statements 70465/77526 (90.89%, floor 90.00%); "
+    "branches 20641/25112 (82.20%, floor 80.00%)\n"
+    "  - Uploading files to /sandbox...\n"
+    "Error:   x ssh exited with status exit status: 1"
+)
+
+
+def test_the_publication_gates_second_reduction_no_longer_loses_the_verdict():
+    """The bug, stated end to end.
+
+    Capture, then reduce again the way the publication path does. The old
+    `[-2000:]` there is asserted to fail on the same input, so this cannot
+    quietly pass because the excerpt happened to get small.
+    """
+    excerpt = _hub_verify_output_excerpt(FAILING_RUN)
+    assert hub_verification_unavailable_reason(excerpt) is None
+
+    blind_tail = excerpt[-2000:]
+    assert hub_verification_unavailable_reason(blind_tail) == "ssh exited with status"
+    assert FAILED_TEST not in blind_tail
+
+    anchored = capture_failure_window(excerpt)
+    assert hub_verification_unavailable_reason(anchored) is None
+    assert FAILED_TEST in anchored
+    assert "7 failed, 10992 passed" in anchored
+
+
+def test_short_output_is_returned_verbatim():
+    """Most gate failures are small; eliding them would add noise for nothing."""
+    assert capture_failure_window("boom", limit=100) == "boom"
+
+
+def test_a_reason_in_the_middle_survives_when_both_ends_do_not_reach_it():
+    kept = capture_failure_window(FAILING_RUN, limit=6000)
+
+    assert FAILED_TEST in kept
+    assert "short test summary info" in kept
+    assert "chars omitted" in kept  # the elision is stated, not silent
+    assert kept.startswith("============================= test session starts")
+    assert kept.endswith("ssh exited with status exit status: 1")
+
+
+def test_caller_anchors_outrank_the_generic_ones():
+    """How a caller keeps its own classifier fed: pass the strings it keys on."""
+    body = "%s\nWIDGET REGISTRY IS STALE\n%s" % ("a" * 40000, "b" * 40000)
+
+    assert "WIDGET REGISTRY IS STALE" not in capture_failure_window(body)
+    assert "WIDGET REGISTRY IS STALE" in capture_failure_window(
+        body, anchors=("widget registry is stale",)
+    )
+
+
+def test_the_first_matching_anchor_wins_even_against_the_byte_budget():
+    """A budget that can evict the only anchor is a budget that reintroduces
+    this bug on a large enough log. The head and tail yield instead."""
+    body = "%s\nshort test summary info\nFAILED tests/t.py::t\n%s" % (
+        "a" * 40000,
+        "b" * 40000,
+    )
+
+    kept = capture_failure_window(body, limit=200, head=100, tail=100)
+
+    assert "FAILED tests/t.py::t" in kept
+
+
+def test_lower_priority_anchors_yield_once_the_budget_is_spent():
+    """The budget still binds for everything after the first match, so one
+    pathological log cannot expand into the whole transcript."""
+    body = "\n".join(
+        ["z" * 4000] + ["%s\n%s" % (anchor, "z" * 4000) for anchor in CONTRACT_FAILURE_ANCHORS]
+    )
+
+    kept = capture_failure_window(body, limit=8000)
+
+    assert len(kept) < len(body)
+    # The highest-priority anchor present is the pytest FAILURES banner.
+    assert "= failures =" in kept.lower()
+
+
+def test_no_anchor_anywhere_degrades_to_head_and_tail():
+    body = "%s%s" % ("a" * 30000, "b" * 30000)
+
+    kept = capture_failure_window(body, limit=4000, head=1000, tail=1000)
+
+    assert kept.startswith("a" * 1000)
+    assert kept.endswith("b" * 1000)
+    assert "[58000 chars omitted]" in kept
+
+
+def test_empty_and_none_are_not_errors():
+    assert capture_failure_window("") == ""
+    assert capture_failure_window(None) == ""  # type: ignore[arg-type]

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -158,6 +158,60 @@ def test_full_contract_failure_is_fail_closed(repo: Path):
     assert verdict.error == "full repository contract test failed"
 
 
+def test_full_contract_failure_keeps_the_reason_out_of_the_middle(repo: Path):
+    """The verdict took ``output_tail[-2000:]`` -- a second blind tail.
+
+    The runner hands this function output whose failure sits in the MIDDLE,
+    because that is the shape ``scripts/run-contract-tests.sh`` produces: the
+    pytest failure first, then a whole-repo coverage table, then a coverage
+    line whose floors PASSED, then the transport's exit. Chopping 2000 bytes
+    off the end threw the reason away again, right after the capture site had
+    gone to the trouble of keeping it.
+    """
+    _branch_commit(repo, "topic", "topic.txt", "topic\n")
+    reason = "FAILED tests/test_contract.py::test_scope - AssertionError: nope"
+    coverage_table = "\n".join(
+        "src/mac/module_%03d.py   %4d   %3d   9%d%%" % (i, 300 + i, i % 40, i % 10)
+        for i in range(400)
+    )
+    output = (
+        "=========================== short test summary info ===========================\n"
+        "%s\n%s\ncoverage safety: floors PASSED\nssh exited with status 1"
+        % (reason, coverage_table)
+    )
+    assert reason not in output[-2000:]  # the premise: a tail cannot reach it
+
+    verdict = validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (1, output),
+    )
+
+    assert verdict.passed is False
+    assert reason in verdict.output_tail
+    assert "short test summary info" in verdict.output_tail
+
+
+def test_full_contract_failure_output_stays_bounded(repo: Path):
+    """Not truncating is not the fix either -- this lands in publication
+    evidence, and a 90KB coverage table there helps nobody."""
+    _branch_commit(repo, "topic", "topic.txt", "topic\n")
+    output = "x" * 200_000 + "\nshort test summary info\nFAILED tests/t.py::t\n" + "y" * 200_000
+
+    verdict = validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (1, output),
+    )
+
+    assert "FAILED tests/t.py::t" in verdict.output_tail
+    assert len(verdict.output_tail) < 20_000
+
+
 def test_full_contract_never_runs_for_conflict_or_empty_command(repo: Path):
     _branch_commit(repo, "topic", "f.txt", "topic\nline2\nline3\n")
     (repo / "f.txt").write_text("main\nline2\nline3\n")


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_68ed61db520d438ca8304979e58ac755`
- head: `b4a5861bcea2a2d4888f223de1972f163a582b41`
- base at push: `4434ccd1379bc9d44d0c2b24e14ab9141405617d`
