### PR TITLE
Add task stop and restart hub routes

### DIFF
--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -363,11 +363,13 @@ request and response definitions.
 | `POST` | `/tasks/{task_id}/force-complete` | Force Complete Task |
 | `POST` | `/tasks/{task_id}/release` | Release Task |
 | `POST` | `/tasks/{task_id}/reopen` | Reopen Task |
+| `POST` | `/tasks/{task_id}/restart` | Restart Stopped Task |
 | `POST` | `/tasks/{task_id}/review-experiment` | Assign Review Experiment |
 | `GET` | `/tasks/{task_id}/review-observation` | Review Observation |
 | `POST` | `/tasks/{task_id}/review-outcomes` | Record Review Outcome |
 | `POST` | `/tasks/{task_id}/reviews` | Request Review |
 | `POST` | `/tasks/{task_id}/start` | Start Task |
+| `POST` | `/tasks/{task_id}/stop` | Stop Task |
 | `POST` | `/tasks/{task_id}/submit-for-review` | Submit For Review |
 | `GET` | `/tasks/{task_id}/summary` | Task Summary |
 | `GET` | `/tasks/{task_id}/transcript` | Get Task Transcript |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -888,6 +888,11 @@ class TaskRecoveryRequest(BaseModel):
     reason: Optional[str] = None
 
 
+class TaskStopRequest(BaseModel):
+    actor: str = "human"
+    reason: str
+
+
 class TaskAskRequest(BaseModel):
     questions: List[Any]
     actor: str
@@ -6188,6 +6193,24 @@ def create_app(
             limit=20,
         )
         return task.to_dict()
+
+    @app.post("/tasks/{task_id}/stop")
+    def stop_task(
+        task_id: str,
+        body: TaskStopRequest,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.require_admin()
+        return cp.stop_task(task_id, actor=body.actor, reason=body.reason).to_dict()
+
+    @app.post("/tasks/{task_id}/restart")
+    def restart_stopped_task(
+        task_id: str,
+        body: TaskRelease = TaskRelease(),
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.require_admin()
+        return cp.start_stopped_task(task_id, actor=body.actor).to_dict()
 
     @app.post("/tasks/{task_id}/release")
     def release_task(

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -321,6 +321,22 @@ class RemoteDispatch:
         )
         return _Dictish(self._post("/tasks", body))
 
+    def stop_task(self, task_id: str, *, actor: str, reason: str) -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/tasks/%s/stop" % quote(task_id, safe=""),
+                {"actor": actor, "reason": reason},
+            )
+        )
+
+    def start_stopped_task(self, task_id: str, *, actor: str) -> _Dictish:
+        return _Dictish(
+            self._post(
+                "/tasks/%s/restart" % quote(task_id, safe=""),
+                {"actor": actor},
+            )
+        )
+
     # Wrapped here as well as on the ControlPlane because hub mode is the only
     # mode an operator uses: /humans shipped without these and `mac admin human`
     # simply failed against a live fleet.

--- a/tests/test_task_stop_start.py
+++ b/tests/test_task_stop_start.py
@@ -238,6 +238,29 @@ def test_the_next_agent_sees_the_new_text_not_the_old(tmp_path):
     assert cp.get_task(task.id).description == "BUILD THE OTHER THING"
 
 
+def test_stop_and_restart_routes_work_in_hub_mode(tmp_path):
+    from fastapi.testclient import TestClient
+    from mac.api import create_app
+
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+    client = TestClient(create_app(control_plane=cp))
+
+    stopped = client.post(
+        "/tasks/%s/stop" % task.id,
+        json={"actor": "operator", "reason": "correct scope"},
+    )
+    assert stopped.status_code == 200
+    assert stopped.json()["state"] == "stopped"
+
+    restarted = client.post(
+        "/tasks/%s/restart" % task.id,
+        json={"actor": "operator"},
+    )
+    assert restarted.status_code == 200
+    assert restarted.json()["state"] == "open"
+
+
 # --- the blast radius that nearly shipped ----------------------------------
 
 def test_a_metadata_only_update_does_not_stop_a_running_task(tmp_path):


### PR DESCRIPTION
Fixes task_ffd62788. Adds admin-authorized stop/restart API routes and RemoteDispatch wrappers so mac task stop/start work against the configured hub. Verification: 26 focused API/lifecycle/route-contract tests pass.