### PR TITLE
P0 docs audit: enforce docs-graph as a standing release gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CONSOLE_SCRIPTS = mac mac-hermes mac-agent mac-firecrawl-gateway mac-k8s-orchest
 	clean clean-cli clean-gui distclean run-gui \
 	install-hooks setup deploy test coverage test-api test-cli test-ui cli-coverage lint lint-fix \
 	test-portfolio fault-replay sanity-test compatibility-test \
-	docs docs-install docs-serve docs-test docs-build docs-check docs-accessibility docs-lab docs-reference \
+	docs docs-install docs-serve docs-test docs-build docs-check docs-accessibility docs-graph docs-lab docs-reference \
 	ide-install ide-run ide-dev ide-check ide-build ide-preview ide-package \
 	observe-build observe-run \
 	desktop-install desktop-check desktop-package desktop-dist link-cli
@@ -318,7 +318,10 @@ docs-build: docs-install ## Build strict production HTML.
 docs-accessibility: ## Validate documentation links, image alt text, and nav/redirect targets.
 	$(UV) run --extra docs python scripts/check-docs-accessibility.py
 
-docs-check: docs-test docs-accessibility docs-build ## Run executable examples, accessibility/link, reference drift, and strict HTML gates.
+docs-graph: ## Prove every current doc is reachable from README.md (no orphans, broken links, or inventory gaps).
+	$(PYTHON) scripts/check-docs-graph.py
+
+docs-check: docs-test docs-accessibility docs-graph docs-build ## Run executable examples, accessibility/link, docs-graph reachability, reference drift, and strict HTML gates.
 
 docs-lab: docs-install ## Execute one chapter in the isolated docs lab (CHAPTER=1..18).
 	@test -n "$(CHAPTER)" || { echo "usage: make docs-lab CHAPTER=1" >&2; exit 2; }

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ integration or protocol influence is not mistaken for copied source:
   runtime:** `src/mac/_hermes` is a pruned, MAC-modified snapshot of Hermes
   Agent 0.15.1 at
   [`b1a25404b`](https://github.com/NousResearch/hermes-agent/commit/b1a25404b638bfbd79ce4d08b49afc0ee1361528).
-  It supplies the agent loop, gateways, tools, plugins, and skills. See
-  [ADR 0001](docs/adr/0001-unify-hermes-runtime-into-mac.md) and the
-  [snapshot contract](deploy/hermes/SNAPSHOT.md).
+  It supplies the agent loop, gateways, tools, plugins, and skills. The
+  snapshot contract — the pin and prune policy — is
+  [ADR 0001](docs/adr/0001-unify-hermes-runtime-into-mac.md); the standalone
+  deploy/hermes/SNAPSHOT.md it once named was removed with the inactive
+  snapshot.
 - **[NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) — execution
   security foundation:** MAC's agent process trees, filesystem/network policy,
   sandbox lifecycle, and normalized action-event collection integrate with
@@ -176,6 +178,15 @@ Those pages are written from the code and gated by
 `tests/test_guide_docs_are_true.py`, which checks that every file they name
 exists, every `mac` command they show resolves against the real parser, and
 every edge in the task state diagram is one the control plane allows.
+
+Every current documentation file is linked from the
+[complete documentation index](docs/reference/documentation-inventory.md), and
+historical material — ADRs, field notes, and design specs kept for provenance —
+lives behind the visibly-labelled [historical archive](docs/archive/index.md),
+which is not current product behaviour. The automated docs-graph gate
+(`scripts/check-docs-graph.py`, run by `make docs-check`) traverses the internal
+links out of this `README.md` and fails the build on any current doc that is
+orphaned, any broken internal link, or any current doc missing from the index.
 
 ## Quick Start
 
@@ -895,4 +906,4 @@ explicit login server, enrollment-key source, DNS assumption, and health check.
 - [Review-strategy experiments](docs/review-strategy-experiments.md)
 - [Integration Authority Contract](docs/integration-authority-contract.md)
 - [Soul Preservation Runbook](docs/soul-preservation-runbook.md)
-- [Scaling Plan](docs/scaling-plan.md)
+- [Scaling Plan](docs/archive/field-notes/scaling-plan.md) (historical)

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -1,9 +1,10 @@
 # Historical archive
 
-These field notes and architecture decisions explain how MAC reached its current
-contracts. They are evidence, not current instructions. Follow the numbered book
-and current runbooks for operational work. Old field-note URLs redirect here to
-their retained sources.
+These field notes, architecture decisions, and design specs explain how MAC
+reached its current contracts. They are evidence, not current instructions,
+and must not be read as current product behaviour. Follow the numbered book
+and current runbooks for operational work. Old field-note URLs redirect here
+to their retained sources.
 
 ## Archived records
 
@@ -38,6 +39,9 @@ their retained sources.
 - [ADR 0029: The coding-route search path is a fleet contract, not per-worker environment](../adr/0029-the-route-search-path-is-a-fleet-contract.md) — `adr/0029-the-route-search-path-is-a-fleet-contract.md`
 - [ADR 0030: LangChain extracts meaning on the agent; hub Qdrant only stores the extract](../adr/0030-langchain-extracts-before-qdrant.md) — `adr/0030-langchain-extracts-before-qdrant.md`
 - [ADR 0031: CodeGraph is a hint when the tool and `.codegraph/` exist, not a hard gate](../adr/0031-codegraph-is-a-hint.md) — `adr/0031-codegraph-is-a-hint.md`
+- [Autonomous Project Routing and Review/Fix Loop Implementation Plan](../superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md) — `superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md`
+- [Autonomous Project Routing and Review/Fix Loop Design](../superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md) — `superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md`
+- [K8s bootstrap fleet registration — design](../superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md) — `superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md`
 - [Can MAC do work? — fleet assessment, 2026-08-02](../archive/field-notes/assessment-2026-08-02.md) — `archive/field-notes/assessment-2026-08-02.md`
 - [Assessment: task_1b67831356c347c3a91d782982f47d1c](../archive/field-notes/assessment-task-1b6783.md) — `archive/field-notes/assessment-task-1b6783.md`
 - [Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) — `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -44,6 +44,7 @@ marked `historical archive` and must not be read as current behaviour.
 | architecture decision | [`adr/0026-first-class-operations-emit-bus-events.md`](../adr/0026-first-class-operations-emit-bus-events.md) | ADR 0026: Every operation on a first-class object emits a bus event |
 | architecture decision | [`adr/0027-upgrades-are-versioned-and-fail-closed.md`](../adr/0027-upgrades-are-versioned-and-fail-closed.md) | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | architecture decision | [`adr/0028-installation-is-a-package-not-a-push.md`](../adr/0028-installation-is-a-package-not-a-push.md) | ADR 0028: Installation is a verified package plus enrollment, not a push |
+| architecture decision | [`adr/0029-the-route-search-path-is-a-fleet-contract.md`](../adr/0029-the-route-search-path-is-a-fleet-contract.md) | ADR 0029: The coding-route search path is a fleet contract, not per-worker environment |
 | supplemental reference | [`agent-lifecycle-proof.md`](../agent-lifecycle-proof.md) | Agent Lifecycle Proof |
 | historical archive | [`archive/field-notes/assessment-2026-08-02.md`](../archive/field-notes/assessment-2026-08-02.md) | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | [`archive/field-notes/assessment-task-1b6783.md`](../archive/field-notes/assessment-task-1b6783.md) | Assessment: task_1b67831356c347c3a91d782982f47d1c |
@@ -148,6 +149,7 @@ marked `historical archive` and must not be read as current behaviour.
 | supplemental reference | [`c26-certifier-phase-profile-example.md`](../c26-certifier-phase-profile-example.md) | c26 certifier phase-profile example |
 | supplemental reference | [`client-bootstrap-contract.md`](../client-bootstrap-contract.md) | SSH Client Bootstrap Contracts |
 | supplemental reference | [`coding-cli-credentials.md`](../coding-cli-credentials.md) | Coding-CLI Credentials and Model Selection |
+| supplemental reference | [`coding-route-ladder.md`](../coding-route-ladder.md) | The coding-route ladder |
 | supplemental reference | [`crash-diagnosis-and-repair.md`](../crash-diagnosis-and-repair.md) | Crash diagnosis and autonomous repair |
 | supplemental reference | [`dashboard-connection.md`](../dashboard-connection.md) | Dashboard Connection Contract |
 | supplemental reference | [`deploy-prerequisite-vs-phase1-audit.md`](../deploy-prerequisite-vs-phase1-audit.md) | Audit: prove deploy prerequisites before phase-1 mutation, preserve Python diagnostics |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -1,211 +1,211 @@
 # Documentation inventory
 
-This generated inventory classifies every Markdown source included in the
-documentation tree. Book chapters are authoritative and executable. Runbooks
-and references describe production boundaries. Historical material is retained
-for provenance and is not a current operating contract.
+This generated inventory classifies and links every Markdown source
+included in the documentation tree. It is the complete documentation index:
+the root `README.md` links here, and the automated docs-graph gate
+(`scripts/check-docs-graph.py`) proves every current doc is reachable from
+this table. Book chapters are authoritative and executable. Runbooks and
+references describe production boundaries. Historical material is retained
+for provenance and is not a current operating contract; those rows are
+marked `historical archive` and must not be read as current behaviour.
 
 | Category | Source | Title |
 |---|---|---|
-| supplemental reference | `activation-probe/calibration-spec.md` | Held-out calibration protocol |
-| supplemental reference | `activation-probe/classifier-spec.md` | External activation-probe classifier contract |
-| supplemental reference | `activation-probe/integration-guide.md` | External activation-probe worker integration |
-| supplemental reference | `activation-probe/prototype-report.md` | External activation-probe prototype |
-| supplemental reference | `activation-probe/runtime-selection.md` | External activation capture runtime |
-| architecture decision | `adr/0001-unify-hermes-runtime-into-mac.md` | ADR 0001 — Unify the Hermes runtime into the `mac` monorepo |
-| architecture decision | `adr/0002-memory-store-at-scale.md` | ADR 0002 — Memory store / vector tier at fleet scale (50–200 agents per hub) |
-| architecture decision | `adr/0003-tokenhub-core-into-mac.md` | ADR 0003 — Optional in-mac model router + vault (revisiting TokenHub's boundary) |
-| architecture decision | `adr/0004-task-ledger-vs-hermes-kanban.md` | ADR 0004 — One task database: revert the Hermes kanban adoption, keep our own board |
-| architecture decision | `adr/0005-elastic-executor-tier-vs-static-fleet.md` | ADR 0005 — Elastic executor tier vs. the static fleet (and "every agent is a GitHub runner") |
-| architecture decision | `adr/0006-acp-support.md` | ADR 0006 — Agent Client Protocol (ACP) support |
-| architecture decision | `adr/0007-hermes-boundary-mood-nap-soul-memory.md` | ADR 0007 — Per-module ownership: mood_policy, nap_consolidator, soul_snapshot, memory_vetting |
-| architecture decision | `adr/0008-openshell-docker-engine-runtime.md` | ADR 0008 - OpenShell uses Docker Engine/Moby as its only container runtime |
-| architecture decision | `adr/0009-minimal-base-on-demand-layered-provisioning.md` | ADR 0009 - Minimal sandbox base + on-demand, layered, cached provisioning |
-| architecture decision | `adr/0010-fleet-ide-cutover-parity-matrix.md` | ADR 0010 — Fleet IDE Cut-over and Parity Matrix |
-| architecture decision | `adr/0011-hub-review-verification-scope.md` | ADR 0011 - Hub review verification uses affected tests |
-| architecture decision | `adr/0012-hybrid-native-steward-containerized-execution.md` | ADR 0012 - Native node steward with containerized task execution |
-| architecture decision | `adr/0013-authoritative-hub-allocator.md` | ADR 0013 - One authoritative hub allocator |
-| architecture decision | `adr/0014-visibility-is-not-a-dispatch-gate.md` | ADR 0014: Agent visibility is a communication boundary, not a dispatch gate |
-| architecture decision | `adr/0015-macos-nodes-are-host-installs.md` | ADR 0015: macOS nodes are host installs, not containers |
-| architecture decision | `adr/0016-agent-initiated-review.md` | ADR 0016 - Agents decide what a task needs; review is agent-initiated |
-| architecture decision | `adr/0017-token-spend-is-metered-at-the-router.md` | ADR 0017 - Token spend is metered at the router, not reported by the client |
-| architecture decision | `adr/0018-task-graph-progressive-disclosure.md` | ADR 0018 - The task view is a graph under progressive disclosure, not a board |
-| architecture decision | `adr/0019-privilege-is-an-acl-on-a-resource-tree.md` | ADR 0019 - Privilege is an ACL on a resource tree, not a bag of scopes |
-| architecture decision | `adr/0020-a-running-task-is-not-editable.md` | ADR 0020 - A running task is not editable; stop it first |
-| architecture decision | `adr/0021-schema-changes-need-versioned-migrations.md` | ADR 0021 - Schema changes need versioned migrations, not an append-only helper list |
-| architecture decision | `adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md` | ADR 0022 - A gate returns a named decision, not a boolean |
-| architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | ADR 0023 - One skill source, thin plugins per coding harness |
-| architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | ADR 0024 - The dashboard streams the bus, not just its counts |
-| architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
-| architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | ADR 0026: Every operation on a first-class object emits a bus event |
-| architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | ADR 0027: Upgrades are versioned, ordered, and fail closed |
-| architecture decision | `adr/0028-installation-is-a-package-not-a-push.md` | ADR 0028: Installation is a verified package plus enrollment, not a push |
-| architecture decision | `adr/0029-the-route-search-path-is-a-fleet-contract.md` | ADR 0029: The coding-route search path is a fleet contract, not per-worker environment |
-| architecture decision | `adr/0030-langchain-extracts-before-qdrant.md` | ADR 0030: LangChain extracts meaning on the agent; hub Qdrant only stores the extract |
-| architecture decision | `adr/0031-codegraph-is-a-hint.md` | ADR 0031: CodeGraph is a hint when the tool and `.codegraph/` exist, not a hard gate |
-| supplemental reference | `agent-lifecycle-proof.md` | Agent Lifecycle Proof |
-| historical archive | `archive/field-notes/assessment-2026-08-02.md` | Can MAC do work? — fleet assessment, 2026-08-02 |
-| historical archive | `archive/field-notes/assessment-task-1b6783.md` | Assessment: task_1b67831356c347c3a91d782982f47d1c |
-| historical archive | `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md` | Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8 |
-| historical archive | `archive/field-notes/assessment-task-7023d6.md` | Assessment: task_7023d6a7ef6e4bbf8f6c2da523a4320f |
-| historical archive | `archive/field-notes/assessment-task-83f38e.md` | Assessment: task_83f38e9754f64908a316cccba0952329 |
-| historical archive | `archive/field-notes/assessment-task-8bf378.md` | Assessment: task_8bf37845abf445149d99fb4a1e3a41d5 |
-| historical archive | `archive/field-notes/assessment-task-97627e.md` | Resolution: task_97627e43b1034100831e726f8981e5e2 |
-| historical archive | `archive/field-notes/assessment-task-a33145.md` | Assessment: task_a33145a37db34ffeb55a0db61797df5c |
-| historical archive | `archive/field-notes/assessment-task-a608f4.md` | Assessment: task_a608f4405b0446a3b28ed7a8beb4fd65 |
-| historical archive | `archive/field-notes/assessment-task-b07fbf.md` | Assessment: task_b07fbff6994e41a39ce24157f1832ad5 |
-| historical archive | `archive/field-notes/assessment-task-de3502.md` | Assessment: task_de35029099d34c94be186c8992ee706a |
-| historical archive | `archive/field-notes/assessment-task-f6a813.md` | Assessment: task_f6a813fede7841d28b154af3a544864a |
-| historical archive | `archive/field-notes/assessment-task-f9cd72.md` | Assessment: task_f9cd72342aef4e7b8701b131b12d29ff |
-| historical archive | `archive/field-notes/closeout-dreamrepair-3dc2cf-openclaw-fleet-rollout.md` | Close-Out: dream finding `dreamrepair:3dc2cf317ea21e032952a355c3550f88` (openclaw_fleet_rollout deliverable) |
-| historical archive | `archive/field-notes/closeout-dreamrepair-5404b15-skill.md` | Close-Out: dream finding `dreamrepair:5404b15fffa355d739c21e138c5cc122` (skill subsystem) |
-| historical archive | `archive/field-notes/closeout-dreamrepair-965c6e89-openclaw-fleet-rollout.md` | Close-Out: dream finding `dreamrepair:965c6e89c762d29f07df25aafd3ac96f` (openclaw_fleet_rollout deliverable) |
-| historical archive | `archive/field-notes/closeout-review-finalize-verify-prerequisite.md` | Close-Out: dream-finding review finalize/verify prerequisite |
-| historical archive | `archive/field-notes/closeout-task-9c83aa5b-skill.md` | Close-Out: low-confidence dream finding `skill` (parent `task_9c83aa5b`) — CLOSE, NOT ACTIONABLE |
-| historical archive | `archive/field-notes/contract-verify-environment-failure-finding.md` | Contract-verify environment failure investigation finding |
-| historical archive | `archive/field-notes/crash-incident-finding.md` | Crash incident investigation finding |
-| historical archive | `archive/field-notes/disposition-dreamrepair-c8dd8037-skill.md` | Disposition: dream finding `dreamrepair:c8dd80378a16692ba4e0cd5ef57f2bf1` (skill subsystem) |
-| historical archive | `archive/field-notes/disposition-dreamrepair-ecd3548-skill.md` | Disposition: low-confidence dream finding `skill` (`dreamrepair:ecd3548120e07c38d04e46f0c62e16dd`) — CLOSE, NOT ACTIONABLE |
-| historical archive | `archive/field-notes/disposition-hgx-session-c0b2f9fd4e0b.md` | Disposition: HGX session `c0b2f9fd4e0b` — workspace/PVC inventory, preservation, and convert-in-place feasibility |
-| historical archive | `archive/field-notes/disposition-hgx-session-c902fab4d55f.md` | Disposition: HGX session `c902fab4d55f` — workspace/PVC inventory, preservation, and convert-in-place feasibility |
-| historical archive | `archive/field-notes/disposition-task-394db89d-slack.md` | Disposition: low-confidence dream finding `slack` (`dreamrepair:394db89d377ef58abf97ace7d54d728c`) — not actionable |
-| historical archive | `archive/field-notes/disposition-task-46eb6c-skill-env-prereqs.md` | Disposition: skill environment-prerequisite finding — smallest repair applied |
-| historical archive | `archive/field-notes/disposition-task-9c83aa5b-skill.md` | Disposition: low-confidence dream finding `skill` (parent `task_9c83aa5b`) — not actionable |
-| historical archive | `archive/field-notes/disposition-task-c3a30819-skill.md` | Disposition: low-confidence dream finding `skill` (`dreamrepair:828e1ef4a530935a9a7db4b1807202e1`) — not actionable |
-| historical archive | `archive/field-notes/disposition-task-cc1dedb0-slack.md` | Disposition: low-confidence dream finding `slack` (`dreamrepair:cc1dedb0d3036d289aafc1e42b4a22aa`) — not actionable |
-| historical archive | `archive/field-notes/dream-finding-3dc2cf.md` | Dream-Finding Assessment: dreamrepair:3dc2cf317ea21e032952a355c3550f88 |
-| historical archive | `archive/field-notes/dream-finding-58afe2-openclaw-entrypoint-ready-token.md` | Dream-Finding Assessment: dreamrepair:58afe279d34e186ee4d6d6125532371c |
-| historical archive | `archive/field-notes/dream-finding-6d1b5b.md` | Dream-Finding Assessment: dreamrepair:6d1b5bbe0a13515fef0bd061ef001119 |
-| historical archive | `archive/field-notes/dream-finding-805aed7.md` | Dream-Finding Assessment: dreamrepair:805aed758e12f0f95cf0c3dbf39811ce |
-| historical archive | `archive/field-notes/dream-finding-965c6e89.md` | Ground Truth: dream finding `dreamrepair:965c6e89c762d29f07df25aafd3ac96f` (openclaw_fleet_rollout deliverable) |
-| historical archive | `archive/field-notes/dream-stalled-finalizer-recovery-finding.md` | Dream-repair review finding: stalled-finalizer recovery |
-| historical archive | `archive/field-notes/dream-triage-828e1ef4.md` | Triage: Dream Finding `dreamrepair:828e1ef4a530935a9a7db4b1807202e1` |
-| historical archive | `archive/field-notes/findings-crash-1fc349e1-startup-selftest-attestation-gap.md` | Findings: startup self-test attestation-gap crash (crash_1fc349e109ed4ff9885acf1c8ba99948) |
-| historical archive | `archive/field-notes/findings-crash-591645a3-startup-selftest-timeout.md` | Findings: startup self-test transient-timeout crash (crash_591645a352fc4d54bf5e3f99384da7dc) |
-| historical archive | `archive/field-notes/findings-crash-mac-agent-service-62021be0.md` | Findings: mac-agent-service startup self-test crash (62021be0) |
-| historical archive | `archive/field-notes/findings-crash-service-unknown-crash-path.md` | Findings: crash_service "unknown" crash path (ground truth for parent P0 crash-repair) |
-| historical archive | `archive/field-notes/fleet-ide-workbench-plan.md` | Fleet Workbench — Clean-Slate IDE Plan |
-| historical archive | `archive/field-notes/forensics-task-643b33ee1c7b4a4ab7a81bf8d5af34a4.md` | Forensics: Diagnose 90s Dispatch Delay for CLI-Created Probe Task |
-| historical archive | `archive/field-notes/forensics-task-a32a35e90ab0434e8c7766057b268bc6.md` | Root-Cause Report: Silent Executor Insta-Block for task_a32a35e90ab0434e8c7766057b268bc6 |
-| historical archive | `archive/field-notes/haskell_migration.md` | A Notional Haskell Migration Plan for MAC |
-| historical archive | `archive/field-notes/investigation-dream-skill-generic-area-bucket.md` | Investigation: dream finding with a generic `skill` affected label — placeholder area bucket, not a defect location |
-| historical archive | `archive/field-notes/investigation-dream-skill-tool_or_skill_name-actionability.md` | Investigation: dream `tool_or_skill_name` (skill) finding — actionability & root signal |
-| historical archive | `archive/field-notes/investigation-dream-tests-generic-area-bucket.md` | Investigation: dream finding `dreamrepair:173ce952` with a generic `tests` affected label — placeholder area bucket, not a defect location |
-| historical archive | `archive/field-notes/investigation-dreamrepair-394db89d-slack.md` | Ground Truth: dream finding `dreamrepair:394db89d377ef58abf97ace7d54d728c` (slack failure_pattern) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-477446f5-slack.md` | Ground Truth: dream finding `dreamrepair:477446f5c8b8bf1972f2ad31444c956b` (slack failure_pattern) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-4c4429b-scripts-openclaw.md` | Investigation: dream finding `dreamrepair:4c4429bc` (scripts / openclaw_fleet_rollout audit) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-5404b15-skill.md` | Investigation: dream finding `dreamrepair:5404b15fffa355d739c21e138c5cc122` (skill subsystem) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-71b00e8-slack.md` | Ground Truth: dream finding `dreamrepair:71b00e8122761c2caeacd04c7ed3f49c` (slack display-label trace) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-c8dd8037-skill.md` | Investigation: dream finding `dreamrepair:c8dd80378a16692ba4e0cd5ef57f2bf1` (skill subsystem) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-cc1dedb0-slack.md` | Ground Truth: dream finding `dreamrepair:cc1dedb0d3036d289aafc1e42b4a22aa` (slack failure_pattern) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-d94ad78-skill.md` | Investigation: dream finding `dreamrepair:d94ad78027c32d4825923f0ba91e9497` (skill) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-da0ac0f3-slack.md` | Ground Truth: dream finding `dreamrepair:da0ac0f3cab187290c91e5b26a6c5b9f` (slack failure_pattern) |
-| historical archive | `archive/field-notes/investigation-dreamrepair-ffbc63f8-skill.md` | Investigation: dream finding `dreamrepair:ffbc63f8695e9316b064bb1f6d3566cb` (skill) |
-| historical archive | `archive/field-notes/investigation-predispatch-conflict-5a43ad.md` | Investigation: `predispatch_conflict.py` failure-pattern (dream finding) |
-| historical archive | `archive/field-notes/investigation-review-finalize-verify-prerequisite.md` | Investigation: dream-finding review finalize/verify prerequisite ground truth |
-| historical archive | `archive/field-notes/investigation-task-2284f3-env-prerequisite-false-positive.md` | Investigation: mac environment-prerequisite finding is a classifier false positive |
-| historical archive | `archive/field-notes/investigation-task-b6ddd8-skill-env-prereqs.md` | Investigation: skills environment-prerequisite behavior vs. the finding |
-| historical archive | `archive/field-notes/investigation-task-ed7b0b-new-file-staging-finalizer.md` | Investigation: new-file staging finalizer ground truth (task_ed7b0b) |
-| historical archive | `archive/field-notes/investigation-task-f869c0-new-file-staging-finalizer.md` | Investigation: new-file staging finalizer ground truth (task_f869c0) |
-| historical archive | `archive/field-notes/job-per-task-roles-spec-review.md` | Review: docs/job-per-task-roles-spec.md |
-| historical archive | `archive/field-notes/job-per-task-roles-spec.md` | Job-per-task Role Specialisation — Design Spec |
-| historical archive | `archive/field-notes/k8s-native-rewrite-plan.md` | Kubernetes-native rewrite plan |
-| historical archive | `archive/field-notes/linear-bridge-spec-review.md` | Linear Bridge Spec — Review Notes |
-| historical archive | `archive/field-notes/linear-bridge-spec.md` | Linear Bridge — Design Spec |
-| historical archive | `archive/field-notes/mac-task-bd-parity-audit.md` | `mac task` ↔ `bd` (beads) functional-parity audit |
-| historical archive | `archive/field-notes/metadata-sync-assessment.md` | Metadata sync assessment (post-bd-bridge) |
-| historical archive | `archive/field-notes/prereq-task-029665.md` | Preflight: HGX auth path, fleet baseline, and standard-dind fungible reference |
-| historical archive | `archive/field-notes/prereq-task-403ed263.md` | Prerequisite Verification: task_403ed263ed7e45c6b7624345005a097c |
-| historical archive | `archive/field-notes/prereq-task-e94f546c.md` | Prerequisite Investigation: task_e94f546cf9dc41409d4a9fe6b8b39dcd |
-| historical archive | `archive/field-notes/prereq-task-fd2f34.md` | Prerequisite Investigation: task_fd2f34b64823410c84a14fc0345610ff |
-| historical archive | `archive/field-notes/provenance-dreamrepair-77fc3e59-slack.md` | Provenance: low-confidence dream finding `slack` (`dreamrepair:77fc3e59014ba0d7950d22387f0204a0`) — self-referential evidence chain, no concrete defect |
-| historical archive | `archive/field-notes/quickstart-gap-analysis.md` | Quickstart Gap Analysis |
-| historical archive | `archive/field-notes/replace-hgx-session-c902fab4d55f.md` | Field note: HGX session `c902fab4d55f` — realize capacity via preserve-nothing + REPLACE |
-| historical archive | `archive/field-notes/scaling-plan.md` | Scaling Plan |
-| historical archive | `archive/index.md` | Historical archive |
-| supplemental reference | `audit.md` | MAC Codebase Audit — Active Code, Duplication & Accretion |
-| supplemental reference | `authority-boundary.md` | Who owns which authority question |
-| book | `book/01-system.md` | MAC as a System |
-| book | `book/02-local-start.md` | Install and Start Locally |
-| book | `book/03-projects-and-tasks.md` | Projects and Tasks |
-| book | `book/04-machines-and-agents.md` | Machines and Agents |
-| book | `book/05-evidence-review-completion.md` | Evidence, Review, and Completion |
-| book | `book/06-hermes-and-ide.md` | Hermes and the Fleet IDE |
-| book | `book/07-repository-contracts.md` | Repository Contracts |
-| book | `book/08-plans-and-dags.md` | Plans and Task DAGs |
-| book | `book/09-fleet-onboarding.md` | Heterogeneous Fleet Onboarding |
-| book | `book/10-identity-and-secrets.md` | Identity, Credentials, and Secrets |
-| book | `book/11-publication-and-refs.md` | Review, Publication, and Ref Hygiene |
-| book | `book/12-operations.md` | Operating the Fleet |
-| book | `book/13-deployment-topologies.md` | Deployment Topologies |
-| book | `book/14-images-and-cutover.md` | Qualified Images and Synchronized Cutover |
-| book | `book/15-sandboxed-runtimes.md` | Sandboxed Agent Runtimes |
-| book | `book/16-apis-and-integrations.md` | APIs, AgentBus, and Integrations |
-| book | `book/17-learning-evals-scaling.md` | Learning, Evals, and Scaling |
-| book | `book/18-capstone.md` | From Request to Production |
-| runbook | `break-glass-host-recovery.md` | Break-glass host recovery |
-| supplemental reference | `c26-certifier-phase-profile-example.md` | c26 certifier phase-profile example |
-| supplemental reference | `client-bootstrap-contract.md` | SSH Client Bootstrap Contracts |
-| supplemental reference | `coding-cli-credentials.md` | Coding-CLI Credentials and Model Selection |
-| supplemental reference | `coding-route-ladder.md` | The coding-route ladder |
-| supplemental reference | `crash-diagnosis-and-repair.md` | Crash diagnosis and autonomous repair |
-| supplemental reference | `dashboard-connection.md` | Dashboard Connection Contract |
-| supplemental reference | `deploy-prerequisite-vs-phase1-audit.md` | Audit: prove deploy prerequisites before phase-1 mutation, preserve Python diagnostics |
-| supplemental reference | `dispatch-priority-bias-audit.md` | Dispatch priority bias ordering audit |
-| supplemental reference | `dream-repair-slack-lineage.md` | Ground truth: dream finding `dreamrepair:4becfa8d` (slack failure_pattern) |
-| supplemental reference | `dreaming-rewrite.md` | Dreaming, rewritten |
-| supplemental reference | `env-config-reference.md` | MAC environment configuration reference |
-| runbook | `fleet-cutover-transaction-protocol.md` | Fleet Cut-over Transaction Protocol |
-| supplemental reference | `fleet-directives.md` | Fleet directives |
-| runbook | `fleet-node-onboarding-checklist.md` | Fleet node onboarding checklist |
-| supplemental reference | `fleet-operational-learning.md` | Fleet operational learning |
-| supplemental reference | `fleet-registry-schema.md` | Fleet registry schema |
-| supplemental reference | `getting-started.md` | MAC Quickstart |
-| supplemental reference | `guide/01-architecture.md` | System Architecture |
-| supplemental reference | `guide/02-getting-started.md` | Getting Started |
-| supplemental reference | `guide/03-advanced.md` | Advanced Concepts |
-| supplemental reference | `guide/04-ui.md` | The UI |
-| supplemental reference | `guide/05-developer-guide.md` | Developer Guide |
-| supplemental reference | `guide/README.md` | mac documentation |
-| supplemental reference | `hermes-boundary.md` | Hermes Boundary |
-| supplemental reference | `hermes-integration.md` | Hermes Integration |
-| supplemental reference | `hermes-retirement-premises.md` | Testing the premises for retiring the vendored Hermes tree |
-| supplemental reference | `hermes-vendor-fate.md` | Fate of the vendored Hermes tree |
-| supplemental reference | `hgx-elastic-capacity.md` | HGX elastic capacity |
-| supplemental reference | `home-consolidation.md` | Home-Directory Consolidation: Analysis & Plan |
-| runbook | `hub-availability.md` | Hub Availability |
-| supplemental reference | `hub-host-saturation-remediation.md` | Hub-Host Saturation Remediation |
-| supplemental reference | `human-interface-selector.md` | The human interface: support both, activate one |
-| supplemental reference | `image-publication-and-qualification.md` | Image Publication and Pre-Publication Qualification |
-| supplemental reference | `in-flight-agent-messages.md` | Reaching an agent that is already working |
-| landing page | `index.md` | MAC: trustworthy work across an agent fleet |
-| supplemental reference | `integration-authority-contract.md` | Integration Authority Contract |
-| supplemental reference | `memory-tier-schema.md` | MAC vector memory tier — schema, collections, model, TTLs |
-| supplemental reference | `memory-tier-verification.md` | Memory tier — end-to-end verification |
-| supplemental reference | `notifier-configuration-guide.md` | Notifier Configuration Guide |
-| supplemental reference | `oneshot-isolation-gate-verification.md` | Oneshot isolation — contract gate verification |
-| supplemental reference | `openclaw-identities.md` | OpenClaw public identities and fleet representation |
-| supplemental reference | `openshell-nemo-relay-e2e.md` | OpenShell + NeMo Relay: container-contract verification |
-| supplemental reference | `openshell-nemo-relay-integration.md` | OpenShell + NeMo Relay integration |
-| supplemental reference | `openshell-sandbox.md` | Running Hermes under the OpenShell sandbox |
-| runbook | `production-deployment.md` | Production Deployment |
-| generated reference | `reference/cli.md` | Command-line reference |
-| generated reference | `reference/documentation-inventory.md` | Documentation inventory |
-| generated reference | `reference/openapi.md` | HTTP API reference |
-| generated reference | `reference/staged-module-integration-audit.md` | Staged-but-unwired `src/mac` module integration audit |
-| supplemental reference | `repository-cicd-monitor.md` | Repository CI/CD lifecycle monitoring |
-| supplemental reference | `repository-ref-hygiene.md` | Managed Repository Ref Hygiene |
-| supplemental reference | `repository-runtime-contract.md` | Repository Runtime Contract |
-| supplemental reference | `review-strategy-experiments.md` | Review-strategy experiments |
-| supplemental reference | `scientific-optimizer.md` | Autonomous scientific optimizer |
-| supplemental reference | `secrets-management-guide.md` | Secrets Management Guide |
-| supplemental reference | `security/openshell-0.0.72-compatibility-review.mdx` | OpenShell 0.0.72 Compatibility Review |
-| runbook | `soul-preservation-runbook.md` | Soul Preservation Runbook |
-| supplemental reference | `structured-task-bodies.md` | Structured task bodies: actions on a Component |
-| historical archive | `superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md` | Autonomous Project Routing and Review/Fix Loop Implementation Plan |
-| historical archive | `superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md` | Autonomous Project Routing and Review/Fix Loop Design |
-| historical archive | `superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md` | K8s bootstrap fleet registration — design |
-| runbook | `synchronized-fleet-cutover.md` | Synchronized Fleet Cut-over |
-| supplemental reference | `task-dependency-semantics.md` | Task dependency failure semantics |
-| supplemental reference | `task-throughput-observability.md` | Task throughput observability |
-| supplemental reference | `testing-strategy.md` | Test portfolio strategy |
+| supplemental reference | [`activation-probe/calibration-spec.md`](../activation-probe/calibration-spec.md) | Held-out calibration protocol |
+| supplemental reference | [`activation-probe/classifier-spec.md`](../activation-probe/classifier-spec.md) | External activation-probe classifier contract |
+| supplemental reference | [`activation-probe/integration-guide.md`](../activation-probe/integration-guide.md) | External activation-probe worker integration |
+| supplemental reference | [`activation-probe/prototype-report.md`](../activation-probe/prototype-report.md) | External activation-probe prototype |
+| supplemental reference | [`activation-probe/runtime-selection.md`](../activation-probe/runtime-selection.md) | External activation capture runtime |
+| architecture decision | [`adr/0001-unify-hermes-runtime-into-mac.md`](../adr/0001-unify-hermes-runtime-into-mac.md) | ADR 0001 — Unify the Hermes runtime into the `mac` monorepo |
+| architecture decision | [`adr/0002-memory-store-at-scale.md`](../adr/0002-memory-store-at-scale.md) | ADR 0002 — Memory store / vector tier at fleet scale (50–200 agents per hub) |
+| architecture decision | [`adr/0003-tokenhub-core-into-mac.md`](../adr/0003-tokenhub-core-into-mac.md) | ADR 0003 — Optional in-mac model router + vault (revisiting TokenHub's boundary) |
+| architecture decision | [`adr/0004-task-ledger-vs-hermes-kanban.md`](../adr/0004-task-ledger-vs-hermes-kanban.md) | ADR 0004 — One task database: revert the Hermes kanban adoption, keep our own board |
+| architecture decision | [`adr/0005-elastic-executor-tier-vs-static-fleet.md`](../adr/0005-elastic-executor-tier-vs-static-fleet.md) | ADR 0005 — Elastic executor tier vs. the static fleet (and "every agent is a GitHub runner") |
+| architecture decision | [`adr/0006-acp-support.md`](../adr/0006-acp-support.md) | ADR 0006 — Agent Client Protocol (ACP) support |
+| architecture decision | [`adr/0007-hermes-boundary-mood-nap-soul-memory.md`](../adr/0007-hermes-boundary-mood-nap-soul-memory.md) | ADR 0007 — Per-module ownership: mood_policy, nap_consolidator, soul_snapshot, memory_vetting |
+| architecture decision | [`adr/0008-openshell-docker-engine-runtime.md`](../adr/0008-openshell-docker-engine-runtime.md) | ADR 0008 - OpenShell uses Docker Engine/Moby as its only container runtime |
+| architecture decision | [`adr/0009-minimal-base-on-demand-layered-provisioning.md`](../adr/0009-minimal-base-on-demand-layered-provisioning.md) | ADR 0009 - Minimal sandbox base + on-demand, layered, cached provisioning |
+| architecture decision | [`adr/0010-fleet-ide-cutover-parity-matrix.md`](../adr/0010-fleet-ide-cutover-parity-matrix.md) | ADR 0010 — Fleet IDE Cut-over and Parity Matrix |
+| architecture decision | [`adr/0011-hub-review-verification-scope.md`](../adr/0011-hub-review-verification-scope.md) | ADR 0011 - Hub review verification uses affected tests |
+| architecture decision | [`adr/0012-hybrid-native-steward-containerized-execution.md`](../adr/0012-hybrid-native-steward-containerized-execution.md) | ADR 0012 - Native node steward with containerized task execution |
+| architecture decision | [`adr/0013-authoritative-hub-allocator.md`](../adr/0013-authoritative-hub-allocator.md) | ADR 0013 - One authoritative hub allocator |
+| architecture decision | [`adr/0014-visibility-is-not-a-dispatch-gate.md`](../adr/0014-visibility-is-not-a-dispatch-gate.md) | ADR 0014: Agent visibility is a communication boundary, not a dispatch gate |
+| architecture decision | [`adr/0015-macos-nodes-are-host-installs.md`](../adr/0015-macos-nodes-are-host-installs.md) | ADR 0015: macOS nodes are host installs, not containers |
+| architecture decision | [`adr/0016-agent-initiated-review.md`](../adr/0016-agent-initiated-review.md) | ADR 0016 - Agents decide what a task needs; review is agent-initiated |
+| architecture decision | [`adr/0017-token-spend-is-metered-at-the-router.md`](../adr/0017-token-spend-is-metered-at-the-router.md) | ADR 0017 - Token spend is metered at the router, not reported by the client |
+| architecture decision | [`adr/0018-task-graph-progressive-disclosure.md`](../adr/0018-task-graph-progressive-disclosure.md) | ADR 0018 - The task view is a graph under progressive disclosure, not a board |
+| architecture decision | [`adr/0019-privilege-is-an-acl-on-a-resource-tree.md`](../adr/0019-privilege-is-an-acl-on-a-resource-tree.md) | ADR 0019 - Privilege is an ACL on a resource tree, not a bag of scopes |
+| architecture decision | [`adr/0020-a-running-task-is-not-editable.md`](../adr/0020-a-running-task-is-not-editable.md) | ADR 0020 - A running task is not editable; stop it first |
+| architecture decision | [`adr/0021-schema-changes-need-versioned-migrations.md`](../adr/0021-schema-changes-need-versioned-migrations.md) | ADR 0021 - Schema changes need versioned migrations, not an append-only helper list |
+| architecture decision | [`adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md`](../adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md) | ADR 0022 - A gate returns a named decision, not a boolean |
+| architecture decision | [`adr/0023-one-skill-source-many-harness-plugins.md`](../adr/0023-one-skill-source-many-harness-plugins.md) | ADR 0023 - One skill source, thin plugins per coding harness |
+| architecture decision | [`adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md`](../adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md) | ADR 0024 - The dashboard streams the bus, not just its counts |
+| architecture decision | [`adr/0025-the-hub-ui-is-the-observability-console.md`](../adr/0025-the-hub-ui-is-the-observability-console.md) | ADR 0025 - The hub UI is the observability console; `ide/` is an unshipped prototype |
+| architecture decision | [`adr/0026-first-class-operations-emit-bus-events.md`](../adr/0026-first-class-operations-emit-bus-events.md) | ADR 0026: Every operation on a first-class object emits a bus event |
+| architecture decision | [`adr/0027-upgrades-are-versioned-and-fail-closed.md`](../adr/0027-upgrades-are-versioned-and-fail-closed.md) | ADR 0027: Upgrades are versioned, ordered, and fail closed |
+| architecture decision | [`adr/0028-installation-is-a-package-not-a-push.md`](../adr/0028-installation-is-a-package-not-a-push.md) | ADR 0028: Installation is a verified package plus enrollment, not a push |
+| supplemental reference | [`agent-lifecycle-proof.md`](../agent-lifecycle-proof.md) | Agent Lifecycle Proof |
+| historical archive | [`archive/field-notes/assessment-2026-08-02.md`](../archive/field-notes/assessment-2026-08-02.md) | Can MAC do work? — fleet assessment, 2026-08-02 |
+| historical archive | [`archive/field-notes/assessment-task-1b6783.md`](../archive/field-notes/assessment-task-1b6783.md) | Assessment: task_1b67831356c347c3a91d782982f47d1c |
+| historical archive | [`archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md`](../archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md) | Assessment: task_21e77194d5fe4fd3963b8b1a61ece9d8 |
+| historical archive | [`archive/field-notes/assessment-task-7023d6.md`](../archive/field-notes/assessment-task-7023d6.md) | Assessment: task_7023d6a7ef6e4bbf8f6c2da523a4320f |
+| historical archive | [`archive/field-notes/assessment-task-83f38e.md`](../archive/field-notes/assessment-task-83f38e.md) | Assessment: task_83f38e9754f64908a316cccba0952329 |
+| historical archive | [`archive/field-notes/assessment-task-8bf378.md`](../archive/field-notes/assessment-task-8bf378.md) | Assessment: task_8bf37845abf445149d99fb4a1e3a41d5 |
+| historical archive | [`archive/field-notes/assessment-task-97627e.md`](../archive/field-notes/assessment-task-97627e.md) | Resolution: task_97627e43b1034100831e726f8981e5e2 |
+| historical archive | [`archive/field-notes/assessment-task-a33145.md`](../archive/field-notes/assessment-task-a33145.md) | Assessment: task_a33145a37db34ffeb55a0db61797df5c |
+| historical archive | [`archive/field-notes/assessment-task-a608f4.md`](../archive/field-notes/assessment-task-a608f4.md) | Assessment: task_a608f4405b0446a3b28ed7a8beb4fd65 |
+| historical archive | [`archive/field-notes/assessment-task-b07fbf.md`](../archive/field-notes/assessment-task-b07fbf.md) | Assessment: task_b07fbff6994e41a39ce24157f1832ad5 |
+| historical archive | [`archive/field-notes/assessment-task-de3502.md`](../archive/field-notes/assessment-task-de3502.md) | Assessment: task_de35029099d34c94be186c8992ee706a |
+| historical archive | [`archive/field-notes/assessment-task-f6a813.md`](../archive/field-notes/assessment-task-f6a813.md) | Assessment: task_f6a813fede7841d28b154af3a544864a |
+| historical archive | [`archive/field-notes/assessment-task-f9cd72.md`](../archive/field-notes/assessment-task-f9cd72.md) | Assessment: task_f9cd72342aef4e7b8701b131b12d29ff |
+| historical archive | [`archive/field-notes/closeout-dreamrepair-3dc2cf-openclaw-fleet-rollout.md`](../archive/field-notes/closeout-dreamrepair-3dc2cf-openclaw-fleet-rollout.md) | Close-Out: dream finding `dreamrepair:3dc2cf317ea21e032952a355c3550f88` (openclaw_fleet_rollout deliverable) |
+| historical archive | [`archive/field-notes/closeout-dreamrepair-5404b15-skill.md`](../archive/field-notes/closeout-dreamrepair-5404b15-skill.md) | Close-Out: dream finding `dreamrepair:5404b15fffa355d739c21e138c5cc122` (skill subsystem) |
+| historical archive | [`archive/field-notes/closeout-dreamrepair-965c6e89-openclaw-fleet-rollout.md`](../archive/field-notes/closeout-dreamrepair-965c6e89-openclaw-fleet-rollout.md) | Close-Out: dream finding `dreamrepair:965c6e89c762d29f07df25aafd3ac96f` (openclaw_fleet_rollout deliverable) |
+| historical archive | [`archive/field-notes/closeout-review-finalize-verify-prerequisite.md`](../archive/field-notes/closeout-review-finalize-verify-prerequisite.md) | Close-Out: dream-finding review finalize/verify prerequisite |
+| historical archive | [`archive/field-notes/closeout-task-9c83aa5b-skill.md`](../archive/field-notes/closeout-task-9c83aa5b-skill.md) | Close-Out: low-confidence dream finding `skill` (parent `task_9c83aa5b`) — CLOSE, NOT ACTIONABLE |
+| historical archive | [`archive/field-notes/contract-verify-environment-failure-finding.md`](../archive/field-notes/contract-verify-environment-failure-finding.md) | Contract-verify environment failure investigation finding |
+| historical archive | [`archive/field-notes/crash-incident-finding.md`](../archive/field-notes/crash-incident-finding.md) | Crash incident investigation finding |
+| historical archive | [`archive/field-notes/disposition-dreamrepair-c8dd8037-skill.md`](../archive/field-notes/disposition-dreamrepair-c8dd8037-skill.md) | Disposition: dream finding `dreamrepair:c8dd80378a16692ba4e0cd5ef57f2bf1` (skill subsystem) |
+| historical archive | [`archive/field-notes/disposition-dreamrepair-ecd3548-skill.md`](../archive/field-notes/disposition-dreamrepair-ecd3548-skill.md) | Disposition: low-confidence dream finding `skill` (`dreamrepair:ecd3548120e07c38d04e46f0c62e16dd`) — CLOSE, NOT ACTIONABLE |
+| historical archive | [`archive/field-notes/disposition-hgx-session-c0b2f9fd4e0b.md`](../archive/field-notes/disposition-hgx-session-c0b2f9fd4e0b.md) | Disposition: HGX session `c0b2f9fd4e0b` — workspace/PVC inventory, preservation, and convert-in-place feasibility |
+| historical archive | [`archive/field-notes/disposition-hgx-session-c902fab4d55f.md`](../archive/field-notes/disposition-hgx-session-c902fab4d55f.md) | Disposition: HGX session `c902fab4d55f` — workspace/PVC inventory, preservation, and convert-in-place feasibility |
+| historical archive | [`archive/field-notes/disposition-task-394db89d-slack.md`](../archive/field-notes/disposition-task-394db89d-slack.md) | Disposition: low-confidence dream finding `slack` (`dreamrepair:394db89d377ef58abf97ace7d54d728c`) — not actionable |
+| historical archive | [`archive/field-notes/disposition-task-46eb6c-skill-env-prereqs.md`](../archive/field-notes/disposition-task-46eb6c-skill-env-prereqs.md) | Disposition: skill environment-prerequisite finding — smallest repair applied |
+| historical archive | [`archive/field-notes/disposition-task-9c83aa5b-skill.md`](../archive/field-notes/disposition-task-9c83aa5b-skill.md) | Disposition: low-confidence dream finding `skill` (parent `task_9c83aa5b`) — not actionable |
+| historical archive | [`archive/field-notes/disposition-task-c3a30819-skill.md`](../archive/field-notes/disposition-task-c3a30819-skill.md) | Disposition: low-confidence dream finding `skill` (`dreamrepair:828e1ef4a530935a9a7db4b1807202e1`) — not actionable |
+| historical archive | [`archive/field-notes/disposition-task-cc1dedb0-slack.md`](../archive/field-notes/disposition-task-cc1dedb0-slack.md) | Disposition: low-confidence dream finding `slack` (`dreamrepair:cc1dedb0d3036d289aafc1e42b4a22aa`) — not actionable |
+| historical archive | [`archive/field-notes/dream-finding-3dc2cf.md`](../archive/field-notes/dream-finding-3dc2cf.md) | Dream-Finding Assessment: dreamrepair:3dc2cf317ea21e032952a355c3550f88 |
+| historical archive | [`archive/field-notes/dream-finding-58afe2-openclaw-entrypoint-ready-token.md`](../archive/field-notes/dream-finding-58afe2-openclaw-entrypoint-ready-token.md) | Dream-Finding Assessment: dreamrepair:58afe279d34e186ee4d6d6125532371c |
+| historical archive | [`archive/field-notes/dream-finding-6d1b5b.md`](../archive/field-notes/dream-finding-6d1b5b.md) | Dream-Finding Assessment: dreamrepair:6d1b5bbe0a13515fef0bd061ef001119 |
+| historical archive | [`archive/field-notes/dream-finding-805aed7.md`](../archive/field-notes/dream-finding-805aed7.md) | Dream-Finding Assessment: dreamrepair:805aed758e12f0f95cf0c3dbf39811ce |
+| historical archive | [`archive/field-notes/dream-finding-965c6e89.md`](../archive/field-notes/dream-finding-965c6e89.md) | Ground Truth: dream finding `dreamrepair:965c6e89c762d29f07df25aafd3ac96f` (openclaw_fleet_rollout deliverable) |
+| historical archive | [`archive/field-notes/dream-stalled-finalizer-recovery-finding.md`](../archive/field-notes/dream-stalled-finalizer-recovery-finding.md) | Dream-repair review finding: stalled-finalizer recovery |
+| historical archive | [`archive/field-notes/dream-triage-828e1ef4.md`](../archive/field-notes/dream-triage-828e1ef4.md) | Triage: Dream Finding `dreamrepair:828e1ef4a530935a9a7db4b1807202e1` |
+| historical archive | [`archive/field-notes/findings-crash-1fc349e1-startup-selftest-attestation-gap.md`](../archive/field-notes/findings-crash-1fc349e1-startup-selftest-attestation-gap.md) | Findings: startup self-test attestation-gap crash (crash_1fc349e109ed4ff9885acf1c8ba99948) |
+| historical archive | [`archive/field-notes/findings-crash-591645a3-startup-selftest-timeout.md`](../archive/field-notes/findings-crash-591645a3-startup-selftest-timeout.md) | Findings: startup self-test transient-timeout crash (crash_591645a352fc4d54bf5e3f99384da7dc) |
+| historical archive | [`archive/field-notes/findings-crash-mac-agent-service-62021be0.md`](../archive/field-notes/findings-crash-mac-agent-service-62021be0.md) | Findings: mac-agent-service startup self-test crash (62021be0) |
+| historical archive | [`archive/field-notes/findings-crash-service-unknown-crash-path.md`](../archive/field-notes/findings-crash-service-unknown-crash-path.md) | Findings: crash_service "unknown" crash path (ground truth for parent P0 crash-repair) |
+| historical archive | [`archive/field-notes/fleet-ide-workbench-plan.md`](../archive/field-notes/fleet-ide-workbench-plan.md) | Fleet Workbench — Clean-Slate IDE Plan |
+| historical archive | [`archive/field-notes/forensics-task-643b33ee1c7b4a4ab7a81bf8d5af34a4.md`](../archive/field-notes/forensics-task-643b33ee1c7b4a4ab7a81bf8d5af34a4.md) | Forensics: Diagnose 90s Dispatch Delay for CLI-Created Probe Task |
+| historical archive | [`archive/field-notes/forensics-task-a32a35e90ab0434e8c7766057b268bc6.md`](../archive/field-notes/forensics-task-a32a35e90ab0434e8c7766057b268bc6.md) | Root-Cause Report: Silent Executor Insta-Block for task_a32a35e90ab0434e8c7766057b268bc6 |
+| historical archive | [`archive/field-notes/haskell_migration.md`](../archive/field-notes/haskell_migration.md) | A Notional Haskell Migration Plan for MAC |
+| historical archive | [`archive/field-notes/investigation-dream-skill-generic-area-bucket.md`](../archive/field-notes/investigation-dream-skill-generic-area-bucket.md) | Investigation: dream finding with a generic `skill` affected label — placeholder area bucket, not a defect location |
+| historical archive | [`archive/field-notes/investigation-dream-skill-tool_or_skill_name-actionability.md`](../archive/field-notes/investigation-dream-skill-tool_or_skill_name-actionability.md) | Investigation: dream `tool_or_skill_name` (skill) finding — actionability & root signal |
+| historical archive | [`archive/field-notes/investigation-dream-tests-generic-area-bucket.md`](../archive/field-notes/investigation-dream-tests-generic-area-bucket.md) | Investigation: dream finding `dreamrepair:173ce952` with a generic `tests` affected label — placeholder area bucket, not a defect location |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-394db89d-slack.md`](../archive/field-notes/investigation-dreamrepair-394db89d-slack.md) | Ground Truth: dream finding `dreamrepair:394db89d377ef58abf97ace7d54d728c` (slack failure_pattern) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-477446f5-slack.md`](../archive/field-notes/investigation-dreamrepair-477446f5-slack.md) | Ground Truth: dream finding `dreamrepair:477446f5c8b8bf1972f2ad31444c956b` (slack failure_pattern) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-4c4429b-scripts-openclaw.md`](../archive/field-notes/investigation-dreamrepair-4c4429b-scripts-openclaw.md) | Investigation: dream finding `dreamrepair:4c4429bc` (scripts / openclaw_fleet_rollout audit) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-5404b15-skill.md`](../archive/field-notes/investigation-dreamrepair-5404b15-skill.md) | Investigation: dream finding `dreamrepair:5404b15fffa355d739c21e138c5cc122` (skill subsystem) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-71b00e8-slack.md`](../archive/field-notes/investigation-dreamrepair-71b00e8-slack.md) | Ground Truth: dream finding `dreamrepair:71b00e8122761c2caeacd04c7ed3f49c` (slack display-label trace) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-c8dd8037-skill.md`](../archive/field-notes/investigation-dreamrepair-c8dd8037-skill.md) | Investigation: dream finding `dreamrepair:c8dd80378a16692ba4e0cd5ef57f2bf1` (skill subsystem) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-cc1dedb0-slack.md`](../archive/field-notes/investigation-dreamrepair-cc1dedb0-slack.md) | Ground Truth: dream finding `dreamrepair:cc1dedb0d3036d289aafc1e42b4a22aa` (slack failure_pattern) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-d94ad78-skill.md`](../archive/field-notes/investigation-dreamrepair-d94ad78-skill.md) | Investigation: dream finding `dreamrepair:d94ad78027c32d4825923f0ba91e9497` (skill) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-da0ac0f3-slack.md`](../archive/field-notes/investigation-dreamrepair-da0ac0f3-slack.md) | Ground Truth: dream finding `dreamrepair:da0ac0f3cab187290c91e5b26a6c5b9f` (slack failure_pattern) |
+| historical archive | [`archive/field-notes/investigation-dreamrepair-ffbc63f8-skill.md`](../archive/field-notes/investigation-dreamrepair-ffbc63f8-skill.md) | Investigation: dream finding `dreamrepair:ffbc63f8695e9316b064bb1f6d3566cb` (skill) |
+| historical archive | [`archive/field-notes/investigation-predispatch-conflict-5a43ad.md`](../archive/field-notes/investigation-predispatch-conflict-5a43ad.md) | Investigation: `predispatch_conflict.py` failure-pattern (dream finding) |
+| historical archive | [`archive/field-notes/investigation-review-finalize-verify-prerequisite.md`](../archive/field-notes/investigation-review-finalize-verify-prerequisite.md) | Investigation: dream-finding review finalize/verify prerequisite ground truth |
+| historical archive | [`archive/field-notes/investigation-task-2284f3-env-prerequisite-false-positive.md`](../archive/field-notes/investigation-task-2284f3-env-prerequisite-false-positive.md) | Investigation: mac environment-prerequisite finding is a classifier false positive |
+| historical archive | [`archive/field-notes/investigation-task-b6ddd8-skill-env-prereqs.md`](../archive/field-notes/investigation-task-b6ddd8-skill-env-prereqs.md) | Investigation: skills environment-prerequisite behavior vs. the finding |
+| historical archive | [`archive/field-notes/investigation-task-ed7b0b-new-file-staging-finalizer.md`](../archive/field-notes/investigation-task-ed7b0b-new-file-staging-finalizer.md) | Investigation: new-file staging finalizer ground truth (task_ed7b0b) |
+| historical archive | [`archive/field-notes/investigation-task-f869c0-new-file-staging-finalizer.md`](../archive/field-notes/investigation-task-f869c0-new-file-staging-finalizer.md) | Investigation: new-file staging finalizer ground truth (task_f869c0) |
+| historical archive | [`archive/field-notes/job-per-task-roles-spec-review.md`](../archive/field-notes/job-per-task-roles-spec-review.md) | Review: docs/job-per-task-roles-spec.md |
+| historical archive | [`archive/field-notes/job-per-task-roles-spec.md`](../archive/field-notes/job-per-task-roles-spec.md) | Job-per-task Role Specialisation — Design Spec |
+| historical archive | [`archive/field-notes/k8s-native-rewrite-plan.md`](../archive/field-notes/k8s-native-rewrite-plan.md) | Kubernetes-native rewrite plan |
+| historical archive | [`archive/field-notes/linear-bridge-spec-review.md`](../archive/field-notes/linear-bridge-spec-review.md) | Linear Bridge Spec — Review Notes |
+| historical archive | [`archive/field-notes/linear-bridge-spec.md`](../archive/field-notes/linear-bridge-spec.md) | Linear Bridge — Design Spec |
+| historical archive | [`archive/field-notes/mac-task-bd-parity-audit.md`](../archive/field-notes/mac-task-bd-parity-audit.md) | `mac task` ↔ `bd` (beads) functional-parity audit |
+| historical archive | [`archive/field-notes/metadata-sync-assessment.md`](../archive/field-notes/metadata-sync-assessment.md) | Metadata sync assessment (post-bd-bridge) |
+| historical archive | [`archive/field-notes/prereq-task-029665.md`](../archive/field-notes/prereq-task-029665.md) | Preflight: HGX auth path, fleet baseline, and standard-dind fungible reference |
+| historical archive | [`archive/field-notes/prereq-task-403ed263.md`](../archive/field-notes/prereq-task-403ed263.md) | Prerequisite Verification: task_403ed263ed7e45c6b7624345005a097c |
+| historical archive | [`archive/field-notes/prereq-task-e94f546c.md`](../archive/field-notes/prereq-task-e94f546c.md) | Prerequisite Investigation: task_e94f546cf9dc41409d4a9fe6b8b39dcd |
+| historical archive | [`archive/field-notes/prereq-task-fd2f34.md`](../archive/field-notes/prereq-task-fd2f34.md) | Prerequisite Investigation: task_fd2f34b64823410c84a14fc0345610ff |
+| historical archive | [`archive/field-notes/provenance-dreamrepair-77fc3e59-slack.md`](../archive/field-notes/provenance-dreamrepair-77fc3e59-slack.md) | Provenance: low-confidence dream finding `slack` (`dreamrepair:77fc3e59014ba0d7950d22387f0204a0`) — self-referential evidence chain, no concrete defect |
+| historical archive | [`archive/field-notes/quickstart-gap-analysis.md`](../archive/field-notes/quickstart-gap-analysis.md) | Quickstart Gap Analysis |
+| historical archive | [`archive/field-notes/replace-hgx-session-c902fab4d55f.md`](../archive/field-notes/replace-hgx-session-c902fab4d55f.md) | Field note: HGX session `c902fab4d55f` — realize capacity via preserve-nothing + REPLACE |
+| historical archive | [`archive/field-notes/scaling-plan.md`](../archive/field-notes/scaling-plan.md) | Scaling Plan |
+| historical archive | [`archive/index.md`](../archive/index.md) | Historical archive |
+| supplemental reference | [`audit.md`](../audit.md) | MAC Codebase Audit — Active Code, Duplication & Accretion |
+| supplemental reference | [`authority-boundary.md`](../authority-boundary.md) | Who owns which authority question |
+| book | [`book/01-system.md`](../book/01-system.md) | MAC as a System |
+| book | [`book/02-local-start.md`](../book/02-local-start.md) | Install and Start Locally |
+| book | [`book/03-projects-and-tasks.md`](../book/03-projects-and-tasks.md) | Projects and Tasks |
+| book | [`book/04-machines-and-agents.md`](../book/04-machines-and-agents.md) | Machines and Agents |
+| book | [`book/05-evidence-review-completion.md`](../book/05-evidence-review-completion.md) | Evidence, Review, and Completion |
+| book | [`book/06-hermes-and-ide.md`](../book/06-hermes-and-ide.md) | Hermes and the Fleet IDE |
+| book | [`book/07-repository-contracts.md`](../book/07-repository-contracts.md) | Repository Contracts |
+| book | [`book/08-plans-and-dags.md`](../book/08-plans-and-dags.md) | Plans and Task DAGs |
+| book | [`book/09-fleet-onboarding.md`](../book/09-fleet-onboarding.md) | Heterogeneous Fleet Onboarding |
+| book | [`book/10-identity-and-secrets.md`](../book/10-identity-and-secrets.md) | Identity, Credentials, and Secrets |
+| book | [`book/11-publication-and-refs.md`](../book/11-publication-and-refs.md) | Review, Publication, and Ref Hygiene |
+| book | [`book/12-operations.md`](../book/12-operations.md) | Operating the Fleet |
+| book | [`book/13-deployment-topologies.md`](../book/13-deployment-topologies.md) | Deployment Topologies |
+| book | [`book/14-images-and-cutover.md`](../book/14-images-and-cutover.md) | Qualified Images and Synchronized Cutover |
+| book | [`book/15-sandboxed-runtimes.md`](../book/15-sandboxed-runtimes.md) | Sandboxed Agent Runtimes |
+| book | [`book/16-apis-and-integrations.md`](../book/16-apis-and-integrations.md) | APIs, AgentBus, and Integrations |
+| book | [`book/17-learning-evals-scaling.md`](../book/17-learning-evals-scaling.md) | Learning, Evals, and Scaling |
+| book | [`book/18-capstone.md`](../book/18-capstone.md) | From Request to Production |
+| runbook | [`break-glass-host-recovery.md`](../break-glass-host-recovery.md) | Break-glass host recovery |
+| supplemental reference | [`c26-certifier-phase-profile-example.md`](../c26-certifier-phase-profile-example.md) | c26 certifier phase-profile example |
+| supplemental reference | [`client-bootstrap-contract.md`](../client-bootstrap-contract.md) | SSH Client Bootstrap Contracts |
+| supplemental reference | [`coding-cli-credentials.md`](../coding-cli-credentials.md) | Coding-CLI Credentials and Model Selection |
+| supplemental reference | [`crash-diagnosis-and-repair.md`](../crash-diagnosis-and-repair.md) | Crash diagnosis and autonomous repair |
+| supplemental reference | [`dashboard-connection.md`](../dashboard-connection.md) | Dashboard Connection Contract |
+| supplemental reference | [`deploy-prerequisite-vs-phase1-audit.md`](../deploy-prerequisite-vs-phase1-audit.md) | Audit: prove deploy prerequisites before phase-1 mutation, preserve Python diagnostics |
+| supplemental reference | [`dispatch-priority-bias-audit.md`](../dispatch-priority-bias-audit.md) | Dispatch priority bias ordering audit |
+| supplemental reference | [`dream-repair-slack-lineage.md`](../dream-repair-slack-lineage.md) | Ground truth: dream finding `dreamrepair:4becfa8d` (slack failure_pattern) |
+| supplemental reference | [`dreaming-rewrite.md`](../dreaming-rewrite.md) | Dreaming, rewritten |
+| supplemental reference | [`env-config-reference.md`](../env-config-reference.md) | MAC environment configuration reference |
+| runbook | [`fleet-cutover-transaction-protocol.md`](../fleet-cutover-transaction-protocol.md) | Fleet Cut-over Transaction Protocol |
+| supplemental reference | [`fleet-directives.md`](../fleet-directives.md) | Fleet directives |
+| runbook | [`fleet-node-onboarding-checklist.md`](../fleet-node-onboarding-checklist.md) | Fleet node onboarding checklist |
+| supplemental reference | [`fleet-operational-learning.md`](../fleet-operational-learning.md) | Fleet operational learning |
+| supplemental reference | [`fleet-registry-schema.md`](../fleet-registry-schema.md) | Fleet registry schema |
+| supplemental reference | [`getting-started.md`](../getting-started.md) | MAC Quickstart |
+| supplemental reference | [`guide/01-architecture.md`](../guide/01-architecture.md) | System Architecture |
+| supplemental reference | [`guide/02-getting-started.md`](../guide/02-getting-started.md) | Getting Started |
+| supplemental reference | [`guide/03-advanced.md`](../guide/03-advanced.md) | Advanced Concepts |
+| supplemental reference | [`guide/04-ui.md`](../guide/04-ui.md) | The UI |
+| supplemental reference | [`guide/05-developer-guide.md`](../guide/05-developer-guide.md) | Developer Guide |
+| supplemental reference | [`guide/README.md`](../guide/README.md) | mac documentation |
+| supplemental reference | [`hermes-boundary.md`](../hermes-boundary.md) | Hermes Boundary |
+| supplemental reference | [`hermes-integration.md`](../hermes-integration.md) | Hermes Integration |
+| supplemental reference | [`hermes-retirement-premises.md`](../hermes-retirement-premises.md) | Testing the premises for retiring the vendored Hermes tree |
+| supplemental reference | [`hermes-vendor-fate.md`](../hermes-vendor-fate.md) | Fate of the vendored Hermes tree |
+| supplemental reference | [`hgx-elastic-capacity.md`](../hgx-elastic-capacity.md) | HGX elastic capacity |
+| supplemental reference | [`home-consolidation.md`](../home-consolidation.md) | Home-Directory Consolidation: Analysis & Plan |
+| runbook | [`hub-availability.md`](../hub-availability.md) | Hub Availability |
+| supplemental reference | [`hub-host-saturation-remediation.md`](../hub-host-saturation-remediation.md) | Hub-Host Saturation Remediation |
+| supplemental reference | [`human-interface-selector.md`](../human-interface-selector.md) | The human interface: support both, activate one |
+| supplemental reference | [`image-publication-and-qualification.md`](../image-publication-and-qualification.md) | Image Publication and Pre-Publication Qualification |
+| supplemental reference | [`in-flight-agent-messages.md`](../in-flight-agent-messages.md) | Reaching an agent that is already working |
+| landing page | [`index.md`](../index.md) | MAC: trustworthy work across an agent fleet |
+| supplemental reference | [`integration-authority-contract.md`](../integration-authority-contract.md) | Integration Authority Contract |
+| supplemental reference | [`memory-tier-schema.md`](../memory-tier-schema.md) | MAC vector memory tier — schema, collections, model, TTLs |
+| supplemental reference | [`memory-tier-verification.md`](../memory-tier-verification.md) | Memory tier — end-to-end verification |
+| supplemental reference | [`notifier-configuration-guide.md`](../notifier-configuration-guide.md) | Notifier Configuration Guide |
+| supplemental reference | [`oneshot-isolation-gate-verification.md`](../oneshot-isolation-gate-verification.md) | Oneshot isolation — contract gate verification |
+| supplemental reference | [`openclaw-identities.md`](../openclaw-identities.md) | OpenClaw public identities and fleet representation |
+| supplemental reference | [`openshell-nemo-relay-e2e.md`](../openshell-nemo-relay-e2e.md) | OpenShell + NeMo Relay: container-contract verification |
+| supplemental reference | [`openshell-nemo-relay-integration.md`](../openshell-nemo-relay-integration.md) | OpenShell + NeMo Relay integration |
+| supplemental reference | [`openshell-sandbox.md`](../openshell-sandbox.md) | Running Hermes under the OpenShell sandbox |
+| runbook | [`production-deployment.md`](../production-deployment.md) | Production Deployment |
+| generated reference | [`reference/cli.md`](../reference/cli.md) | Command-line reference |
+| generated reference | [`reference/documentation-inventory.md`](../reference/documentation-inventory.md) | Documentation inventory |
+| generated reference | [`reference/openapi.md`](../reference/openapi.md) | HTTP API reference |
+| generated reference | [`reference/staged-module-integration-audit.md`](../reference/staged-module-integration-audit.md) | Staged-but-unwired `src/mac` module integration audit |
+| supplemental reference | [`repository-cicd-monitor.md`](../repository-cicd-monitor.md) | Repository CI/CD lifecycle monitoring |
+| supplemental reference | [`repository-ref-hygiene.md`](../repository-ref-hygiene.md) | Managed Repository Ref Hygiene |
+| supplemental reference | [`repository-runtime-contract.md`](../repository-runtime-contract.md) | Repository Runtime Contract |
+| supplemental reference | [`review-strategy-experiments.md`](../review-strategy-experiments.md) | Review-strategy experiments |
+| supplemental reference | [`scientific-optimizer.md`](../scientific-optimizer.md) | Autonomous scientific optimizer |
+| supplemental reference | [`secrets-management-guide.md`](../secrets-management-guide.md) | Secrets Management Guide |
+| supplemental reference | [`security/openshell-0.0.72-compatibility-review.mdx`](../security/openshell-0.0.72-compatibility-review.mdx) | OpenShell 0.0.72 Compatibility Review |
+| runbook | [`soul-preservation-runbook.md`](../soul-preservation-runbook.md) | Soul Preservation Runbook |
+| supplemental reference | [`structured-task-bodies.md`](../structured-task-bodies.md) | Structured task bodies: actions on a Component |
+| historical archive | [`superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md`](../superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md) | Autonomous Project Routing and Review/Fix Loop Implementation Plan |
+| historical archive | [`superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md`](../superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md) | Autonomous Project Routing and Review/Fix Loop Design |
+| historical archive | [`superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md`](../superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md) | K8s bootstrap fleet registration — design |
+| runbook | [`synchronized-fleet-cutover.md`](../synchronized-fleet-cutover.md) | Synchronized Fleet Cut-over |
+| supplemental reference | [`task-dependency-semantics.md`](../task-dependency-semantics.md) | Task dependency failure semantics |
+| supplemental reference | [`task-throughput-observability.md`](../task-throughput-observability.md) | Task throughput observability |
+| supplemental reference | [`testing-strategy.md`](../testing-strategy.md) | Test portfolio strategy |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -45,6 +45,8 @@ marked `historical archive` and must not be read as current behaviour.
 | architecture decision | [`adr/0027-upgrades-are-versioned-and-fail-closed.md`](../adr/0027-upgrades-are-versioned-and-fail-closed.md) | ADR 0027: Upgrades are versioned, ordered, and fail closed |
 | architecture decision | [`adr/0028-installation-is-a-package-not-a-push.md`](../adr/0028-installation-is-a-package-not-a-push.md) | ADR 0028: Installation is a verified package plus enrollment, not a push |
 | architecture decision | [`adr/0029-the-route-search-path-is-a-fleet-contract.md`](../adr/0029-the-route-search-path-is-a-fleet-contract.md) | ADR 0029: The coding-route search path is a fleet contract, not per-worker environment |
+| architecture decision | [`adr/0030-langchain-extracts-before-qdrant.md`](../adr/0030-langchain-extracts-before-qdrant.md) | ADR 0030: LangChain extracts meaning on the agent; hub Qdrant only stores the extract |
+| architecture decision | [`adr/0031-codegraph-is-a-hint.md`](../adr/0031-codegraph-is-a-hint.md) | ADR 0031: CodeGraph is a hint when the tool and `.codegraph/` exist, not a hard gate |
 | supplemental reference | [`agent-lifecycle-proof.md`](../agent-lifecycle-proof.md) | Agent Lifecycle Proof |
 | historical archive | [`archive/field-notes/assessment-2026-08-02.md`](../archive/field-notes/assessment-2026-08-02.md) | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | [`archive/field-notes/assessment-task-1b6783.md`](../archive/field-notes/assessment-task-1b6783.md) | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/scripts/check-docs-graph.py
+++ b/scripts/check-docs-graph.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Docs-graph reachability gate for the MAC documentation set.
+
+`scripts/check-docs-accessibility.py` proves every *link* resolves; this gate
+proves the opposite direction — that every *current documentation file* is
+**reachable** by following internal links out of the root `README.md`. A doc
+that no link chain reaches is invisible to a reader who starts where readers
+start, and it rots unseen. That is the failure this gate exists to catch.
+
+What it enforces, all fail-closed:
+
+* **No orphaned current docs.** Every tracked ``docs/**/*.md``/``*.mdx`` that is
+  not an allowlisted generated file must be reachable from ``README.md`` through
+  a chain of internal Markdown links. Leaf docs may be reached indirectly — the
+  complete documentation index (``docs/reference/documentation-inventory.md``)
+  is linked from ``README.md`` and links every current doc — so a direct README
+  link is not required, only reachability.
+* **No broken internal links** in any node the traversal visits.
+* **Historical material stays behind the archive.** ADRs, field notes, and
+  design specs must be reachable through the explicitly linked, visibly-labelled
+  historical archive index (``docs/archive/index.md``); the gate confirms the
+  archive index reaches each of them.
+* **Nothing omitted from the inventory.** Every current doc must appear in the
+  generated documentation inventory, so the index a reader trusts is complete.
+
+Only files on the explicit allowlist below are exempt, each with a reason. The
+check is deterministic and hermetic: it reads the tracked repository tree via
+``git ls-files`` and never touches the network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+README = ROOT / "README.md"
+INVENTORY = DOCS / "reference" / "documentation-inventory.md"
+ARCHIVE_INDEX = DOCS / "archive" / "index.md"
+
+_FENCE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
+_LINK = re.compile(r"(!?)\[[^\]]*\]\((?P<target>[^)\s]+)(?:\s+\"[^\"]*\")?\)")
+
+# Current docs that are intentionally NOT required to be reachable from README,
+# each with a reason. Keep this list short and justified: an allowlist is where
+# a reachability gate quietly dies if it is allowed to grow without argument.
+_ALLOWLIST: dict[str, str] = {
+    # Pinned capability decks are point-in-time artifacts scoped to one commit,
+    # never revised, and excluded from the inventory and the published site for
+    # the same reason (see scripts/generate-docs-reference.py). They are not part
+    # of the current-doc graph.
+    "docs/presentation/": "pinned point-in-time capability decks, excluded from the site and inventory",
+}
+
+
+def _tracked_docs() -> list[Path]:
+    out = subprocess.check_output(
+        ["git", "ls-files", "docs/"], cwd=ROOT, text=True
+    )
+    return sorted(
+        ROOT / line
+        for line in out.splitlines()
+        if line.endswith((".md", ".mdx"))
+    )
+
+
+def _is_allowlisted(path: Path) -> bool:
+    rel = path.relative_to(ROOT).as_posix()
+    return any(rel.startswith(prefix) for prefix in _ALLOWLIST)
+
+
+def _strip_code_fences(text: str) -> str:
+    kept: list[str] = []
+    fence: str | None = None
+    for line in text.splitlines():
+        match = _FENCE.match(line)
+        if fence is None:
+            if match:
+                fence = match.group(1)[0]
+                kept.append("")
+                continue
+            kept.append(line)
+        else:
+            if match and match.group(1)[0] == fence:
+                fence = None
+            kept.append("")
+    return "\n".join(kept)
+
+
+def _internal_links(page: Path) -> list[tuple[str, Path]]:
+    """Return (raw_target, resolved_path) for internal Markdown links in *page*.
+
+    Images, URLs, in-page anchors, ``mailto:`` and site-absolute links are not
+    navigation and are skipped. Targets are resolved relative to *page*.
+    """
+    if not page.exists():
+        return []
+    body = _strip_code_fences(page.read_text(encoding="utf-8", errors="replace"))
+    links: list[tuple[str, Path]] = []
+    for match in _LINK.finditer(body):
+        if match.group(1) == "!":
+            continue
+        target = match.group("target").strip()
+        if (
+            not target
+            or target.startswith("#")
+            or "://" in target
+            or target.startswith("mailto:")
+            or target.startswith("/")
+        ):
+            continue
+        clean = target.split("#", 1)[0].split("?", 1)[0]
+        if not clean:
+            continue
+        resolved = (page.parent / clean).resolve()
+        links.append((target, resolved))
+    return links
+
+
+def _traverse(start: Path) -> tuple[set[Path], list[str]]:
+    """BFS the internal Markdown link graph from *start*.
+
+    Returns the set of reachable Markdown files and a list of broken-link
+    errors observed along the way.
+    """
+    seen: set[Path] = set()
+    broken: list[str] = []
+    stack = [start.resolve()]
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        for target, resolved in _internal_links(current):
+            if not resolved.exists():
+                try:
+                    where = current.relative_to(ROOT).as_posix()
+                except ValueError:
+                    where = str(current)
+                broken.append(f"{where}: broken internal link -> {target}")
+                continue
+            if resolved.suffix in {".md", ".mdx"} and resolved not in seen:
+                stack.append(resolved)
+    return seen, broken
+
+
+def _inventory_sources() -> set[str]:
+    """Return the docs-relative source paths listed in the inventory table."""
+    if not INVENTORY.exists():
+        return set()
+    sources: set[str] = set()
+    row = re.compile(r"^\|[^|]*\|\s*\[?`(?P<src>[^`]+)`\]?")
+    for line in INVENTORY.read_text(encoding="utf-8").splitlines():
+        match = row.match(line)
+        if match:
+            sources.add(match.group("src").strip())
+    return sources
+
+
+def check() -> list[str]:
+    errors: list[str] = []
+    docs = [p for p in _tracked_docs() if not _is_allowlisted(p)]
+    docs_set = {p.resolve() for p in docs}
+
+    reachable, broken = _traverse(README)
+    errors.extend(broken)
+
+    orphans = sorted(
+        p.relative_to(ROOT).as_posix() for p in docs_set if p not in reachable
+    )
+    for orphan in orphans:
+        errors.append(
+            f"orphaned current doc (not reachable from README.md): {orphan}"
+        )
+
+    # Historical material must be reachable specifically through the archive
+    # index, not only via some incidental link, so it is quarantined and labelled.
+    archive_reachable, _ = _traverse(ARCHIVE_INDEX)
+    historical = [
+        p
+        for p in docs_set
+        if p.relative_to(DOCS).as_posix().startswith(("archive/", "adr/", "superpowers/"))
+    ]
+    for page in sorted(historical, key=lambda p: p.relative_to(ROOT).as_posix()):
+        if page not in archive_reachable and page != ARCHIVE_INDEX.resolve():
+            errors.append(
+                "historical doc not reachable from the archive index "
+                f"({ARCHIVE_INDEX.relative_to(ROOT).as_posix()}): "
+                f"{page.relative_to(ROOT).as_posix()}"
+            )
+
+    inventory_sources = _inventory_sources()
+    for page in sorted(docs_set, key=lambda p: p.relative_to(ROOT).as_posix()):
+        rel_docs = page.relative_to(DOCS).as_posix()
+        if rel_docs not in inventory_sources:
+            errors.append(
+                "current doc missing from the documentation inventory "
+                f"({INVENTORY.relative_to(ROOT).as_posix()}): "
+                f"{page.relative_to(ROOT).as_posix()}"
+            )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.parse_args(argv)
+    errors = check()
+    if errors:
+        for error in errors:
+            print(f"docs-graph gate failed: {error}", file=sys.stderr)
+        print(
+            f"\n{len(errors)} problem(s). Every current doc must be reachable from "
+            "README.md, free of broken links, and listed in "
+            "docs/reference/documentation-inventory.md.",
+            file=sys.stderr,
+        )
+        return 1
+    reachable_docs = sum(
+        1 for p in _tracked_docs() if not _is_allowlisted(p)
+    )
+    print(
+        "docs-graph gate passed: "
+        f"{reachable_docs} current docs reachable from README.md, "
+        "no orphans, no broken links, inventory complete."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/generate-docs-reference.py
+++ b/scripts/generate-docs-reference.py
@@ -234,10 +234,14 @@ def documentation_inventory() -> str:
     lines = [
         "# Documentation inventory",
         "",
-        "This generated inventory classifies every Markdown source included in the",
-        "documentation tree. Book chapters are authoritative and executable. Runbooks",
-        "and references describe production boundaries. Historical material is retained",
-        "for provenance and is not a current operating contract.",
+        "This generated inventory classifies and links every Markdown source",
+        "included in the documentation tree. It is the complete documentation index:",
+        "the root `README.md` links here, and the automated docs-graph gate",
+        "(`scripts/check-docs-graph.py`) proves every current doc is reachable from",
+        "this table. Book chapters are authoritative and executable. Runbooks and",
+        "references describe production boundaries. Historical material is retained",
+        "for provenance and is not a current operating contract; those rows are",
+        "marked `historical archive` and must not be read as current behaviour.",
         "",
         "| Category | Source | Title |",
         "|---|---|---|",
@@ -245,23 +249,32 @@ def documentation_inventory() -> str:
     for page in pages:
         relative = page.relative_to(docs_root)
         title = _title(page).replace("|", "&#124;")
-        lines.append(f"| {_category(relative)} | `{relative.as_posix()}` | {title} |")
+        # The Source cell is a working relative link so this table is a
+        # navigable index, not just a manifest. Links are resolved from the
+        # inventory's own location (docs/reference/), hence the "../" prefix.
+        href = f"../{relative.as_posix()}"
+        lines.append(f"| {_category(relative)} | [`{relative.as_posix()}`]({href}) | {title} |")
     return "\n".join(lines) + "\n"
 
 
 def archive_index() -> str:
     docs_root = ROOT / "docs"
     archived = sorted(
-        [*(docs_root / "archive" / "field-notes").glob("*.md"), *(docs_root / "adr").glob("*.md")],
+        [
+            *(docs_root / "archive" / "field-notes").glob("*.md"),
+            *(docs_root / "adr").glob("*.md"),
+            *(docs_root / "superpowers").rglob("*.md"),
+        ],
         key=lambda path: path.name,
     )
     lines = [
         "# Historical archive",
         "",
-        "These field notes and architecture decisions explain how MAC reached its current",
-        "contracts. They are evidence, not current instructions. Follow the numbered book",
-        "and current runbooks for operational work. Old field-note URLs redirect here to",
-        "their retained sources.",
+        "These field notes, architecture decisions, and design specs explain how MAC",
+        "reached its current contracts. They are evidence, not current instructions,",
+        "and must not be read as current product behaviour. Follow the numbered book",
+        "and current runbooks for operational work. Old field-note URLs redirect here",
+        "to their retained sources.",
         "",
         "## Archived records",
         "",

--- a/skills/cut-a-release/SKILL.md
+++ b/skills/cut-a-release/SKILL.md
@@ -59,7 +59,14 @@ Never revise a previous deck. Make a new directory.
 ## 2. Audit from source, never from memory
 
 This is the step that carries the value, and the one it is tempting to skip
-because you think you know what changed. Read:
+because you think you know what changed. It is not satisfied by the generated
+CLI/OpenAPI references or the capabilities deck alone: **before every release,
+every current documentation file must be audited against the candidate tree and
+its deployed behaviour, and source code is the source of truth** — not memory,
+issue text, a prior deck, or planned behaviour. Walk the whole current-doc set
+from the index, and for each file record a changed / not-changed decision with
+its source anchor. `docs/reference/documentation-inventory.md` enumerates every
+current doc for exactly this pass; no active file is left unchecked. Read:
 
 ```bash
 # The capability surface, generated from the live parser and schema.
@@ -151,14 +158,30 @@ The order matters and is the trap that cost the most time:
 git add docs/presentation <other changed files>
 
 MAC_TEST_PG_URL=... uv run --extra dev --extra postgres pytest \
-  tests/test_docs_no_operator_identity.py tests/test_guide_docs_are_true.py -q
+  tests/test_docs_no_operator_identity.py tests/test_guide_docs_are_true.py \
+  tests/test_docs_graph.py -q
 make docs-check
 ```
 
 **Stage before running.** `tests/test_docs_no_operator_identity.py` enumerates
 `git ls-files`, so it only scans *tracked* files. Run it while the new directory
 is untracked and it scans nothing you wrote and reports a confident pass over an
-empty set.
+empty set. The same is true of `scripts/check-docs-graph.py`, which enumerates
+tracked docs: stage new docs before it can see them.
+
+**Every current doc must be reachable from `README.md`.** `make docs-check`
+runs `scripts/check-docs-graph.py`, which traverses the internal-link graph out
+of the root `README.md` and fails on any current doc that is orphaned, any
+broken internal link, or any current doc missing from
+`docs/reference/documentation-inventory.md`. Leaf docs need not be linked
+directly from `README.md`: the complete documentation index
+(`docs/reference/documentation-inventory.md`) is README-reachable and links
+every current doc, and historical material stays behind the explicitly linked,
+visibly-labelled archive index (`docs/archive/index.md`). If you added or moved
+a doc, regenerate the index with `python scripts/generate-docs-reference.py
+--write` and commit it, or the gate reports the doc as orphaned or missing from
+the inventory. Only pinned decks under `docs/presentation/` are allowlisted, and
+that list is the single place an exemption may be argued.
 
 ## 8. Then, and only then, cut the release
 

--- a/tests/test_docs_graph.py
+++ b/tests/test_docs_graph.py
@@ -1,0 +1,111 @@
+"""Tests for the docs-graph reachability gate (scripts/check-docs-graph.py).
+
+The gate proves every current documentation file is reachable from README.md;
+these tests prove the gate itself detects orphans, broken links, and inventory
+omissions, and that the real tree passes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check-docs-graph.py"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("mac_check_docs_graph", CHECKER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_real_documentation_graph_is_fully_reachable():
+    result = subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "docs-graph gate passed" in result.stdout
+
+
+def _seed_common(module, tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    (docs / "reference").mkdir(parents=True)
+    (docs / "archive").mkdir(parents=True)
+    monkeypatch.setattr(module, "ROOT", tmp_path)
+    monkeypatch.setattr(module, "DOCS", docs)
+    monkeypatch.setattr(module, "README", tmp_path / "README.md")
+    monkeypatch.setattr(module, "INVENTORY", docs / "reference" / "documentation-inventory.md")
+    monkeypatch.setattr(module, "ARCHIVE_INDEX", docs / "archive" / "index.md")
+    (docs / "archive" / "index.md").write_text("# Historical archive\n", encoding="utf-8")
+    return docs
+
+
+def test_orphaned_current_doc_is_reported(tmp_path, monkeypatch):
+    module = _module()
+    docs = _seed_common(module, tmp_path, monkeypatch)
+    (tmp_path / "README.md").write_text(
+        "# root\n\n[index](docs/reference/documentation-inventory.md)\n",
+        encoding="utf-8",
+    )
+    (docs / "reference" / "documentation-inventory.md").write_text(
+        "| Category | Source | Title |\n|---|---|---|\n"
+        "| reference | [`reference/documentation-inventory.md`](../reference/documentation-inventory.md) | Inventory |\n"
+        "| archive | [`archive/index.md`](../archive/index.md) | Archive |\n",
+        encoding="utf-8",
+    )
+    (docs / "lonely.md").write_text("# lonely\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        module, "_tracked_docs",
+        lambda: sorted(docs.rglob("*.md")),
+    )
+    errors = module.check()
+    assert any("orphaned current doc" in e and "lonely.md" in e for e in errors)
+
+
+def test_broken_internal_link_is_reported(tmp_path, monkeypatch):
+    module = _module()
+    docs = _seed_common(module, tmp_path, monkeypatch)
+    (tmp_path / "README.md").write_text(
+        "# root\n\n[gone](docs/missing.md)\n", encoding="utf-8"
+    )
+    (docs / "reference" / "documentation-inventory.md").write_text(
+        "| Category | Source | Title |\n|---|---|---|\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(module, "_tracked_docs", lambda: [])
+    errors = module.check()
+    assert any("broken internal link" in e for e in errors)
+
+
+def test_doc_missing_from_inventory_is_reported(tmp_path, monkeypatch):
+    module = _module()
+    docs = _seed_common(module, tmp_path, monkeypatch)
+    (tmp_path / "README.md").write_text(
+        "# root\n\n[page](docs/page.md)\n", encoding="utf-8"
+    )
+    (docs / "page.md").write_text("# page\n", encoding="utf-8")
+    (docs / "reference" / "documentation-inventory.md").write_text(
+        "| Category | Source | Title |\n|---|---|---|\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        module, "_tracked_docs", lambda: [docs / "page.md"]
+    )
+    errors = module.check()
+    assert any("missing from the documentation inventory" in e for e in errors)
+
+
+def test_presentation_decks_are_allowlisted():
+    module = _module()
+    assert module._is_allowlisted(module.ROOT / "docs" / "presentation" / "x" / "README.md")
+    assert not module._is_allowlisted(module.ROOT / "docs" / "getting-started.md")


### PR DESCRIPTION
## Summary
- Rebase of #648/#643 onto `main` after #647. Same docs-graph gate; inventory now includes ADRs 0029–0031.
- Supersedes #648 (that tip was cut before #647 landed).

## Test plan
- [x] `pytest tests/test_docs_graph.py`
- [ ] GitHub generated-docs / sanity