### PR TITLE
ADR: data-driven provider abstraction - JSON-specified provider CLI CRUD wrapper replacing hard-wired hgx internals (task_981b3b28cbb54a798a3fda85290d2054)

### DIFF
--- a/docs/adr/0028-a-provider-is-data-not-source.md
+++ b/docs/adr/0028-a-provider-is-data-not-source.md
@@ -1,0 +1,247 @@
+# ADR 0028: A provider is data, not mac source
+
+- Status: Proposed
+- Date: 2026-08-22
+- Decision owner: MAC fleet owner
+- Related: [ADR 0005](0005-elastic-executor-tier-vs-static-fleet.md) — the
+  elastic tier is the thing that needs providers at all;
+  [ADR 0015](0015-macos-nodes-are-host-installs.md) — some capacity is not a
+  provider API and must not be modelled as one;
+  [ADR 0022](0022-a-gate-returns-a-named-decision-not-a-boolean.md) — a
+  capability mac does not have must be named, not silently absent
+
+## Context
+
+mac's capacity providers are Python modules today, and one of them is a wrapper
+around a CLI that only exists inside one company's network.
+
+Measured in this repository on 2026-08-22:
+
+| file | lines | what it hard-wires |
+| --- | --- | --- |
+| `src/mac/hgx_provider.py` | 594 | the `hgx` CLI's verbs, flags, JSON shapes |
+| `src/mac/hgx_elastic_capacity.py` | 1251 | bounded planning over `HgxSession` |
+| `src/mac/hgx_autoscaler.py` | 597 | demand → `hgx` create/retire |
+
+`hgx` is NVIDIA's internal Horde DGXC tool. It is not on PyPI, not on GitHub, and
+not installable by anyone outside that network. So mac — a product whose whole
+claim is that it coordinates a fleet — currently ships 2,442 lines of provider
+integration that **nobody outside one employer can execute**, and offers a user
+on any other cloud exactly one way to add their own provider: fork mac and write
+a fourth `*_provider.py`.
+
+That is the wrong shape twice over.
+
+**It is wrong for the outside user.** "Which cloud am I on" is a property of the
+deployment, not of the software. Every other deployment-shaped fact in mac —
+which hub, which fleet, which model router, which node — is already
+configuration. Providers are the one that leaked into source.
+
+**It is wrong for us.** The `hgx` wrapper is not clever code. Read it and it is
+a table: verb → argv → how to read the output back. `create` is
+`["--json", "create", "--type", flavor]`; `status` is
+`["--json", "status", id]`; `delete` is `["delete", id]`. The interesting parts
+— immutable-ID-only addressing, refusing an ambiguous name, never invoking
+`hgx info` because it can echo a bootstrap password, proving reachability with a
+nonce rather than an exit code — are **policies that are not specific to
+`hgx` at all**. We wrote a generic controller and a vendor table, then compiled
+them together and shipped the result as one module per vendor.
+
+### The thing that is genuinely not a provider
+
+`local` is direct connectivity to a machine the operator already has, expressed
+as `user@machine:directory` plus ssh. There is no CLI to wrap, no lifecycle to
+drive, nothing to create or destroy. Modelling it as a degenerate spec would
+mean inventing a fake tool to describe. It stays exactly as it is.
+
+## Decision
+
+**mac core carries an interpreter. A provider is a JSON file.**
+
+`src/mac/provider_spec.py` reads a provider description — which binary, which
+argv per CRUD verb, how to map the output back onto mac's provider model — and
+executes it. `aws`, `azure`, `gcp` and `nvidia` ship as templates in
+`src/mac/data/provider-specs/`. `local` is untouched.
+
+### 1. The vocabulary is CRUD plus a transport verb
+
+`create`, `list`, `status`, `update`, `delete`, `stop`, `start`, `exec`. That is
+the whole surface, and it is closed: a verb outside it is a load-time error, not
+an extension point. A spec need not define all of them.
+
+The closed list is the point. An open verb namespace would let a spec name
+anything, and "anything" is how `hgx info` — the verb that prints a fallback
+password — would come back. The current adapter bans that verb by name in
+Python. Under the spec vocabulary there is simply no way to express it.
+
+### 2. argv is built, never a shell string
+
+Every invocation is an explicit argv list executed with `shell=False`. There is
+no point at which a value is concatenated into a string that a shell later
+re-splits.
+
+This changes what "injection" even means here, and it is worth being precise,
+because the obvious instinct — ban `;` and `$(` and backticks — defends against
+the wrong thing. With `execve` and no shell, shell metacharacters are ordinary
+bytes in an argument. The real residual risk is **argument** injection: a value
+that begins with `-` and is re-read by the target tool as a flag. A provider ID
+of `--output-file=/etc/passwd` is the attack; `; rm -rf /` is not.
+
+So the interpreter refuses a leading `-` by default, and a spec that genuinely
+needs one says `"allow_leading_dash": true` on that parameter and thereby
+declares it in a file a reviewer reads.
+
+### 3. Every substituted value is declared and shape-checked
+
+A verb's argv template may only reference parameters the spec declares, each
+with a regex. An undeclared placeholder fails at load time, so a spec cannot
+smuggle an unvalidated value into argv. Values default to a conservative
+character class; widening it is an explicit, reviewable edit to the spec.
+
+### 4. Credentials never enter argv
+
+A spec names environment variables (`env_passthrough`, `credential_env_var`); it
+can never interpolate one. The child process gets `PATH` and exactly the
+variables the spec declared — nothing else — so adding a provider does not
+silently widen what a subprocess can read.
+
+The consequence worth stating plainly: a credential cannot leak through the
+process table, a command log, or an error that echoes argv, because it was never
+in argv. That is stronger than redacting argv after the fact, and it is why the
+validator **rejects** a parameter whose name looks like a credential rather than
+accepting it and scrubbing later.
+
+### 5. Output parsing is declarative and secret-free on the way out
+
+`parse.select` walks into the payload; `fields` maps mac's model
+(`id`, `name`, `flavor`, `state`, `host`, `user`, `port`, `endpoint`) onto
+candidate source keys. Model field names are a closed set too.
+
+Provider records routinely carry a `root_password` or a `token`. Those field
+*names* are recorded in `scrubbed_fields`; their values are never copied into a
+`ProviderInstance`, which is the same contract
+`mac.hgx_provider.HgxSession.observable()` already keeps and the same one
+`mac.agent_provider.ProviderDecision` keeps.
+
+### 6. Readiness stays a capability, and it fails closed
+
+The nonce attestation is expressible: a provider that describes `exec` can be
+attested, because attestation is "run `printf <nonce>` over the transport and
+require the exact line back".
+
+A provider that describes no `exec` verb **cannot** be attested, and `attest()`
+raises a named capability error rather than returning success. This matters more
+than it looks: two of the four shipped templates are in exactly that position.
+EC2 has no synchronous non-interactive remote-exec verb, and `az vm run-command
+invoke` wraps remote output inside a JSON envelope rather than putting it on
+stdout. Both templates therefore ship *without* `exec`, and the honest outcome
+is a provider that says "I cannot prove this machine is reachable" — not one
+that quietly treats a successful `create` as readiness.
+
+This is [ADR 0022](0022-a-gate-returns-a-named-decision-not-a-boolean.md)
+applied to capacity: the absent capability is named.
+
+### 7. Specs live in user config; shipped files are templates
+
+Search order, nearest wins:
+
+1. `$MAC_PROVIDER_SPEC_PATH` (colon-separated) — operators and tests
+2. `<mac home>/provider-specs/` — **the user's own providers**
+3. the shipped templates inside the installed package
+
+A user overrides a shipped template by dropping a same-named file into their own
+directory. They never edit anything mac ships, so an upgrade never conflicts
+with their provider and never silently reverts it.
+
+Two rules keep precedence honest. A spec's `name` must equal its filename stem,
+so a file cannot shadow a name that `ls` does not show. And one unparseable file
+does not hide the rest of the directory — a bad third-party spec must not make
+every provider disappear.
+
+### 8. Everything is bounded, because a spec file is an execution surface
+
+Binary must be a bare command name (no path, no `..`, no separator) — *which*
+binary a name resolves to is the operator's `PATH` decision, not a downloaded
+file's. Spec ≤ 256 KiB, ≤ 32 verbs, ≤ 64 argv tokens per verb, ≤ 512 chars per
+token, ≤ 64 parameters, ≤ 1024 chars per value, ≤ 64 splat items, timeout in
+1..3600s. A spec that cannot be proved within bounds does not load at all.
+
+**The review story for a third-party spec is `build_argv()`.** It returns the
+exact argv a verb would execute without executing it, so "what does this file
+actually run" is answerable by a reviewer in one call rather than by reading a
+template and imagining the substitution.
+
+### 9. The hgx modules become consumers; the migration is additive first
+
+`ProviderInstance` deliberately mirrors `HgxSession`'s shape, and
+`hgx_elastic_capacity` already talks to a `_Provider` **Protocol** rather than to
+`HgxProvider` directly. The seam exists.
+
+So the order is: interpreter and `nvidia.json` land first and are proved to
+build byte-identical argv to the hard-wired adapter; then the capacity
+controller and autoscaler are re-pointed at a spec-driven provider; then
+`hgx_provider.py` is deleted. Each step is separately revertible, and at no
+point is NVIDIA capacity broken to make external capacity work.
+
+`hgx_provider.py` is **deprecated on landing, not removed** — removing it in the
+same change would couple a refactor of 2,442 lines to a new execution surface's
+first day.
+
+## Consequences
+
+- mac becomes usable outside NVIDIA. A user with any CLI-driven cloud writes one
+  JSON file in their own config and gets create/list/status/exec/delete with
+  mac's addressing, redaction and attestation policies applied for free.
+- The interesting policies stop being per-vendor. Immutable-ID addressing,
+  ambiguous-name refusal, credential scrubbing and nonce attestation are
+  implemented once and inherited by every provider, including ones we never see.
+- mac gains a **data-driven execution surface**, which is a real new risk and
+  the reason §2–§4 and §8 exist rather than being left to reviewer discipline. A
+  spec is still code in the sense that matters: it decides what runs.
+- A spec cannot express everything a hand-written adapter can. Retries,
+  pagination, multi-call verbs and nested-payload gymnastics are all outside the
+  vocabulary today. Some providers will need `--query`/`--format` projections to
+  flatten their output, which is exactly what the `aws`, `gcp` and `azure`
+  templates demonstrate — and some will need a capability interface instead.
+  That is the trade for a declarative surface, and it should be met by adding a
+  *named capability*, never by adding a general escape hatch.
+- Provider bugs move from mac's issue tracker to the user's spec file. That is
+  the right place for them and a worse debugging experience, which is why
+  `build_argv()` is public API rather than an internal helper.
+- We now maintain four vendor templates we cannot integration-test against the
+  real clouds. They are labelled TEMPLATE, they say what to edit, and the tests
+  assert their *shape* — that they parse, that they can create/list/status/
+  delete, that `nvidia` matches the adapter it replaces. Nothing claims they are
+  verified against a live account.
+
+## Alternatives considered
+
+**Keep a Python module per provider, just write more of them.** Rejected: it
+does not solve the problem for anyone who is not us. A user cannot add a
+provider without forking mac, and every new module re-implements the addressing
+and redaction policy, differently.
+
+**A plugin entry point — users install a Python package implementing a
+Provider protocol.** Not rejected on capability; it is strictly more expressive.
+Rejected on the security and operations trade. A plugin is arbitrary code in
+mac's process with mac's credentials and no bounds at all, and "add a provider"
+becomes "publish and install a package". A JSON file that can only build argv
+for one named binary is a surface a reviewer can actually read. If a provider
+genuinely needs code, that is a signal for a named capability interface in mac,
+not for a general plugin loader.
+
+**Embed a small expression language for output parsing.** Rejected: it grows
+until it is a language, and the flattening it would do is already available in
+every one of these CLIs as `--query` / `--format`, evaluated by the vendor's own
+tool rather than by ours.
+
+**Adopt an existing multi-cloud abstraction (libcloud, Pulumi, Terraform).**
+Rejected for this layer. They are strong at declarative *desired state* and
+heavy as a dependency; mac needs imperative, bounded, attestable single-machine
+lifecycle calls it can run from a controller loop. They also would not cover
+`hgx`, which is the one provider we actually have to keep working.
+
+**Ship no templates; make every user author a spec from scratch.** Rejected:
+the templates are the documentation. The correct way to learn this vocabulary is
+to read `nvidia.json` — a real, working provider — beside `aws.json`, and diff
+them.

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -34,6 +34,7 @@ their retained sources.
 - [ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype](../adr/0025-the-hub-ui-is-the-observability-console.md) — `adr/0025-the-hub-ui-is-the-observability-console.md`
 - [ADR 0026: Every operation on a first-class object emits a bus event](../adr/0026-first-class-operations-emit-bus-events.md) — `adr/0026-first-class-operations-emit-bus-events.md`
 - [ADR 0027: Upgrades are versioned, ordered, and fail closed](../adr/0027-upgrades-are-versioned-and-fail-closed.md) — `adr/0027-upgrades-are-versioned-and-fail-closed.md`
+- [ADR 0028: A provider is data, not mac source](../adr/0028-a-provider-is-data-not-source.md) — `adr/0028-a-provider-is-data-not-source.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/provider-specs.md
+++ b/docs/provider-specs.md
@@ -1,0 +1,225 @@
+# Provider specs: adding your own capacity provider
+
+mac talks to capacity providers through a **JSON description of a CLI**, not
+through provider-specific Python. To add a provider, you write one file in your
+own configuration directory. You do not fork or patch mac.
+
+The reasoning is in [ADR 0028](adr/0028-a-provider-is-data-not-source.md); this
+page is the how.
+
+> `local` is not a provider spec. It is direct connectivity to a machine you
+> already have — `user@machine:directory` over ssh — with no CLI to wrap and no
+> lifecycle to drive. It is configured the way it always was.
+
+## Where specs live
+
+Search order, nearest wins:
+
+| # | Location | For |
+| --- | --- | --- |
+| 1 | `$MAC_PROVIDER_SPEC_PATH` (colon-separated dirs) | operators, tests |
+| 2 | `<mac home>/provider-specs/` | **your providers** |
+| 3 | the templates shipped inside the mac package | examples to copy |
+
+`<mac home>` is `~/.mac` unless `MAC_HOME` says otherwise.
+
+Dropping `~/.mac/provider-specs/nvidia.json` overrides the shipped `nvidia`
+template. You never edit a file mac ships, so upgrades never conflict with your
+provider and never silently revert it.
+
+Two rules keep this honest:
+
+- **A spec's `name` must equal its filename stem.** Otherwise a file could
+  shadow a provider name that `ls` does not show.
+- **One broken file does not hide the directory.** An unparseable spec is
+  skipped during discovery; `discover_specs(strict=True)` raises so you can see
+  exactly what is wrong.
+
+## Getting started: copy a template
+
+Four templates ship with mac, in `src/mac/data/provider-specs/`:
+
+| Template | Wraps | Has `exec`? |
+| --- | --- | --- |
+| `nvidia.json` | NVIDIA Horde DGXC via `hgx` | yes |
+| `gcp.json` | Google Compute Engine via `gcloud` | yes |
+| `aws.json` | Amazon EC2 via `aws` | no — see [attestation](#attestation-is-a-capability) |
+| `azure.json` | Azure VMs via `az` | no — see [attestation](#attestation-is-a-capability) |
+
+`nvidia.json` is the one to read first: it is a real, working provider rather
+than an illustration. Read `aws.json` next and diff them.
+
+```bash
+mkdir -p ~/.mac/provider-specs
+cp "$(python3 -c 'import mac.provider_spec as m; print(m.SHIPPED_SPEC_DIR)')/gcp.json" \
+   ~/.mac/provider-specs/mycloud.json
+# edit it, and remember to change "name" to "mycloud" so it matches the filename
+```
+
+## Anatomy of a spec
+
+```json
+{
+  "schema": "mac.provider_spec.v1",
+  "name": "mycloud",
+  "kind": "external",
+  "description": "What this is and what to edit.",
+  "binary": "mycloud",
+  "timeout_seconds": 120,
+  "env_passthrough": ["MYCLOUD_REGION"],
+  "credential_env_var": "MYCLOUD_API_TOKEN",
+  "parameters": {
+    "instance_id": {"required": true, "pattern": "^vm-[0-9]{4}$"},
+    "instance_name": {"pattern": "^[a-z0-9-]{1,32}$", "default": "mac-worker"},
+    "flavor": {"required": true, "pattern": "^[a-z0-9-]{1,32}$"},
+    "command": {"splat": true, "pattern": "^[^\\u0000\\n\\r]{1,128}$", "default": []}
+  },
+  "fields": {
+    "id": ["uuid"],
+    "name": ["label"],
+    "flavor": ["size"],
+    "state": ["phase"],
+    "host": ["ipv4"],
+    "user": ["login"]
+  },
+  "verbs": {
+    "create": {
+      "args": ["vm-create", "--label", "{instance_name}", "--size", "{flavor}"],
+      "parse": {"format": "json", "select": "vm"}
+    },
+    "list":   {"args": ["vm-list"], "parse": {"format": "json", "select": "vms"}},
+    "status": {"args": ["vm-show", "{instance_id}"], "parse": {"format": "json", "select": "vm"}},
+    "delete": {"args": ["vm-destroy", "{instance_id}"], "parse": {"format": "none"}},
+    "exec":   {"args": ["vm-run", "{instance_id}", "--", "{command...}"], "parse": {"format": "none"}}
+  }
+}
+```
+
+### Verbs
+
+The vocabulary is closed: `create`, `list`, `status`, `update`, `delete`,
+`stop`, `start`, `exec`. Anything else is a load error. Define only the verbs
+your provider has; asking for one you did not define raises a named capability
+error rather than doing nothing.
+
+`args` is the argv **after** the binary. It is a list, always — there is no
+shell, so nothing you write is re-split or re-interpreted.
+
+### Parameters and substitution
+
+`{param}` substitutes a declared parameter into a token. `{param...}` — only
+ever as a whole token, and only for a parameter marked `"splat": true` —
+expands a list into one argv item per element. That is how `exec` passes a
+command through.
+
+Every placeholder must name a declared parameter. Every value is checked against
+that parameter's `pattern` before it reaches argv.
+
+`required` is judged **per verb**, from the placeholders that verb actually
+uses: `image_id` is required to create an instance and meaningless when deleting
+one.
+
+### Reading output back
+
+`parse.format` is `json` or `none`. `parse.select` is a dotted path into the
+payload (`"vm"`, `"data.instances"`). `fields` maps mac's model onto candidate
+source keys, first non-empty wins:
+
+| mac field | meaning |
+| --- | --- |
+| `id` | **required** — the immutable selector for every lifecycle call |
+| `name` | human display label; never used to address an instance |
+| `flavor`, `state` | reported as-is |
+| `endpoint`, or `host` + `user` + `port` | composed into a validated ssh target |
+
+Most cloud CLIs return deeply nested payloads. Flatten them with the vendor's
+own projection flag rather than expecting mac to understand the shape — that is
+what `--query` does in `aws.json` and `--format` does in `gcp.json`.
+
+## Security model
+
+A spec decides what runs, so the interpreter treats one as untrusted input.
+
+- **`binary` is a bare command name.** No path, no `..`, no separator. Which
+  binary that name resolves to is your `PATH`'s decision, not a downloaded
+  file's.
+- **argv is never a shell string.** Shell metacharacters in a value are inert
+  bytes. The risk that *is* live for `execve` is a value the target tool re-reads
+  as a **flag**, so a value starting with `-` is refused unless the parameter
+  sets `"allow_leading_dash": true`.
+- **Credentials never enter argv.** A spec names environment variables; it can
+  never interpolate one. A parameter whose *name* looks like a credential
+  (`token`, `api_key`, `password`, …) is rejected at load time.
+- **The child environment is only what you declared.** `PATH`, `HOME`, `LANG`,
+  `LC_ALL`, `TMPDIR`, plus `env_passthrough` and `credential_env_var`.
+- **Secrets in output are scrubbed on the way in.** A `root_password` field in a
+  provider record is recorded in `scrubbed_fields` by name; its value is never
+  copied into a `ProviderInstance` and so never reaches a log or an evidence
+  blob.
+- **Everything is bounded.** ≤ 256 KiB per file, ≤ 32 verbs, ≤ 64 argv tokens
+  per verb, ≤ 512 chars per token, ≤ 64 parameters, ≤ 1024 chars per value,
+  ≤ 64 splat items, timeout 1–3600 s. A spec that cannot be proved within bounds
+  does not load.
+
+### Reviewing someone else's spec
+
+Ask it what it would run, without running it:
+
+```python
+from mac.provider_spec import SpecProvider, load_spec
+
+provider = SpecProvider(load_spec("mycloud"))
+print(provider.build_argv("create", {"instance_name": "w1", "flavor": "medium"}))
+# ['mycloud', 'vm-create', '--label', 'w1', '--size', 'medium']
+```
+
+`build_argv()` is public API precisely so this is a one-liner rather than an
+exercise in reading a template and imagining the substitution.
+
+## Attestation is a capability
+
+`attest(instance_id)` proves a machine is really reachable: it runs
+`printf <nonce>` over the provider's own transport and requires the exact line
+back. A zero exit from `create` is never treated as readiness.
+
+Attestation needs an `exec` verb. A spec without one **fails closed** —
+`attest()` raises `ProviderCapabilityError` instead of returning success. Two
+shipped templates are in that position on purpose:
+
+- **EC2** has no synchronous non-interactive remote-exec CLI verb.
+- **`az vm run-command invoke`** returns remote output wrapped inside a JSON
+  envelope rather than on stdout, so it cannot satisfy a line-exact nonce check.
+
+If you need attested capacity from those providers, add an ssh-based `exec` verb
+of your own. An unattested provider is honest about what it does not know; a
+provider that reports "ready" because a create call exited zero is not.
+
+## Using a provider
+
+```python
+from mac.provider_spec import SpecProvider, discover_specs, load_spec
+
+print(sorted(discover_specs()))          # what is on the search path
+
+provider = SpecProvider(load_spec("mycloud"))
+instance = provider.create(instance_name="mac-worker-1", flavor="medium")
+provider.attest(instance.instance_id)     # raises unless really reachable
+print(instance.observable())              # secret-free, safe for logs/evidence
+provider.delete(instance.instance_id)
+```
+
+Addressing is by immutable ID everywhere. `resolve_instance_id(name)` maps a
+display name to an ID and refuses when the name matches zero or more than one
+instance — guessing there means operating on the wrong machine.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| `no provider spec named 'x' on the search path: …` | file missing, or its `name` does not match the filename stem |
+| `verb 'x' is not one of …` | verb outside the closed vocabulary |
+| `verb 'x' references undeclared parameter 'y'` | add `y` to `parameters` |
+| `value '…' starts with '-'` | set `allow_leading_dash` if the provider really expects a flag there |
+| `does not match its declared pattern` | widen that parameter's `pattern` deliberately |
+| `parameter 'x' looks like a credential` | pass it via `env_passthrough` / `credential_env_var` instead |
+| `cannot be attested: its spec describes no 'exec' verb` | add an `exec` verb, or accept unattested capacity |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -39,6 +39,7 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
 | architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
 | architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
+| architecture decision | `adr/0028-a-provider-is-data-not-source.md` | ADR 0028: A provider is data, not mac source |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |
@@ -184,6 +185,7 @@ for provenance and is not a current operating contract.
 | supplemental reference | `openshell-nemo-relay-integration.md` | OpenShell + NeMo Relay integration |
 | supplemental reference | `openshell-sandbox.md` | Running Hermes under the OpenShell sandbox |
 | runbook | `production-deployment.md` | Production Deployment |
+| supplemental reference | `provider-specs.md` | Provider specs: adding your own capacity provider |
 | generated reference | `reference/cli.md` | Command-line reference |
 | generated reference | `reference/documentation-inventory.md` | Documentation inventory |
 | generated reference | `reference/openapi.md` | HTTP API reference |

--- a/src/mac/data/provider-specs/aws.json
+++ b/src/mac/data/provider-specs/aws.json
@@ -1,0 +1,89 @@
+{
+  "schema": "mac.provider_spec.v1",
+  "name": "aws",
+  "kind": "external",
+  "description": "Amazon EC2 instances via the 'aws' CLI. TEMPLATE: copy into your own provider-specs directory and edit. The --query projections flatten EC2's nested payloads into the flat records mac's field mapper reads, which is the idiomatic way to keep a spec declarative instead of teaching the interpreter one vendor's response shape. No exec verb: EC2 has no synchronous non-interactive remote-exec CLI verb, so attest() fails closed on this spec rather than reporting a machine ready it cannot reach. Add one (SSM, or an ssh wrapper of your own) before using this provider for capacity that must be attested.",
+  "binary": "aws",
+  "timeout_seconds": 300,
+  "env_passthrough": ["AWS_PROFILE", "AWS_REGION", "AWS_DEFAULT_REGION", "AWS_CONFIG_FILE"],
+  "credential_env_var": "AWS_SECRET_ACCESS_KEY",
+  "parameters": {
+    "instance_id": {
+      "required": true,
+      "pattern": "^i-[0-9a-f]{8,32}$"
+    },
+    "instance_name": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$",
+      "default": "mac-worker"
+    },
+    "image_id": {
+      "required": true,
+      "pattern": "^ami-[0-9a-f]{8,32}$"
+    },
+    "flavor": {
+      "required": true,
+      "pattern": "^[a-z0-9]+\\.[a-z0-9]+$",
+      "default": "t3.large"
+    },
+    "subnet_id": {
+      "pattern": "^subnet-[0-9a-f]{8,32}$"
+    }
+  },
+  "fields": {
+    "id": ["id"],
+    "name": ["name"],
+    "flavor": ["flavor"],
+    "state": ["state"],
+    "host": ["host"],
+    "user": ["user"]
+  },
+  "verbs": {
+    "create": {
+      "args": [
+        "ec2", "run-instances",
+        "--image-id", "{image_id}",
+        "--instance-type", "{flavor}",
+        "--subnet-id", "{subnet_id}",
+        "--count", "1",
+        "--tag-specifications",
+        "ResourceType=instance,Tags=[{Key=Name,Value={instance_name}},{Key=managed-by,Value=mac}]",
+        "--output", "json",
+        "--query",
+        "Instances[0].{id:InstanceId,name:Tags[?Key=='Name']|[0].Value,flavor:InstanceType,state:State.Name,host:PrivateDnsName}"
+      ],
+      "parse": {"format": "json"}
+    },
+    "list": {
+      "args": [
+        "ec2", "describe-instances",
+        "--filters", "Name=tag:managed-by,Values=mac",
+        "--output", "json",
+        "--query",
+        "Reservations[].Instances[].{id:InstanceId,name:Tags[?Key=='Name']|[0].Value,flavor:InstanceType,state:State.Name,host:PrivateDnsName}"
+      ],
+      "parse": {"format": "json"}
+    },
+    "status": {
+      "args": [
+        "ec2", "describe-instances",
+        "--instance-ids", "{instance_id}",
+        "--output", "json",
+        "--query",
+        "Reservations[0].Instances[0].{id:InstanceId,name:Tags[?Key=='Name']|[0].Value,flavor:InstanceType,state:State.Name,host:PrivateDnsName}"
+      ],
+      "parse": {"format": "json"}
+    },
+    "stop": {
+      "args": ["ec2", "stop-instances", "--instance-ids", "{instance_id}", "--output", "json"],
+      "parse": {"format": "none"}
+    },
+    "start": {
+      "args": ["ec2", "start-instances", "--instance-ids", "{instance_id}", "--output", "json"],
+      "parse": {"format": "none"}
+    },
+    "delete": {
+      "args": ["ec2", "terminate-instances", "--instance-ids", "{instance_id}", "--output", "json"],
+      "parse": {"format": "none"}
+    }
+  }
+}

--- a/src/mac/data/provider-specs/azure.json
+++ b/src/mac/data/provider-specs/azure.json
@@ -1,0 +1,95 @@
+{
+  "schema": "mac.provider_spec.v1",
+  "name": "azure",
+  "kind": "external",
+  "description": "Azure virtual machines via the 'az' CLI. TEMPLATE: copy into your own provider-specs directory and edit. Every lifecycle verb addresses the VM by its ARM resource id through '--ids', which is the one selector 'az' accepts uniformly and is immutable for the life of the VM. No exec verb: 'az vm run-command invoke' returns its remote output wrapped inside a JSON envelope rather than on stdout, so it cannot satisfy mac's line-exact nonce attestation. attest() therefore fails closed on this spec; add an ssh-based exec verb of your own before using this provider for capacity that must be proved reachable.",
+  "binary": "az",
+  "timeout_seconds": 600,
+  "env_passthrough": ["AZURE_CONFIG_DIR", "AZURE_SUBSCRIPTION_ID", "AZURE_DEFAULTS_GROUP"],
+  "credential_env_var": "AZURE_CLIENT_SECRET",
+  "parameters": {
+    "instance_id": {
+      "required": true,
+      "pattern": "^/subscriptions/[0-9a-fA-F-]{36}/resourceGroups/[A-Za-z0-9._()-]{1,90}/providers/Microsoft\\.Compute/virtualMachines/[A-Za-z0-9._-]{1,64}$"
+    },
+    "instance_name": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$",
+      "default": "mac-worker"
+    },
+    "resource_group": {
+      "required": true,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._()-]{0,89}$"
+    },
+    "flavor": {
+      "required": true,
+      "pattern": "^Standard_[A-Za-z0-9_]{1,32}$",
+      "default": "Standard_D8s_v5"
+    },
+    "image_id": {
+      "required": true,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$",
+      "default": "Ubuntu2204"
+    },
+    "admin_user": {
+      "pattern": "^[a-z_][a-z0-9_-]{0,31}$",
+      "default": "macagent"
+    }
+  },
+  "fields": {
+    "id": ["id"],
+    "name": ["name"],
+    "flavor": ["hardwareProfile"],
+    "state": ["powerState", "provisioningState"],
+    "host": ["privateIps", "privateIpAddress"],
+    "user": ["adminUsername"]
+  },
+  "verbs": {
+    "create": {
+      "args": [
+        "vm", "create",
+        "--resource-group", "{resource_group}",
+        "--name", "{instance_name}",
+        "--image", "{image_id}",
+        "--size", "{flavor}",
+        "--admin-username", "{admin_user}",
+        "--tags", "managed-by=mac",
+        "--output", "json"
+      ],
+      "parse": {"format": "json"}
+    },
+    "list": {
+      "args": [
+        "vm", "list",
+        "--resource-group", "{resource_group}",
+        "--show-details",
+        "--output", "json",
+        "--query",
+        "[?tags.\"managed-by\"=='mac'].{id:id,name:name,powerState:powerState,privateIps:privateIps,adminUsername:osProfile.adminUsername,hardwareProfile:hardwareProfile.vmSize}"
+      ],
+      "parse": {"format": "json"}
+    },
+    "status": {
+      "args": [
+        "vm", "show",
+        "--ids", "{instance_id}",
+        "--show-details",
+        "--output", "json",
+        "--query",
+        "{id:id,name:name,powerState:powerState,privateIps:privateIps,adminUsername:osProfile.adminUsername,hardwareProfile:hardwareProfile.vmSize}"
+      ],
+      "parse": {"format": "json"}
+    },
+    "stop": {
+      "args": ["vm", "deallocate", "--ids", "{instance_id}", "--output", "json"],
+      "parse": {"format": "none"}
+    },
+    "start": {
+      "args": ["vm", "start", "--ids", "{instance_id}", "--output", "json"],
+      "parse": {"format": "none"}
+    },
+    "delete": {
+      "args": ["vm", "delete", "--ids", "{instance_id}", "--yes", "--output", "json"],
+      "parse": {"format": "none"}
+    }
+  }
+}

--- a/src/mac/data/provider-specs/gcp.json
+++ b/src/mac/data/provider-specs/gcp.json
@@ -1,0 +1,104 @@
+{
+  "schema": "mac.provider_spec.v1",
+  "name": "gcp",
+  "kind": "external",
+  "description": "Google Compute Engine instances via the 'gcloud' CLI. TEMPLATE: copy into your own provider-specs directory and edit. GCE's CLI addresses an instance by NAME within a zone and refuses to create two instances with the same name there, so the name is the immutable selector for this provider and fields.id maps to it. exec runs through 'gcloud compute ssh ... -- <argv>', which is a real remote execution path, so attest() works against this spec.",
+  "binary": "gcloud",
+  "timeout_seconds": 300,
+  "env_passthrough": ["CLOUDSDK_CORE_PROJECT", "CLOUDSDK_COMPUTE_ZONE", "CLOUDSDK_CONFIG"],
+  "credential_env_var": "GOOGLE_APPLICATION_CREDENTIALS",
+  "parameters": {
+    "instance_id": {
+      "required": true,
+      "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$"
+    },
+    "instance_name": {
+      "pattern": "^[a-z][a-z0-9-]{0,61}[a-z0-9]$",
+      "default": "mac-worker"
+    },
+    "zone": {
+      "required": true,
+      "pattern": "^[a-z]+-[a-z]+[0-9]-[a-z]$",
+      "default": "us-central1-a"
+    },
+    "flavor": {
+      "required": true,
+      "pattern": "^[a-z0-9]+-[a-z0-9-]{1,32}$",
+      "default": "n2-standard-8"
+    },
+    "image_family": {
+      "pattern": "^[a-z0-9][a-z0-9-]{0,63}$",
+      "default": "debian-12"
+    },
+    "image_project": {
+      "pattern": "^[a-z0-9][a-z0-9-]{0,63}$",
+      "default": "debian-cloud"
+    },
+    "command": {
+      "splat": true,
+      "pattern": "^[^\\x00\\n\\r]{1,256}$",
+      "default": []
+    }
+  },
+  "fields": {
+    "id": ["name"],
+    "name": ["name"],
+    "flavor": ["machineType"],
+    "state": ["status"],
+    "host": ["natIP", "networkIP"]
+  },
+  "verbs": {
+    "create": {
+      "args": [
+        "compute", "instances", "create", "{instance_name}",
+        "--zone", "{zone}",
+        "--machine-type", "{flavor}",
+        "--image-family", "{image_family}",
+        "--image-project", "{image_project}",
+        "--labels", "managed-by=mac",
+        "--format",
+        "json(name,status,machineType.basename():label=machineType,networkInterfaces[0].networkIP:label=networkIP)"
+      ],
+      "parse": {"format": "json"}
+    },
+    "list": {
+      "args": [
+        "compute", "instances", "list",
+        "--filter", "labels.managed-by=mac",
+        "--format",
+        "json(name,status,machineType.basename():label=machineType,networkInterfaces[0].networkIP:label=networkIP)"
+      ],
+      "parse": {"format": "json"}
+    },
+    "status": {
+      "args": [
+        "compute", "instances", "describe", "{instance_id}",
+        "--zone", "{zone}",
+        "--format",
+        "json(name,status,machineType.basename():label=machineType,networkInterfaces[0].networkIP:label=networkIP)"
+      ],
+      "parse": {"format": "json"}
+    },
+    "stop": {
+      "args": ["compute", "instances", "stop", "{instance_id}", "--zone", "{zone}"],
+      "parse": {"format": "none"}
+    },
+    "start": {
+      "args": ["compute", "instances", "start", "{instance_id}", "--zone", "{zone}"],
+      "parse": {"format": "none"}
+    },
+    "delete": {
+      "args": ["compute", "instances", "delete", "{instance_id}", "--zone", "{zone}", "--quiet"],
+      "parse": {"format": "none"}
+    },
+    "exec": {
+      "args": [
+        "compute", "ssh", "{instance_id}",
+        "--zone", "{zone}",
+        "--tunnel-through-iap",
+        "--", "{command...}"
+      ],
+      "parse": {"format": "none"}
+    }
+  }
+}

--- a/src/mac/data/provider-specs/nvidia.json
+++ b/src/mac/data/provider-specs/nvidia.json
@@ -1,0 +1,69 @@
+{
+  "schema": "mac.provider_spec.v1",
+  "name": "nvidia",
+  "kind": "external",
+  "description": "NVIDIA Horde DGXC sessions via the internal 'hgx' CLI. This is the profile that replaces the hard-wired mac.hgx_provider module: the same argv, the same immutable-id-only addressing, and the same nonce attestation over 'hgx ssh <id> -- <command>'. 'hgx info' is deliberately absent because it can echo a fallback bootstrap password; the vocabulary has no verb that would invoke it.",
+  "binary": "hgx",
+  "timeout_seconds": 120,
+  "env_passthrough": ["HGX_CLUSTER", "HGX_ENDPOINT"],
+  "parameters": {
+    "instance_id": {
+      "required": true,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "instance_name": {
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$",
+      "default": "mac-worker"
+    },
+    "flavor": {
+      "required": true,
+      "pattern": "^[a-z0-9][a-z0-9-]{0,31}$",
+      "default": "standard-dind"
+    },
+    "command": {
+      "splat": true,
+      "pattern": "^[^\\x00\\n\\r]{1,256}$",
+      "default": []
+    }
+  },
+  "fields": {
+    "id": ["id", "session_id", "sessionId", "uuid"],
+    "name": ["name", "display_name", "displayName", "label"],
+    "flavor": ["agent_type", "agentType", "flavor", "type"],
+    "state": ["state", "status", "phase"],
+    "endpoint": ["ssh", "ssh_target", "sshTarget", "endpoint"],
+    "host": ["hostname", "ip", "ipv4"],
+    "user": ["user", "username", "login"],
+    "port": ["port", "ssh_port", "sshPort"]
+  },
+  "verbs": {
+    "create": {
+      "args": ["--json", "create", "--type", "{flavor}", "--name", "{instance_name}"],
+      "parse": {"format": "json"}
+    },
+    "list": {
+      "args": ["--json", "list"],
+      "parse": {"format": "json", "select": "sessions"}
+    },
+    "status": {
+      "args": ["--json", "status", "{instance_id}"],
+      "parse": {"format": "json", "select": "session"}
+    },
+    "stop": {
+      "args": ["stop", "{instance_id}"],
+      "parse": {"format": "none"}
+    },
+    "start": {
+      "args": ["resume", "{instance_id}"],
+      "parse": {"format": "none"}
+    },
+    "delete": {
+      "args": ["delete", "{instance_id}"],
+      "parse": {"format": "none"}
+    },
+    "exec": {
+      "args": ["ssh", "{instance_id}", "--", "{command...}"],
+      "parse": {"format": "none"}
+    }
+  }
+}

--- a/src/mac/provider_spec.py
+++ b/src/mac/provider_spec.py
@@ -1,0 +1,1095 @@
+"""Data-driven provider CRUD wrapper: providers are JSON specs, not mac source.
+
+mac's capacity providers used to be Python modules that hard-wired one vendor's
+CLI (``mac.hgx_provider`` wraps NVIDIA's internal ``hgx`` tool). That makes mac
+unusable outside the network where that tool exists, and it gives a user with a
+different cloud no way to express their own provider short of patching mac.
+
+This module is the other half of ``docs/adr/0028-a-provider-is-data-not-source.md``:
+mac core carries an **interpreter**, and a *provider* is a JSON description of
+which binary to invoke, with which arguments, for each CRUD verb, plus how to
+read the result back into mac's provider model. ``docs/provider-specs.md`` is
+the authoring guide.
+
+Three properties are load-bearing and are enforced here rather than documented
+and hoped for:
+
+- **argv is built, never a shell string.** Every invocation is an explicit argv
+  list executed with ``shell=False``. There is no interpolation into a string
+  that a shell later re-splits, so shell metacharacters in a value are inert
+  data. The residual injection risk for a shell-free ``execve`` is *argument*
+  injection -- a value that begins with ``-`` and is read by the target tool as
+  a flag -- so that is what :func:`_substitute` refuses by default.
+- **Credentials never reach argv.** A spec names environment variables; it can
+  never interpolate one into an argument. Secrets therefore cannot leak through
+  a process table, a command log, or an error message that echoes argv.
+- **Everything is bounded.** Binary names, argv widths, value shapes, timeouts
+  and file sizes all have explicit ceilings, because a spec file is an execution
+  surface and a third-party spec is untrusted input.
+
+The LOCAL provider is deliberately out of scope: it is direct
+``user@machine:directory`` connectivity over ssh, not a CLI to wrap.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from mac.fleet_deploy import SshTarget, parse_ssh_target
+from mac.mac_paths import mac_home
+from mac.models import MACError
+
+__all__ = [
+    "PROVIDER_SPEC_SCHEMA",
+    "SHIPPED_SPEC_DIR",
+    "USER_SPEC_DIR_NAME",
+    "SPEC_PATH_ENV_VAR",
+    "CRUD_VERBS",
+    "ProviderSpecError",
+    "ProviderSpecValidationError",
+    "ProviderCommandError",
+    "ProviderInstanceNotFoundError",
+    "ProviderAmbiguousNameError",
+    "ProviderCapabilityError",
+    "ProviderEndpoint",
+    "ProviderInstance",
+    "VerbSpec",
+    "ParameterSpec",
+    "ProviderSpec",
+    "SpecProvider",
+    "spec_search_path",
+    "discover_specs",
+    "load_spec",
+]
+
+
+# Versioned schema constant for every spec file and emitted structure.
+PROVIDER_SPEC_SCHEMA = "mac.provider_spec.v1"
+
+# Shipped templates live beside the interpreter so a wheel carries them.
+SHIPPED_SPEC_DIR = Path(__file__).resolve().parent / "data" / "provider-specs"
+
+# User-authored specs live in the mac home, i.e. they are user CONFIGURATION.
+USER_SPEC_DIR_NAME = "provider-specs"
+
+# Colon-separated highest-precedence override, mainly for tests and operators.
+SPEC_PATH_ENV_VAR = "MAC_PROVIDER_SPEC_PATH"
+
+# The verb vocabulary an interpreter understands. A spec need not define all of
+# them; a caller asking for one a spec omits gets an explicit capability error
+# rather than a silent no-op.
+CRUD_VERBS: Tuple[str, ...] = (
+    "create",
+    "list",
+    "status",
+    "update",
+    "delete",
+    "stop",
+    "start",
+    "exec",
+)
+
+# --- Bounds. A spec file is an execution surface; every dimension is capped. --
+_MAX_SPEC_BYTES = 256 * 1024
+_MAX_VERBS = 32
+_MAX_ARGV_TOKENS = 64
+_MAX_TOKEN_CHARS = 512
+_MAX_PARAMETERS = 64
+_MAX_VALUE_CHARS = 1024
+_MAX_ENV_PASSTHROUGH = 64
+_MAX_SPLAT_ITEMS = 64
+_MIN_TIMEOUT_SECONDS = 1.0
+_MAX_TIMEOUT_SECONDS = 3600.0
+_DEFAULT_TIMEOUT_SECONDS = 120.0
+
+_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+_BINARY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_ENV_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+_PARAM_NAME_RE = re.compile(r"^[a-z][a-z0-9_]{0,31}$")
+# ``{param}`` or the splat form ``{param...}``, which expands a list parameter
+# into one argv item per element.
+_PLACEHOLDER_RE = re.compile(r"\{([a-z][a-z0-9_]{0,31})(\.\.\.)?\}")
+
+# Deny-by-default value shape. Specs widen it per parameter with "pattern".
+_DEFAULT_VALUE_PATTERN = r"^[A-Za-z0-9._@:/+=,-]{1,256}$"
+
+# Field names that may carry a credential in provider output. Their VALUES are
+# never copied into a returned structure; only the field name is recorded.
+# Kept in step with the same list in :mod:`mac.hgx_provider`.
+_SECRET_FIELD_KEYS = (
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "credential",
+    "private_key",
+)
+
+_MODEL_FIELDS = ("id", "name", "flavor", "state", "host", "user", "port", "endpoint")
+
+
+class ProviderSpecError(MACError):
+    """Base class for every spec-driven provider failure."""
+
+
+class ProviderSpecValidationError(ProviderSpecError):
+    """A spec file is malformed, unbounded, or otherwise refused at load time.
+
+    Validation is deliberately fail-closed: a spec that cannot be proved to be
+    within bounds is not loaded at all, rather than loaded and trusted to be
+    used carefully.
+    """
+
+
+class ProviderCommandError(ProviderSpecError):
+    """The provider CLI could not be executed or exited non-zero.
+
+    ``stderr`` is captured for the operator's terminal but never copied into an
+    observable structure: provider stderr routinely carries credential hints.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        argv: Sequence[str],
+        returncode: Optional[int] = None,
+        stderr: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.argv: List[str] = list(argv)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+class ProviderInstanceNotFoundError(ProviderSpecError):
+    """No instance matched the requested selector."""
+
+
+class ProviderAmbiguousNameError(ProviderSpecError):
+    """A display name matched more than one instance; refuse to guess.
+
+    Acting on an ambiguous name can operate on the wrong machine, so the caller
+    must disambiguate with the immutable provider ID.
+    """
+
+    def __init__(self, name: str, instance_ids: Sequence[str]) -> None:
+        self.name = name
+        self.instance_ids: List[str] = sorted(set(instance_ids))
+        super().__init__(
+            "instance name %r is ambiguous; it maps to %d instances: %s. "
+            "Select by immutable instance id instead."
+            % (name, len(self.instance_ids), ", ".join(self.instance_ids))
+        )
+
+
+class ProviderCapabilityError(ProviderSpecError):
+    """The spec does not describe the verb or capability the caller asked for."""
+
+
+def _has_secret_hint(key: str) -> bool:
+    lowered = str(key).lower()
+    return any(marker in lowered for marker in _SECRET_FIELD_KEYS)
+
+
+# --------------------------------------------------------------------------
+# The provider model the interpreter parses output back into.
+# --------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ProviderEndpoint:
+    """A validated SSH endpoint for a spec-driven provider instance."""
+
+    target: SshTarget
+    raw: str = ""
+
+    @property
+    def user_host(self) -> str:
+        return self.target.user_host
+
+    @property
+    def port(self) -> Optional[int]:
+        return self.target.port
+
+    def observable(self) -> Dict[str, Any]:
+        return {"user_host": self.target.user_host, "port": self.target.port}
+
+
+@dataclass(frozen=True)
+class ProviderInstance:
+    """A secret-free, structured view of one provider instance.
+
+    The shape intentionally matches :class:`mac.hgx_provider.HgxSession` so the
+    existing HGX consumers (elastic capacity, autoscaler) can be re-pointed at a
+    spec-driven provider without changing what they read.
+    """
+
+    instance_id: str
+    provider: str = ""
+    name: str = ""
+    flavor: str = ""
+    state: str = ""
+    endpoint: Optional[ProviderEndpoint] = None
+    credential_env_var: Optional[str] = None
+    credential_present: bool = False
+    scrubbed_fields: List[str] = field(default_factory=list)
+
+    def observable(self) -> Dict[str, Any]:
+        """Secret-free dict suitable for logs, evidence and observability."""
+        return {
+            "schema": PROVIDER_SPEC_SCHEMA,
+            "provider": self.provider or None,
+            "instance_id": self.instance_id,
+            "name": self.name or None,
+            "flavor": self.flavor or None,
+            "state": self.state or None,
+            "endpoint": self.endpoint.observable() if self.endpoint else None,
+            "credential_env_var": self.credential_env_var,
+            "credential_present": self.credential_present,
+            "scrubbed_fields": list(self.scrubbed_fields),
+        }
+
+
+# --------------------------------------------------------------------------
+# Spec structures.
+# --------------------------------------------------------------------------
+@dataclass(frozen=True)
+class ParameterSpec:
+    """One declared, shape-checked input to a verb's argv template.
+
+    Every placeholder a verb uses must resolve to one of these. An undeclared
+    placeholder is a load-time error, so a spec can never smuggle an
+    unvalidated value into argv.
+    """
+
+    name: str
+    required: bool = False
+    default: Optional[Any] = None
+    pattern: str = _DEFAULT_VALUE_PATTERN
+    allow_leading_dash: bool = False
+    splat: bool = False
+
+    def compiled(self) -> "re.Pattern[str]":
+        return re.compile(self.pattern)
+
+
+@dataclass(frozen=True)
+class VerbSpec:
+    """The argv template and output contract for one CRUD verb."""
+
+    name: str
+    args: Tuple[str, ...]
+    parse_format: str = "json"
+    select: Tuple[str, ...] = ()
+    fields: Mapping[str, Tuple[str, ...]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """A validated, bounded provider description loaded from JSON."""
+
+    name: str
+    kind: str
+    binary: str
+    verbs: Mapping[str, VerbSpec]
+    parameters: Mapping[str, ParameterSpec]
+    fields: Mapping[str, Tuple[str, ...]]
+    description: str = ""
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
+    env_passthrough: Tuple[str, ...] = ()
+    credential_env_var: Optional[str] = None
+    source_path: Optional[Path] = None
+
+    def has_verb(self, verb: str) -> bool:
+        return verb in self.verbs
+
+    def observable(self) -> Dict[str, Any]:
+        """Secret-free description, safe to print in ``mac`` output and evidence."""
+        return {
+            "schema": PROVIDER_SPEC_SCHEMA,
+            "name": self.name,
+            "kind": self.kind,
+            "description": self.description or None,
+            "binary": self.binary,
+            "verbs": sorted(self.verbs),
+            "parameters": sorted(self.parameters),
+            "env_passthrough": list(self.env_passthrough),
+            "credential_env_var": self.credential_env_var,
+            "timeout_seconds": self.timeout_seconds,
+            "source_path": str(self.source_path) if self.source_path else None,
+        }
+
+    # -- parsing ---------------------------------------------------------
+    @classmethod
+    def from_mapping(
+        cls, payload: Mapping[str, Any], *, source_path: Optional[Path] = None
+    ) -> "ProviderSpec":
+        """Validate ``payload`` and return a spec, or raise.
+
+        Everything is checked here, once, at load time. The interpreter below
+        may then assume its spec is well-formed and within bounds.
+        """
+        where = str(source_path) if source_path else "<memory>"
+        if not isinstance(payload, Mapping):
+            raise ProviderSpecValidationError("%s: provider spec must be a JSON object" % where)
+
+        schema = payload.get("schema")
+        if schema != PROVIDER_SPEC_SCHEMA:
+            raise ProviderSpecValidationError(
+                "%s: schema must be %r, got %r" % (where, PROVIDER_SPEC_SCHEMA, schema)
+            )
+
+        name = str(payload.get("name") or "").strip()
+        if not _NAME_RE.match(name):
+            raise ProviderSpecValidationError(
+                "%s: name must be 1..64 lowercase letters, digits, '-' or '_'; got %r"
+                % (where, name)
+            )
+
+        kind = str(payload.get("kind") or "external").strip()
+        if kind not in ("external", "internal"):
+            raise ProviderSpecValidationError(
+                "%s: kind must be 'external' or 'internal', got %r" % (where, kind)
+            )
+
+        binary = str(payload.get("binary") or "").strip()
+        if not _BINARY_RE.match(binary):
+            # A bare command name only: no path separator, no '..', no absolute
+            # path. Which binary a name resolves to is then the operator's PATH
+            # decision, not something a downloaded spec file can choose.
+            raise ProviderSpecValidationError(
+                "%s: binary must be a bare command name matching %s; got %r"
+                % (where, _BINARY_RE.pattern, binary)
+            )
+
+        timeout = _coerce_timeout(payload.get("timeout_seconds"), where)
+        env_passthrough = _coerce_env_passthrough(payload.get("env_passthrough"), where)
+        credential_env_var = _coerce_credential_env(payload.get("credential_env_var"), where)
+        parameters = _coerce_parameters(payload.get("parameters"), where)
+        spec_fields = _coerce_fields(payload.get("fields"), where, "fields")
+        verbs = _coerce_verbs(payload.get("verbs"), where, parameters)
+
+        if not verbs:
+            raise ProviderSpecValidationError("%s: at least one verb is required" % where)
+
+        return cls(
+            name=name,
+            kind=kind,
+            binary=binary,
+            verbs=verbs,
+            parameters=parameters,
+            fields=spec_fields,
+            description=str(payload.get("description") or "").strip(),
+            timeout_seconds=timeout,
+            env_passthrough=env_passthrough,
+            credential_env_var=credential_env_var,
+            source_path=source_path,
+        )
+
+    @classmethod
+    def from_file(cls, path: Path) -> "ProviderSpec":
+        resolved = Path(path)
+        try:
+            size = resolved.stat().st_size
+        except OSError as exc:
+            raise ProviderSpecValidationError(
+                "%s: provider spec is unreadable: %s" % (resolved, exc)
+            ) from exc
+        if size > _MAX_SPEC_BYTES:
+            raise ProviderSpecValidationError(
+                "%s: provider spec is %d bytes, over the %d byte ceiling"
+                % (resolved, size, _MAX_SPEC_BYTES)
+            )
+        try:
+            payload = json.loads(resolved.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            raise ProviderSpecValidationError(
+                "%s: provider spec is not readable JSON: %s" % (resolved, exc)
+            ) from exc
+        return cls.from_mapping(payload, source_path=resolved)
+
+
+# --------------------------------------------------------------------------
+# Validation helpers.
+# --------------------------------------------------------------------------
+def _coerce_timeout(value: Any, where: str) -> float:
+    if value is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ProviderSpecValidationError("%s: timeout_seconds must be a number" % where)
+    if not _MIN_TIMEOUT_SECONDS <= float(value) <= _MAX_TIMEOUT_SECONDS:
+        raise ProviderSpecValidationError(
+            "%s: timeout_seconds must be within %g..%g"
+            % (where, _MIN_TIMEOUT_SECONDS, _MAX_TIMEOUT_SECONDS)
+        )
+    return float(value)
+
+
+def _coerce_env_passthrough(value: Any, where: str) -> Tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ProviderSpecValidationError("%s: env_passthrough must be a list of names" % where)
+    if len(value) > _MAX_ENV_PASSTHROUGH:
+        raise ProviderSpecValidationError(
+            "%s: env_passthrough has %d entries, over the %d ceiling"
+            % (where, len(value), _MAX_ENV_PASSTHROUGH)
+        )
+    names: List[str] = []
+    for item in value:
+        text = str(item or "").strip()
+        if not _ENV_NAME_RE.match(text):
+            raise ProviderSpecValidationError(
+                "%s: env_passthrough entry %r is not a valid environment variable name"
+                % (where, item)
+            )
+        names.append(text)
+    return tuple(dict.fromkeys(names))
+
+
+def _coerce_credential_env(value: Any, where: str) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not _ENV_NAME_RE.match(text):
+        raise ProviderSpecValidationError(
+            "%s: credential_env_var %r is not a valid environment variable name" % (where, value)
+        )
+    return text
+
+
+def _coerce_parameters(value: Any, where: str) -> Mapping[str, ParameterSpec]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ProviderSpecValidationError("%s: parameters must be an object" % where)
+    if len(value) > _MAX_PARAMETERS:
+        raise ProviderSpecValidationError(
+            "%s: %d parameters declared, over the %d ceiling"
+            % (where, len(value), _MAX_PARAMETERS)
+        )
+    out: Dict[str, ParameterSpec] = {}
+    for raw_name, raw in value.items():
+        name = str(raw_name)
+        if not _PARAM_NAME_RE.match(name):
+            raise ProviderSpecValidationError(
+                "%s: parameter name %r must match %s" % (where, name, _PARAM_NAME_RE.pattern)
+            )
+        if not isinstance(raw, Mapping):
+            raise ProviderSpecValidationError(
+                "%s: parameter %r must be an object" % (where, name)
+            )
+        pattern = str(raw.get("pattern") or _DEFAULT_VALUE_PATTERN)
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            raise ProviderSpecValidationError(
+                "%s: parameter %r has an invalid pattern: %s" % (where, name, exc)
+            ) from exc
+        if _has_secret_hint(name):
+            # Secrets travel in the child environment, by name. A spec that
+            # wants one in argv is refused rather than redacted after the fact.
+            raise ProviderSpecValidationError(
+                "%s: parameter %r looks like a credential; credentials are passed "
+                "via env_passthrough/credential_env_var and never interpolated into argv"
+                % (where, name)
+            )
+        out[name] = ParameterSpec(
+            name=name,
+            required=bool(raw.get("required", False)),
+            default=raw.get("default"),
+            pattern=pattern,
+            allow_leading_dash=bool(raw.get("allow_leading_dash", False)),
+            splat=bool(raw.get("splat", False)),
+        )
+    return out
+
+
+def _coerce_fields(value: Any, where: str, label: str) -> Mapping[str, Tuple[str, ...]]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ProviderSpecValidationError("%s: %s must be an object" % (where, label))
+    out: Dict[str, Tuple[str, ...]] = {}
+    for raw_key, raw in value.items():
+        key = str(raw_key)
+        if key not in _MODEL_FIELDS:
+            raise ProviderSpecValidationError(
+                "%s: %s key %r is not one of %s" % (where, label, key, ", ".join(_MODEL_FIELDS))
+            )
+        if isinstance(raw, str):
+            candidates: Sequence[Any] = [raw]
+        elif isinstance(raw, list):
+            candidates = raw
+        else:
+            raise ProviderSpecValidationError(
+                "%s: %s[%r] must be a source key or a list of source keys" % (where, label, key)
+            )
+        names = [str(item).strip() for item in candidates if str(item).strip()]
+        if not names:
+            raise ProviderSpecValidationError(
+                "%s: %s[%r] names no source key" % (where, label, key)
+            )
+        out[key] = tuple(names)
+    return out
+
+
+def _coerce_verbs(
+    value: Any, where: str, parameters: Mapping[str, ParameterSpec]
+) -> Mapping[str, VerbSpec]:
+    if not isinstance(value, Mapping):
+        raise ProviderSpecValidationError("%s: verbs must be an object" % where)
+    if len(value) > _MAX_VERBS:
+        raise ProviderSpecValidationError(
+            "%s: %d verbs declared, over the %d ceiling" % (where, len(value), _MAX_VERBS)
+        )
+    out: Dict[str, VerbSpec] = {}
+    for raw_name, raw in value.items():
+        verb = str(raw_name)
+        if verb not in CRUD_VERBS:
+            raise ProviderSpecValidationError(
+                "%s: verb %r is not one of %s" % (where, verb, ", ".join(CRUD_VERBS))
+            )
+        if not isinstance(raw, Mapping):
+            raise ProviderSpecValidationError("%s: verb %r must be an object" % (where, verb))
+        args = raw.get("args")
+        if not isinstance(args, list) or not args:
+            raise ProviderSpecValidationError(
+                "%s: verb %r needs a non-empty args list" % (where, verb)
+            )
+        if len(args) > _MAX_ARGV_TOKENS:
+            raise ProviderSpecValidationError(
+                "%s: verb %r has %d argv tokens, over the %d ceiling"
+                % (where, verb, len(args), _MAX_ARGV_TOKENS)
+            )
+        tokens: List[str] = []
+        for item in args:
+            if not isinstance(item, str) or not item:
+                raise ProviderSpecValidationError(
+                    "%s: verb %r argv items must be non-empty strings" % (where, verb)
+                )
+            if len(item) > _MAX_TOKEN_CHARS:
+                raise ProviderSpecValidationError(
+                    "%s: verb %r has an argv token over %d characters"
+                    % (where, verb, _MAX_TOKEN_CHARS)
+                )
+            for param_name, splat in _PLACEHOLDER_RE.findall(item):
+                declared = parameters.get(param_name)
+                if declared is None:
+                    raise ProviderSpecValidationError(
+                        "%s: verb %r references undeclared parameter %r"
+                        % (where, verb, param_name)
+                    )
+                if bool(splat) != declared.splat:
+                    raise ProviderSpecValidationError(
+                        "%s: verb %r uses %s for parameter %r but its splat flag is %s"
+                        % (
+                            where,
+                            verb,
+                            "{%s...}" % param_name if splat else "{%s}" % param_name,
+                            param_name,
+                            declared.splat,
+                        )
+                    )
+                if declared.splat and item != "{%s...}" % param_name:
+                    raise ProviderSpecValidationError(
+                        "%s: verb %r splat %r must be the whole argv token"
+                        % (where, verb, item)
+                    )
+            tokens.append(item)
+
+        parse = raw.get("parse") or {}
+        if not isinstance(parse, Mapping):
+            raise ProviderSpecValidationError("%s: verb %r parse must be an object" % (where, verb))
+        parse_format = str(parse.get("format") or "json")
+        if parse_format not in ("json", "none"):
+            raise ProviderSpecValidationError(
+                "%s: verb %r parse.format must be 'json' or 'none', got %r"
+                % (where, verb, parse_format)
+            )
+        select_raw = parse.get("select")
+        if select_raw is None:
+            select: Tuple[str, ...] = ()
+        elif isinstance(select_raw, str):
+            select = tuple(part for part in select_raw.split(".") if part)
+        elif isinstance(select_raw, list):
+            select = tuple(str(part) for part in select_raw if str(part))
+        else:
+            raise ProviderSpecValidationError(
+                "%s: verb %r parse.select must be a dotted string or list" % (where, verb)
+            )
+        verb_fields = _coerce_fields(parse.get("fields"), where, "verbs.%s.parse.fields" % verb)
+        out[verb] = VerbSpec(
+            name=verb,
+            args=tuple(tokens),
+            parse_format=parse_format,
+            select=select,
+            fields=verb_fields,
+        )
+    return out
+
+
+# --------------------------------------------------------------------------
+# Discovery and precedence.
+# --------------------------------------------------------------------------
+def spec_search_path(*, env: Optional[Mapping[str, str]] = None) -> List[Path]:
+    """Ordered spec directories, nearest (highest precedence) first.
+
+    1. ``$MAC_PROVIDER_SPEC_PATH`` -- colon-separated, for operators and tests.
+    2. ``<mac home>/provider-specs`` -- the user's own specs. This is where a
+       user's providers live, because a provider is configuration.
+    3. the shipped templates inside the installed package -- examples to copy,
+       and the profile the NVIDIA/hgx integration is expressed in.
+
+    A name found in an earlier directory shadows the same name later, so a user
+    can override a shipped template by dropping a file with the same name into
+    their own directory without editing anything mac ships.
+    """
+    environ = os.environ if env is None else env
+    out: List[Path] = []
+    raw = (environ.get(SPEC_PATH_ENV_VAR) or "").strip()
+    if raw:
+        out.extend(Path(part).expanduser() for part in raw.split(os.pathsep) if part.strip())
+    out.append(mac_home() / USER_SPEC_DIR_NAME)
+    out.append(SHIPPED_SPEC_DIR)
+    # Preserve order while removing duplicates, so a directory named twice does
+    # not report itself as shadowing itself.
+    seen: set[str] = set()
+    unique: List[Path] = []
+    for path in out:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    return unique
+
+
+def discover_specs(
+    *, env: Optional[Mapping[str, str]] = None, strict: bool = False
+) -> Dict[str, ProviderSpec]:
+    """Load every spec on the search path, nearest-wins, keyed by provider name.
+
+    With ``strict=False`` (the default) an unparseable file in one directory
+    does not stop the rest from loading -- one bad third-party spec must not
+    make every provider disappear. ``strict=True`` re-raises, which is what
+    ``mac``'s validation surface and the tests want.
+    """
+    found: Dict[str, ProviderSpec] = {}
+    for directory in spec_search_path(env=env):
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.glob("*.json")):
+            try:
+                spec = ProviderSpec.from_file(path)
+            except ProviderSpecValidationError:
+                if strict:
+                    raise
+                continue
+            # A spec whose declared name disagrees with its filename is a
+            # precedence trap: the operator would shadow a name they cannot see.
+            if spec.name != path.stem:
+                if strict:
+                    raise ProviderSpecValidationError(
+                        "%s: spec name %r must match its filename stem %r"
+                        % (path, spec.name, path.stem)
+                    )
+                continue
+            found.setdefault(spec.name, spec)
+    return found
+
+
+def load_spec(name: str, *, env: Optional[Mapping[str, str]] = None) -> ProviderSpec:
+    """Return the highest-precedence spec named ``name``."""
+    target = (name or "").strip()
+    if not target:
+        raise ProviderSpecValidationError("a provider name is required")
+    specs = discover_specs(env=env)
+    spec = specs.get(target)
+    if spec is None:
+        raise ProviderSpecValidationError(
+            "no provider spec named %r on the search path: %s"
+            % (target, ", ".join(str(p) for p in spec_search_path(env=env)))
+        )
+    return spec
+
+
+# --------------------------------------------------------------------------
+# The interpreter.
+# --------------------------------------------------------------------------
+def _substitute(spec: ProviderSpec, token: str, values: Mapping[str, Any]) -> List[str]:
+    """Expand one argv template token into zero or more concrete argv items."""
+    splat_match = re.fullmatch(r"\{([a-z][a-z0-9_]{0,31})\.\.\.\}", token)
+    if splat_match:
+        param = spec.parameters[splat_match.group(1)]
+        raw = values.get(param.name, param.default)
+        if raw is None:
+            raw = []
+        if isinstance(raw, (str, bytes)) or not isinstance(raw, Sequence):
+            raise ProviderSpecValidationError(
+                "parameter %r expands an argv list and needs a sequence of strings" % param.name
+            )
+        items = list(raw)
+        if len(items) > _MAX_SPLAT_ITEMS:
+            raise ProviderSpecValidationError(
+                "parameter %r expanded to %d items, over the %d ceiling"
+                % (param.name, len(items), _MAX_SPLAT_ITEMS)
+            )
+        return [_checked_value(param, item) for item in items]
+
+    def replace(match: "re.Match[str]") -> str:
+        param = spec.parameters[match.group(1)]
+        raw = values.get(param.name, param.default)
+        if raw is None:
+            if param.required:
+                raise ProviderSpecValidationError("parameter %r is required" % param.name)
+            raise ProviderSpecValidationError(
+                "parameter %r has no value and no default" % param.name
+            )
+        return _checked_value(param, raw)
+
+    return [_PLACEHOLDER_RE.sub(replace, token)]
+
+
+def _checked_value(param: ParameterSpec, raw: Any) -> str:
+    """Return ``raw`` as a string, or refuse it."""
+    if isinstance(raw, bool) or raw is None:
+        raise ProviderSpecValidationError(
+            "parameter %r must be a string or number, got %r" % (param.name, raw)
+        )
+    text = raw if isinstance(raw, str) else str(raw)
+    if len(text) > _MAX_VALUE_CHARS:
+        raise ProviderSpecValidationError(
+            "parameter %r value is %d characters, over the %d ceiling"
+            % (param.name, len(text), _MAX_VALUE_CHARS)
+        )
+    if "\x00" in text:
+        raise ProviderSpecValidationError("parameter %r value contains a NUL byte" % param.name)
+    if not param.allow_leading_dash and text.startswith("-"):
+        # argv is executed without a shell, so shell metacharacters are inert.
+        # The live risk is a value the target tool re-reads as a FLAG.
+        raise ProviderSpecValidationError(
+            "parameter %r value %r starts with '-'; set allow_leading_dash on the "
+            "parameter if the provider really expects a flag here" % (param.name, text)
+        )
+    if not param.compiled().fullmatch(text):
+        raise ProviderSpecValidationError(
+            "parameter %r value %r does not match its declared pattern %s"
+            % (param.name, text, param.pattern)
+        )
+    return text
+
+
+class SpecProvider:
+    """Executes a :class:`ProviderSpec` against a real provider CLI.
+
+    The instance holds no credentials. It builds argv from the spec, runs it
+    with ``shell=False``, and parses stdout back into
+    :class:`ProviderInstance` values that are secret-free by construction.
+    """
+
+    def __init__(
+        self,
+        spec: ProviderSpec,
+        *,
+        env: Optional[Mapping[str, str]] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        self.spec = spec
+        self._environ = dict(os.environ if env is None else env)
+        self._timeout = float(timeout) if timeout is not None else spec.timeout_seconds
+
+    # -- plumbing --------------------------------------------------------
+    def _child_env(self) -> Dict[str, str]:
+        """The child environment: PATH plus exactly the declared passthroughs.
+
+        A spec cannot read a variable it did not name, so adding a provider
+        does not silently widen what the child process can see.
+        """
+        env: Dict[str, str] = {}
+        for key in ("PATH", "HOME", "LANG", "LC_ALL", "TMPDIR"):
+            value = self._environ.get(key)
+            if value is not None:
+                env[key] = value
+        names = list(self.spec.env_passthrough)
+        if self.spec.credential_env_var:
+            names.append(self.spec.credential_env_var)
+        for name in names:
+            value = self._environ.get(name)
+            if value is not None:
+                env[name] = value
+        return env
+
+    def build_argv(self, verb: str, values: Optional[Mapping[str, Any]] = None) -> List[str]:
+        """Return the concrete argv for ``verb``, without running anything.
+
+        Exposed deliberately: an operator reviewing a third-party spec should be
+        able to see exactly what it would execute before it executes.
+        """
+        template = self.spec.verbs.get(verb)
+        if template is None:
+            raise ProviderCapabilityError(
+                "provider %r does not describe verb %r (it has: %s)"
+                % (self.spec.name, verb, ", ".join(sorted(self.spec.verbs)))
+            )
+        supplied = dict(values or {})
+        # Requiredness is per-verb, judged by what this verb's template actually
+        # references: ``image_id`` is required to create an instance and
+        # meaningless when deleting one.
+        for token in template.args:
+            for param_name, _splat in _PLACEHOLDER_RE.findall(token):
+                param = self.spec.parameters[param_name]
+                if param.required and supplied.get(param.name, param.default) is None:
+                    raise ProviderSpecValidationError(
+                        "provider %r verb %r requires parameter %r"
+                        % (self.spec.name, verb, param.name)
+                    )
+        argv: List[str] = [self.spec.binary]
+        for token in template.args:
+            argv.extend(_substitute(self.spec, token, supplied))
+        return argv
+
+    def run(self, verb: str, values: Optional[Mapping[str, Any]] = None) -> str:
+        """Execute ``verb`` and return stdout."""
+        argv = self.build_argv(verb, values)
+        env = self._child_env()
+        resolved = shutil.which(argv[0], path=env.get("PATH"))
+        if resolved is None:
+            raise ProviderCommandError(
+                "provider %r binary %r not found on PATH" % (self.spec.name, argv[0]),
+                argv=argv,
+            )
+        try:
+            completed = subprocess.run(
+                [resolved, *argv[1:]],
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+                check=False,
+                env=env,
+            )
+        except OSError as exc:
+            raise ProviderCommandError(
+                "provider %r %s could not be executed: %s" % (self.spec.name, verb, exc),
+                argv=argv,
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise ProviderCommandError(
+                "provider %r %s timed out after %ss" % (self.spec.name, verb, self._timeout),
+                argv=argv,
+            ) from exc
+        if completed.returncode != 0:
+            raise ProviderCommandError(
+                "provider %r %s failed (exit %d)"
+                % (self.spec.name, verb, completed.returncode),
+                argv=argv,
+                returncode=completed.returncode,
+                stderr=completed.stderr or "",
+            )
+        return completed.stdout or ""
+
+    # -- output -> model -------------------------------------------------
+    def _field_map(self, verb: str) -> Mapping[str, Tuple[str, ...]]:
+        merged: Dict[str, Tuple[str, ...]] = dict(self.spec.fields)
+        template = self.spec.verbs.get(verb)
+        if template is not None:
+            merged.update(template.fields)
+        return merged
+
+    def _rows(self, verb: str, stdout: str) -> List[Mapping[str, Any]]:
+        template = self.spec.verbs[verb]
+        if template.parse_format == "none":
+            return []
+        try:
+            payload: Any = json.loads(stdout.strip() or "null")
+        except ValueError:
+            return []
+        for key in template.select:
+            if isinstance(payload, Mapping):
+                payload = payload.get(key)
+            elif isinstance(payload, list) and key.isdigit() and int(key) < len(payload):
+                payload = payload[int(key)]
+            else:
+                return []
+        if payload is None:
+            return []
+        if isinstance(payload, Mapping):
+            return [payload]
+        if isinstance(payload, list):
+            return [row for row in payload if isinstance(row, Mapping)]
+        return []
+
+    def _instance(self, verb: str, row: Mapping[str, Any]) -> ProviderInstance:
+        mapping = self._field_map(verb)
+
+        def pick(model_field: str) -> str:
+            for source in mapping.get(model_field, ()):  # declared candidates, in order
+                value = row.get(source)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+                if isinstance(value, int) and not isinstance(value, bool):
+                    return str(value)
+            return ""
+
+        instance_id = pick("id")
+        if not instance_id:
+            raise ProviderSpecValidationError(
+                "provider %r %s output has no immutable id; the spec must map "
+                "fields.id to a source key" % (self.spec.name, verb)
+            )
+        scrubbed = sorted(str(key) for key in row if _has_secret_hint(key))
+        endpoint = self._endpoint(row, mapping)
+        return ProviderInstance(
+            instance_id=instance_id,
+            provider=self.spec.name,
+            name=pick("name"),
+            flavor=pick("flavor"),
+            state=pick("state"),
+            endpoint=endpoint,
+            credential_env_var=self.spec.credential_env_var,
+            credential_present=bool(scrubbed) or self.spec.credential_env_var is not None,
+            scrubbed_fields=scrubbed,
+        )
+
+    def _endpoint(
+        self, row: Mapping[str, Any], mapping: Mapping[str, Tuple[str, ...]]
+    ) -> Optional[ProviderEndpoint]:
+        def pick(model_field: str) -> str:
+            for source in mapping.get(model_field, ()):
+                value = row.get(source)
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+                if isinstance(value, int) and not isinstance(value, bool):
+                    return str(value)
+            return ""
+
+        port_text = pick("port")
+        port = int(port_text) if port_text.isdigit() else None
+        for candidate in (pick("endpoint"), _compose(pick("user"), pick("host"))):
+            if not candidate:
+                continue
+            try:
+                target = parse_ssh_target(candidate, port=port)
+            except ValueError:
+                continue
+            return ProviderEndpoint(target=target, raw=candidate)
+        return None
+
+    # -- CRUD verbs ------------------------------------------------------
+    def create(self, **values: Any) -> ProviderInstance:
+        rows = self._rows("create", self.run("create", values))
+        if not rows:
+            raise ProviderSpecError(
+                "provider %r create returned no parseable instance" % self.spec.name
+            )
+        return self._instance("create", rows[0])
+
+    def list(self, **values: Any) -> List[ProviderInstance]:
+        rows = self._rows("list", self.run("list", values))
+        return [self._instance("list", row) for row in rows]
+
+    def status(self, instance_id: str, **values: Any) -> ProviderInstance:
+        target = _require_instance_id(instance_id)
+        rows = self._rows("status", self.run("status", {**values, "instance_id": target}))
+        if not rows:
+            raise ProviderInstanceNotFoundError(
+                "provider %r has no instance %r" % (self.spec.name, target)
+            )
+        instance = self._instance("status", rows[0])
+        if instance.instance_id != target:
+            raise ProviderInstanceNotFoundError(
+                "provider %r status returned id %r for requested %r"
+                % (self.spec.name, instance.instance_id, target)
+            )
+        return instance
+
+    def update(self, instance_id: str, **values: Any) -> str:
+        target = _require_instance_id(instance_id)
+        self.run("update", {**values, "instance_id": target})
+        return target
+
+    def delete(self, instance_id: str, **values: Any) -> str:
+        target = _require_instance_id(instance_id)
+        self.run("delete", {**values, "instance_id": target})
+        return target
+
+    def stop(self, instance_id: str, **values: Any) -> str:
+        target = _require_instance_id(instance_id)
+        self.run("stop", {**values, "instance_id": target})
+        return target
+
+    def start(self, instance_id: str, **values: Any) -> str:
+        target = _require_instance_id(instance_id)
+        self.run("start", {**values, "instance_id": target})
+        return target
+
+    def exec(self, instance_id: str, command: Sequence[str], **values: Any) -> str:
+        """Run a non-interactive command on an instance through the spec's transport."""
+        target = _require_instance_id(instance_id)
+        if isinstance(command, (str, bytes)) or not command:
+            raise ProviderSpecValidationError("exec requires a non-empty argv sequence")
+        return self.run("exec", {**values, "instance_id": target, "command": list(command)})
+
+    def attest(self, instance_id: str, **values: Any) -> str:
+        """Prove real remote execution and return the instance ID.
+
+        The readiness contract that ``mac.hgx_provider.attest_ssh`` implements
+        in Python is expressed here in spec vocabulary: a provider that
+        describes ``exec`` can be attested, and one that cannot is refused
+        rather than assumed ready. A zero exit is never treated as proof --
+        the remote side must echo an unpredictable nonce back.
+        """
+        target = _require_instance_id(instance_id)
+        if not self.spec.has_verb("exec"):
+            raise ProviderCapabilityError(
+                "provider %r cannot be attested: its spec describes no 'exec' verb, "
+                "so there is no transport to prove reachability over" % self.spec.name
+            )
+        nonce = "mac-provider-attest-" + secrets.token_hex(16)
+        stdout = self.exec(target, ["printf", nonce], **values)
+        if nonce not in stdout.splitlines():
+            raise ProviderSpecError(
+                "provider %r attestation nonce was not returned for instance %r"
+                % (self.spec.name, target)
+            )
+        return target
+
+    # -- name -> immutable id -------------------------------------------
+    def resolve_instance_id(self, name: str, **values: Any) -> str:
+        """Resolve a display ``name`` to exactly one immutable instance ID."""
+        target = (name or "").strip()
+        if not target:
+            raise ProviderInstanceNotFoundError("a non-empty instance name is required")
+        instances = self.list(**values)
+        matches = sorted({item.instance_id for item in instances if item.name == target})
+        if not matches:
+            ids = [item.instance_id for item in instances if item.instance_id == target]
+            if len(set(ids)) == 1:
+                return ids[0]
+            raise ProviderInstanceNotFoundError(
+                "provider %r has no instance named %r" % (self.spec.name, target)
+            )
+        if len(matches) > 1:
+            raise ProviderAmbiguousNameError(target, matches)
+        return matches[0]
+
+
+def _require_instance_id(instance_id: str) -> str:
+    target = (instance_id or "").strip()
+    if not target:
+        raise ProviderInstanceNotFoundError("an immutable instance id is required")
+    return target
+
+
+def _compose(user: str, host: str) -> str:
+    if not host:
+        return ""
+    return "%s@%s" % (user, host) if user else host

--- a/tests/test_provider_spec.py
+++ b/tests/test_provider_spec.py
@@ -1,0 +1,991 @@
+"""Contract tests for the data-driven provider wrapper (``mac.provider_spec``).
+
+Three groups, in the order the ADR argues them:
+
+1. **Validation** -- a spec that cannot be proved to be within bounds does not
+   load. This is the review story for third-party spec files, so it is tested
+   as behaviour rather than trusted as documentation.
+2. **Shipped templates** -- ``aws``/``azure``/``gcp``/``nvidia`` all parse, all
+   name themselves after their file, and the ``nvidia`` profile builds the same
+   argv the hard-wired :mod:`mac.hgx_provider` builds today.
+3. **End to end, no mac source change** -- a *user-authored* spec for a
+   fictional non-NVIDIA cloud drives create/list/status/exec/attest/delete
+   against a real executable through real ``subprocess`` calls. Nothing in this
+   group imports the provider it is exercising; the only mac code involved is
+   the interpreter.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from mac.provider_spec import (
+    CRUD_VERBS,
+    PROVIDER_SPEC_SCHEMA,
+    SHIPPED_SPEC_DIR,
+    SPEC_PATH_ENV_VAR,
+    ProviderAmbiguousNameError,
+    ProviderCapabilityError,
+    ProviderCommandError,
+    ProviderInstanceNotFoundError,
+    ProviderSpec,
+    ProviderSpecValidationError,
+    SpecProvider,
+    discover_specs,
+    load_spec,
+    spec_search_path,
+)
+
+
+def _minimal(**overrides):
+    payload = {
+        "schema": PROVIDER_SPEC_SCHEMA,
+        "name": "demo",
+        "kind": "external",
+        "binary": "demotool",
+        "parameters": {
+            "instance_id": {"required": True},
+            "flavor": {"required": True, "default": "small"},
+        },
+        "fields": {"id": ["id"], "name": ["name"], "state": ["state"]},
+        "verbs": {
+            "create": {"args": ["create", "--type", "{flavor}"]},
+            "status": {"args": ["show", "{instance_id}"]},
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+# --------------------------------------------------------------------------
+# 1. Validation: fail closed.
+# --------------------------------------------------------------------------
+def test_minimal_spec_round_trips():
+    spec = ProviderSpec.from_mapping(_minimal())
+    assert spec.name == "demo"
+    assert spec.kind == "external"
+    assert spec.has_verb("create")
+    assert not spec.has_verb("delete")
+    assert spec.observable()["schema"] == PROVIDER_SPEC_SCHEMA
+
+
+def test_wrong_schema_is_refused():
+    with pytest.raises(ProviderSpecValidationError, match="schema must be"):
+        ProviderSpec.from_mapping(_minimal(schema="mac.provider_spec.v99"))
+
+
+@pytest.mark.parametrize(
+    "binary",
+    ["/usr/bin/aws", "../../bin/sh", "aws;rm -rf /", "aws tool", "", "a" * 200],
+)
+def test_binary_must_be_a_bare_bounded_command_name(binary):
+    """A spec cannot choose a path. Which binary a name resolves to is the
+    operator's PATH decision, not a downloaded file's."""
+    with pytest.raises(ProviderSpecValidationError, match="bare command name"):
+        ProviderSpec.from_mapping(_minimal(binary=binary))
+
+
+def test_undeclared_placeholder_is_refused():
+    payload = _minimal(verbs={"create": {"args": ["create", "--name", "{whatever}"]}})
+    with pytest.raises(ProviderSpecValidationError, match="undeclared parameter"):
+        ProviderSpec.from_mapping(payload)
+
+
+def test_unknown_verb_is_refused():
+    payload = _minimal(verbs={"exfiltrate": {"args": ["go"]}})
+    with pytest.raises(ProviderSpecValidationError, match="is not one of"):
+        ProviderSpec.from_mapping(payload)
+
+
+def test_credential_shaped_parameter_is_refused():
+    """Secrets travel in the child environment, by name. A spec that wants one
+    in argv is refused outright rather than redacted after the fact."""
+    payload = _minimal(
+        parameters={"api_key": {"required": True}, "instance_id": {}, "flavor": {}},
+        verbs={"create": {"args": ["create", "--key", "{api_key}"]}},
+    )
+    with pytest.raises(ProviderSpecValidationError, match="looks like a credential"):
+        ProviderSpec.from_mapping(payload)
+
+
+@pytest.mark.parametrize(
+    "field,value,match",
+    [
+        ("timeout_seconds", 0, "timeout_seconds must be within"),
+        ("timeout_seconds", 99999, "timeout_seconds must be within"),
+        ("env_passthrough", ["lower_case"], "not a valid environment variable name"),
+        ("credential_env_var", "not-an-env-var", "not a valid environment variable name"),
+        ("kind", "sideways", "kind must be"),
+        ("name", "Not Valid", "name must be"),
+    ],
+)
+def test_bounded_scalars_are_enforced(field, value, match):
+    with pytest.raises(ProviderSpecValidationError, match=match):
+        ProviderSpec.from_mapping(_minimal(**{field: value}))
+
+
+def test_verbs_are_capped():
+    payload = _minimal(verbs={})
+    with pytest.raises(ProviderSpecValidationError, match="at least one verb"):
+        ProviderSpec.from_mapping(payload)
+
+
+def test_argv_token_count_is_capped():
+    payload = _minimal(verbs={"create": {"args": ["arg"] * 65}})
+    with pytest.raises(ProviderSpecValidationError, match="over the 64 ceiling"):
+        ProviderSpec.from_mapping(payload)
+
+
+def test_field_map_keys_are_closed():
+    with pytest.raises(ProviderSpecValidationError, match="is not one of"):
+        ProviderSpec.from_mapping(_minimal(fields={"arbitrary": ["x"]}))
+
+
+def test_oversized_spec_file_is_refused(tmp_path):
+    path = tmp_path / "big.json"
+    path.write_text(json.dumps({"pad": "x" * (300 * 1024)}), encoding="utf-8")
+    with pytest.raises(ProviderSpecValidationError, match="over the .* byte ceiling"):
+        ProviderSpec.from_file(path)
+
+
+def test_unparseable_spec_file_is_refused(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ProviderSpecValidationError, match="not readable JSON"):
+        ProviderSpec.from_file(path)
+
+
+# --------------------------------------------------------------------------
+# argv construction bounds.
+# --------------------------------------------------------------------------
+def _provider(**overrides) -> SpecProvider:
+    return SpecProvider(ProviderSpec.from_mapping(_minimal(**overrides)))
+
+
+def test_argv_is_a_list_and_shell_metacharacters_stay_inert():
+    """The value is passed through as one argv item. There is no shell to
+    re-split it, so ';' and '$(...)' are ordinary characters in a filename-ish
+    string -- and the pattern still governs which are accepted at all."""
+    provider = _provider(
+        parameters={
+            "instance_id": {"required": True, "pattern": "^.{1,64}$"},
+            "flavor": {"default": "small"},
+        }
+    )
+    argv = provider.build_argv("status", {"instance_id": "a;b$(id)"})
+    assert argv == ["demotool", "show", "a;b$(id)"]
+
+
+def test_value_starting_with_dash_is_refused_by_default():
+    """Shell-free execve's live injection risk is a value the target tool
+    re-reads as a FLAG."""
+    provider = _provider(
+        parameters={"instance_id": {"required": True, "pattern": "^.{1,64}$"}, "flavor": {}}
+    )
+    with pytest.raises(ProviderSpecValidationError, match="starts with '-'"):
+        provider.build_argv("status", {"instance_id": "--output-file=/etc/passwd"})
+
+
+def test_leading_dash_is_allowed_when_the_spec_says_so():
+    provider = _provider(
+        parameters={
+            "instance_id": {
+                "required": True,
+                "pattern": "^-{0,2}[A-Za-z0-9=/._-]{1,64}$",
+                "allow_leading_dash": True,
+            },
+            "flavor": {},
+        }
+    )
+    assert provider.build_argv("status", {"instance_id": "--verbose"})[-1] == "--verbose"
+
+
+def test_value_must_match_its_declared_pattern():
+    provider = _provider()
+    with pytest.raises(ProviderSpecValidationError, match="does not match its declared pattern"):
+        provider.build_argv("status", {"instance_id": "has spaces"})
+
+
+def test_nul_byte_is_refused():
+    provider = _provider(
+        parameters={"instance_id": {"required": True, "pattern": "^.{1,64}$"}, "flavor": {}}
+    )
+    with pytest.raises(ProviderSpecValidationError, match="NUL byte"):
+        provider.build_argv("status", {"instance_id": "a\x00b"})
+
+
+def test_required_is_per_verb_not_per_spec():
+    """``flavor`` is required to create and meaningless when showing."""
+    provider = _provider()
+    assert provider.build_argv("status", {"instance_id": "i-1"}) == ["demotool", "show", "i-1"]
+    with pytest.raises(ProviderSpecValidationError, match="requires parameter 'instance_id'"):
+        provider.build_argv("status", {})
+
+
+def test_missing_verb_is_a_capability_error():
+    provider = _provider()
+    with pytest.raises(ProviderCapabilityError, match="does not describe verb 'delete'"):
+        provider.build_argv("delete", {"instance_id": "i-1"})
+
+
+def test_splat_expands_a_list_into_separate_argv_items():
+    provider = _provider(
+        parameters={
+            "instance_id": {"required": True},
+            "flavor": {},
+            "command": {"splat": True, "pattern": "^[^\\x00]{1,64}$", "default": []},
+        },
+        verbs={"exec": {"args": ["ssh", "{instance_id}", "--", "{command...}"]}},
+    )
+    argv = provider.build_argv("exec", {"instance_id": "i-1", "command": ["printf", "a b"]})
+    assert argv == ["demotool", "ssh", "i-1", "--", "printf", "a b"]
+
+
+def test_splat_must_be_the_whole_token():
+    payload = _minimal(
+        parameters={"instance_id": {}, "flavor": {}, "command": {"splat": True}},
+        verbs={"exec": {"args": ["ssh", "x{command...}"]}},
+    )
+    with pytest.raises(ProviderSpecValidationError, match="must be the whole argv token"):
+        ProviderSpec.from_mapping(payload)
+
+
+def test_splat_items_are_capped():
+    provider = _provider(
+        parameters={
+            "instance_id": {"required": True},
+            "flavor": {},
+            "command": {"splat": True, "pattern": "^[^\\x00]{1,64}$", "default": []},
+        },
+        verbs={"exec": {"args": ["ssh", "{instance_id}", "--", "{command...}"]}},
+    )
+    with pytest.raises(ProviderSpecValidationError, match="over the 64 ceiling"):
+        provider.build_argv("exec", {"instance_id": "i-1", "command": ["x"] * 65})
+
+
+def test_child_environment_is_only_what_the_spec_declared(monkeypatch):
+    monkeypatch.setenv("DEMO_REGION", "eu-west-1")
+    monkeypatch.setenv("UNRELATED_FLEET_TOKEN", "super-secret")
+    provider = _provider(env_passthrough=["DEMO_REGION"])
+    env = provider._child_env()
+    assert env["DEMO_REGION"] == "eu-west-1"
+    assert "UNRELATED_FLEET_TOKEN" not in env
+    assert "PATH" in env
+
+
+def test_missing_binary_is_a_command_error_naming_argv():
+    provider = _provider(binary="definitely-not-installed-xyz")
+    with pytest.raises(ProviderCommandError) as excinfo:
+        provider.run("status", {"instance_id": "i-1"})
+    assert excinfo.value.argv[0] == "definitely-not-installed-xyz"
+
+
+# --------------------------------------------------------------------------
+# 2. Shipped templates.
+# --------------------------------------------------------------------------
+SHIPPED = ("aws", "azure", "gcp", "nvidia")
+
+
+@pytest.mark.parametrize("name", SHIPPED)
+def test_shipped_template_parses_and_matches_its_filename(name):
+    spec = ProviderSpec.from_file(SHIPPED_SPEC_DIR / ("%s.json" % name))
+    assert spec.name == name
+    assert spec.kind == "external"
+    assert spec.description, "a shipped template must say what it is and what to edit"
+    assert set(spec.verbs) <= set(CRUD_VERBS)
+    # Every template must be able to create, enumerate, inspect and destroy.
+    assert {"create", "list", "status", "delete"} <= set(spec.verbs)
+
+
+def test_shipped_templates_are_discoverable_together(monkeypatch):
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(SHIPPED_SPEC_DIR))
+    monkeypatch.setenv("MAC_HOME", "/nonexistent-mac-home-for-tests")
+    assert set(discover_specs(strict=True)) >= set(SHIPPED)
+
+
+def test_nvidia_template_builds_the_same_argv_as_the_hard_wired_adapter(monkeypatch):
+    """The migration claim, tested rather than asserted: the shipped nvidia
+    profile issues byte-identical argv to what :mod:`mac.hgx_provider` issues,
+    so the hgx consumers can move onto the interpreter without a behaviour
+    change."""
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(SHIPPED_SPEC_DIR))
+    provider = SpecProvider(load_spec("nvidia"))
+    assert provider.build_argv("create", {"flavor": "standard-dind", "instance_name": "w1"}) == [
+        "hgx",
+        "--json",
+        "create",
+        "--type",
+        "standard-dind",
+        "--name",
+        "w1",
+    ]
+    assert provider.build_argv("list") == ["hgx", "--json", "list"]
+    assert provider.build_argv("status", {"instance_id": "s-1"}) == [
+        "hgx",
+        "--json",
+        "status",
+        "s-1",
+    ]
+    assert provider.build_argv("delete", {"instance_id": "s-1"}) == ["hgx", "delete", "s-1"]
+    assert provider.build_argv("exec", {"instance_id": "s-1", "command": ["printf", "x"]}) == [
+        "hgx",
+        "ssh",
+        "s-1",
+        "--",
+        "printf",
+        "x",
+    ]
+
+
+def test_nvidia_template_has_no_verb_that_could_invoke_hgx_info(monkeypatch):
+    """``hgx info`` can echo a fallback bootstrap password. The hard-wired
+    adapter bans the verb; the spec simply has no way to reach it."""
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(SHIPPED_SPEC_DIR))
+    spec = load_spec("nvidia")
+    for verb in spec.verbs.values():
+        assert "info" not in verb.args
+
+
+def test_templates_without_an_exec_verb_refuse_attestation(monkeypatch):
+    """A provider that cannot be reached cannot be attested, and says so,
+    instead of treating a zero exit as readiness."""
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(SHIPPED_SPEC_DIR))
+    provider = SpecProvider(load_spec("aws"))
+    with pytest.raises(ProviderCapabilityError, match="no 'exec' verb"):
+        provider.attest("i-0123456789abcdef")
+
+
+# --------------------------------------------------------------------------
+# Discovery and precedence.
+# --------------------------------------------------------------------------
+def test_search_path_is_env_then_user_home_then_shipped(monkeypatch, tmp_path):
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(tmp_path / "a") + os.pathsep + str(tmp_path / "b"))
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    assert spec_search_path() == [
+        tmp_path / "a",
+        tmp_path / "b",
+        tmp_path / "home" / "provider-specs",
+        SHIPPED_SPEC_DIR,
+    ]
+
+
+def test_a_user_spec_shadows_a_shipped_template_of_the_same_name(monkeypatch, tmp_path):
+    user_dir = tmp_path / "specs"
+    user_dir.mkdir()
+    override = _minimal(name="nvidia", binary="hgx-wrapper")
+    (user_dir / "nvidia.json").write_text(json.dumps(override), encoding="utf-8")
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(user_dir))
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    assert load_spec("nvidia").binary == "hgx-wrapper"
+
+
+def test_spec_name_must_match_its_filename(monkeypatch, tmp_path):
+    """Otherwise a file could shadow a name the operator cannot see in `ls`."""
+    user_dir = tmp_path / "specs"
+    user_dir.mkdir()
+    (user_dir / "harmless.json").write_text(json.dumps(_minimal(name="nvidia")), encoding="utf-8")
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(user_dir))
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    with pytest.raises(ProviderSpecValidationError, match="must match its filename stem"):
+        discover_specs(strict=True)
+    assert "nvidia" not in {
+        name: spec for name, spec in discover_specs().items() if spec.binary == "demotool"
+    }
+
+
+def test_one_bad_spec_does_not_hide_the_good_ones(monkeypatch, tmp_path):
+    user_dir = tmp_path / "specs"
+    user_dir.mkdir()
+    (user_dir / "good.json").write_text(json.dumps(_minimal(name="good")), encoding="utf-8")
+    (user_dir / "broken.json").write_text("{", encoding="utf-8")
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(user_dir))
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    found = discover_specs()
+    assert "good" in found
+    with pytest.raises(ProviderSpecValidationError):
+        discover_specs(strict=True)
+
+
+def test_unknown_provider_name_names_the_search_path(monkeypatch, tmp_path):
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(tmp_path))
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    with pytest.raises(ProviderSpecValidationError, match="no provider spec named 'nope'"):
+        load_spec("nope")
+
+
+# --------------------------------------------------------------------------
+# 3. End to end against a real executable, from a user-authored spec.
+# --------------------------------------------------------------------------
+# A fictional non-NVIDIA cloud VM service. It is a real program: it is executed
+# by real subprocess calls, keeps real state on disk between verbs, and runs the
+# argv it is handed after `--` for `exec`. Nothing about it is known to mac.
+_FAKE_CLI = '''#!/usr/bin/env python3
+"""democloud - a tiny stand-in for a third-party cloud VM CLI."""
+import json
+import os
+import subprocess
+import sys
+
+STATE = os.path.join(os.environ["DEMOCLOUD_STATE_DIR"], "vms.json")
+
+
+def load():
+    try:
+        with open(STATE) as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        return []
+
+
+def save(rows):
+    with open(STATE, "w") as handle:
+        json.dump(rows, handle)
+
+
+def main(argv):
+    if not argv:
+        return 2
+    verb, rest = argv[0], argv[1:]
+    rows = load()
+    if verb == "vm-create":
+        opts = dict(zip(rest[::2], rest[1::2]))
+        row = {
+            "uuid": "vm-%04d" % (len(rows) + 1),
+            "label": opts.get("--label", ""),
+            "size": opts.get("--size", ""),
+            "phase": "running",
+            "ipv4": "10.0.0.%d" % (len(rows) + 1),
+            "login": "democloud",
+            "root_password": "hunter2",
+        }
+        rows.append(row)
+        save(rows)
+        print(json.dumps({"vm": row}))
+        return 0
+    if verb == "vm-list":
+        print(json.dumps({"vms": rows}))
+        return 0
+    if verb == "vm-show":
+        match = [r for r in rows if r["uuid"] == rest[0]]
+        if not match:
+            print("no such vm", file=sys.stderr)
+            return 1
+        print(json.dumps({"vm": match[0]}))
+        return 0
+    if verb == "vm-destroy":
+        save([r for r in rows if r["uuid"] != rest[0]])
+        return 0
+    if verb == "vm-run":
+        target, command = rest[0], rest[rest.index("--") + 1:]
+        if not any(r["uuid"] == target for r in rows):
+            print("no such vm", file=sys.stderr)
+            return 1
+        return subprocess.call(command)
+    print("unknown verb %s" % verb, file=sys.stderr)
+    return 2
+
+
+sys.exit(main(sys.argv[1:]))
+'''
+
+_USER_SPEC = {
+    "schema": PROVIDER_SPEC_SCHEMA,
+    "name": "democloud",
+    "kind": "external",
+    "description": "A user-authored external provider for a fictional cloud VM service.",
+    "binary": "democloud",
+    "timeout_seconds": 60,
+    "env_passthrough": ["DEMOCLOUD_STATE_DIR"],
+    "parameters": {
+        "instance_id": {"required": True, "pattern": "^vm-[0-9]{4}$"},
+        "instance_name": {"pattern": "^[a-z0-9-]{1,32}$", "default": "mac-worker"},
+        "flavor": {"required": True, "pattern": "^[a-z0-9-]{1,32}$", "default": "medium"},
+        "command": {"splat": True, "pattern": "^[^\\x00\\n\\r]{1,128}$", "default": []},
+    },
+    "fields": {
+        "id": ["uuid"],
+        "name": ["label"],
+        "flavor": ["size"],
+        "state": ["phase"],
+        "host": ["ipv4"],
+        "user": ["login"],
+    },
+    "verbs": {
+        "create": {
+            "args": ["vm-create", "--label", "{instance_name}", "--size", "{flavor}"],
+            "parse": {"format": "json", "select": "vm"},
+        },
+        "list": {"args": ["vm-list"], "parse": {"format": "json", "select": "vms"}},
+        "status": {
+            "args": ["vm-show", "{instance_id}"],
+            "parse": {"format": "json", "select": "vm"},
+        },
+        "delete": {"args": ["vm-destroy", "{instance_id}"], "parse": {"format": "none"}},
+        "exec": {
+            "args": ["vm-run", "{instance_id}", "--", "{command...}"],
+            "parse": {"format": "none"},
+        },
+    },
+}
+
+
+@pytest.fixture()
+def democloud(monkeypatch, tmp_path) -> SpecProvider:
+    """A provider driven entirely by a user-authored JSON file on disk."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    cli = bin_dir / "democloud"
+    cli.write_text(_FAKE_CLI, encoding="utf-8")
+    cli.chmod(cli.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    spec_dir = tmp_path / "provider-specs"
+    spec_dir.mkdir()
+    (spec_dir / "democloud.json").write_text(json.dumps(_USER_SPEC, indent=2), encoding="utf-8")
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    monkeypatch.setenv(SPEC_PATH_ENV_VAR, str(spec_dir))
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ["PATH"])
+    monkeypatch.setenv("DEMOCLOUD_STATE_DIR", str(state_dir))
+    return SpecProvider(load_spec("democloud"))
+
+
+def test_user_authored_spec_is_discovered_without_any_mac_source_change(democloud):
+    assert democloud.spec.name == "democloud"
+    assert democloud.spec.source_path is not None
+    assert democloud.spec.source_path.name == "democloud.json"
+
+
+def test_end_to_end_create_list_status_attest_delete(democloud):
+    created = democloud.create(instance_name="mac-worker-1", flavor="medium")
+    assert created.instance_id == "vm-0001"
+    assert created.provider == "democloud"
+    assert created.name == "mac-worker-1"
+    assert created.flavor == "medium"
+    assert created.state == "running"
+    assert created.endpoint is not None
+    assert created.endpoint.user_host == "democloud@10.0.0.1"
+
+    listed = democloud.list()
+    assert [item.instance_id for item in listed] == ["vm-0001"]
+
+    fetched = democloud.status("vm-0001")
+    assert fetched.instance_id == "vm-0001"
+    assert fetched.state == "running"
+
+    # Real remote execution, proved by a nonce the caller did not tell the CLI.
+    assert democloud.attest("vm-0001") == "vm-0001"
+
+    assert democloud.delete("vm-0001") == "vm-0001"
+    assert democloud.list() == []
+
+
+def test_end_to_end_output_never_carries_the_providers_credential(democloud):
+    """The fake CLI emits ``root_password`` on every record, exactly like real
+    provider CLIs do. It must be recorded as scrubbed and never carried."""
+    created = democloud.create(instance_name="mac-worker-1", flavor="medium")
+    assert created.scrubbed_fields == ["root_password"]
+    assert created.credential_present is True
+    observable = created.observable()
+    assert "hunter2" not in json.dumps(observable)
+    assert observable["scrubbed_fields"] == ["root_password"]
+
+
+def test_end_to_end_exec_runs_the_argv_it_was_given(democloud):
+    democloud.create(instance_name="mac-worker-1", flavor="medium")
+    assert democloud.exec("vm-0001", ["printf", "hello"]).strip() == "hello"
+
+
+def test_end_to_end_attestation_fails_closed_when_the_nonce_is_not_echoed(
+    democloud, monkeypatch
+):
+    """A zero exit is not readiness. Swap exec for a command that succeeds
+    silently and attestation must still refuse."""
+    democloud.create(instance_name="mac-worker-1", flavor="medium")
+    monkeypatch.setattr(SpecProvider, "exec", lambda self, instance_id, command, **kw: "")
+    with pytest.raises(Exception, match="nonce was not returned"):
+        democloud.attest("vm-0001")
+
+
+def test_end_to_end_nonzero_exit_becomes_a_command_error_without_leaking_stderr(democloud):
+    with pytest.raises(ProviderCommandError) as excinfo:
+        democloud.status("vm-9999")
+    error = excinfo.value
+    assert error.returncode == 1
+    assert error.argv[:2] == ["democloud", "vm-show"]
+    # stderr is available to the operator's terminal but is not part of any
+    # structure mac persists.
+    assert "no such vm" in error.stderr
+
+
+def test_end_to_end_ambiguous_name_refuses_to_guess(democloud):
+    democloud.create(instance_name="twin", flavor="medium")
+    democloud.create(instance_name="twin", flavor="medium")
+    with pytest.raises(ProviderAmbiguousNameError) as excinfo:
+        democloud.resolve_instance_id("twin")
+    assert excinfo.value.instance_ids == ["vm-0001", "vm-0002"]
+    assert democloud.resolve_instance_id("vm-0002") == "vm-0002"
+
+
+def test_end_to_end_unique_name_resolves_to_its_immutable_id(democloud):
+    democloud.create(instance_name="solo", flavor="medium")
+    assert democloud.resolve_instance_id("solo") == "vm-0001"
+    with pytest.raises(ProviderInstanceNotFoundError):
+        democloud.resolve_instance_id("absent")
+
+
+def test_end_to_end_instance_id_must_match_the_declared_shape(democloud):
+    with pytest.raises(ProviderSpecValidationError, match="does not match its declared pattern"):
+        democloud.status("not-a-vm-id")
+
+
+def test_end_to_end_argv_is_inspectable_before_it_runs(democloud):
+    """The review story: an operator can see exactly what a third-party spec
+    would execute without executing it."""
+    assert democloud.build_argv("create", {"instance_name": "w1", "flavor": "medium"}) == [
+        "democloud",
+        "vm-create",
+        "--label",
+        "w1",
+        "--size",
+        "medium",
+    ]
+
+
+def test_shipped_spec_dir_is_packaged():
+    assert SHIPPED_SPEC_DIR.is_dir()
+    assert sorted(p.stem for p in SHIPPED_SPEC_DIR.glob("*.json")) == sorted(SHIPPED)
+    assert Path(SHIPPED_SPEC_DIR).parent.name == "data"
+
+
+# --------------------------------------------------------------------------
+# Remaining validation branches and parse paths.
+#
+# These use a canned-stdout provider rather than a real binary: the point under
+# test is the interpreter's own decisions, not the subprocess plumbing that the
+# end-to-end group above already exercises for real.
+# --------------------------------------------------------------------------
+def _canned(stdout: str, **overrides) -> SpecProvider:
+    provider = _provider(**overrides)
+    provider.run = lambda verb, values=None: stdout  # type: ignore[assignment]
+    return provider
+
+
+def test_non_object_spec_is_refused():
+    with pytest.raises(ProviderSpecValidationError, match="must be a JSON object"):
+        ProviderSpec.from_mapping(["not", "an", "object"])  # type: ignore[arg-type]
+
+
+def test_missing_spec_file_is_refused(tmp_path):
+    with pytest.raises(ProviderSpecValidationError, match="unreadable"):
+        ProviderSpec.from_file(tmp_path / "absent.json")
+
+
+@pytest.mark.parametrize(
+    "payload,match",
+    [
+        ({"timeout_seconds": "soon"}, "timeout_seconds must be a number"),
+        ({"env_passthrough": "AWS_REGION"}, "env_passthrough must be a list"),
+        ({"env_passthrough": ["V%d" % i for i in range(65)]}, "over the 64 ceiling"),
+        ({"parameters": ["nope"]}, "parameters must be an object"),
+        ({"fields": ["nope"]}, "fields must be an object"),
+        ({"verbs": ["nope"]}, "verbs must be an object"),
+    ],
+)
+def test_container_types_are_enforced(payload, match):
+    with pytest.raises(ProviderSpecValidationError, match=match):
+        ProviderSpec.from_mapping(_minimal(**payload))
+
+
+def test_parameter_count_is_capped():
+    params = {"p%d" % i: {} for i in range(65)}
+    with pytest.raises(ProviderSpecValidationError, match="over the 64 ceiling"):
+        ProviderSpec.from_mapping(_minimal(parameters=params, verbs={"list": {"args": ["ls"]}}))
+
+
+def test_parameter_name_shape_is_enforced():
+    with pytest.raises(ProviderSpecValidationError, match="must match"):
+        ProviderSpec.from_mapping(_minimal(parameters={"NotLower": {}}))
+
+
+def test_parameter_body_must_be_an_object():
+    with pytest.raises(ProviderSpecValidationError, match="must be an object"):
+        ProviderSpec.from_mapping(_minimal(parameters={"flavor": "small"}))
+
+
+def test_parameter_pattern_must_compile():
+    with pytest.raises(ProviderSpecValidationError, match="invalid pattern"):
+        ProviderSpec.from_mapping(_minimal(parameters={"flavor": {"pattern": "([unclosed"}}))
+
+
+def test_field_map_accepts_a_bare_string_source_key():
+    spec = ProviderSpec.from_mapping(_minimal(fields={"id": "uuid"}))
+    assert spec.fields["id"] == ("uuid",)
+
+
+def test_field_map_rejects_a_non_string_source():
+    with pytest.raises(ProviderSpecValidationError, match="must be a source key"):
+        ProviderSpec.from_mapping(_minimal(fields={"id": {"deep": "no"}}))
+
+
+def test_field_map_rejects_an_empty_source_list():
+    with pytest.raises(ProviderSpecValidationError, match="names no source key"):
+        ProviderSpec.from_mapping(_minimal(fields={"id": ["", "  "]}))
+
+
+def test_verb_count_is_capped():
+    verbs = {verb: {"args": ["x"]} for verb in CRUD_VERBS}
+    spec = ProviderSpec.from_mapping(
+        _minimal(verbs=verbs, parameters={"flavor": {}, "instance_id": {}})
+    )
+    assert len(spec.verbs) == len(CRUD_VERBS)
+
+
+@pytest.mark.parametrize(
+    "verbs,match",
+    [
+        ({"create": "go"}, "must be an object"),
+        ({"create": {"args": []}}, "non-empty args list"),
+        ({"create": {"args": [""]}}, "must be non-empty strings"),
+        ({"create": {"args": ["x" * 600]}}, "over 512 characters"),
+        ({"create": {"args": ["x"], "parse": "json"}}, "parse must be an object"),
+        ({"create": {"args": ["x"], "parse": {"format": "yaml"}}}, "parse.format must be"),
+        ({"create": {"args": ["x"], "parse": {"select": 7}}}, "parse.select must be"),
+    ],
+)
+def test_verb_bodies_are_validated(verbs, match):
+    with pytest.raises(ProviderSpecValidationError, match=match):
+        ProviderSpec.from_mapping(_minimal(verbs=verbs))
+
+
+def test_select_accepts_a_list_form():
+    spec = ProviderSpec.from_mapping(
+        _minimal(verbs={"list": {"args": ["ls"], "parse": {"select": ["data", "rows"]}}})
+    )
+    assert spec.verbs["list"].select == ("data", "rows")
+
+
+def test_splat_flag_must_agree_between_declaration_and_use():
+    payload = _minimal(
+        parameters={"instance_id": {}, "flavor": {}, "command": {"splat": True}},
+        verbs={"exec": {"args": ["ssh", "{command}"]}},
+    )
+    with pytest.raises(ProviderSpecValidationError, match="splat flag"):
+        ProviderSpec.from_mapping(payload)
+
+
+def test_load_spec_requires_a_name():
+    with pytest.raises(ProviderSpecValidationError, match="a provider name is required"):
+        load_spec("   ")
+
+
+def test_splat_default_of_none_expands_to_nothing():
+    provider = _provider(
+        parameters={"instance_id": {"required": True}, "flavor": {}, "command": {"splat": True}},
+        verbs={"exec": {"args": ["ssh", "{instance_id}", "{command...}"]}},
+    )
+    assert provider.build_argv("exec", {"instance_id": "i-1"}) == ["demotool", "ssh", "i-1"]
+
+
+def test_splat_requires_a_sequence():
+    provider = _provider(
+        parameters={"instance_id": {"required": True}, "flavor": {}, "command": {"splat": True}},
+        verbs={"exec": {"args": ["ssh", "{instance_id}", "{command...}"]}},
+    )
+    with pytest.raises(ProviderSpecValidationError, match="needs a sequence of strings"):
+        provider.build_argv("exec", {"instance_id": "i-1", "command": "printf x"})
+
+
+def test_optional_parameter_without_a_value_or_default_is_an_error():
+    provider = _provider(
+        parameters={"instance_id": {"required": True}, "flavor": {}},
+        verbs={"create": {"args": ["create", "--type", "{flavor}"]}},
+    )
+    with pytest.raises(ProviderSpecValidationError, match="no value and no default"):
+        provider.build_argv("create", {})
+
+
+def test_boolean_values_are_refused():
+    provider = _provider()
+    with pytest.raises(ProviderSpecValidationError, match="must be a string or number"):
+        provider.build_argv("status", {"instance_id": True})
+
+
+def test_oversized_value_is_refused():
+    provider = _provider(
+        parameters={"instance_id": {"required": True, "pattern": "^.*$"}, "flavor": {}}
+    )
+    with pytest.raises(ProviderSpecValidationError, match="over the 1024 ceiling"):
+        provider.build_argv("status", {"instance_id": "x" * 1100})
+
+
+def test_numeric_values_are_stringified():
+    provider = _provider(
+        parameters={"instance_id": {"required": True, "pattern": "^[0-9]+$"}, "flavor": {}}
+    )
+    assert provider.build_argv("status", {"instance_id": 42})[-1] == "42"
+
+
+def test_credential_env_var_reaches_the_child_environment(monkeypatch):
+    monkeypatch.setenv("DEMO_TOKEN", "t0ken")
+    provider = _provider(credential_env_var="DEMO_TOKEN")
+    assert provider._child_env()["DEMO_TOKEN"] == "t0ken"
+
+
+def test_execution_oserror_becomes_a_command_error(monkeypatch, tmp_path):
+    """A binary that exists but cannot be executed is a command error, not a
+    traceback out of subprocess."""
+    not_executable = tmp_path / "demotool"
+    not_executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    not_executable.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ["PATH"])
+
+    def boom(*args, **kwargs):
+        raise OSError("exec format error")
+
+    provider = _provider()
+    monkeypatch.setattr("mac.provider_spec.subprocess.run", boom)
+    with pytest.raises(ProviderCommandError, match="could not be executed"):
+        provider.run("status", {"instance_id": "i-1"})
+
+
+def test_execution_timeout_becomes_a_command_error(monkeypatch, tmp_path):
+    import subprocess as sp
+
+    slow = tmp_path / "demotool"
+    slow.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    slow.chmod(0o755)
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ["PATH"])
+
+    def timeout(*args, **kwargs):
+        raise sp.TimeoutExpired(cmd="demotool", timeout=1)
+
+    provider = _provider()
+    monkeypatch.setattr("mac.provider_spec.subprocess.run", timeout)
+    with pytest.raises(ProviderCommandError, match="timed out"):
+        provider.run("status", {"instance_id": "i-1"})
+
+
+@pytest.mark.parametrize("stdout", ["", "not json at all", "null", "42"])
+def test_unparseable_or_scalar_output_yields_no_rows(stdout):
+    provider = _canned(stdout)
+    assert provider._rows("status", stdout) == []
+
+
+def test_parse_format_none_never_parses():
+    provider = _canned(
+        '{"id": "i-1"}',
+        verbs={"delete": {"args": ["rm", "{instance_id}"], "parse": {"format": "none"}}},
+    )
+    assert provider._rows("delete", '{"id": "i-1"}') == []
+
+
+def test_select_indexes_into_a_list():
+    provider = _canned(
+        "x",
+        verbs={"status": {"args": ["show", "{instance_id}"], "parse": {"select": "rows.0"}}},
+    )
+    rows = provider._rows("status", '{"rows": [{"id": "i-7"}]}')
+    assert rows == [{"id": "i-7"}]
+
+
+def test_select_that_misses_yields_no_rows():
+    provider = _canned(
+        "x",
+        verbs={"status": {"args": ["show", "{instance_id}"], "parse": {"select": "absent"}}},
+    )
+    assert provider._rows("status", '{"rows": []}') == []
+    assert provider._rows("status", '["a", "b"]') == []
+
+
+def test_output_without_a_mapped_id_is_refused():
+    provider = _canned('{"other": "x"}')
+    with pytest.raises(ProviderSpecValidationError, match="has no immutable id"):
+        provider._instance("status", {"other": "x"})
+
+
+def test_integer_fields_are_read_and_a_port_is_composed():
+    provider = _canned(
+        "x",
+        fields={
+            "id": ["id"],
+            "user": ["user"],
+            "host": ["host"],
+            "port": ["port"],
+        },
+    )
+    instance = provider._instance("status", {"id": 7, "user": "ops", "host": "h1", "port": 2201})
+    assert instance.instance_id == "7"
+    assert instance.endpoint is not None
+    assert instance.endpoint.user_host == "ops@h1"
+    assert instance.endpoint.port == 2201
+    assert instance.observable()["endpoint"] == {"user_host": "ops@h1", "port": 2201}
+
+
+def test_an_unusable_endpoint_is_dropped_rather_than_guessed():
+    provider = _canned("x", fields={"id": ["id"], "endpoint": ["ssh"]})
+    assert provider._instance("status", {"id": "i-1", "ssh": "   "}).endpoint is None
+
+
+def test_create_without_a_parseable_instance_is_an_error():
+    provider = _canned("null")
+    with pytest.raises(Exception, match="returned no parseable instance"):
+        provider.create(flavor="small")
+
+
+def test_status_for_a_missing_instance_is_not_found():
+    provider = _canned("null")
+    with pytest.raises(ProviderInstanceNotFoundError, match="has no instance"):
+        provider.status("i-1")
+
+
+def test_status_returning_a_different_id_is_not_found():
+    provider = _canned('{"id": "i-2"}')
+    with pytest.raises(ProviderInstanceNotFoundError, match="returned id"):
+        provider.status("i-1")
+
+
+@pytest.mark.parametrize("verb", ["update", "stop", "start"])
+def test_side_effect_verbs_return_the_id_they_acted_on(verb):
+    provider = _canned(
+        "",
+        verbs={verb: {"args": [verb, "{instance_id}"], "parse": {"format": "none"}}},
+    )
+    assert getattr(provider, verb)("i-1") == "i-1"
+
+
+def test_exec_requires_an_argv_sequence():
+    provider = _canned(
+        "",
+        parameters={"instance_id": {"required": True}, "flavor": {}, "command": {"splat": True}},
+        verbs={"exec": {"args": ["ssh", "{instance_id}", "{command...}"]}},
+    )
+    with pytest.raises(ProviderSpecValidationError, match="non-empty argv sequence"):
+        provider.exec("i-1", "printf x")
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_selectors_are_refused(blank):
+    provider = _canned("[]")
+    with pytest.raises(ProviderInstanceNotFoundError, match="immutable instance id is required"):
+        provider.status(blank)
+    with pytest.raises(ProviderInstanceNotFoundError, match="instance name is required"):
+        provider.resolve_instance_id(blank)
+
+
+def test_spec_observable_is_secret_free_and_complete():
+    spec = ProviderSpec.from_mapping(
+        _minimal(env_passthrough=["DEMO_REGION"], credential_env_var="DEMO_TOKEN")
+    )
+    observed = spec.observable()
+    assert observed["env_passthrough"] == ["DEMO_REGION"]
+    assert observed["credential_env_var"] == "DEMO_TOKEN"
+    assert observed["verbs"] == ["create", "status"]
+    assert observed["source_path"] is None


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_981b3b28cbb54a798a3fda85290d2054`
- head: `c13e7f826519fdcd7ad01c46ebe0a04a7ebfdc67`
- base at push: `3445f9afa9d7ef7b4b5b42c3bd784eae2455447b`
