### PR TITLE
Hub verify discarded the reason it failed before classifying it (task_68ed61db520d438ca8304979e58ac755)

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -32,6 +32,8 @@ their retained sources.
 - [ADR 0023 - One skill source, thin plugins per coding harness](../adr/0023-one-skill-source-many-harness-plugins.md) — `adr/0023-one-skill-source-many-harness-plugins.md`
 - [ADR 0024 - The dashboard streams the bus, not just its counts](../adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md) — `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md`
 - [ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype](../adr/0025-the-hub-ui-is-the-observability-console.md) — `adr/0025-the-hub-ui-is-the-observability-console.md`
+- [ADR 0026: Every operation on a first-class object emits a bus event](../adr/0026-first-class-operations-emit-bus-events.md) — `adr/0026-first-class-operations-emit-bus-events.md`
+- [ADR 0027: Upgrades are versioned, ordered, and fail closed](../adr/0027-upgrades-are-versioned-and-fail-closed.md) — `adr/0027-upgrades-are-versioned-and-fail-closed.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -253,6 +253,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_HERMES_SURFACE_B64` | str | consumer-defined | deployment | Deployment setting: deploy hermes surface b64. |
 | `MAC_DEPLOY_HOLD_ADOPTIONS_FILE` | str | consumer-defined | deployment | Deployment setting: deploy hold adoptions file. |
 | `MAC_DEPLOY_HUB_AGENT` | str | consumer-defined | deployment | Deployment setting: deploy hub agent. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof attempts. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof interval seconds. |
 | `MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub tick interval seconds. |
 | `MAC_DEPLOY_HUB_TOKEN` | str | consumer-defined | deployment | Deployment setting: deploy hub token. |
 | `MAC_DEPLOY_HUB_TUNNEL_PUBKEY` | str | consumer-defined | deployment | Deployment setting: deploy hub tunnel pubkey. |
@@ -843,6 +845,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_PREREQ_QDRANT_REQUIRED` | bool | consumer-defined | core | Core setting: prereq qdrant required. |
 | `MAC_PREREQ_QDRANT_URL` | str | consumer-defined | core | Core setting: prereq qdrant url. |
 | `MAC_PREREQ_ROOT` | str | consumer-defined | core | Core setting: prereq root. |
+| `MAC_PREREQ_ROUTE_HUB_REQUIRED` | bool | consumer-defined | core | Core setting: prereq route hub required. |
 | `MAC_PREREQ_SUPERVISOR` | str | consumer-defined | core | Core setting: prereq supervisor. |
 | `MAC_PREREQ_WEBDAV_ENABLED` | bool | consumer-defined | core | Core setting: prereq webdav enabled. |
 | `MAC_PREREQ_WEBDAV_URL` | str | consumer-defined | core | Core setting: prereq webdav url. |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -37,6 +37,8 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | ADR 0023 - One skill source, thin plugins per coding harness |
 | architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | ADR 0024 - The dashboard streams the bus, not just its counts |
 | architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
+| architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
+| architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/src/mac/contract_failure.py
+++ b/src/mac/contract_failure.py
@@ -24,16 +24,26 @@ The causes are genuinely different and want different responses:
 Deliberately a pure function over evidence, with no I/O: it is the shape ADR
 0022 asks for, and it means the classifier can be tested directly against real
 failure text rather than only through a live task.
+
+This module also owns the step BEFORE classification -- deciding which bytes of
+a long failing run survive to be classified. The two belong together: a
+classifier is only as good as the text it is handed, and every classifier here
+keys on strings that a blind tail throws away. Keeping the anchors next to the
+signatures they are derived from is what makes "the excerpt still contains
+something the classifier can act on" checkable rather than hoped for.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional, Sequence, Tuple
 
 __all__ = [
     "ContractFailureCause",
     "ContractFailure",
     "classify_contract_failure",
+    "VERDICT_SIGNATURES",
+    "FAILURE_ANCHORS",
+    "capture_failure_window",
 ]
 
 
@@ -158,3 +168,103 @@ def classify_contract_failure(
             "should be rare enough to notice."
         ),
     )
+
+
+#: Output signatures proving a contract run RAN AND JUDGED THE CHANGE WANTING,
+#: as opposed to a harness that died without reaching a judgement.
+#:
+#: Lived in services.py next to the transport-fault signatures it is checked
+#: against. It moved here so the capture below can be derived from it in the
+#: same file: the anchors and the signatures are one invariant ("the excerpt
+#: keeps what the classifier reads"), and two modules cannot hold one
+#: invariant. `mac.services` re-exports it under its original name.
+#:
+#: Every entry must appear ONLY on failure. That is the whole discipline here,
+#: and it is easy to get wrong in the direction that reintroduces PR #478:
+#: `coverage safety:` was an obvious-looking candidate and is emitted whether
+#: the floors pass or fail, so it would have marked a passed-then-the-stream-
+#: died run as a rejection -- exactly the bug #478 existed to fix. Likewise
+#: `repository contract` appears in "running fail-fast repository contract
+#: preflight", which is a start message, not a verdict.
+#:
+#: When in doubt leave a signature OUT. A missing signature means a real
+#: rejection is retried as "unavailable", which wastes a run. A wrong one
+#: means a transport fault is signed as a rejection, which discards correct
+#: work.
+VERDICT_SIGNATURES: Tuple[str, ...] = (
+    "documentation contract failed",
+    "is stale:",
+    "stale generated",
+    "regenerate with",
+    "contract test failed",
+    " failed, ",         # pytest summary: "3 failed, 40 passed"
+    "assertionerror",
+    "error: process completed with exit code",
+)
+
+
+#: Where the reason for a failure is announced, in the order a run prints it.
+#: "short test summary info" is pytest's own answer to "what failed"; the rest
+#: are the verdict signatures, so anything the classifier can act on is kept.
+FAILURE_ANCHORS: Tuple[str, ...] = ("short test summary info",) + VERDICT_SIGNATURES
+
+
+def capture_failure_window(
+    output: str,
+    *,
+    anchors: Sequence[str] = FAILURE_ANCHORS,
+    head: int = 1500,
+    window: int = 2000,
+    tail: int = 1000,
+) -> str:
+    """Keep the head, the TAIL, and the part that says why the run failed.
+
+    Head-and-tail is not enough here, which is the trap this replaced a blind
+    tail with. A failing contract run prints, in order: a session header,
+    several hundred lines of pytest progress, the failure and its summary, a
+    whole-repo coverage report (one row per source file, ~14KB), a coverage
+    line whose floors both PASSED, and -- last -- OpenShell's generic
+    "ssh exited with status 1". The verdict sits in the middle, out of reach
+    of both ends, so a fixed head and tail preserve the two regions that say
+    nothing and drop the only one that does.
+
+    Position is the wrong selector. Anchor on the text that announces the
+    failure and keep a window around its LAST occurrence, so the excerpt still
+    carries a verdict signature after truncation and a rejection stays
+    classifiable as a rejection.
+
+    Safe to apply more than once, which is what lets every stage that bounds
+    the same output call THIS instead of slicing a tail of its own: re-running
+    it re-finds the same anchor, converges within two passes, and keeps the
+    reason on every one. A second `[-2000:]` downstream instead cuts the
+    anchored middle back out and restores the original bug one layer further
+    down.
+    """
+
+    text = (output or "").strip()
+    if len(text) <= head + window + tail:
+        return text
+
+    spans = [(0, head), (len(text) - tail, len(text))]
+    lowered = text.lower()
+    found = [lowered.rfind(a) for a in anchors]
+    anchor_at = max(found) if found else -1
+    if anchor_at >= 0:
+        start = max(0, anchor_at - window // 4)
+        spans.append((start, min(len(text), start + window)))
+
+    merged: List[Tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+
+    parts: List[str] = []
+    previous = 0
+    for start, end in merged:
+        if start > previous:
+            parts.append("... [%d chars omitted] ..." % (start - previous))
+        parts.append(text[start:end])
+        previous = end
+    return "\n".join(parts)

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -2981,6 +2981,28 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy hub route proof attempts.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy hub route proof interval seconds.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy hub tick interval seconds.",
     "family": "deployment",
     "name": "MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS",
@@ -9938,6 +9960,17 @@
       "deploy/deploy-mac-fleet.sh"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: prereq route hub required.",
+    "family": "core",
+    "name": "MAC_PREREQ_ROUTE_HUB_REQUIRED",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "bool"
   },
   {
     "default": null,

--- a/src/mac/merge_queue.py
+++ b/src/mac/merge_queue.py
@@ -56,6 +56,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
+from mac.contract_failure import capture_failure_window
+
 GitRunner = Callable[[Sequence[str]], "subprocess.CompletedProcess"]
 ContractTestRunner = Callable[[str, str, str, str], Tuple[int, str]]
 
@@ -264,7 +266,16 @@ def validate_projected_merge_contract(
             projected_sha=projected_sha,
             test_command=command,
             test_returncode=returncode,
-            output_tail=output_tail[-2000:],
+            # NOT `output_tail[-2000:]`. The runner already hands back a
+            # relevance-selected excerpt, and a blind tail of a contract run
+            # is its coverage table plus "ssh exited with status 1" -- the two
+            # regions that say nothing about why it failed. Re-slicing here
+            # cut the anchored middle back out, so a gate that rejected a
+            # change for a stale generated registry recorded a transport
+            # fault instead. Bound it with the same anchored capture the hub
+            # uses: re-selecting an anchored window converges on the same
+            # region, so applying it twice is safe where slicing twice is not.
+            output_tail=capture_failure_window(output_tail),
             error=error,
         )
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -60,6 +60,7 @@ from mac.agentbus_control import (
 if TYPE_CHECKING:
     from mac.executor_directive import TaskOwnershipVerdict
 from mac.attempt_failure_classifier import classify_attempt_failure
+from mac.contract_failure import VERDICT_SIGNATURES, capture_failure_window
 from mac.dispatch_advisor import DISPATCH_ASSIGNMENT_ADVISOR_VERSION
 from mac.gitops import validate_git_ref
 from mac.repository_contract import (
@@ -1006,7 +1007,9 @@ REPOSITORY_CONTRACT_FILES = (
 #: judging the work deficient. One task was rejected, redone more thoroughly
 #: (58 tests -> 60, 2 files -> 11, ruff and a CodeGraph audit added), and
 #: rejected identically, because the verdict never depended on the diff.
-#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING.
+#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING now
+#: live in mac.contract_failure, next to the failure anchors derived from them
+#: and the capture that keeps them; re-exported here under the original name.
 #:
 #: Checked BEFORE the unavailable signatures, and they win, because the two
 #: overlap in exactly the case that matters.
@@ -1032,30 +1035,10 @@ REPOSITORY_CONTRACT_FILES = (
 #: The discriminator is whether the gate reached a judgement. It is not
 #: "did the gate produce output": in the #478 case the coverage gate ran and
 #: PASSED before the stream died, so output alone would have called that a
-#: rejection too. Only an explicit FAILING verdict counts.
-#: Every entry must appear ONLY on failure. That is the whole discipline here,
-#: and it is easy to get wrong in the direction that reintroduces #478:
-#: `coverage safety:` was an obvious-looking candidate and is emitted whether
-#: the floors pass or fail, so it would have marked the original
-#: passed-then-the-stream-died run as a rejection -- exactly the bug #478
-#: existed to fix. Likewise `repository contract` appears in
-#: "running fail-fast repository contract preflight", which is a start
-#: message, not a verdict.
-#:
-#: When in doubt leave a signature OUT. A missing signature means a real
-#: rejection is retried as "unavailable", which wastes a run. A wrong one
-#: means a transport fault is signed as a rejection, which discards correct
-#: work and is what this pair of fixes is for.
-_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = (
-    "documentation contract failed",
-    "is stale:",
-    "stale generated",
-    "regenerate with",
-    "contract test failed",
-    " failed, ",         # pytest summary: "3 failed, 40 passed"
-    "assertionerror",
-    "error: process completed with exit code",
-)
+#: rejection too. Only an explicit FAILING verdict counts. The rule for adding
+#: an entry, and why a wrong one is worse than a missing one, is recorded with
+#: the tuple itself.
+_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = VERDICT_SIGNATURES
 
 
 _HUB_VERIFY_UNAVAILABLE_SIGNATURES: Tuple[str, ...] = (
@@ -1127,61 +1110,6 @@ def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 15
     )
 
 
-#: Where the reason for a failure is announced, in the order a run prints it.
-#: "short test summary info" is pytest's own answer to "what failed"; the rest
-#: are the verdict signatures, so anything the classifier can act on is kept.
-_HUB_VERIFY_FAILURE_ANCHORS: Tuple[str, ...] = (
-    "short test summary info",
-) + _HUB_VERIFY_VERDICT_SIGNATURES
-
-
-def _hub_verify_output_excerpt(
-    output: str, *, head: int = 1500, window: int = 2000, tail: int = 1000
-) -> str:
-    """Keep the head, the TAIL, and the part that says why the run failed.
-
-    Head-and-tail is not enough here, which is the trap this replaced a blind
-    tail with. A failing contract run prints, in order: a session header,
-    several hundred lines of pytest progress, the failure and its summary, a
-    whole-repo coverage report (one row per source file, ~14KB), a coverage
-    line whose floors both PASSED, and -- last -- OpenShell's generic
-    "ssh exited with status 1". The verdict sits in the middle, out of reach
-    of both ends, so a fixed head and tail preserve the two regions that say
-    nothing and drop the only one that does.
-
-    Position is the wrong selector. Anchor on the text that announces the
-    failure and keep a window around its LAST occurrence, so the excerpt still
-    carries a verdict signature after truncation and a rejection stays
-    classifiable as a rejection.
-    """
-
-    text = (output or "").strip()
-    if len(text) <= head + window + tail:
-        return text
-
-    spans = [(0, head), (len(text) - tail, len(text))]
-    lowered = text.lower()
-    found = [lowered.rfind(a) for a in _HUB_VERIFY_FAILURE_ANCHORS]
-    anchor_at = max(found)
-    if anchor_at >= 0:
-        start = max(0, anchor_at - window // 4)
-        spans.append((start, min(len(text), start + window)))
-
-    merged: List[Tuple[int, int]] = []
-    for start, end in sorted(spans):
-        if merged and start <= merged[-1][1]:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-        else:
-            merged.append((start, end))
-
-    parts: List[str] = []
-    previous = 0
-    for start, end in merged:
-        if start > previous:
-            parts.append("... [%d chars omitted] ..." % (start - previous))
-        parts.append(text[start:end])
-        previous = end
-    return "\n".join(parts)
 
 
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
@@ -27833,7 +27761,10 @@ class ControlPlane:
                 # table and OpenShell's generic "ssh exited with status 1" --
                 # so a real rejection was unclassifiable by construction and
                 # retried forever (six tasks, ~6 hours, 2026-08-20).
-                return int(proc.returncode), _hub_verify_output_excerpt(out)
+                #
+                # The publication gate bounds this same text again, and calls
+                # THIS function to do it. One capture, one place to change it.
+                return int(proc.returncode), capture_failure_window(out)
             finally:
                 subprocess.run([openshell, "sandbox", "delete", name], capture_output=True, text=True, timeout=60, check=False)
         finally:
@@ -28270,7 +28201,7 @@ class ControlPlane:
                 int(returncode),
                 str(test_command or "scripts/run-contract-tests.sh")[:200],
                 # Already bounded and relevance-selected at the capture site
-                # (_hub_verify_output_excerpt). Excerpting an excerpt would
+                # (capture_failure_window). Excerpting an excerpt would
                 # cut the middle back out -- and the middle is the anchored
                 # window holding the reason this was rejected.
                 output.strip() or "nonzero exit",

--- a/tests/test_publication_gate_failure_window.py
+++ b/tests/test_publication_gate_failure_window.py
@@ -1,0 +1,197 @@
+"""The publication gate was the last place the failure reason was thrown away.
+
+The hub's capture was fixed to keep an anchored window around the text that
+announces a failure, so a rejection stays classifiable as a rejection. The
+publication path then ran the SAME output through
+``validate_projected_merge_contract``, whose verdict helper took
+``output_tail[-2000:]``.
+
+A blind tail of a contract run is its coverage table plus OpenShell's generic
+"ssh exited with status 1" -- run-contract-tests.sh prints the pytest failure
+first, then an unconditional whole-repo ``coverage report`` (one row per source
+file, ~14KB), then a coverage summary whose floors both PASSED, and only then
+exits with the saved pytest status. So the second truncation cut the anchored
+middle back out and restored the original bug one layer down: a gate that
+rejected a change for a real, actionable reason recorded a transport fault.
+
+Observed as the reason a real task was rejected on 2026-08-21 -- the gate had
+found "stale generated environment registry: src/mac/data/env_config_registry
+.json; run scripts/generate-env-config-registry.py", which is a verdict
+signature, and none of it reached the recorded evidence.
+
+The invariant these tests hold is one sentence: every stage that bounds the
+same output calls the same anchored capture, and re-applying that capture
+never loses the reason.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mac.contract_failure import (
+    FAILURE_ANCHORS,
+    VERDICT_SIGNATURES,
+    capture_failure_window,
+)
+from mac.merge_queue import validate_projected_merge_contract
+from mac.services import hub_verification_unavailable_reason
+
+# One row per source file, emitted AFTER the failure and BEFORE the exit, so it
+# is exactly what a blind tail keeps. It grows with the repository, which is
+# why no fixed tail size wins this race.
+COVERAGE_TABLE = "\n".join(
+    "src/mac/module_%03d.py%s500     40    92%%" % (i, " " * 8) for i in range(235)
+)
+
+PYTEST_PROGRESS = "\n".join(
+    "tests/test_module_%03d.py ......................... [ %2d%%]" % (i, i % 100)
+    for i in range(400)
+)
+
+# The reason, sitting between several hundred lines of progress and the
+# coverage table -- out of reach of a head and of a tail alike.
+PYTEST_FAILURE = (
+    "=================================== FAILURES ===================================\n"
+    "E   AssertionError: expected 1 got 0\n"
+    "=========================== short test summary info ===========================\n"
+    "FAILED tests/test_task_batch.py::test_the_preview_and_the_apply_agree\n"
+    "3 failed, 1204 passed, 11 skipped in 612.44s\n"
+)
+
+FAILING_RUN = (
+    "============================= test session starts ==============================\n"
+    "collected 1218 items\n"
+    + PYTEST_PROGRESS
+    + "\n"
+    + PYTEST_FAILURE
+    + COVERAGE_TABLE
+    + "\ncoverage safety: statements 70802/77880 (90.91%, floor 90.00%); "
+    "branches 20708/25192 (82.20%, floor 80.00%)\n"
+    "  - Uploading files to /sandbox...\n  + Files uploaded\n"
+    "Error:   x ssh exited with status exit status: 1"
+)
+
+#: What the hub's runner actually hands the publication gate: already bounded,
+#: already relevance-selected. The gate's job is to record it, not to re-cut it.
+HUB_CAPTURE = capture_failure_window(FAILING_RUN)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "r"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "t@t.invalid")
+    _git(r, "config", "user.name", "t")
+    (r / "f.txt").write_text("base\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    _git(r, "checkout", "-q", "-b", "topic", "main")
+    (r / "topic.txt").write_text("topic\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "topic change")
+    _git(r, "checkout", "-q", "main")
+    return r
+
+
+def _gate_verdict(repo: Path, output: str):
+    return validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (1, output),
+    )
+
+
+def test_the_recorded_reason_still_classifies_as_a_rejection(repo: Path):
+    """The bug, stated as the behaviour that matters."""
+    verdict = _gate_verdict(repo, HUB_CAPTURE)
+
+    assert verdict.passed is False
+    assert hub_verification_unavailable_reason(verdict.output_tail) is None
+
+
+def test_the_recorded_reason_names_what_failed(repo: Path):
+    """A rejection nobody can act on is barely better than no verdict."""
+    verdict = _gate_verdict(repo, HUB_CAPTURE)
+
+    assert "short test summary info" in verdict.output_tail
+    assert "3 failed, 1204 passed" in verdict.output_tail
+    assert "test_the_preview_and_the_apply_agree" in verdict.output_tail
+
+
+def test_the_blind_tail_that_caused_this_would_still_fail(repo: Path):
+    """Guards against a revert to a tail with a bigger number.
+
+    The coverage table grows with the repository, so the discarded prefix grows
+    with it too; only anchoring on the failure text is stable.
+    """
+    assert (
+        hub_verification_unavailable_reason(HUB_CAPTURE[-2000:])
+        == "ssh exited with status"
+    )
+
+
+def test_the_gate_still_bounds_what_it_records(repo: Path):
+    """Fixing the truncation must not turn the verdict into a 14KB blob.
+
+    ``ProjectedMergeContractVerdict.to_dict()`` is recorded on the task, so an
+    unbounded tail would put a whole contract run into the ledger for every
+    failed publication.
+    """
+    verdict = _gate_verdict(repo, FAILING_RUN)
+
+    assert len(FAILING_RUN) > 10_000
+    assert len(verdict.output_tail) < len(FAILING_RUN) // 2
+
+
+def test_applying_the_capture_again_never_loses_the_reason():
+    """Why calling it twice (hub, then gate) is safe where slicing twice is not.
+
+    Re-selecting an anchored window converges -- it re-finds the same anchor
+    and settles within two passes -- and every pass keeps the reason. A second
+    ``[-2000:]`` instead discards it, which is the defect this file is about.
+    """
+    text = FAILING_RUN
+    for _pass in range(4):
+        text = capture_failure_window(text)
+        assert "short test summary info" in text
+        assert hub_verification_unavailable_reason(text) is None
+
+    assert capture_failure_window(text) == text
+
+
+def test_a_passing_gate_records_its_output_unchanged(repo: Path):
+    """Short output is kept verbatim; the window only applies once it must."""
+    verdict = validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (0, "full suite passed"),
+    )
+
+    assert verdict.passed is True
+    assert verdict.output_tail == "full suite passed"
+
+
+@pytest.mark.parametrize("signature", sorted(VERDICT_SIGNATURES))
+def test_every_verdict_signature_is_also_a_capture_anchor(signature: str):
+    """The invariant that ties the capture to the classifier.
+
+    A signature the classifier reads but the capture does not anchor on is a
+    rejection that survives classification only by luck of position -- which is
+    the whole failure mode. Adding one without the other should fail here
+    rather than six hours into a retry loop.
+    """
+    assert signature in FAILURE_ANCHORS


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_68ed61db520d438ca8304979e58ac755`
- head: `b068f5f29f3928cc162677b08e8d66d65c9ce019`
- base at push: `4434ccd1379bc9d44d0c2b24e14ab9141405617d`
