### PR TITLE
Restore green main after Hermes runtime retirement

### DIFF
--- a/deploy/openclaw/relocate-script-job-home.py
+++ b/deploy/openclaw/relocate-script-job-home.py
@@ -71,7 +71,7 @@ def openclaw_home() -> Path:
 
 
 def gateway_home() -> Path:
-    return _env_dir("HERMES_HOME") or (Path.home() / ".hermes")
+    return _env_dir("HERMES_HOME") or (mac_home() / "openclaw")
 
 
 def script_jobs_dir() -> Path:

--- a/deploy/openclaw/run-script-cron-job.py
+++ b/deploy/openclaw/run-script-cron-job.py
@@ -90,7 +90,7 @@ def openclaw_home() -> Path:
 
 
 def gateway_home() -> Path:
-    return _env_dir("HERMES_HOME") or (Path.home() / ".hermes")
+    return _env_dir("HERMES_HOME") or (mac_home() / "openclaw")
 
 
 def script_jobs_dir() -> Path:

--- a/tests/test_fleet_prerequisite_receipts.py
+++ b/tests/test_fleet_prerequisite_receipts.py
@@ -134,7 +134,7 @@ def test_path_verifier_preserves_setgid_directory_mode(tmp_path: Path) -> None:
     shared.chmod(0o2755)
     contract = {
         "schema": receipts.CONTRACT_SCHEMA,
-        "participant": "hermes",
+        "participant": "service-topology",
         "agent_id": AGENT,
         "node_identity_sha256": IDENTITY,
         "checks": [

--- a/tests/test_script_job_home.py
+++ b/tests/test_script_job_home.py
@@ -95,7 +95,7 @@ def test_script_job_home_relocates_with_its_root(clean_home, monkeypatch):
 def test_no_live_runner_path_resolves_into_a_hermes_home(clean_home):
     """With a clean environment, nothing the runner reads or writes is under
     the gateway home — the fallback aside, which is asserted separately."""
-    gateway = mac_paths.gateway_home()
+    legacy_gateway = clean_home / ".hermes"
     live = {
         "scripts": Path(runner.script_jobs_scripts_dir()),
         "output": Path(runner.script_jobs_output_dir()),
@@ -104,7 +104,7 @@ def test_no_live_runner_path_resolves_into_a_hermes_home(clean_home):
         "jobs_home": mac_paths.openclaw_home(),
     }
     for label, path in live.items():
-        assert gateway not in path.parents and path != gateway, (
+        assert legacy_gateway not in path.parents and path != legacy_gateway, (
             "%s still resolves into the Hermes home: %s" % (label, path)
         )
         assert mac_paths.mac_home() in path.parents, (
@@ -124,7 +124,7 @@ def test_runner_defaults_have_no_hermes_literal_left():
         for line in source.splitlines()
         if '".hermes"' in line and not line.lstrip().startswith("#")
     ]
-    assert hermes_lines == ['    return _env_dir("HERMES_HOME") or (Path.home() / ".hermes")']
+    assert hermes_lines == []
 
 
 def test_installer_schedules_the_openclaw_scripts_home_not_hermes():


### PR DESCRIPTION
Fixes the currently red mainline gate after the Hermes runtime and prerequisite participant were removed. Aligns the stdlib script-job path mirrors with mac_paths, retains the explicit legacy scripts fallback, and updates the prerequisite helper test to use a supported participant. Verification: 63 focused tests pass.