### PR TITLE
Expose mac CLI on coding-agent shell paths

### DIFF
--- a/deploy/openshell/mac-hermes.Containerfile
+++ b/deploy/openshell/mac-hermes.Containerfile
@@ -220,8 +220,14 @@ COPY src /tmp/mac-src/src
 # in-sandbox verification of a repo-coupled code task fails to execute
 # (ModuleNotFoundError) and the substance gate can never pass, so no autonomous
 # code change can land through OpenShell.
+# Coding-agent shell tools may install their own PATH while retaining
+# /usr/local/bin. Keep the image-owned mac entry point available there instead
+# of relying only on the image ENV's /opt/mac-venv/bin prefix.
 RUN uv sync --frozen --no-editable --extra dev --project /tmp/mac-src \
     && /opt/mac-venv/bin/python -c "import mac; print('IMPORT_OK')" \
+    && ln -sfn /opt/mac-venv/bin/mac /usr/local/bin/mac \
+    && command -v mac \
+    && mac --version \
     && rm -rf /tmp/mac-src
 
 # The executor uploads the task workspace to /sandbox and the upload (ssh+tar)

--- a/tests/test_openshell_runtime.py
+++ b/tests/test_openshell_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from mac.openshell_runtime import (
     DEFAULT_REQUIRED_AGENT_NAMES,
     SANDBOX_BASE_PATH,
@@ -9,6 +11,9 @@ from mac.openshell_runtime import (
     openshell_required_for_local_agent,
     truthy,
 )
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTAINERFILE = ROOT / "deploy" / "openshell" / "mac-hermes.Containerfile"
 
 
 def test_base_agent_name_normalizes_ids_hosts_and_empty_values():
@@ -35,6 +40,15 @@ def test_sandbox_base_path_prefers_image_runtime():
         "/usr/bin",
         "/bin",
     ]
+
+
+def test_mac_cli_is_linked_into_the_agent_shell_path():
+    """Coding-agent shell tools retain /usr/local/bin but may replace image PATH."""
+    text = CONTAINERFILE.read_text(encoding="utf-8")
+
+    assert "ln -sfn /opt/mac-venv/bin/mac /usr/local/bin/mac" in text
+    assert "command -v mac" in text
+    assert "mac --version" in text
 
 
 def test_required_for_identity_explicit_and_resources_override():


### PR DESCRIPTION
## Summary
- link the image-owned `/opt/mac-venv/bin/mac` entry point into `/usr/local/bin`, which coding-agent shell tools retain
- fail the runtime image build unless `mac` resolves and executes
- add a regression contract for the link and probes

## Test plan
- [x] `.venv/bin/python -m pytest -q tests/test_openshell_runtime.py tests/test_dispatch_route_contract.py` (18 passed)
- [x] `make lint`
- [x] `codegraph sync && codegraph affected deploy/openshell/mac-hermes.Containerfile tests/test_openshell_runtime.py`
- [ ] GitHub container build and runtime publication

## Local full-gate note
The macOS full gate reached 11,457 passes with seven unrelated failures: six known launchd/process tests tracked by `task_09bea26a`, plus the pre-existing dispatch-route extraction failure. The focused runtime and dispatch-route tests pass when run directly.