### PR TITLE
Export pytest pythonpath so OpenShell hub-verify uses the worktree

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,10 @@
-"""Repository-wide pytest hooks for opt-in test-portfolio measurement and for
-test-gate checkpointing (src/mac/test_checkpoint.py).
+"""Repository-wide pytest hooks for opt-in test-portfolio measurement, for
+test-gate checkpointing (src/mac/test_checkpoint.py), and for making the
+``pythonpath`` ini option reach child processes.
 
-Both are inert unless the corresponding environment variable is set, so a plain
-``pytest`` invocation behaves exactly as it did before either existed.
+The first two are inert unless the corresponding environment variable is set,
+so a plain ``pytest`` invocation behaves exactly as it did before either
+existed. The third always runs; see ``_export_ini_pythonpath``.
 """
 
 from __future__ import annotations
@@ -48,8 +50,61 @@ _CHECKPOINT_SPAWNED_BY_A_TEST = bool(os.environ.get("PYTEST_CURRENT_TEST"))
 _CHECKPOINT_OWNED = False
 
 
+# --------------------------------------------------------------------------
+# Make ``pythonpath = ["src"]`` (pyproject) reach child processes.
+#
+# The ini option only prepends to the *pytest process's* ``sys.path``. It does
+# not touch ``PYTHONPATH``, so a test that shells out to
+# ``[sys.executable, "-m", "mac.cli", ...]`` imports whatever ``mac`` that
+# interpreter has installed -- NOT the worktree pytest itself imported.
+#
+# On a dev box the two agree, because .venv carries an editable install. In the
+# OpenShell verification sandbox they do not: there is no .venv, the runner
+# resolves /opt/mac-venv/bin/python, and that image bakes a released `mac`.
+# Every in-process assertion then tests the worktree while every subprocess
+# assertion tests the image, and the suite fails on code the diff never
+# touched. Observed as `mac --version` exiting 2 with "the following arguments
+# are required: SUBCOMMAND" (tests/cli/test_cli_version_flag.py) and as a
+# worker child that never releases its lease because the baked worker.py has no
+# shutdown_grace_seconds (tests/test_worker_shutdown_abandon.py) -- one cause,
+# two unrelated-looking failures, neither reproducible anywhere else.
+#
+# Exporting the same entries closes the gap for every subprocess at once, so
+# individual tests no longer each have to remember to rebuild PYTHONPATH by
+# hand (several already do; they keep working -- prepending is idempotent).
+# This deliberately does NOT weaken the environment-scrubbing contracts: code
+# that strips PYTHONPATH before spawning a managed process still strips it.
+# --------------------------------------------------------------------------
+
+
+def _export_ini_pythonpath(config) -> None:
+    """Prepend the ``pythonpath`` ini entries to ``os.environ['PYTHONPATH']``."""
+
+    try:
+        entries = config.getini("pythonpath")
+    except (ValueError, KeyError):  # option absent on this pytest
+        return
+
+    roots: list[str] = []
+    for entry in entries or ():
+        try:
+            resolved = Path(str(config.rootpath), str(entry)).resolve()
+        except OSError:
+            continue
+        if resolved.is_dir():
+            roots.append(str(resolved))
+    if not roots:
+        return
+
+    existing = [p for p in os.environ.get("PYTHONPATH", "").split(os.pathsep) if p]
+    merged = roots + [p for p in existing if p not in roots]
+    os.environ["PYTHONPATH"] = os.pathsep.join(merged)
+
+
 def pytest_configure(config) -> None:
     """Decide whether this session owns the checkpoint recording namespace."""
+
+    _export_ini_pythonpath(config)
 
     global _CHECKPOINT_OWNED
     expected = os.environ.get("MAC_TEST_CHECKPOINT_ROOT", "").strip()

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -197,6 +197,12 @@ fi
 # checked-out worktree shadow any installed mac, so tests exercise the
 # worktree's code regardless of which interpreter runs them.
 #
+# That last sentence holds for SUBPROCESSES only because the repository
+# conftest.py re-exports those ini entries into PYTHONPATH. The ini option by
+# itself edits the pytest process's sys.path and nothing else, which is why the
+# sandbox once ran in-process assertions against the worktree and shelled-out
+# assertions against the mac baked into /opt/mac-venv. See _export_ini_pythonpath.
+#
 # The pre-baked runtime venv location is overridable via MAC_CONTRACT_RUNTIME_VENV
 # (default /opt/mac-venv). This keeps production behavior byte-identical while
 # letting the runner's own contract tests stay hermetic on hosts that DO ship a

--- a/tests/test_subprocess_imports_the_worktree.py
+++ b/tests/test_subprocess_imports_the_worktree.py
@@ -1,0 +1,116 @@
+"""A test that shells out must reach the same ``mac`` the test imported.
+
+`pythonpath = ["src"]` in pyproject.toml prepends to the *pytest process's*
+``sys.path``. It does not set ``PYTHONPATH``, so until conftest.py re-exported
+it, ``subprocess.run([sys.executable, "-m", "mac.cli", ...])`` imported
+whatever ``mac`` that interpreter had installed.
+
+On a dev box nothing showed, because .venv carries an editable install and the
+two copies are the same files. The verification sandbox has no .venv: the
+runner resolves /opt/mac-venv/bin/python, whose image bakes a released ``mac``.
+So in-process assertions tested the worktree and shelled-out assertions tested
+the image, and the split surfaced as two unrelated-looking failures:
+
+  * tests/cli/test_cli_version_flag.py -- the 4 cases that shell out AND expect
+    success failed with ``mac: error: the following arguments are required:
+    SUBCOMMAND``, the pre-``--version`` behaviour its own docstring quotes. The
+    two that shell out expecting failure passed, and so did the one that never
+    leaves the process. That split is the fingerprint: it is not about
+    ``--version`` at all, it is about which ``mac`` answered.
+  * tests/test_worker_shutdown_abandon.py::
+    test_real_sigterm_then_sigkill_still_releases_the_lease -- its child script
+    sets ``worker.shutdown_grace_seconds``, an attribute the baked worker.py
+    does not have, so the child never ran the release path and the lease stayed
+    held.
+
+Neither reproduced outside the sandbox, so both read as flakes and cost a
+doc-only task most of its attempts. These tests pin the invariant directly,
+against any interpreter, so the next drift fails here with one clear reason
+instead of scattering across the suite.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import mac
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _child(*code: str) -> subprocess.CompletedProcess:
+    """Run a snippet the way an ordinary test shells out: inherited env only."""
+
+    return subprocess.run(
+        [sys.executable, "-c", "\n".join(code)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def test_a_subprocess_imports_the_same_mac_as_this_process():
+    """The whole defect, reduced to one assertion."""
+
+    result = _child("import mac", "print(mac.__file__)")
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()).resolve() == Path(mac.__file__).resolve(), (
+        "a child process imported a different mac than the test did; the "
+        "worktree is at %s" % Path(mac.__file__).resolve().parent
+    )
+
+
+def test_the_worktree_source_is_what_a_subprocess_gets():
+    """Not merely 'the same as us' -- specifically this checkout."""
+
+    result = _child("import mac", "print(mac.__file__)")
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()).resolve().is_relative_to(ROOT), (
+        "a child imported mac from outside the worktree (%s); an installed "
+        "copy is shadowing src/" % result.stdout.strip()
+    )
+
+
+def test_pythonpath_carries_the_ini_entry():
+    """conftest re-exports pythonpath so children inherit it."""
+
+    entries = [
+        Path(p).resolve()
+        for p in os.environ.get("PYTHONPATH", "").split(os.pathsep)
+        if p
+    ]
+
+    assert (ROOT / "src").resolve() in entries, (
+        "src/ is missing from PYTHONPATH=%r; pythonpath=[\"src\"] in "
+        "pyproject.toml only edits this process's sys.path"
+        % os.environ.get("PYTHONPATH", "")
+    )
+
+
+def test_the_cli_entrypoint_resolves_to_the_worktree():
+    """`python -m mac.cli` is the exact form the version-flag tests use."""
+
+    result = _child("import mac.cli", "print(mac.cli.__file__)")
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()).resolve() == (ROOT / "src/mac/cli.py").resolve()
+
+
+def test_exporting_is_idempotent():
+    """A test that rebuilds PYTHONPATH by hand must not duplicate src/.
+
+    Several tests predate the conftest export and still prepend ROOT/src
+    themselves. That has to stay harmless.
+    """
+
+    entries = [p for p in os.environ.get("PYTHONPATH", "").split(os.pathsep) if p]
+    resolved = [str(Path(p).resolve()) for p in entries]
+
+    assert resolved.count(str((ROOT / "src").resolve())) == 1, (
+        "src/ appears more than once in PYTHONPATH: %r" % entries
+    )


### PR DESCRIPTION
## Summary
- Re-apply the #590 sandbox-verify fix onto current `main`: `conftest.py` exports `pythonpath = ["src"]` into `PYTHONPATH` so subprocesses import the checkout, not the image-baked `mac`.
- Pins the invariant in `tests/test_subprocess_imports_the_worktree.py`.
- #590 itself is stale and red; do not merge that tip.

This is the OpenShell-only split that rejected hub-verify on #634 (`test_cli_version_flag` + `test_real_sigterm_then_sigkill_still_releases_the_lease`) while GitHub CI on the same SHA passed.

## Test plan
- [x] `pytest tests/test_subprocess_imports_the_worktree.py tests/cli/test_cli_version_flag.py`
- [ ] GitHub sanity + generated-docs
- [ ] After merge+deploy, re-tick hub-verify for remaining route-ladder review if the ledger task is still open