### PR TITLE
Isolate rollback sandbox timeout coverage

### DIFF
--- a/tests/test_openclaw_gateway_deploy.py
+++ b/tests/test_openclaw_gateway_deploy.py
@@ -3091,7 +3091,12 @@ esac
         "MAC_OPENSHELL_BIN": str(openshell),
         "MAC_OPENCLAW_SUBPROCESS_TIMEOUT_SECONDS": "1",
         "MAC_OPENCLAW_SANDBOX_DELETE_TIMEOUT_SECONDS": "0",
-        "MAC_LAUNCHD_COMMAND_TIMEOUT_SECONDS": "0.2",
+        # The sandbox-timeout case must reach the OpenShell probe. Giving the
+        # unrelated launchctl shim the same tiny contention-sensitive budget
+        # can fail at supervisor inspection first and test the wrong boundary.
+        "MAC_LAUNCHD_COMMAND_TIMEOUT_SECONDS": (
+            "2" if scenario == "sandbox-timeout" else "0.2"
+        ),
         "MAC_LAUNCHD_TRANSITION_TIMEOUT_SECONDS": "0.3",
         "MAC_LAUNCHD_POLL_INTERVAL_SECONDS": "0.01",
         "MAC_TEST_CALLS": str(calls),


### PR DESCRIPTION
## Summary
- prevent the launchd shim's contention-sensitive 0.2s budget from preempting the sandbox-timeout scenario
- preserve the tight launchd budget for every other rollback scenario
- make the contract deterministically reach the intended OpenShell subprocess timeout

## Root cause
Main CI run 32689049165 failed after 11,464 passes because launchd inspection timed out before the test reached its deliberately sleeping OpenShell shim. Both independent timeout boundaries were configured in one fixture, so load selected the wrong boundary.

## Test plan
- [x] failing case reproduced before the change
- [x] failing case passed 10 consecutive runs after the change
- [x] related rollback/withdrawal slice: 39 passed
- [x] `make lint`
- [x] CodeGraph affected-path audit via the existing runtime worktree index