### PR TITLE
Hub verify discarded the reason it failed before classifying it (task_68ed61db520d438ca8304979e58ac755)

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -32,6 +32,8 @@ their retained sources.
 - [ADR 0023 - One skill source, thin plugins per coding harness](../adr/0023-one-skill-source-many-harness-plugins.md) — `adr/0023-one-skill-source-many-harness-plugins.md`
 - [ADR 0024 - The dashboard streams the bus, not just its counts](../adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md) — `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md`
 - [ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype](../adr/0025-the-hub-ui-is-the-observability-console.md) — `adr/0025-the-hub-ui-is-the-observability-console.md`
+- [ADR 0026: Every operation on a first-class object emits a bus event](../adr/0026-first-class-operations-emit-bus-events.md) — `adr/0026-first-class-operations-emit-bus-events.md`
+- [ADR 0027: Upgrades are versioned, ordered, and fail closed](../adr/0027-upgrades-are-versioned-and-fail-closed.md) — `adr/0027-upgrades-are-versioned-and-fail-closed.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -253,6 +253,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_HERMES_SURFACE_B64` | str | consumer-defined | deployment | Deployment setting: deploy hermes surface b64. |
 | `MAC_DEPLOY_HOLD_ADOPTIONS_FILE` | str | consumer-defined | deployment | Deployment setting: deploy hold adoptions file. |
 | `MAC_DEPLOY_HUB_AGENT` | str | consumer-defined | deployment | Deployment setting: deploy hub agent. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof attempts. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof interval seconds. |
 | `MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub tick interval seconds. |
 | `MAC_DEPLOY_HUB_TOKEN` | str | consumer-defined | deployment | Deployment setting: deploy hub token. |
 | `MAC_DEPLOY_HUB_TUNNEL_PUBKEY` | str | consumer-defined | deployment | Deployment setting: deploy hub tunnel pubkey. |
@@ -843,6 +845,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_PREREQ_QDRANT_REQUIRED` | bool | consumer-defined | core | Core setting: prereq qdrant required. |
 | `MAC_PREREQ_QDRANT_URL` | str | consumer-defined | core | Core setting: prereq qdrant url. |
 | `MAC_PREREQ_ROOT` | str | consumer-defined | core | Core setting: prereq root. |
+| `MAC_PREREQ_ROUTE_HUB_REQUIRED` | bool | consumer-defined | core | Core setting: prereq route hub required. |
 | `MAC_PREREQ_SUPERVISOR` | str | consumer-defined | core | Core setting: prereq supervisor. |
 | `MAC_PREREQ_WEBDAV_ENABLED` | bool | consumer-defined | core | Core setting: prereq webdav enabled. |
 | `MAC_PREREQ_WEBDAV_URL` | str | consumer-defined | core | Core setting: prereq webdav url. |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -37,6 +37,8 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | ADR 0023 - One skill source, thin plugins per coding harness |
 | architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | ADR 0024 - The dashboard streams the bus, not just its counts |
 | architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
+| architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
+| architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/src/mac/contract_output.py
+++ b/src/mac/contract_output.py
@@ -1,0 +1,243 @@
+"""What a contract run's output says, and how much of it is worth keeping.
+
+Two questions are asked of every hub contract verification, and until now the
+answers lived inside ``services`` where only the review path could reach them:
+
+  * **Did the gate judge the change, or did the harness die?**
+    ``unavailable_reason`` -- #478 then #522.
+  * **Which bytes of a multi-megabyte run do we keep?**
+    ``failure_window_excerpt`` -- the anchored capture.
+
+They belong together and they belong outside ``services``, because the review
+path is not the only caller. ``merge_queue.validate_projected_merge_contract``
+runs the SAME verification (``_hub_verify_run_contract_test`` is its default
+``test_runner``) at publication time, and re-truncated the answer with a blind
+``output_tail[-2000:]`` -- the exact tail this repository already established
+cannot reach the reason a run failed. The anchored capture was applied and then
+undone one layer downstream, so the publication gate reported "full repository
+contract test failed" and nothing else.
+
+A pure module with no I/O, like :mod:`mac.contract_failure`: the capture and
+classification rules can then be tested directly against real failure text
+rather than only through a live verification.
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+
+__all__ = [
+    "VERDICT_SIGNATURES",
+    "UNAVAILABLE_SIGNATURES",
+    "FAILURE_ANCHORS",
+    "unavailable_reason",
+    "head_and_tail_excerpt",
+    "failure_window_excerpt",
+]
+
+#: Output signatures that mean the verification COULD NOT RUN, as opposed to
+#: ran and found the change wanting.
+#:
+#: These are transport and environment faults of the harness itself. On
+#: 2026-08-19 every review in a 90-minute window was rejected, and the signed
+#: verdict for one of them ended:
+#:
+#:     coverage safety: statements 69300/76238 (90.90%, floor 90.00%);
+#:                      branches   20216/24618 (82.12%, floor 80.00%)
+#:       - Uploading files to /sandbox...
+#:       + Files uploaded
+#:     Error:   x ssh exited with status exit status: 1
+#:
+#: BOTH COVERAGE FLOORS PASSED. The gate the run exists to enforce was
+#: satisfied, and the coding-agent's ssh stream then died. That exit status
+#: became `rejected`, signed, and indistinguishable downstream from a reviewer
+#: judging the work deficient. One task was rejected, redone more thoroughly
+#: (58 tests -> 60, 2 files -> 11, ruff and a CodeGraph audit added), and
+#: rejected identically, because the verdict never depended on the diff.
+#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING.
+#:
+#: Checked BEFORE the unavailable signatures, and they win, because the two
+#: overlap in exactly the case that matters.
+#:
+#: `ssh exited with status` is the generic wrapper exit printed whenever a
+#: remote command returns non-zero -- it accompanies every failure through the
+#: ssh transport, not only a transport fault. Listing it as "unavailable"
+#: (2026-08-19, PR #478) therefore inverted the original bug instead of fixing
+#: it. Before, a transport death was signed as a rejection. After, a genuine
+#: rejection was swallowed as "could not verify", so NO verdict was signed and
+#: the task sat in REVIEWING forever.
+#:
+#: Observed live on 2026-08-20: twelve `hub_verify_unavailable` events in
+#: ninety minutes whose real failures were
+#:     "documentation contract failed: published shell fences outside the
+#:      executable book are forbidden"
+#: and
+#:     "documentation-inventory.md is stale: regenerate with
+#:      scripts/generate-docs-reference.py --write"
+#: -- both real, actionable, and both discarded. Twenty tasks accumulated in
+#: REVIEWING, five of them for over a hundred hours.
+#:
+#: The discriminator is whether the gate reached a judgement. It is not
+#: "did the gate produce output": in the #478 case the coverage gate ran and
+#: PASSED before the stream died, so output alone would have called that a
+#: rejection too. Only an explicit FAILING verdict counts.
+#: Every entry must appear ONLY on failure. That is the whole discipline here,
+#: and it is easy to get wrong in the direction that reintroduces #478:
+#: `coverage safety:` was an obvious-looking candidate and is emitted whether
+#: the floors pass or fail, so it would have marked the original
+#: passed-then-the-stream-died run as a rejection -- exactly the bug #478
+#: existed to fix. Likewise `repository contract` appears in
+#: "running fail-fast repository contract preflight", which is a start
+#: message, not a verdict.
+#:
+#: When in doubt leave a signature OUT. A missing signature means a real
+#: rejection is retried as "unavailable", which wastes a run. A wrong one
+#: means a transport fault is signed as a rejection, which discards correct
+#: work and is what this pair of fixes is for.
+VERDICT_SIGNATURES: Tuple[str, ...] = (
+    "documentation contract failed",
+    "is stale:",
+    "stale generated",
+    "regenerate with",
+    "contract test failed",
+    " failed, ",         # pytest summary: "3 failed, 40 passed"
+    "assertionerror",
+    "error: process completed with exit code",
+)
+
+
+UNAVAILABLE_SIGNATURES: Tuple[str, ...] = (
+    # cursor-agent's stream transport, the observed cause
+    "ssh exited with status",
+    "connection reset by peer",
+    "connection refused",
+    "retriableerror",
+    "resource_exhausted",
+    # no route to run anything at all
+    "no acceptable coding agent",
+    "agent_binary_missing",
+    "sandbox_policy_denied",
+    # the harness never got far enough to test the change
+    "failed to create sandbox",
+    "error: could not create sandbox",
+)
+
+
+#: Where the reason for a failure is announced, in the order a run prints it.
+#: "short test summary info" is pytest's own answer to "what failed"; the rest
+#: are the verdict signatures, so anything the classifier can act on is kept.
+FAILURE_ANCHORS: Tuple[str, ...] = ("short test summary info",) + VERDICT_SIGNATURES
+
+
+def unavailable_reason(output: str) -> Optional[str]:
+    """The signature saying this run could not verify anything, if present.
+
+    Returning a reason means "we do not know whether the change is good" --
+    which must NOT be recorded as a rejection. A signature over "rejected" is
+    a claim the evidence does not support, and downstream nothing can tell it
+    apart from a real verdict.
+
+    Deliberately narrow. An unrecognised failure stays a rejection, because
+    treating unknown failures as infrastructure would let a genuinely broken
+    change pass through as "could not verify" and retry forever -- failing
+    open on the gate this exists to enforce.
+    """
+    text = (output or "").lower()
+    # A gate that judged the change wanting is a REJECTION, whatever the
+    # transport did afterwards. Checked first because the two sets overlap:
+    # a real contract failure still exits through ssh and still prints
+    # "ssh exited with status".
+    for verdict in VERDICT_SIGNATURES:
+        if verdict in text:
+            return None
+    for signature in UNAVAILABLE_SIGNATURES:
+        if signature in text:
+            return signature
+    return None
+
+
+def head_and_tail_excerpt(output: str, *, head: int = 2000, tail: int = 1500) -> str:
+    """Keep the head AND the tail of a rejected verification's output.
+
+    The tail alone was kept, and the tail of a pytest run is its summary line:
+    "36 failed, 84 passed, 588 errors". That says the gate failed, which the
+    verdict already said. WHY it failed is announced once, at the top -- an
+    unprovisionable database, a bootstrap that never finished, a collection
+    error -- and 500 characters of tail cannot reach it.
+
+    Diagnosing one such rejection took a hub-side archaeology session that
+    ended in the evidence being gone: the sandbox that produced it had been
+    cleaned up, and nothing else recorded the run.
+
+    Still position-based, so still blind to a reason that sits in the middle:
+    use :func:`failure_window_excerpt` for anything a classifier reads.
+    """
+
+    text = (output or "").strip()
+    if len(text) <= head + tail:
+        return text
+    omitted = len(text) - head - tail
+    return "%s\n... [%d chars omitted] ...\n%s" % (
+        text[:head],
+        omitted,
+        text[-tail:],
+    )
+
+
+def failure_window_excerpt(
+    output: str,
+    *,
+    head: int = 1500,
+    window: int = 2000,
+    tail: int = 1000,
+    anchors: Sequence[str] = FAILURE_ANCHORS,
+) -> str:
+    """Keep the head, the TAIL, and the part that says why the run failed.
+
+    Head-and-tail is not enough here, which is the trap this replaced a blind
+    tail with. A failing contract run prints, in order: a session header,
+    several hundred lines of pytest progress, the failure and its summary, a
+    whole-repo coverage report (one row per source file, ~14KB), a coverage
+    line whose floors both PASSED, and -- last -- OpenShell's generic
+    "ssh exited with status 1". The verdict sits in the middle, out of reach
+    of both ends, so a fixed head and tail preserve the two regions that say
+    nothing and drop the only one that does.
+
+    Position is the wrong selector. Anchor on the text that announces the
+    failure and keep a window around its LAST occurrence, so the excerpt still
+    carries a verdict signature after truncation and a rejection stays
+    classifiable as a rejection.
+
+    Idempotent on its own output by construction: an excerpt is shorter than
+    the budget unless the anchored window was itself bigger, and it still
+    contains the anchor. Callers handed an already-excerpted string should
+    nonetheless pass it through unchanged rather than re-truncating it --
+    re-truncation is what put the blind tail back at the publication gate.
+    """
+
+    text = (output or "").strip()
+    if len(text) <= head + window + tail:
+        return text
+
+    spans = [(0, head), (len(text) - tail, len(text))]
+    lowered = text.lower()
+    found = [lowered.rfind(a) for a in anchors]
+    anchor_at = max(found) if found else -1
+    if anchor_at >= 0:
+        start = max(0, anchor_at - window // 4)
+        spans.append((start, min(len(text), start + window)))
+
+    merged: List[Tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+
+    parts: List[str] = []
+    previous = 0
+    for start, end in merged:
+        if start > previous:
+            parts.append("... [%d chars omitted] ..." % (start - previous))
+        parts.append(text[start:end])
+        previous = end
+    return "\n".join(parts)

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -2981,6 +2981,28 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy hub route proof attempts.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy hub route proof interval seconds.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy hub tick interval seconds.",
     "family": "deployment",
     "name": "MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS",
@@ -9938,6 +9960,17 @@
       "deploy/deploy-mac-fleet.sh"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: prereq route hub required.",
+    "family": "core",
+    "name": "MAC_PREREQ_ROUTE_HUB_REQUIRED",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "bool"
   },
   {
     "default": null,

--- a/src/mac/merge_queue.py
+++ b/src/mac/merge_queue.py
@@ -56,6 +56,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
+from mac.contract_output import failure_window_excerpt
+
 GitRunner = Callable[[Sequence[str]], "subprocess.CompletedProcess"]
 ContractTestRunner = Callable[[str, str, str, str], Tuple[int, str]]
 
@@ -264,7 +266,13 @@ def validate_projected_merge_contract(
             projected_sha=projected_sha,
             test_command=command,
             test_returncode=returncode,
-            output_tail=output_tail[-2000:],
+            # NOT a tail. This gate's default runner is the hub's contract
+            # verification, whose output is a failure followed by a ~14KB
+            # whole-repo coverage report and a generic "ssh exited with
+            # status 1" -- so trailing bytes hold everything except the
+            # reason. `output_tail[-2000:]` here undid the anchored capture
+            # the runner had already applied, one layer downstream of it.
+            output_tail=failure_window_excerpt(output_tail),
             error=error,
         )
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -210,6 +210,7 @@ from mac.agentbus_service import AgentBusService
 from mac.deploy_service import DeployService
 from mac.directive_service import DirectiveService
 from mac.codegraph_audit import codegraph_audit_manifest_problems
+from mac import contract_output
 from mac import evidence_blobs
 from mac.evidence_validators import rejected_verdict_feedback_problems, validate_evidence_type
 from mac.eval_service import EvalService
@@ -987,201 +988,16 @@ REPOSITORY_CONTRACT_FILES = (
     Path(".mac") / "project.yml",
 )
 
-#: Output signatures that mean the verification COULD NOT RUN, as opposed to
-#: ran and found the change wanting.
-#:
-#: These are transport and environment faults of the harness itself. On
-#: 2026-08-19 every review in a 90-minute window was rejected, and the signed
-#: verdict for one of them ended:
-#:
-#:     coverage safety: statements 69300/76238 (90.90%, floor 90.00%);
-#:                      branches   20216/24618 (82.12%, floor 80.00%)
-#:       - Uploading files to /sandbox...
-#:       + Files uploaded
-#:     Error:   x ssh exited with status exit status: 1
-#:
-#: BOTH COVERAGE FLOORS PASSED. The gate the run exists to enforce was
-#: satisfied, and the coding-agent's ssh stream then died. That exit status
-#: became `rejected`, signed, and indistinguishable downstream from a reviewer
-#: judging the work deficient. One task was rejected, redone more thoroughly
-#: (58 tests -> 60, 2 files -> 11, ruff and a CodeGraph audit added), and
-#: rejected identically, because the verdict never depended on the diff.
-#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING.
-#:
-#: Checked BEFORE the unavailable signatures, and they win, because the two
-#: overlap in exactly the case that matters.
-#:
-#: `ssh exited with status` is the generic wrapper exit printed whenever a
-#: remote command returns non-zero -- it accompanies every failure through the
-#: ssh transport, not only a transport fault. Listing it as "unavailable"
-#: (2026-08-19, PR #478) therefore inverted the original bug instead of fixing
-#: it. Before, a transport death was signed as a rejection. After, a genuine
-#: rejection was swallowed as "could not verify", so NO verdict was signed and
-#: the task sat in REVIEWING forever.
-#:
-#: Observed live on 2026-08-20: twelve `hub_verify_unavailable` events in
-#: ninety minutes whose real failures were
-#:     "documentation contract failed: published shell fences outside the
-#:      executable book are forbidden"
-#: and
-#:     "documentation-inventory.md is stale: regenerate with
-#:      scripts/generate-docs-reference.py --write"
-#: -- both real, actionable, and both discarded. Twenty tasks accumulated in
-#: REVIEWING, five of them for over a hundred hours.
-#:
-#: The discriminator is whether the gate reached a judgement. It is not
-#: "did the gate produce output": in the #478 case the coverage gate ran and
-#: PASSED before the stream died, so output alone would have called that a
-#: rejection too. Only an explicit FAILING verdict counts.
-#: Every entry must appear ONLY on failure. That is the whole discipline here,
-#: and it is easy to get wrong in the direction that reintroduces #478:
-#: `coverage safety:` was an obvious-looking candidate and is emitted whether
-#: the floors pass or fail, so it would have marked the original
-#: passed-then-the-stream-died run as a rejection -- exactly the bug #478
-#: existed to fix. Likewise `repository contract` appears in
-#: "running fail-fast repository contract preflight", which is a start
-#: message, not a verdict.
-#:
-#: When in doubt leave a signature OUT. A missing signature means a real
-#: rejection is retried as "unavailable", which wastes a run. A wrong one
-#: means a transport fault is signed as a rejection, which discards correct
-#: work and is what this pair of fixes is for.
-_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = (
-    "documentation contract failed",
-    "is stale:",
-    "stale generated",
-    "regenerate with",
-    "contract test failed",
-    " failed, ",         # pytest summary: "3 failed, 40 passed"
-    "assertionerror",
-    "error: process completed with exit code",
-)
-
-
-_HUB_VERIFY_UNAVAILABLE_SIGNATURES: Tuple[str, ...] = (
-    # cursor-agent's stream transport, the observed cause
-    "ssh exited with status",
-    "connection reset by peer",
-    "connection refused",
-    "retriableerror",
-    "resource_exhausted",
-    # no route to run anything at all
-    "no acceptable coding agent",
-    "agent_binary_missing",
-    "sandbox_policy_denied",
-    # the harness never got far enough to test the change
-    "failed to create sandbox",
-    "error: could not create sandbox",
-)
-
-
-def hub_verification_unavailable_reason(output: str) -> Optional[str]:
-    """The signature saying this run could not verify anything, if present.
-
-    Returning a reason means "we do not know whether the change is good" --
-    which must NOT be recorded as a rejection. A signature over "rejected" is
-    a claim the evidence does not support, and downstream nothing can tell it
-    apart from a real verdict.
-
-    Deliberately narrow. An unrecognised failure stays a rejection, because
-    treating unknown failures as infrastructure would let a genuinely broken
-    change pass through as "could not verify" and retry forever -- failing
-    open on the gate this exists to enforce.
-    """
-    text = (output or "").lower()
-    # A gate that judged the change wanting is a REJECTION, whatever the
-    # transport did afterwards. Checked first because the two sets overlap:
-    # a real contract failure still exits through ssh and still prints
-    # "ssh exited with status".
-    for verdict in _HUB_VERIFY_VERDICT_SIGNATURES:
-        if verdict in text:
-            return None
-    for signature in _HUB_VERIFY_UNAVAILABLE_SIGNATURES:
-        if signature in text:
-            return signature
-    return None
-
-
-def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 1500) -> str:
-    """Keep the head AND the tail of a rejected verification's output.
-
-    The tail alone was kept, and the tail of a pytest run is its summary line:
-    "36 failed, 84 passed, 588 errors". That says the gate failed, which the
-    verdict already said. WHY it failed is announced once, at the top -- an
-    unprovisionable database, a bootstrap that never finished, a collection
-    error -- and 500 characters of tail cannot reach it.
-
-    Diagnosing one such rejection took a hub-side archaeology session that
-    ended in the evidence being gone: the sandbox that produced it had been
-    cleaned up, and nothing else recorded the run.
-    """
-
-    text = (output or "").strip()
-    if len(text) <= head + tail:
-        return text
-    omitted = len(text) - head - tail
-    return "%s\n... [%d chars omitted] ...\n%s" % (
-        text[:head],
-        omitted,
-        text[-tail:],
-    )
-
-
-#: Where the reason for a failure is announced, in the order a run prints it.
-#: "short test summary info" is pytest's own answer to "what failed"; the rest
-#: are the verdict signatures, so anything the classifier can act on is kept.
-_HUB_VERIFY_FAILURE_ANCHORS: Tuple[str, ...] = (
-    "short test summary info",
-) + _HUB_VERIFY_VERDICT_SIGNATURES
-
-
-def _hub_verify_output_excerpt(
-    output: str, *, head: int = 1500, window: int = 2000, tail: int = 1000
-) -> str:
-    """Keep the head, the TAIL, and the part that says why the run failed.
-
-    Head-and-tail is not enough here, which is the trap this replaced a blind
-    tail with. A failing contract run prints, in order: a session header,
-    several hundred lines of pytest progress, the failure and its summary, a
-    whole-repo coverage report (one row per source file, ~14KB), a coverage
-    line whose floors both PASSED, and -- last -- OpenShell's generic
-    "ssh exited with status 1". The verdict sits in the middle, out of reach
-    of both ends, so a fixed head and tail preserve the two regions that say
-    nothing and drop the only one that does.
-
-    Position is the wrong selector. Anchor on the text that announces the
-    failure and keep a window around its LAST occurrence, so the excerpt still
-    carries a verdict signature after truncation and a rejection stays
-    classifiable as a rejection.
-    """
-
-    text = (output or "").strip()
-    if len(text) <= head + window + tail:
-        return text
-
-    spans = [(0, head), (len(text) - tail, len(text))]
-    lowered = text.lower()
-    found = [lowered.rfind(a) for a in _HUB_VERIFY_FAILURE_ANCHORS]
-    anchor_at = max(found)
-    if anchor_at >= 0:
-        start = max(0, anchor_at - window // 4)
-        spans.append((start, min(len(text), start + window)))
-
-    merged: List[Tuple[int, int]] = []
-    for start, end in sorted(spans):
-        if merged and start <= merged[-1][1]:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-        else:
-            merged.append((start, end))
-
-    parts: List[str] = []
-    previous = 0
-    for start, end in merged:
-        if start > previous:
-            parts.append("... [%d chars omitted] ..." % (start - previous))
-        parts.append(text[start:end])
-        previous = end
-    return "\n".join(parts)
+#: Contract-run output capture and classification live in a pure module so the
+#: publication gate can reuse them (mac.contract_output). Re-exported here
+#: under their established names: every caller and test in the tree reaches
+#: them through `mac.services`.
+_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = contract_output.VERDICT_SIGNATURES
+_HUB_VERIFY_UNAVAILABLE_SIGNATURES: Tuple[str, ...] = contract_output.UNAVAILABLE_SIGNATURES
+_HUB_VERIFY_FAILURE_ANCHORS: Tuple[str, ...] = contract_output.FAILURE_ANCHORS
+hub_verification_unavailable_reason = contract_output.unavailable_reason
+_hub_review_failure_excerpt = contract_output.head_and_tail_excerpt
+_hub_verify_output_excerpt = contract_output.failure_window_excerpt
 
 
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"
@@ -21800,7 +21616,17 @@ class ControlPlane:
                     {"name": "publication_contract_gate", **contract_gate.to_dict()}
                 )
                 if not contract_gate.passed:
-                    diagnosis = contract_gate.error or contract_gate.output_tail
+                    # `error` is a FIXED string when the suite ran and failed
+                    # ("full repository contract test failed"), so
+                    # `error or output_tail` never reached the output and the
+                    # only thing recorded about a refused publication was that
+                    # it had been refused. Lead with the named cause, then the
+                    # captured evidence -- both, not whichever came first.
+                    diagnosis = "\n\n".join(
+                        part
+                        for part in (contract_gate.error, contract_gate.output_tail)
+                        if str(part or "").strip()
+                    )
                     if queue is not None and queue_entry_id:
                         eviction = queue.evict(
                             queue_entry_id,

--- a/tests/test_publication_gate_failure_window.py
+++ b/tests/test_publication_gate_failure_window.py
@@ -1,0 +1,190 @@
+"""The publication gate must keep the reason it refused, not just the refusal.
+
+The hub's contract verification stopped keeping a blind ``out[-2000:]`` and
+started keeping an anchored window around the text that announces the failure.
+That fix was applied at the capture site -- and then undone one layer
+downstream.
+
+``validate_projected_merge_contract`` runs the SAME verification at publication
+time (``_hub_verify_run_contract_test`` is its default ``test_runner``) and
+stored the result as ``output_tail[-2000:]``. A failing contract run prints the
+pytest failure, then a whole-repo coverage report (one row per source file,
+~14KB), then a coverage summary whose floors both PASSED, and only then exits.
+So the surviving 2000 bytes were coverage rows and a passing coverage line: the
+anchored window was cut back out and the publication record said nothing.
+
+The operator-facing half was worse. ``diagnosis = error or output_tail`` reads
+as "the output when there is no error", but ``error`` is the FIXED string
+"full repository contract test failed" whenever the suite ran and failed -- so
+the output was unreachable by construction and every refused publication was
+reported with the same eight words.
+
+Both halves are asserted here against a realistic run: several hundred lines of
+pytest progress, the failure, a large coverage table, and a passing coverage
+line at the end.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mac import contract_output, services
+from mac.merge_queue import validate_projected_merge_contract
+from mac.models import ValidationError
+from mac.services import ControlPlane, hub_verification_unavailable_reason
+from tests.test_publication_pull_request import (
+    FakeForge,
+    build_repo,
+    drive_to_approval,
+    install_forge,
+)
+
+# Everything a failing contract run prints, in the order it prints it.
+PYTEST_PROGRESS = "\n".join(
+    "tests/test_module_%03d.py ......................... [ %2d%%]" % (i, i % 100)
+    for i in range(400)
+)
+PYTEST_FAILURE = (
+    "=========================== short test summary info ============================\n"
+    "FAILED tests/test_projected_merge.py::test_the_two_branches_agree\n"
+    "= 4 failed, 9812 passed, 3 skipped in 1204.55s (0:20:04) =\n"
+)
+COVERAGE_TABLE = "\n".join(
+    "src/mac/module_%03d.py%s500     40    92%%" % (i, " " * 8) for i in range(235)
+)
+COVERAGE_PASSED = (
+    "coverage safety: statements 70802/77880 (90.91%, floor 90.00%); "
+    "branches 20708/25192 (82.20%, floor 80.00%)\n"
+    "Error:   x ssh exited with status exit status: 1"
+)
+FAILING_RUN = (
+    "============================= test session starts ==============================\n"
+    "collected 9819 items\n"
+    + PYTEST_PROGRESS
+    + "\n"
+    + PYTEST_FAILURE
+    + COVERAGE_TABLE
+    + "\n"
+    + COVERAGE_PASSED
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "r"
+    r.mkdir()
+    _git(r, "init", "-q", "-b", "main")
+    _git(r, "config", "user.email", "t@t.invalid")
+    _git(r, "config", "user.name", "t")
+    (r / "f.txt").write_text("line1\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "base")
+    _git(r, "checkout", "-q", "-b", "topic", "main")
+    (r / "topic.txt").write_text("topic\n")
+    _git(r, "add", "-A")
+    _git(r, "commit", "-qm", "topic")
+    _git(r, "checkout", "-q", "main")
+    return r
+
+
+def _failed_gate(repo: Path):
+    return validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (1, FAILING_RUN),
+    )
+
+
+def test_the_gate_keeps_the_test_that_failed(repo: Path):
+    """The bug, stated as the behaviour that matters."""
+    verdict = _failed_gate(repo)
+
+    assert verdict.passed is False
+    assert "short test summary info" in verdict.output_tail
+    assert "test_the_two_branches_agree" in verdict.output_tail
+    assert "4 failed, 9812 passed" in verdict.output_tail
+
+
+def test_the_blind_tail_that_caused_this_would_still_fail(repo: Path):
+    """Guards against a revert to a tail with a bigger number: the coverage
+    table grows with the repository, so any fixed tail loses this race."""
+    blind = FAILING_RUN[-2000:]
+
+    assert "test_the_two_branches_agree" not in blind
+    assert "4 failed, 9812 passed" not in blind
+    # ...and what it kept instead reads as a healthy run that lost its ssh.
+    assert "floor 90.00%" in blind
+    assert hub_verification_unavailable_reason(blind) == "ssh exited with status"
+
+
+def test_the_kept_output_stays_classifiable_as_a_rejection(repo: Path):
+    """The point of anchoring: a verdict signature survives truncation, so the
+    gate's own classifier still calls this a rejection rather than a dead
+    harness that should be retried forever."""
+    verdict = _failed_gate(repo)
+
+    assert hub_verification_unavailable_reason(verdict.output_tail) is None
+
+
+def test_the_gate_is_still_bounded(repo: Path):
+    """Not a licence to store the whole run: the record is bounded, it is just
+    no longer bounded by position alone."""
+    verdict = _failed_gate(repo)
+
+    assert len(verdict.output_tail) < len(FAILING_RUN) // 2
+    assert "chars omitted" in verdict.output_tail
+
+
+def test_a_short_run_is_kept_verbatim(repo: Path):
+    """Runs that fit are not excerpted, so the common case reads unchanged."""
+    verdict = validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (17, "contract test failed: 1 failed, 2 passed"),
+    )
+
+    assert verdict.output_tail == "contract test failed: 1 failed, 2 passed"
+    assert verdict.error == "full repository contract test failed"
+
+
+def test_a_refused_publication_reports_the_cause_and_the_evidence(
+    tmp_path, monkeypatch
+):
+    """``error or output_tail`` never reached the output, because ``error`` is
+    always set once the suite has run. The operator got eight fixed words."""
+    cp = ControlPlane.in_memory()
+    remote, source, _main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    # No required forge checks -> the hub's own contract gate is the gate.
+    install_forge(monkeypatch, forge, checks=())
+    task, evidence, reviewer = drive_to_approval(cp, source, task_head)
+    cp._publication_merge_test_runner = lambda *a, **k: (1, FAILING_RUN)
+
+    with pytest.raises(ValidationError) as raised:
+        cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    message = str(raised.value)
+    assert "full repository contract test failed" in message  # the named cause
+    assert "test_the_two_branches_agree" in message           # ...and the reason
+
+
+def test_both_gates_share_one_capture_rule():
+    """The review path and the publication path must not drift apart again:
+    the anchored capture is one implementation, re-exported under the name
+    `services` already used it by."""
+    assert services._hub_verify_output_excerpt is contract_output.failure_window_excerpt
+    assert services.hub_verification_unavailable_reason is contract_output.unavailable_reason
+    assert services._HUB_VERIFY_VERDICT_SIGNATURES is contract_output.VERDICT_SIGNATURES
+    assert contract_output.FAILURE_ANCHORS[0] == "short test summary info"


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_68ed61db520d438ca8304979e58ac755`
- head: `bca6c8b1164003608076c424af5a146a32fa2d52`
- base at push: `4434ccd1379bc9d44d0c2b24e14ab9141405617d`
