### PR TITLE
Pin task sandboxes to reviewed runtime digests

### DIFF
--- a/deploy/openshell/bootstrap-openshell.sh
+++ b/deploy/openshell/bootstrap-openshell.sh
@@ -1835,6 +1835,7 @@ else
 fi
 cp -a "$ENVF" "$ENVF.bak-openshell-$(date +%Y%m%dT%H%M%S 2>/dev/null || echo bootstrap)"
 sed -i '/^# OpenShell sandbox enforcement/d;/^MAC_OPENSHELL_SANDBOX=/d;/^MAC_OPENSHELL_GC=/d;/^MAC_OPENSHELL_STALE_AFTER_SECONDS=/d;/^MAC_HERMES_PYTHON=/d;/^MAC_OPENSHELL_POLICY=/d;/^MAC_OPENSHELL_BIN=/d;/^MAC_OPENSHELL_CREATE_ARGS=/d;/^MAC_OPENSHELL_GPU_AVAILABLE=/d;/^MAC_ALLOW_UNSANDBOXED_YOLO=/d;/^MAC_OPENSHELL_REPO_REQUIRES_CODING_AGENT=/d' "$ENVF"
+sandbox_image_ref="${OSH_RUNTIME_IMAGE_REF:-$OSH_IMAGE_TAG}"
 {
   echo ""
   echo "# OpenShell sandbox enforcement (bootstrap-openshell.sh; Docker Engine/Moby driver, gpu=$OSH_GPU)"
@@ -1843,7 +1844,7 @@ sed -i '/^# OpenShell sandbox enforcement/d;/^MAC_OPENSHELL_SANDBOX=/d;/^MAC_OPE
   echo "MAC_OPENSHELL_STALE_AFTER_SECONDS=86400"
   echo "MAC_OPENSHELL_POLICY=$MAC_HOME/openshell-policy.yaml"
   echo "MAC_OPENSHELL_BIN=$BIN/openshell"
-  echo "MAC_OPENSHELL_CREATE_ARGS=\"--from $OSH_IMAGE_TAG$codex_uploads\""
+  echo "MAC_OPENSHELL_CREATE_ARGS=\"--from $sandbox_image_ref$codex_uploads\""
   echo "MAC_OPENSHELL_GPU_AVAILABLE=$gpu_runtime_available"
   echo "MAC_OPENSHELL_REPO_REQUIRES_CODING_AGENT=1"
   [ "$DO_FAILCLOSED" = 1 ] && echo "MAC_ALLOW_UNSANDBOXED_YOLO=0"

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -4190,6 +4190,11 @@ def test_fleet_deploy_pins_one_openshell_runtime_digest_across_nodes():
     assert '"$OSH_DOCKER_BIN" tag "$OSH_RUNTIME_IMAGE_REF" "$OSH_IMAGE_TAG"' in bootstrap
     assert 'runtime_ref_file="$OSH_DIR/runtime-image-ref"' in bootstrap
     assert 'printf \'%s\\n\' "$OSH_RUNTIME_IMAGE_REF" > "$runtime_ref_tmp"' in bootstrap
+    assert 'sandbox_image_ref="${OSH_RUNTIME_IMAGE_REF:-$OSH_IMAGE_TAG}"' in bootstrap
+    assert (
+        'echo "MAC_OPENSHELL_CREATE_ARGS=\\"--from $sandbox_image_ref$codex_uploads\\""'
+        in bootstrap
+    )
     assert "MAC_DEPLOY_ALLOW_LOCAL_OPENSHELL_IMAGE_BUILD" in script
     assert "production OpenShell deployment requires MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE" in script
     assert "--skip-image is incompatible with a digest-managed OpenShell deployment" in script


### PR DESCRIPTION
## Summary
- write the immutable reviewed runtime digest into OpenShell task creation arguments
- retain the local image tag only for development builds without a publication digest
- add a deployment contract assertion preventing regression to the stale mutable alias

## Test plan
- [x] RED: focused sanity gate failed on the missing immutable task recipe assertion
- [x] GREEN: focused sanity gate passed (782 passed, 4 skipped)
- [x] `make lint`
- [x] CodeGraph affected audit
- [ ] Full `make test` is blocked by 10 existing macOS parallel timing/process failures tracked separately; coverage gates passed