### PR TITLE
Hub verify discarded the reason it failed before classifying it (task_68ed61db520d438ca8304979e58ac755)

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -32,6 +32,8 @@ their retained sources.
 - [ADR 0023 - One skill source, thin plugins per coding harness](../adr/0023-one-skill-source-many-harness-plugins.md) — `adr/0023-one-skill-source-many-harness-plugins.md`
 - [ADR 0024 - The dashboard streams the bus, not just its counts](../adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md) — `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md`
 - [ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype](../adr/0025-the-hub-ui-is-the-observability-console.md) — `adr/0025-the-hub-ui-is-the-observability-console.md`
+- [ADR 0026: Every operation on a first-class object emits a bus event](../adr/0026-first-class-operations-emit-bus-events.md) — `adr/0026-first-class-operations-emit-bus-events.md`
+- [ADR 0027: Upgrades are versioned, ordered, and fail closed](../adr/0027-upgrades-are-versioned-and-fail-closed.md) — `adr/0027-upgrades-are-versioned-and-fail-closed.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -253,6 +253,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_HERMES_SURFACE_B64` | str | consumer-defined | deployment | Deployment setting: deploy hermes surface b64. |
 | `MAC_DEPLOY_HOLD_ADOPTIONS_FILE` | str | consumer-defined | deployment | Deployment setting: deploy hold adoptions file. |
 | `MAC_DEPLOY_HUB_AGENT` | str | consumer-defined | deployment | Deployment setting: deploy hub agent. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof attempts. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof interval seconds. |
 | `MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub tick interval seconds. |
 | `MAC_DEPLOY_HUB_TOKEN` | str | consumer-defined | deployment | Deployment setting: deploy hub token. |
 | `MAC_DEPLOY_HUB_TUNNEL_PUBKEY` | str | consumer-defined | deployment | Deployment setting: deploy hub tunnel pubkey. |
@@ -843,6 +845,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_PREREQ_QDRANT_REQUIRED` | bool | consumer-defined | core | Core setting: prereq qdrant required. |
 | `MAC_PREREQ_QDRANT_URL` | str | consumer-defined | core | Core setting: prereq qdrant url. |
 | `MAC_PREREQ_ROOT` | str | consumer-defined | core | Core setting: prereq root. |
+| `MAC_PREREQ_ROUTE_HUB_REQUIRED` | bool | consumer-defined | core | Core setting: prereq route hub required. |
 | `MAC_PREREQ_SUPERVISOR` | str | consumer-defined | core | Core setting: prereq supervisor. |
 | `MAC_PREREQ_WEBDAV_ENABLED` | bool | consumer-defined | core | Core setting: prereq webdav enabled. |
 | `MAC_PREREQ_WEBDAV_URL` | str | consumer-defined | core | Core setting: prereq webdav url. |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -37,6 +37,8 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | ADR 0023 - One skill source, thin plugins per coding harness |
 | architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | ADR 0024 - The dashboard streams the bus, not just its counts |
 | architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
+| architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
+| architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/src/mac/contract_output.py
+++ b/src/mac/contract_output.py
@@ -1,0 +1,201 @@
+"""Keep the part of a contract run's output that says WHY it failed.
+
+Every gate in this repo that runs ``scripts/run-contract-tests.sh`` gets back
+one large blob and has to store a small one. The reduction is where the reason
+was being lost, and it was being lost by POSITION: a blind ``out[-2000:]``.
+
+``run-contract-tests.sh`` prints, in this order:
+
+    1. a session header and several hundred lines of pytest progress
+    2. the failure and pytest's "short test summary info"
+    3. an unconditional whole-repo ``coverage report`` -- one row per source
+       file, ~14KB in this repo
+    4. a coverage summary whose floors both PASSED
+    5. OpenShell's generic "ssh exited with status 1"
+
+and only then exits with the saved pytest status. So the last 2000 bytes of a
+FAILING run are the coverage table's tail, a passing coverage line, and a
+generic transport message. Every string in :data:`CONTRACT_VERDICT_SIGNATURES`
+lives in the discarded prefix, which made a genuine rejection unclassifiable by
+construction: read as a dead harness, no verdict signed, review retried,
+identical output produced again. Observed 2026-08-20 -- six tasks retried 3-4
+times each over ~6 hours while `completed` stayed frozen and all three agents
+sat idle.
+
+Head-and-tail is not sufficient either. The reason sits in region 2, between
+several hundred lines of progress and a 14KB table, out of reach of both ends.
+Position is simply the wrong selector. :func:`capture_failure_window` anchors
+on the text that ANNOUNCES the failure and keeps a window around its last
+occurrence, so a rejection still reads as a rejection after truncation.
+
+Deliberately pure -- no I/O, no hub, no subprocess -- so both the hub verifier
+and the publication merge gate can share one implementation, and so it can be
+tested directly against real failure transcripts instead of only through a live
+task.
+"""
+from __future__ import annotations
+
+from typing import List, Sequence, Tuple
+
+__all__ = [
+    "CONTRACT_VERDICT_SIGNATURES",
+    "CONTRACT_FAILURE_ANCHORS",
+    "capture_failure_window",
+    "failure_reason_line",
+]
+
+
+#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING.
+#:
+#: Checked BEFORE the "harness could not run" signatures, and they win, because
+#: the two overlap in exactly the case that matters.
+#:
+#: `ssh exited with status` is the generic wrapper exit printed whenever a
+#: remote command returns non-zero -- it accompanies every failure through the
+#: ssh transport, not only a transport fault. Listing it as "unavailable"
+#: (2026-08-19, PR #478) therefore inverted the original bug instead of fixing
+#: it. Before, a transport death was signed as a rejection. After, a genuine
+#: rejection was swallowed as "could not verify", so NO verdict was signed and
+#: the task sat in REVIEWING forever.
+#:
+#: Observed live on 2026-08-20: twelve `hub_verify_unavailable` events in
+#: ninety minutes whose real failures were
+#:     "documentation contract failed: published shell fences outside the
+#:      executable book are forbidden"
+#: and
+#:     "documentation-inventory.md is stale: regenerate with
+#:      scripts/generate-docs-reference.py --write"
+#: -- both real, actionable, and both discarded. Twenty tasks accumulated in
+#: REVIEWING, five of them for over a hundred hours.
+#:
+#: The discriminator is whether the gate reached a judgement. It is not
+#: "did the gate produce output": in the #478 case the coverage gate ran and
+#: PASSED before the stream died, so output alone would have called that a
+#: rejection too. Only an explicit FAILING verdict counts.
+#: Every entry must appear ONLY on failure. That is the whole discipline here,
+#: and it is easy to get wrong in the direction that reintroduces #478:
+#: `coverage safety:` was an obvious-looking candidate and is emitted whether
+#: the floors pass or fail, so it would have marked the original
+#: passed-then-the-stream-died run as a rejection -- exactly the bug #478
+#: existed to fix. Likewise `repository contract` appears in
+#: "running fail-fast repository contract preflight", which is a start
+#: message, not a verdict.
+#:
+#: When in doubt leave a signature OUT. A missing signature means a real
+#: rejection is retried as "unavailable", which wastes a run. A wrong one
+#: means a transport fault is signed as a rejection, which discards correct
+#: work.
+CONTRACT_VERDICT_SIGNATURES: Tuple[str, ...] = (
+    "documentation contract failed",
+    "is stale:",
+    "stale generated",
+    "regenerate with",
+    "contract test failed",
+    " failed, ",         # pytest summary: "3 failed, 40 passed"
+    "assertionerror",
+    "error: process completed with exit code",
+)
+
+#: Where the reason for a failure is announced, in the order a run prints it.
+#: "short test summary info" is pytest's own answer to "what failed"; the rest
+#: are the verdict signatures, so anything a classifier can act on is kept.
+CONTRACT_FAILURE_ANCHORS: Tuple[str, ...] = (
+    "short test summary info",
+) + CONTRACT_VERDICT_SIGNATURES
+
+
+def capture_failure_window(
+    output: str,
+    *,
+    head: int = 1500,
+    window: int = 2000,
+    tail: int = 1000,
+    anchors: Sequence[str] = CONTRACT_FAILURE_ANCHORS,
+) -> str:
+    """Keep the head, the TAIL, and the part that says why the run failed.
+
+    The head carries the session header (which sandbox, which command); the
+    tail carries the exit; the anchored window carries the reason. Omitted
+    regions are replaced by an explicit ``... [N chars omitted] ...`` marker so
+    a reader can tell a short run from a reduced one.
+
+    Idempotent in the way that matters: applying it to its own result keeps the
+    anchored window, because the window still contains the anchor. That is what
+    makes it safe at a second gate downstream of the first, which is where the
+    blind tail kept coming back.
+    """
+
+    text = (output or "").strip()
+    if len(text) <= head + window + tail:
+        return text
+
+    spans = [(0, head), (len(text) - tail, len(text))]
+    lowered = text.lower()
+    anchor_at = max([lowered.rfind(a) for a in anchors] or [-1])
+    if anchor_at >= 0:
+        start = max(0, anchor_at - window // 4)
+        spans.append((start, min(len(text), start + window)))
+
+    merged: List[Tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+
+    parts: List[str] = []
+    previous = 0
+    for start, end in merged:
+        if start > previous:
+            parts.append("... [%d chars omitted] ..." % (start - previous))
+        parts.append(text[start:end])
+        previous = end
+    return "\n".join(parts)
+
+
+def failure_reason_line(
+    output: str,
+    *,
+    limit: int = 300,
+    anchors: Sequence[str] = CONTRACT_FAILURE_ANCHORS,
+) -> str:
+    """One line naming why the run failed, for callers with no room for more.
+
+    An eviction reason is truncated to 200 characters and a publication error
+    is read by a human in a ledger; neither can hold an excerpt. They were
+    given a constant instead ("full repository contract test failed"), which is
+    true of every failing gate and diagnostic of none.
+
+    Returns the line holding the LAST anchor -- pytest's count line, the stale
+    generated artifact, the documentation contract -- skipping pytest's ``===``
+    banners, which announce a section rather than state a result. Falls back to
+    the last non-empty line when nothing is recognised, because an unrecognised
+    reason is still a better answer than a fixed sentence. Returns ``""`` for
+    empty output, so callers can supply their own wording for "no output".
+    """
+
+    text = (output or "").strip()
+    if not text:
+        return ""
+
+    lines = text.splitlines()
+    lowered = text.lower()
+    anchor_at = max([lowered.rfind(a) for a in anchors] or [-1])
+    index = len(lines) - 1
+    if anchor_at >= 0:
+        consumed = 0
+        for position, line in enumerate(lines):
+            consumed += len(line) + 1
+            if consumed > anchor_at:
+                index = position
+                break
+
+    for line in lines[index:]:
+        candidate = line.strip().strip("=").strip()
+        if candidate:
+            return candidate[:limit]
+    for line in reversed(lines):
+        candidate = line.strip()
+        if candidate:
+            return candidate[:limit]
+    return ""

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -2981,6 +2981,28 @@
   },
   {
     "default": null,
+    "description": "Deployment setting: deploy hub route proof attempts.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy hub route proof interval seconds.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Deployment setting: deploy hub tick interval seconds.",
     "family": "deployment",
     "name": "MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS",
@@ -9938,6 +9960,17 @@
       "deploy/deploy-mac-fleet.sh"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: prereq route hub required.",
+    "family": "core",
+    "name": "MAC_PREREQ_ROUTE_HUB_REQUIRED",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "bool"
   },
   {
     "default": null,

--- a/src/mac/merge_queue.py
+++ b/src/mac/merge_queue.py
@@ -56,6 +56,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional, Sequence, Tuple
 
+from mac.contract_output import capture_failure_window, failure_reason_line
+
 GitRunner = Callable[[Sequence[str]], "subprocess.CompletedProcess"]
 ContractTestRunner = Callable[[str, str, str, str], Tuple[int, str]]
 
@@ -264,7 +266,16 @@ def validate_projected_merge_contract(
             projected_sha=projected_sha,
             test_command=command,
             test_returncode=returncode,
-            output_tail=output_tail[-2000:],
+            # NOT a tail. `run-contract-tests.sh` prints the failure first and
+            # a ~14KB whole-repo coverage table afterwards, so the last 2000
+            # bytes of a failing run are the coverage table and a generic
+            # "ssh exited with status 1" -- the reason is thousands of bytes
+            # earlier. This gate's runner is the hub verifier, which already
+            # anchored its capture; a tail here re-truncated the anchored
+            # window back out and put a genuine rejection behind the transport
+            # message a second time. capture_failure_window composes with
+            # itself, so applying it twice keeps the reason.
+            output_tail=capture_failure_window(output_tail),
             error=error,
         )
 
@@ -358,12 +369,20 @@ def validate_projected_merge_contract(
             rc = int(returncode)
             tail = str(output or "")
             if rc != 0:
+                # Name the reason in `error`, not only in `output_tail`. The
+                # caller reads `error or output_tail`, so a constant here meant
+                # the tail was never consulted and every refused publication
+                # reported the same eight words -- true of every failing gate
+                # and diagnostic of none. The eviction reason it feeds is cut
+                # to 200 characters, which is why this is one line rather than
+                # an excerpt.
                 return verdict(
                     False,
                     projected_sha=projected_sha,
                     returncode=rc,
                     output_tail=tail,
-                    error="full repository contract test failed",
+                    error="full repository contract test failed: %s"
+                    % (failure_reason_line(tail) or "no output captured"),
                 )
             return verdict(
                 True,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -60,6 +60,11 @@ from mac.agentbus_control import (
 if TYPE_CHECKING:
     from mac.executor_directive import TaskOwnershipVerdict
 from mac.attempt_failure_classifier import classify_attempt_failure
+from mac.contract_output import (
+    CONTRACT_FAILURE_ANCHORS,
+    CONTRACT_VERDICT_SIGNATURES,
+    capture_failure_window,
+)
 from mac.dispatch_advisor import DISPATCH_ASSIGNMENT_ADVISOR_VERSION
 from mac.gitops import validate_git_ref
 from mac.repository_contract import (
@@ -987,6 +992,14 @@ REPOSITORY_CONTRACT_FILES = (
     Path(".mac") / "project.yml",
 )
 
+#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING.
+#:
+#: They live in :mod:`mac.contract_output` so the publication merge gate can
+#: key on the same strings without importing the control plane; re-exported
+#: here under the historic name. The reasoning for each entry is with the
+#: definition, where anyone tempted to add one will read it.
+_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = CONTRACT_VERDICT_SIGNATURES
+
 #: Output signatures that mean the verification COULD NOT RUN, as opposed to
 #: ran and found the change wanting.
 #:
@@ -1006,58 +1019,6 @@ REPOSITORY_CONTRACT_FILES = (
 #: judging the work deficient. One task was rejected, redone more thoroughly
 #: (58 tests -> 60, 2 files -> 11, ruff and a CodeGraph audit added), and
 #: rejected identically, because the verdict never depended on the diff.
-#: Output signatures proving the gate RAN AND JUDGED THE CHANGE WANTING.
-#:
-#: Checked BEFORE the unavailable signatures, and they win, because the two
-#: overlap in exactly the case that matters.
-#:
-#: `ssh exited with status` is the generic wrapper exit printed whenever a
-#: remote command returns non-zero -- it accompanies every failure through the
-#: ssh transport, not only a transport fault. Listing it as "unavailable"
-#: (2026-08-19, PR #478) therefore inverted the original bug instead of fixing
-#: it. Before, a transport death was signed as a rejection. After, a genuine
-#: rejection was swallowed as "could not verify", so NO verdict was signed and
-#: the task sat in REVIEWING forever.
-#:
-#: Observed live on 2026-08-20: twelve `hub_verify_unavailable` events in
-#: ninety minutes whose real failures were
-#:     "documentation contract failed: published shell fences outside the
-#:      executable book are forbidden"
-#: and
-#:     "documentation-inventory.md is stale: regenerate with
-#:      scripts/generate-docs-reference.py --write"
-#: -- both real, actionable, and both discarded. Twenty tasks accumulated in
-#: REVIEWING, five of them for over a hundred hours.
-#:
-#: The discriminator is whether the gate reached a judgement. It is not
-#: "did the gate produce output": in the #478 case the coverage gate ran and
-#: PASSED before the stream died, so output alone would have called that a
-#: rejection too. Only an explicit FAILING verdict counts.
-#: Every entry must appear ONLY on failure. That is the whole discipline here,
-#: and it is easy to get wrong in the direction that reintroduces #478:
-#: `coverage safety:` was an obvious-looking candidate and is emitted whether
-#: the floors pass or fail, so it would have marked the original
-#: passed-then-the-stream-died run as a rejection -- exactly the bug #478
-#: existed to fix. Likewise `repository contract` appears in
-#: "running fail-fast repository contract preflight", which is a start
-#: message, not a verdict.
-#:
-#: When in doubt leave a signature OUT. A missing signature means a real
-#: rejection is retried as "unavailable", which wastes a run. A wrong one
-#: means a transport fault is signed as a rejection, which discards correct
-#: work and is what this pair of fixes is for.
-_HUB_VERIFY_VERDICT_SIGNATURES: Tuple[str, ...] = (
-    "documentation contract failed",
-    "is stale:",
-    "stale generated",
-    "regenerate with",
-    "contract test failed",
-    " failed, ",         # pytest summary: "3 failed, 40 passed"
-    "assertionerror",
-    "error: process completed with exit code",
-)
-
-
 _HUB_VERIFY_UNAVAILABLE_SIGNATURES: Tuple[str, ...] = (
     # cursor-agent's stream transport, the observed cause
     "ssh exited with status",
@@ -1128,60 +1089,17 @@ def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 15
 
 
 #: Where the reason for a failure is announced, in the order a run prints it.
-#: "short test summary info" is pytest's own answer to "what failed"; the rest
-#: are the verdict signatures, so anything the classifier can act on is kept.
-_HUB_VERIFY_FAILURE_ANCHORS: Tuple[str, ...] = (
-    "short test summary info",
-) + _HUB_VERIFY_VERDICT_SIGNATURES
+#: Defined with the signatures it is built from; re-exported under the historic
+#: name.
+_HUB_VERIFY_FAILURE_ANCHORS: Tuple[str, ...] = CONTRACT_FAILURE_ANCHORS
 
-
-def _hub_verify_output_excerpt(
-    output: str, *, head: int = 1500, window: int = 2000, tail: int = 1000
-) -> str:
-    """Keep the head, the TAIL, and the part that says why the run failed.
-
-    Head-and-tail is not enough here, which is the trap this replaced a blind
-    tail with. A failing contract run prints, in order: a session header,
-    several hundred lines of pytest progress, the failure and its summary, a
-    whole-repo coverage report (one row per source file, ~14KB), a coverage
-    line whose floors both PASSED, and -- last -- OpenShell's generic
-    "ssh exited with status 1". The verdict sits in the middle, out of reach
-    of both ends, so a fixed head and tail preserve the two regions that say
-    nothing and drop the only one that does.
-
-    Position is the wrong selector. Anchor on the text that announces the
-    failure and keep a window around its LAST occurrence, so the excerpt still
-    carries a verdict signature after truncation and a rejection stays
-    classifiable as a rejection.
-    """
-
-    text = (output or "").strip()
-    if len(text) <= head + window + tail:
-        return text
-
-    spans = [(0, head), (len(text) - tail, len(text))]
-    lowered = text.lower()
-    found = [lowered.rfind(a) for a in _HUB_VERIFY_FAILURE_ANCHORS]
-    anchor_at = max(found)
-    if anchor_at >= 0:
-        start = max(0, anchor_at - window // 4)
-        spans.append((start, min(len(text), start + window)))
-
-    merged: List[Tuple[int, int]] = []
-    for start, end in sorted(spans):
-        if merged and start <= merged[-1][1]:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-        else:
-            merged.append((start, end))
-
-    parts: List[str] = []
-    previous = 0
-    for start, end in merged:
-        if start > previous:
-            parts.append("... [%d chars omitted] ..." % (start - previous))
-        parts.append(text[start:end])
-        previous = end
-    return "\n".join(parts)
+#: Keep the head, the TAIL, and the part that says why the run failed.
+#:
+#: Head-and-tail is not enough here, which is the trap that replaced a blind
+#: tail with. The reason sits in the middle of a failing run, out of reach of
+#: both ends -- see :mod:`mac.contract_output`, which owns the selection so the
+#: publication merge gate reduces its output the same way this does.
+_hub_verify_output_excerpt = capture_failure_window
 
 
 VERIFICATION_SCHEMA = "mac.worker_evidence.v1"

--- a/tests/test_merge_queue.py
+++ b/tests/test_merge_queue.py
@@ -155,7 +155,9 @@ def test_full_contract_failure_is_fail_closed(repo: Path):
     assert verdict.passed is False
     assert verdict.test_returncode == 17
     assert verdict.output_tail == "suite failed"
-    assert verdict.error == "full repository contract test failed"
+    # The error names the reason, not just the category: it is what the caller
+    # reads (`error or output_tail`) and what the eviction record keeps.
+    assert verdict.error == "full repository contract test failed: suite failed"
 
 
 def test_full_contract_never_runs_for_conflict_or_empty_command(repo: Path):

--- a/tests/test_publication_gate_failure_window.py
+++ b/tests/test_publication_gate_failure_window.py
@@ -1,0 +1,215 @@
+"""The publication gate threw the reason away after the hub verifier kept it.
+
+The hub verifier stopped taking a blind ``out[-2000:]`` and started keeping an
+anchored window around the text that announces the failure. The publication
+path then ran the SAME verification through
+``validate_projected_merge_contract``, which reduced the result with its own
+``output_tail[-2000:]`` -- a tail of an excerpt whose middle IS the answer --
+and reported a constant ``error`` that the caller reads in preference to the
+tail. So a genuine rejection arrived at the operator as:
+
+    git publication contract gate failed on the projected current-main merge:
+    full repository contract test failed
+
+which is true of every failing gate and diagnostic of none, with the captured
+evidence re-truncated back to the coverage table and "ssh exited with status".
+
+These tests use a realistic failing transcript: the failure is announced
+several hundred lines in and followed by a whole-repo coverage table, so any
+fixed tail loses the race as the repo grows.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from mac.contract_output import (
+    CONTRACT_FAILURE_ANCHORS,
+    capture_failure_window,
+    failure_reason_line,
+)
+from mac.merge_queue import validate_projected_merge_contract
+from mac.services import hub_verification_unavailable_reason
+
+# One row per source file, printed AFTER the failure and BEFORE the exit --
+# which is exactly what a tail keeps and why a tail cannot work here.
+COVERAGE_TABLE = "\n".join(
+    "src/mac/module_%03d.py%s500     40    92%%" % (i, " " * 8) for i in range(235)
+)
+
+PYTEST_PROGRESS = "\n".join(
+    "tests/test_module_%03d.py ......................... [ %2d%%]" % (i, i % 100)
+    for i in range(400)
+)
+
+FAILING_RUN = (
+    "============================= test session starts ==============================\n"
+    "collected 1218 items\n"
+    + PYTEST_PROGRESS
+    + "\n=================================== FAILURES ===================================\n"
+    "E   AssertionError: expected 1 got 0\n"
+    "=========================== short test summary info ===========================\n"
+    "FAILED tests/test_task_batch.py::test_the_preview_and_the_apply_agree\n"
+    "3 failed, 1204 passed, 11 skipped in 612.44s\n"
+    + COVERAGE_TABLE
+    + "\ncoverage safety: statements 70802/77880 (90.91%, floor 90.00%); "
+    "branches 20708/25192 (82.20%, floor 80.00%)\n"
+    "  - Uploading files to /sandbox...\n  + Files uploaded\n"
+    "Error:   x ssh exited with status exit status: 1"
+)
+
+# The preflight refuses before any test runs, so there is no pytest summary at
+# all -- the whole reason is one line. This is what rejected a live task on
+# 2026-08-21.
+STALE_ARTIFACT_RUN = (
+    "run-contract-tests.sh: running fail-fast repository contract preflight\n"
+    + PYTEST_PROGRESS
+    + "\nstale generated environment registry: src/mac/data/env_config_registry.json, "
+    "docs/env-config-reference.md; run scripts/generate-env-config-registry.py\n"
+    + COVERAGE_TABLE
+    + "\nError:   x ssh exited with status exit status: 1"
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "gate@example.invalid")
+    _git(root, "config", "user.name", "Gate")
+    (root / "base.txt").write_text("base\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "base")
+    _git(root, "checkout", "-q", "-b", "topic")
+    (root / "topic.txt").write_text("topic\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "topic")
+    _git(root, "checkout", "-q", "main")
+    return root
+
+
+def _gate(repo: Path, output: str):
+    return validate_projected_merge_contract(
+        str(repo),
+        "main",
+        "topic",
+        "scripts/run-contract-tests.sh",
+        test_runner=lambda *_args: (1, output),
+    )
+
+
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        (FAILING_RUN, "3 failed, 1204 passed"),
+        (STALE_ARTIFACT_RUN, "stale generated environment registry"),
+    ],
+)
+def test_the_refusal_names_the_reason_instead_of_a_constant(repo, output, expected):
+    """The bug, stated as the behaviour that matters.
+
+    `error` is what the caller reports (`contract_gate.error or output_tail`),
+    so a constant here is the whole failure: it is what the operator reads and
+    what the eviction record keeps.
+    """
+    verdict = _gate(repo, output)
+
+    assert verdict.passed is False
+    assert expected in verdict.error
+
+
+def test_the_reason_survives_the_eviction_records_200_character_cut(repo):
+    """The eviction reason is cut to 200 characters, so the reason has to be
+    at the FRONT of `error`, not appended after an excerpt."""
+    verdict = _gate(repo, STALE_ARTIFACT_RUN)
+
+    assert "stale generated environment registry" in verdict.error[:200]
+
+
+def test_the_captured_output_still_classifies_as_a_rejection(repo):
+    """The tail this replaced kept a passing coverage line and a generic
+    transport message, so the classifier called a real rejection a dead
+    harness -- no verdict signed, review retried, same output again."""
+    verdict = _gate(repo, FAILING_RUN)
+
+    assert hub_verification_unavailable_reason(verdict.output_tail) is None
+    assert "short test summary info" in verdict.output_tail
+    assert "test_the_preview_and_the_apply_agree" in verdict.output_tail
+
+
+def test_the_blind_tail_this_replaced_would_still_lose_the_reason():
+    """Guards the fix against being reverted to a tail with a bigger number."""
+    assert hub_verification_unavailable_reason(
+        FAILING_RUN[-2000:]
+    ) == "ssh exited with status"
+
+
+def test_the_capture_is_still_bounded(repo):
+    """Keeping the reason must not mean keeping the whole run: the verdict is
+    stored on the task and read back on every publication sweep."""
+    verdict = _gate(repo, FAILING_RUN)
+
+    assert len(verdict.output_tail) < len(FAILING_RUN) // 2
+    assert "chars omitted" in verdict.output_tail
+
+
+def test_the_capture_composes_with_itself():
+    """This gate's runner is the hub verifier, which has already captured. A
+    second reduction must be a no-op on the reason, or the fix upstream is
+    undone here -- which is precisely what happened."""
+    once = capture_failure_window(FAILING_RUN)
+    twice = capture_failure_window(once)
+
+    assert "3 failed, 1204 passed" in twice
+    assert hub_verification_unavailable_reason(twice) is None
+
+
+def test_a_passing_run_is_bounded_without_an_anchor():
+    """No anchor is present in a passing run, so the capture falls back to head
+    and tail rather than dropping everything or keeping everything."""
+    passing = "start\n" + PYTEST_PROGRESS + "\n" + COVERAGE_TABLE + "\nall good"
+
+    captured = capture_failure_window(passing)
+
+    assert captured.startswith("start")
+    assert captured.endswith("all good")
+    assert len(captured) < len(passing)
+
+
+def test_short_output_is_returned_whole():
+    assert capture_failure_window("suite failed") == "suite failed"
+
+
+def test_the_reason_line_skips_pytest_banners():
+    """`=== short test summary info ===` announces a section; the count line
+    below it states the result. Returning the banner would swap one
+    uninformative constant for another."""
+    reason = failure_reason_line(FAILING_RUN)
+
+    assert reason == "3 failed, 1204 passed, 11 skipped in 612.44s"
+
+
+def test_the_reason_line_falls_back_to_the_last_line_when_unrecognised():
+    """An unrecognised reason is still a better answer than a fixed sentence;
+    the alternative is silently reporting the constant again."""
+    assert failure_reason_line("boom: the thing broke") == "boom: the thing broke"
+    assert failure_reason_line("") == ""
+
+
+def test_every_anchor_is_reachable_after_capture():
+    """A signature the classifier keys on but the capture drops is the bug in
+    miniature, so assert the two agree for each of them."""
+    for anchor in CONTRACT_FAILURE_ANCHORS:
+        run = PYTEST_PROGRESS + "\nverdict line: %s here\n" % anchor + COVERAGE_TABLE
+
+        assert anchor in capture_failure_window(run).lower(), anchor


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_68ed61db520d438ca8304979e58ac755`
- head: `a062e068532ba5bf65da29021928c67a7c840af6`
- base at push: `4434ccd1379bc9d44d0c2b24e14ab9141405617d`
