### PR TITLE
ADR: extract-then-publish to Qdrant, and CodeGraph as a hint

### DIFF
--- a/docs/adr/0030-langchain-extracts-before-qdrant.md
+++ b/docs/adr/0030-langchain-extracts-before-qdrant.md
@@ -1,0 +1,144 @@
+# ADR 0030: LangChain extracts meaning on the agent; hub Qdrant only stores the extract
+
+- Status: Proposed
+- Date: 2026-08-23
+- Decision owner: MAC fleet owner
+- Related: [ADR 0002](0002-memory-store-at-scale.md) — Qdrant is the production
+  vector store; this ADR does not reopen that choice
+- Related: [ADR 0007](0007-hermes-boundary-mood-nap-soul-memory.md) — nap and
+  soul memory already hand off to `VectorWriterService`; the handoff stays,
+  the *payload* changes
+- Related: [ADR 0017](0017-token-spend-is-metered-at-the-router.md) — extraction
+  is a metered model call on the agent, not an unmetered hub side-effect
+- Numbering: **0029** is claimed by the in-flight route-ladder ADR on #634
+
+## Context
+
+Qdrant on the hub is the right destination. The suspicion, recorded 2026-08-23
+as `task_b5351642`, is that we are not giving it good data.
+
+`VectorWriterService.embed_memory` takes `record.content` and embeds it. The
+payload builder will JSON-parse that content when it can, copy a few known
+keys (`mac.dream.v1`, `mac.deployment_learning.v1`), and otherwise set
+`summary` to the first 2,000 characters of whatever the writer had. Transcripts
+are split on a 4,000-character window so the embedding backend does not
+truncate; that is a length cap, not a meaning extract.
+
+The writers that feed this path today are hub-side and agent-adjacent, not
+extractors:
+
+| Call site | What it currently embeds |
+| --- | --- |
+| `VectorWriterService.embed_memory` / `embed_backlog` | raw `memory_records.content` |
+| `memory_promotion.py` | the same content, re-embedded into a warmer tier |
+| `nap_consolidator.py` | nap summaries, then `embed_memory` |
+| `dreaming/store.py`, `dream_log_import.py` | dream records (already structured) and imported logs |
+| `macong memory embed` / control-plane remember | whatever the operator or agent posted |
+| transcript chunker (`TRANSCRIPT_COLLECTION`) | raw dialogue windows |
+
+#580 / `task_cf393901` repaired the pipe: mixed embedding spaces, ingestion
+outage, model/dim provenance. That work is complementary. A reliable pipe that
+carries undifferentiated text still stores undifferentiated text.
+
+Recall then searches those vectors. Near-neighbours of a transcript window or a
+raw task body are not near-neighbours of a claim. The collection looks full
+and answers confidently; the answers are the wrong objects.
+
+## Decision
+
+### 1. Qdrant stays the fleet store
+
+One hub Qdrant, shared across that hub's agents, remains the destination.
+No second vector store. No agent-local ANN index that later has to be
+reconciled. ADR 0002 still holds.
+
+### 2. LangChain on the agent is the arbiter of meaning
+
+Before a record is published to hub Qdrant, the agent that produced the data
+runs a LangChain extraction step locally: chunk by discourse (not by character
+count), summarise, type, and cite. The hub embeds *that extract* and upserts
+it. The hub does not run LangChain over raw payloads "to be helpful".
+
+LangChain is required at the publish edge, not on the hub process. An agent
+without it does not silently fall back to embedding the raw dump. No extract,
+no upsert. The ledger row may still exist; the vector must not.
+
+### 3. Only an extract record is a legal Qdrant point
+
+The published unit is a versioned extract, not `memory_records.content`.
+Minimum shape (`mac.memory_extract.v1`):
+
+- `text` — the meaning-bearing string that will be embedded
+- `kind` — closed set (`claim`, `decision`, `procedure`, `outcome`,
+  `preference`, `incident`, `citation_only`, …)
+- `citations` — pointers back to the source (memory id, evidence id, transcript
+  span, file/line, URL). An extract without a citation is a rumour.
+- `source_schema` / `source_id` — what was extracted
+- `extractor` — `{library: "langchain", chain, model}` so a bad extract is
+  attributable
+- the existing multi-tenant payload keys from ADR 0002 (`tenant_id`,
+  `agent_id`, `project`, `tier`, `record_type`)
+
+`VectorWriterService` rejects an upsert whose payload is not this schema, or
+whose `text` is a raw dump (no `kind`, no `citations`). That rejection is the
+test the task named: a raw dump without an extract record does not become a
+point.
+
+Records that are *already* extracts may pass without a second LLM call.
+`mac.dream.v1`, `mac.deployment_learning.v1`, and `mac.fleet_learning.v1` qualify
+when they already carry a summary, a kind, and citations. Character-chunked
+transcripts do not.
+
+### 4. The writers change; the store does not
+
+Implementation (not this document) walks the call sites in the table above
+and inserts the extract step *before* `embed_memory`. The writer keeps
+`ensure_collection / upsert / query / delete`. It gains a schema check.
+It loses the right to embed freeform content.
+
+Backfill of existing points is a later, bounded job. This ADR does not require
+re-embedding history before the contract is adopted for new writes.
+
+## Consequences
+
+- Recall quality becomes a property of the extract, not of whoever happened
+  to call `remember`. That is the point.
+- Publish costs a model call per extract. Meter it at the agent router
+  (ADR 0017). Do not hide it inside the hub upsert.
+- Agents that cannot run LangChain stop contributing vectors. That is
+  fail-closed on *quality*, and fail-soft on *availability*: ledger writes
+  and task progress continue; semantic recall is thinner until the agent
+  can extract.
+- Tests must cover the rejection, not only the happy path: posting
+  `record.content = "<transcript>"` and calling `embed_memory` is a failure.
+- Prompt text and skills that say "write this to Qdrant" have to say
+  "extract, then publish".
+
+## Alternatives considered
+
+**Keep embedding raw content and hope a better embedding model is enough.**
+Rejected. A better embedding of a 4,000-character transcript window is still
+an embedding of a transcript window. #580 already moved the embedding model;
+recall did not become meaning-aware.
+
+**Run LangChain on the hub as a Qdrant write interceptor.** Rejected. The hub
+does not have the agent's working set, the files, or the conversation that
+made the record. Extraction without that context is a second guess. It also
+puts unmetered model spend on the control plane.
+
+**Agent-local vector stores, sync to hub later.** Rejected. That is a second
+store and a reconciliation problem. The destination is not in doubt.
+
+**Make extraction optional, embed raw as a fallback.** Rejected. Optional
+extraction is the current behaviour with extra steps. The collection would
+again mix claims with dumps, and recall cannot tell them apart.
+
+## Non-goals
+
+- Replacing Qdrant, or adding a second ANN backend.
+- Choosing a specific LangChain chain, chunker, or chat model. Those are
+  implementation; this ADR fixes the contract: extract on the agent, store
+  the extract on the hub.
+- Re-embedding the existing collection. New writes first.
+- Changing the hash-stub embedding backend used in tests. The stub embeds
+  extract `text`, not raw dumps.

--- a/docs/adr/0031-codegraph-is-a-hint.md
+++ b/docs/adr/0031-codegraph-is-a-hint.md
@@ -1,0 +1,169 @@
+# ADR 0031: CodeGraph is a hint when the tool and `.codegraph/` exist, not a hard gate
+
+- Status: Proposed
+- Date: 2026-08-23
+- Decision owner: MAC fleet owner
+- Related: [ADR 0011](0011-hub-review-verification-scope.md) — hub-verify uses
+  the sanity contract; this ADR changes what that contract does when CodeGraph
+  cannot be trusted
+- Related: [ADR 0022](0022-a-gate-returns-a-named-decision-not-a-boolean.md) —
+  "CodeGraph failed" is not a decision; the named outcomes below are
+- Numbering: **0029** is claimed by the in-flight route-ladder ADR on #634
+
+## Context
+
+CodeGraph is a legitimate analysis tool. It is also known to lie on complex
+trees: incomplete indexes, lock stalls, `affected` exiting non-zero, and
+JSON that names the wrong tests. Treating those failures as proof that the
+change is unsafe is how a passing, pushed branch becomes a review reject.
+
+Observed 2026-08-23 on PR #634 (`task_ae2fc223`):
+
+1. The first hub-verify reject was real — a docs example used an operator
+   identity. That belongs to `test_docs_no_operator_identity`. It was fixed.
+2. The second reject selected `sanity selection: full (codegraph_affected_failed)`
+   and ran the entire contract suite. Eleven failures, about eleven minutes,
+   none of them the defect under review.
+
+The flip lives in `scripts/resolve-impacted-tests.py`. CodeGraph is unioned
+into the focused set, then:
+
+```
+if unresolved_source and (codegraph_problem is not None or not codegraph_tests):
+    return _full(codegraph_problem or "unresolved_source_without_reliable_affected_tests", ...)
+```
+
+`codegraph affected` returning non-zero becomes `codegraph_affected_failed`,
+which becomes a full run. A missing binary becomes `codegraph_unavailable`
+and the same full run. The selector cannot tell "the index lied" from "we
+do not know the blast radius".
+
+The worker pre-push gate is the same class. `mac.codegraph_audit.v1` is
+required for any source/build/dependency/runtime change. `run_codegraph_audit`
+**fails** when the binary is missing (`codegraph_not_available`) and when
+`init`/`sync`/`affected` is non-zero. `codegraph_audit_manifest_problems`
+then blocks publication unless status is exactly `pass` and both an index
+command and an `affected` command succeeded. AGENTS.md states the same
+rule as a hard evidence gate. A docs-only change may record
+`codegraph.status=skipped` with `reason=non_code_change`; a Python change
+may not.
+
+So a tree without a trustworthy `.codegraph/`, or a tool that cannot answer,
+cannot publish — or, if it gets past the worker, pays for the full suite
+at review. That is the wrong place for this check.
+
+## Decision
+
+### 1. CodeGraph is a hint, never a gate
+
+A hint may widen a focused test set. It may not:
+
+- fail the worker pre-push audit by itself
+- fail hub-verify by itself
+- flip sanity from focused (or from the repository's declared test command)
+  to a full-suite run
+
+The declared test command and the changed-file list remain the gate.
+CodeGraph, when it answers, is extra names in that list.
+
+### 2. A hint is only eligible when both prerequisites exist
+
+CodeGraph may be consulted if and only if:
+
+1. a `codegraph` binary is on `PATH` (or `MAC_CODEGRAPH_BIN`), **and**
+2. a `.codegraph/` directory already exists for that source tree.
+
+If either is missing, the decision is `hint_unavailable`. Do not run
+`codegraph init` to create an index just so the gate has something to
+fail closed on. An index created under time pressure in a sandbox is
+exactly the index that lies.
+
+If both exist and `affected` (or `init`/`sync`) fails, times out, or
+returns unusable JSON, the decision is `hint_untrusted`. Same
+consequence as unavailable: ignore the hint.
+
+If both exist and `affected` returns a usable test list, the decision
+is `hint_applied`: union those tests into the focused set.
+
+### 3. The decision is named (ADR 0022)
+
+| Code | Meaning | What the gate does |
+| --- | --- | --- |
+| `hint_applied` | tool + `.codegraph/` present; `affected` usable | union the extra tests; continue |
+| `hint_unavailable` | no binary, or no `.codegraph/` | skip CodeGraph; use changed files + declared tests |
+| `hint_untrusted` | tool and index exist; output failed or is not believed | skip CodeGraph; do **not** escalate to full |
+| `non_code_change` | no source/build files in the diff | skip, as today |
+
+`codegraph_affected_failed` and `codegraph_not_available` stop being
+reasons for `_full(...)`. They map onto `hint_untrusted` and
+`hint_unavailable`. Unresolved source without a hint is still allowed
+to fail closed *on the impact map* (`unresolved_source_without_reliable_affected_tests`)
+only when the repository has no other declared way to test the change.
+It is not allowed to blame CodeGraph for that escalation.
+
+### 4. `mac.codegraph_audit.v1` records the hint; it does not block
+
+The worker still runs the audit when the hint is eligible, and still
+records the manifest. Status values that must be legal on a *passing*
+publication:
+
+- `pass` / `hint_applied`
+- `skipped` / `non_code_change`
+- `skipped` / `hint_unavailable`
+- `skipped` / `hint_untrusted`
+
+`codegraph_audit_manifest_problems` returns empty for those. It does
+not demand a successful `init`/`sync`/`affected` pair as a condition of
+push. `codegraph.status=skipped` is no longer reserved for docs-only
+changes.
+
+AGENTS.md, the executor policy, and the pre-push evidence list change
+to match: CodeGraph is analysis support, recorded when used, never a
+hard requirement.
+
+## Consequences
+
+- A branch whose own tests pass publishes even when CodeGraph is absent,
+  stale, or wrong. That is the #634 second-reject fix.
+- Focused sanity may be slightly smaller on complex trees (the lying
+  `affected` list is dropped rather than replaced by the entire suite).
+  The cost of a missed edge is paid at mainline integration (ADR 0011),
+  not by every review.
+- Deploy can keep installing CodeGraph. Installation is not a gate.
+  Presence of the binary without a `.codegraph/` directory is
+  `hint_unavailable`, not a fail.
+- Tests the task named become the pin:
+  - `codegraph_affected_failed` does not flip sanity to full-suite
+  - a repository without `.codegraph/` still publishes when its own
+    tests pass
+- Call sites that must change: `scripts/resolve-impacted-tests.py`
+  (`codegraph_affected`, the `_full` branch), `src/mac/codegraph_audit.py`
+  (`run_codegraph_audit`, `codegraph_audit_manifest_problems`),
+  `src/mac/worker.py` / `executor_finalizer.py` / `evidence_validators.py`
+  (publication problems), AGENTS.md and the executor policy.
+
+## Alternatives considered
+
+**Keep fail-closed; fix CodeGraph so it stops lying.** Rejected as the
+gate. Improving the index is useful analysis work. It does not justify
+blocking publish or expanding to the full suite when the tool is wrong
+*today*. A gate that depends on an untrusted oracle will keep producing
+#634's second reject.
+
+**Treat only a missing binary as skippable; keep `affected` failure as
+full-suite.** Rejected. That is the current behaviour for any tree that
+has the tool installed, which is every fleet image. The lie is in
+`affected`, not in `which codegraph`.
+
+**Drop CodeGraph entirely.** Rejected. When the index is present and
+`affected` answers, the extra tests are cheap and sometimes right. A
+hint that sometimes helps is worth recording. A requirement that
+sometimes lies is not.
+
+## Non-goals
+
+- Replacing the impact map or the declared repository test command.
+- Changing what `codegraph init` / `codegraph affected` compute when an
+  operator runs them by hand.
+- Making CodeGraph optional to *install* on fleet images. Install it.
+  Do not require its answer.

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -35,6 +35,8 @@ their retained sources.
 - [ADR 0026: Every operation on a first-class object emits a bus event](../adr/0026-first-class-operations-emit-bus-events.md) — `adr/0026-first-class-operations-emit-bus-events.md`
 - [ADR 0027: Upgrades are versioned, ordered, and fail closed](../adr/0027-upgrades-are-versioned-and-fail-closed.md) — `adr/0027-upgrades-are-versioned-and-fail-closed.md`
 - [ADR 0028: Installation is a verified package plus enrollment, not a push](../adr/0028-installation-is-a-package-not-a-push.md) — `adr/0028-installation-is-a-package-not-a-push.md`
+- [ADR 0030: LangChain extracts meaning on the agent; hub Qdrant only stores the extract](../adr/0030-langchain-extracts-before-qdrant.md) — `adr/0030-langchain-extracts-before-qdrant.md`
+- [ADR 0031: CodeGraph is a hint when the tool and `.codegraph/` exist, not a hard gate](../adr/0031-codegraph-is-a-hint.md) — `adr/0031-codegraph-is-a-hint.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -40,6 +40,8 @@ for provenance and is not a current operating contract.
 | architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
 | architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | architecture decision | `adr/0028-installation-is-a-package-not-a-push.md` | ADR 0028: Installation is a verified package plus enrollment, not a push |
+| architecture decision | `adr/0030-langchain-extracts-before-qdrant.md` | ADR 0030: LangChain extracts meaning on the agent; hub Qdrant only stores the extract |
+| architecture decision | `adr/0031-codegraph-is-a-hint.md` | ADR 0031: CodeGraph is a hint when the tool and `.codegraph/` exist, not a hard gate |
 | supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
 | historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |


### PR DESCRIPTION
## Summary
- **ADR 0030** (`task_b5351642`): LangChain on each agent extracts meaning (chunk, summarize, type, cite) before publish. Hub Qdrant stays the store and rejects a raw dump without an extract record. Complementary to #580, not a replacement.
- **ADR 0031** (`task_5cda1ace`): CodeGraph is a hint only when the `codegraph` tool *and* a `.codegraph/` directory exist. `codegraph_affected_failed` must not flip sanity to the full suite; `mac.codegraph_audit.v1` records the hint and does not block publish.
- Numbered 0030/0031 because **0029** is claimed by the in-flight route-ladder ADR on #634.

Docs only. Writer and gate changes stay on the same tasks until the ADRs land.

## Test plan
- [x] Inventory and archive index regenerated for the two new ADR pages
- [ ] Hub-verify / docs gate on this PR
- [ ] Follow-up (same tasks, not this PR): reject raw `embed_memory` dumps; pin `codegraph_affected_failed` so it does not select `full`