### PR TITLE
Add secure hub-local console enrollment (task_800de5f4abb34c85ae61c11080bac732)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ LOCAL_BIN ?= $(HOME)/.local/bin
 NPM ?= npm
 UV ?= uv
 CODEGRAPH ?= codegraph
+LOCAL_CONSOLE_TESTS ?= tests/test_local_console.py tests/cli/test_cli_login.py tests/test_client_login_remote_command_shape.py tests/test_mac_cli_skill.py tests/test_env_config.py
 IDE_DIR ?= ide
 IDE_API_URL ?=
 IDE_AUTH ?= auto
@@ -35,13 +36,13 @@ DESKTOP_NODE_MODULES_STAMP := desktop/node_modules/.package-lock.json
 # Console scripts declared in pyproject.toml [project.scripts]; keep in sync.
 CONSOLE_SCRIPTS = mac mac-hermes mac-agent mac-firecrawl-gateway mac-k8s-orchestrator mac-k8s-bootstrap mac-task-runner mac-webdav-server mac-evidence mac-hermes-gateway
 
-.PHONY: help require-python require-npm require-uv codegraph-sync install-codegraph \
+.PHONY: help require-python require-npm require-uv codegraph-sync codegraph-affected install-codegraph \
 	install install-cli install-gui uninstall uninstall-cli \
 	build build-cli build-gui package package-cli package-gui publish \
 	clean clean-cli clean-gui distclean run-gui \
-	install-hooks setup deploy test coverage test-api test-cli test-ui cli-coverage lint lint-fix \
+	install-hooks setup deploy test coverage test-api test-cli test-local-console test-systemd-local-console test-ui cli-coverage lint lint-fix lint-local-console format-local-console \
 	test-portfolio fault-replay sanity-test compatibility-test \
-	docs docs-install docs-serve docs-test docs-build docs-check docs-accessibility docs-graph docs-lab docs-reference \
+	docs docs-install docs-serve docs-test docs-build docs-check docs-accessibility docs-graph docs-lab docs-reference env-reference \
 	ide-install ide-run ide-dev ide-check ide-build ide-preview ide-package \
 	observe-build observe-run \
 	desktop-install desktop-check desktop-package desktop-dist link-cli
@@ -83,6 +84,9 @@ require-uv:
 
 codegraph-sync: ## Initialize or incrementally refresh the CodeGraph index.
 	@MAC_CODEGRAPH_BIN="$(CODEGRAPH)" scripts/sync-codegraph.sh
+
+codegraph-affected: codegraph-sync ## Show the impact surface for changed paths in ARGS.
+	@CODEGRAPH_NO_DAEMON=1 "$(CODEGRAPH)" affected $(ARGS)
 
 install-codegraph: ## Install CodeGraph if absent (litai init and the skills need it).
 	@MAC_CODEGRAPH_BIN="$(CODEGRAPH)" scripts/install-codegraph.sh
@@ -275,6 +279,16 @@ test-api: codegraph-sync ## Run API-marked tests.
 test-cli: codegraph-sync ## Run CLI-marked tests.
 	uv run --extra dev pytest -q -m cli tests/
 
+test-local-console: codegraph-sync ## Run local-console enrollment and SSH login regressions.
+	@export MAC_TEST_PG_PORT="$${MAC_TEST_PG_PORT:-$$((56000 + $$$$ % 9000))}"; \
+		export MAC_TEST_PG_CONTAINER="$${MAC_TEST_PG_CONTAINER:-mac-test-postgres-local-console-$$$$}"; \
+		trap 'docker rm -f "$$MAC_TEST_PG_CONTAINER" >/dev/null 2>&1 || true' EXIT; \
+		eval "$$(scripts/start-test-postgres.sh)" && \
+		uv run --extra dev pytest -q $(LOCAL_CONSOLE_TESTS)
+
+test-systemd-local-console: ## Run the packaged systemd local-console contract.
+	@$(MAKE) test-local-console LOCAL_CONSOLE_TESTS='tests/test_local_console.py::test_systemd_unit_sets_safe_socket_default_before_operator_environment'
+
 test-ui: require-npm codegraph-sync $(IDE_NODE_MODULES_STAMP) ## Run API UI contracts, Fleet IDE browser tests and console unit tests.
 	uv run --extra dev pytest -q -m ui tests/
 	cd $(IDE_DIR) && $(NPM) run test:ui
@@ -291,6 +305,16 @@ lint: ## Run the shared Ruff lint gate (check-only, same rules on every host).
 
 lint-fix: ## Apply the shared Ruff safe autofixes and formatting in place.
 	@scripts/run-lint.sh --fix
+
+lint-local-console: ## Check local-console Python changes and new-file formatting.
+	@uv run --with ruff ruff check src/mac/local_console.py src/mac/client_login.py \
+		src/mac/api.py src/mac/client_principals.py tests/test_local_console.py \
+		tests/cli/test_cli_login.py scripts/generate-env-config-registry.py
+	@uv run --with ruff ruff check --ignore F821 src/mac/cli.py
+	@uv run --with ruff ruff format --check src/mac/local_console.py tests/test_local_console.py
+
+format-local-console: ## Format newly added local-console Python files.
+	@uv run --with ruff ruff format src/mac/local_console.py tests/test_local_console.py
 
 # ---------------------------------------------------------------------------
 # Production documentation book.
@@ -310,6 +334,9 @@ docs-test: docs-install ## Execute every published shell example hermetically.
 
 docs-reference: docs-install ## Regenerate CLI and OpenAPI reference pages.
 	$(UV) run --extra docs python scripts/generate-docs-reference.py --write
+
+env-reference: require-uv ## Regenerate the environment registry and operator reference.
+	$(UV) run python scripts/generate-env-config-registry.py $(ARGS)
 
 docs-build: docs-install ## Build strict production HTML.
 	$(UV) run --extra docs python scripts/generate-docs-reference.py --check

--- a/deploy/systemd/mac.env.example
+++ b/deploy/systemd/mac.env.example
@@ -51,6 +51,13 @@ SLACK_STRICT_MENTION=true
 # MAC_HERMES_STARTUP_CHECK=1
 MAC_URL=http://hub.example.internal:8789
 MAC_CLIENT_PRINCIPALS_FILE=/var/lib/mac/client-principals.json
+# Hub-local client enrollment. Enabled by default for the production API
+# factory and disabled by default for injected/embedded apps.
+MAC_LOCAL_CONSOLE_ENABLED=1
+MAC_LOCAL_CONSOLE_SOCKET=/run/mac/local-console.sock
+# Optional. Also add this group with SupplementaryGroups= in mac.service so the
+# service can safely assign the socket directory and socket to it.
+# MAC_LOCAL_CONSOLE_GROUP=mac-console
 MAC_FLEET_TENANT_ID=tenant_example
 MAC_AGENT_ID=agent_example
 MAC_HERMES_PERSONA_ID=persona_example

--- a/deploy/systemd/mac.service
+++ b/deploy/systemd/mac.service
@@ -8,7 +8,12 @@ Type=simple
 User=mac
 Group=mac
 WorkingDirectory=/var/lib/mac
+# EnvironmentFile overrides this packaged default when an operator explicitly
+# configures MAC_LOCAL_CONSOLE_SOCKET in /etc/mac/mac.env.
+Environment=MAC_LOCAL_CONSOLE_SOCKET=/run/mac/local-console.sock
 EnvironmentFile=/etc/mac/mac.env
+RuntimeDirectory=mac
+RuntimeDirectoryMode=0700
 # MAC_SECRET_KEY MUST be set in /etc/mac/mac.env. The service refuses to
 # start without it.
 # Optional: MAC_API_TOKEN or MAC_API_TOKENS for scoped bearer auth.
@@ -16,6 +21,9 @@ EnvironmentFile=/etc/mac/mac.env
 # Optional: MAC_PORT=8789 (default). Hub agents typically bind 0.0.0.0;
 #   worker agents typically bind 127.0.0.1. Set MAC_BIND_HOST accordingly.
 # Optional: MAC_BIND_HOST=127.0.0.1 (default for workers; hubs use 0.0.0.0).
+# The hub-local enrollment socket defaults to /run/mac/local-console.sock.
+# MAC_LOCAL_CONSOLE_GROUP requires a matching SupplementaryGroups= override;
+# the API then changes the runtime directory/socket boundary to 0750/0660.
 ExecStart=/usr/local/bin/uvicorn mac.api:create_app --factory \
     --host ${MAC_BIND_HOST:-127.0.0.1} --port ${MAC_PORT:-8789} --workers 1 --log-level warning --no-access-log
 Restart=on-failure
@@ -28,7 +36,7 @@ ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
 PrivateDevices=true
-ReadWritePaths=/var/lib/mac
+ReadWritePaths=/var/lib/mac /run/mac
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true

--- a/docs/client-bootstrap-contract.md
+++ b/docs/client-bootstrap-contract.md
@@ -1,4 +1,4 @@
-# SSH Client Bootstrap Contracts
+# Client Bootstrap Contracts
 
 MAC ships the complete SSH-first login orchestration plus its three lower-level
 security contracts:
@@ -12,8 +12,42 @@ security contracts:
   record.
 - `mac admin login`, `mac admin login status`, `mac admin login renew`, and `mac admin logout --revoke`
   compose those primitives into a verified, recoverable client lifecycle.
+- `mac admin login --local-console` provides a separate hub-local enrollment
+  path through the running API service without exposing the shared admin token.
 
 ## Managed Login
+
+From a shell on the hub, use the kernel-authenticated local console instead of
+SSH:
+
+```console
+mac admin login --local-console --profile local --client-id hub-console
+mac admin login renew --local-console --profile local
+```
+
+The client sends one bounded JSON request to `MAC_LOCAL_CONSOLE_SOCKET`. The
+packaged systemd configuration sets `/run/mac/local-console.sock`; an
+unconfigured user service defaults to `~/.mac/local-console.sock`. The API
+service authorizes the Unix-socket peer UID from kernel credentials; loopback
+TCP is not an enrollment authority. By default only the service UID and root
+can connect. `MAC_LOCAL_CONSOLE_GROUP` may grant an explicit local group access,
+with the socket directory and socket set to `0750` and `0660` for that same
+group. Without a group they are `0700` and `0600`.
+
+The direct profile URL is selected from `MAC_API_URL`, `MAC_URL`, or
+`MAC_HUB_URL`, then falls back to `http://127.0.0.1:$MAC_PORT`. The issued
+bearer is validated against that API before the profile is installed or
+activated. Validation failure triggers best-effort revocation and leaves no
+local profile. Ordinary enrollment is limited to `read,write,dispatch`; any
+broader scope requires both root and `--allow-elevated`.
+
+Local-console renewal rotates through the same kernel-authenticated socket and
+validates the replacement bearer before atomically replacing the profile
+credential. The old bearer is invalid as soon as the service rotates it. If
+replacement validation fails, the service revokes the new bearer and keeps the
+local profile file unchanged, while reporting explicitly that its retained old
+credential is no longer valid. Renewing a credential whose scopes exceed
+`read,write,dispatch` still requires root and `--allow-elevated`.
 
 For an explicit hub route:
 
@@ -99,10 +133,12 @@ the remote principal active.
 
 ## Trust Boundary
 
-Enrollment is a hub-local operation invoked through an SSH session that has
-already authenticated the human or automation identity. It is not an HTTP
-endpoint and does not accept the shared administrator bearer as a bootstrap
-credential.
+Enrollment is a hub-local operation invoked through either an SSH session that
+already authenticated the human or automation identity, or the API service's
+Unix socket after kernel peer-credential authorization. It is not an HTTP
+endpoint, does not trust loopback TCP as an enrollment authority, and does not
+accept or copy the shared administrator bearer as a bootstrap credential. Only
+the API service writes the principal registry on the local-console path.
 
 The hub registry defaults to
 `$MAC_HOME/client-principals.json` and can be overridden with

--- a/docs/client-bootstrap-contract.md
+++ b/docs/client-bootstrap-contract.md
@@ -38,8 +38,11 @@ The direct profile URL is selected from `MAC_API_URL`, `MAC_URL`, or
 `MAC_HUB_URL`, then falls back to `http://127.0.0.1:$MAC_PORT`. The issued
 bearer is validated against that API before the profile is installed or
 activated. Validation failure triggers best-effort revocation and leaves no
-local profile. Ordinary enrollment is limited to `read,write,dispatch`; any
-broader scope requires both root and `--allow-elevated`.
+local profile. Ordinary enrollment is limited to `read,write,dispatch`. A
+broader scope requires explicit `--allow-elevated` acknowledgement and the peer
+must be root or the OS account running the API service. This matches the
+authority that account already has when it invokes enrollment through SSH;
+supplementary-group users remain limited to ordinary scopes.
 
 Local-console renewal rotates through the same kernel-authenticated socket and
 validates the replacement bearer before atomically replacing the profile
@@ -47,7 +50,8 @@ credential. The old bearer is invalid as soon as the service rotates it. If
 replacement validation fails, the service revokes the new bearer and keeps the
 local profile file unchanged, while reporting explicitly that its retained old
 credential is no longer valid. Renewing a credential whose scopes exceed
-`read,write,dispatch` still requires root and `--allow-elevated`.
+`read,write,dispatch` still requires the service owner or root plus
+`--allow-elevated`.
 
 For an explicit hub route:
 

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -620,6 +620,9 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_LINUX_SERVICE_TX_SAVED_HUP_TRAP` | str | consumer-defined | core | Core setting: linux service tx saved hup trap. |
 | `MAC_LINUX_SERVICE_TX_SAVED_INT_TRAP` | str | consumer-defined | core | Core setting: linux service tx saved int trap. |
 | `MAC_LINUX_SERVICE_TX_SAVED_TERM_TRAP` | str | consumer-defined | core | Core setting: linux service tx saved term trap. |
+| `MAC_LOCAL_CONSOLE_ENABLED` | bool | consumer-defined | client-auth | Client Auth setting: local console enabled. |
+| `MAC_LOCAL_CONSOLE_GROUP` | str | consumer-defined | client-auth | Client Auth setting: local console group. |
+| `MAC_LOCAL_CONSOLE_SOCKET` | str | consumer-defined | client-auth | Client Auth setting: local console socket. |
 | `MAC_LOOP_HEARTBEAT_SECONDS` | int | consumer-defined | core | Core setting: loop heartbeat seconds. |
 | `MAC_LOOP_STALL_THRESHOLD_SECONDS` | int | consumer-defined | core | Core setting: loop stall threshold seconds. |
 | `MAC_MACHINE_ID` | str | consumer-defined | core | Core setting: machine id. |

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -149,7 +149,7 @@ marked `historical archive` and must not be read as current behaviour.
 | book | [`book/18-capstone.md`](../book/18-capstone.md) | From Request to Production |
 | runbook | [`break-glass-host-recovery.md`](../break-glass-host-recovery.md) | Break-glass host recovery |
 | supplemental reference | [`c26-certifier-phase-profile-example.md`](../c26-certifier-phase-profile-example.md) | c26 certifier phase-profile example |
-| supplemental reference | [`client-bootstrap-contract.md`](../client-bootstrap-contract.md) | SSH Client Bootstrap Contracts |
+| supplemental reference | [`client-bootstrap-contract.md`](../client-bootstrap-contract.md) | Client Bootstrap Contracts |
 | supplemental reference | [`coding-cli-credentials.md`](../coding-cli-credentials.md) | Coding-CLI Credentials and Model Selection |
 | supplemental reference | [`coding-route-ladder.md`](../coding-route-ladder.md) | The coding-route ladder |
 | supplemental reference | [`crash-diagnosis-and-repair.md`](../crash-diagnosis-and-repair.md) | Crash diagnosis and autonomous repair |

--- a/scripts/generate-env-config-registry.py
+++ b/scripts/generate-env-config-registry.py
@@ -39,6 +39,7 @@ FAMILIES = (
     ("MAC_CODING_ROUTE_", "coding-route-ladder"),
     ("MAC_CODING_AGENT_", "coding-agent-auth"),
     ("MAC_CLIENT_PRINCIPALS_", "client-auth"),
+    ("MAC_LOCAL_CONSOLE_", "client-auth"),
     ("MAC_DEPLOY_ROUTER_", "deploy-router"),
     ("MAC_DEPLOY_AGENT_GEN_", "deploy-agent-generation"),
     ("MAC_DEPLOY_", "deployment"),

--- a/skills/mac-cli/SKILL.md
+++ b/skills/mac-cli/SKILL.md
@@ -162,6 +162,17 @@ called "help".
     mac admin dispatch submit <file>    literate-ai execution requests
     mac admin judgement status          process-quality daemon last report
     mac admin judgement run             run one judgement cycle now
+    mac admin login --local-console     hub-local enrollment without SSH
+
+`mac admin login --local-console` is only for a shell on the hub. It asks the
+running API service for a new scoped, independently revocable credential over
+its kernel-authenticated Unix socket; it never reads the shared hub admin token.
+The ordinary scope boundary is `read,write,dispatch`. Any broader scope requires
+root plus `--allow-elevated`. Remote clients continue to use `mac admin login
+--ssh ...` or a registered fleet SSH route.
+Use `mac admin login renew --local-console` to rotate a direct local-console
+profile through the same socket; the new bearer is validated before replacing
+the local credential.
 
 ## File tasks in dependency order, because there is no second chance
 
@@ -307,7 +318,6 @@ nothing else. `attempt_count: 0` with idle capable agents and no dispatch
 hold is a real state, and it means the fault is in dispatch rather than in
 anything about the task. Do not read a bare `why-unclaimed` as "nothing is
 wrong".
-
 ## Requirements: capabilities versus hardware
 
 Capabilities are set membership over a DECLARED vocabulary — agents advertise

--- a/skills/mac-cli/SKILL.md
+++ b/skills/mac-cli/SKILL.md
@@ -168,8 +168,9 @@ called "help".
 running API service for a new scoped, independently revocable credential over
 its kernel-authenticated Unix socket; it never reads the shared hub admin token.
 The ordinary scope boundary is `read,write,dispatch`. Any broader scope requires
-root plus `--allow-elevated`. Remote clients continue to use `mac admin login
---ssh ...` or a registered fleet SSH route.
+the API service's OS account or root plus `--allow-elevated`; a configured
+supplementary group grants ordinary enrollment only. Remote clients continue to
+use `mac admin login --ssh ...` or a registered fleet SSH route.
 Use `mac admin login renew --local-console` to rotate a direct local-console
 profile through the same socket; the new bearer is validated before replacing
 the local credential.

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -4337,6 +4337,8 @@ def create_app(
     auth_tokens: Optional[AuthTokenMapping] = None,
     record_http_observations: Optional[bool] = None,
     client_principals_path: Optional[str] = None,
+    local_console_socket_path: Optional[str] = None,
+    local_console_group: Optional[str] = None,
 ) -> FastAPI:
     # db_path is the explicit SQLite override (e.g. for tests). When it is
     # None, make_store_from_env requires MAC_DATABASE_URL or MAC_DB. This keeps
@@ -4388,6 +4390,15 @@ def create_app(
         WorkerCredentialPrincipalProvider,
     )
 
+    injected_app = control_plane is not None or db_path is not None
+    if injected_app:
+        # An injected app is hermetic unless its constructor explicitly opts in.
+        local_console_enabled = local_console_socket_path is not None
+    else:
+        local_console_enabled = (
+            os.environ.get("MAC_LOCAL_CONSOLE_ENABLED", "1").strip().lower()
+            not in {"0", "false", "no", "off"}
+        )
     configured_client_path = client_principals_path or os.environ.get(
         "MAC_CLIENT_PRINCIPALS_FILE"
     )
@@ -4398,7 +4409,7 @@ def create_app(
             if configured_client_path
             else None
         )
-        if configured_client_path or use_default_client_registry
+        if configured_client_path or use_default_client_registry or local_console_enabled
         else None
     )
     client_registry_seen = bool(
@@ -4406,6 +4417,22 @@ def create_app(
     )
     worker_principals = WorkerCredentialPrincipalProvider(cp.store)
     worker_identity_policy = WorkerCredentialPolicyProvider(cp.store)
+    local_console_service = None
+    if local_console_enabled:
+        from mac.client_principals import ClientPrincipalStore
+        from mac.local_console import LocalConsoleService, configured_socket_path
+
+        assert client_principals is not None
+        configured_group = (
+            local_console_group
+            if injected_app
+            else local_console_group or os.environ.get("MAC_LOCAL_CONSOLE_GROUP")
+        )
+        local_console_service = LocalConsoleService(
+            configured_socket_path(local_console_socket_path),
+            ClientPrincipalStore(client_principals.path),
+            allowed_group=configured_group,
+        )
 
     def _current_auth_tokens() -> Dict[str, TokenPrincipal]:
         nonlocal client_registry_seen
@@ -4543,6 +4570,14 @@ def create_app(
             # hub wedged and the supervisor restarted it" into a measurement.
             ("loop_stall_detector", loop_stall_detector.start, loop_stall_detector.stop),
         ]
+        if local_console_service is not None:
+            services.append(
+                (
+                    "local_console",
+                    local_console_service.start,
+                    local_console_service.stop,
+                )
+            )
         started: List[Tuple[str, Callable[[], Any]]] = []
 
         def _stop_started() -> None:
@@ -4581,6 +4616,7 @@ def create_app(
     app.state.client_principals = client_principals
     app.state.worker_principals = worker_principals
     app.state.worker_identity_policy = worker_identity_policy
+    app.state.local_console_service = local_console_service
     app.state.repository_ref_reconciler = repository_ref_reconciler
     app.state.github_ingestor = github_ingestor
     app.state.cicd_monitor = cicd_monitor

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -867,6 +867,8 @@ def cmd_login(args: argparse.Namespace) -> None:
         default_client_id,
         login,
         login_status,
+        local_console_login,
+        renew_local_console_login,
         renew_login,
         resolve_login_spec,
     )
@@ -875,13 +877,39 @@ def cmd_login(args: argparse.Namespace) -> None:
     fleet = args.login_fleet or args.fleet
     profile = _login_profile(args, fleet=fleet)
     try:
+        if args.local_console and args.ssh_target:
+            raise ClientLoginError("--local-console cannot be combined with --ssh")
         if args.login_action == "status":
             result = login_status(profile)
         elif args.login_action == "renew":
-            result = renew_login(
-                profile,
+            if args.local_console:
+                result = renew_local_console_login(
+                    profile,
+                    expires_in=args.expires_in,
+                    socket_path=args.local_console_socket,
+                    allow_elevated=args.allow_elevated,
+                    connect_timeout=args.connect_timeout,
+                )
+            else:
+                result = renew_login(
+                    profile,
+                    expires_in=args.expires_in,
+                    remote_mac=args.remote_mac,
+                    connect_timeout=args.connect_timeout,
+                )
+        elif args.local_console:
+            result = local_console_login(
+                profile=profile,
+                client_id=args.client_id or default_client_id(),
+                display_name=args.name or "",
+                fleet=fleet or "",
+                scopes=_csv(args.scopes),
+                capabilities=_csv(args.capabilities),
                 expires_in=args.expires_in,
-                remote_mac=args.remote_mac,
+                api_url=args.login_api_url,
+                socket_path=args.local_console_socket,
+                allow_elevated=args.allow_elevated,
+                rotate=args.rotate,
                 connect_timeout=args.connect_timeout,
             )
         else:
@@ -7718,7 +7746,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     login_parser = sub.add_parser(
         "login",
-        help="bootstrap or inspect a scoped client login over verified SSH",
+        help="bootstrap or inspect a scoped client login over SSH or a local Unix socket",
     )
     login_parser.add_argument(
         "login_action",
@@ -7727,6 +7755,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="inspect or renew the selected login; omit to enroll",
     )
     login_parser.add_argument("--ssh", dest="ssh_target", help="hub SSH target user@host")
+    login_parser.add_argument(
+        "--local-console",
+        action="store_true",
+        help="enroll through the running hub API service's kernel-authenticated Unix socket",
+    )
+    login_parser.add_argument(
+        "--local-console-socket",
+        help="Unix socket path (default: MAC_LOCAL_CONSOLE_SOCKET or service default)",
+    )
+    login_parser.add_argument(
+        "--api-url",
+        dest="login_api_url",
+        help="direct profile API URL (default: MAC_API_URL/MAC_URL/MAC_HUB_URL)",
+    )
     login_parser.add_argument("--ssh-port", type=int)
     login_parser.add_argument("--proxy-jump")
     login_parser.add_argument("--identity-file")

--- a/src/mac/client_login.py
+++ b/src/mac/client_login.py
@@ -880,6 +880,230 @@ def login(
             raise ClientLoginError("login failed before credentials could be committed") from exc
 
 
+def local_console_login(
+    *,
+    profile: str,
+    client_id: str,
+    display_name: str = "",
+    fleet: str = "",
+    scopes: Iterable[str] = DEFAULT_SCOPES,
+    capabilities: Iterable[str] = (),
+    expires_in: int = 30 * 24 * 60 * 60,
+    api_url: Optional[str] = None,
+    socket_path: Optional[str] = None,
+    allow_elevated: bool = False,
+    rotate: bool = False,
+    connect_timeout: int = 10,
+) -> Dict[str, Any]:
+    """Enroll through the API service's kernel-authenticated Unix socket."""
+    from mac.client_principals import ELEVATED_SCOPES
+    from mac.local_console import (
+        DEFAULT_SCOPES as LOCAL_DEFAULT_SCOPES,
+        LocalConsoleError,
+        default_api_url,
+        request_local_console,
+    )
+
+    profile = _name(profile)
+    normalized_scopes = [str(item).strip().lower() for item in scopes if str(item).strip()]
+    privileged = set(normalized_scopes) - set(LOCAL_DEFAULT_SCOPES)
+    if privileged and (not allow_elevated or os.geteuid() != 0):
+        raise ClientLoginError(
+            "local-console scopes outside read,write,dispatch require root and "
+            "explicit --allow-elevated"
+        )
+    if set(normalized_scopes) & ELEVATED_SCOPES and not allow_elevated:
+        raise ClientLoginError("elevated scopes require explicit --allow-elevated")
+    resolved_api_url = (api_url or default_api_url()).rstrip("/")
+    issued = False
+    with _session_lock(profile):
+        exists = any(item.get("profile") == profile for item in list_profiles())
+        if exists and not rotate:
+            raise ClientLoginError(
+                "client profile %r already exists; use --rotate" % profile
+            )
+        request = {
+            "action": "enroll",
+            "client_id": client_id,
+            "display_name": display_name or client_id,
+            "fleet": fleet,
+            "profile": profile,
+            "scopes": normalized_scopes,
+            "capabilities": [str(item) for item in capabilities],
+            "expires_in": int(expires_in),
+            "api_url": resolved_api_url,
+            "allow_elevated": bool(allow_elevated),
+            "rotate": bool(rotate),
+        }
+        try:
+            manifest = request_local_console(
+                request, socket_path=socket_path, timeout=connect_timeout
+            )
+            issued = True
+            validate_enrollment_manifest(manifest, profile_override=profile)
+            manifest_api_url = str(
+                (manifest.get("connection") or {}).get("api_url") or ""
+            ).rstrip("/")
+            if manifest_api_url != resolved_api_url:
+                raise ClientLoginError(
+                    "local-console manifest changed the requested API authority"
+                )
+            token = str((manifest.get("credential") or {}).get("token") or "")
+            valid, reason = _validate_token(
+                resolved_api_url, token, timeout=connect_timeout
+            )
+            if not valid:
+                raise ClientLoginError(
+                    "hub rejected the local-console credential (%s)" % reason
+                )
+            result = install_enrollment_manifest(
+                manifest, profile_override=profile, activate=True
+            )
+            return {
+                "status": "logged_in",
+                "profile": profile,
+                "client_id": manifest.get("client_id"),
+                "fleet": manifest.get("fleet"),
+                "api_url": resolved_api_url,
+                "scopes": list((manifest.get("credential") or {}).get("scopes") or []),
+                "expires_at": (manifest.get("credential") or {}).get("expires_at"),
+                "session": {"status": "direct"},
+                "changed": bool(result.get("changed")),
+            }
+        except Exception as exc:
+            if issued:
+                try:
+                    request_local_console(
+                        {"action": "revoke", "client_id": client_id},
+                        socket_path=socket_path,
+                        timeout=connect_timeout,
+                    )
+                except Exception:
+                    pass
+            if isinstance(exc, (ClientLoginError, ClientProfileError, LocalConsoleError)):
+                raise ClientLoginError(str(exc)) from exc
+            raise ClientLoginError(
+                "local-console login failed before credentials could be committed"
+            ) from exc
+
+
+def renew_local_console_login(
+    profile: Optional[str] = None,
+    *,
+    expires_in: int = 30 * 24 * 60 * 60,
+    socket_path: Optional[str] = None,
+    allow_elevated: bool = False,
+    connect_timeout: int = 10,
+) -> Dict[str, Any]:
+    """Rotate a direct login through the kernel-authenticated Unix socket."""
+    from mac.local_console import LocalConsoleError, request_local_console
+
+    selected = _name(profile) if profile else active_profile_name()
+    if not selected:
+        raise ClientLoginError("no active login profile")
+    with _session_lock(selected):
+        current = load_profile(selected, include_token=True)
+        connection = dict(current.get("connection") or {})
+        if connection.get("mode") != "direct":
+            raise ClientLoginError(
+                "--local-console renewal requires a direct local-console profile"
+            )
+        credential = dict(current.get("credential") or {})
+        privileged = set(credential.get("scopes") or []) - {
+            "read",
+            "write",
+            "dispatch",
+        }
+        if privileged and (not allow_elevated or os.geteuid() != 0):
+            raise ClientLoginError(
+                "renewing local-console scopes outside read,write,dispatch "
+                "requires root and explicit --allow-elevated"
+            )
+        client_id = str(current.get("client_id") or "")
+        api_url = str(connection.get("api_url") or "").rstrip("/")
+        if int(expires_in) < 60:
+            raise ClientLoginError("expires-in must be at least 60 seconds")
+        renew_attempted = False
+        issued = False
+        install_started = False
+        try:
+            renew_attempted = True
+            manifest = request_local_console(
+                {
+                    "action": "renew",
+                    "client_id": client_id,
+                    "expires_in": int(expires_in),
+                    "allow_elevated": bool(allow_elevated),
+                },
+                socket_path=socket_path,
+                timeout=connect_timeout,
+            )
+            issued = True
+            validate_enrollment_manifest(manifest, profile_override=selected)
+            manifest_api_url = str(
+                (manifest.get("connection") or {}).get("api_url") or ""
+            ).rstrip("/")
+            if manifest_api_url != api_url:
+                raise ClientLoginError(
+                    "local-console renewal changed the profile API authority"
+                )
+            token = str((manifest.get("credential") or {}).get("token") or "")
+            valid, reason = _validate_token(api_url, token, timeout=connect_timeout)
+            if not valid:
+                raise ClientLoginError(
+                    "renewed local-console credential failed validation (%s)" % reason
+                )
+            install_started = True
+            result = install_enrollment_manifest(
+                manifest, profile_override=selected, activate=True
+            )
+            return {
+                "status": "renewed",
+                "profile": selected,
+                "client_id": client_id,
+                "api_url": api_url,
+                "scopes": list((manifest.get("credential") or {}).get("scopes") or []),
+                "expires_at": (manifest.get("credential") or {}).get("expires_at"),
+                "changed": bool(result.get("changed")),
+            }
+        except Exception as exc:
+            if renew_attempted:
+                try:
+                    request_local_console(
+                        {"action": "revoke", "client_id": client_id},
+                        socket_path=socket_path,
+                        timeout=connect_timeout,
+                    )
+                except Exception as rollback_exc:
+                    if install_started:
+                        raise ClientLoginError(
+                            "local-console renewal failed and rollback revocation "
+                            "could not be confirmed; local profile state should be "
+                            "inspected"
+                        ) from rollback_exc
+                    raise ClientLoginError(
+                        "local-console renewal outcome and rollback revocation "
+                        "could not be confirmed; the local profile was not "
+                        "replaced and its credential validity is unknown"
+                    ) from rollback_exc
+                if install_started:
+                    raise ClientLoginError(
+                        "%s; the new credential was revoked, but profile "
+                        "installation failed and local state should be inspected" % exc
+                    ) from exc
+                credential = "new credential" if issued else "hub credential"
+                raise ClientLoginError(
+                    "%s; the %s was revoked and the local profile was not "
+                    "replaced; its old credential is no longer valid"
+                    % (exc, credential)
+                ) from exc
+            if isinstance(exc, (ClientLoginError, ClientProfileError, LocalConsoleError)):
+                raise ClientLoginError(str(exc)) from exc
+            raise ClientLoginError(
+                "local-console renewal failed before a credential was issued"
+            ) from exc
+
+
 def _ensure_session_unlocked(profile_name: str) -> Dict[str, Any]:
     profile = load_profile(profile_name, include_token=True)
     connection = dict(profile.get("connection") or {})

--- a/src/mac/client_login.py
+++ b/src/mac/client_login.py
@@ -907,10 +907,10 @@ def local_console_login(
     profile = _name(profile)
     normalized_scopes = [str(item).strip().lower() for item in scopes if str(item).strip()]
     privileged = set(normalized_scopes) - set(LOCAL_DEFAULT_SCOPES)
-    if privileged and (not allow_elevated or os.geteuid() != 0):
+    if privileged and not allow_elevated:
         raise ClientLoginError(
-            "local-console scopes outside read,write,dispatch require root and "
-            "explicit --allow-elevated"
+            "local-console scopes outside read,write,dispatch require explicit "
+            "--allow-elevated and authorization by the service"
         )
     if set(normalized_scopes) & ELEVATED_SCOPES and not allow_elevated:
         raise ClientLoginError("elevated scopes require explicit --allow-elevated")
@@ -1014,10 +1014,10 @@ def renew_local_console_login(
             "write",
             "dispatch",
         }
-        if privileged and (not allow_elevated or os.geteuid() != 0):
+        if privileged and not allow_elevated:
             raise ClientLoginError(
                 "renewing local-console scopes outside read,write,dispatch "
-                "requires root and explicit --allow-elevated"
+                "requires explicit --allow-elevated and authorization by the service"
             )
         client_id = str(current.get("client_id") or "")
         api_url = str(connection.get("api_url") or "").rstrip("/")

--- a/src/mac/client_principals.py
+++ b/src/mac/client_principals.py
@@ -1,9 +1,10 @@
 """Hub-local, independently revocable MAC client credentials.
 
-Enrollment is intentionally a local command.  A remote client invokes it over
-an already-authenticated SSH session, so no bootstrap HTTP credential is
-needed.  The registry stores only SHA-256 token hashes and scoped principal
-metadata.  Live token material is returned once in the enrollment manifest and
+Enrollment is intentionally hub-local. A remote client invokes the command over
+an already-authenticated SSH session; a hub shell asks the running API service
+over its kernel-authenticated Unix socket. Neither path needs a bootstrap HTTP
+credential. The registry stores only SHA-256 token hashes and scoped principal
+metadata. Live token material is returned once in the enrollment manifest and
 is never written to the registry or audit log.
 """
 from __future__ import annotations
@@ -372,6 +373,7 @@ class ClientPrincipalStore:
         human_id: str = "",
         principal_kind: str = "client",
         credential_metadata: Optional[Mapping[str, Any]] = None,
+        required_existing_metadata: Optional[Mapping[str, Any]] = None,
         token_prefix: str = "mac_client_",
         allow_elevated: bool = False,
         rotate: bool = False,
@@ -389,6 +391,15 @@ class ClientPrincipalStore:
                     "client %r already exists; use `mac admin client renew` or --rotate"
                     % client_id
                 )
+            if existing and required_existing_metadata is not None:
+                existing_metadata = existing.get("credential_metadata")
+                if not isinstance(existing_metadata, Mapping) or any(
+                    existing_metadata.get(key) != value
+                    for key, value in required_existing_metadata.items()
+                ):
+                    raise ClientPrincipalError(
+                        "client %r is not owned by this enrollment authority" % client_id
+                    )
             return self._issue_locked(
                 registry,
                 client_id,
@@ -415,6 +426,8 @@ class ClientPrincipalStore:
         client_id: str,
         *,
         expires_in: int = 30 * 24 * 60 * 60,
+        allowed_scopes: Optional[Iterable[str]] = None,
+        required_metadata: Optional[Mapping[str, Any]] = None,
         actor: str = "operator",
     ) -> IssuedCredential:
         client_id = _validate_id(client_id)
@@ -429,13 +442,32 @@ class ClientPrincipalStore:
                 raise ClientPrincipalError(
                     "client %r is revoked; enroll a new client identity" % client_id
                 )
+            existing_metadata = existing.get("credential_metadata")
+            if required_metadata is not None and (
+                not isinstance(existing_metadata, Mapping)
+                or any(
+                    existing_metadata.get(key) != value
+                    for key, value in required_metadata.items()
+                )
+            ):
+                raise ClientPrincipalError(
+                    "client %r is not owned by this enrollment authority" % client_id
+                )
+            existing_scopes = list(existing.get("scopes") or DEFAULT_SCOPES)
+            if allowed_scopes is not None:
+                disallowed = sorted(set(existing_scopes) - set(allowed_scopes))
+                if disallowed:
+                    raise ClientPrincipalError(
+                        "renewal is not authorized for scope(s): %s"
+                        % ", ".join(disallowed)
+                    )
             return self._issue_locked(
                 registry,
                 client_id,
                 display_name=str(existing.get("display_name") or client_id),
                 fleet=str(existing.get("fleet") or ""),
                 profile=str(existing.get("profile") or client_id),
-                scopes=list(existing.get("scopes") or DEFAULT_SCOPES),
+                scopes=existing_scopes,
                 expires_in=int(expires_in),
                 api_url=str(existing.get("api_url") or "http://127.0.0.1:8789"),
                 ssh_host_key_fingerprint=str(existing.get("ssh_host_key_fingerprint") or ""),
@@ -457,13 +489,30 @@ class ClientPrincipalStore:
                 event="client.renewed",
             )
 
-    def revoke(self, client_id: str, *, actor: str = "operator") -> Dict[str, Any]:
+    def revoke(
+        self,
+        client_id: str,
+        *,
+        required_metadata: Optional[Mapping[str, Any]] = None,
+        actor: str = "operator",
+    ) -> Dict[str, Any]:
         client_id = _validate_id(client_id)
         with self._lock():
             registry = self._read_unlocked()
             record = registry["clients"].get(client_id)
             if not isinstance(record, dict):
                 raise ClientPrincipalError("client %r does not exist" % client_id)
+            existing_metadata = record.get("credential_metadata")
+            if required_metadata is not None and (
+                not isinstance(existing_metadata, Mapping)
+                or any(
+                    existing_metadata.get(key) != value
+                    for key, value in required_metadata.items()
+                )
+            ):
+                raise ClientPrincipalError(
+                    "client %r is not owned by this enrollment authority" % client_id
+                )
             if not record.get("revoked_at"):
                 record["revoked_at"] = _timestamp()
                 registry["updated_at"] = record["revoked_at"]

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -637,7 +637,8 @@
       "src/mac/cli.py",
       "src/mac/dispatch.py",
       "src/mac/gitops.py",
-      "src/mac/ide_launcher.py"
+      "src/mac/ide_launcher.py",
+      "src/mac/local_console.py"
     ],
     "type": "str"
   },
@@ -6379,6 +6380,7 @@
       "src/mac/hermes_startup.py",
       "src/mac/k8s/job_executor.py",
       "src/mac/k8s/runner.py",
+      "src/mac/local_console.py",
       "src/mac/openshell_collector.py",
       "src/mac/openshell_supervisor.py",
       "src/mac/worker.py"
@@ -7323,6 +7325,42 @@
     "retired": false,
     "sources": [
       "deploy/deploy-mac-fleet.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Client Auth setting: local console enabled.",
+    "family": "client-auth",
+    "name": "MAC_LOCAL_CONSOLE_ENABLED",
+    "retired": false,
+    "sources": [
+      "src/mac/api.py"
+    ],
+    "type": "bool"
+  },
+  {
+    "default": null,
+    "description": "Client Auth setting: local console group.",
+    "family": "client-auth",
+    "name": "MAC_LOCAL_CONSOLE_GROUP",
+    "retired": false,
+    "sources": [
+      "deploy/systemd/mac.service",
+      "src/mac/api.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Client Auth setting: local console socket.",
+    "family": "client-auth",
+    "name": "MAC_LOCAL_CONSOLE_SOCKET",
+    "retired": false,
+    "sources": [
+      "deploy/systemd/mac.service",
+      "src/mac/cli.py",
+      "src/mac/local_console.py"
     ],
     "type": "str"
   },
@@ -9943,7 +9981,8 @@
       "deploy/systemd/mac.service",
       "scripts/escrow-upstream-key.sh",
       "scripts/migrate-tokenhub-vault.sh",
-      "src/mac/deploy_env.py"
+      "src/mac/deploy_env.py",
+      "src/mac/local_console.py"
     ],
     "type": "int"
   },
@@ -13610,6 +13649,7 @@
       "src/mac/k8s/job_executor.py",
       "src/mac/k8s/orchestrator.py",
       "src/mac/k8s/runner.py",
+      "src/mac/local_console.py",
       "src/mac/openshell_collector.py",
       "src/mac/worker.py"
     ],

--- a/src/mac/local_console.py
+++ b/src/mac/local_console.py
@@ -1,0 +1,452 @@
+"""Kernel-authenticated, hub-local client enrollment over a Unix socket."""
+
+from __future__ import annotations
+
+import errno
+import grp
+import json
+import logging
+import os
+import pwd
+import socket
+import stat
+import struct
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+from urllib.parse import urlsplit
+
+from mac.client_principals import (
+    ELEVATED_SCOPES,
+    KNOWN_SCOPES,
+    ClientPrincipalError,
+    ClientPrincipalStore,
+    enrollment_manifest,
+)
+
+
+DEFAULT_SOCKET_PATH = "~/.mac/local-console.sock"
+DEFAULT_SCOPES = frozenset({"read", "write", "dispatch"})
+MAX_FRAME_BYTES = 64 * 1024
+MAX_RESPONSE_BYTES = 128 * 1024
+_REQUEST_KEYS = frozenset(
+    {
+        "action",
+        "client_id",
+        "display_name",
+        "fleet",
+        "profile",
+        "scopes",
+        "capabilities",
+        "expires_in",
+        "api_url",
+        "allow_elevated",
+        "rotate",
+    }
+)
+_LOG = logging.getLogger("mac.local_console")
+
+
+class LocalConsoleError(RuntimeError):
+    """A secret-safe local-console transport or enrollment failure."""
+
+
+@dataclass(frozen=True)
+class PeerIdentity:
+    uid: int
+    gid: int
+    pid: Optional[int] = None
+
+    @property
+    def username(self) -> str:
+        try:
+            value = pwd.getpwuid(self.uid).pw_name
+        except KeyError:
+            return "unknown"
+        return "".join(ch for ch in value if ch.isalnum() or ch in "._-")[:64] or "unknown"
+
+
+def configured_socket_path(value: Optional[str] = None) -> Path:
+    raw = value or os.environ.get("MAC_LOCAL_CONSOLE_SOCKET") or DEFAULT_SOCKET_PATH
+    return Path(raw).expanduser()
+
+
+def default_api_url() -> str:
+    for name in ("MAC_API_URL", "MAC_URL", "MAC_HUB_URL"):
+        value = (os.environ.get(name) or "").strip()
+        if value:
+            return value.rstrip("/")
+    raw_port = (os.environ.get("MAC_PORT") or "8789").strip()
+    try:
+        port = int(raw_port)
+    except ValueError as exc:
+        raise LocalConsoleError("MAC_PORT must be an integer") from exc
+    if not 1 <= port <= 65535:
+        raise LocalConsoleError("MAC_PORT must be between 1 and 65535")
+    return "http://127.0.0.1:%d" % port
+
+
+def _json_without_duplicates(raw: bytes) -> Any:
+    def pairs(items: Iterable[tuple[str, Any]]) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for key, value in items:
+            if key in result:
+                raise ValueError("duplicate JSON key")
+            result[key] = value
+        return result
+
+    return json.loads(raw.decode("utf-8"), object_pairs_hook=pairs)
+
+
+def _receive_frame(conn: socket.socket, limit: int) -> bytes:
+    data = bytearray()
+    while True:
+        chunk = conn.recv(min(4096, limit + 1 - len(data)))
+        if not chunk:
+            raise LocalConsoleError("connection closed before a complete request")
+        data.extend(chunk)
+        if len(data) > limit:
+            raise LocalConsoleError("request exceeds the local-console size limit")
+        newline = data.find(b"\n")
+        if newline >= 0:
+            if data[newline + 1 :].strip():
+                raise LocalConsoleError("only one local-console request is allowed")
+            return bytes(data[:newline])
+
+
+def _peer_identity(conn: socket.socket) -> PeerIdentity:
+    # BSD/macOS exposes getpeereid(); prefer it there. Some platforms also
+    # define SO_PEERCRED with a non-Linux payload, so testing the constant first
+    # and unpacking Linux's three integers can misidentify the peer.
+    getter = getattr(conn, "getpeereid", None)
+    if callable(getter):
+        uid, gid = getter()
+        return PeerIdentity(uid=int(uid), gid=int(gid))
+    if hasattr(socket, "SO_PEERCRED"):
+        raw = conn.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+        pid, uid, gid = struct.unpack("3i", raw)
+        return PeerIdentity(uid=uid, gid=gid, pid=pid)
+    # CPython doesn't expose socket.getpeereid() on every macOS build even
+    # though libc and the kernel provide it. Calling libc still retrieves the
+    # credentials attached to this connected socket; no process-supplied data
+    # participates.
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        getpeereid = libc.getpeereid
+        getpeereid.argtypes = [
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_uint),
+            ctypes.POINTER(ctypes.c_uint),
+        ]
+        getpeereid.restype = ctypes.c_int
+        uid = ctypes.c_uint()
+        gid = ctypes.c_uint()
+        if getpeereid(conn.fileno(), ctypes.byref(uid), ctypes.byref(gid)) == 0:
+            return PeerIdentity(uid=int(uid.value), gid=int(gid.value))
+    except (AttributeError, OSError):
+        pass
+    raise LocalConsoleError("kernel peer credentials are unavailable on this platform")
+
+
+def _group_gid(name: Optional[str]) -> Optional[int]:
+    if not name:
+        return None
+    try:
+        return int(grp.getgrnam(name).gr_gid)
+    except KeyError as exc:
+        raise LocalConsoleError("configured local-console group does not exist") from exc
+
+
+def _peer_in_group(peer: PeerIdentity, gid: int) -> bool:
+    if peer.gid == gid:
+        return True
+    try:
+        account = pwd.getpwuid(peer.uid)
+        group = grp.getgrgid(gid)
+    except KeyError:
+        return False
+    return account.pw_gid == gid or account.pw_name in group.gr_mem
+
+
+def _validate_api_url(value: Any) -> str:
+    url = str(value or "").strip().rstrip("/")
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise LocalConsoleError("api_url must be an http or https URL")
+    if parsed.username or parsed.password:
+        raise LocalConsoleError("api_url must not contain credentials")
+    return url
+
+
+def _string_list(value: Any, *, field: str, maximum: int = 64) -> list[str]:
+    if not isinstance(value, list) or len(value) > maximum:
+        raise LocalConsoleError("%s must be a bounded JSON array" % field)
+    result = []
+    for item in value:
+        text = str(item or "").strip()
+        if not text or len(text) > 256 or any(ord(ch) < 32 for ch in text):
+            raise LocalConsoleError("%s contains an invalid value" % field)
+        result.append(text)
+    return result
+
+
+class LocalConsoleService:
+    """Single-request JSON enrollment service authenticated by peer credentials."""
+
+    def __init__(
+        self,
+        socket_path: Path,
+        principal_store: ClientPrincipalStore,
+        *,
+        allowed_group: Optional[str] = None,
+        service_uid: Optional[int] = None,
+        request_timeout: float = 5.0,
+    ) -> None:
+        self.path = Path(socket_path)
+        self.store = principal_store
+        self.service_uid = os.geteuid() if service_uid is None else int(service_uid)
+        self.allowed_group = allowed_group or None
+        self.allowed_gid = _group_gid(self.allowed_group)
+        self.request_timeout = max(0.1, float(request_timeout))
+        self._listener: Optional[socket.socket] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+
+    def _prepare_parent(self) -> None:
+        parent = self.path.parent
+        existed = parent.exists()
+        if existed and (parent.is_symlink() or not parent.is_dir()):
+            raise LocalConsoleError("local-console socket parent is not a directory")
+        parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        current = parent.stat()
+        if current.st_uid not in {0, self.service_uid}:
+            raise LocalConsoleError("local-console socket parent has an unsafe owner")
+        if existed and current.st_mode & 0o007:
+            # Never "repair" /tmp, /run, or another shared directory in place,
+            # especially when the API runs as root. Require a dedicated private
+            # parent instead of changing unrelated filesystem policy.
+            raise LocalConsoleError(
+                "local-console socket parent must not be accessible to other users"
+            )
+        mode = 0o750 if self.allowed_gid is not None else 0o700
+        if self.allowed_gid is not None and current.st_gid != self.allowed_gid:
+            try:
+                os.chown(parent, -1, self.allowed_gid)
+            except OSError as exc:
+                raise LocalConsoleError(
+                    "could not assign the configured local-console group to the socket directory"
+                ) from exc
+        if (current.st_mode & 0o777) != mode:
+            try:
+                parent.chmod(mode)
+            except OSError as exc:
+                raise LocalConsoleError(
+                    "could not enforce local-console socket directory permissions"
+                ) from exc
+
+    def start(self) -> None:
+        if self._listener is not None:
+            return
+        self._prepare_parent()
+        if os.path.lexists(self.path):
+            current = self.path.lstat()
+            if not stat.S_ISSOCK(current.st_mode) or current.st_uid != self.service_uid:
+                raise LocalConsoleError("refusing to replace an unsafe local-console socket path")
+            probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            probe.settimeout(0.2)
+            try:
+                probe.connect(str(self.path))
+            except (ConnectionRefusedError, FileNotFoundError):
+                pass
+            except OSError as exc:
+                raise LocalConsoleError(
+                    "could not verify the existing local-console socket"
+                ) from exc
+            else:
+                raise LocalConsoleError("another local-console service is already active")
+            finally:
+                probe.close()
+            self.path.unlink()
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            listener.bind(str(self.path))
+            if self.allowed_gid is not None:
+                os.chown(self.path, -1, self.allowed_gid)
+            self.path.chmod(0o660 if self.allowed_gid is not None else 0o600)
+            listener.listen(8)
+            listener.settimeout(0.2)
+        except Exception:
+            listener.close()
+            self.path.unlink(missing_ok=True)
+            raise
+        self._stop.clear()
+        self._listener = listener
+        self._thread = threading.Thread(target=self._serve, name="mac-local-console", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        listener, self._listener = self._listener, None
+        if listener is not None:
+            listener.close()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+        try:
+            if self.path.is_socket() and self.path.lstat().st_uid == self.service_uid:
+                self.path.unlink()
+        except OSError:
+            pass
+
+    def _serve(self) -> None:
+        while not self._stop.is_set():
+            listener = self._listener
+            if listener is None:
+                return
+            try:
+                conn, _address = listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                if self._stop.is_set():
+                    return
+                continue
+            with conn:
+                conn.settimeout(self.request_timeout)
+                self._handle_connection(conn)
+
+    def _authorized(self, peer: PeerIdentity) -> bool:
+        return peer.uid in {0, self.service_uid} or (
+            self.allowed_gid is not None and _peer_in_group(peer, self.allowed_gid)
+        )
+
+    def _handle_connection(self, conn: socket.socket) -> None:
+        try:
+            peer = _peer_identity(conn)
+            if not self._authorized(peer):
+                raise PermissionError("local-console peer is not authorized")
+            request = _json_without_duplicates(_receive_frame(conn, MAX_FRAME_BYTES))
+            response = {"ok": True, "manifest": self._dispatch(peer, request)}
+        except PermissionError:
+            response = {"ok": False, "error": "access denied by local-console policy"}
+        except (ClientPrincipalError, LocalConsoleError, ValueError, TypeError):
+            _LOG.warning("local-console request rejected", exc_info=True)
+            response = {"ok": False, "error": "local-console request was rejected"}
+        except Exception:
+            _LOG.error("local-console enrollment failed", exc_info=True)
+            response = {"ok": False, "error": "local-console enrollment failed"}
+        raw = (json.dumps(response, separators=(",", ":")) + "\n").encode("utf-8")
+        if len(raw) > MAX_RESPONSE_BYTES:
+            raw = b'{"ok":false,"error":"local-console enrollment failed"}\n'
+        try:
+            conn.sendall(raw)
+        except OSError:
+            pass
+
+    def _dispatch(self, peer: PeerIdentity, request: Any) -> Mapping[str, Any]:
+        if not isinstance(request, dict) or set(request) - _REQUEST_KEYS:
+            raise LocalConsoleError("request is not a supported object")
+        action = request.get("action")
+        client_id = str(request.get("client_id") or "")
+        actor = "local-console:uid=%d:user=%s" % (peer.uid, peer.username)
+        owner = {"enrollment_channel": "local-console", "local_uid": peer.uid}
+        if action == "revoke":
+            self.store.revoke(client_id, required_metadata=owner, actor=actor)
+            return {"revoked": True}
+        if action == "renew":
+            acknowledged = request.get("allow_elevated") is True
+            issued = self.store.renew(
+                client_id,
+                expires_in=int(request.get("expires_in") or 0),
+                allowed_scopes=(KNOWN_SCOPES if peer.uid == 0 and acknowledged else DEFAULT_SCOPES),
+                required_metadata=owner,
+                actor=actor,
+            )
+            return enrollment_manifest(issued)
+        if action != "enroll":
+            raise LocalConsoleError("unsupported local-console action")
+        scopes = _string_list(request.get("scopes"), field="scopes")
+        privileged = set(scopes) - DEFAULT_SCOPES
+        acknowledged = request.get("allow_elevated") is True
+        if privileged and (peer.uid != 0 or not acknowledged):
+            raise PermissionError("elevated local-console scopes require root")
+        if set(scopes) & ELEVATED_SCOPES and not acknowledged:
+            raise PermissionError("elevated local-console scopes require acknowledgement")
+        capabilities = _string_list(request.get("capabilities") or [], field="capabilities")
+        issued = self.store.enroll(
+            client_id,
+            display_name=str(request.get("display_name") or client_id),
+            fleet=str(request.get("fleet") or ""),
+            profile=str(request.get("profile") or client_id),
+            scopes=scopes,
+            capabilities=capabilities,
+            expires_in=int(request.get("expires_in") or 0),
+            api_url=_validate_api_url(request.get("api_url")),
+            allow_elevated=acknowledged,
+            rotate=request.get("rotate") is True,
+            actor=actor,
+            credential_metadata={
+                **owner,
+                "local_username": peer.username,
+            },
+            required_existing_metadata=owner,
+        )
+        return enrollment_manifest(issued)
+
+
+def request_local_console(
+    payload: Mapping[str, Any],
+    *,
+    socket_path: Optional[str] = None,
+    timeout: int = 10,
+) -> Dict[str, Any]:
+    """Send one bounded request to the local enrollment service."""
+    path = configured_socket_path(socket_path)
+    try:
+        current = path.lstat()
+    except FileNotFoundError as exc:
+        raise LocalConsoleError(
+            "local-console socket is missing at %s; verify the MAC API service is running" % path
+        ) from exc
+    if not stat.S_ISSOCK(current.st_mode):
+        raise LocalConsoleError("local-console path is not a Unix-domain socket")
+    conn = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    conn.settimeout(max(1, int(timeout)))
+    try:
+        conn.connect(str(path))
+        raw_request = (json.dumps(dict(payload), separators=(",", ":")) + "\n").encode("utf-8")
+        if len(raw_request) > MAX_FRAME_BYTES:
+            raise LocalConsoleError("local-console request exceeds the size limit")
+        conn.sendall(raw_request)
+        raw = _receive_frame(conn, MAX_RESPONSE_BYTES)
+    except PermissionError as exc:
+        raise LocalConsoleError(
+            "access denied to local-console socket; use an authorized account or group"
+        ) from exc
+    except OSError as exc:
+        if exc.errno in {errno.EACCES, errno.EPERM}:
+            raise LocalConsoleError(
+                "access denied to local-console socket; use an authorized account or group"
+            ) from exc
+        raise LocalConsoleError("could not reach the local-console socket") from exc
+    finally:
+        conn.close()
+    try:
+        response = _json_without_duplicates(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise LocalConsoleError("local-console service returned malformed JSON") from exc
+    if not isinstance(response, dict) or response.get("ok") is not True:
+        detail = str(response.get("error") or "") if isinstance(response, dict) else ""
+        allowed = {
+            "access denied by local-console policy",
+            "local-console request was rejected",
+            "local-console enrollment failed",
+        }
+        raise LocalConsoleError(detail if detail in allowed else "local-console request failed")
+    manifest = response.get("manifest")
+    if not isinstance(manifest, dict):
+        raise LocalConsoleError("local-console service returned no enrollment manifest")
+    return manifest

--- a/src/mac/local_console.py
+++ b/src/mac/local_console.py
@@ -358,10 +358,13 @@ class LocalConsoleService:
             return {"revoked": True}
         if action == "renew":
             acknowledged = request.get("allow_elevated") is True
+            elevated_authority = peer.uid in {0, self.service_uid}
             issued = self.store.renew(
                 client_id,
                 expires_in=int(request.get("expires_in") or 0),
-                allowed_scopes=(KNOWN_SCOPES if peer.uid == 0 and acknowledged else DEFAULT_SCOPES),
+                allowed_scopes=(
+                    KNOWN_SCOPES if elevated_authority and acknowledged else DEFAULT_SCOPES
+                ),
                 required_metadata=owner,
                 actor=actor,
             )
@@ -371,8 +374,8 @@ class LocalConsoleService:
         scopes = _string_list(request.get("scopes"), field="scopes")
         privileged = set(scopes) - DEFAULT_SCOPES
         acknowledged = request.get("allow_elevated") is True
-        if privileged and (peer.uid != 0 or not acknowledged):
-            raise PermissionError("elevated local-console scopes require root")
+        if privileged and (peer.uid not in {0, self.service_uid} or not acknowledged):
+            raise PermissionError("elevated local-console scopes require the service owner or root")
         if set(scopes) & ELEVATED_SCOPES and not acknowledged:
             raise PermissionError("elevated local-console scopes require acknowledgement")
         capabilities = _string_list(request.get("capabilities") or [], field="capabilities")

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import tempfile
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -17,6 +18,12 @@ from mac.agentbus_control import (
 from mac.api import create_app
 from mac.deploy_env import parse_env_text
 from mac.services import ControlPlane, sign_verification_manifest
+
+
+@pytest.fixture()
+def short_socket_dir():
+    with tempfile.TemporaryDirectory(prefix="mac-lc-", dir="/tmp") as directory:
+        yield Path(directory)
 
 
 def _write_repository_contract(repo_path: Path, project: str) -> None:
@@ -3358,7 +3365,7 @@ def test_create_app_refuses_to_start_with_placeholder_secret_key():
         )
 
 
-def test_create_app_via_env_only_works_with_real_secret_key(monkeypatch, tmp_path):
+def test_create_app_via_env_only_works_with_real_secret_key(monkeypatch, short_socket_dir):
     """Simulate the Docker / systemd path: env-only configuration, a fresh
     database, no MAC_API_TOKEN. The factory should succeed and /health should
     answer 200."""
@@ -3367,11 +3374,13 @@ def test_create_app_via_env_only_works_with_real_secret_key(monkeypatch, tmp_pat
     from mac.test_support import ephemeral_dsn
 
     dsn = ephemeral_dsn()
+    console_socket = short_socket_dir / "console.sock"
     monkeypatch.setenv(
         "MAC_SECRET_KEY",
         "deploy-smoke-key-with-32-plus-characters-of-entropy-abc",
     )
     monkeypatch.setenv("MAC_DB", dsn)
+    monkeypatch.setenv("MAC_LOCAL_CONSOLE_SOCKET", str(console_socket))
     monkeypatch.delenv("MAC_API_TOKEN", raising=False)
     monkeypatch.delenv("MAC_API_TOKENS", raising=False)
     # Factory mode imports this module before calling create_app(). Importing it
@@ -3383,6 +3392,7 @@ def test_create_app_via_env_only_works_with_real_secret_key(monkeypatch, tmp_pat
 
     with TestClient(api_module.create_app()) as client:
         assert client.get("/health").json() == {"status": "ok"}
+    assert not console_socket.exists()
     # The schema answers, which is the Postgres equivalent of the old
     # "the DB file was created on first connect" assertion.
     from mac.test_support import store_on

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1486,6 +1486,7 @@ def test_create_app_refuses_open_mode_on_non_loopback_bind(monkeypatch):
     from mac.models import ValidationError as _VE
     monkeypatch.delenv("MAC_API_TOKEN", raising=False)
     monkeypatch.delenv("MAC_API_TOKENS", raising=False)
+    monkeypatch.setenv("MAC_LOCAL_CONSOLE_ENABLED", "0")
     monkeypatch.setenv("MAC_BIND_HOST", "0.0.0.0")
     with pytest.raises(_VE, match="mac-853j"):
         create_app(control_plane=ControlPlane.in_memory(), auth_tokens={})

--- a/tests/cli/test_cli_login.py
+++ b/tests/cli/test_cli_login.py
@@ -73,6 +73,75 @@ def test_login_cli_enroll_status_and_renew(tmp_path, monkeypatch):
     assert rc == 0 and result["status"] == "renewed"
 
 
+def test_login_cli_local_console_uses_no_ssh_resolution(tmp_path, monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        client_login,
+        "resolve_login_spec",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("SSH was consulted")),
+    )
+    monkeypatch.setattr(
+        client_login,
+        "local_console_login",
+        lambda **kwargs: captured.update(kwargs)
+        or {"status": "logged_in", "profile": kwargs["profile"]},
+    )
+    rc, result, error = _run(
+        tmp_path,
+        "admin",
+        "login",
+        "--local-console",
+        "--local-console-socket",
+        "/run/mac/custom.sock",
+        "--api-url",
+        "http://127.0.0.1:9999",
+        "--profile",
+        "console",
+    )
+    assert rc == 0 and not error
+    assert result == {"profile": "console", "status": "logged_in"}
+    assert captured["socket_path"] == "/run/mac/custom.sock"
+    assert captured["api_url"] == "http://127.0.0.1:9999"
+
+    monkeypatch.setattr(
+        client_login,
+        "renew_local_console_login",
+        lambda profile, **kwargs: captured.update(renew=(profile, kwargs))
+        or {"status": "renewed", "profile": profile},
+    )
+    rc, result, error = _run(
+        tmp_path,
+        "admin",
+        "login",
+        "renew",
+        "--local-console",
+        "--local-console-socket",
+        "/run/mac/custom.sock",
+        "--profile",
+        "console",
+    )
+    assert rc == 0 and not error
+    assert result == {"profile": "console", "status": "renewed"}
+    assert captured["renew"][1]["socket_path"] == "/run/mac/custom.sock"
+
+    monkeypatch.setattr(
+        client_login,
+        "login_status",
+        lambda profile: {"status": "connected", "profile": profile},
+    )
+    rc, result, error = _run(
+        tmp_path,
+        "admin",
+        "login",
+        "status",
+        "--local-console",
+        "--profile",
+        "console",
+    )
+    assert rc == 0 and not error
+    assert result == {"profile": "console", "status": "connected"}
+
+
 def test_logout_cli_and_secret_safe_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(
         client_login,

--- a/tests/test_local_console.py
+++ b/tests/test_local_console.py
@@ -1,0 +1,438 @@
+from __future__ import annotations
+
+import grp
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from mac import client_login, local_console
+from mac.api import create_app
+from mac.client_principals import (
+    ClientPrincipalError,
+    ClientPrincipalProvider,
+    ClientPrincipalStore,
+)
+from mac.client_profiles import load_profile
+from mac.local_console import (
+    LocalConsoleError,
+    LocalConsoleService,
+    MAX_FRAME_BYTES,
+    PeerIdentity,
+    _receive_frame,
+    default_api_url,
+    request_local_console,
+)
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def short_socket_dir():
+    path = Path(tempfile.mkdtemp(prefix="mac-lc-", dir="/tmp"))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _request(client_id: str = "console-client") -> dict:
+    return {
+        "action": "enroll",
+        "client_id": client_id,
+        "display_name": "Console Client",
+        "fleet": "local",
+        "profile": "local",
+        "scopes": ["read", "write", "dispatch"],
+        "capabilities": [],
+        "expires_in": 3600,
+        "api_url": "http://127.0.0.1:8789",
+        "allow_elevated": False,
+        "rotate": False,
+    }
+
+
+def test_framing_is_bounded_and_accepts_exactly_one_request():
+    class Connection:
+        def __init__(self, data):
+            self.data = data
+
+        def recv(self, _size):
+            data, self.data = self.data, b""
+            return data
+
+    with pytest.raises(LocalConsoleError, match="only one"):
+        _receive_frame(Connection(b"{}\n{}\n"), MAX_FRAME_BYTES)
+    with pytest.raises(LocalConsoleError, match="size limit"):
+        _receive_frame(Connection(b"x" * (MAX_FRAME_BYTES + 1)), MAX_FRAME_BYTES)
+
+
+def test_direct_api_url_environment_order_and_port_fallback(monkeypatch):
+    monkeypatch.delenv("MAC_API_URL", raising=False)
+    monkeypatch.delenv("MAC_URL", raising=False)
+    monkeypatch.delenv("MAC_HUB_URL", raising=False)
+    monkeypatch.setenv("MAC_PORT", "9911")
+    assert default_api_url() == "http://127.0.0.1:9911"
+    monkeypatch.setenv("MAC_HUB_URL", "https://hub.example/")
+    assert default_api_url() == "https://hub.example"
+    monkeypatch.setenv("MAC_URL", "https://preferred.example/")
+    assert default_api_url() == "https://preferred.example"
+    monkeypatch.setenv("MAC_API_URL", "https://first.example/")
+    assert default_api_url() == "https://first.example"
+
+
+def test_peer_authorization_and_socket_mode(tmp_path, short_socket_dir):
+    group_name = grp.getgrgid(os.getgid()).gr_name
+    service = LocalConsoleService(
+        short_socket_dir / "console.sock",
+        ClientPrincipalStore(tmp_path / "principals.json"),
+        allowed_group=group_name,
+    )
+    assert service._authorized(PeerIdentity(uid=os.geteuid(), gid=os.getegid()))
+    assert service._authorized(PeerIdentity(uid=0, gid=0))
+    assert not service._authorized(PeerIdentity(uid=987654, gid=987654))
+    assert (
+        service._dispatch(
+            PeerIdentity(uid=os.geteuid(), gid=os.getegid()), _request("direct-check")
+        )["client_id"]
+        == "direct-check"
+    )
+
+    service.start()
+    try:
+        assert service.path.stat().st_mode & 0o777 == 0o660
+        assert service.path.parent.stat().st_mode & 0o777 == 0o750
+    finally:
+        service.stop()
+
+
+def test_unauthorized_peer_is_rejected_even_for_loopback_api_url(
+    tmp_path, short_socket_dir, monkeypatch
+):
+    registry = tmp_path / "principals.json"
+    service = LocalConsoleService(
+        short_socket_dir / "console.sock",
+        ClientPrincipalStore(registry),
+    )
+    monkeypatch.setattr(
+        local_console,
+        "_peer_identity",
+        lambda _conn: PeerIdentity(uid=987654, gid=987654),
+    )
+    service.start()
+    try:
+        with pytest.raises(LocalConsoleError, match="access denied"):
+            request_local_console(_request(), socket_path=str(service.path))
+    finally:
+        service.stop()
+    assert not registry.exists()
+
+
+def test_non_root_cannot_request_elevated_local_console_scopes(tmp_path):
+    service = LocalConsoleService(
+        tmp_path / "console.sock",
+        ClientPrincipalStore(tmp_path / "principals.json"),
+        service_uid=1234,
+    )
+    request = _request()
+    request["scopes"] = ["read", "admin"]
+    request["allow_elevated"] = True
+    with pytest.raises(PermissionError, match="require root"):
+        service._dispatch(PeerIdentity(uid=1234, gid=1234), request)
+
+
+def test_root_requires_explicit_elevated_acknowledgement(tmp_path):
+    service = LocalConsoleService(
+        tmp_path / "console.sock",
+        ClientPrincipalStore(tmp_path / "principals.json"),
+    )
+    request = _request()
+    request["scopes"] = ["read", "admin"]
+    with pytest.raises(PermissionError):
+        service._dispatch(PeerIdentity(uid=0, gid=0), request)
+
+
+def test_elevated_local_console_renew_requires_root_and_acknowledgement(tmp_path):
+    service = LocalConsoleService(
+        tmp_path / "console.sock",
+        ClientPrincipalStore(tmp_path / "principals.json"),
+    )
+    request = _request("elevated-client")
+    request["scopes"] = ["read", "admin"]
+    request["allow_elevated"] = True
+    service._dispatch(PeerIdentity(uid=0, gid=0), request)
+    renew = {
+        "action": "renew",
+        "client_id": "elevated-client",
+        "expires_in": 3600,
+        "allow_elevated": True,
+    }
+    with pytest.raises(ClientPrincipalError, match="not owned"):
+        service._dispatch(PeerIdentity(uid=1234, gid=1234), renew)
+    renew["allow_elevated"] = False
+    with pytest.raises(ClientPrincipalError, match="not authorized"):
+        service._dispatch(PeerIdentity(uid=0, gid=0), renew)
+    renew["allow_elevated"] = True
+    assert (
+        service._dispatch(PeerIdentity(uid=0, gid=0), renew)["credential"]["id"]
+        == "elevated-client.v2"
+    )
+
+
+def test_local_console_cannot_mutate_another_uid_or_ssh_credential(tmp_path):
+    store = ClientPrincipalStore(tmp_path / "principals.json")
+    service = LocalConsoleService(tmp_path / "console.sock", store, service_uid=1234)
+    first = _request("first-owner")
+    service._dispatch(PeerIdentity(uid=1234, gid=1234), first)
+    store.enroll("ssh-client", actor="ssh:operator")
+
+    for client_id in ("first-owner", "ssh-client"):
+        with pytest.raises(ClientPrincipalError, match="not owned"):
+            service._dispatch(
+                PeerIdentity(uid=5678, gid=5678),
+                {"action": "renew", "client_id": client_id, "expires_in": 3600},
+            )
+        with pytest.raises(ClientPrincipalError, match="not owned"):
+            service._dispatch(
+                PeerIdentity(uid=5678, gid=5678),
+                {"action": "revoke", "client_id": client_id},
+            )
+
+    rotated = _request("first-owner")
+    rotated["rotate"] = True
+    with pytest.raises(ClientPrincipalError, match="not owned"):
+        service._dispatch(PeerIdentity(uid=5678, gid=5678), rotated)
+
+
+def test_local_console_login_validates_then_installs_direct_profile(
+    tmp_path, short_socket_dir, monkeypatch
+):
+    home = tmp_path / "home"
+    registry = tmp_path / "principals.json"
+    service = LocalConsoleService(
+        short_socket_dir / "console.sock",
+        ClientPrincipalStore(registry),
+    )
+    monkeypatch.setenv("MAC_HOME", str(home))
+    checked = {}
+
+    def validate(api_url, token, *, timeout):
+        checked.update(api_url=api_url, token=token, timeout=timeout)
+        return True, "authenticated"
+
+    monkeypatch.setattr(client_login, "_validate_token", validate)
+    service.start()
+    try:
+        result = client_login.local_console_login(
+            profile="local",
+            client_id="console-client",
+            socket_path=str(service.path),
+            api_url="http://127.0.0.1:9988",
+        )
+    finally:
+        service.stop()
+
+    profile = load_profile("local", include_token=True)
+    assert result["session"] == {"status": "direct"}
+    assert profile["connection"] == {
+        "api_url": "http://127.0.0.1:9988",
+        "mode": "direct",
+    }
+    assert checked["api_url"] == "http://127.0.0.1:9988"
+    assert checked["token"] == profile["credential"]["token"]
+    assert profile["credential"]["token"].startswith("mac_client_")
+    assert profile["credential"]["token"] not in registry.read_text(encoding="utf-8")
+    assert len(ClientPrincipalProvider(registry).tokens()) == 1
+    audit = json.loads(
+        ClientPrincipalStore(registry).audit_path.read_text(encoding="utf-8").splitlines()[0]
+    )
+    assert audit["actor"].startswith("local-console:uid=")
+    assert ":user=" in audit["actor"]
+
+
+def test_failed_http_validation_revokes_and_does_not_install(
+    tmp_path, short_socket_dir, monkeypatch
+):
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    registry = tmp_path / "principals.json"
+    service = LocalConsoleService(
+        short_socket_dir / "console.sock",
+        ClientPrincipalStore(registry),
+    )
+    monkeypatch.setattr(
+        client_login,
+        "_validate_token",
+        lambda *_args, **_kwargs: (False, "credential_rejected"),
+    )
+    service.start()
+    try:
+        with pytest.raises(client_login.ClientLoginError, match="rejected"):
+            client_login.local_console_login(
+                profile="local",
+                client_id="console-client",
+                socket_path=str(service.path),
+                api_url="http://127.0.0.1:9988",
+            )
+    finally:
+        service.stop()
+    assert ClientPrincipalProvider(registry).tokens() == {}
+    assert not (tmp_path / "home" / "clients" / "local.yaml").exists()
+
+
+def test_local_console_renew_validates_then_atomically_replaces_profile(
+    tmp_path, short_socket_dir, monkeypatch
+):
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    registry = tmp_path / "principals.json"
+    service = LocalConsoleService(
+        short_socket_dir / "console.sock",
+        ClientPrincipalStore(registry),
+    )
+    checked_tokens = []
+
+    def validate(_api_url, token, *, timeout):
+        checked_tokens.append((token, timeout))
+        return True, "authenticated"
+
+    monkeypatch.setattr(client_login, "_validate_token", validate)
+    service.start()
+    try:
+        client_login.local_console_login(
+            profile="local",
+            client_id="console-client",
+            socket_path=str(service.path),
+            api_url="http://127.0.0.1:9988",
+        )
+        old_token = load_profile("local", include_token=True)["credential"]["token"]
+        result = client_login.renew_local_console_login(
+            "local", socket_path=str(service.path), expires_in=7200
+        )
+    finally:
+        service.stop()
+
+    renewed = load_profile("local", include_token=True)
+    new_token = renewed["credential"]["token"]
+    assert result["status"] == "renewed"
+    assert result["changed"] is True
+    assert new_token != old_token
+    assert checked_tokens[-1][0] == new_token
+    assert renewed["credential"]["id"] == "console-client.v2"
+    events = [
+        json.loads(line)
+        for line in ClientPrincipalStore(registry)
+        .audit_path.read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    assert events[-1]["event"] == "client.renewed"
+    assert events[-1]["actor"].startswith("local-console:uid=")
+
+
+def test_local_console_renew_validation_failure_revokes_new_and_keeps_profile(
+    tmp_path, short_socket_dir, monkeypatch
+):
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "home"))
+    registry = tmp_path / "principals.json"
+    service = LocalConsoleService(
+        short_socket_dir / "console.sock",
+        ClientPrincipalStore(registry),
+    )
+    validation = {"ok": True}
+    monkeypatch.setattr(
+        client_login,
+        "_validate_token",
+        lambda *_args, **_kwargs: (
+            validation["ok"],
+            "authenticated" if validation["ok"] else "credential_rejected",
+        ),
+    )
+    service.start()
+    try:
+        client_login.local_console_login(
+            profile="local",
+            client_id="console-client",
+            socket_path=str(service.path),
+            api_url="http://127.0.0.1:9988",
+        )
+        old_token = load_profile("local", include_token=True)["credential"]["token"]
+        validation["ok"] = False
+        with pytest.raises(
+            client_login.ClientLoginError,
+            match="new credential was revoked.*profile was not replaced",
+        ):
+            client_login.renew_local_console_login("local", socket_path=str(service.path))
+    finally:
+        service.stop()
+
+    assert load_profile("local", include_token=True)["credential"]["token"] == old_token
+    assert ClientPrincipalProvider(registry).tokens() == {}
+
+
+def test_missing_socket_error_is_safe_and_useful(tmp_path):
+    with pytest.raises(LocalConsoleError, match="socket is missing"):
+        request_local_console(_request(), socket_path=str(tmp_path / "missing.sock"))
+
+
+def test_injected_apps_default_off_and_explicit_socket_tracks_lifespan(tmp_path, short_socket_dir):
+    plain = create_app(control_plane=ControlPlane.in_memory(), auth_tokens={"recovery": ["admin"]})
+    assert plain.state.local_console_service is None
+
+    socket_path = short_socket_dir / "console.sock"
+    app = create_app(
+        control_plane=ControlPlane.in_memory(),
+        auth_tokens={"recovery": ["admin"]},
+        client_principals_path=str(tmp_path / "principals.json"),
+        local_console_socket_path=str(socket_path),
+    )
+    assert not socket_path.exists()
+    with TestClient(app):
+        assert socket_path.is_socket()
+    assert not socket_path.exists()
+
+
+def test_local_console_credential_hot_reloads_into_http_bearer_auth(tmp_path, short_socket_dir):
+    socket_path = short_socket_dir / "console.sock"
+    registry = tmp_path / "principals.json"
+    app = create_app(
+        control_plane=ControlPlane.in_memory(),
+        auth_tokens={"recovery": ["admin"]},
+        client_principals_path=str(registry),
+        local_console_socket_path=str(socket_path),
+    )
+    with TestClient(app) as client:
+        enrolled = request_local_console(_request(), socket_path=str(socket_path))
+        old_token = enrolled["credential"]["token"]
+        assert (
+            client.get("/agents", headers={"Authorization": "Bearer %s" % old_token}).status_code
+            == 200
+        )
+
+        renewed = request_local_console(
+            {"action": "renew", "client_id": "console-client", "expires_in": 7200},
+            socket_path=str(socket_path),
+        )
+        new_token = renewed["credential"]["token"]
+        assert new_token != old_token
+        assert (
+            client.get("/agents", headers={"Authorization": "Bearer %s" % old_token}).status_code
+            == 403
+        )
+        assert (
+            client.get("/agents", headers={"Authorization": "Bearer %s" % new_token}).status_code
+            == 200
+        )
+
+
+def test_systemd_unit_sets_safe_socket_default_before_operator_environment():
+    unit = (Path(__file__).resolve().parents[1] / "deploy" / "systemd" / "mac.service").read_text(
+        encoding="utf-8"
+    )
+    default = "Environment=MAC_LOCAL_CONSOLE_SOCKET=/run/mac/local-console.sock"
+    env_file = "EnvironmentFile=/etc/mac/mac.env"
+    assert default in unit
+    assert unit.index(default) < unit.index(env_file)
+    assert "RuntimeDirectory=mac" in unit
+    assert "ReadWritePaths=/var/lib/mac /run/mac" in unit
+    assert "ProtectHome=true" in unit

--- a/tests/test_local_console.py
+++ b/tests/test_local_console.py
@@ -131,7 +131,7 @@ def test_unauthorized_peer_is_rejected_even_for_loopback_api_url(
     assert not registry.exists()
 
 
-def test_non_root_cannot_request_elevated_local_console_scopes(tmp_path):
+def test_non_owner_cannot_request_elevated_local_console_scopes(tmp_path):
     service = LocalConsoleService(
         tmp_path / "console.sock",
         ClientPrincipalStore(tmp_path / "principals.json"),
@@ -140,8 +140,21 @@ def test_non_root_cannot_request_elevated_local_console_scopes(tmp_path):
     request = _request()
     request["scopes"] = ["read", "admin"]
     request["allow_elevated"] = True
-    with pytest.raises(PermissionError, match="require root"):
-        service._dispatch(PeerIdentity(uid=1234, gid=1234), request)
+    with pytest.raises(PermissionError, match="service owner or root"):
+        service._dispatch(PeerIdentity(uid=5678, gid=5678), request)
+
+
+def test_service_owner_can_explicitly_request_elevated_scopes(tmp_path):
+    service = LocalConsoleService(
+        tmp_path / "console.sock",
+        ClientPrincipalStore(tmp_path / "principals.json"),
+        service_uid=1234,
+    )
+    request = _request("service-owner")
+    request["scopes"] = ["read", "admin"]
+    request["allow_elevated"] = True
+    manifest = service._dispatch(PeerIdentity(uid=1234, gid=1234), request)
+    assert manifest["credential"]["scopes"] == ["admin", "read"]
 
 
 def test_root_requires_explicit_elevated_acknowledgement(tmp_path):
@@ -155,15 +168,16 @@ def test_root_requires_explicit_elevated_acknowledgement(tmp_path):
         service._dispatch(PeerIdentity(uid=0, gid=0), request)
 
 
-def test_elevated_local_console_renew_requires_root_and_acknowledgement(tmp_path):
+def test_elevated_local_console_renew_requires_owner_and_acknowledgement(tmp_path):
     service = LocalConsoleService(
         tmp_path / "console.sock",
         ClientPrincipalStore(tmp_path / "principals.json"),
+        service_uid=1234,
     )
     request = _request("elevated-client")
     request["scopes"] = ["read", "admin"]
     request["allow_elevated"] = True
-    service._dispatch(PeerIdentity(uid=0, gid=0), request)
+    service._dispatch(PeerIdentity(uid=1234, gid=1234), request)
     renew = {
         "action": "renew",
         "client_id": "elevated-client",
@@ -171,13 +185,13 @@ def test_elevated_local_console_renew_requires_root_and_acknowledgement(tmp_path
         "allow_elevated": True,
     }
     with pytest.raises(ClientPrincipalError, match="not owned"):
-        service._dispatch(PeerIdentity(uid=1234, gid=1234), renew)
+        service._dispatch(PeerIdentity(uid=5678, gid=5678), renew)
     renew["allow_elevated"] = False
     with pytest.raises(ClientPrincipalError, match="not authorized"):
-        service._dispatch(PeerIdentity(uid=0, gid=0), renew)
+        service._dispatch(PeerIdentity(uid=1234, gid=1234), renew)
     renew["allow_elevated"] = True
     assert (
-        service._dispatch(PeerIdentity(uid=0, gid=0), renew)["credential"]["id"]
+        service._dispatch(PeerIdentity(uid=1234, gid=1234), renew)["credential"]["id"]
         == "elevated-client.v2"
     )
 


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_800de5f4abb34c85ae61c11080bac732`
- head: `9920686f14fcf4c010dacb44933d040942e293a7`
- base at push: `83510f157469ab54fa87e91ef334298886c53ddf`
