### PR TITLE
Preserve operator-managed hub database

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -2034,6 +2034,38 @@ install_or_validate_control_plane_database() {
     export MAC_DEPLOY_DATABASE_URL="$POSTGRES_URL_CONFIGURED"
     return
   fi
+  # A host-local operator-managed PostgreSQL DSN is durable authority too. Do
+  # not replace it with a fresh empty managed container merely because fleet
+  # YAML omitted postgres.url during a later deploy.
+  local existing_database_url=""
+  if [ -f "$ENV_FILE" ]; then
+    existing_database_url="$("$PY" - "$ENV_FILE" <<'PY_EXISTING_DATABASE_URL'
+import shlex
+import sys
+
+for raw in open(sys.argv[1], encoding="utf-8"):
+    line = raw.strip()
+    if line.startswith("export "):
+        line = line[7:].lstrip()
+    if not line.startswith("MAC_DATABASE_URL="):
+        continue
+    value = line.split("=", 1)[1].strip()
+    try:
+        parts = shlex.split(value)
+    except ValueError:
+        parts = []
+    print(parts[0] if len(parts) == 1 else "")
+    break
+PY_EXISTING_DATABASE_URL
+)"
+  fi
+  case "$existing_database_url" in
+    postgres://*|postgresql://*)
+      log "preserving existing operator-managed control-plane database"
+      export MAC_DEPLOY_DATABASE_URL="$existing_database_url"
+      return
+      ;;
+  esac
   if ! postgres_install_enabled; then
     log "ERROR: control-plane node has no MAC_DEPLOY_DATABASE_URL and Postgres auto-install is disabled (MAC_DEPLOY_POSTGRES_INSTALL=$POSTGRES_INSTALL)"
     exit 1

--- a/tests/test_postgres_control_plane_provisioning.py
+++ b/tests/test_postgres_control_plane_provisioning.py
@@ -107,6 +107,15 @@ def test_non_control_plane_nodes_never_require_a_local_database() -> None:
     )
 
 
+def test_existing_operator_database_is_preserved_before_auto_install() -> None:
+    function = _function("install_or_validate_control_plane_database")
+    assert "preserving existing operator-managed control-plane database" in function
+    assert function.index("existing_database_url=") < function.index(
+        "installing hub-managed PostgreSQL control-plane database"
+    )
+    assert 'export MAC_DEPLOY_DATABASE_URL="$existing_database_url"' in function
+
+
 def test_install_script_forwards_the_dsn_back_to_the_caller() -> None:
     function = _function("install_or_validate_control_plane_database")
     assert "POSTGRES_DSN_OUT_FILE" in function


### PR DESCRIPTION
## Summary
- treat an existing host-local PostgreSQL DSN as durable operator authority
- prevent fleet deploy from replacing it with a fresh empty managed container when fleet YAML omits postgres.url
- retain auto-install behavior only for genuinely unconfigured hubs

## Verification
- 14 focused PostgreSQL provisioning tests
- bash syntax, Ruff, and diff checks