### PR TITLE
Fix plan evidence ingestion and child-routing classification

### DIFF
--- a/src/mac/executor_scope.py
+++ b/src/mac/executor_scope.py
@@ -28,6 +28,7 @@ from mac.executor_memory import (
     _plan_family_terms,
     _task_project,
 )
+from mac.task_decomposition import decomposition_budget
 
 _SCOPE_LARGE_DESC_WORDS = 200
 _SCOPE_LARGE_DESC_CHARS = 800
@@ -291,6 +292,13 @@ def is_planning_phase(task: Dict[str, Any]) -> bool:
     if not isinstance(metadata, dict):
         metadata = {}
     if metadata.get("no_decompose"):
+        return False
+    # Planning mode's only successful outcome is durable child creation.  The
+    # control plane correctly refuses that write unless the submitter declared
+    # a decomposition budget, so entering planning without one manufactures a
+    # plan that can never be accepted.  Keep the prompt and server policy on
+    # the same authoritative contract.
+    if not decomposition_budget(task).authorised:
         return False
     relationships = metadata.get("relationships")
     if isinstance(relationships, dict) and (

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -7952,16 +7952,11 @@ def _plan_decomposed_is_environment_fault(
 ) -> bool:
     """True when a failed plan is a hub/sandbox environment fault, not scope.
 
-    Empty children and failed child routing are the death spiral from a
-    planning phase the sandbox could not complete. Classify them as
-    environment so they retry instead of burning attempt 1 as non-retryable
-    scope.
+    A recorded failed connectivity probe is authoritative.  A hub rejection is
+    not: it can be a valid policy or evidence response (for example, refusing
+    decomposition the submitter never authorised), and calling that an
+    environment fault hides the actionable server error behind retries.
     """
-    blob = " ".join(str(item) for item in problems).lower()
-    if "could not be routed to durable child tasks" in blob:
-        return True
-    if "non-empty children" in blob:
-        return True
     if task_dir is not None:
         probe_path = task_dir / "sandbox-hub-connectivity.json"
         try:

--- a/tests/test_executor_scope.py
+++ b/tests/test_executor_scope.py
@@ -60,6 +60,7 @@ def test_is_planning_phase_excludes_child_tasks() -> None:
         "attempt_count": 1,
         "metadata": {
             "plan_first": True,
+            "decomposition": {"max_children": 3},
             "relationships": {"parent_task_id": "task_parent"},
         },
     }
@@ -67,7 +68,11 @@ def test_is_planning_phase_excludes_child_tasks() -> None:
 
 
 def test_build_planning_prompt_describes_symbolic_dependencies(tmp_path) -> None:
-    task = {"id": "task_plan", "attempt_count": 1, "metadata": {"plan_first": True}}
+    task = {
+        "id": "task_plan",
+        "attempt_count": 1,
+        "metadata": {"plan_first": True, "decomposition": {"max_children": 3}},
+    }
     prompt = scope.build_planning_prompt(task, tmp_path / "task.json")
     assert "PLANNING MODE" in prompt
     assert "depends_on" in prompt

--- a/tests/test_plan_learning_loop.py
+++ b/tests/test_plan_learning_loop.py
@@ -63,6 +63,7 @@ def _large_task(task_id: str = "task_large_plan") -> Dict[str, Any]:
     return _task(
         task_id=task_id,
         metadata={
+            "decomposition": {"max_children": 10, "kind": "one per subsystem"},
             "scope_estimate": {
                 "schema": "mac.scope_estimate.v1",
                 "size": "large",

--- a/tests/test_planning_phase.py
+++ b/tests/test_planning_phase.py
@@ -61,6 +61,7 @@ def _large_task(
 ) -> Dict[str, Any]:
     """Build a task fixture that already has scope_estimate=large in metadata."""
     metadata: Dict[str, Any] = {
+        "decomposition": {"max_children": 10, "kind": "one per subsystem"},
         "scope_estimate": {
             "schema": "mac.scope_estimate.v1",
             "size": "large",
@@ -97,7 +98,9 @@ class TestIsPlanningPhase:
         assert te.is_planning_phase(task) is True
 
     def test_returns_true_for_plan_first_flag(self):
-        task = _task(metadata={"plan_first": True})
+        task = _task(
+            metadata={"plan_first": True, "decomposition": {"max_children": 3}}
+        )
         assert te.is_planning_phase(task) is True
 
     def test_plan_first_false_does_not_trigger(self):
@@ -106,7 +109,9 @@ class TestIsPlanningPhase:
 
     def test_plan_first_string_true_triggers(self):
         # Truthy strings should trigger
-        task = _task(metadata={"plan_first": "true"})
+        task = _task(
+            metadata={"plan_first": "true", "decomposition": {"max_children": 3}}
+        )
         assert te.is_planning_phase(task) is True
 
     def test_no_decompose_prevents_planning(self):
@@ -418,6 +423,27 @@ class TestRunExecutorPlanningPhase:
         assert "PLANNING MODE" in state["prompts"][0]
         assert "planning_phase_started" in state["telemetry"]
 
+    def test_large_task_without_submitter_budget_uses_normal_prompt(
+        self, monkeypatch, tmp_path: Path
+    ):
+        state = _patch_run_executor_base(monkeypatch, tmp_path=tmp_path)
+        task = _large_task(task_id="task_large_atomic")
+        task["metadata"].pop("decomposition", None)
+
+        te._run_executor(
+            runner=_fake_runner,
+            task=task,
+            task_file=tmp_path / "task.json",
+            task_workspace=tmp_path,
+            task_id="task_large_atomic",
+            review_context=None,
+            is_review=False,
+        )
+
+        assert len(state["prompts"]) == 1
+        assert "PLANNING MODE" not in state["prompts"][0]
+        assert "planning_phase_started" not in state["telemetry"]
+
     def test_large_task_skips_planning_when_hub_writes_unavailable(
         self, monkeypatch, tmp_path: Path
     ):
@@ -563,7 +589,7 @@ class TestRunExecutorPlanningPhase:
         monkeypatch.setattr(te, "_invoke_agent", fake_invoke_with_evidence)
 
         task = _task(
-            metadata={"plan_first": True},
+            metadata={"plan_first": True, "decomposition": {"max_children": 3}},
             task_id="task_planfirst001",
             attempt_count=1,
         )

--- a/tests/test_sandbox_hub_connectivity.py
+++ b/tests/test_sandbox_hub_connectivity.py
@@ -81,17 +81,32 @@ def test_reject_empty_plan_leaves_routable_plans(tmp_path: Path) -> None:
     assert loaded["evidence_type"] == "plan_decomposed"
 
 
-def test_empty_children_are_an_environment_fault() -> None:
-    assert _plan_decomposed_is_environment_fault(
+def test_empty_children_are_a_plan_contract_fault() -> None:
+    assert not _plan_decomposed_is_environment_fault(
         {},
         ["plan_decomposed evidence requires a non-empty children list"],
     )
 
 
-def test_unroutable_children_are_an_environment_fault() -> None:
+def test_hub_policy_rejection_is_not_an_environment_fault() -> None:
+    assert not _plan_decomposed_is_environment_fault(
+        {},
+        [
+            "plan_decomposed evidence could not be routed to durable child tasks: "
+            "cannot add child tasks: this task did not authorise decomposition"
+        ],
+    )
+
+
+def test_routing_error_with_failed_probe_is_an_environment_fault(tmp_path: Path) -> None:
+    (tmp_path / "sandbox-hub-connectivity.json").write_text(
+        json.dumps({"ready": False, "reason": "hub_unreachable"}),
+        encoding="utf-8",
+    )
     assert _plan_decomposed_is_environment_fault(
         {},
-        ["plan_decomposed evidence could not be routed to durable child tasks: 401"],
+        ["plan_decomposed evidence could not be routed to durable child tasks: timed out"],
+        tmp_path,
     )
 
 

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -147,6 +147,7 @@ def test_new_file_commit_rule_in_both_prompts_for_repo_coupled_task(tmp_path):
     # build_planning_prompt requires scope_estimate=large or plan_first to enter
     # planning mode; use plan_first to avoid scope-signal complexity.
     task["metadata"]["plan_first"] = True
+    task["metadata"]["decomposition"] = {"max_children": 10}
     planning_prompt = te.build_planning_prompt(task, tmp_path / "task.json")
     assert te.NEW_FILE_COMMIT_RULE in planning_prompt, (
         "build_planning_prompt must include NEW_FILE_COMMIT_RULE"

--- a/tests/test_worker_contract_edges.py
+++ b/tests/test_worker_contract_edges.py
@@ -215,6 +215,87 @@ def test_execute_assignment_routes_plan_to_durable_children(tmp_path) -> None:
     ]
 
 
+def test_plan_policy_rejection_reports_verification_failure_not_environment(
+    tmp_path,
+) -> None:
+    manifest = {
+        "schema": "mac.worker_evidence.v1",
+        "status": "complete",
+        "evidence_type": "plan_decomposed",
+        "children": [{"title": "Inspect"}, {"title": "Repair"}],
+        "ordering_rationale": "Inspect before repair.",
+        "coverage_claim": "Diagnosis and repair cover the parent scope.",
+    }
+
+    class Client:
+        def __init__(self):
+            self.posts = []
+
+        def post(self, path, payload):
+            self.posts.append((path, payload))
+            if path.endswith("/children"):
+                raise worker.MacApiError(
+                    "cannot add child tasks: this task did not authorise decomposition"
+                )
+            return {"id": "task-plan", "state": payload.get("target_state", "running")}
+
+    class Harness:
+        execute_assignment = worker.MacWorker.execute_assignment
+        agent_id = "agent-planner"
+
+        def __init__(self):
+            self.client = Client()
+
+        def _observe_log(self, *args, **kwargs):
+            return None
+
+        def _observe_metric(self, *args, **kwargs):
+            return None
+
+        def _set_active_assignment(self, task_id, lease_id):
+            return None
+
+        def _clear_active_assignment(self, task_id, lease_id):
+            return None
+
+        def _prepare_task_workspace(self, task, lease):
+            (tmp_path / "task.json").write_text(json.dumps({"task": task, "lease": lease}))
+            (tmp_path / "sandbox-hub-connectivity.json").write_text(
+                json.dumps({"ready": True, "reason": "ready"})
+            )
+            return tmp_path
+
+        def _execute_with_lease_renewal(self, task, lease, task_dir):
+            return worker.WorkerExecution(0, "planned")
+
+        def _assignment_is_current(self, task_id, lease_id):
+            return True
+
+        def _record_execution(
+            self, task_id, task_dir, execution, *, lease_id, attempt_state=None
+        ):
+            return {"id": "evidence-plan", "metadata": {"verification": manifest}}
+
+        def _execution_submission_problems(self, task_dir, evidence):
+            return []
+
+        def _post_task_activity(self, *args, **kwargs):
+            return None
+
+    harness = Harness()
+    result = harness.execute_assignment(
+        {"id": "task-plan", "title": "Plan work", "metadata": {}},
+        {"id": "lease-plan"},
+    )
+
+    transitions = [
+        payload for path, payload in harness.client.posts if path.endswith("/transition")
+    ]
+    assert transitions
+    assert transitions[-1]["detail"].get("reason") != "sandbox_hub_environment_fault"
+    assert "did not authorise decomposition" in str(result.error)
+
+
 def test_executor_verification_manifest_shapes(tmp_path) -> None:
     path = tmp_path / "executor-evidence.json"
     assert worker._executor_verification_manifest_from_review_workspace(tmp_path) == {}


### PR DESCRIPTION
Fixes task_8644b376. Planning mode now requires the submitter's decomposition budget before execution, keeping executor behavior aligned with the server child-creation policy. Hub policy/evidence rejections retain their actionable error instead of being mislabeled sandbox_hub_environment_fault; only a recorded failed connectivity probe is an environment fault. Verification: 349 focused tests and 107 worker/planning tests pass.