### PR TITLE
Native merge queue for mac#main head-of-line blocked since 2026-08-19: stale tested front entry strands all queued publications (task_83937fb1c50c4a71a7617e863c0e7e97)

### DIFF
--- a/docs/guide/03-advanced.md
+++ b/docs/guide/03-advanced.md
@@ -62,6 +62,61 @@ The AIMD window grows by one on a land and halves on a failure, floor 1 and
 ceiling 4. `MAC_MERGE_QUEUE_WINDOW_CEILING=1` disables speculation without
 disabling the queue.
 
+#### When the queue stops draining
+
+Every recovery in the queue — reclaiming a dead lease, discarding stale
+speculation, evicting a conflicting entry — is driven by a *publication
+attempt*, and a publication attempt happens because some task's publication loop
+is still retrying. That leaves one entry nobody can rescue: the **front**.
+Entries behind it are deferred by the window and never reach the land gate, so
+if the front's own loop stops — abandoned task, terminal failure, a hub that
+went away — the queue stops.
+
+It happened: `mac#main` was head-of-line blocked from 2026-08-19 to 2026-08-22
+with twelve entries behind one `tested` front whose recorded tree `main` had
+long since moved off. One landing in three days; an approved task waited four
+hours and was merged by hand.
+
+So the front is on a deadline, enforced by a reconcile sweep that runs on every
+publication attempt against that queue — which means the deferred entries behind
+a block are themselves what heals it:
+
+1. slots whose holder stopped renewing the lease are reclaimed;
+2. a front tested against a tree the canonical tip has moved off is sent back to
+   `queued` so its next attempt re-tests against the tree that exists now
+   (`main` advancing outside the queue is normal, and no longer strands it);
+3. an entry with no live lease that retried past the cap, or that finished an
+   attempt without ever learning its pull request, is evicted with a reason;
+4. a front with no live lease that has not moved for
+   `MAC_MERGE_QUEUE_FRONT_IDLE_SECONDS` (default 5400) is evicted, and the queue
+   drains.
+
+A live lease is always honoured — that is a worker inside a contract run, and
+evicting it would throw away work that was about to succeed.
+
+The same commit is also not allowed to churn: after an eviction it backs off
+before rejoining, doubling per eviction, and after three evictions of the *same
+commit* the queue refuses to re-queue it at all and says to rebase or re-review.
+A new commit for the same task is admitted immediately — the history is held
+against the commit, not the task.
+
+To act on a queue directly:
+
+```bash
+mac admin merge-queue list                       # which queues exist
+mac admin merge-queue show <repository>          # depth, window, front, evictions
+mac admin merge-queue reconcile <repository> \
+    --canonical-tip-tree "$(git rev-parse origin/main^{tree})"
+mac admin merge-queue requeue <entry_id> --reason "tip moved under it"
+mac admin merge-queue evict   <entry_id> --reason "abandoned"
+```
+
+`reconcile` needs `--canonical-tip-tree` from a checkout to run step 2 — the hub
+has none. Without it the sweep still does the rest rather than guessing at the
+tip. `requeue` is usually the right verb for a stuck front: the change keeps its
+place in line and is re-tested, rather than being thrown out for a result that
+went stale under it.
+
 ## Dispatch: why a task is or is not claimable
 
 Claimability is a conjunction, and all of it must hold:

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -1580,6 +1580,25 @@ class AgentBusBroadcast(BaseModel):
     payload: Dict[str, Any] = Field(default_factory=dict)
 
 
+class MergeQueueReconcileRequest(BaseModel):
+    """Run the native merge queue's recovery sweep against one queue."""
+
+    repository: str
+    branch: str = "main"
+    #: ``git rev-parse origin/<branch>^{tree}``, from a checkout the operator
+    #: has and the hub does not. Optional: without it the sweep skips the
+    #: stale-result step rather than guessing at the tip.
+    canonical_tip_tree: str = ""
+    actor: str = ""
+
+
+class MergeQueueEntryAction(BaseModel):
+    """Evict or requeue one entry, with a reason that outlives the session."""
+
+    reason: str = ""
+    actor: str = ""
+
+
 class AgentBusRepoUpdate(BaseModel):
     sender_agent_id: str
     recipient_agent_ids: List[str] = Field(default_factory=list)
@@ -2221,6 +2240,12 @@ def _required_scope(method: str, path: str) -> Optional[str]:
     if path.startswith("/repository-refs"):
         # A forced reconciliation in prune mode can delete remote branches.
         # Status is ordinary read data; every mutating trigger is admin-only.
+        return "read" if method == "GET" else "admin"
+    if path == "/merge-queue" or path.startswith("/merge-queue/"):
+        # What is waiting to land is ordinary fleet visibility -- the console
+        # already shows it. Evicting and requeueing decide which changes reach
+        # the trunk and in what order, which is a control-plane operation, not
+        # a task write.
         return "read" if method == "GET" else "admin"
     if path.startswith("/optimizer"):
         # Learned policy changes future task execution across a project.  Reads
@@ -5022,6 +5047,84 @@ def create_app(
         """The decompressed text of one transcript turn. Read-only."""
         del principal
         return build_transcript_entry(cp, transcript_id)
+
+    # -- the native merge queue, as something an operator can act on --------
+    #
+    # The console has shown this queue's depth and evictions since it was
+    # built, and there was no verb anywhere to change any of it. When mac#main
+    # went head-of-line blocked for three days the recovery available to an
+    # operator was: merge the pull request by hand on GitHub -- which does not
+    # touch the queue's state, so the queue stayed blocked afterwards. Watching
+    # without acting is how a stall becomes a three-day stall.
+
+    @app.get("/merge-queue")
+    def list_merge_queues(
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> List[Dict[str, Any]]:
+        """Every (repository, branch) the native queue holds entries for."""
+        del principal  # read-only; scope is enforced by _required_scope
+        return cp.list_merge_queues()
+
+    @app.get("/merge-queue/entries")
+    def merge_queue_snapshot(
+        repository: str = Query(...),
+        branch: str = Query(default="main"),
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        """Depth, window, front, live entries and why the last ones were evicted.
+
+        Repository and branch are query parameters rather than path segments:
+        a repository is a URL and would need double-escaping to survive a path.
+        """
+        del principal
+        return cp.merge_queue_snapshot(repository, branch)
+
+    @app.post("/merge-queue/reconcile")
+    def reconcile_merge_queue(
+        body: MergeQueueReconcileRequest,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        """Run the recovery sweep now.
+
+        Admin: it evicts entries. The sweep is normally driven by publication
+        attempts, and this route exists for the state where there are none left
+        to drive it -- which is exactly the state that blocks a queue.
+        """
+        principal.require_admin()
+        return cp.reconcile_merge_queue(
+            body.repository,
+            body.branch,
+            canonical_tip_tree=body.canonical_tip_tree,
+            actor=body.actor,
+        )
+
+    @app.post("/merge-queue/entries/{entry_id}/evict")
+    def evict_merge_queue_entry(
+        entry_id: str,
+        body: MergeQueueEntryAction,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        """Take one entry out of the queue and discard speculation behind it."""
+        principal.require_admin()
+        return cp.evict_merge_queue_entry(
+            entry_id, reason=body.reason, actor=body.actor
+        )
+
+    @app.post("/merge-queue/entries/{entry_id}/requeue")
+    def requeue_merge_queue_entry(
+        entry_id: str,
+        body: MergeQueueEntryAction,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        """Send one entry back to `queued`, discarding its test result.
+
+        The gentler verb, and usually the right one: the change keeps its place
+        in line and is re-tested against the tree that exists now.
+        """
+        principal.require_admin()
+        return cp.requeue_merge_queue_entry(
+            entry_id, reason=body.reason, actor=body.actor
+        )
 
     @app.get("/dashboard/state")
     def dashboard_state(

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -5934,6 +5934,49 @@ def cmd_agentbus_broadcast(args: argparse.Namespace) -> None:
     )
 
 
+def cmd_merge_queue_list(args: argparse.Namespace) -> None:
+    _print(_plane(args).list_merge_queues())
+
+
+def cmd_merge_queue_show(args: argparse.Namespace) -> None:
+    _print(_plane(args).merge_queue_snapshot(args.repository, args.branch))
+
+
+def cmd_merge_queue_reconcile(args: argparse.Namespace) -> None:
+    """Run the queue's recovery sweep now.
+
+    ``--canonical-tip-tree`` is what lets the sweep tell a stale test result
+    from a current one, and the hub cannot read it: it has no checkout. Pass
+    ``git rev-parse origin/<branch>^{tree}`` from one you do have. Without it
+    the sweep still reclaims dead leases and evicts entries that cannot
+    progress -- it just will not discard a result on suspicion.
+    """
+    _print(
+        _plane(args).reconcile_merge_queue(
+            args.repository,
+            args.branch,
+            canonical_tip_tree=args.canonical_tip_tree,
+            actor=args.actor,
+        )
+    )
+
+
+def cmd_merge_queue_evict(args: argparse.Namespace) -> None:
+    _print(
+        _plane(args).evict_merge_queue_entry(
+            args.entry_id, reason=args.reason, actor=args.actor
+        )
+    )
+
+
+def cmd_merge_queue_requeue(args: argparse.Namespace) -> None:
+    _print(
+        _plane(args).requeue_merge_queue_entry(
+            args.entry_id, reason=args.reason, actor=args.actor
+        )
+    )
+
+
 def cmd_agentbus_publish(args: argparse.Namespace) -> None:
     _print(
         _plane(args).publish_agentbus_content(
@@ -10660,6 +10703,70 @@ def build_parser() -> argparse.ArgumentParser:
     inbox.add_argument("agent_id")
     inbox.add_argument("--limit", type=int, default=50)
     _set(cmd_message_inbox, inbox)
+
+    merge_queue = sub.add_parser(
+        "merge-queue",
+        help="mac's own merge queue: what is waiting to land, and why",
+        description=(
+            "The queue mac runs for repositories the forge will not serialize "
+            "(GitHub merge queues are organization-only, so every User-owned "
+            "repository uses this one). `show` answers why nothing is landing; "
+            "`reconcile` runs the recovery sweep the queue normally drives from "
+            "publication attempts; `evict` and `requeue` act on one entry when "
+            "the sweep's judgement is not the one you want."
+        ),
+    ).add_subparsers(dest="merge_queue_command", required=True)
+
+    mq_list = merge_queue.add_parser(
+        "list", help="every (repository, branch) with queue entries"
+    )
+    _set(cmd_merge_queue_list, mq_list)
+
+    mq_show = merge_queue.add_parser(
+        "show", help="depth, window, the front entry, and recent evictions"
+    )
+    mq_show.add_argument("repository")
+    mq_show.add_argument("--branch", default="main")
+    _set(cmd_merge_queue_show, mq_show)
+
+    mq_reconcile = merge_queue.add_parser(
+        "reconcile",
+        help="reclaim dead leases, discard stale results, drop what cannot progress",
+        description=(
+            "Pass --canonical-tip-tree `git rev-parse origin/<branch>^{tree}` "
+            "from a checkout: the hub has none, and without the tip tree the "
+            "sweep cannot tell a stale test result from a current one, so it "
+            "leaves results alone rather than discarding on suspicion."
+        ),
+    )
+    mq_reconcile.add_argument("repository")
+    mq_reconcile.add_argument("--branch", default="main")
+    mq_reconcile.add_argument("--canonical-tip-tree", default="")
+    mq_reconcile.add_argument("--actor", default="")
+    _set(cmd_merge_queue_reconcile, mq_reconcile)
+
+    mq_evict = merge_queue.add_parser(
+        "evict",
+        help="remove one entry, discarding every speculative result behind it",
+    )
+    mq_evict.add_argument("entry_id")
+    mq_evict.add_argument("--reason", default="")
+    mq_evict.add_argument("--actor", default="")
+    _set(cmd_merge_queue_evict, mq_evict)
+
+    mq_requeue = merge_queue.add_parser(
+        "requeue",
+        help="send one entry back to `queued`, discarding only its test result",
+        description=(
+            "Usually the right verb for a stuck front: the change keeps its "
+            "place in line and is re-tested against the tree that exists now, "
+            "rather than being thrown out for a result that went stale under it."
+        ),
+    )
+    mq_requeue.add_argument("entry_id")
+    mq_requeue.add_argument("--reason", default="")
+    mq_requeue.add_argument("--actor", default="")
+    _set(cmd_merge_queue_requeue, mq_requeue)
 
     agentbus = sub.add_parser(
         "agentbus",

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -211,6 +211,7 @@ COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
             ("dispatch", "the loop that matches ready tasks to eligible agents"),
             ("review", "adversarial review of completed work"),
             ("publish", "publish reviewed work to its destination"),
+            ("merge-queue", "mac's own merge queue: what is waiting to land, and why"),
             ("pull-request", "pull requests raised from task work"),
             ("workflow", "multi-step workflow definitions and runs"),
             ("plan", "planning helpers, including dependency ordering"),

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -1770,6 +1770,56 @@ class RemoteDispatch:
             )
         )
 
+    # -- the native merge queue ---------------------------------------------
+
+    def list_merge_queues(self) -> List[_Dictish]:
+        return _wrap_list(self._get("/merge-queue"))
+
+    def merge_queue_snapshot(self, repository: str, branch: str) -> _Dictish:
+        return _Dictish(
+            self._get("/merge-queue/entries", repository=repository, branch=branch)
+        )
+
+    def reconcile_merge_queue(
+        self,
+        repository: str,
+        branch: str,
+        *,
+        canonical_tip_tree: str = "",
+        actor: str = "",
+    ) -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/merge-queue/reconcile",
+                {
+                    "repository": repository,
+                    "branch": branch,
+                    "canonical_tip_tree": canonical_tip_tree,
+                    "actor": actor,
+                },
+            )
+        )
+
+    def evict_merge_queue_entry(
+        self, entry_id: str, *, reason: str = "", actor: str = ""
+    ) -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/merge-queue/entries/%s/evict" % quote(entry_id, safe=""),
+                {"reason": reason, "actor": actor},
+            )
+        )
+
+    def requeue_merge_queue_entry(
+        self, entry_id: str, *, reason: str = "", actor: str = ""
+    ) -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/merge-queue/entries/%s/requeue" % quote(entry_id, safe=""),
+                {"reason": reason, "actor": actor},
+            )
+        )
+
     def read_agentbus_broadcasts(
         self,
         agent_id: str,

--- a/src/mac/native_merge_queue.py
+++ b/src/mac/native_merge_queue.py
@@ -191,6 +191,43 @@ def lease_seconds_from_env(environ: Optional[Dict[str, str]] = None) -> int:
     return max(60, value)
 
 
+def front_idle_seconds_from_env(environ: Optional[Dict[str, str]] = None) -> int:
+    """How long the FRONT may sit untouched before the queue gives up on it.
+
+    ``MAC_MERGE_QUEUE_FRONT_IDLE_SECONDS``, default 5400 (90 minutes, the same
+    order as the slot lease).
+
+    This exists because of a failure mode the rest of this module cannot see.
+    Every recovery path here -- reclaiming a dead lease, discarding stale
+    speculation, evicting a conflicting entry -- is driven by a *publication
+    attempt*, and a publication attempt only happens because some task's
+    publication loop is still retrying.  The front entry is the one entry whose
+    recovery nothing else can trigger: entries behind it are deferred by the
+    window and never reach the land gate, so if the front's own loop stops --
+    the task was abandoned, failed terminally, or the hub that owned it went
+    away -- the front sits at position 1 forever and every approved change
+    behind it defers on a ~6 minute cycle, permanently.
+
+    That is not hypothetical: mac#main was head-of-line blocked this way from
+    2026-08-19 to 2026-08-22 with depth 12 and one landing in three days, and
+    the only way anything shipped was an operator merging by hand.
+
+    So the front is on a deadline.  A front that has not moved for this long,
+    and that no live lease says is being tested right now, is evicted with a
+    reason.  Evicting a change that was going to land is recoverable -- its
+    task re-admits and re-tests.  A queue that cannot drain is not.
+    """
+
+    env = os.environ if environ is None else environ
+    try:
+        value = int(
+            str(env.get("MAC_MERGE_QUEUE_FRONT_IDLE_SECONDS", "")).strip() or 5400
+        )
+    except (TypeError, ValueError):
+        value = 5400
+    return max(60, value)
+
+
 # ----------------------------------------------------------------------------
 # Entries and pure planning.
 # ----------------------------------------------------------------------------
@@ -369,7 +406,17 @@ def landing_is_safe(
 
 @dataclass(frozen=True)
 class SlotDecision:
-    """Whether this publication attempt may proceed, and on what base."""
+    """Whether this publication attempt may proceed, and on what base.
+
+    ``terminal`` separates the two reasons a slot can be refused, which the
+    caller must treat differently.  A full window is a *deferral*: wait and ask
+    again, the entry keeps its place.  A change that has been evicted from this
+    queue over and over for the same reason is a *verdict*: asking again in six
+    minutes produces the identical eviction, and the retry budget it burns is
+    taken from changes that could have landed.  Deferring forever is how one
+    task on the live hub accumulated dozens of evictions with the same
+    "projected merge conflicts with the queue base" reason.
+    """
 
     admitted: bool
     entry: Optional[QueueEntry] = None
@@ -379,6 +426,7 @@ class SlotDecision:
     depth_in_queue: int = 0
     reason: str = ""
     defer_seconds: int = 0
+    terminal: bool = False
 
     def to_dict(self) -> JsonDict:
         return {
@@ -393,6 +441,7 @@ class SlotDecision:
             "queue_depth": self.depth_in_queue,
             "reason": self.reason,
             "defer_seconds": self.defer_seconds,
+            "terminal": self.terminal,
         }
 
 
@@ -417,6 +466,7 @@ class NativeMergeQueue:
         *,
         bounds: Optional[WindowBounds] = None,
         lease_seconds: Optional[int] = None,
+        front_idle_seconds: Optional[int] = None,
         now: Callable[[], str] = utcnow,
         observe: Optional[Callable[..., Any]] = None,
     ) -> None:
@@ -424,6 +474,11 @@ class NativeMergeQueue:
         self._bounds = bounds or bounds_from_env()
         self._lease_seconds = (
             int(lease_seconds) if lease_seconds is not None else lease_seconds_from_env()
+        )
+        self._front_idle_seconds = (
+            int(front_idle_seconds)
+            if front_idle_seconds is not None
+            else front_idle_seconds_from_env()
         )
         self._now = now
         self._observe_hook = observe
@@ -629,6 +684,14 @@ class NativeMergeQueue:
         keeps its place in line.
         """
 
+        # Re-admission, not admission, is where churn starts. An entry that is
+        # already live keeps its place and is never held back here; one that is
+        # coming BACK after an eviction is asked whether returning is likely to
+        # do anything but repeat the eviction.
+        if self._live_entry_for_task(repository, branch, task_id) is None:
+            refusal = self._readmission_refusal(repository, branch, task_id, head_sha)
+            if refusal is not None:
+                return refusal
         entry = self.admit(
             repository=repository,
             branch=branch,
@@ -1057,7 +1120,378 @@ class NativeMergeQueue:
         )
         return int(getattr(result, "rowcount", 0) or 0) >= 1
 
+    def requeue(self, entry_id: str, *, reason: str) -> JsonDict:
+        """Send a live entry back to ``queued`` with its test result discarded.
+
+        The operator's counterpart to :meth:`evict`, and the gentler of the
+        two: the entry keeps its POSITION and its place in line, it just stops
+        claiming to have been tested.  That is the right verb for the case this
+        queue got stuck on -- a front entry whose recorded result was taken
+        against a tree the canonical branch has since moved off.  The result is
+        worthless, but the change is fine and its turn is still its turn.
+
+        Discarding the trees is not optional.  :func:`landing_is_safe` reads
+        them, and an entry left in ``tested`` carrying a stale
+        ``tested_base_tree`` is exactly the state that refuses to land and
+        refuses to move.
+        """
+
+        entry = self.entry(entry_id)
+        if entry is None:
+            return {"changed": False, "reason": "entry not found"}
+        if not entry.live:
+            return {"changed": False, "reason": "entry is %s" % entry.state}
+        changed = self._reset_to_queued(entry_id)
+        if not changed:
+            return {"changed": False, "reason": "entry is no longer live"}
+        self._emit(
+            "merge_queue.requeued",
+            entry.repository,
+            entry.branch,
+            {
+                "entry_id": entry_id,
+                "task_id": entry.task_id,
+                "from_state": entry.state,
+                "reason": str(reason)[:300],
+                "value": 1,
+            },
+            level="warning",
+        )
+        return {
+            "changed": True,
+            "entry_id": entry_id,
+            "task_id": entry.task_id,
+            "from_state": entry.state,
+            "reason": str(reason)[:300],
+        }
+
+    # -- reconciliation: the recovery nothing else can trigger -------------
+
+    def queues(self) -> List[JsonDict]:
+        """Every (repository, branch) this queue has ever held an entry for.
+
+        The operator verbs need this because there is no registry of queues:
+        a queue exists because something was admitted to it.  Answering "which
+        queues are there" from the entries themselves is the only way to name
+        one without already knowing it.
+        """
+
+        rows = self._store.query_all(
+            """
+            SELECT repository, branch,
+                   SUM(CASE WHEN state IN (?, ?, ?) THEN 1 ELSE 0 END) AS live,
+                   COUNT(*) AS total
+              FROM merge_queue_entries
+             GROUP BY repository, branch
+             ORDER BY repository, branch
+            """,
+            LIVE_STATES,
+        )
+        return [
+            {
+                "repository": str(row["repository"] or ""),
+                "branch": str(row["branch"] or ""),
+                "queue_depth": int(row["live"] or 0),
+                "entries_total": int(row["total"] or 0),
+            }
+            for row in rows
+        ]
+
+    def reconcile(
+        self,
+        repository: str,
+        branch: str,
+        *,
+        canonical_tip_tree: str = "",
+    ) -> JsonDict:
+        """Heal the head of the queue.  Safe to call from anywhere, often.
+
+        Everything else in this module runs on behalf of ONE task's publication
+        attempt and can only touch what that attempt reaches.  This runs on
+        behalf of the QUEUE, and it exists because of the one entry no
+        publication attempt can rescue: the front.
+
+        Four things, in the order that tries the cheapest recovery first:
+
+        1. **Reclaim dead leases.**  A slot whose holder stopped renewing is
+           returned to ``queued`` with its partial result dropped.
+        2. **Discard a stale front result.**  If the canonical tip's tree is no
+           longer the tree the front was tested on top of -- because main
+           advanced outside the queue, which is normal and allowed -- the front
+           is carrying a result that :func:`landing_is_safe` will refuse
+           forever.  Send it back to ``queued`` so its next attempt re-tests
+           against the tree that now exists.  This is a *recovery*, not a
+           failure: the window is not halved and nothing is evicted.
+        3. **Evict what cannot progress.**  An entry with no live lease that
+           has retried past the cap, or that finished an attempt without ever
+           learning its pull request, is going nowhere.  A live lease is
+           respected: that is a worker in the middle of a contract run, and
+           evicting it would throw away work that was about to succeed.
+        4. **Evict an abandoned front.**  A front with no live lease that has
+           not moved for ``front_idle_seconds`` has no publication loop behind
+           it.  Nothing will ever re-test it, so it is evicted and the queue
+           drains.  Ordered last deliberately: a front that only needed its
+           stale result discarded got that in step 2 and its idle clock starts
+           again from there, so a live change gets a full idle window to come
+           back before this reaches it.
+
+        ``canonical_tip_tree`` is optional.  Without it step 2 is skipped --
+        an unreadable tip is never grounds to discard a result, for the same
+        reason it is never grounds to land one.
+        """
+
+        report: JsonDict = {
+            "schema": "mac.native_merge_queue.reconcile.v1",
+            "repository": repository,
+            "branch": branch,
+            "canonical_tip_tree": str(canonical_tip_tree or "").strip(),
+            "reclaimed": 0,
+            "invalidated": [],
+            "evicted": [],
+            "idle_evicted": [],
+        }
+        report["reclaimed"] = self._reclaim_expired(repository, branch)
+
+        tip = str(canonical_tip_tree or "").strip()
+        front = self.front(repository, branch)
+        if (
+            front is not None
+            and tip
+            and front.tested_base_tree
+            and front.tested_base_tree != tip
+            and not self._lease_is_live(front)
+        ):
+            if self._reset_to_queued(front.id):
+                report["invalidated"].append(front.id)
+                self._emit(
+                    "merge_queue.speculation_invalidated",
+                    repository,
+                    branch,
+                    {
+                        "entry_id": front.id,
+                        "task_id": front.task_id,
+                        "tested_base_tree": front.tested_base_tree[:12],
+                        "canonical_tip_tree": tip[:12],
+                        "value": 1,
+                    },
+                    level="warning",
+                )
+
+        for candidate in self.live_entries(repository, branch):
+            # Re-read: an earlier eviction in this same loop resets every
+            # survivor behind it, so the snapshot taken before the loop may
+            # already describe a state that no longer exists.
+            entry = self.entry(candidate.id)
+            if entry is None or not entry.live:
+                continue
+            # A live lease is a worker inside a contract run. The lease, not
+            # this sweep, is what reclaims a slot from a worker that died.
+            if self._lease_is_live(entry):
+                continue
+            reason = ""
+            if entry.attempts >= self.MAX_ATTEMPTS_BEFORE_EVICTION:
+                reason = "exhausted after %d attempts" % entry.attempts
+                if not entry.pull_request_number:
+                    reason += " with no pull request recorded"
+            elif (
+                entry.state in self.PR_REQUIRING_STATES
+                and entry.attempts >= 1
+                and not entry.pull_request_number
+            ):
+                reason = (
+                    "cannot progress: no pull request recorded after %d attempt(s), "
+                    "so the entry can neither be landed nor observed as merged"
+                    % entry.attempts
+                )
+            if reason:
+                self.evict(entry.id, reason=reason)
+                report["evicted"].append(entry.id)
+
+        front = self.front(repository, branch)
+        if front is not None and self._front_is_abandoned(front):
+            self.evict(
+                front.id,
+                reason=(
+                    "front of the queue has not progressed in %d seconds and no "
+                    "worker holds its slot; nothing is driving it, so every "
+                    "entry behind it is blocked. Evicted to let the queue drain "
+                    "-- re-publish the task to rejoin the queue."
+                    % self._front_idle_seconds
+                ),
+            )
+            report["idle_evicted"].append(front.id)
+
+        live = self.live_entries(repository, branch)
+        report["queue_depth"] = len(live)
+        report["front"] = live[0].to_dict() if live else None
+        report["changed"] = bool(
+            report["reclaimed"]
+            or report["invalidated"]
+            or report["evicted"]
+            or report["idle_evicted"]
+        )
+        return report
+
     # -- internals -------------------------------------------------------
+
+    #: How many times the same commit may be evicted from the same queue before
+    #: re-admission is refused outright.  The live hub showed one task evicted
+    #: dozens of times with the identical "projected merge conflicts with the
+    #: queue base" reason: the conflict was a property of the commit, so every
+    #: re-admission reproduced it exactly, halved the window again, and spent a
+    #: publication attempt that a landable change could have used.
+    MAX_EVICTIONS_PER_HEAD = 3
+
+    #: First re-admission backoff, doubled per prior eviction, capped at an
+    #: hour.  A first eviction may well have been the queue's fault (a
+    #: predecessor that has since been evicted itself), so the first retry is
+    #: soon; by the third the evidence says otherwise.
+    READMISSION_BACKOFF_SECONDS = 300
+    READMISSION_BACKOFF_CEILING_SECONDS = 3600
+
+    def _eviction_history(
+        self, repository: str, branch: str, task_id: str, head_sha: str
+    ) -> List[QueueEntry]:
+        """Prior evictions of this exact commit from this exact queue.
+
+        Keyed on ``head_sha`` and not on the task: a task that was re-reviewed
+        at a new commit is a different change with a different chance of
+        landing, and holding its old commit's failures against it would block
+        the fix for those failures.
+        """
+
+        rows = self._store.query_all(
+            """
+            SELECT * FROM merge_queue_entries
+             WHERE repository = ? AND branch = ? AND task_id = ?
+               AND head_sha = ? AND state = ?
+             ORDER BY updated_at, id
+            """,
+            (repository, branch, task_id, str(head_sha), STATE_EVICTED),
+        )
+        return [self._from_row(row) for row in rows]
+
+    def _readmission_refusal(
+        self, repository: str, branch: str, task_id: str, head_sha: str
+    ) -> Optional[SlotDecision]:
+        """``None`` to admit; a refusing :class:`SlotDecision` otherwise."""
+
+        history = self._eviction_history(repository, branch, task_id, head_sha)
+        if not history:
+            return None
+        count = len(history)
+        last = history[-1]
+        if count >= self.MAX_EVICTIONS_PER_HEAD:
+            self._emit(
+                "merge_queue.readmission_refused",
+                repository,
+                branch,
+                {
+                    "task_id": task_id,
+                    "head_sha": str(head_sha)[:12],
+                    "evictions": count,
+                    "last_reason": last.eviction_reason[:200],
+                    "value": count,
+                },
+                level="warning",
+            )
+            return SlotDecision(
+                admitted=False,
+                terminal=True,
+                reason=(
+                    "commit %s has been evicted from the %s merge queue %d times, "
+                    "most recently: %s. Re-queueing it would reproduce that "
+                    "outcome, so the queue is refusing rather than spending "
+                    "further attempts on it. Rebase or re-review this change and "
+                    "publish the new commit."
+                    % (
+                        str(head_sha)[:12],
+                        branch,
+                        count,
+                        last.eviction_reason[:200] or "no reason recorded",
+                    )
+                ),
+            )
+        wait = min(
+            self.READMISSION_BACKOFF_CEILING_SECONDS,
+            self.READMISSION_BACKOFF_SECONDS * (2 ** (count - 1)),
+        )
+        try:
+            ready_at = parse_time(last.updated_at) + timedelta(seconds=wait)
+            remaining = int((ready_at - parse_time(self._now())).total_seconds())
+        except (TypeError, ValueError):
+            # An unparseable timestamp is not grounds to hold a change back.
+            # Admission is the safe direction: the land gate, not this, is what
+            # protects the trunk.
+            return None
+        if remaining <= 0:
+            return None
+        return SlotDecision(
+            admitted=False,
+            reason=(
+                "commit %s was evicted from this queue %d time(s); backing off "
+                "%ds before re-queueing it (last reason: %s)"
+                % (
+                    str(head_sha)[:12],
+                    count,
+                    wait,
+                    last.eviction_reason[:160] or "no reason recorded",
+                )
+            ),
+            defer_seconds=max(60, remaining),
+        )
+
+    def _lease_is_live(self, entry: QueueEntry) -> bool:
+        """Is a worker holding this slot right now?
+
+        Fails toward *yes*: an unparseable expiry means we cannot show the
+        holder is gone, and acting on that guess would evict a contract run
+        that is halfway through.
+        """
+
+        if not entry.lease_owner:
+            return False
+        if not entry.lease_expires_at:
+            return False
+        try:
+            return parse_time(entry.lease_expires_at) > parse_time(self._now())
+        except (TypeError, ValueError):
+            return True
+
+    def _front_is_abandoned(self, entry: QueueEntry) -> bool:
+        """Has the front been left with nothing driving it?"""
+
+        if self._lease_is_live(entry):
+            return False
+        try:
+            age = (
+                parse_time(self._now()) - parse_time(entry.updated_at)
+            ).total_seconds()
+        except (TypeError, ValueError):
+            return False
+        return age >= self._front_idle_seconds
+
+    def _reset_to_queued(self, entry_id: str) -> bool:
+        """Live -> ``queued``, lease dropped, any test result discarded."""
+
+        result = self._store.execute(
+            """
+            UPDATE merge_queue_entries
+               SET state = ?, tested_base_sha = '', tested_base_tree = '',
+                   tested_merge_tree = '', lease_owner = NULL,
+                   lease_expires_at = NULL, updated_at = ?
+             WHERE id = ? AND state IN (?, ?, ?)
+            """,
+            (
+                STATE_QUEUED,
+                self._now(),
+                entry_id,
+                STATE_QUEUED,
+                STATE_TESTING,
+                STATE_TESTED,
+            ),
+        )
+        return int(getattr(result, "rowcount", 0) or 0) >= 1
 
     def _live_entry_for_task(
         self, repository: str, branch: str, task_id: str
@@ -1261,6 +1695,7 @@ __all__ = [
     "SlotDecision",
     "WindowBounds",
     "bounds_from_env",
+    "front_idle_seconds_from_env",
     "landing_is_safe",
     "lease_seconds_from_env",
     "next_window",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -20707,6 +20707,79 @@ class ControlPlane:
             self._native_merge_queue_instance = queue
         return queue
 
+    # -- operator verbs over the native queue -----------------------------
+    #
+    # `queue.evict` and the rest existed in code with no way to reach them: an
+    # operator watching a head-of-line-blocked queue on /dashboard/observe
+    # could see the depth climbing and the front stuck and had no verb short of
+    # writing SQL against the control plane. When mac#main blocked for three
+    # days the only recovery available was merging by hand on GitHub, which
+    # leaves the queue's own state untouched and therefore still blocked.
+
+    def list_merge_queues(self) -> List[JsonDict]:
+        """Every (repository, branch) the native queue holds entries for."""
+
+        return list(self._native_merge_queue().queues())
+
+    def merge_queue_snapshot(self, repository: str, branch: str) -> JsonDict:
+        """Depth, window, front, live entries and recent evictions."""
+
+        return self._native_merge_queue().snapshot(str(repository), str(branch))
+
+    def reconcile_merge_queue(
+        self,
+        repository: str,
+        branch: str,
+        *,
+        canonical_tip_tree: str = "",
+        actor: str = "",
+    ) -> JsonDict:
+        """Run the queue's own recovery sweep now, without waiting for a land.
+
+        The sweep is normally driven by publication attempts. An operator needs
+        it on demand for the case where there are no publication attempts left
+        to drive it -- which is precisely the state that made this verb
+        necessary.
+
+        ``canonical_tip_tree`` is optional and unverified here: this control
+        plane has no checkout of the repository to read it from. Supplying it
+        (``git rev-parse origin/main^{tree}``) enables the stale-result
+        recovery; omitting it leaves that step skipped rather than guessed.
+        """
+
+        report = self._native_merge_queue().reconcile(
+            str(repository),
+            str(branch),
+            canonical_tip_tree=str(canonical_tip_tree or ""),
+        )
+        report["actor"] = str(actor or "")
+        return report
+
+    def evict_merge_queue_entry(
+        self, entry_id: str, *, reason: str = "", actor: str = ""
+    ) -> JsonDict:
+        """Remove one entry from the queue, discarding speculation behind it."""
+
+        note = str(reason or "").strip() or "evicted by operator"
+        if actor:
+            note = "%s (by %s)" % (note, actor)
+        return self._native_merge_queue().evict(str(entry_id), reason=note)
+
+    def requeue_merge_queue_entry(
+        self, entry_id: str, *, reason: str = "", actor: str = ""
+    ) -> JsonDict:
+        """Send one entry back to ``queued`` with its test result discarded.
+
+        The right verb when the change is fine but its recorded result is not:
+        the entry keeps its place in line and is re-tested against the tree
+        that exists now.
+        """
+
+        note = str(reason or "").strip() or "requeued by operator"
+        if actor:
+            note = "%s (by %s)" % (note, actor)
+        return self._native_merge_queue().requeue(str(entry_id), reason=note)
+
     def _merge_queue_snapshot(self, queue: Any, entry_id: str) -> Optional[JsonDict]:
         """Depth, window, and eviction history for the queue this entry is in.
 
@@ -21583,6 +21656,57 @@ class ControlPlane:
                 queue = self._native_merge_queue()
                 queue_owner = self._merge_queue_owner()
                 queue_repository = _canonicalize_git_url(clone_url) or clone_url
+                # HEAL THE HEAD BEFORE ASKING FOR A SLOT.
+                #
+                # Every other recovery in the queue is driven by the entry's own
+                # publication loop, which leaves exactly one entry unrecoverable:
+                # the front. Entries behind it are deferred by the window and
+                # never reach the land gate, so when the front's loop stops --
+                # abandoned task, terminal failure, hub restart -- nothing
+                # re-tests it and nothing evicts it. mac#main was blocked that
+                # way for three days with twelve entries behind a `tested` front
+                # whose recorded tree main had long since moved off.
+                #
+                # Reconciling HERE is what makes the fix self-driving rather
+                # than another thing an operator has to remember: the deferred
+                # entries are already asking for a slot every few minutes, and
+                # each of those attempts now heals the head of the queue it is
+                # waiting behind. The tip tree comes from the canonical checkout
+                # this publication already made, so it costs one rev-parse.
+                reconcile_tip_tree = str(
+                    git_step(
+                        "merge_queue_reconcile_tip_tree",
+                        ["rev-parse", "HEAD^{tree}"],
+                        check=False,
+                    ).get("stdout")
+                    or ""
+                ).strip()
+                try:
+                    reconciled = queue.reconcile(
+                        queue_repository,
+                        canonical_branch,
+                        canonical_tip_tree=reconcile_tip_tree,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    # Recovery is not a gate. It can only send entries BACKWARDS
+                    # -- to `queued` or to `evicted` -- so failing to run it
+                    # cannot land an untested tree, and letting it block this
+                    # publication would turn one unreadable row into a stop for
+                    # every task in the queue. Recorded rather than swallowed:
+                    # a sweep that silently stopped sweeping is how this queue
+                    # got stuck in the first place.
+                    reconciled = {
+                        "changed": True,
+                        "error": _gitops._scrub_secret(str(exc))[:400],
+                    }
+                if reconciled.get("changed"):
+                    commands.append(
+                        {
+                            "name": "merge_queue_reconcile",
+                            "attempt": attempt,
+                            **reconciled,
+                        }
+                    )
                 decision = queue.claim_slot(
                     repository=queue_repository,
                     branch=canonical_branch,
@@ -21598,6 +21722,24 @@ class ControlPlane:
                         **decision.to_dict(),
                     }
                 )
+                if not decision.admitted and decision.terminal:
+                    # NOT a deferral. This commit has been evicted from this
+                    # queue repeatedly for the same reason, so the next attempt
+                    # produces the same eviction; retrying at the normal cadence
+                    # spends the publication worker on an outcome that is
+                    # already known. Park it for a day so an operator or a
+                    # re-review is what brings it back, the way
+                    # `reviewed_commit_missing` parks a SHA that will never
+                    # resolve.
+                    refused = ValidationError(
+                        "mac merge queue refused to re-queue %s: %s"
+                        % (task.id, decision.reason)
+                    )
+                    refused.publication_retry_after_seconds = 86400
+                    refused.publication_failure_kind = (
+                        "merge_queue_readmission_refused"
+                    )
+                    raise refused
                 if not decision.admitted:
                     # The window is full, or another worker holds this slot.
                     # Deferring is the correct answer: the entry keeps its place

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -1061,6 +1061,26 @@ network_policies:
     ctx["task_group_name"] = "route-group"
     ctx["task_group_delete_name"] = "route-group-delete"
 
+    # Two native-merge-queue entries, one per mutating verb, so evict and
+    # requeue do not fight over the same row. Admitted through the queue rather
+    # than inserted, because the entry id and the position bookkeeping are the
+    # queue's to assign.
+    merge_queue = cp._native_merge_queue()
+    ctx["merge_queue_repository"] = "github.invalid/route/coverage"
+    ctx["merge_queue_branch"] = "main"
+    ctx["merge_queue_evict_entry_id"] = merge_queue.admit(
+        repository=ctx["merge_queue_repository"],
+        branch=ctx["merge_queue_branch"],
+        task_id="task_route_coverage_evict",
+        head_sha="a" * 40,
+    ).id
+    ctx["merge_queue_requeue_entry_id"] = merge_queue.admit(
+        repository=ctx["merge_queue_repository"],
+        branch=ctx["merge_queue_branch"],
+        task_id="task_route_coverage_requeue",
+        head_sha="b" * 40,
+    ).id
+
     secret = _ok(
         client.post(
             "/secrets",
@@ -1441,6 +1461,12 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         # not remove the human_id row used by GET /humans/{human_id}.
         ("DELETE", "/humans/{human_id}"): {"human_id": "delete_human_id"},
         ("DELETE", "/secrets/{name}"): {"name": "delete_secret_name"},
+        ("POST", "/merge-queue/entries/{entry_id}/evict"): {
+            "entry_id": "merge_queue_evict_entry_id"
+        },
+        ("POST", "/merge-queue/entries/{entry_id}/requeue"): {
+            "entry_id": "merge_queue_requeue_entry_id"
+        },
         ("GET", "/task-groups/{name}"): {"name": "task_group_name"},
         ("DELETE", "/task-groups/{name}"): {"name": "task_group_delete_name"},
         ("GET", "/optimizer/policies/{policy_id}"): {"policy_id": "sci_policy_id"},
@@ -1591,6 +1617,13 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
             kwargs["params"] = {"q": "route coverage dream", "limit": 1, "min_confidence": "low"}
         elif path_template == "/tasks/search":
             kwargs["params"] = {"q": "route coverage"}
+        elif path_template == "/merge-queue/entries":
+            # repository/branch are query params, not path segments: a
+            # repository is a URL and would need double-escaping in a path.
+            kwargs["params"] = {
+                "repository": ctx["merge_queue_repository"],
+                "branch": ctx["merge_queue_branch"],
+            }
         elif path_template == "/humans/resolve":
             # GET /humans/resolve requires the `anchor` query param.
             kwargs["params"] = {"anchor": "route-coverage-human"}
@@ -1632,6 +1665,22 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
         ("PUT", "/work-packages/{package_id}"): {
             "goal": "route coverage goal",
             "metadata": {"lane": "coverage"},
+            "actor": "route-coverage",
+        },
+        # No canonical_tip_tree: the hub has no checkout to read one from, and
+        # the sweep must be callable without it (it skips the stale-result step
+        # rather than guessing at the tip).
+        ("POST", "/merge-queue/reconcile"): {
+            "repository": "github.invalid/route/coverage",
+            "branch": "main",
+            "actor": "route-coverage",
+        },
+        ("POST", "/merge-queue/entries/{entry_id}/evict"): {
+            "reason": "route coverage",
+            "actor": "route-coverage",
+        },
+        ("POST", "/merge-queue/entries/{entry_id}/requeue"): {
+            "reason": "route coverage",
             "actor": "route-coverage",
         },
         # Dry run: exercise the route without re-supervising live tasks in the

--- a/tests/cli/test_cli_merge_queue.py
+++ b/tests/cli/test_cli_merge_queue.py
@@ -1,0 +1,211 @@
+"""`mac admin merge-queue` end to end, against a real database.
+
+The queue's recovery verbs existed in code with no way to reach them. When
+mac#main went head-of-line blocked for three days the recovery available to an
+operator was to merge the pull request by hand on GitHub -- which does not touch
+the queue's state, so the queue stayed blocked afterwards.
+
+These tests drive the real command line, because that is the surface the claim
+is about. A ControlPlane method nobody can call from a terminal is the state
+this change exists to leave behind.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from mac.cli import main
+from mac.services import ControlPlane
+from mac.test_support import dsn_for, store_on
+
+REPO = "github.invalid/acme/widgets"
+BRANCH = "main"
+
+
+def _run(tmp_path, *args):
+    """Run `mac --db <tmp> <args>` and return (rc, stdout, stderr)."""
+    out, err = io.StringIO(), io.StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = out, err
+    try:
+        rc = main(["--json", "--db", dsn_for(tmp_path), *args])
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+    return rc, out.getvalue().strip(), err.getvalue().strip()
+
+
+def _ok(result):
+    """Assert the command succeeded and return its JSON body.
+
+    Takes the RESULT of ``_run`` rather than its arguments so every call site
+    below spells ``_run(tmp_path, "admin", "merge-queue", <verb>)`` literally --
+    which is what tests/cli/test_cli_coverage_gate.py scans for when it checks
+    that no CLI subcommand ships without a test.
+    """
+    rc, raw, err = result
+    assert rc == 0, err or raw
+    return json.loads(raw) if raw else None
+
+
+def _queue(tmp_path):
+    cp = ControlPlane(store_on(dsn_for(tmp_path)), secret_key="k" * 32)
+    return cp._native_merge_queue()
+
+
+def _admit(tmp_path, task_id, head):
+    return _queue(tmp_path).admit(
+        repository=REPO, branch=BRANCH, task_id=task_id, head_sha=head
+    )
+
+
+def test_merge_queue_list_names_the_queues_that_exist(tmp_path):
+    """There is no registry of queues -- a queue exists because something was
+    admitted to it -- so without this an operator cannot name one to inspect."""
+    _admit(tmp_path, "task_a", "a" * 40)
+
+    listed = _ok(_run(tmp_path, "admin", "merge-queue", "list"))
+
+    assert listed == [
+        {
+            "repository": REPO,
+            "branch": BRANCH,
+            "queue_depth": 1,
+            "entries_total": 1,
+        }
+    ]
+
+
+def test_merge_queue_show_answers_why_nothing_is_landing(tmp_path):
+    entry = _admit(tmp_path, "task_a", "a" * 40)
+
+    snapshot = _ok(_run(tmp_path, "admin", "merge-queue", "show", REPO))
+
+    assert snapshot["queue_depth"] == 1
+    assert snapshot["front"]["id"] == entry.id
+    assert snapshot["front"]["task_id"] == "task_a"
+
+
+def test_merge_queue_requeue_discards_the_result_and_keeps_the_place(tmp_path):
+    """The usual verb for a stuck front: the change keeps its turn and is
+    re-tested against the tree that exists now."""
+    queue = _queue(tmp_path)
+    front = _admit(tmp_path, "task_front", "a" * 40)
+    behind = _admit(tmp_path, "task_behind", "b" * 40)
+    queue._store.execute(
+        """
+        UPDATE merge_queue_entries
+           SET state = 'tested', tested_base_tree = ?, tested_merge_tree = ?
+         WHERE id = ?
+        """,
+        ("c" * 40, "d" * 40, front.id),
+    )
+
+    outcome = _ok(
+        _run(
+            tmp_path,
+            "admin",
+            "merge-queue",
+            "requeue",
+            front.id,
+            "--reason",
+            "tip moved under it",
+            "--actor",
+            "operator",
+        )
+    )
+
+    assert outcome["changed"] is True
+    after = _queue(tmp_path).entry(front.id)
+    assert after.state == "queued"
+    assert after.tested_base_tree == ""
+    assert [e.id for e in _queue(tmp_path).live_entries(REPO, BRANCH)] == [
+        front.id,
+        behind.id,
+    ]
+
+
+def test_merge_queue_evict_records_who_did_it_and_why(tmp_path):
+    """`recent_evictions` is where an operator reads why a change stopped
+    moving; an eviction with no hand on it cannot be explained later."""
+    entry = _admit(tmp_path, "task_stuck", "a" * 40)
+
+    outcome = _ok(
+        _run(
+            tmp_path,
+            "admin",
+            "merge-queue",
+            "evict",
+            entry.id,
+            "--reason",
+            "abandoned, unblocking main",
+            "--actor",
+            "operator",
+        )
+    )
+
+    assert outcome["changed"] is True
+    after = _queue(tmp_path).entry(entry.id)
+    assert after.state == "evicted"
+    assert "abandoned, unblocking main" in after.eviction_reason
+    assert "by operator" in after.eviction_reason
+
+
+def test_merge_queue_reconcile_discards_a_stale_front_result(tmp_path):
+    """The three-day block, recovered from a terminal.
+
+    ``--canonical-tip-tree`` comes from a checkout because the hub has none;
+    without it the sweep leaves results alone rather than guessing at the tip.
+    """
+    queue = _queue(tmp_path)
+    front = _admit(tmp_path, "task_front", "a" * 40)
+    queue._store.execute(
+        """
+        UPDATE merge_queue_entries
+           SET state = 'tested', tested_base_tree = ?, tested_merge_tree = ?,
+               pull_request_number = 608, attempts = 1
+         WHERE id = ?
+        """,
+        ("c" * 40, "d" * 40, front.id),
+    )
+
+    report = _ok(
+        _run(
+            tmp_path,
+            "admin",
+            "merge-queue",
+            "reconcile",
+            REPO,
+            "--canonical-tip-tree",
+            "e" * 40,
+            "--actor",
+            "operator",
+        )
+    )
+
+    assert report["invalidated"] == [front.id]
+    assert report["actor"] == "operator"
+    assert _queue(tmp_path).entry(front.id).state == "queued"
+
+
+def test_merge_queue_reconcile_without_a_tip_tree_discards_nothing(tmp_path):
+    """An unreadable tip is a refusal everywhere else in the queue. It is a
+    refusal here too: the sweep still reclaims and evicts, but it will not
+    throw away a test result on suspicion."""
+    queue = _queue(tmp_path)
+    front = _admit(tmp_path, "task_front", "a" * 40)
+    queue._store.execute(
+        """
+        UPDATE merge_queue_entries
+           SET state = 'tested', tested_base_tree = ?, tested_merge_tree = ?,
+               pull_request_number = 608, attempts = 1
+         WHERE id = ?
+        """,
+        ("c" * 40, "d" * 40, front.id),
+    )
+
+    report = _ok(_run(tmp_path, "admin", "merge-queue", "reconcile", REPO))
+
+    assert report["invalidated"] == []
+    assert _queue(tmp_path).entry(front.id).state == "tested"

--- a/tests/test_merge_queue_reconcile.py
+++ b/tests/test_merge_queue_reconcile.py
@@ -1,0 +1,608 @@
+"""Head-of-line recovery for mac's own merge queue.
+
+MEASURED on the live hub, 2026-08-19 to 2026-08-22:
+
+    depth=12 (11 queued + 1 tested at the front)
+    last_event: "landed task_3141dce7..." at 2026-08-19T19:27:46
+    landed_count=1, failure_count=211
+
+For three days nothing landed. main advanced through GitHub pull requests, so
+the front entry's ``tested_base_tree`` stopped matching the canonical tip and
+``landing_is_safe`` refused it -- correctly; that gate is the one invariant this
+module will not trade. What was missing is what happens NEXT. Nothing re-tested
+the front, because re-testing is driven by the front's own publication loop and
+that task was no longer retrying. Nothing evicted it either, because eviction is
+also driven by a publication attempt reaching the land gate, and the eleven
+entries behind it never got that far: each was deferred by the window every ~6
+minutes, forever. An approved task sat reviewed for four hours and had to be
+merged by hand.
+
+The shape of the bug is worth naming, because it is not "a gate was wrong": the
+queue had recovery paths for every entry EXCEPT the one whose failure blocks
+everyone else. These tests pin the recovery for that entry, and pin that the
+recovery cannot become a new way to throw away work that was about to land.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from mac.native_merge_queue import (
+    STATE_EVICTED,
+    STATE_QUEUED,
+    STATE_TESTED,
+    NativeMergeQueue,
+    WindowBounds,
+)
+from mac.services import ControlPlane
+
+REPO = "github.invalid/acme/widgets"
+BRANCH = "main"
+OLD_TREE = "a" * 40
+NEW_TREE = "b" * 40
+IDLE_SECONDS = 5400
+
+
+class Clock:
+    """A hand-wound clock, in the exact format ``mac.models.utcnow`` emits."""
+
+    def __init__(self) -> None:
+        self._at = datetime(2026, 8, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+    def __call__(self) -> str:
+        return self._at.isoformat(timespec="microseconds")
+
+    def advance(self, seconds: float) -> None:
+        self._at += timedelta(seconds=seconds)
+
+
+@pytest.fixture()
+def clock():
+    return Clock()
+
+
+@pytest.fixture()
+def queue(clock):
+    cp = ControlPlane.in_memory()
+    return NativeMergeQueue(
+        cp.store,
+        # ceiling=1 is the serial queue: exactly the live configuration, and
+        # the one where a stuck front blocks absolutely everything.
+        bounds=WindowBounds(floor=1, ceiling=1),
+        lease_seconds=5400,
+        front_idle_seconds=IDLE_SECONDS,
+        now=clock,
+    )
+
+
+def _admit(queue, task_id: str, head: str = ""):
+    return queue.admit(
+        repository=REPO,
+        branch=BRANCH,
+        task_id=task_id,
+        head_sha=head or (task_id + "0" * 40)[:40],
+    )
+
+
+def _claim(queue, task_id: str, head: str = "", owner: str = "hub-a"):
+    return queue.claim_slot(
+        repository=REPO,
+        branch=BRANCH,
+        task_id=task_id,
+        head_sha=head or (task_id + "0" * 40)[:40],
+        owner=owner,
+    )
+
+
+def _make_stale_front(queue, entry_id: str, *, tested_base_tree: str = OLD_TREE):
+    """The observed state: `tested` against a tree main has moved off, with no
+    lease left because the holder stopped renewing it.
+
+    The pull request number matters -- an entry that never learned one is a
+    DIFFERENT defect with its own recovery (it is evicted as unable to
+    progress), and using it here would prove that rule rather than this one.
+    """
+    queue._store.execute(
+        """
+        UPDATE merge_queue_entries
+           SET state = ?, tested_base_sha = ?, tested_base_tree = ?,
+               tested_merge_tree = ?, lease_owner = NULL,
+               lease_expires_at = NULL, attempts = 1, pull_request_number = 608
+         WHERE id = ?
+        """,
+        (STATE_TESTED, "c" * 40, tested_base_tree, "d" * 40, entry_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. a stale result is discarded, not left to refuse the land forever
+# ---------------------------------------------------------------------------
+
+
+def test_a_front_tested_against_a_tree_main_moved_off_is_requeued(queue):
+    """The three-day block, in four lines.
+
+    Discarding the RESULT and not the entry is the whole point: the change was
+    never the problem, only the tree it was measured against.
+    """
+    front = _admit(queue, "task_front")
+    _make_stale_front(queue, front.id)
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+
+    assert report["invalidated"] == [front.id]
+    after = queue.entry(front.id)
+    assert after.state == STATE_QUEUED
+    assert after.tested_base_tree == ""
+    assert after.tested_merge_tree == ""
+    # It kept its turn. Recovery must not reorder the queue.
+    assert queue.front(REPO, BRANCH).id == front.id
+
+
+def test_a_front_still_tested_against_the_current_tip_is_untouched(queue):
+    """The gate would let this land. Recovery must not race it."""
+    front = _admit(queue, "task_front")
+    _make_stale_front(queue, front.id, tested_base_tree=NEW_TREE)
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+
+    assert report["invalidated"] == []
+    assert queue.entry(front.id).state == STATE_TESTED
+
+
+def test_an_unreadable_tip_discards_nothing(queue):
+    """An empty tip tree is a refusal everywhere else in this module; it is a
+    refusal here too. Guessing would throw away a good result."""
+    front = _admit(queue, "task_front")
+    _make_stale_front(queue, front.id)
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree="")
+
+    assert report["invalidated"] == []
+    assert queue.entry(front.id).state == STATE_TESTED
+
+
+def test_a_front_being_tested_right_now_is_not_disturbed(queue):
+    """A live lease is a worker inside a contract run.
+
+    Its ``tested_base_tree`` legitimately differs from the tip while the run is
+    in flight. Discarding it here would throw away up to 45 minutes of testing
+    and hand the slot back for no reason.
+    """
+    claimed = _claim(queue, "task_front")
+    assert claimed.admitted
+    queue.record_tested(
+        claimed.entry.id,
+        owner="hub-a",
+        base_sha="c" * 40,
+        base_tree=OLD_TREE,
+        merge_tree="d" * 40,
+    )
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+
+    assert report["invalidated"] == []
+    assert queue.entry(claimed.entry.id).state == STATE_TESTED
+
+
+# ---------------------------------------------------------------------------
+# 2. a front nothing is driving is evicted, so the queue drains
+# ---------------------------------------------------------------------------
+
+
+def test_an_abandoned_front_is_evicted_with_a_reason(queue, clock):
+    front = _admit(queue, "task_dead")
+    _make_stale_front(queue, front.id, tested_base_tree=NEW_TREE)
+    clock.advance(IDLE_SECONDS + 1)
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+
+    assert report["idle_evicted"] == [front.id]
+    after = queue.entry(front.id)
+    assert after.state == STATE_EVICTED
+    assert "not progressed" in after.eviction_reason
+    assert "blocked" in after.eviction_reason
+
+
+def test_a_front_that_only_needed_its_result_discarded_gets_a_full_window(
+    queue, clock
+):
+    """Invalidation restarts the idle clock, on purpose.
+
+    A front whose task IS still publishing needs one more attempt, not an
+    eviction. Discarding its stale result and evicting it in the same sweep
+    would make recovery indistinguishable from giving up.
+    """
+    front = _admit(queue, "task_front")
+    _make_stale_front(queue, front.id)
+    clock.advance(IDLE_SECONDS + 1)
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+
+    assert report["invalidated"] == [front.id]
+    assert report["idle_evicted"] == []
+    assert queue.entry(front.id).state == STATE_QUEUED
+
+
+def test_a_fresh_front_is_never_evicted_for_idling(queue):
+    front = _admit(queue, "task_front")
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+
+    assert report["idle_evicted"] == []
+    assert queue.entry(front.id).state == STATE_QUEUED
+
+
+def test_a_leased_front_is_never_evicted_for_idling(queue, clock):
+    """The lease outranks the idle clock while it is live; once it expires the
+    ordinary reclaim path, not this one, takes the slot back."""
+    claimed = _claim(queue, "task_front")
+    clock.advance(IDLE_SECONDS + 1)  # idle, but the lease runs to 5400s
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+
+    assert report["idle_evicted"] == []
+    assert queue.entry(claimed.entry.id).state != STATE_EVICTED
+
+
+# ---------------------------------------------------------------------------
+# 3. the acceptance criterion: the queue drains and the change behind publishes
+# ---------------------------------------------------------------------------
+
+
+def test_the_queue_drains_and_the_entry_behind_can_publish(queue, clock):
+    """The whole failure, start to finish, with no operator in it.
+
+    Three entries, a serial window, a dead front. Before: the front refuses to
+    land and the two behind defer forever -- which is exactly what four hours of
+    an approved task's life looked like. After: the front is gone, the next
+    change is at the head, and it gets a slot.
+    """
+    front = _admit(queue, "task_dead")
+    second = _admit(queue, "task_next")
+    _admit(queue, "task_third")
+    _make_stale_front(queue, front.id)
+
+    # Before: the change behind the block cannot get a slot, however often it
+    # asks. This is the ~6-minute defer loop, reproduced.
+    for _ in range(3):
+        clock.advance(360)
+        blocked = _claim(queue, "task_next", owner="hub-b")
+        assert not blocked.admitted
+        assert "this entry is #2 in line" in blocked.reason
+
+    # One sweep discards the stale result; the next gives up on the front.
+    queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+    clock.advance(IDLE_SECONDS + 1)
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+    assert report["idle_evicted"] == [front.id]
+
+    # After: the queue moved, and the next change publishes on its own.
+    assert queue.front(REPO, BRANCH).id == second.id
+    admitted = _claim(queue, "task_next", owner="hub-b")
+    assert admitted.admitted is True
+    assert admitted.depth == 0  # tested against the real tip, not speculation
+    assert queue.snapshot(REPO, BRANCH)["queue_depth"] == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. entries that cannot progress, without evicting ones that can
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_evicts_an_entry_that_retried_past_the_cap(queue):
+    entry = _admit(queue, "task_burned")
+    queue._store.execute(
+        "UPDATE merge_queue_entries SET attempts = ? WHERE id = ?",
+        (NativeMergeQueue.MAX_ATTEMPTS_BEFORE_EVICTION, entry.id),
+    )
+
+    report = queue.reconcile(REPO, BRANCH)
+
+    assert report["evicted"] == [entry.id]
+    assert "exhausted after 12 attempts" in queue.entry(entry.id).eviction_reason
+
+
+def test_reconcile_evicts_an_entry_that_never_learned_its_pull_request(queue):
+    """The seventy-attempt zombie, caught by the sweep instead of by nothing."""
+    entry = _admit(queue, "task_nopr")
+    queue._store.execute(
+        "UPDATE merge_queue_entries SET state = ?, attempts = 1 WHERE id = ?",
+        (STATE_TESTED, entry.id),
+    )
+
+    report = queue.reconcile(REPO, BRANCH)
+
+    assert report["evicted"] == [entry.id]
+    assert "no pull request recorded" in queue.entry(entry.id).eviction_reason
+
+
+def test_reconcile_does_not_evict_a_worker_mid_contract_run(queue):
+    """The false positive that would be worse than the bug.
+
+    ``claim_slot`` runs before the pull request is opened and the contract suite
+    runs for the ~45 minutes in between. During that window the entry is in
+    `testing`, has one attempt, and has no PR number -- indistinguishable from
+    the zombie above by state alone. The lease is what tells them apart, and
+    honouring it is why this sweep is safe to run on every publication attempt.
+    """
+    claimed = _claim(queue, "task_working")
+    assert claimed.admitted
+    assert queue.entry(claimed.entry.id).pull_request_number == 0
+
+    report = queue.reconcile(REPO, BRANCH)
+
+    assert report["evicted"] == []
+    assert queue.entry(claimed.entry.id).state != STATE_EVICTED
+
+
+def test_reconcile_reclaims_a_dead_workers_slot(queue, clock):
+    claimed = _claim(queue, "task_crashed")
+    clock.advance(5401)  # the lease expired; the hub holding it never came back
+
+    report = queue.reconcile(REPO, BRANCH)
+
+    assert report["reclaimed"] == 1
+    assert queue.entry(claimed.entry.id).state == STATE_QUEUED
+
+
+def test_a_quiet_queue_reports_no_change(queue):
+    _admit(queue, "task_fine")
+
+    report = queue.reconcile(REPO, BRANCH, canonical_tip_tree=NEW_TREE)
+
+    assert report["changed"] is False
+    assert report["queue_depth"] == 1
+    assert report["front"]["task_id"] == "task_fine"
+
+
+def test_reconciling_an_empty_queue_is_harmless(queue):
+    report = queue.reconcile("github.invalid/never/seen", "release")
+
+    assert report["changed"] is False
+    assert report["queue_depth"] == 0
+    assert report["front"] is None
+
+
+# ---------------------------------------------------------------------------
+# 5. eviction churn: the same commit, refused instead of retried forever
+# ---------------------------------------------------------------------------
+
+
+def test_a_re_admitted_commit_backs_off_after_an_eviction(queue, clock):
+    """Observed: one task evicted dozens of times with the identical reason.
+
+    The conflict was a property of the commit, so every re-admission reproduced
+    it exactly -- halving the window again and spending an attempt that a
+    landable change could have used.
+    """
+    first = _claim(queue, "task_churn")
+    queue.evict(first.entry.id, reason="projected merge conflicts with the queue base")
+
+    clock.advance(30)
+    again = _claim(queue, "task_churn")
+
+    assert again.admitted is False
+    assert again.terminal is False
+    assert again.defer_seconds > 0
+    assert "evicted from this queue 1 time(s)" in again.reason
+    assert "projected merge conflicts" in again.reason
+
+
+def test_the_backoff_expires_and_the_commit_is_tried_again(queue, clock):
+    """A first eviction may have been the queue's fault -- a predecessor that
+    has since been evicted itself. Backing off is not giving up."""
+    first = _claim(queue, "task_churn")
+    queue.evict(first.entry.id, reason="projected merge conflicts with the queue base")
+
+    clock.advance(NativeMergeQueue.READMISSION_BACKOFF_SECONDS + 1)
+
+    assert _claim(queue, "task_churn").admitted is True
+
+
+def test_a_commit_evicted_repeatedly_is_refused_terminally(queue, clock):
+    for _ in range(NativeMergeQueue.MAX_EVICTIONS_PER_HEAD):
+        clock.advance(NativeMergeQueue.READMISSION_BACKOFF_CEILING_SECONDS + 1)
+        claimed = _claim(queue, "task_churn")
+        assert claimed.admitted, "setup: the commit should still be re-admitted"
+        queue.evict(
+            claimed.entry.id, reason="projected merge conflicts with the queue base"
+        )
+
+    clock.advance(NativeMergeQueue.READMISSION_BACKOFF_CEILING_SECONDS + 1)
+    refused = _claim(queue, "task_churn")
+
+    assert refused.admitted is False
+    assert refused.terminal is True
+    assert refused.defer_seconds == 0
+    assert "Rebase or re-review" in refused.reason
+    assert refused.to_dict()["terminal"] is True
+
+
+def test_a_new_commit_for_the_same_task_is_admitted_immediately(queue, clock):
+    """The history is held against the COMMIT, not the task.
+
+    A re-reviewed change is a different change with a different chance of
+    landing; refusing it would block the fix for the very conflicts that got it
+    evicted.
+    """
+    for _ in range(NativeMergeQueue.MAX_EVICTIONS_PER_HEAD):
+        clock.advance(NativeMergeQueue.READMISSION_BACKOFF_CEILING_SECONDS + 1)
+        claimed = _claim(queue, "task_churn")
+        queue.evict(claimed.entry.id, reason="projected merge conflicts")
+
+    assert _claim(queue, "task_churn", head="f" * 40).admitted is True
+
+
+def test_a_live_entry_is_never_held_back_by_its_own_history(queue, clock):
+    """Backoff applies to REJOINING the queue. An entry already in line keeps
+    its slot -- otherwise a change that was evicted once could never be
+    re-tested even while it sat at the front."""
+    first = _claim(queue, "task_churn")
+    queue.evict(first.entry.id, reason="projected merge conflicts")
+    clock.advance(NativeMergeQueue.READMISSION_BACKOFF_SECONDS + 1)
+    second = _claim(queue, "task_churn")
+    assert second.admitted
+    queue.release(second.entry.id, owner="hub-a")
+
+    assert _claim(queue, "task_churn").admitted is True
+
+
+# ---------------------------------------------------------------------------
+# 6. the operator verbs
+# ---------------------------------------------------------------------------
+
+
+def test_requeue_discards_the_result_and_keeps_the_place_in_line(queue):
+    front = _admit(queue, "task_front")
+    _make_stale_front(queue, front.id)
+    behind = _admit(queue, "task_behind")
+
+    outcome = queue.requeue(front.id, reason="tip moved under it")
+
+    assert outcome["changed"] is True
+    assert outcome["from_state"] == STATE_TESTED
+    after = queue.entry(front.id)
+    assert after.state == STATE_QUEUED
+    assert after.tested_base_tree == ""
+    assert [entry.id for entry in queue.live_entries(REPO, BRANCH)] == [
+        front.id,
+        behind.id,
+    ]
+
+
+def test_requeueing_a_terminal_entry_changes_nothing(queue):
+    entry = _admit(queue, "task_gone")
+    queue.evict(entry.id, reason="conflicts")
+
+    outcome = queue.requeue(entry.id, reason="operator")
+
+    assert outcome["changed"] is False
+    assert queue.entry(entry.id).state == STATE_EVICTED
+
+
+def test_requeueing_an_unknown_entry_is_reported_not_raised(queue):
+    assert queue.requeue("mergeq_nope", reason="operator") == {
+        "changed": False,
+        "reason": "entry not found",
+    }
+
+
+def test_queues_lists_what_an_operator_can_name(queue):
+    """There is no registry of queues -- a queue exists because something was
+    admitted to it -- so an operator cannot inspect one without this."""
+    _admit(queue, "task_a")
+    queue.admit(
+        repository=REPO, branch="release", task_id="task_b", head_sha="e" * 40
+    )
+    evicted = queue.admit(
+        repository="github.invalid/other/repo",
+        branch=BRANCH,
+        task_id="task_c",
+        head_sha="f" * 40,
+    )
+    queue.evict(evicted.id, reason="conflicts")
+
+    listed = queue.queues()
+
+    assert {(item["repository"], item["branch"]) for item in listed} == {
+        (REPO, BRANCH),
+        (REPO, "release"),
+        ("github.invalid/other/repo", BRANCH),
+    }
+    by_key = {(item["repository"], item["branch"]): item for item in listed}
+    assert by_key[(REPO, BRANCH)]["queue_depth"] == 1
+    # A queue whose only entry is terminal still exists, at depth zero.
+    assert by_key[("github.invalid/other/repo", BRANCH)]["queue_depth"] == 0
+    assert by_key[("github.invalid/other/repo", BRANCH)]["entries_total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# 7. the same verbs, reachable from the control plane
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def plane():
+    return ControlPlane.in_memory()
+
+
+def _plane_entry(plane, task_id: str = "task_a"):
+    queue = plane._native_merge_queue()
+    return queue, queue.admit(
+        repository=REPO, branch=BRANCH, task_id=task_id, head_sha="a" * 40
+    )
+
+
+def test_the_control_plane_can_list_and_read_a_queue(plane):
+    _plane_entry(plane)
+
+    assert plane.list_merge_queues() == [
+        {
+            "repository": REPO,
+            "branch": BRANCH,
+            "queue_depth": 1,
+            "entries_total": 1,
+        }
+    ]
+    assert plane.merge_queue_snapshot(REPO, BRANCH)["queue_depth"] == 1
+
+
+def test_the_control_plane_can_evict_and_names_who_did_it(plane):
+    """`recent_evictions` is where an operator reads why a change stopped
+    moving. An eviction with no hand on it is the one entry that cannot be
+    explained later."""
+    _, entry = _plane_entry(plane)
+
+    outcome = plane.evict_merge_queue_entry(
+        entry.id, reason="stale front, unblocking main", actor="operator"
+    )
+
+    assert outcome["changed"] is True
+    reason = plane._native_merge_queue().entry(entry.id).eviction_reason
+    assert "stale front, unblocking main" in reason
+    assert "by operator" in reason
+
+
+def test_the_control_plane_can_requeue(plane):
+    queue, entry = _plane_entry(plane)
+    _make_stale_front(queue, entry.id)
+
+    outcome = plane.requeue_merge_queue_entry(entry.id, actor="operator")
+
+    assert outcome["changed"] is True
+    assert queue.entry(entry.id).state == STATE_QUEUED
+
+
+def test_reading_the_queue_is_ordinary_visibility_and_changing_it_is_not():
+    """`_required_scope` is the authorization gate (docs/authority-boundary.md).
+
+    Depth and evictions are already on the observability console, so a read
+    token can see them. Evicting and requeueing decide which changes reach the
+    trunk and in what order -- that is a control-plane operation, and a `write`
+    token that may file tasks has no business making it.
+    """
+    from mac.api import _required_scope
+
+    assert _required_scope("GET", "/merge-queue") == "read"
+    assert _required_scope("GET", "/merge-queue/entries") == "read"
+    assert _required_scope("POST", "/merge-queue/reconcile") == "admin"
+    assert _required_scope("POST", "/merge-queue/entries/mergeq_1/evict") == "admin"
+    assert _required_scope("POST", "/merge-queue/entries/mergeq_1/requeue") == "admin"
+
+
+def test_the_control_plane_can_run_the_sweep_on_demand(plane):
+    """The verb exists for the state that made it necessary: a queue with no
+    publication attempts left to drive its own recovery."""
+    queue, entry = _plane_entry(plane)
+    _make_stale_front(queue, entry.id)
+
+    report = plane.reconcile_merge_queue(
+        REPO, BRANCH, canonical_tip_tree=NEW_TREE, actor="operator"
+    )
+
+    assert report["invalidated"] == [entry.id]
+    assert report["actor"] == "operator"
+    assert queue.entry(entry.id).state == STATE_QUEUED


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_83937fb1c50c4a71a7617e863c0e7e97`
- head: `843b4b72da1d822642b5539bcb3d515bb975160e`
- base at push: `3445f9afa9d7ef7b4b5b42c3bd784eae2455447b`
