### PR TITLE
Implement task stop/restart HTTP and RemoteDispatch wrappers for hub mode (task_ffd6278803b54260b72a94b7a7bfa15b)

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -6140,6 +6140,26 @@ def create_app(
         # stranded in a terminal state. Bypasses the review gate (audited).
         return cp.force_complete_task(task_id, body.actor, body.reason).to_dict()
 
+    @app.post("/tasks/{task_id}/stop")
+    def stop_task(
+        task_id: str,
+        body: TaskRecoveryRequest,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.require_admin()
+        return cp.stop_task(
+            task_id, actor=body.actor, reason=body.reason or ""
+        ).to_dict()
+
+    @app.post("/tasks/{task_id}/restart")
+    def restart_task(
+        task_id: str,
+        body: TaskRecoveryRequest,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.require_admin()
+        return cp.start_stopped_task(task_id, actor=body.actor).to_dict()
+
     @app.post("/leases/{lease_id}/renew")
     def renew_lease(
         lease_id: str,

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -852,6 +852,37 @@ class RemoteDispatch:
         body = _drop_none({"actor": actor, "reason": reason})
         return _Dictish(self._post("/tasks/%s/force-complete" % quote(task_id, safe=""), body))
 
+    def stop_task(
+        self,
+        task_id: str,
+        *,
+        actor: str,
+        reason: str = "",
+        drain_outbox: bool = True,
+    ) -> _Dictish:
+        del drain_outbox
+        return _Dictish(
+            self._post(
+                "/tasks/%s/stop" % quote(task_id, safe=""),
+                {"actor": actor, "reason": reason},
+            )
+        )
+
+    def start_stopped_task(
+        self,
+        task_id: str,
+        *,
+        actor: str,
+        drain_outbox: bool = True,
+    ) -> _Dictish:
+        del drain_outbox
+        return _Dictish(
+            self._post(
+                "/tasks/%s/restart" % quote(task_id, safe=""),
+                {"actor": actor},
+            )
+        )
+
     def start_task(
         self,
         task_id: str,

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -702,6 +702,13 @@ network_policies:
     )
     ctx["answer_task_id"] = answer_task["id"]
     ctx["force_complete_task_id"] = task("route force-complete task")["id"]
+    stop_task = task("route stop task")
+    cp.claim_task(stop_task["id"], ctx["agent_id"], sync_beads=False)
+    cp.start_task(stop_task["id"], ctx["agent_id"])
+    ctx["stop_task_id"] = stop_task["id"]
+    restart_task = task("route restart task")
+    cp.stop_task(restart_task["id"], actor="route-coverage")
+    ctx["restart_task_id"] = restart_task["id"]
     ctx["claim_task_id"] = task("route claim task")["id"]
     ctx["claim_next_task_id"] = task("route claim-next task")["id"]
     evidence_task = task("route evidence task")
@@ -1328,6 +1335,8 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("POST", "/tasks/{task_id}/ask"): {"task_id": "ask_task_id"},
         ("POST", "/tasks/{task_id}/answer"): {"task_id": "answer_task_id"},
         ("POST", "/tasks/{task_id}/force-complete"): {"task_id": "force_complete_task_id"},
+        ("POST", "/tasks/{task_id}/stop"): {"task_id": "stop_task_id"},
+        ("POST", "/tasks/{task_id}/restart"): {"task_id": "restart_task_id"},
         ("POST", "/tasks/{task_id}/claim"): {"task_id": "claim_task_id"},
         ("POST", "/tasks/{task_id}/start"): {"task_id": "start_task_id"},
         ("POST", "/tasks/{task_id}/submit-for-review"): {"task_id": "submit_task_id"},
@@ -1848,6 +1857,11 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
             "actor": "operator",
             "reason": "route coverage force-complete",
         },
+        ("POST", "/tasks/{task_id}/stop"): {
+            "actor": "operator",
+            "reason": "route coverage stop",
+        },
+        ("POST", "/tasks/{task_id}/restart"): {"actor": "operator"},
         ("POST", "/leases/{lease_id}/renew"): {"agent_id": ctx["lease_agent_id"], "lease_seconds": 120},
         ("POST", "/leases/{lease_id}/delegate"): {
             "agent_id": ctx["lease_agent_id"],

--- a/tests/test_dispatch_remote_contract.py
+++ b/tests/test_dispatch_remote_contract.py
@@ -214,6 +214,23 @@ def test_update_agent_uses_hub_put_endpoint_and_preserves_actor() -> None:
     )
 
 
+def test_task_stop_and_restart_use_operator_lifecycle_endpoints() -> None:
+    client = RecordingClient()
+    dispatch = RemoteDispatch(client)
+
+    dispatch.stop_task("task/one", actor="operator", reason="correct scope")
+    dispatch.start_stopped_task("task/one", actor="operator")
+
+    assert client.calls[-2:] == [
+        (
+            "POST",
+            "/tasks/task%2Fone/stop",
+            {"actor": "operator", "reason": "correct scope"},
+        ),
+        ("POST", "/tasks/task%2Fone/restart", {"actor": "operator"}),
+    ]
+
+
 def test_dispatch_hold_uses_hub_endpoints_and_quotes_agent_id() -> None:
     client = RecordingClient()
     dispatch = RemoteDispatch(client)

--- a/tests/test_task_stop_start.py
+++ b/tests/test_task_stop_start.py
@@ -9,7 +9,9 @@ against criteria written after it.
 from __future__ import annotations
 
 import pytest
+from fastapi.testclient import TestClient
 
+from mac.api import create_app
 from mac.models import (
     ACTIVE_TASK_STATES,
     TASK_TRANSITIONS,
@@ -128,6 +130,52 @@ def test_starting_a_task_that_is_not_stopped_is_refused(tmp_path):
     task = cp.create_task(title="t", description="d")
     with pytest.raises(TransitionError):
         cp.start_stopped_task(task.id, actor="op")
+
+
+def test_stop_and_restart_http_lifecycle_requires_admin_and_revokes_lease(tmp_path):
+    cp = _cp(tmp_path)
+    task, _agent = _running_task(cp)
+    client = TestClient(
+        create_app(
+            control_plane=cp,
+            auth_tokens={"writer": ["write"], "admin": ["admin"]},
+        )
+    )
+    body = {"actor": "operator", "reason": "correct scope"}
+
+    blocked = client.post(
+        "/tasks/%s/stop" % task.id,
+        headers={"Authorization": "Bearer writer"},
+        json=body,
+    )
+    assert blocked.status_code == 403
+    assert cp.get_task(task.id).state == TaskState.RUNNING.value
+
+    stopped = client.post(
+        "/tasks/%s/stop" % task.id,
+        headers={"Authorization": "Bearer admin"},
+        json=body,
+    )
+    assert stopped.status_code == 200
+    assert stopped.json()["state"] == TaskState.STOPPED.value
+    assert stopped.json()["owner_agent_id"] is None
+    assert stopped.json()["lease_id"] is None
+
+    blocked_restart = client.post(
+        "/tasks/%s/restart" % task.id,
+        headers={"Authorization": "Bearer writer"},
+        json={"actor": "operator"},
+    )
+    assert blocked_restart.status_code == 403
+    assert cp.get_task(task.id).state == TaskState.STOPPED.value
+
+    restarted = client.post(
+        "/tasks/%s/restart" % task.id,
+        headers={"Authorization": "Bearer admin"},
+        json={"actor": "operator"},
+    )
+    assert restarted.status_code == 200
+    assert restarted.json()["state"] == TaskState.OPEN.value
 
 
 # --- the atomic update ------------------------------------------------------


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_ffd6278803b54260b72a94b7a7bfa15b`
- head: `872fd1cb3df098cba5a2b95ca4e204b408445667`
- base at push: `bcbeeea8b8792a68a8b37bb391e3c01c7cd04bc2`
