### PR TITLE
OpenClaw gateway installer hardcodes a Linux image path and has no working darwin route (task_c2c1c5897cf74a9ca534074db49b4b1c)

### DIFF
--- a/deploy/openclaw/install-openclaw-gateway.sh
+++ b/deploy/openclaw/install-openclaw-gateway.sh
@@ -47,6 +47,11 @@ export OPENSHELL_GATEWAY_ENDPOINT="${OPENSHELL_GATEWAY_ENDPOINT:-${MAC_OPENSHELL
 
 log() { printf '[install-openclaw-gateway] %s\n' "$*"; }
 die() { log "ERROR: $*" >&2; exit 1; }
+
+if [ "$(uname -s)" = Darwin ]; then
+  die "OpenClaw gateways are unsupported on darwin; run the gateway on a Linux node (ADR 0015)"
+fi
+
 truthy() {
   case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
     1|true|yes|on) return 0 ;;

--- a/docs/adr/0015-macos-nodes-are-host-installs.md
+++ b/docs/adr/0015-macos-nodes-are-host-installs.md
@@ -180,7 +180,8 @@ It is no longer the macOS posture, because macOS no longer has one to waive.
 - macOS nodes run tasks unconfined by MAC. Anything that must be confined must
   run on a Linux node.
 - The host install must now supply, natively, everything the runtime image
-  supplied. It does not yet: Node/npm/pnpm, the reviewed coding-agent CLIs
+  supplied. It does not yet: OpenClaw (so macOS gateways must be served from a
+  Linux node), Node/npm/pnpm, the reviewed coding-agent CLIs
   (`claude`, `codex`, `cursor-agent`), the `[dev]` extra needed to run contract
   tests in place, cmake/ninja/llvm-objcopy/ld.lld/qemu-system-riscv64, java and
   lein have no darwin install path, and `deploy/verify-bash-contract.sh`'s

--- a/tests/test_openclaw_gateway_deploy.py
+++ b/tests/test_openclaw_gateway_deploy.py
@@ -215,6 +215,38 @@ def test_stock_openclaw_artifacts_are_pinned_and_do_not_invoke_nemoclaw() -> Non
     assert "/opt/mac-openclaw/plugins/mac-continuity" in container
 
 
+def test_openclaw_gateway_installer_refuses_darwin_with_adr_explanation(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uname = fake_bin / "uname"
+    uname.write_text("#!/bin/sh\nprintf 'Darwin\\n'\n", encoding="utf-8")
+    uname.chmod(0o755)
+
+    result = subprocess.run(
+        [str(INSTALLER), "prepare"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
+    )
+
+    assert result.returncode != 0
+    assert "unsupported on darwin" in result.stderr
+    assert "Linux node" in result.stderr
+    assert "ADR 0015" in result.stderr
+
+
+def test_macos_host_adr_names_openclaw_install_gap() -> None:
+    adr = (ROOT / "docs" / "adr" / "0015-macos-nodes-are-host-installs.md").read_text(
+        encoding="utf-8"
+    )
+    consequences = adr.split("## Consequences", maxsplit=1)[1]
+    assert "OpenClaw" in consequences
+    assert "macOS gateways must be served from a Linux node" in consequences
+
+
 def test_openclaw_policy_is_deny_by_default_and_narrowly_allows_required_services() -> None:
     text = POLICY.read_text(encoding="utf-8")
     assert "run_as_user: sandbox" in text


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_c2c1c5897cf74a9ca534074db49b4b1c`
- head: `801bc4c60913a614a30bf0ea11fb9560e144a748`
- base at push: `7c1699290096bcec9e99d7eb6e141bd7e68d680f`
