### PR TITLE
Hub verify discarded the reason it failed before classifying it (task_68ed61db520d438ca8304979e58ac755)

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -32,6 +32,8 @@ their retained sources.
 - [ADR 0023 - One skill source, thin plugins per coding harness](../adr/0023-one-skill-source-many-harness-plugins.md) — `adr/0023-one-skill-source-many-harness-plugins.md`
 - [ADR 0024 - The dashboard streams the bus, not just its counts](../adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md) — `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md`
 - [ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype](../adr/0025-the-hub-ui-is-the-observability-console.md) — `adr/0025-the-hub-ui-is-the-observability-console.md`
+- [ADR 0026: Every operation on a first-class object emits a bus event](../adr/0026-first-class-operations-emit-bus-events.md) — `adr/0026-first-class-operations-emit-bus-events.md`
+- [ADR 0027: Upgrades are versioned, ordered, and fail closed](../adr/0027-upgrades-are-versioned-and-fail-closed.md) — `adr/0027-upgrades-are-versioned-and-fail-closed.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -253,6 +253,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_HERMES_SURFACE_B64` | str | consumer-defined | deployment | Deployment setting: deploy hermes surface b64. |
 | `MAC_DEPLOY_HOLD_ADOPTIONS_FILE` | str | consumer-defined | deployment | Deployment setting: deploy hold adoptions file. |
 | `MAC_DEPLOY_HUB_AGENT` | str | consumer-defined | deployment | Deployment setting: deploy hub agent. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof attempts. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof interval seconds. |
 | `MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub tick interval seconds. |
 | `MAC_DEPLOY_HUB_TOKEN` | str | consumer-defined | deployment | Deployment setting: deploy hub token. |
 | `MAC_DEPLOY_HUB_TUNNEL_PUBKEY` | str | consumer-defined | deployment | Deployment setting: deploy hub tunnel pubkey. |
@@ -843,6 +845,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_PREREQ_QDRANT_REQUIRED` | bool | consumer-defined | core | Core setting: prereq qdrant required. |
 | `MAC_PREREQ_QDRANT_URL` | str | consumer-defined | core | Core setting: prereq qdrant url. |
 | `MAC_PREREQ_ROOT` | str | consumer-defined | core | Core setting: prereq root. |
+| `MAC_PREREQ_ROUTE_HUB_REQUIRED` | bool | consumer-defined | core | Core setting: prereq route hub required. |
 | `MAC_PREREQ_SUPERVISOR` | str | consumer-defined | core | Core setting: prereq supervisor. |
 | `MAC_PREREQ_WEBDAV_ENABLED` | bool | consumer-defined | core | Core setting: prereq webdav enabled. |
 | `MAC_PREREQ_WEBDAV_URL` | str | consumer-defined | core | Core setting: prereq webdav url. |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -37,6 +37,8 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | ADR 0023 - One skill source, thin plugins per coding harness |
 | architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | ADR 0024 - The dashboard streams the bus, not just its counts |
 | architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
+| architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
+| architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/src/mac/contract_failure.py
+++ b/src/mac/contract_failure.py
@@ -24,16 +24,28 @@ The causes are genuinely different and want different responses:
 Deliberately a pure function over evidence, with no I/O: it is the shape ADR
 0022 asks for, and it means the classifier can be tested directly against real
 failure text rather than only through a live task.
+
+This module also owns the step BEFORE classification: deciding which bytes of
+a long failing run survive to be classified at all. The two belong together,
+because a classifier is only as good as the text it is handed and every
+classifier here keys on strings that a blind tail throws away. Keeping the
+capture next to the signatures it is derived from is what makes "the excerpt
+still contains something a classifier can act on" checkable rather than hoped
+for -- and it gives every stage that bounds the same output one function to
+call instead of a tail of its own.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional, Sequence, Tuple
 
 __all__ = [
     "ContractFailureCause",
     "ContractFailure",
     "classify_contract_failure",
+    "VERDICT_SIGNATURES",
+    "FAILURE_ANCHORS",
+    "capture_failure_window",
 ]
 
 
@@ -158,3 +170,104 @@ def classify_contract_failure(
             "should be rare enough to notice."
         ),
     )
+
+
+#: Output signatures proving a contract run RAN AND JUDGED THE CHANGE WANTING,
+#: as opposed to a harness that died before reaching a judgement.
+#:
+#: These lived in `mac.services`, next to the transport-fault signatures they
+#: are checked against. They moved here so the capture below can be derived
+#: from them in the same file: the anchors and the signatures are one
+#: invariant -- "the excerpt keeps what the classifier reads" -- and two
+#: modules cannot hold one invariant between them. `mac.services` re-exports
+#: this tuple under its original name.
+#:
+#: Every entry must appear ONLY on failure. That is the whole discipline here,
+#: and it is easy to get wrong in the direction that reintroduces PR #478:
+#: `coverage safety:` was an obvious-looking candidate and is emitted whether
+#: the floors pass or fail, so it would have marked a passed-then-the-stream-
+#: died run as a rejection -- exactly the bug #478 existed to fix. Likewise
+#: `repository contract` appears in "running fail-fast repository contract
+#: preflight", which is a start message, not a verdict.
+#:
+#: When in doubt leave a signature OUT. A missing signature means a real
+#: rejection is retried as "unavailable", which wastes a run. A wrong one
+#: means a transport fault is signed as a rejection, which discards correct
+#: work.
+VERDICT_SIGNATURES: Tuple[str, ...] = (
+    "documentation contract failed",
+    "is stale:",
+    "stale generated",
+    "regenerate with",
+    "contract test failed",
+    " failed, ",         # pytest summary: "3 failed, 40 passed"
+    "assertionerror",
+    "error: process completed with exit code",
+)
+
+
+#: Where the reason for a failure is announced, in the order a run prints it.
+#: "short test summary info" is pytest's own answer to "what failed"; the rest
+#: are the verdict signatures, so anything a classifier can act on is kept.
+FAILURE_ANCHORS: Tuple[str, ...] = ("short test summary info",) + VERDICT_SIGNATURES
+
+
+def capture_failure_window(
+    output: str,
+    *,
+    anchors: Sequence[str] = FAILURE_ANCHORS,
+    head: int = 1500,
+    window: int = 2000,
+    tail: int = 1000,
+) -> str:
+    """Keep the head, the TAIL, and the part that says why the run failed.
+
+    Head-and-tail is not enough here, which is the trap that replaced a blind
+    tail. A failing contract run prints, in order: a session header, several
+    hundred lines of pytest progress, the failure and its summary, a whole-repo
+    coverage report (one row per source file, ~14KB), a coverage line whose
+    floors both PASSED, and -- last -- OpenShell's generic "ssh exited with
+    status 1". The verdict sits in the middle, out of reach of both ends, so a
+    fixed head and tail preserve the two regions that say nothing and drop the
+    only one that does.
+
+    Position is the wrong selector. Anchor on the text that announces the
+    failure and keep a window around its LAST occurrence, so the excerpt still
+    carries a verdict signature after truncation and a rejection stays
+    classifiable as a rejection.
+
+    Safe to apply more than once, which is what lets every stage that bounds
+    the same output call THIS instead of slicing a tail of its own: re-running
+    it re-finds the same anchor and keeps the reason on every pass. A blind
+    `[-2000:]` applied downstream instead cuts the anchored middle back out and
+    restores the original bug one layer further down -- which is exactly what
+    the publication gate was doing to the hub's already-anchored capture.
+    """
+
+    text = (output or "").strip()
+    if len(text) <= head + window + tail:
+        return text
+
+    spans = [(0, head), (len(text) - tail, len(text))]
+    lowered = text.lower()
+    found = [lowered.rfind(anchor.lower()) for anchor in anchors]
+    anchor_at = max(found) if found else -1
+    if anchor_at >= 0:
+        start = max(0, anchor_at - window // 4)
+        spans.append((start, min(len(text), start + window)))
+
+    merged: List[Tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+
+    parts: List[str] = []
+    previous = 0
+    for start, end in merged:
+        if start > previous:
+            parts.append("... [%d chars omitted] ..." % (start - previous))
+        parts.append(text[start:end])
+        previous = end
+    return "\n".join(parts)

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -2981,6 +2981,28 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy hub route proof attempts.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy hub route proof interval seconds.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy hub tick interval seconds.",
     "family": "deployment",
     "name": "MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS",
@@ -9938,6 +9960,17 @@
       "deploy/deploy-mac-fleet.sh"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: prereq route hub required.",
+    "family": "core",
+    "name": "MAC_PREREQ_ROUTE_HUB_REQUIRED",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "bool"
   },
   {
     "default": null,

--- a/src/mac/merge_queue.py
+++ b/src/mac/merge_queue.py
@@ -56,6 +56,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
+from mac.contract_failure import capture_failure_window
+
 GitRunner = Callable[[Sequence[str]], "subprocess.CompletedProcess"]
 ContractTestRunner = Callable[[str, str, str, str], Tuple[int, str]]
 
@@ -264,7 +266,17 @@ def validate_projected_merge_contract(
             projected_sha=projected_sha,
             test_command=command,
             test_returncode=returncode,
-            output_tail=output_tail[-2000:],
+            # NOT `output_tail[-2000:]`. The runner hands back an excerpt that
+            # is already bounded and already selected for relevance, and a
+            # blind tail of a contract run is its coverage table plus "ssh
+            # exited with status 1" -- the two regions that say nothing about
+            # why it failed. Re-slicing here cut the anchored middle back out,
+            # so a gate that rejected a change for a stale generated registry
+            # was recorded, one layer down, as an unexplained failure. Bound
+            # it with the same anchored capture the hub uses: re-selecting an
+            # anchored window re-finds the same region, so applying it twice
+            # is safe where slicing twice is not.
+            output_tail=capture_failure_window(output_tail),
             error=error,
         )
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -60,6 +60,7 @@ from mac.agentbus_control import (
 if TYPE_CHECKING:
     from mac.executor_directive import TaskOwnershipVerdict
 from mac.attempt_failure_classifier import classify_attempt_failure
+from mac.contract_failure import VERDICT_SIGNATURES, capture_failure_window
 from mac.dispatch_advisor import DISPATCH_ASSIGNMENT_ADVISOR_VERSION
 from mac.gitops import validate_git_ref
 from mac.repository_contract import (
@@ -1006,7 +1007,10 @@ REPOSITORY_CONTRACT_FILES = (
 #: judging the work deficient. One task was rejected, redone more thoroughly
 #: (58 tests -> 60, 2 files -> 11, ruff and a CodeGraph audit added), and
 #: rejected identically, because the verdict never depended on the diff.
-#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING.
+#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING now
+#: live in `mac.contract_failure`, next to the failure anchors derived from
+#: them and the capture that keeps them; re-exported here under the original
+#: name.
 #:
 #: Checked BEFORE the unavailable signatures, and they win, because the two
 #: overlap in exactly the case that matters.
@@ -1032,30 +1036,10 @@ REPOSITORY_CONTRACT_FILES = (
 #: The discriminator is whether the gate reached a judgement. It is not
 #: "did the gate produce output": in the #478 case the coverage gate ran and
 #: PASSED before the stream died, so output alone would have called that a
-#: rejection too. Only an explicit FAILING verdict counts.
-#: Every entry must appear ONLY on failure. That is the whole discipline here,
-#: and it is easy to get wrong in the direction that reintroduces #478:
-#: `coverage safety:` was an obvious-looking candidate and is emitted whether
-#: the floors pass or fail, so it would have marked the original
-#: passed-then-the-stream-died run as a rejection -- exactly the bug #478
-#: existed to fix. Likewise `repository contract` appears in
-#: "running fail-fast repository contract preflight", which is a start
-#: message, not a verdict.
-#:
-#: When in doubt leave a signature OUT. A missing signature means a real
-#: rejection is retried as "unavailable", which wastes a run. A wrong one
-#: means a transport fault is signed as a rejection, which discards correct
-#: work and is what this pair of fixes is for.
-_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = (
-    "documentation contract failed",
-    "is stale:",
-    "stale generated",
-    "regenerate with",
-    "contract test failed",
-    " failed, ",         # pytest summary: "3 failed, 40 passed"
-    "assertionerror",
-    "error: process completed with exit code",
-)
+#: rejection too. Only an explicit FAILING verdict counts. The rule for adding
+#: an entry -- every signature must appear ONLY on failure -- and why a wrong
+#: one is worse than a missing one are recorded with the tuple itself.
+_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = VERDICT_SIGNATURES
 
 
 _HUB_VERIFY_UNAVAILABLE_SIGNATURES: Tuple[str, ...] = (
@@ -1125,63 +1109,6 @@ def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 15
         omitted,
         text[-tail:],
     )
-
-
-#: Where the reason for a failure is announced, in the order a run prints it.
-#: "short test summary info" is pytest's own answer to "what failed"; the rest
-#: are the verdict signatures, so anything the classifier can act on is kept.
-_HUB_VERIFY_FAILURE_ANCHORS: Tuple[str, ...] = (
-    "short test summary info",
-) + _HUB_VERIFY_VERDICT_SIGNATURES
-
-
-def _hub_verify_output_excerpt(
-    output: str, *, head: int = 1500, window: int = 2000, tail: int = 1000
-) -> str:
-    """Keep the head, the TAIL, and the part that says why the run failed.
-
-    Head-and-tail is not enough here, which is the trap this replaced a blind
-    tail with. A failing contract run prints, in order: a session header,
-    several hundred lines of pytest progress, the failure and its summary, a
-    whole-repo coverage report (one row per source file, ~14KB), a coverage
-    line whose floors both PASSED, and -- last -- OpenShell's generic
-    "ssh exited with status 1". The verdict sits in the middle, out of reach
-    of both ends, so a fixed head and tail preserve the two regions that say
-    nothing and drop the only one that does.
-
-    Position is the wrong selector. Anchor on the text that announces the
-    failure and keep a window around its LAST occurrence, so the excerpt still
-    carries a verdict signature after truncation and a rejection stays
-    classifiable as a rejection.
-    """
-
-    text = (output or "").strip()
-    if len(text) <= head + window + tail:
-        return text
-
-    spans = [(0, head), (len(text) - tail, len(text))]
-    lowered = text.lower()
-    found = [lowered.rfind(a) for a in _HUB_VERIFY_FAILURE_ANCHORS]
-    anchor_at = max(found)
-    if anchor_at >= 0:
-        start = max(0, anchor_at - window // 4)
-        spans.append((start, min(len(text), start + window)))
-
-    merged: List[Tuple[int, int]] = []
-    for start, end in sorted(spans):
-        if merged and start <= merged[-1][1]:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-        else:
-            merged.append((start, end))
-
-    parts: List[str] = []
-    previous = 0
-    for start, end in merged:
-        if start > previous:
-            parts.append("... [%d chars omitted] ..." % (start - previous))
-        parts.append(text[start:end])
-        previous = end
-    return "\n".join(parts)
 
 
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
@@ -27833,7 +27760,11 @@ class ControlPlane:
                 # table and OpenShell's generic "ssh exited with status 1" --
                 # so a real rejection was unclassifiable by construction and
                 # retried forever (six tasks, ~6 hours, 2026-08-20).
-                return int(proc.returncode), _hub_verify_output_excerpt(out)
+                #
+                # The publication gate bounds this same text again on its own
+                # path, and calls THIS function to do it. One capture, one
+                # place to change it, and no stage that can undo another's.
+                return int(proc.returncode), capture_failure_window(out)
             finally:
                 subprocess.run([openshell, "sandbox", "delete", name], capture_output=True, text=True, timeout=60, check=False)
         finally:
@@ -28270,7 +28201,7 @@ class ControlPlane:
                 int(returncode),
                 str(test_command or "scripts/run-contract-tests.sh")[:200],
                 # Already bounded and relevance-selected at the capture site
-                # (_hub_verify_output_excerpt). Excerpting an excerpt would
+                # (capture_failure_window). Excerpting an excerpt would
                 # cut the middle back out -- and the middle is the anchored
                 # window holding the reason this was rejected.
                 output.strip() or "nonzero exit",

--- a/tests/test_publication_gate_failure_window.py
+++ b/tests/test_publication_gate_failure_window.py
@@ -1,0 +1,189 @@
+"""The publication gate must not re-truncate the hub's anchored capture.
+
+`_hub_verify_run_contract_test` selects the bytes of a failing contract run
+that say WHY it failed, because a blind tail of that run says nothing: the
+pytest failure is printed first, then an unconditional whole-repo `coverage
+report` (one row per source file, ~14KB), then a coverage summary whose floors
+both PASSED, and only last OpenShell's generic "ssh exited with status 1".
+
+The publication gate calls that same runner, and then applied
+``output_tail[-2000:]`` to what came back. A tail of an anchored excerpt is a
+tail again -- it cuts out precisely the middle the capture existed to keep --
+and `contract_gate.output_tail` is the whole diagnosis a publication failure
+carries. So the fix at the hub's capture site was undone one layer down, on the
+path that decides whether a change may land.
+
+These tests pin the composition, not either half: whatever the runner hands
+back, what the gate records still names the reason.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mac.contract_failure import capture_failure_window
+from mac.merge_queue import validate_projected_merge_contract
+from mac.services import hub_verification_unavailable_reason
+
+# A whole-repo `coverage report` is one row per source file, emitted AFTER the
+# failure and before the exit. It is what a blind tail keeps.
+COVERAGE_TABLE = "\n".join(
+    "src/mac/module_%03d.py%s500     40    92%%" % (i, " " * 8) for i in range(235)
+)
+
+# pytest's own progress output, which precedes the failure it reports.
+PYTEST_PROGRESS = "\n".join(
+    "tests/test_module_%03d.py ......................... [ %2d%%]" % (i, i % 100)
+    for i in range(400)
+)
+
+# The real rejection reason from a run on 2026-08-21, verbatim in shape: a
+# generated artifact the change left stale. It is announced once, in the
+# middle, and it is actionable -- which is the whole point of keeping it.
+STALE_REGISTRY = (
+    "stale generated environment registry: src/mac/data/env_config_registry.json, "
+    "docs/env-config-reference.md; run scripts/generate-env-config-registry.py"
+)
+
+TAIL_AFTER_THE_VERDICT = (
+    "\ncoverage safety: statements 70802/77880 (90.91%, floor 90.00%); "
+    "branches 20708/25192 (82.20%, floor 80.00%)\n"
+    "  - Uploading files to /sandbox...\n  + Files uploaded\n"
+    "Error:   x ssh exited with status exit status: 1"
+)
+
+FAILING_RUN = (
+    "============================= test session starts ==============================\n"
+    "collected 1218 items\n"
+    + PYTEST_PROGRESS
+    + "\n"
+    + STALE_REGISTRY
+    + "\n=========================== short test summary info ===========================\n"
+    "FAILED tests/test_task_batch.py::test_the_preview_and_the_apply_agree\n"
+    "3 failed, 1204 passed, 11 skipped in 612.44s\n"
+    + COVERAGE_TABLE
+    + TAIL_AFTER_THE_VERDICT
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "r"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "t@t.invalid")
+    _git(r, "config", "user.name", "t")
+    (r / "f.txt").write_text("line1\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    _git(r, "checkout", "-q", "-b", "topic", "main")
+    (r / "topic.txt").write_text("topic\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "topic change")
+    _git(r, "checkout", "-q", "main")
+    return r
+
+
+def _gate(repo: Path, output: str):
+    """Run the real gate against a runner that fails with ``output``."""
+    return validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (1, output),
+    )
+
+
+def test_the_gate_records_why_the_contract_run_failed(repo: Path):
+    """The bug, stated as the behaviour that matters."""
+    verdict = _gate(repo, FAILING_RUN)
+
+    assert verdict.passed is False
+    assert STALE_REGISTRY in verdict.output_tail
+
+
+def test_the_recorded_diagnosis_names_the_failing_test(repo: Path):
+    """`contract_gate.output_tail` IS the diagnosis a publication failure
+    carries (services.py raises `error or output_tail`). A diagnosis nobody can
+    act on costs an attempt and teaches the next one nothing."""
+    verdict = _gate(repo, FAILING_RUN)
+
+    assert "short test summary info" in verdict.output_tail
+    assert "test_the_preview_and_the_apply_agree" in verdict.output_tail
+    assert "3 failed, 1204 passed" in verdict.output_tail
+
+
+def test_the_recorded_output_is_still_bounded(repo: Path):
+    """Keeping the reason is not a licence to record the whole run: the tail
+    was there to bound a ~50KB capture, and that bound still holds."""
+    verdict = _gate(repo, FAILING_RUN)
+
+    assert len(FAILING_RUN) > 20000
+    assert len(verdict.output_tail) <= 6000
+    assert "chars omitted" in verdict.output_tail
+
+
+def test_the_blind_tail_that_caused_this_would_still_fail(repo: Path):
+    """Guards against a revert to a tail with a bigger number: the coverage
+    table grows with the repo, so any fixed tail loses this race."""
+    blind = FAILING_RUN[-2000:]
+
+    assert STALE_REGISTRY not in blind
+    assert hub_verification_unavailable_reason(blind) == "ssh exited with status"
+
+
+def test_a_rejection_stays_classifiable_as_a_rejection(repo: Path):
+    """The verdict/transport split (#478, #522) only works on text that still
+    contains a verdict signature. That is a property of the capture, so it is
+    checked on what the gate actually stores."""
+    verdict = _gate(repo, FAILING_RUN)
+
+    assert hub_verification_unavailable_reason(verdict.output_tail) is None
+
+
+def test_the_capture_composes_with_itself(repo: Path):
+    """Why the gate may call the same capture the runner already applied.
+
+    Every stage that bounds this text calls `capture_failure_window`, so the
+    real path applies it twice. Re-selecting an anchored window re-finds the
+    same anchor; slicing a tail of a tail does not.
+    """
+    once = capture_failure_window(FAILING_RUN)
+    verdict = _gate(repo, once)
+
+    assert STALE_REGISTRY in once
+    assert STALE_REGISTRY in verdict.output_tail
+    assert verdict.output_tail == capture_failure_window(once)
+
+
+def test_a_short_failure_is_recorded_verbatim(repo: Path):
+    """Most gate failures are one line (a clone error, an empty command). They
+    must not grow "chars omitted" scaffolding around themselves."""
+    verdict = _gate(repo, "full repository contract test failed: boom")
+
+    assert verdict.output_tail == "full repository contract test failed: boom"
+
+
+def test_a_passing_run_is_bounded_the_same_way(repo: Path):
+    """`output_tail` is set on success too. It goes through one capture, so a
+    passing run cannot be the path that records an unbounded blob."""
+    verdict = validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (0, PYTEST_PROGRESS + "\n" + COVERAGE_TABLE),
+    )
+
+    assert verdict.passed is True
+    assert len(verdict.output_tail) <= 6000


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_68ed61db520d438ca8304979e58ac755`
- head: `4aa85d3aedc9f0884aad02530b6482173ba15845`
- base at push: `4434ccd1379bc9d44d0c2b24e14ab9141405617d`
