### PR TITLE
Add mandatory Prompt Master rewrite boundary

### DIFF
--- a/deploy/codex-runner/mac-task-executor-opencode-build
+++ b/deploy/codex-runner/mac-task-executor-opencode-build
@@ -52,6 +52,14 @@ fi
 
 started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+compile_coding_prompt() {
+    local kind="$1"
+    local source_root
+    source_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/src"
+    PYTHONPATH="${MAC_PROMPT_MASTER_PYTHONPATH:-${source_root}}${PYTHONPATH:+:${PYTHONPATH}}" \
+        python3 -m mac.prompt_master --target opencode --model "${OPENCODE_MODEL}" --kind "${kind}"
+}
+
 echo "===== mac-task-executor-opencode-build ====="
 echo "started_at:       ${started_at}"
 echo "MAC_TASK_ID:      ${MAC_TASK_ID:-<unset>}"
@@ -751,6 +759,7 @@ dependencies are required so that the command \`${cmd}\` can EXECUTE in \
 this repository. Do NOT modify any source files, test files, or the test \
 command. Do NOT attempt to make tests pass — only make the toolchain \
 available. When the environment is ready, stop."
+    prompt="$(printf '%s' "${prompt}" | compile_coding_prompt provisioning)" || return 1
 
     # Snapshot HEAD so we can hard-revert any tracked-file changes the agent makes (the verdict-safety guard).
     local pre_sha=""
@@ -1272,6 +1281,10 @@ For source, build, dependency, or runtime config changes, use CodeGraph during a
 ${PROMPT}"
 else
     FULL_PROMPT="${PROMPT}"
+fi
+if ! FULL_PROMPT="$(printf '%s' "${FULL_PROMPT}" | compile_coding_prompt task)"; then
+    echo "[opencode-build] prompt policy rejected dispatch" >&2
+    exit 4
 fi
 opencode run --agent build --format json "${FULL_PROMPT}" > "${opencode_stdout}" 2> "${opencode_stderr}"
 opencode_rc=$?

--- a/deploy/codex-runner/mac-task-executor-opencode-review
+++ b/deploy/codex-runner/mac-task-executor-opencode-review
@@ -53,6 +53,14 @@ fi
 
 started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+compile_coding_prompt() {
+    local kind="$1"
+    local source_root
+    source_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/src"
+    PYTHONPATH="${MAC_PROMPT_MASTER_PYTHONPATH:-${source_root}}${PYTHONPATH:+:${PYTHONPATH}}" \
+        python3 -m mac.prompt_master --target opencode --model "${OPENCODE_MODEL}" --kind "${kind}"
+}
+
 echo "===== mac-task-executor-opencode-review ====="
 echo "started_at:       ${started_at}"
 echo "MAC_TASK_ID:      ${MAC_TASK_ID:-<unset>}"
@@ -137,6 +145,7 @@ if [ "${review_experiment_blind}" = "1" ]; then
     trap restore_executor_evidence EXIT HUP INT TERM
     rm -f "${executor_evidence_path}"
     DISCOVERY_PROMPT="Run the evidence-withheld discovery phase for review experiment ${review_experiment_id}, arm ${review_experiment_arm}. The host has physically removed executor-evidence.json. Read ${MAC_TASK_WORKSPACE}/executor-task.json, inspect the prepared checkout and diff at ${MAC_TASK_REPO_WORKTREE:-<none>}, and run focused checks. Do not decide approval yet. Return a fenced JSON object with findings as a list and no_findings_reason as a non-empty string when the list is empty. Each finding should include summary and, when applicable, severity, path, line, and supporting_check."
+    DISCOVERY_PROMPT="$(printf '%s' "${DISCOVERY_PROMPT}" | compile_coding_prompt review_discovery)"
     set +e
     (cd "${review_cwd}" && opencode run --agent review --format json "${DISCOVERY_PROMPT}") > "${discovery_stdout}" 2>&1
     discovery_rc=$?
@@ -272,6 +281,10 @@ fi
 
 opencode_stdout="$(mktemp)"
 set +e
+if ! PROMPT="$(printf '%s' "${PROMPT}" | compile_coding_prompt review)"; then
+    echo "[opencode-review] prompt policy rejected dispatch" >&2
+    exit 4
+fi
 (cd "${review_cwd}" && opencode run --agent review --format json "${PROMPT}") > "${opencode_stdout}" 2>&1
 opencode_rc=$?
 set -e

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -994,6 +994,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_ROUTER_VIDEO_TIMEOUT` | int | consumer-defined | router | Router setting: router video timeout. |
 | `MAC_ROUTER_VIDEO_UPSTREAM` | str | consumer-defined | router | Router setting: router video upstream. |
 | `MAC_ROUTER_WILDCARD_MODELS` | str | consumer-defined | router | Router setting: router wildcard models. |
+| `MAC_ROUTE_FINGERPRINT` | str | consumer-defined | core | Core setting: route fingerprint. |
 | `MAC_RUNNER_ACTIVE_DEADLINE_SECONDS` | int | consumer-defined | kubernetes-runner | Kubernetes Runner setting: runner active deadline seconds. |
 | `MAC_RUNNER_AGENT_TOKEN_SECRETS` | str | consumer-defined | kubernetes-runner | Kubernetes Runner setting: runner agent token secrets. |
 | `MAC_RUNNER_CAPABILITIES` | str | consumer-defined | kubernetes-runner | Kubernetes Runner setting: runner capabilities. |
@@ -1071,6 +1072,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_TAILSCALE_IP` | str | consumer-defined | core | Core setting: tailscale ip. |
 | `MAC_TAILSCALE_NETWORKING_MODE` | str | consumer-defined | core | Core setting: tailscale networking mode. |
 | `MAC_TAILSCALE_SOCKS5_PROXY` | str | consumer-defined | core | Core setting: tailscale socks5 proxy. |
+| `MAC_TASK_ATTEMPT` | str | consumer-defined | task-execution | Task Execution setting: task attempt. |
 | `MAC_TASK_CANONICAL_REMOTE` | str | consumer-defined | task-execution | Task Execution setting: task canonical remote. |
 | `MAC_TASK_EVIDENCE_MANIFEST_PATH` | str | consumer-defined | task-execution | Task Execution setting: task evidence manifest path. |
 | `MAC_TASK_EXECUTOR_COMMAND` | str | consumer-defined | task-execution | Task Execution setting: task executor command. |

--- a/src/mac/auto_land.py
+++ b/src/mac/auto_land.py
@@ -483,7 +483,22 @@ def run_adversarial_review(
         )
 
     prompt = _ADVERSARIAL_PROMPT.format(target=target)
-    argv = build_argv(choice, prompt, env=env)
+    from mac.prompt_master import compile_prompt
+
+    compiled = compile_prompt(
+        prompt,
+        target=choice.agent,
+        model=getattr(choice, "model", ""),
+        prompt_kind="auto_land_review",
+        task_id=str((env or os.environ).get("MAC_TASK_ID") or target),
+        agent_id=str((env or os.environ).get("MAC_AGENT_ID") or ""),
+        route_fingerprint=(
+            choice.route_fingerprint()
+            if callable(getattr(choice, "route_fingerprint", None))
+            else ""
+        ),
+    )
+    argv = build_argv(choice, compiled.text, env=env)
     proc = runner(argv, cwd=repo_dir)
     output = (getattr(proc, "stdout", "") or "") + (getattr(proc, "stderr", "") or "")
     if int(getattr(proc, "returncode", 1)) != 0 and not output.strip():

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -320,6 +320,7 @@
       "src/mac/openshell_collector.py",
       "src/mac/openshell_runtime.py",
       "src/mac/openshell_supervisor.py",
+      "src/mac/prompt_master.py",
       "src/mac/router_app.py",
       "src/mac/source_convergence_service.py",
       "src/mac/worker.py",
@@ -1312,6 +1313,7 @@
     "retired": false,
     "sources": [
       "src/mac/coding_agent.py",
+      "src/mac/prompt_master.py",
       "src/mac/router_app.py"
     ],
     "type": "str"
@@ -11726,6 +11728,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: route fingerprint.",
+    "family": "core",
+    "name": "MAC_ROUTE_FINGERPRINT",
+    "retired": false,
+    "sources": [
+      "src/mac/prompt_master.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Kubernetes Runner setting: runner active deadline seconds.",
     "family": "kubernetes-runner",
     "name": "MAC_RUNNER_ACTIVE_DEADLINE_SECONDS",
@@ -12629,6 +12642,17 @@
   },
   {
     "default": null,
+    "description": "Task Execution setting: task attempt.",
+    "family": "task-execution",
+    "name": "MAC_TASK_ATTEMPT",
+    "retired": false,
+    "sources": [
+      "src/mac/prompt_master.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Task Execution setting: task canonical remote.",
     "family": "task-execution",
     "name": "MAC_TASK_CANONICAL_REMOTE",
@@ -12750,10 +12774,12 @@
     "name": "MAC_TASK_ID",
     "retired": false,
     "sources": [
+      "src/mac/auto_land.py",
       "src/mac/coding_agent.py",
       "src/mac/executor_sandbox.py",
       "src/mac/k8s/job_executor.py",
       "src/mac/k8s/runner.py",
+      "src/mac/prompt_master.py",
       "src/mac/router_app.py",
       "src/mac/worker_subprocess.py"
     ],

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -124,6 +124,7 @@ from mac.repository_access_env import (
     fence_read_only_repository_environment,
     read_only_repository_content_digest,
 )
+from mac.prompt_master import compile_prompt
 from mac.read_only_report_verifier import (
     INTEGRITY_SCHEMA as _READ_ONLY_VERIFICATION_INTEGRITY_SCHEMA,
     raw_git_control_digest as _authoritative_read_only_git_control_digest,
@@ -5637,6 +5638,8 @@ def _invoke_acp_agent(
             )
         executor = ACPExecutor(argv, cwd=str(workspace))
 
+    prompt = _compile_outbound_prompt(prompt, "acp", opts, audit_id=audit_id)
+
     text_chunks: List[str] = []
 
     def _on_update(params: Dict[str, Any]) -> None:
@@ -5745,6 +5748,33 @@ def _opts_with_route(opts: dict, route: Dict[str, str]) -> dict:
     return merged
 
 
+def _compile_outbound_prompt(
+    prompt: str,
+    target: str,
+    opts: Mapping[str, Any],
+    *,
+    audit_id: Any,
+    model: str = "",
+    route_fingerprint: str = "",
+) -> str:
+    """Apply the mandatory policy after routing and before prompt byte staging."""
+
+    task = opts.get("task") if isinstance(opts.get("task"), dict) else {}
+    result = compile_prompt(
+        prompt,
+        target=target,
+        model=model,
+        prompt_kind=str(opts.get("execution_kind") or "task"),
+        task_id=str(task.get("id") or audit_id or ""),
+        attempt=task.get("attempt_count"),
+        agent_id=local_agent_id(),
+        route_fingerprint=route_fingerprint,
+        command_id=str(opts.get("command_id") or ""),
+    )
+    emit_telemetry("prompt_rewrite", **result.evidence)
+    return result.text
+
+
 def _invoke_agent(
     runner: Callable[..., Any], prompt: str, workspace: Path, audit_id: Any, opts: dict
 ) -> Any:
@@ -5802,7 +5832,15 @@ def _invoke_agent(
         task=opts.get("task"),
         chosen=route,
     )
-    bundle = _write_agent_command_bundle(workspace, prompt, agent_argv)
+    compiled_prompt = _compile_outbound_prompt(
+        prompt,
+        route.get("agent") or "universal",
+        opts,
+        audit_id=audit_id,
+        model=route.get("model") or "",
+        route_fingerprint=route.get("fingerprint") or "",
+    )
+    bundle = _write_agent_command_bundle(workspace, compiled_prompt, agent_argv)
     try:
         if wrap:
             sandbox_workspace = "%s/%s" % (
@@ -5842,8 +5880,16 @@ def _invoke_agent(
                 )
                 if fallback_route.get("agent"):
                     bundle.cleanup()
+                    fallback_prompt = _compile_outbound_prompt(
+                        prompt,
+                        fallback_route.get("agent") or "universal",
+                        opts,
+                        audit_id=audit_id,
+                        model=fallback_route.get("model") or "",
+                        route_fingerprint=fallback_route.get("fingerprint") or "",
+                    )
                     bundle = _write_agent_command_bundle(
-                        workspace, prompt, fallback_argv
+                        workspace, fallback_prompt, fallback_argv
                     )
                     _record_runner_choice(
                         fallback_route["agent"],

--- a/src/mac/prompt_master.py
+++ b/src/mac/prompt_master.py
@@ -1,0 +1,175 @@
+"""Deterministic policy boundary for outbound coding-agent prompts.
+
+The policy is derived from the pinned Prompt Master material vendored under
+``mac/third_party/prompt-master``.  That material is inert data: this module is
+the only executable interpretation, and it never calls a model or the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, Mapping, Optional
+
+POLICY_VERSION = "mac-prompt-master-v1"
+UPSTREAM_COMMIT = "d15eabbe5d2122eedc060bae8a771381e9873d1b"
+MAX_INPUT_BYTES = 1024 * 1024
+MAX_OUTPUT_BYTES = MAX_INPUT_BYTES + 4096
+_MARKER = "<!-- mac.prompt_master.v1 -->\n"
+_KNOWN_TARGETS = {"claude", "codex", "cursor", "opencode", "pi", "acp", "api"}
+_SECRET_ASSIGNMENT = re.compile(
+    r"(?im)\b((?:[A-Z][A-Z0-9_]*_)?(?:TOKEN|SECRET|PASSWORD|API_KEY|PRIVATE_KEY))"
+    r"(\s*[=:]\s*)([^\s,;]+)"
+)
+_BEARER = re.compile(r"(?i)\b(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}")
+
+
+class PromptPolicyError(ValueError):
+    """The prompt cannot safely cross the coding-agent boundary."""
+
+
+@dataclass(frozen=True)
+class CompiledPrompt:
+    text: str
+    evidence: Dict[str, Any]
+
+
+def _digest(text: str) -> str:
+    return "sha256:" + hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _redact_secrets(text: str) -> tuple[str, bool]:
+    changed = False
+
+    def assignment(match: re.Match[str]) -> str:
+        nonlocal changed
+        value = match.group(3)
+        if value in {"<redacted>", "${%s}" % match.group(1), "$" + match.group(1)}:
+            return match.group(0)
+        changed = True
+        return match.group(1) + match.group(2) + "<redacted>"
+
+    text = _SECRET_ASSIGNMENT.sub(assignment, text)
+    rewritten, count = _BEARER.subn(r"\1<redacted>", text)
+    return rewritten, changed or bool(count)
+
+
+def compile_prompt(
+    prompt: str,
+    *,
+    target: str,
+    model: str = "",
+    prompt_kind: str = "task",
+    task_id: str = "",
+    attempt: Optional[Any] = None,
+    agent_id: str = "",
+    route_fingerprint: str = "",
+    command_id: str = "",
+) -> CompiledPrompt:
+    """Validate and deterministically rewrite one final outbound prompt.
+
+    Callers must invoke this after route selection and before staging prompt
+    bytes in a file, argv, ACP request, or HTTP body.
+    """
+
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise PromptPolicyError("coding-agent prompt must be non-empty")
+    source_bytes = len(prompt.encode("utf-8"))
+    if source_bytes > MAX_INPUT_BYTES:
+        raise PromptPolicyError(
+            "coding-agent prompt exceeds %d-byte input limit" % MAX_INPUT_BYTES
+        )
+    normalized_target = str(target or "").strip().lower()
+    profile = normalized_target if normalized_target in _KNOWN_TARGETS else "universal"
+
+    if prompt.startswith(_MARKER):
+        rewritten = prompt
+        changed_dimensions = []
+        source_digest = _digest(prompt)
+    else:
+        redacted, secrets_changed = _redact_secrets(prompt)
+        guidance = {
+            "constraints": "Higher-authority MAC policy and explicit safe user constraints win.",
+            "evidence": "Produce the requested deterministic evidence; do not expose chain-of-thought.",
+            "profile": profile,
+            "stop": "Stop on a policy, scope, safety, or missing-critical-context failure; never wait for chat.",
+            "target_model": str(model or ""),
+        }
+        header = _MARKER + json.dumps(
+            guidance, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ) + "\n\n"
+        rewritten = header + redacted
+        changed_dimensions = ["policy_envelope"]
+        if secrets_changed:
+            changed_dimensions.append("secret_redaction")
+        source_digest = _digest(prompt)
+
+    if len(rewritten.encode("utf-8")) > MAX_OUTPUT_BYTES:
+        raise PromptPolicyError(
+            "rewritten coding-agent prompt exceeds %d-byte output limit" % MAX_OUTPUT_BYTES
+        )
+    evidence: Dict[str, Any] = {
+        "schema": "mac.prompt_rewrite.v1",
+        "policy_version": POLICY_VERSION,
+        "policy_commit": UPSTREAM_COMMIT,
+        "source_sha256": source_digest,
+        "rewritten_sha256": _digest(rewritten),
+        "target_profile": profile,
+        "model": str(model or "") or None,
+        "prompt_kind": str(prompt_kind or "task"),
+        "task_id": str(task_id or "") or None,
+        "attempt": attempt,
+        "agent_id": str(agent_id or "") or None,
+        "route_fingerprint": str(route_fingerprint or "") or None,
+        "command_id": str(command_id or "") or None,
+        "diagnostics": [],
+        "changed_dimensions": changed_dimensions,
+    }
+    return CompiledPrompt(rewritten, evidence)
+
+
+def compile_for_environment(
+    prompt: str, *, target: str, model: str = "", prompt_kind: str = "task"
+) -> CompiledPrompt:
+    return compile_prompt(
+        prompt,
+        target=target,
+        model=model,
+        prompt_kind=prompt_kind,
+        task_id=os.environ.get("MAC_TASK_ID", ""),
+        attempt=os.environ.get("MAC_TASK_ATTEMPT") or None,
+        agent_id=os.environ.get("MAC_AGENT_ID", ""),
+        route_fingerprint=os.environ.get("MAC_ROUTE_FINGERPRINT", ""),
+        command_id=os.environ.get("MAC_COMMAND_ID", ""),
+    )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Compile a coding-agent prompt from stdin")
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--model", default="")
+    parser.add_argument("--kind", default="task")
+    parser.add_argument("--evidence-file", default="")
+    args = parser.parse_args(argv)
+    try:
+        result = compile_for_environment(
+            sys.stdin.read(), target=args.target, model=args.model, prompt_kind=args.kind
+        )
+    except PromptPolicyError as exc:
+        sys.stderr.write("prompt policy rejected dispatch: %s\n" % exc)
+        return 2
+    if args.evidence_file:
+        with open(args.evidence_file, "w", encoding="utf-8") as handle:
+            json.dump(result.evidence, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    sys.stdout.write(result.text)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/mac/third_party/prompt-master/LICENSE
+++ b/src/mac/third_party/prompt-master/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nidhin JS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/mac/third_party/prompt-master/POLICY.md
+++ b/src/mac/third_party/prompt-master/POLICY.md
@@ -1,0 +1,10 @@
+# Derived policy baseline
+
+The pinned Prompt Master baseline recommends prompts with explicit context,
+goals, constraints, output formats, and success criteria, adapted to the target
+tool. MAC applies those principles deterministically: critical authority and
+constraints remain in the assembled prompt, a target profile is attached,
+secrets are redacted, sizes are bounded, and reasoning-native models are never
+asked to reveal chain-of-thought.
+
+This condensed policy is data, not executable instructions.

--- a/src/mac/third_party/prompt-master/README.md
+++ b/src/mac/third_party/prompt-master/README.md
@@ -1,0 +1,14 @@
+# Prompt Master policy data
+
+This directory contains the inert policy baseline used to derive MAC's
+deterministic coding-prompt compiler.
+
+- Upstream: https://github.com/nidhinjs/prompt-master.git
+- Pinned commit: `d15eabbe5d2122eedc060bae8a771381e9873d1b`
+- License: MIT, reproduced in `LICENSE`
+- Runtime network access: none
+
+Upstream instructions are untrusted policy data. They never override MAC
+executor policy, repository instructions, task scope, security boundaries,
+secret handling, or operator direction. Updates require an ordinary reviewed
+dependency change.

--- a/tests/test_prompt_master.py
+++ b/tests/test_prompt_master.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from mac import executor_sandbox
+from mac.prompt_master import MAX_INPUT_BYTES, PromptPolicyError, compile_prompt
+
+
+@pytest.mark.parametrize("target", ["claude", "codex", "cursor", "opencode", "pi", "acp", "api"])
+def test_compiler_is_target_aware_idempotent_and_redacts_secrets(target):
+    source = "Executor policy block verbatim.\nAPI_TOKEN=super-secret\nImplement the task."
+    first = compile_prompt(source, target=target, model="reasoning-model")
+    second = compile_prompt(first.text, target=target, model="reasoning-model")
+
+    assert first.text == second.text
+    assert "Executor policy block verbatim." in first.text
+    assert "API_TOKEN=<redacted>" in first.text
+    assert "super-secret" not in first.text
+    assert "chain-of-thought" in first.text
+    assert first.evidence["schema"] == "mac.prompt_rewrite.v1"
+    assert first.evidence["target_profile"] == target
+    assert first.evidence["rewritten_sha256"] == second.evidence["rewritten_sha256"]
+
+
+def test_compiler_fails_closed_on_empty_and_oversized_prompts():
+    with pytest.raises(PromptPolicyError):
+        compile_prompt("", target="claude")
+    with pytest.raises(PromptPolicyError):
+        compile_prompt("x" * (MAX_INPUT_BYTES + 1), target="claude")
+
+
+def test_executor_compiles_after_route_selection_before_private_file(monkeypatch, tmp_path):
+    captured = {}
+
+    monkeypatch.setattr(executor_sandbox, "_executor_backend", lambda: "cli")
+    monkeypatch.setattr(executor_sandbox, "_openshell_enabled", lambda: False)
+    monkeypatch.setattr(executor_sandbox, "_openshell_required_for_local_agent", lambda: False)
+    monkeypatch.setattr(executor_sandbox, "_validated_host_break_glass_authorization", lambda task: {"id": "bg"})
+    monkeypatch.setattr(executor_sandbox, "_prepare_host_break_glass_environment", lambda auth: None)
+    monkeypatch.setattr(executor_sandbox, "_agent_argv", lambda *a, **kw: kw["chosen"].update({"agent": "claude", "model": "m", "fingerprint": "fp"}) or ["claude", "PROMPT"])
+    monkeypatch.setattr(executor_sandbox, "_unsandboxed_agent_argv", lambda argv, **kw: argv)
+
+    def fake_bundle(workspace, prompt, argv):
+        captured["prompt"] = prompt
+        class Bundle:
+            def argv(self, **kwargs): return argv
+            def cleanup(self): pass
+        return Bundle()
+
+    monkeypatch.setattr(executor_sandbox, "_write_agent_command_bundle", fake_bundle)
+    result = executor_sandbox._invoke_agent(
+        lambda *args: type("R", (), {"returncode": 0})(),
+        "Do work. TOKEN=secret", tmp_path, "task_1", {"task": {"id": "task_1"}},
+    )
+    assert result.returncode == 0
+    assert captured["prompt"].startswith("<!-- mac.prompt_master.v1 -->")
+    assert "secret" not in captured["prompt"]
+
+
+def test_all_known_script_dispatches_cross_compiler_boundary():
+    root = Path(__file__).parents[1]
+    for relative in (
+        "deploy/codex-runner/mac-task-executor-opencode-build",
+        "deploy/codex-runner/mac-task-executor-opencode-review",
+    ):
+        text = (root / relative).read_text(encoding="utf-8")
+        assert "compile_coding_prompt" in text
+        for line in text.splitlines():
+            if "opencode run" in line and not line.lstrip().startswith("#"):
+                assert "${" in line
+
+    source = inspect.getsource(executor_sandbox._invoke_agent)
+    assert source.index("_agent_argv(") < source.index("_compile_outbound_prompt(")
+    assert source.index("_compile_outbound_prompt(") < source.index("_write_agent_command_bundle(")


### PR DESCRIPTION
Recovers the verified implementation from task_c4935176 attempt 2 after the worker committed locally but could not push. Adds pinned MIT policy data and deterministic rewrite coverage across central executor, ACP, auto-land, and OpenCode runner prompts. Task: task_c493517685934be286fc0fc3cc3a316c.