### PR TITLE
Verify coding routes directly on Darwin hosts

### DIFF
--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -32,6 +32,8 @@ their retained sources.
 - [ADR 0023 - One skill source, thin plugins per coding harness](../adr/0023-one-skill-source-many-harness-plugins.md) — `adr/0023-one-skill-source-many-harness-plugins.md`
 - [ADR 0024 - The dashboard streams the bus, not just its counts](../adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md) — `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md`
 - [ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype](../adr/0025-the-hub-ui-is-the-observability-console.md) — `adr/0025-the-hub-ui-is-the-observability-console.md`
+- [ADR 0026: Every operation on a first-class object emits a bus event](../adr/0026-first-class-operations-emit-bus-events.md) — `adr/0026-first-class-operations-emit-bus-events.md`
+- [ADR 0027: Upgrades are versioned, ordered, and fail closed](../adr/0027-upgrades-are-versioned-and-fail-closed.md) — `adr/0027-upgrades-are-versioned-and-fail-closed.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -253,6 +253,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_DEPLOY_HERMES_SURFACE_B64` | str | consumer-defined | deployment | Deployment setting: deploy hermes surface b64. |
 | `MAC_DEPLOY_HOLD_ADOPTIONS_FILE` | str | consumer-defined | deployment | Deployment setting: deploy hold adoptions file. |
 | `MAC_DEPLOY_HUB_AGENT` | str | consumer-defined | deployment | Deployment setting: deploy hub agent. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof attempts. |
+| `MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub route proof interval seconds. |
 | `MAC_DEPLOY_HUB_TICK_INTERVAL_SECONDS` | int | consumer-defined | deployment | Deployment setting: deploy hub tick interval seconds. |
 | `MAC_DEPLOY_HUB_TOKEN` | str | consumer-defined | deployment | Deployment setting: deploy hub token. |
 | `MAC_DEPLOY_HUB_TUNNEL_PUBKEY` | str | consumer-defined | deployment | Deployment setting: deploy hub tunnel pubkey. |
@@ -843,6 +845,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_PREREQ_QDRANT_REQUIRED` | bool | consumer-defined | core | Core setting: prereq qdrant required. |
 | `MAC_PREREQ_QDRANT_URL` | str | consumer-defined | core | Core setting: prereq qdrant url. |
 | `MAC_PREREQ_ROOT` | str | consumer-defined | core | Core setting: prereq root. |
+| `MAC_PREREQ_ROUTE_HUB_REQUIRED` | bool | consumer-defined | core | Core setting: prereq route hub required. |
 | `MAC_PREREQ_SUPERVISOR` | str | consumer-defined | core | Core setting: prereq supervisor. |
 | `MAC_PREREQ_WEBDAV_ENABLED` | bool | consumer-defined | core | Core setting: prereq webdav enabled. |
 | `MAC_PREREQ_WEBDAV_URL` | str | consumer-defined | core | Core setting: prereq webdav url. |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -37,6 +37,8 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | ADR 0023 - One skill source, thin plugins per coding harness |
 | architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | ADR 0024 - The dashboard streams the bus, not just its counts |
 | architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
+| architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
+| architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -1244,7 +1244,8 @@
     "name": "MAC_CODING_AGENT_PREFLIGHT_TIMEOUT",
     "retired": false,
     "sources": [
-      "src/mac/executor_sandbox.py"
+      "src/mac/executor_sandbox.py",
+      "src/mac/worker.py"
     ],
     "type": "int"
   },
@@ -2978,6 +2979,28 @@
       "src/mac/fleet_setup.py"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy hub route proof attempts.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_ATTEMPTS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Deployment setting: deploy hub route proof interval seconds.",
+    "family": "deployment",
+    "name": "MAC_DEPLOY_HUB_ROUTE_PROOF_INTERVAL_SECONDS",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "int"
   },
   {
     "default": null,
@@ -9938,6 +9961,17 @@
       "deploy/deploy-mac-fleet.sh"
     ],
     "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Core setting: prereq route hub required.",
+    "family": "core",
+    "name": "MAC_PREREQ_ROUTE_HUB_REQUIRED",
+    "retired": false,
+    "sources": [
+      "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "bool"
   },
   {
     "default": null,

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -5970,15 +5970,47 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
     def _probe_coding_route(self) -> None:
         reports: JsonDict = {}
         try:
-            from mac.coding_agent import resolve_coding_agent
+            from mac import coding_agent as _ca
             from mac.task_executor import (
                 coding_agent_sandbox_verification,
                 coding_agent_sandbox_which,
             )
 
+            sandboxed = _env_truthy(os.environ.get("MAC_OPENSHELL_SANDBOX", "1"))
+
             def _verify(choice: Any) -> bool:
                 try:
-                    checked = dict(coding_agent_sandbox_verification(choice))
+                    if sandboxed:
+                        checked = dict(coding_agent_sandbox_verification(choice))
+                    else:
+                        argv = _ca.coding_agent_argv(choice, _ca.PREFLIGHT_PROMPT)
+                        completed = subprocess.run(
+                            argv,
+                            capture_output=True,
+                            text=True,
+                            timeout=_env_float(
+                                "MAC_CODING_AGENT_PREFLIGHT_TIMEOUT", 180.0
+                            ),
+                            check=False,
+                        )
+                        output = (completed.stdout or "") + (completed.stderr or "")
+                        verified = (
+                            completed.returncode == 0
+                            and _ca.PREFLIGHT_SENTINEL in output
+                        )
+                        checked = {
+                            **choice.observable(),
+                            "schema": "mac.coding_agent.verification.v1",
+                            "agent": choice.agent,
+                            "binary": choice.binary,
+                            "execution_binary": choice.binary,
+                            "binary_status": "present",
+                            "route_fingerprint": choice.route_fingerprint(),
+                            "verified": verified,
+                            "checked_at": _utcnow(),
+                            "returncode": completed.returncode,
+                            "failure_class": "" if verified else "host_probe_failed",
+                        }
                 except Exception as exc:  # noqa: BLE001
                     # Continue to the next configured route after a probe crash.
                     checked = {
@@ -5995,8 +6027,8 @@ class MacWorker(DebugTerminalMixin, ReflectMixin, DirectableMixin, WorkspaceGCMi
                 reports[choice.agent] = checked
                 return checked.get("verified") is True
 
-            choice = resolve_coding_agent(
-                which=coding_agent_sandbox_which,
+            choice = _ca.resolve_coding_agent(
+                which=coding_agent_sandbox_which if sandboxed else None,
                 accept=_verify,
                 verify_all=True,
             )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3386,6 +3386,79 @@ def test_worker_publishes_matching_sandbox_route_verification(
     assert "secret-not-reported" not in json.dumps(resources)
 
 
+def test_worker_verifies_darwin_host_route_without_openshell(
+    tmp_path: Path,
+    monkeypatch,
+):
+    from mac import coding_agent
+
+    cp = ControlPlane.in_memory()
+    client = TestClient(create_app(control_plane=cp))
+    api = MacApiClient("http://mac.test", transport=api_transport(client))
+    machine = cp.register_machine("darwin-host")
+    agent = cp.register_agent(
+        machine.id,
+        "darwin-worker",
+        resources={"openshell_required": False},
+    )
+    choice = coding_agent.CodingAgentChoice(
+        agent="opencode",
+        available=True,
+        binary="/Users/test/.mac/bin/opencode",
+        auth_source="~/.local/share/opencode/auth.json",
+        provider="opencode",
+        protocol="opencode-run",
+        auth_kind="api_key_file",
+    )
+
+    def resolve_for_test(*, accept=None, which=None, verify_all=False, exclude=None):
+        assert accept is not None
+        assert which is None
+        assert verify_all is True
+        return (
+            choice
+            if accept(choice)
+            else coding_agent.CodingAgentChoice(agent="", available=False)
+        )
+
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "0")
+    monkeypatch.setattr(coding_agent, "resolve_coding_agent", resolve_for_test)
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args[0], 0, coding_agent.PREFLIGHT_SENTINEL, ""
+        ),
+    )
+    monkeypatch.setattr(
+        coding_agent,
+        "_DETECTORS",
+        {
+            **coding_agent._DETECTORS,
+            "opencode": lambda *_args: (
+                True,
+                choice.binary,
+                choice.auth_source,
+                "opencode: configured for test",
+            ),
+        },
+    )
+
+    worker = MacWorker(
+        api,
+        agent.id,
+        tmp_path,
+        lambda _t, _d: WorkerExecution(0, "ok"),
+    )
+    worker._probe_coding_route()
+    resources = worker._maybe_command_inventory_resources()
+
+    opencode = resources["coding_clis"]["clis"]["opencode"]
+    assert opencode["verified"] is True
+    assert opencode["verification"]["execution_binary"] == choice.binary
+    assert worker._coding_route_report["agent"] == "opencode"
+
+
 def test_worker_falls_through_failed_claude_and_publishes_verified_codex(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary

- verify coding-agent routes in the host execution context when OpenShell is disabled
- preserve existing in-sandbox verification for Linux workers
- add a regression test for host-native OpenCode verification
- refresh generated environment references

## Verification

- `scripts/run-sanity-tests.sh --changed-file src/mac/worker.py --changed-file tests/test_worker.py --changed-file src/mac/data/env_config_registry.json --changed-file docs/env-config-reference.md` (705 passed, 4 skipped)
- `ruff check src/mac/worker.py tests/test_worker.py`
- `codegraph affected src/mac/worker.py tests/test_worker.py src/mac/data/env_config_registry.json docs/env-config-reference.md`

Task: `task_59e5e74d9f76461f9c23151c63112188`
