### PR TITLE
Document that Docker on a macOS host is for system services, never for OpenShell sandboxes (task_e803b02ec80b44e5ac7dbefe5455e190)

### DIFF
--- a/docs/adr/0015-macos-nodes-are-host-installs.md
+++ b/docs/adr/0015-macos-nodes-are-host-installs.md
@@ -71,9 +71,23 @@ and, on what a macOS agent is:
 
 ## Decision
 
-**The managed OpenShell runtime is Linux-only. A macOS fleet node is a plain
-host install: a standard macOS application, installed on the host, with no
-container runtime.**
+**The managed OpenShell execution sandbox is Linux-only. A macOS fleet node is
+a plain host install: a standard macOS application installed on the host, never
+inside an OpenShell container.**
+
+This decision is about execution confinement, not a ban on every use of
+containers on a macOS host. Docker may run ordinary long-lived system services
+such as Qdrant, Firecrawl, test PostgreSQL, and telemetry collectors. Those
+services happen to ship as images; their container boundary is not asserted in
+an agent attestation and is not used to authorize task execution. Docker must
+never be used for an OpenShell execution sandbox on darwin.
+
+The distinction is security-relevant. Docker Desktop executes Linux containers
+under a LinuxKit kernel, which cannot enforce Landlock against the macOS host.
+An OpenShell sandbox there would therefore advertise confinement it does not
+provide. A darwin node instead attests `macos_host`, with no execution
+confinement fields. Neither the presence nor absence of Docker changes that
+posture or may be used as evidence that a darwin executor is sandboxed.
 
 macOS nodes attest the isolation posture **`macos_host`**.
 

--- a/docs/fleet-node-onboarding-checklist.md
+++ b/docs/fleet-node-onboarding-checklist.md
@@ -115,9 +115,12 @@ network first; do not deploy to a guessed host.
       provision exact Python `3.12.11` instead of inheriting an old base-image
       Python. The reviewed asset matrix covers Linux amd64/arm64 and Darwin
       x86_64/arm64; an unknown OS/architecture or SHA-256 mismatch stops deploy.
-- [ ] `git`, `gh`, `codegraph`, the selected coding CLIs, container runtime, and
-      OpenShell prerequisites are present in the worker's service PATH, not only
-      an interactive login shell.
+- [ ] `git`, `gh`, `codegraph`, and the selected coding CLIs are present in the
+      worker's service PATH, not only an interactive login shell. On Linux,
+      verify the Docker Engine/Moby runtime and OpenShell prerequisites there as
+      well. On darwin, OpenShell and its execution container runtime must be
+      absent; Docker is optional and may serve only system services such as
+      Qdrant, Firecrawl, test PostgreSQL, and telemetry collectors.
 - [ ] CodeGraph `v1.5.0` is installed from its versioned native release archive
       after SHA-256 verification. No fleet credential-bearing process executes
       a downloaded installer script. Verified archives are cached under
@@ -132,6 +135,11 @@ unsupported tool OS/architecture, reviewed-asset download or checksum failure,
 missing supervisor control, or a required tool visible only in an interactive
 shell. Do not bypass a checksum failure with an ambient `curl | sh` installer.
 A credential sync does not repair any of these failures.
+
+On a macOS hub, use `docker ps` to verify that any containers are expected
+system services. Stop if a container is presented as an OpenShell execution
+sandbox, or if Docker availability is used to claim confinement: darwin tasks
+run on the host and must attest `macos_host`.
 
 ## Phase 3: secrets and credential projection
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -529,6 +529,15 @@ describe local Hermes soul/conversation state, mac operational provenance, and
 hub-managed shared level-2 memory. `/startup/hermes` reports
 `qdrant_level2` readiness using redacted endpoints only.
 
+On a macOS hub, Docker containers for system services are expected. Qdrant,
+Firecrawl, test PostgreSQL, and telemetry collectors are long-lived network
+services whose container isolation is not part of an executor attestation.
+This does not permit OpenShell execution sandboxes on darwin: those tasks run
+as host applications and attest `macos_host`, because Docker Desktop's
+LinuxKit kernel cannot enforce Landlock against the macOS host. Use `docker ps`
+to confirm that observed containers are known system services; no container
+may be treated as a sandbox or as evidence of execution confinement.
+
 Deployment logs and migration reports are written under `~/.mac/logs/` on each
 host:
 
@@ -1085,6 +1094,12 @@ dashboard; use the API/CLI for workflow creation and editing until that UI is
 built.
 
 ## Docker Engine / Moby
+
+Docker on a darwin hub is supported for system services, including Qdrant,
+Firecrawl, test PostgreSQL, and telemetry collectors. It is never an OpenShell
+execution runtime on darwin, and its availability does not alter the node's
+`macos_host` posture. `docker ps` should therefore show only the expected
+service containers; investigate any container presented as a task sandbox.
 
 ```console
 docker build -t mac:latest .


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_e803b02ec80b44e5ac7dbefe5455e190`
- head: `60f14782bcc7ce1eaf304746a86210b3b6665b72`
- base at push: `7c1699290096bcec9e99d7eb6e141bd7e68d680f`
