### PR TITLE
QUICKDEMO: tailscaled can't start in gke-newhouse pods -- no /dev/net/tun, no NET_ADMIN (task_4ca2519c980f47e0a5f8bc050037475f)

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -32,6 +32,8 @@ their retained sources.
 - [ADR 0023 - One skill source, thin plugins per coding harness](../adr/0023-one-skill-source-many-harness-plugins.md) — `adr/0023-one-skill-source-many-harness-plugins.md`
 - [ADR 0024 - The dashboard streams the bus, not just its counts](../adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md) — `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md`
 - [ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype](../adr/0025-the-hub-ui-is-the-observability-console.md) — `adr/0025-the-hub-ui-is-the-observability-console.md`
+- [ADR 0026: Every operation on a first-class object emits a bus event](../adr/0026-first-class-operations-emit-bus-events.md) — `adr/0026-first-class-operations-emit-bus-events.md`
+- [ADR 0027: Upgrades are versioned, ordered, and fail closed](../adr/0027-upgrades-are-versioned-and-fail-closed.md) — `adr/0027-upgrades-are-versioned-and-fail-closed.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -253,6 +253,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_HERMES_SURFACE_B64` | str | consumer-defined | deployment | Deployment setting: deploy hermes surface b64. |
 | `MAC_DEPLOY_HOLD_ADOPTIONS_FILE` | str | consumer-defined | deployment | Deployment setting: deploy hold adoptions file. |
 | `MAC_DEPLOY_HUB_AGENT` | str | consumer-defined | deployment | Deployment setting: deploy hub agent. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof attempts. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof interval seconds. |
 | `MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub tick interval seconds. |
 | `MAC_DEPLOY_HUB_TOKEN` | str | consumer-defined | deployment | Deployment setting: deploy hub token. |
 | `MAC_DEPLOY_HUB_TUNNEL_PUBKEY` | str | consumer-defined | deployment | Deployment setting: deploy hub tunnel pubkey. |
@@ -490,6 +492,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HGX_AUTOSCALE_CLUSTER` | str | consumer-defined | core | Core setting: hgx autoscale cluster. |
 | `MAC_HGX_AUTOSCALE_COOLDOWN_SECONDS` | int | consumer-defined | core | Core setting: hgx autoscale cooldown seconds. |
 | `MAC_HGX_AUTOSCALE_CPU` | str | consumer-defined | core | Core setting: hgx autoscale cpu. |
+| `MAC_HGX_AUTOSCALE_CREATE_ARGS` | str | consumer-defined | core | Core setting: hgx autoscale create args. |
 | `MAC_HGX_AUTOSCALE_ENABLED` | bool | consumer-defined | core | Core setting: hgx autoscale enabled. |
 | `MAC_HGX_AUTOSCALE_GPU` | str | consumer-defined | core | Core setting: hgx autoscale gpu. |
 | `MAC_HGX_AUTOSCALE_HEADROOM` | str | consumer-defined | core | Core setting: hgx autoscale headroom. |
@@ -843,6 +846,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_PREREQ_QDRANT_REQUIRED` | bool | consumer-defined | core | Core setting: prereq qdrant required. |
 | `MAC_PREREQ_QDRANT_URL` | str | consumer-defined | core | Core setting: prereq qdrant url. |
 | `MAC_PREREQ_ROOT` | str | consumer-defined | core | Core setting: prereq root. |
+| `MAC_PREREQ_ROUTE_HUB_REQUIRED` | bool | consumer-defined | core | Core setting: prereq route hub required. |
 | `MAC_PREREQ_SUPERVISOR` | str | consumer-defined | core | Core setting: prereq supervisor. |
 | `MAC_PREREQ_WEBDAV_ENABLED` | bool | consumer-defined | core | Core setting: prereq webdav enabled. |
 | `MAC_PREREQ_WEBDAV_URL` | str | consumer-defined | core | Core setting: prereq webdav url. |

--- a/docs/hgx-elastic-capacity.md
+++ b/docs/hgx-elastic-capacity.md
@@ -51,6 +51,78 @@ memory to 8..256 GiB, and CPU to 1..64. The controller records the immutable
 provider session ID immediately after the provider accepts the create request.
 That request is not readiness evidence.
 
+## Linux network capability (`/dev/net/tun`, `NET_ADMIN`)
+
+**An HGX session is not guaranteed to be able to run kernel-mode Tailscale, a
+VPN client, or anything else that opens a TUN device.** On `gke-newhouse`, a
+`standard-dind` pod has no `/dev/net/tun` and is not granted `CAP_NET_ADMIN`:
+`tailscaled` fails with `CreateTUN("tailscale0") failed; /dev/net/tun does not
+exist`, and its `iptables` calls are denied with "Permission denied (you must be
+root)" even when the process really is root. Those two symptoms are one cause —
+the pod spec withholds the capability — so a missing kernel module is not the
+thing to go fix.
+
+Capability is a property of the cluster and profile you provision into. `hgx
+create` exposes no flag that requests it, so neither this controller nor
+`deploy/` can ask for it. Check a session rather than assuming:
+
+```console
+$ hgx ssh <session-or-name> -- 'ls /dev/net/tun 2>/dev/null || echo NO-TUN'
+$ hgx ssh <session-or-name> -- 'grep CapEff /proc/self/status'
+```
+
+| Cluster / profile | `/dev/net/tun` | `NET_ADMIN` | Kernel-mode Tailscale |
+|---|---|---|---|
+| `gke-newhouse`, `standard` pod (2026-08-20) | absent | not granted | no — userspace mode only |
+| `gke-newhouse`, `standard-dind` (what this controller creates) | expected absent | expected absent | probe before relying on it |
+| any other cluster/profile | unverified | unverified | probe before relying on it |
+
+Only the first row is a direct observation: one `hgx`-provisioned `standard`
+pod, whose `tailscaled` log carried both symptoms above. The rest is
+deliberately left unverified. Recording a guess here would be worse than
+recording nothing, because the failure it produces surfaces in a `tailscaled`
+log long after provisioning succeeded. Add a row when you have run the probe.
+
+MAC's answer to a node without the capability is not to fail: it is
+`deploy/install-tailscale.sh`, which detects the missing device and starts
+`tailscaled` in Tailscale's userspace networking mode. Such a node joins the
+mesh and gets a Tailscale IP, but the host does not route into the mesh —
+outbound mesh traffic must go through the local SOCKS5/HTTP proxy and inbound
+reachability is limited to what `tailscale serve` publishes. That is workable
+for a worker and poor for a hub. See `QUICKDEMO.md` for the operator-facing
+version.
+
+If a provider build does expose a capability-granting argument, pass it through
+instead of forking the create contract:
+
+```console
+$ mac admin hgx capacity execute --pending-requests 1 \
+    --create-arg=--some-cap-flag --create-arg=NET_ADMIN
+```
+
+Use the `--create-arg=VALUE` form. A pass-through argument almost always starts
+with a dash, and `--create-arg --some-cap-flag` makes `argparse` read the flag
+as a missing value rather than as the argument you meant.
+
+`--create-arg` is repeatable and bounded: at most 8 arguments, each 1..64
+characters drawn from letters, digits and `-_=:./,+`, and
+`--cluster`/`--gpu`/`--memory`/`--cpu`/`--name` are rejected because the policy
+and the immutable session name own them. The accepted arguments are appended
+after the policy-derived ones and echoed in the `status`, `plan`, and `execute`
+documents under `policy.create_extra_args`, so what a run actually requested is
+visible without re-deriving it. MAC does not guess a flag name: an empty
+`--create-arg` list is the correct default until the provider documents one.
+
+The background autoscaler takes the same list, whitespace-separated:
+
+```text
+MAC_HGX_AUTOSCALE_CREATE_ARGS=--cap-add=NET_ADMIN --device=/dev/net/tun
+```
+
+It is validated through the same policy at configuration time, so a rejected
+value surfaces as `hgx.autoscaler.configuration_invalid` and leaves the
+autoscaler inactive rather than failing once per reconciliation.
+
 Before a session is reported as attested capacity, the controller:
 
 1. addresses it only by immutable session ID;

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -37,6 +37,8 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | ADR 0023 - One skill source, thin plugins per coding harness |
 | architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | ADR 0024 - The dashboard streams the bus, not just its counts |
 | architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
+| architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
+| architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -7299,6 +7299,7 @@ def _hgx_capacity_controller(args: argparse.Namespace) -> Any:
         cooldown_seconds=args.cooldown_seconds,
         wait_timeout_seconds=args.wait_timeout_seconds,
         poll_interval_seconds=args.poll_interval_seconds,
+        create_extra_args=tuple(args.create_arg or ()),
     )
     provider = HgxProvider(
         binary=args.hgx_binary,
@@ -7403,6 +7404,21 @@ def _add_hgx_capacity_args(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=1,
         help="maximum sessions created by one execute invocation (default: 1)",
+    )
+    parser.add_argument(
+        "--create-arg",
+        action="append",
+        default=None,
+        metavar="ARG",
+        help=(
+            "extra argument appended verbatim to 'hgx create' (repeatable, at "
+            "most 8). Use it to request provider capabilities MAC cannot "
+            "derive, such as a build that exposes a Linux capability flag for "
+            "/dev/net/tun and NET_ADMIN; --cluster/--gpu/--memory/--cpu/--name "
+            "are reserved by the policy and rejected here. Write it as "
+            "--create-arg=--flag: a bare dashed value is read as a missing "
+            "argument"
+        ),
     )
     parser.add_argument("--cooldown-seconds", type=float, default=300.0)
     parser.add_argument("--wait-timeout-seconds", type=float, default=300.0)

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -2981,6 +2981,28 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy hub route proof attempts.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy hub route proof interval seconds.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy hub tick interval seconds.",
     "family": "deployment",
     "name": "MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS",
@@ -5787,6 +5809,17 @@
     "description": "Core setting: hgx autoscale cpu.",
     "family": "core",
     "name": "MAC_HGX_AUTOSCALE_CPU",
+    "retired": false,
+    "sources": [
+      "src/mac/hgx_autoscaler.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: hgx autoscale create args.",
+    "family": "core",
+    "name": "MAC_HGX_AUTOSCALE_CREATE_ARGS",
     "retired": false,
     "sources": [
       "src/mac/hgx_autoscaler.py"
@@ -9938,6 +9971,17 @@
       "deploy/deploy-mac-fleet.sh"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: prereq route hub required.",
+    "family": "core",
+    "name": "MAC_PREREQ_ROUTE_HUB_REQUIRED",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "bool"
   },
   {
     "default": null,

--- a/src/mac/hgx_autoscaler.py
+++ b/src/mac/hgx_autoscaler.py
@@ -80,6 +80,12 @@ class HgxAutoscalerConfig:
     state_path: str = DEFAULT_STATE_PATH
     registered_agents_file: str = ""
     name_prefix: str = "mac-fungible"
+    # Whitespace-separated `hgx create` pass-through, e.g. a provider build's
+    # capability flag for /dev/net/tun and NET_ADMIN. Held as the raw string so
+    # the config stays a flat, JSON-serialisable observability payload; the
+    # bounds live in HgxCapacityPolicy and a rejected value becomes a
+    # configuration_error rather than a crashed autoscaler thread.
+    create_extra_args: str = ""
     configuration_error: str = ""
 
     @property
@@ -102,6 +108,7 @@ class HgxAutoscalerConfig:
             cooldown_seconds=self.cooldown_seconds,
             wait_timeout_seconds=self.wait_timeout_seconds,
             poll_interval_seconds=self.poll_interval_seconds,
+            create_extra_args=tuple(self.create_extra_args.split()),
         )
 
     @classmethod
@@ -242,6 +249,9 @@ class HgxAutoscalerConfig:
             ),
             name_prefix=env_str(
                 "MAC_HGX_AUTOSCALE_NAME_PREFIX", "mac-fungible", environ=env
+            ),
+            create_extra_args=env_str(
+                "MAC_HGX_AUTOSCALE_CREATE_ARGS", "", environ=env
             ),
         )
         error = ""

--- a/src/mac/hgx_elastic_capacity.py
+++ b/src/mac/hgx_elastic_capacity.py
@@ -36,6 +36,8 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
+    Sequence,
+    Tuple,
 )
 
 from mac.hgx_provider import (
@@ -50,6 +52,27 @@ from mac.models import MACError, ValidationError
 
 CAPACITY_SCHEMA = "mac.hgx_elastic_capacity.v1"
 DEFAULT_STATE_PATH = "~/.mac/hgx-elastic-capacity.json"
+
+# `hgx create` has no flag for Linux capabilities, so a session provisioned on
+# a cluster whose pod spec withholds CAP_NET_ADMIN has no `/dev/net/tun` and
+# cannot run kernel-mode Tailscale (see docs/hgx-elastic-capacity.md). Whether
+# a capability-granting argument exists is a property of the provider build,
+# not of MAC, so the controller neither invents one nor hardcodes a candidate:
+# it accepts a bounded, validated argument list from the operator and appends
+# it verbatim to the arguments it already derives.
+MAX_CREATE_EXTRA_ARGS = 8
+MAX_CREATE_EXTRA_ARG_LENGTH = 64
+_CREATE_EXTRA_ARG_CHARS = frozenset(
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "0123456789"
+    "-_=:./,+"
+)
+# Placement, resource, and identity arguments are derived from the validated
+# policy and from the immutable controller-assigned name. Letting a pass-through
+# token restate them would let an operator escape the bounds this dataclass
+# exists to enforce, or rename a session the receipt already tracks by name.
+RESERVED_CREATE_ARG_FLAGS = ("--cluster", "--gpu", "--memory", "--cpu", "--name")
 
 _TERMINAL_PROVIDER_STATES = frozenset(
     {"dead", "deleted", "error", "failed", "stopped", "terminated"}
@@ -74,6 +97,46 @@ class _Provider(Protocol):
     def delete(self, session_id: str) -> str: ...
 
 
+def _validated_create_extra_args(value: Any) -> Tuple[str, ...]:
+    """Normalise operator-supplied ``hgx create`` arguments, or raise.
+
+    The tokens are appended to an argv list, never to a shell string, so the
+    hazard being guarded is not quoting: it is an argument that quietly
+    overrides the bounded placement/resource contract, or that carries
+    whitespace the provider would resplit.
+    """
+
+    if value is None:
+        return ()
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValidationError("create_extra_args must be a sequence of strings")
+    tokens = tuple(value)
+    if len(tokens) > MAX_CREATE_EXTRA_ARGS:
+        raise ValidationError(
+            "create_extra_args must contain at most %d arguments"
+            % MAX_CREATE_EXTRA_ARGS
+        )
+    for token in tokens:
+        if isinstance(token, bool) or not isinstance(token, str):
+            raise ValidationError("create_extra_args must be a sequence of strings")
+        if not token or len(token) > MAX_CREATE_EXTRA_ARG_LENGTH:
+            raise ValidationError(
+                "each create_extra_args entry must be 1..%d characters"
+                % MAX_CREATE_EXTRA_ARG_LENGTH
+            )
+        if any(ch not in _CREATE_EXTRA_ARG_CHARS for ch in token):
+            raise ValidationError(
+                "create_extra_args entries must be letters, digits, or '-_=:./,+'"
+            )
+        for reserved in RESERVED_CREATE_ARG_FLAGS:
+            if token == reserved or token.startswith(reserved + "="):
+                raise ValidationError(
+                    "%s is controlled by the capacity policy and cannot be "
+                    "passed through create_extra_args" % reserved
+                )
+    return tokens
+
+
 @dataclass(frozen=True)
 class HgxCapacityPolicy:
     """Explicit bounds for one controller invocation."""
@@ -89,6 +152,7 @@ class HgxCapacityPolicy:
     cooldown_seconds: float = 300.0
     wait_timeout_seconds: float = 300.0
     poll_interval_seconds: float = 5.0
+    create_extra_args: Tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         for name in ("min_ready", "max_sessions", "headroom", "max_create_per_run"):
@@ -144,6 +208,11 @@ class HgxCapacityPolicy:
             raise ValidationError("wait_timeout_seconds must be greater than zero")
         if self.poll_interval_seconds <= 0:
             raise ValidationError("poll_interval_seconds must be greater than zero")
+        object.__setattr__(
+            self,
+            "create_extra_args",
+            _validated_create_extra_args(self.create_extra_args),
+        )
 
     def desired_ready(self, pending_request_count: int) -> int:
         pending = _pending_count(pending_request_count)
@@ -165,7 +234,29 @@ class HgxCapacityPolicy:
             "cooldown_seconds": self.cooldown_seconds,
             "wait_timeout_seconds": self.wait_timeout_seconds,
             "poll_interval_seconds": self.poll_interval_seconds,
+            "create_extra_args": list(self.create_extra_args),
         }
+
+    def create_arguments(self) -> List[str]:
+        """The exact `hgx create` argv tail for one controller-created session.
+
+        Policy-derived placement and resource arguments come first so that an
+        operator pass-through can only add to the request, never restate a
+        bound; ``_validated_create_extra_args`` rejects the reserved flags that
+        would make the ordering matter.
+        """
+
+        return [
+            "--cluster",
+            self.cluster,
+            "--gpu",
+            str(self.gpu_count),
+            "--memory",
+            "%dGi" % self.memory_gib,
+            "--cpu",
+            str(self.cpu_count),
+            *self.create_extra_args,
+        ]
 
 
 def count_pending_provisioning_requests(requests: Iterable[Any]) -> int:
@@ -657,16 +748,7 @@ class HgxElasticCapacityController:
                 try:
                     session = self.provider.create_standard_dind(
                         name=self._new_session_name(len(created) + 1),
-                        extra_args=[
-                            "--cluster",
-                            self.policy.cluster,
-                            "--gpu",
-                            str(self.policy.gpu_count),
-                            "--memory",
-                            "%dGi" % self.policy.memory_gib,
-                            "--cpu",
-                            str(self.policy.cpu_count),
-                        ],
+                        extra_args=self.policy.create_arguments(),
                     )
                 except HgxCommandError as exc:
                     create_failure_class = _classify_create_failure(exc)

--- a/tests/test_hgx_autoscaler.py
+++ b/tests/test_hgx_autoscaler.py
@@ -218,3 +218,39 @@ def test_config_from_env_builds_bounded_step_policy() -> None:
     assert config.max_sessions == 7
     assert config.scale_up_stabilization_seconds == 180
     assert config.capacity_policy().max_create_per_run == 2
+
+
+def test_config_passes_create_args_through_and_fails_closed_on_a_bad_one() -> None:
+    """The background autoscaler creates sessions too, so it needs the same
+    `hgx create` pass-through the manual controller exposes -- and an operator
+    typo must disable the autoscaler visibly instead of crashing its thread."""
+
+    config = HgxAutoscalerConfig.from_env(
+        {
+            "MAC_HGX_AUTOSCALE_ENABLED": "1",
+            "MAC_HGX_AUTOSCALE_CREATE_ARGS": "--cap-add=NET_ADMIN --device=/dev/net/tun",
+        }
+    )
+
+    assert config.active is True
+    assert config.capacity_policy().create_extra_args == (
+        "--cap-add=NET_ADMIN",
+        "--device=/dev/net/tun",
+    )
+    assert config.to_dict()["create_extra_args"] == (
+        "--cap-add=NET_ADMIN --device=/dev/net/tun"
+    )
+
+    assert HgxAutoscalerConfig.from_env(
+        {"MAC_HGX_AUTOSCALE_ENABLED": "1"}
+    ).capacity_policy().create_extra_args == ()
+
+    rejected = HgxAutoscalerConfig.from_env(
+        {
+            "MAC_HGX_AUTOSCALE_ENABLED": "1",
+            "MAC_HGX_AUTOSCALE_CREATE_ARGS": "--cluster sneaky-cluster",
+        }
+    )
+
+    assert rejected.active is False
+    assert "--cluster" in rejected.configuration_error

--- a/tests/test_hgx_elastic_capacity.py
+++ b/tests/test_hgx_elastic_capacity.py
@@ -916,3 +916,99 @@ def test_cli_accepts_registered_agents_file_for_capacity_commands() -> None:
     assert parser.parse_args(
         ["admin", "hgx", "capacity", "status"]
     ).registered_agents_file is None
+
+
+def test_create_extra_args_are_bounded_and_cannot_restate_policy_bounds() -> None:
+    """`hgx create` has no capability flag, so the pass-through is the only way
+    an operator can request one -- and it must not become a hole in the bounds
+    the policy exists to enforce."""
+
+    policy = HgxCapacityPolicy(create_extra_args=["--cap-add=NET_ADMIN", "--tun"])
+
+    assert policy.create_extra_args == ("--cap-add=NET_ADMIN", "--tun")
+    assert policy.to_dict()["create_extra_args"] == ["--cap-add=NET_ADMIN", "--tun"]
+    assert HgxCapacityPolicy().create_extra_args == ()
+    assert HgxCapacityPolicy().to_dict()["create_extra_args"] == []
+
+    for reserved in ("--cluster", "--gpu", "--memory", "--cpu", "--name"):
+        with pytest.raises(ValidationError, match="capacity policy"):
+            HgxCapacityPolicy(create_extra_args=[reserved, "smuggled"])
+        with pytest.raises(ValidationError, match="capacity policy"):
+            HgxCapacityPolicy(create_extra_args=["%s=smuggled" % reserved])
+
+    # A flag whose name merely starts with a reserved one is not reserved.
+    assert HgxCapacityPolicy(
+        create_extra_args=["--cpu-manager-policy=static"]
+    ).create_extra_args == ("--cpu-manager-policy=static",)
+
+    with pytest.raises(ValidationError, match="at most 8"):
+        HgxCapacityPolicy(create_extra_args=["--a%d" % index for index in range(9)])
+    with pytest.raises(ValidationError, match="sequence of strings"):
+        HgxCapacityPolicy(create_extra_args="--cap-add=NET_ADMIN")
+    with pytest.raises(ValidationError, match="sequence of strings"):
+        HgxCapacityPolicy(create_extra_args=[7])
+    with pytest.raises(ValidationError, match="1..64 characters"):
+        HgxCapacityPolicy(create_extra_args=[""])
+    with pytest.raises(ValidationError, match="1..64 characters"):
+        HgxCapacityPolicy(create_extra_args=["-" * 65])
+    for hostile in ("--cap add", "--cap;rm -rf /", "--cap$(id)", "--cap\n--name"):
+        with pytest.raises(ValidationError, match="letters, digits"):
+            HgxCapacityPolicy(create_extra_args=[hostile])
+
+
+def test_execute_appends_create_extra_args_after_the_policy_arguments(
+    tmp_path: Path,
+) -> None:
+    provider = FakeProvider()
+    clock = FakeClock()
+    controller = _controller(
+        tmp_path,
+        provider,
+        clock,
+        policy=HgxCapacityPolicy(
+            min_ready=1,
+            max_sessions=2,
+            wait_timeout_seconds=10,
+            poll_interval_seconds=1,
+            create_extra_args=["--cap-add=NET_ADMIN"],
+        ),
+    )
+
+    result = controller.execute()
+
+    assert provider.created[0][2] == [
+        "--cluster",
+        "gke-newhouse",
+        "--gpu",
+        "1",
+        "--memory",
+        "64Gi",
+        "--cpu",
+        "8",
+        "--cap-add=NET_ADMIN",
+    ]
+    # The receipt records the request, so a capability-bearing session is
+    # distinguishable from a default one after the fact.
+    assert result["policy"]["create_extra_args"] == ["--cap-add=NET_ADMIN"]
+
+
+def test_capacity_cli_accepts_repeated_create_arg_and_defaults_to_none() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(
+        [
+            "admin", "hgx",
+            "capacity",
+            "execute",
+            "--create-arg=--cap-add=NET_ADMIN",
+            "--create-arg=--device=/dev/net/tun",
+        ]
+    )
+
+    assert args.create_arg == ["--cap-add=NET_ADMIN", "--device=/dev/net/tun"]
+    assert parser.parse_args(
+        ["admin", "hgx", "capacity", "plan"]
+    ).create_arg is None
+    assert parser.parse_args(
+        ["admin", "hgx", "capacity", "status"]
+    ).create_arg is None


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_4ca2519c980f47e0a5f8bc050037475f`
- head: `e3cced28cb3b075ec7aca277d56c4b38b18d66f0`
- base at push: `4434ccd1379bc9d44d0c2b24e14ab9141405617d`
