### PR TITLE
Keep script-job legacy fallback on the evicted Hermes tree

### DIFF
--- a/deploy/openclaw/relocate-script-job-home.py
+++ b/deploy/openclaw/relocate-script-job-home.py
@@ -71,7 +71,7 @@ def openclaw_home() -> Path:
 
 
 def gateway_home() -> Path:
-    return _env_dir("HERMES_HOME") or (Path.home() / ".hermes")
+    return _env_dir("HERMES_HOME") or (mac_home() / "openclaw")
 
 
 def script_jobs_dir() -> Path:
@@ -85,7 +85,7 @@ def script_jobs_scripts_dir() -> Path:
 
 
 def legacy_gateway_scripts_dir() -> Path:
-    return gateway_home() / "scripts"
+    return (_env_dir("HERMES_HOME") or (Path.home() / ".hermes")) / "scripts"
 
 
 def backups_dir() -> Path:

--- a/deploy/openclaw/run-script-cron-job.py
+++ b/deploy/openclaw/run-script-cron-job.py
@@ -90,7 +90,7 @@ def openclaw_home() -> Path:
 
 
 def gateway_home() -> Path:
-    return _env_dir("HERMES_HOME") or (Path.home() / ".hermes")
+    return _env_dir("HERMES_HOME") or (mac_home() / "openclaw")
 
 
 def script_jobs_dir() -> Path:
@@ -111,7 +111,7 @@ def script_jobs_output_dir() -> Path:
 
 def legacy_gateway_scripts_dir() -> Path:
     """Read-only pre-untangle scripts home; see the module docstring."""
-    return gateway_home() / "scripts"
+    return (_env_dir("HERMES_HOME") or (Path.home() / ".hermes")) / "scripts"
 
 
 # --------------------------------------------------------------------------- #

--- a/docs/home-consolidation.md
+++ b/docs/home-consolidation.md
@@ -201,8 +201,10 @@ named read-only fallback below.
 
 **Rollout is read-old / write-new**, which is what makes flipping the default
 safe. `select_scripts_dir()` prefers the sanctioned home and consults
-`legacy_gateway_scripts_dir()` (`$HERMES_HOME/scripts`) only for a script the new
-home does not have, so the three enabled jobs on a host that has not been
+`legacy_gateway_scripts_dir()` only for a script the new home does not have.
+That fallback is `$HERMES_HOME/scripts` when set, otherwise `~/.hermes/scripts`
+— it does not follow Phase 2's `gateway_home()` (`$MAC_HOME/openclaw`), so the
+three enabled jobs on a host that has not been
 re-installed keep running instead of failing silently — the parent task's stated
 risk. Every fallback is reported in the runner's result as
 `legacy_scripts_home: true`, so the fleet can be swept for stragglers rather than

--- a/src/mac/mac_paths.py
+++ b/src/mac/mac_paths.py
@@ -180,8 +180,14 @@ def legacy_gateway_scripts_dir() -> Path:
     (``deploy/openclaw/relocate-script-job-home.py``) yet — enabling the new
     default must never silently stop an enabled job. Nothing writes here, and
     the fallback disappears with the legacy tree.
+
+    Phase 2 moved ``gateway_home()`` under ``$MAC_HOME/openclaw``. Do not follow
+    it: the evicted tree is still ``~/.hermes`` (or ``$HERMES_HOME`` when a host
+    has not migrated). Routing this through ``gateway_home()`` would make the
+    fallback look at the live OpenClaw tree and miss leftover Hermes scripts.
     """
-    return gateway_home() / "scripts"
+    return (_env_path("HERMES_HOME") or (Path.home() / ".hermes")) / "scripts"
+
 
 def gateway_env_file() -> Path:
     """Gateway secrets file the gateway process sources: ``$HERMES_HOME/.env``."""

--- a/tests/test_mac_paths.py
+++ b/tests/test_mac_paths.py
@@ -57,6 +57,18 @@ def test_hermes_home_relocates_gateway_paths(clean_home, monkeypatch):
     assert mac_paths.gateway_home() == gw
     assert mac_paths.gateway_env_file() == gw / ".env"
     assert mac_paths.dream_logs_dir() == gw / "dream_logs"
+    assert mac_paths.legacy_gateway_scripts_dir() == gw / "scripts"
+
+
+def test_legacy_scripts_stay_on_evicted_hermes_after_phase2(clean_home):
+    """Phase 2 moved live gateway state under MAC_HOME; the read-only
+    fallback must still name the pre-untangle tree, or unmigrated hosts
+    lose ~/.hermes/scripts and the runner fallback becomes a no-op."""
+    assert mac_paths.gateway_home() == clean_home / ".mac" / "openclaw"
+    assert mac_paths.legacy_gateway_scripts_dir() == clean_home / ".hermes" / "scripts"
+    assert mac_paths.legacy_gateway_scripts_dir() != (
+        mac_paths.gateway_home() / "scripts"
+    )
 
 
 def test_per_file_overrides_win(clean_home, monkeypatch):

--- a/tests/test_script_job_home.py
+++ b/tests/test_script_job_home.py
@@ -94,8 +94,12 @@ def test_script_job_home_relocates_with_its_root(clean_home, monkeypatch):
 # --------------------------------------------------------------------------- #
 def test_no_live_runner_path_resolves_into_a_hermes_home(clean_home):
     """With a clean environment, nothing the runner reads or writes is under
-    the gateway home — the fallback aside, which is asserted separately."""
-    gateway = mac_paths.gateway_home()
+    the evicted Hermes tree — the fallback aside, which is asserted separately.
+
+    After Phase 2, ``gateway_home()`` is ``$MAC_HOME/openclaw``, which IS the
+    live OpenClaw tree; that is no longer the Hermes home to stay out of.
+    """
+    hermes = Path.home() / ".hermes"
     live = {
         "scripts": Path(runner.script_jobs_scripts_dir()),
         "output": Path(runner.script_jobs_output_dir()),
@@ -104,7 +108,7 @@ def test_no_live_runner_path_resolves_into_a_hermes_home(clean_home):
         "jobs_home": mac_paths.openclaw_home(),
     }
     for label, path in live.items():
-        assert gateway not in path.parents and path != gateway, (
+        assert hermes not in path.parents and path != hermes, (
             "%s still resolves into the Hermes home: %s" % (label, path)
         )
         assert mac_paths.mac_home() in path.parents, (
@@ -124,7 +128,9 @@ def test_runner_defaults_have_no_hermes_literal_left():
         for line in source.splitlines()
         if '".hermes"' in line and not line.lstrip().startswith("#")
     ]
-    assert hermes_lines == ['    return _env_dir("HERMES_HOME") or (Path.home() / ".hermes")']
+    assert hermes_lines == [
+        '    return (_env_dir("HERMES_HOME") or (Path.home() / ".hermes")) / "scripts"'
+    ]
 
 
 def test_installer_schedules_the_openclaw_scripts_home_not_hermes():


### PR DESCRIPTION
## Summary
- Phase 2 moved `gateway_home()` to `$MAC_HOME/openclaw`. The script-job runner still needs a read-only fallback on leftover `~/.hermes/scripts` (or `$HERMES_HOME/scripts`) so unmigrated hosts do not lose enabled jobs.
- Stop deriving `legacy_gateway_scripts_dir()` from `gateway_home()`. Mirror the same split in the stdlib deploy scripts, and pin the tests so live OpenClaw paths are not treated as the Hermes home.

Fixes `tests/test_script_job_home.py` failures on current `main`. Ledger: `task_c4b003bb`.

## Test plan
- [x] `uv run --extra dev pytest -q tests/test_mac_paths.py tests/test_script_job_home.py` (45 passed)
- [x] `make lint`
- [ ] CI green on this PR