### PR TITLE
Fix trusted certifier publication after plugin removal

### DIFF
--- a/deploy/certifier/harness_manifest.py
+++ b/deploy/certifier/harness_manifest.py
@@ -23,7 +23,6 @@ MANAGED_TREES = ("tests",)
 MANAGED_FILES = (
     "deploy/certifier/select-tests.py",
     "deploy/certifier/supplemental-contract-tests",
-    "plugin/test_tools.py",
     "conftest.py",
     "pyproject.toml",
     "test-policy.toml",

--- a/tests/test_certifier_harness_manifest.py
+++ b/tests/test_certifier_harness_manifest.py
@@ -1,0 +1,25 @@
+"""Contracts for the immutable trusted certifier harness inventory."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "deploy" / "certifier" / "harness_manifest.py"
+
+
+def _load_manifest_module():
+    spec = importlib.util.spec_from_file_location("certifier_harness_manifest", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_every_required_harness_file_exists_in_the_repository() -> None:
+    """A stale required path must fail before the image-publication workflow."""
+    manifest = _load_manifest_module()
+
+    manifest._inventory(ROOT)


### PR DESCRIPTION
## Summary
- remove the deleted Hermes plugin test from the trusted certifier manifest
- add a regression that validates every required harness path before image publication

## Root cause
PR #430 removed the Hermes persona plugin, including `plugin/test_tools.py`, but the trusted certifier manifest still required that path. Main CI therefore failed while building the certifier image.

## Test plan
- [x] TDD red: focused sanity gate failed with `trusted harness file is missing: plugin/test_tools.py`
- [x] Focused sanity gate: 634 passed, 4 skipped
- [x] `make lint`
- [x] CodeGraph affected audit
- [ ] Full macOS contract gate: regression passed, but the existing baseline reported 7 unrelated failures (launchd/process timing and dispatch-route contract); GitHub CI is authoritative for this Linux image-publication fix