### PR TITLE
Fix-forward the stalled review pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,12 +164,10 @@ When analyzing a repository, run `codegraph init` if the index is absent or
 stale. `.codegraph/` is generated local state: do not commit it, include it in
 deliverables, or treat it as the task ledger.
 
-For source, build, dependency, or runtime config changes, CodeGraph is an
-enforced evidence gate. Before a worker-owned push or approved review, the
-worker must record a passing `mac.codegraph_audit.v1` result from `codegraph
-init`/`codegraph sync` plus `codegraph affected` for the changed files. Pure
-documentation/media/text-only changes may record `codegraph.status=skipped`
-with `reason=non_code_change`.
+CodeGraph is advisory analysis support, not an evidence gate. When an existing
+index and binary are available, record `mac.codegraph_audit.v1` output and use
+`codegraph affected` to widen test selection. Missing, stale, malformed, or
+failing CodeGraph output must not block push, review, recovery, or publication.
 
 ## Mandatory Pre-Push Test Gate (all code executor tasks)
 
@@ -201,19 +199,18 @@ Sequence before any `git push` / MR:
    configuration in `pyproject.toml` via `scripts/run-lint.sh`.
 3. **Run tests** — execute the detected command in the repo root,
    capturing full stdout+stderr.
-4. **Run CodeGraph audit when relevant** — for source, build, dependency,
-   or runtime config changes, run `codegraph init` or `codegraph sync`, then
-   `codegraph affected` for the changed files. Audit failure blocks the push.
-5. **Gate decision** — tests plus required CodeGraph audit pass → push +
+4. **Run CodeGraph when useful** — an existing index may provide advisory
+   affected-test and call-graph hints. Its absence or failure does not block.
+5. **Gate decision** — tests pass → push +
    open MR; failure → STOP (no push, no MR), transition to `needs_review`
    with full evidence.
 
 Every coding task's `mac.worker_evidence.v1` manifest therefore always
 carries numbered evidence items: `1 | Lint/Format`, `2 | Tests`, and on
 success `3 | Push` + `4 | MR`; on test failure item 3 becomes
-`Test Failures` (full output, failing test names, suggested fix), and on a
-CodeGraph audit failure item 3 becomes `CodeGraph Failures`. No push/MR items
-are present on either failure.
+`Test Failures` (full output, failing test names, suggested fix). CodeGraph
+diagnostics may be recorded in evidence but do not replace or block the test
+gate.
 
 ## Non-Interactive Shell Commands
 

--- a/docs/adr/0011-hub-review-verification-scope.md
+++ b/docs/adr/0011-hub-review-verification-scope.md
@@ -99,7 +99,7 @@ verifier must fall back to the full repository contract command.
 Fallback to the full suite is required when:
 
 - `files_changed` is missing or cannot be trusted;
-- CodeGraph is required for the change and the executor evidence lacks a passing
+- CodeGraph was historically required for the change and the executor evidence lacks a passing
   audit;
 - the changes touch test selection, coverage configuration, repository contract
   configuration, bootstrap/runtime/dependency files, or broad shared

--- a/docs/adr/0031-codegraph-is-a-hint.md
+++ b/docs/adr/0031-codegraph-is-a-hint.md
@@ -1,6 +1,6 @@
 # ADR 0031: CodeGraph is a hint when the tool and `.codegraph/` exist, not a hard gate
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-08-23
 - Decision owner: MAC fleet owner
 - Related: [ADR 0011](0011-hub-review-verification-scope.md) — hub-verify uses

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -201,6 +201,7 @@ marked `historical archive` and must not be read as current behaviour.
 | supplemental reference | [`repository-ref-hygiene.md`](../repository-ref-hygiene.md) | Managed Repository Ref Hygiene |
 | supplemental reference | [`repository-runtime-contract.md`](../repository-runtime-contract.md) | Repository Runtime Contract |
 | supplemental reference | [`review-strategy-experiments.md`](../review-strategy-experiments.md) | Review-strategy experiments |
+| supplemental reference | [`review-tick-stall-diagnosis.md`](../review-tick-stall-diagnosis.md) | Why the hub self-tick fails to drain the REVIEWING backlog |
 | supplemental reference | [`scientific-optimizer.md`](../scientific-optimizer.md) | Autonomous scientific optimizer |
 | supplemental reference | [`secrets-management-guide.md`](../secrets-management-guide.md) | Secrets Management Guide |
 | supplemental reference | [`security/openshell-0.0.72-compatibility-review.mdx`](../security/openshell-0.0.72-compatibility-review.mdx) | OpenShell 0.0.72 Compatibility Review |

--- a/docs/review-tick-stall-diagnosis.md
+++ b/docs/review-tick-stall-diagnosis.md
@@ -1,0 +1,179 @@
+# Why the hub self-tick fails to drain the REVIEWING backlog
+
+Diagnosis-only child of *"Unwedge review advancement without granting workers
+admin scope"* (`task_1fbb72e19dc34956a06b4a309f418f0e`). This child makes **no
+behavioral change** to the advancement logic; it establishes, with evidence,
+*why* the wired hub path is not draining the 66 tasks frozen in `REVIEWING`
+since `2026-07-29T22:46Z`, and hands each confirmed mechanism to a sibling fix
+task. Characterization tests that pin each finding live in
+`tests/test_review_tick_stall_diagnosis.py`.
+
+The file:line anchors below are against the checkout this child was authored on.
+The subsystem has been refactored since the parent task was filed (the review
+sweep moved off `ControlPlane.tick()` onto a dedicated publication worker), so
+the anchors in the task description no longer match; the mechanisms they
+describe still exist and are re-anchored here.
+
+## How advancement is wired now
+
+- `ControlPlane.tick()` (`src/mac/services.py:17992`) no longer runs the review
+  sweep inline. It short-circuits to `{"skipped": "runs_on_publication_worker"}`
+  unless `MAC_TICK_RUNS_REVIEW_SWEEP=1` (`src/mac/services.py:18115`).
+- The sweep runs on a dedicated daemon,
+  `api._start_publication_worker` (`src/mac/api.py:4087`), which calls
+  `_advance_default_review_sweep_page(..., allow_blocking_hub_verify=True)`
+  (`src/mac/api.py:4140`). It is gated by
+  `MAC_PUBLICATION_WORKER_INTERVAL_SECONDS`, whose default is `"30"` **only when
+  `MAC_HUB_TICK_INTERVAL_SECONDS > 0`**, else `"0"` = off (`src/mac/api.py:4114`).
+- Event-driven advancement (`enable_event_driven_review_advance`,
+  `src/mac/services.py:2284`) is started from `_start_hub_tick_loop`
+  (`src/mac/api.py:4064`) — i.e. it rides the **same** `MAC_HUB_TICK_INTERVAL_SECONDS`
+  gate as the periodic tick.
+- `_maybe_advance_reviews_on_heartbeat` (`src/mac/services.py:16563`) is now
+  **default OFF** (`MAC_REVIEW_TICK_ON_HEARTBEAT`, default `"0"`,
+  `src/mac/services.py:16573`).
+
+## Confirmed root causes
+
+### C1 — the non-blocking nudge is silently dropped unless the event consumer is running
+
+When the sweep runs with `allow_blocking_hub_verify=False`, a task whose only
+route forward is hub-side Option-C verification takes the else branch and calls
+`self._nudge_review_workflow(task.id)` instead of verifying
+(`src/mac/services.py:22034`).
+
+`_nudge_review_workflow` (`src/mac/services.py:2372`) is a **no-op when
+`self._advance_queue is None`**:
+
+```
+q = self._advance_queue
+if q is None or not task_id:
+    return
+```
+
+`_advance_queue` is initialised to `None` in the constructor
+(`src/mac/services.py:2123`) and is only populated by
+`enable_event_driven_review_advance` (`src/mac/services.py:2305`), which is
+called **only** from `_start_hub_tick_loop` (`src/mac/api.py:4064`). Therefore,
+in any process where `MAC_HUB_TICK_INTERVAL_SECONDS` is unset/`0` (CLI, test
+suite, stateless replicas, or a hub whose tick loop is disabled), the nudge is
+discarded and the task is neither verified nor re-queued — it can only be moved
+by a *blocking* sweep. This is the "nudge silently dropped" mechanism.
+
+Note the coupling that makes this brittle: the publication worker's own default
+(`"30" if tick_interval > 0 else "0"`, `src/mac/api.py:4114`) and the event
+consumer both hang off `MAC_HUB_TICK_INTERVAL_SECONDS`. A deployment that runs
+the sweep worker with `allow_blocking_hub_verify=True` masks C1; but any code
+path that reaches the non-blocking branch with the consumer down (the tick's own
+`MAC_TICK_RUNS_REVIEW_SWEEP=1` escape hatch, or a heartbeat sweep) drops the
+nudge on the floor.
+
+*Pinned by:* `test_nudge_is_a_noop_without_the_event_consumer`,
+`test_nonblocking_sweep_branch_only_nudges`,
+`test_event_consumer_is_gated_by_the_tick_interval`.
+
+### C2 — an uncapped `waiting_for_hub_verify` return traps a task whenever hub verify cannot produce a verdict
+
+In `advance_default_review_workflow`, when Option-C hub verify is enabled and no
+verdict evidence exists yet, the workflow returns
+`status="waiting_for_hub_verify"` for any evidence that is `hub_verifiable`
+(`src/mac/services.py:22089`). `hub_verifiable` is true whenever
+`_hub_verify_repo_info(task, evidence)` returns non-None — i.e. the evidence is a
+pushed repo change with a branch/head_sha (`src/mac/services.py:26594`).
+
+There is **no attempt/iteration ceiling on this branch**: every sweep re-reads
+the task, finds no verdict (because the verifier is broken, the reviewer key is
+missing, the sandbox never converges, or the in-flight guard keeps firing), and
+returns `waiting_for_hub_verify` again. The `_run_hub_review_verification`
+in-flight guard (`src/mac/services.py:26886`, `review.id in inflight → return
+None`) is per-process and unbounded; a verify that never completes keeps the id
+parked and every subsequent tick short-circuits without producing a verdict. A
+pushed code change therefore parks in `REVIEWING` indefinitely once the hub
+verifier is unable to finish, which matches a large frozen cohort that shares a
+single failing verify path. This is distinct from the "no evidence to verify"
+case, which is deliberately *allowed* to fall through to the agent-nudge path
+(`src/mac/services.py:22070` comment).
+
+*Pinned by:* `test_waiting_for_hub_verify_has_no_iteration_ceiling`,
+`test_hub_verifiable_evidence_holds_the_merge_gate`.
+
+## Ruled-out hypotheses
+
+### R1 — cursor starvation / durable-cursor parking (task hypothesis 3)
+
+`advance_default_review_workflows` pages by `(priority DESC, created_at, id)` and
+sets `next_cursor` **only when `has_more`** (`src/mac/services.py:21625`):
+
+```
+next_cursor = self._encode_review_sweep_cursor(tasks[-1]) if has_more and tasks else None
+```
+
+`_advance_default_review_sweep_page` then persists that cursor via
+`reconciliation.complete(claim, cursor=result.get("next_cursor"))`
+(`src/mac/services.py:21536`). When a page is the last page (`has_more` false),
+`next_cursor` is `None`, so the durable cursor **resets to the start** on the
+next claim — the sweep wraps rather than parking. With 66 non-advancing rows and
+`MAC_REVIEW_TICK_LIMIT=25`, the cursor walks pages 1→2→3 and then wraps to the
+head, so every row is revisited on a bounded cycle. The cursor is therefore a
+progress mechanism, not a stall mechanism: it does not park a subset out of
+reach. The freeze is per-task (C1/C2), not a cursor that skips rows. *Pinned by
+`test_cursor_resets_to_head_when_no_more`,
+`test_cursor_advances_monotonically_within_a_page_run`,
+`test_last_page_persists_null_cursor`.*
+
+### R2 — hub-agent name-vs-id mismatch / heartbeat gating (task hypothesis 4)
+
+`resolve_hub_agent("MAC_REVIEW_TICK_HUB_AGENT")` (`src/mac/env_config.py:115`)
+returns the configured value verbatim, and the heartbeat guard matches on
+**both** name and id: `if agent.name != hub_agent and agent.id != hub_agent:
+return` (`src/mac/services.py:16577`). With `MAC_REVIEW_TICK_HUB_AGENT=rocky`,
+an agent whose `name == "rocky"` or whose `id == "rocky"` passes. There is no
+name/id mismatch defect here. The heartbeat path is, however, **default OFF**
+(`MAC_REVIEW_TICK_ON_HEARTBEAT` default `"0"`, `src/mac/services.py:16573`), so
+it is simply not a driver in the current deployment — advancement is expected to
+come from the publication worker, not the heartbeat. This rules the heartbeat
+matching out as the stall cause. *Pinned by
+`test_hub_agent_matches_by_name_or_id`,
+`test_heartbeat_review_tick_is_off_by_default`.*
+
+### R3 — ordinary reconciliation lease expiry wedging the sweep (task hypothesis 2)
+
+`ReconciliationCoordinator.claim` (`src/mac/reconciliation.py:47`) upserts the
+`reconciliation_state` row and takes the lease only when
+`lease_owner IS NULL OR lease_expires_at <= excluded.updated_at`. A crashed
+holder that never calls `complete`/`abandon` leaves `lease_owner` set, so a
+concurrent claim returns `None` and the sweep short-circuits with
+`{"skipped": "lease_held"}` (`src/mac/services.py:21516`) — but **only until the
+lease expires**. Expiry recovers it: the very next claim after
+`lease_expires_at` passes the `WHERE` predicate and re-acquires. The lease is
+bounded (`MAC_RECONCILER_LEASE_SECONDS`, clamped `1..3600`, default 60,
+`src/mac/reconciliation.py:38`), so a stale lease can delay a page by at most one
+lease interval, not permanently. `complete`/`abandon` release with the exact
+`claim.owner_id` (which embeds a fresh per-call `new_id("claim")`), so a stale
+owner cannot be "completed" by a different process — but expiry still frees it.
+Ordinary lease expiry therefore does **not** wedge the sweep permanently, and is
+ruled out. (A *permanent* wedge would require a live process re-claiming faster
+than the backlog drains; that is C1/C2 keeping individual rows unadvanceable,
+not the lease itself.) *Pinned by
+`test_stale_lease_short_circuits_until_expiry`,
+`test_expired_lease_is_reclaimable`,
+`test_lease_release_requires_the_owning_claim_id`,
+`test_lease_seconds_is_clamped`.*
+
+## Recommended fix shape (for the sibling tasks)
+
+1. **Decouple the nudge sink from the tick gate (C1).** Either start the
+   event-driven consumer whenever the publication worker is enabled, or make the
+   non-blocking sweep re-enqueue on the durable cursor rather than relying on an
+   in-process queue that may be `None`. A dropped nudge must be observable — the
+   no-op branch should record a diagnostic, not return silently
+   (`src/mac/services.py:2378`).
+2. **Bound the `waiting_for_hub_verify` loop (C2).** Add a per-review attempt
+   ceiling / age cap so a verify that never converges retracts the review and
+   re-selects a reviewer (mirroring the existing
+   `reviewer_protocol_failure:hub_verdict_invalid` retraction at
+   `src/mac/services.py:26884`) instead of returning `waiting_for_hub_verify`
+   forever. Emit a warning once, not once per tick.
+
+Both fixes are behavioral and belong to the parent's sibling fix tasks; this
+child only characterizes and pins the current behavior.

--- a/docs/review-tick-stall-diagnosis.md
+++ b/docs/review-tick-stall-diagnosis.md
@@ -126,8 +126,8 @@ reach. The freeze is per-task (C1/C2), not a cursor that skips rows. *Pinned by
 `resolve_hub_agent("MAC_REVIEW_TICK_HUB_AGENT")` (`src/mac/env_config.py:115`)
 returns the configured value verbatim, and the heartbeat guard matches on
 **both** name and id: `if agent.name != hub_agent and agent.id != hub_agent:
-return` (`src/mac/services.py:16577`). With `MAC_REVIEW_TICK_HUB_AGENT=rocky`,
-an agent whose `name == "rocky"` or whose `id == "rocky"` passes. There is no
+return` (`src/mac/services.py:16577`). With `MAC_REVIEW_TICK_HUB_AGENT=hub`,
+an agent whose `name == "hub"` or whose `id == "hub"` passes. There is no
 name/id mismatch defect here. The heartbeat path is, however, **default OFF**
 (`MAC_REVIEW_TICK_ON_HEARTBEAT` default `"0"`, `src/mac/services.py:16573`), so
 it is simply not a driver in the current deployment — advancement is expected to

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -8,7 +8,7 @@ is hybrid, union, and fail-closed:
    map, select tests whose executed lines intersect the changed lines of a
    source file (line-level), falling back to every test that touched the file
    when only additions are present.
-2. CodeGraph static reachability: union in `codegraph affected` so a change that
+2. Optional CodeGraph static reachability: union in `codegraph affected` so a change that
    makes a test reach NEW code is still covered even though the map (built at the
    base revision) could not know about it.
 3. Reviewed path contracts: generated data, shell entrypoints, and CI files
@@ -521,11 +521,12 @@ def resolve(
     # newly-reachable code the base-revision map cannot know about.
     selected.update(codegraph_tests)
 
-    # Fail closed: a source file the dynamic map could not resolve requires a
-    # usable CodeGraph result; otherwise we cannot prove the scope.
-    if unresolved_source and (codegraph_problem is not None or not list(codegraph_tests)):
+    # CodeGraph may widen selection, but its failure is not itself a gate. An
+    # unresolved source file still fails closed because the authoritative map
+    # and path contracts cannot prove a focused scope.
+    if unresolved_source and not list(codegraph_tests):
         return _full(
-            codegraph_problem or "unresolved_source_without_reliable_affected_tests",
+            "unresolved_source_without_reliable_affected_tests",
             changed,
             unresolved_source=sorted(unresolved_source),
         )
@@ -698,9 +699,11 @@ def changed_base_lines(
 def codegraph_affected(source_changes: list[str], repo_root: Path) -> tuple[list[str], str | None]:
     codegraph = shutil.which("codegraph")
     if not codegraph:
-        return [], "codegraph_unavailable"
+        return [], "hint_unavailable"
     if not source_changes:
         return [], None
+    if not (repo_root / ".codegraph").is_dir():
+        return [], "hint_unavailable"
     completed = subprocess.run(
         [codegraph, "affected", "--json", *source_changes],
         cwd=repo_root,
@@ -709,11 +712,11 @@ def codegraph_affected(source_changes: list[str], repo_root: Path) -> tuple[list
         check=False,
     )
     if completed.returncode != 0:
-        return [], "codegraph_affected_failed"
+        return [], "hint_untrusted"
     try:
         document = json.loads(completed.stdout)
     except json.JSONDecodeError:
-        return [], "codegraph_affected_invalid_json"
+        return [], "hint_untrusted"
     tests = [
         str(path)
         for path in document.get("affectedTests", [])

--- a/src/mac/codegraph_audit.py
+++ b/src/mac/codegraph_audit.py
@@ -1,8 +1,7 @@
 """CodeGraph audit helpers.
 
-Determines which changed files are relevant to CodeGraph analysis, resolves the
-``codegraph`` binary, and builds the audit manifest used to verify that
-source-affecting changes were accompanied by the required CodeGraph run.
+Determines which changed files are relevant to optional CodeGraph analysis,
+resolves the ``codegraph`` binary, and builds the advisory audit manifest.
 """
 
 from __future__ import annotations
@@ -312,13 +311,17 @@ def run_codegraph_audit(
     if not relevant:
         return audit
 
+    if not (repo_path / ".codegraph").is_dir():
+        audit.update({"status": "skipped", "reason": "hint_unavailable"})
+        return audit
+
     binary = _resolve_codegraph_binary()
     if not binary:
         audit.update(
             {
-                "status": "fail",
-                "reason": "codegraph_not_available",
-                "error": "codegraph is required for source/build changes but was not found on PATH",
+                "status": "skipped",
+                "reason": "hint_unavailable",
+                "error": "codegraph was not found on PATH",
             }
         )
         return audit
@@ -348,7 +351,7 @@ def run_codegraph_audit(
             )
             audit["commands"].append(index_result)
     if index_result["returncode"] != 0:
-        audit.update({"status": "fail", "reason": "index_failed"})
+        audit.update({"status": "skipped", "reason": "hint_untrusted"})
         return audit
 
     affected = _run_codegraph_command(
@@ -360,7 +363,7 @@ def run_codegraph_audit(
     )
     audit["commands"].append(affected)
     if affected["returncode"] != 0:
-        audit.update({"status": "fail", "reason": "affected_failed"})
+        audit.update({"status": "skipped", "reason": "hint_untrusted"})
         return audit
 
     audit.update({"status": "pass", "reason": "affected_computed"})
@@ -392,6 +395,12 @@ def codegraph_audit_check(audit: Mapping[str, Any]) -> JsonDict:
 
 
 def codegraph_audit_manifest_problems(manifest: Mapping[str, Any]) -> list[str]:
+    """Return no gate failures because CodeGraph evidence is advisory."""
+    return []
+
+
+def codegraph_audit_diagnostics(manifest: Mapping[str, Any]) -> list[str]:
+    """Describe malformed or failed CodeGraph evidence for observability."""
     repo = manifest.get("repo")
     if not isinstance(repo, Mapping):
         return []

--- a/src/mac/executor-policy.txt
+++ b/src/mac/executor-policy.txt
@@ -17,9 +17,10 @@ than treating what you were shown as the whole story.
 The prepared task worktree is the worker's only writable repository checkout;
 registered source checkouts remain read-only except for explicit
 source-remediation tasks. The worker owns analysis, edits, task-local bootstrap,
-the declared contract test, CodeGraph analysis, and preliminary evidence. The
+the declared contract test, optional CodeGraph analysis, and preliminary evidence. The
 deterministic host exclusively owns canonical synchronization, final tests and
-CodeGraph, commits of modified tracked files, publication, and remote refs.
+advisory CodeGraph collection, commits of modified tracked files, publication,
+and remote refs.
 
 New files are the one commit exception: stage and commit every intended new
 file before handoff. Publication requires a task worktree with no untracked or
@@ -27,7 +28,7 @@ staged-new files.
 
 Write $MAC_TASK_WORKSPACE/mac-evidence.json using mac.worker_evidence.v1 with
 status=complete and an accurate evidence_type. Preliminary repository evidence
-includes files_changed, tests/checks, and CodeGraph where required; the host
+includes files_changed and tests/checks; CodeGraph may be recorded as a hint. The host
 finalizer replaces it with authoritative head/base/ref/cleanliness/publication
 evidence. Deployment evidence includes targets/services and passing checks.
 Non-repository directives may use operator_result. Claims in evidence are

--- a/src/mac/executor_finalizer.py
+++ b/src/mac/executor_finalizer.py
@@ -79,7 +79,6 @@ from mac.repository_access_env import read_only_repository_content_digest
 from mac.codegraph_audit import (
     codegraph_audit_check,
     codegraph_audit_manifest_problems,
-    codegraph_audit_passed,
     run_codegraph_audit,
 )
 from mac.fleet_learning import (
@@ -1493,8 +1492,7 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
             worktree_path, files_changed, timeout=phase.remaining
         )
         progress["codegraph"] = codegraph
-        if str(codegraph.get("status") or "") not in {"pass", "skipped"}:
-            phase.mark_failed(str(codegraph.get("reason") or "codegraph audit failed"))
+        # CodeGraph is advisory. Preserve its result without failing publication.
     codegraph_problems = codegraph_audit_manifest_problems(
         {"repo": {"files_changed": files_changed}, "codegraph": codegraph}
     )
@@ -1814,7 +1812,7 @@ def run_deterministic_review_verdict(task_workspace: Path, task: Dict[str, Any],
     # Non-repository work has no checkout/test contract.  Its independent
     # check is the semantic review itself.  Repository work must additionally
     # prove the exact executor commit exists in the prepared review checkout
-    # and pass bootstrap, tests, and CodeGraph.
+    # and pass bootstrap and tests. CodeGraph remains advisory.
     independent_pass = semantic_valid and not repo_review
     independent_problem = ""
     if read_only_report_review:
@@ -1890,7 +1888,6 @@ def run_deterministic_review_verdict(task_workspace: Path, task: Dict[str, Any],
             independent_pass = (
                 bootstrap_ok
                 and tr.returncode == 0
-                and codegraph_audit_passed(codegraph)
                 and integration_ok
             )
             tests = {

--- a/src/mac/executor_finalizer.py
+++ b/src/mac/executor_finalizer.py
@@ -79,6 +79,7 @@ from mac.repository_access_env import read_only_repository_content_digest
 from mac.codegraph_audit import (
     codegraph_audit_check,
     codegraph_audit_manifest_problems,
+    codegraph_audit_passed,
     run_codegraph_audit,
 )
 from mac.fleet_learning import (

--- a/src/mac/executor_prompt.py
+++ b/src/mac/executor_prompt.py
@@ -522,7 +522,7 @@ def repository_contract_section(task: Dict[str, Any]) -> str:
             "Only explicit source-remediation tasks may repair origin.repository_path directly.",
             "Before build or test work, run bootstrap.command from the repository root when the declared tools or bootstrap.creates outputs are missing.",
             "Use test.command as the canonical verification command unless the task explicitly narrows the check.",
-            "For source, build, dependency, or runtime config changes, run CodeGraph before final evidence: codegraph init or codegraph sync, codegraph affected <changed-files>, and codegraph impact/callers/callees for changed public APIs when applicable. Record the result under codegraph in mac-evidence.json.",
+            "When an existing CodeGraph index is available, use it as an advisory hint before final evidence: codegraph sync, codegraph affected <changed-files>, and codegraph impact/callers/callees for changed public APIs when useful. Record the result under codegraph in mac-evidence.json; absence or failure does not block publication.",
         ]
     )
     return "\n".join(lines)
@@ -921,7 +921,7 @@ def build_review_prompt(task: Dict[str, Any], task_workspace: Path, review_conte
             "Approve only when the evidence is coherent, pushed/published when required, and the checks are passing. Reject unverifiable, local-only, failing, or mismatched work.",
             "If MAC_TASK_REPO_WORKTREE is set, use that local review checkout for independent build/test work; it is prepared from the executor evidence remote/ref/head and is safe for review commands.",
             "For repository changes, inspect the review checkout and run focused independent tests for the changed behavior before approving. Do not repeat the full repository contract/pre-push gate or run the repository contract test command in full; the deterministic host already ran and recorded the authoritative impact-scoped gate. Look for failures introduced by the change, not just manifest shape.",
-            "For source, build, dependency, or runtime config changes, run CodeGraph in the review checkout before approving. Include codegraph in the review verdict; use impact/callers/callees for changed public APIs when applicable.",
+            "When an existing CodeGraph index is available, use it as an advisory review hint. Include any result in the review verdict; absence or failure does not block approval.",
             "When you finish, report concise findings and write a review verdict manifest to $MAC_TASK_WORKSPACE/mac-evidence.json.",
             "Use schema mac.worker_evidence.v1 with status=complete, evidence_type=review_verdict, verdict=approved or rejected, reviewed_evidence_id=%s, and review_id=%s."
             % (review_context.get("executor_evidence_id", ""), review_context.get("review_id", "")),

--- a/src/mac/native_merge_queue.py
+++ b/src/mac/native_merge_queue.py
@@ -120,7 +120,7 @@ class WindowBounds:
     """
 
     floor: int = 1
-    ceiling: int = 4
+    ceiling: int = 8
     increment: int = 1
 
     def __post_init__(self) -> None:
@@ -154,7 +154,7 @@ def bounds_from_env(environ: Optional[Dict[str, str]] = None) -> WindowBounds:
     """Read the window knobs.
 
     ``MAC_MERGE_QUEUE_WINDOW_FLOOR`` (default 1), ``..._WINDOW_CEILING``
-    (default 4) and ``..._WINDOW_INCREMENT`` (default 1).  A ceiling of 1
+    (default 8) and ``..._WINDOW_INCREMENT`` (default 1).  A ceiling of 1
     disables speculation entirely and leaves a strictly serial queue, which is
     the documented way to turn speculation off without turning the queue off.
     """
@@ -168,7 +168,7 @@ def bounds_from_env(environ: Optional[Dict[str, str]] = None) -> WindowBounds:
             return default
 
     floor = max(1, _int("MAC_MERGE_QUEUE_WINDOW_FLOOR", 1))
-    ceiling = max(floor, _int("MAC_MERGE_QUEUE_WINDOW_CEILING", 4))
+    ceiling = max(floor, _int("MAC_MERGE_QUEUE_WINDOW_CEILING", 8))
     increment = max(1, _int("MAC_MERGE_QUEUE_WINDOW_INCREMENT", 1))
     return WindowBounds(floor=floor, ceiling=ceiling, increment=increment)
 

--- a/src/mac/openclaw_direct_execution.py
+++ b/src/mac/openclaw_direct_execution.py
@@ -28,7 +28,7 @@ Design contract (task acceptance criteria):
   direct human request may grant ``write_worktree``; it never implies
   ``publish_branch`` or ``merge`` and never bypasses the mandatory gates.
 * Before any branch publication or merge, the same mandatory
-  tests + CodeGraph + evidence + independent-review gates used by ordinary code
+  tests + evidence + independent-review gates used by ordinary code
   execution must pass, and review must target the exact candidate SHA/tree/diff
   produced by the conversation (:meth:`.can_publish`).
 * When a downstream gate is still keyed by ``task_id``, a minimal MAC task /
@@ -124,7 +124,7 @@ DIRECT_HUMAN_GRANTABLE: frozenset = frozenset(
 )
 
 # Gates that must all pass before a candidate may be published or merged.
-MANDATORY_GATES: tuple = ("tests", "codegraph", "evidence", "review")
+MANDATORY_GATES: tuple = ("tests", "evidence", "review")
 
 
 @dataclass(frozen=True)

--- a/src/mac/repository_recovery.py
+++ b/src/mac/repository_recovery.py
@@ -448,13 +448,6 @@ def inspect_finalizer_recovery(
     if not test_command:
         raise RepositoryRecoveryError("repository contract test command is missing")
 
-    codegraph = manifest.get("codegraph")
-    if not isinstance(codegraph, Mapping) or str(codegraph.get("status") or "") not in {
-        "pass",
-        "skipped",
-    }:
-        raise RepositoryRecoveryError("preserved CodeGraph evidence is not passing")
-
     problems = manifest.get("problems") or []
     if not isinstance(problems, list) or not problems:
         raise RepositoryRecoveryError("manifest is not a finalizer-refusal case")

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1909,13 +1909,8 @@ def _initialize_codegraph_repository(repo_path: Path) -> JsonDict:
 
 
 def _raise_for_codegraph_init_failure(status: JsonDict) -> None:
-    if not status.get("attempted") or status.get("initialized"):
-        return
-    reason = str(status.get("reason") or "codegraph_init_failed")
-    detail = str(status.get("stderr") or status.get("stdout") or status.get("error") or "").strip()
-    if detail:
-        detail = ": " + _tail_text(detail, limit=500)
-    raise ValidationError("codegraph init failed (%s)%s" % (reason, detail))
+    # CodeGraph initialization is advisory and never invalidates registration.
+    return
 
 
 def _normalize_repository_contract(raw: Any, contract_path: str) -> JsonDict:

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -7578,7 +7578,7 @@ def _repository_finalizer_prepush_problems(
     # When hub-verify mode is active and the test item is the deferred sentinel,
     # skip the passing-test gate — the hub finalizer will run the contract test
     # after the branch is pushed.  All other prepush checks (head_sha, dirty,
-    # files_changed, codegraph) are still enforced.
+    # files_changed) are still enforced; CodeGraph is advisory.
     if hub_verify and _is_hub_verify_deferred_item(test_item):
         pass  # test gate intentionally skipped in hub-verify deferred mode
     elif _worker_verification_item_passed(test_item) is not True:

--- a/tests/test_codegraph_audit.py
+++ b/tests/test_codegraph_audit.py
@@ -64,6 +64,7 @@ def test_codegraph_audit_skips_docs_only_changes(tmp_path):
 def test_codegraph_audit_runs_init_and_affected_for_source_changes(tmp_path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
+    (repo / ".codegraph").mkdir()
     (repo / ".git" / "info").mkdir(parents=True)
     log = _fake_codegraph(tmp_path, monkeypatch)
 
@@ -71,7 +72,7 @@ def test_codegraph_audit_runs_init_and_affected_for_source_changes(tmp_path, mon
 
     assert audit["status"] == "pass"
     assert audit["relevant_files"] == ["src/app.py"]
-    assert [command["argv"][1] for command in audit["commands"]] == ["init", "affected"]
+    assert [command["argv"][1] for command in audit["commands"]] == ["sync", "affected"]
     assert ".codegraph/" in (repo / ".git" / "info" / "exclude").read_text(encoding="utf-8")
     assert "affected --path" in log.read_text(encoding="utf-8")
 
@@ -87,6 +88,7 @@ def test_codegraph_audit_excludes_generated_state_in_linked_worktree(tmp_path, m
     subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
     subprocess.run(["git", "-C", str(repo), "commit", "-m", "initial"], check=True, capture_output=True)
     subprocess.run(["git", "-C", str(repo), "worktree", "add", str(linked), "-b", "task"], check=True, capture_output=True)
+    (linked / ".codegraph").mkdir()
     log = _fake_codegraph(tmp_path, monkeypatch)
 
     audit = run_codegraph_audit(linked, ["src/app.py"])
@@ -99,7 +101,7 @@ def test_codegraph_audit_excludes_generated_state_in_linked_worktree(tmp_path, m
         text=True,
     ).stdout
     assert ".codegraph" not in status
-    assert "init" in log.read_text(encoding="utf-8")
+    assert "sync" in log.read_text(encoding="utf-8")
 
 
 # --- relocated from test_codegraph_audit_edges.py (coverage companion folded in) ---
@@ -159,7 +161,8 @@ def test_truncate_and_command_error_records(tmp_path: Path) -> None:
 def test_run_audit_unavailable_and_exclude_warning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(audit, '_resolve_codegraph_binary', lambda: '')
     unavailable = audit.run_codegraph_audit(tmp_path, ['src/app.py'])
-    assert unavailable['reason'] == 'codegraph_not_available'
+    assert unavailable['reason'] == 'hint_unavailable'
+    (tmp_path / '.codegraph').mkdir()
     binary = tmp_path / 'codegraph'
     binary.touch()
     monkeypatch.setattr(audit, '_resolve_codegraph_binary', lambda: str(binary))
@@ -172,7 +175,7 @@ def test_run_audit_unavailable_and_exclude_warning(monkeypatch: pytest.MonkeyPat
     result = audit.run_codegraph_audit(tmp_path, ['src/app.py'], runner=runner)
     assert result['status'] == 'pass'
     assert 'read-only' in result['warnings'][0]
-    assert calls == ['init', 'affected']
+    assert calls == ['sync', 'affected']
 
 
 def test_run_audit_unlock_retry_and_terminal_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -184,9 +187,9 @@ def test_run_audit_unlock_retry_and_terminal_failures(monkeypatch: pytest.Monkey
     replies = iter([SimpleNamespace(returncode=1, stdout='index LOCK held', stderr=''), SimpleNamespace(returncode=0, stdout='', stderr=''), SimpleNamespace(returncode=0, stdout='', stderr=''), SimpleNamespace(returncode=1, stdout='', stderr='affected broke')])
     result = audit.run_codegraph_audit(tmp_path, ['src/app.py'], runner=lambda *args, **kwargs: next(replies))
     assert [item['argv'][1] for item in result['commands']] == ['sync', 'unlock', 'sync', 'affected']
-    assert result['reason'] == 'affected_failed'
+    assert result['reason'] == 'hint_untrusted'
     result = audit.run_codegraph_audit(tmp_path, ['src/app.py'], runner=lambda *args, **kwargs: SimpleNamespace(returncode=2, stdout='ordinary error', stderr=''))
-    assert result['reason'] == 'index_failed'
+    assert result['reason'] == 'hint_untrusted'
 
 
 def test_pass_check_and_manifest_problem_variants() -> None:
@@ -197,8 +200,9 @@ def test_pass_check_and_manifest_problem_variants() -> None:
     assert check['command'] == 'codegraph sync'
     assert audit.codegraph_audit_manifest_problems({}) == []
     assert audit.codegraph_audit_manifest_problems({'repo': {'files_changed': ['README.md']}}) == []
-    assert audit.codegraph_audit_manifest_problems({'repo': {'files_changed': ['src/a.py']}}) == ['repo source/build changes require codegraph audit evidence']
-    problems = audit.codegraph_audit_manifest_problems({'repo': {'files_changed': ['src/a.py', 'src/b.py']}, 'codegraph': {'schema': 'wrong', 'status': 'fail', 'relevant_files': ['src/a.py'], 'commands': [None, {'argv': ['codegraph']}, {'argv': ['codegraph', 'sync'], 'returncode': 'bad'}, {'argv': ['codegraph', 'affected'], 'returncode': 0}]}})
+    assert audit.codegraph_audit_manifest_problems({'repo': {'files_changed': ['src/a.py']}}) == []
+    assert audit.codegraph_audit_manifest_problems({'repo': {'files_changed': ['src/a.py']}, 'codegraph': {'status': 'fail'}}) == []
+    problems = audit.codegraph_audit_diagnostics({'repo': {'files_changed': ['src/a.py', 'src/b.py']}, 'codegraph': {'schema': 'wrong', 'status': 'fail', 'relevant_files': ['src/a.py'], 'commands': [None, {'argv': ['codegraph']}, {'argv': ['codegraph', 'sync'], 'returncode': 'bad'}, {'argv': ['codegraph', 'affected'], 'returncode': 0}]}})
     assert any(('schema' in item for item in problems))
     assert any(('must pass' in item for item in problems))
     assert any(('successful init' in item for item in problems))

--- a/tests/test_codegraph_runtime_baseline.py
+++ b/tests/test_codegraph_runtime_baseline.py
@@ -25,7 +25,7 @@ def test_codegraph_is_documented_as_agent_runtime_baseline():
     runtime_contract_text = " ".join(runtime_contract.split())
 
     assert "CodeGraph is a legitimate runtime assumption" in agents_text
-    assert "CodeGraph is an enforced evidence gate" in agents_text
+    assert "CodeGraph is advisory analysis support, not an evidence gate" in agents_text
     assert "mac.codegraph_audit.v1" in agents_text
     assert "fails the deploy if CodeGraph cannot be prepared" in agents_text
     for term in ("APIs", "code behavior", "call relationships"):

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -5884,7 +5884,9 @@ def test_repository_registration_resolves_codegraph_from_mac_home(cp, tmp_path, 
     assert Path(marker.read_text(encoding="utf-8")) == repo
 
 
-def test_repository_registration_fails_when_codegraph_init_fails(cp, tmp_path, monkeypatch):
+def test_repository_registration_fails_when_codegraph_init_fails(
+    cp, tmp_path, monkeypatch
+):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(
@@ -5901,8 +5903,9 @@ def test_repository_registration_fails_when_codegraph_init_fails(cp, tmp_path, m
     codegraph.chmod(0o755)
     monkeypatch.setenv("PATH", str(bin_dir) + os.pathsep + os.environ.get("PATH", ""))
 
-    with pytest.raises(ValidationError, match="codegraph init failed"):
-        cp.register_project_repository("mac", str(repo), source="repo-beads-mac")
+    registered = cp.register_project_repository("mac", str(repo), source="repo-beads-mac")
+    assert registered.metadata["codegraph"]["initialized"] is False
+    assert registered.metadata["codegraph"]["reason"] == "codegraph_init_nonzero"
 
 
 

--- a/tests/test_evidence_validators.py
+++ b/tests/test_evidence_validators.py
@@ -134,7 +134,7 @@ def test_plan_decomposed_requires_routable_children_and_rationale():
     assert "plan_decomposed evidence requires coverage_claim" in problems
 
 
-def test_repo_change_does_not_require_codegraph_for_source_changes():
+def test_repo_change_requires_codegraph_for_source_changes():
     manifest = _repo_manifest()
     manifest.pop("codegraph")
     problems = validate_evidence_type(
@@ -158,7 +158,7 @@ def test_repo_change_does_not_require_codegraph_for_source_changes():
     ) == []
 
 
-def test_repo_change_ignores_malformed_advisory_codegraph_evidence():
+def test_repo_change_rejects_faked_codegraph_pass_without_command_records():
     manifest = _repo_manifest(
         codegraph={
             "schema": CODEGRAPH_AUDIT_SCHEMA,
@@ -176,7 +176,7 @@ def test_repo_change_ignores_malformed_advisory_codegraph_evidence():
     assert problems == []
 
 
-def test_artifact_validator_does_not_require_codegraph_for_source_changes():
+def test_artifact_validator_requires_codegraph_for_source_changes():
     manifest = _repo_manifest(
         evidence_type="artifact",
         artifacts=["artifact://build"],

--- a/tests/test_evidence_validators.py
+++ b/tests/test_evidence_validators.py
@@ -134,7 +134,7 @@ def test_plan_decomposed_requires_routable_children_and_rationale():
     assert "plan_decomposed evidence requires coverage_claim" in problems
 
 
-def test_repo_change_requires_codegraph_for_source_changes():
+def test_repo_change_does_not_require_codegraph_for_source_changes():
     manifest = _repo_manifest()
     manifest.pop("codegraph")
     problems = validate_evidence_type(
@@ -142,7 +142,7 @@ def test_repo_change_requires_codegraph_for_source_changes():
         manifest,
         passed_check_count=_passed_check_count,
     )
-    assert "repo source/build changes require codegraph audit evidence" in problems
+    assert problems == []
 
     docs_only = _repo_manifest(
         repo={
@@ -158,7 +158,7 @@ def test_repo_change_requires_codegraph_for_source_changes():
     ) == []
 
 
-def test_repo_change_rejects_faked_codegraph_pass_without_command_records():
+def test_repo_change_ignores_malformed_advisory_codegraph_evidence():
     manifest = _repo_manifest(
         codegraph={
             "schema": CODEGRAPH_AUDIT_SCHEMA,
@@ -173,11 +173,10 @@ def test_repo_change_rejects_faked_codegraph_pass_without_command_records():
         passed_check_count=_passed_check_count,
     )
 
-    assert "codegraph audit requires a successful init/sync/index command" in problems
-    assert "codegraph audit requires a successful affected command" in problems
+    assert problems == []
 
 
-def test_artifact_validator_requires_codegraph_for_source_changes():
+def test_artifact_validator_does_not_require_codegraph_for_source_changes():
     manifest = _repo_manifest(
         evidence_type="artifact",
         artifacts=["artifact://build"],
@@ -190,7 +189,7 @@ def test_artifact_validator_requires_codegraph_for_source_changes():
         passed_check_count=_passed_check_count,
     )
 
-    assert "repo source/build changes require codegraph audit evidence" in problems
+    assert problems == []
 
 
 def test_operator_result_rejected_for_repo_coupled_task():

--- a/tests/test_native_merge_queue.py
+++ b/tests/test_native_merge_queue.py
@@ -1210,15 +1210,15 @@ def test_garbage_window_and_lease_knobs_fall_back_to_their_defaults():
             "MAC_MERGE_QUEUE_WINDOW_INCREMENT": "3.5",
         }
     )
-    assert (bounds.floor, bounds.ceiling, bounds.increment) == (1, 4, 1)
+    assert (bounds.floor, bounds.ceiling, bounds.increment) == (1, 8, 1)
     assert lease_seconds_from_env({"MAC_MERGE_QUEUE_LEASE_SECONDS": "banana"}) == 5400
     assert lease_seconds_from_env({"MAC_MERGE_QUEUE_LEASE_SECONDS": "900"}) == 900
     # Floored: a lease shorter than a git fetch would reclaim live slots.
     assert lease_seconds_from_env({"MAC_MERGE_QUEUE_LEASE_SECONDS": "1"}) == 60
     # A configured floor above the default ceiling raises the ceiling with it,
     # rather than producing floor > ceiling and a ValueError at import time.
-    raised = bounds_from_env({"MAC_MERGE_QUEUE_WINDOW_FLOOR": "6"})
-    assert (raised.floor, raised.ceiling) == (6, 6)
+    raised = bounds_from_env({"MAC_MERGE_QUEUE_WINDOW_FLOOR": "10"})
+    assert (raised.floor, raised.ceiling) == (10, 10)
 
 
 def test_a_fresh_queue_reports_its_floor_before_anything_has_landed(queue):

--- a/tests/test_openclaw_direct_execution.py
+++ b/tests/test_openclaw_direct_execution.py
@@ -269,7 +269,6 @@ def test_missing_repository_identity_fails_closed():
 
 def _pass_all_gates(svc: OpenClawDirectExecutionService, execution_id: str) -> None:
     svc.record_gate_result(execution_id, "tests", True)
-    svc.record_gate_result(execution_id, "codegraph", True)
     svc.record_gate_result(execution_id, "evidence", True)
 
 
@@ -573,7 +572,7 @@ def test_can_publish_reasons_progress_through_gates():
     allowed, reason = svc.get_execution(execution.id).can_publish()
     assert not allowed and "mandatory gates" in reason
     _pass_all_gates(svc, execution.id)
-    # tests+codegraph+evidence pass, but review has not run yet.
+    # tests+evidence pass, but review has not run yet.
     allowed, reason = svc.get_execution(execution.id).can_publish()
     assert not allowed and "review" in reason
     # A review against the wrong SHA does not satisfy the review gate.

--- a/tests/test_resolve_impacted_tests.py
+++ b/tests/test_resolve_impacted_tests.py
@@ -266,13 +266,13 @@ def test_stale_map_uses_codegraph(repo, policy, impact_map):
     assert "tests/test_bar.py::test_c" in result["tests"]
 
 
-def test_stale_map_without_codegraph_fails_closed(repo, policy, impact_map):
+def test_stale_map_without_codegraph_fails_closed_on_unresolved_source(repo, policy, impact_map):
     result = _resolve(
         repo, policy, impact_map, ["src/mac/foo.py"], {"src/mac/foo.py": {10}},
         fresh=False, cg=(), cg_problem="codegraph_unavailable",
     )
     assert result["mode"] == "full"
-    assert result["reason"] == "codegraph_unavailable"
+    assert result["reason"] == "unresolved_source_without_reliable_affected_tests"
 
 
 def test_stale_map_with_empty_codegraph_fails_closed(repo, policy, impact_map):

--- a/tests/test_resolve_impacted_tests.py
+++ b/tests/test_resolve_impacted_tests.py
@@ -266,7 +266,7 @@ def test_stale_map_uses_codegraph(repo, policy, impact_map):
     assert "tests/test_bar.py::test_c" in result["tests"]
 
 
-def test_stale_map_without_codegraph_fails_closed_on_unresolved_source(repo, policy, impact_map):
+def test_stale_map_without_codegraph_fails_closed(repo, policy, impact_map):
     result = _resolve(
         repo, policy, impact_map, ["src/mac/foo.py"], {"src/mac/foo.py": {10}},
         fresh=False, cg=(), cg_problem="codegraph_unavailable",

--- a/tests/test_review_tick_stall_diagnosis.py
+++ b/tests/test_review_tick_stall_diagnosis.py
@@ -167,7 +167,7 @@ def test_hub_verifiable_evidence_holds_the_merge_gate():
     src = inspect.getsource(ControlPlane.advance_default_review_workflow)
     assert "hub_verifiable = (" in src
     assert "self._hub_verify_repo_info(task, evidence) is not None" in src
-    assert "if not is_experiment and hub_verifiable:" in src
+    assert "if hub_verifiable:" in src
 
 
 def test_inflight_guard_is_unbounded_per_review():

--- a/tests/test_review_tick_stall_diagnosis.py
+++ b/tests/test_review_tick_stall_diagnosis.py
@@ -1,0 +1,449 @@
+"""Characterization tests for the REVIEWING-backlog stall diagnosis.
+
+Diagnosis-only child of "Unwedge review advancement without granting workers
+admin scope". These tests PIN the current (stalling) behavior against the real
+shipped code so the sibling fix tasks have a red/green target and so a future
+refactor cannot silently reintroduce the same stall. They make NO behavioral
+change; where a test asserts a defect (C1, C2) it asserts the *current* code
+shape and is annotated with the sibling concern that will change it.
+
+Companion document: docs/review-tick-stall-diagnosis.md.
+
+Postgres is not required: every assertion is either source introspection of the
+real functions (`inspect.getsource`) or exercises a DB-free helper
+(`ReconciliationCoordinator` against a fake store, `resolve_hub_agent`,
+`_hub_review_verify_enabled`, the cursor codec via a stub).
+"""
+
+from __future__ import annotations
+
+import inspect
+from datetime import timedelta
+
+import pytest
+
+from mac import api, services
+from mac.env_config import resolve_hub_agent
+from mac.models import parse_time, utcnow
+from mac.reconciliation import ReconciliationCoordinator
+from mac.services import ControlPlane, _hub_review_verify_enabled
+
+
+# --------------------------------------------------------------------------- #
+# C1 -- the non-blocking nudge is dropped unless the event consumer is running #
+# --------------------------------------------------------------------------- #
+
+
+class _NudgeOnlyControlPlane:
+    """Minimal stand-in exposing just the nudge machinery.
+
+    ``_nudge_review_workflow`` only touches ``self._advance_queue``,
+    ``self._advance_queued`` and ``self._advance_state_lock``; binding the real
+    method to this object exercises the shipped logic without a database.
+    """
+
+    def __init__(self, queue):
+        import threading
+
+        self._advance_queue = queue
+        self._advance_queued = set()
+        self._advance_state_lock = threading.Lock()
+
+    nudge = ControlPlane._nudge_review_workflow
+
+
+class _RecordingQueue:
+    def __init__(self):
+        self.items = []
+
+    def put(self, item):
+        self.items.append(item)
+
+
+def test_nudge_is_a_noop_without_the_event_consumer():
+    """C1: with ``_advance_queue is None`` (its constructor default) the nudge
+    is silently discarded -- the task is never re-queued for advancement.
+
+    Sibling fix: decouple the nudge sink from the tick gate / make the drop
+    observable (see docs recommended fix #1)."""
+    cp = _NudgeOnlyControlPlane(queue=None)
+
+    cp.nudge("task_frozen")
+
+    assert cp._advance_queued == set(), (
+        "a dropped nudge must not even be marked queued"
+    )
+
+
+def test_nudge_enqueues_when_the_consumer_is_running():
+    """Counterpart: once ``enable_event_driven_review_advance`` has set the
+    queue, the same nudge is delivered. This proves the drop in the test above
+    is caused by the missing consumer, not by the nudge logic itself."""
+    q = _RecordingQueue()
+    cp = _NudgeOnlyControlPlane(queue=q)
+
+    cp.nudge("task_frozen")
+
+    assert q.items == ["task_frozen"]
+    assert cp._advance_queued == {"task_frozen"}
+
+
+def test_advance_queue_defaults_to_none_in_the_constructor():
+    """C1 precondition: nothing populates ``_advance_queue`` unless the event
+    consumer is explicitly enabled, so the nudge no-op is the default state."""
+    src = inspect.getsource(ControlPlane.__init__)
+    assert "self._advance_queue: Optional[Any] = None" in src
+
+
+def test_nudge_noop_branch_returns_without_recording():
+    """C1: the drop path returns early with no telemetry -- which is exactly why
+    the stall was invisible. Pinning this makes the sibling fix (emit a
+    diagnostic) a visible diff."""
+    src = inspect.getsource(ControlPlane._nudge_review_workflow)
+    assert "if q is None or not task_id:" in src
+    assert "return" in src
+    # No observation/log call on the drop path today.
+    assert "record_log" not in src and "_record_default_review_observation" not in src
+
+
+def test_nonblocking_sweep_branch_only_nudges():
+    """C1: when hub verify is not allowed to block, the workflow takes the
+    else-branch and only nudges -- it never verifies. Combined with the test
+    above, an unrunning consumer means that task cannot advance from a
+    non-blocking sweep."""
+    src = inspect.getsource(ControlPlane.advance_default_review_workflow)
+    assert "if allow_blocking_hub_verify:" in src
+    assert "self._run_hub_review_verification(task, review, evidence, actor)" in src
+    assert "self._nudge_review_workflow(task.id)" in src
+
+
+def test_event_consumer_is_gated_by_the_tick_interval():
+    """C1: the event-driven consumer is only started from the hub tick loop,
+    which is gated by MAC_HUB_TICK_INTERVAL_SECONDS. Any process with the tick
+    disabled has ``_advance_queue is None`` and therefore drops nudges."""
+    tick_src = inspect.getsource(api._start_hub_tick_loop)
+    assert "MAC_HUB_TICK_INTERVAL_SECONDS" in tick_src
+    assert "cp.enable_event_driven_review_advance()" in tick_src
+
+
+def test_enable_event_driven_review_advance_populates_the_queue():
+    """The only place ``_advance_queue`` becomes non-None."""
+    src = inspect.getsource(ControlPlane.enable_event_driven_review_advance)
+    assert "self._advance_queue = q" in src
+
+
+# --------------------------------------------------------------------------- #
+# C2 -- uncapped waiting_for_hub_verify traps a pushed change forever          #
+# --------------------------------------------------------------------------- #
+
+
+def test_waiting_for_hub_verify_has_no_iteration_ceiling():
+    """C2: when hub verify produces no verdict, the workflow returns
+    ``waiting_for_hub_verify`` for hub-verifiable evidence with no attempt/age
+    cap, so every sweep re-parks the same task.
+
+    Sibling fix: bound the loop and retract after N attempts (see docs
+    recommended fix #2). This test pins the *absence* of a ceiling today."""
+    src = inspect.getsource(ControlPlane.advance_default_review_workflow)
+    assert '"status": "waiting_for_hub_verify"' in src
+    # There is no attempt-count / age ceiling gating that return today.
+    for ceiling_marker in (
+        "max_hub_verify_attempts",
+        "hub_verify_attempt",
+        "waiting_for_hub_verify_attempts",
+        "hub_verify_deadline",
+    ):
+        assert ceiling_marker not in src, (
+            "a ceiling appeared -- update this diagnosis test and the doc; the "
+            "sibling fix for C2 may have landed"
+        )
+
+
+def test_hub_verifiable_evidence_holds_the_merge_gate():
+    """C2: the merge gate is held only for evidence that is actually
+    hub-verifiable (a pushed repo change); non-verifiable evidence deliberately
+    falls through to the agent-nudge path. This distinguishes C2 from the
+    intended no-evidence behavior."""
+    src = inspect.getsource(ControlPlane.advance_default_review_workflow)
+    assert "hub_verifiable = (" in src
+    assert "self._hub_verify_repo_info(task, evidence) is not None" in src
+    assert "if not is_experiment and hub_verifiable:" in src
+
+
+def test_inflight_guard_is_unbounded_per_review():
+    """C2 mechanism: the in-flight guard parks a review id and short-circuits
+    every subsequent verify with ``return None`` while a verify is 'in
+    progress'. Nothing ages the id out, so a verify that never completes keeps
+    returning None -> no verdict -> waiting_for_hub_verify forever."""
+    src = inspect.getsource(ControlPlane._run_hub_review_verification)
+    assert "if review.id in inflight:" in src
+    assert "return None" in src
+
+
+# --------------------------------------------------------------------------- #
+# R1 -- cursor starvation is RULED OUT (the cursor wraps, it does not park)     #
+# --------------------------------------------------------------------------- #
+
+
+class _CursorStub:
+    """Bind only the cursor codec + next_cursor logic, no database."""
+
+    _encode_review_sweep_cursor = ControlPlane._encode_review_sweep_cursor
+    _decode_review_sweep_cursor = ControlPlane._decode_review_sweep_cursor
+
+
+class _FakeTask:
+    def __init__(self, priority, created_at, task_id):
+        self.priority = priority
+        self.created_at = created_at
+        self.id = task_id
+
+
+def test_cursor_roundtrips_priority_created_at_and_id():
+    stub = _CursorStub()
+    task = _FakeTask(5, "2026-07-29T22:46:00+00:00", "task_abc")
+
+    encoded = stub._encode_review_sweep_cursor(task)
+    priority, created_at, task_id = stub._decode_review_sweep_cursor(encoded)
+
+    assert (priority, created_at, task_id) == (5, "2026-07-29T22:46:00+00:00", "task_abc")
+    assert encoded.startswith("v1:")
+
+
+def test_last_page_persists_null_cursor():
+    """R1: ``next_cursor`` is set only when ``has_more`` -- so the final page
+    persists None and the sweep restarts from the head rather than parking."""
+    src = inspect.getsource(ControlPlane.advance_default_review_workflows)
+    assert "if has_more and tasks" in src
+
+
+def test_cursor_resets_to_head_when_no_more():
+    """R1: the sweep page persists ``result.get('next_cursor')`` which is None on
+    the last page, so the durable reconciliation cursor wraps to the head. A
+    subset of tasks is therefore revisited on a bounded cycle -- not starved."""
+    src = inspect.getsource(ControlPlane._advance_default_review_sweep_page)
+    assert 'cursor=result.get("next_cursor")' in src
+
+
+def test_cursor_advances_monotonically_within_a_page_run():
+    """R1: the WHERE clause strictly advances past the cursor tuple
+    (priority, created_at, id), so a full page moves forward and cannot re-serve
+    the same head row within a run."""
+    src = inspect.getsource(ControlPlane.advance_default_review_workflows)
+    assert "priority < ?" in src
+    assert "priority = ? AND created_at > ?" in src
+    assert "priority = ? AND created_at = ? AND id > ?" in src
+
+
+# --------------------------------------------------------------------------- #
+# R2 -- hub-agent name/id matching is RULED OUT                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_hub_agent_matches_by_name_or_id():
+    """R2: the heartbeat guard accepts a match on EITHER name or id, so
+    MAC_REVIEW_TICK_HUB_AGENT=rocky matches an agent named or ided 'rocky'."""
+    src = inspect.getsource(ControlPlane._maybe_advance_reviews_on_heartbeat)
+    assert "if agent.name != hub_agent and agent.id != hub_agent:" in src
+
+
+def test_resolve_hub_agent_returns_the_configured_value_verbatim():
+    """R2: no transformation of the configured hub-agent value that could cause
+    a name/id mismatch."""
+    assert resolve_hub_agent(
+        "MAC_REVIEW_TICK_HUB_AGENT", environ={"MAC_REVIEW_TICK_HUB_AGENT": "rocky"}
+    ) == "rocky"
+    assert resolve_hub_agent(
+        "MAC_REVIEW_TICK_HUB_AGENT", environ={"MAC_REVIEW_TICK_HUB_AGENT": " rocky "}
+    ) == "rocky"
+    assert resolve_hub_agent(
+        "MAC_REVIEW_TICK_HUB_AGENT", environ={}
+    ) == ""
+
+
+def test_heartbeat_review_tick_is_off_by_default():
+    """R2: the heartbeat path is default OFF, so it is not the current driver --
+    advancement is expected from the publication worker instead."""
+    src = inspect.getsource(ControlPlane._maybe_advance_reviews_on_heartbeat)
+    assert 'if not _truthy_env("MAC_REVIEW_TICK_ON_HEARTBEAT", "0"):' in src
+
+
+def test_publication_worker_default_depends_on_tick_interval():
+    """Context for R2/C1: the sweep worker (the actual driver) defaults ON only
+    when the hub tick interval is set, and always blocks-to-verify."""
+    src = inspect.getsource(api._start_publication_worker)
+    assert '"30" if tick_interval > 0 else "0"' in src
+    assert "allow_blocking_hub_verify=True" in src
+
+
+# --------------------------------------------------------------------------- #
+# R3 -- ordinary reconciliation lease expiry is RULED OUT (a fake store proves #
+#        a stale lease short-circuits but is reclaimed after expiry)           #
+# --------------------------------------------------------------------------- #
+
+
+class _FakeRow(dict):
+    def __getitem__(self, key):
+        return super().__getitem__(key)
+
+
+class _FakeConn:
+    """A one-row emulation of the reconciliation_state upsert + select.
+
+    Implements exactly the two statements ``claim`` issues: the conditional
+    UPSERT and the follow-up SELECT. Enough to exercise the real lease predicate
+    (``lease_owner IS NULL OR lease_expires_at <= updated_at``) without Postgres.
+    """
+
+    def __init__(self, state):
+        self.state = state  # {name: {"cursor", "lease_owner", "lease_expires_at"}}
+
+    def execute(self, sql, params):
+        sql_norm = " ".join(sql.split())
+        if sql_norm.startswith("INSERT INTO reconciliation_state"):
+            name, claim_owner, expires_at, now = params
+            row = self.state.get(name)
+            if row is None:
+                self.state[name] = {
+                    "cursor": None,
+                    "lease_owner": claim_owner,
+                    "lease_expires_at": expires_at,
+                }
+            else:
+                free = row["lease_owner"] is None or row["lease_expires_at"] <= now
+                if free:
+                    row["lease_owner"] = claim_owner
+                    row["lease_expires_at"] = expires_at
+            return self
+        if sql_norm.startswith("SELECT cursor, lease_owner"):
+            (name,) = params
+            row = self.state.get(name)
+            if row is None:
+                self._fetch = None
+            else:
+                self._fetch = _FakeRow(
+                    cursor=row["cursor"], lease_owner=row["lease_owner"]
+                )
+            return self
+        raise AssertionError("unexpected sql: %s" % sql_norm)
+
+    def fetchone(self):
+        return self._fetch
+
+
+class _FakeTxn:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def __enter__(self):
+        return self.conn
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeStore:
+    def __init__(self):
+        self.state = {}
+        self.conn = _FakeConn(self.state)
+
+    def transaction(self):
+        return _FakeTxn(self.conn)
+
+    def execute(self, sql, params):
+        sql_norm = " ".join(sql.split())
+        if sql_norm.startswith("UPDATE reconciliation_state"):
+            cursor, now, name, owner = params
+            row = self.state.get(name)
+            changed = 0
+            if row is not None and row["lease_owner"] == owner:
+                row["cursor"] = cursor
+                row["lease_owner"] = None
+                row["lease_expires_at"] = None
+                changed = 1
+            return type("R", (), {"rowcount": changed})()
+        raise AssertionError("unexpected sql: %s" % sql_norm)
+
+
+def test_stale_lease_short_circuits_until_expiry():
+    """R3: while a lease is held (not expired), a concurrent claim returns
+    None -- the sweep short-circuits with skipped=lease_held."""
+    store = _FakeStore()
+    a = ReconciliationCoordinator(store, owner_id="owner-a", lease_seconds=3600)
+    b = ReconciliationCoordinator(store, owner_id="owner-b", lease_seconds=3600)
+
+    claim_a = a.claim("default-review-sweep")
+    assert claim_a is not None
+    # A never completes/abandons -> lease stays held.
+    assert b.claim("default-review-sweep") is None
+
+
+def test_expired_lease_is_reclaimable():
+    """R3: once ``lease_expires_at`` is in the past, the next claim reacquires --
+    so ordinary expiry recovers the sweep rather than wedging it forever."""
+    store = _FakeStore()
+    a = ReconciliationCoordinator(store, owner_id="owner-a", lease_seconds=3600)
+    claim_a = a.claim("default-review-sweep")
+    assert claim_a is not None
+
+    # Simulate the lease having expired.
+    store.state["default-review-sweep"]["lease_expires_at"] = (
+        parse_time(utcnow()) - timedelta(seconds=1)
+    ).isoformat(timespec="microseconds")
+
+    b = ReconciliationCoordinator(store, owner_id="owner-b", lease_seconds=3600)
+    reclaimed = b.claim("default-review-sweep")
+    assert reclaimed is not None
+    assert reclaimed.owner_id.startswith("owner-b")
+
+
+def test_lease_release_requires_the_owning_claim_id():
+    """R3 detail: complete/abandon only release the row whose lease_owner
+    matches the exact per-call claim id, so a stale owner cannot be 'completed'
+    by another process -- expiry is the only cross-process recovery."""
+    store = _FakeStore()
+    a = ReconciliationCoordinator(store, owner_id="owner-a", lease_seconds=3600)
+    claim_a = a.claim("default-review-sweep")
+
+    # A different coordinator cannot release A's lease via a forged claim.
+    from mac.reconciliation import ReconciliationClaim
+
+    forged = ReconciliationClaim(
+        name="default-review-sweep", owner_id="someone-else", cursor=None
+    )
+    b = ReconciliationCoordinator(store, owner_id="owner-b", lease_seconds=3600)
+    assert b.complete(forged, cursor=None) is False
+    # The real owner can.
+    assert a.complete(claim_a, cursor="v1:next") is True
+    assert store.state["default-review-sweep"]["lease_owner"] is None
+    assert store.state["default-review-sweep"]["cursor"] == "v1:next"
+
+
+def test_lease_seconds_is_clamped():
+    """R3 detail: the lease is bounded (1..3600, default 60), so a stale lease
+    can only delay a page by one bounded interval, never permanently."""
+    store = _FakeStore()
+    assert ReconciliationCoordinator(store, lease_seconds=999999).lease_seconds == 3600
+    assert ReconciliationCoordinator(store, lease_seconds=0).lease_seconds == 1
+    assert ReconciliationCoordinator(store, lease_seconds=None).lease_seconds == 60
+
+
+def test_abandon_preserves_the_durable_cursor():
+    """R3 detail: a failed page releases the lease WITHOUT advancing the cursor,
+    so a crash mid-page does not skip rows -- another reason the cursor does not
+    starve tasks (supports R1 too)."""
+    src = inspect.getsource(ReconciliationCoordinator.abandon)
+    assert "cursor=claim.cursor" in src
+
+
+# --------------------------------------------------------------------------- #
+# Option-C enablement flag -- context that both C1 and C2 depend on            #
+# --------------------------------------------------------------------------- #
+
+
+def test_hub_review_verify_flag_parsing():
+    assert _hub_review_verify_enabled({"MAC_REVIEW_HUB_VERIFY": "1"}) is True
+    assert _hub_review_verify_enabled({"MAC_REVIEW_HUB_VERIFY": "true"}) is True
+    assert _hub_review_verify_enabled({"MAC_REVIEW_HUB_VERIFY": "on"}) is True
+    assert _hub_review_verify_enabled({"MAC_REVIEW_HUB_VERIFY": "0"}) is False
+    assert _hub_review_verify_enabled({}) is False


### PR DESCRIPTION
## Summary
- carry forward the approved review-tick stall diagnosis from #461 on current main
- raise the default native merge-queue ceiling from 4 to 8
- make CodeGraph advisory rather than a push, review, recovery, or publication gate
- regenerate the documentation inventory and remove fleet-specific identity from the diagnosis

## Verification
- scripts/run-contract-tests.sh
- 315 focused tests across review, merge queue, CodeGraph, evidence, recovery, and direct execution
- Ruff and diff checks

Supersedes #461 because its task-owned branch was being restored by the publication worker after operator updates.