### PR TITLE
Release v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The guide is in [`docs/guide/`](docs/guide/README.md):
 | [Developer Guide](docs/guide/05-developer-guide.md) | how to hack on mac |
 | [Contributing](CONTRIBUTING.md) | filing issues and PRs that are actually tested |
 | [Presentations](docs/presentation/README.md) | capabilities decks, each pinned to the commit it describes and published to Google Slides |
+| [v1.2.0 capabilities (`e8040fec`)](docs/presentation/20260825T000816Z-e8040fec/README.md) | current release deck: object model, twelve task states, fleet, measurement — [Google Slides](https://docs.google.com/presentation/d/1cLzjGERKojHg0w1FOyUnlqlsVu_OZVM5b_kGc7T3fSw/edit) |
 
 Those pages are written from the code and gated by
 `tests/test_guide_docs_are_true.py`, which checks that every file they name

--- a/docs/presentation/20260825T000816Z-e8040fec/AUDIT.md
+++ b/docs/presentation/20260825T000816Z-e8040fec/AUDIT.md
@@ -1,0 +1,448 @@
+# Audit — every claim in this deck, traced to source
+
+Audited at commit `e8040fec` on 2026-08-25T00:08:16Z, by reading the tree
+directly. Generated references (`docs/reference/cli.md`,
+`docs/reference/openapi.md`) are treated as authoritative for surface counts
+because CI fails when they drift from the live parser and OpenAPI schema.
+
+**Where the README and the code disagree, this audit follows the code**, and
+says so.
+
+The previous capabilities deck (`8b424c20`, 2026-08-20) is not updated. This
+directory is a sibling, pinned to this SHA.
+
+---
+
+## 0. Current-doc pass
+
+`docs/reference/documentation-inventory.md` at this commit lists every
+Markdown file under `docs/` except pinned decks. Each row got a
+changed / not-changed decision against the tree. The summary:
+
+| Class in the inventory | Decision | Source anchor |
+|---|---|---|
+| generated reference (`cli.md`, `openapi.md`, env registry, this inventory) | **not-changed** | `Makefile` `docs-build` runs `scripts/generate-docs-reference.py --check`; CI Documentation on `e8040fec` succeeded |
+| architecture decision `docs/adr/0001`–`0031` | **not-changed as files**; statuses recorded in §7 | status line of each ADR |
+| book chapters `book/01`–`book/18` | **not-changed** | `mkdocs.yml` `nav:`; `make docs-check` executes every shell example |
+| guide `docs/guide/` | **not-changed** | `tests/test_guide_docs_are_true.py` |
+| historical archive | **not current behaviour** | `docs/archive/index.md` label; inventory category `historical archive` |
+| remaining current supplemental / runbook docs | **not-changed**, except the `_hermes` prose listed in §8 | tree vs each file; `_hermes` grep of current docs |
+
+The full per-file table is §11. No current inventory row was left unchecked.
+
+---
+
+## 1. Counts
+
+| Claim | How it was obtained |
+|---|---|
+| 205,258 lines of Python under `src/` | `find src -name "*.py" \| xargs wc -l` at `e8040fec` |
+| 212 modules in `src/mac` | `ls src/mac/*.py \| wc -l` |
+| 506 test files | `ls tests/*.py \| wc -l` |
+| 414 HTTP routes | `grep -cE "^\| \`(GET\|POST\|PUT\|PATCH\|DELETE)" docs/reference/openapi.md` |
+| 125 CLI verbs | Parsed from `docs/reference/cli.md`: task 45, project 9, agent 17, admin 54 |
+| 18 book chapters | `nav:` in `mkdocs.yml`, `book/01`–`book/18` |
+| 31 ADRs | `docs/adr/0001`–`0031`; 16 are Proposed |
+| 5 coding-agent routes | `src/mac/coding_agent.py` `AGENT_PRIORITY`: `opencode`, `pi`, `claude`, `codex`, `cursor` |
+| 129 commits since `v1.1.0` | `git rev-list --count v1.1.0..e8040fec` |
+
+The generated `mac --help` text says "0 administrative commands live under
+`mac admin`". The same generated `docs/reference/cli.md` then lists 54 admin
+groups, including `judgement`. The deck uses 54, not 0. Recorded as a
+generator defect in §8.
+
+---
+
+## 2. The object model (diagram 01)
+
+| Claim | Source |
+|---|---|
+| The CLI is organised around project / task / agent / admin | `docs/reference/cli.md`, `mac --help`: "The objects mac models. Start here: project … task … agent" |
+| project / task / agent blurbs | `mac --help` verbatim in `docs/reference/cli.md` |
+| Project dispatch pause is separate from per-task staging | `README.md` Core Contracts |
+| Recovery verbs | `mac task --help`: `recover-stranded`, `recover-finalizer`, `recover-stalled-finalizer` |
+| Break-glass is grantable/listable/revocable | `mac task --help` |
+| Visibility is not a dispatch gate | `docs/adr/0014-visibility-is-not-a-dispatch-gate.md` |
+| `judgement` is an admin group | `docs/reference/cli.md` Getting work done: `judgement` — "hourly process-quality authority over lifecycle gates" |
+| Generated CLI reference is checked | `scripts/generate-docs-reference.py`; `Makefile` `docs-build --check` |
+| MCP server is a client, not a second implementation | commit `efb428e9` |
+| Python client is contract-checked against the hub | `tests/test_dispatch_route_contract.py` |
+| ACP and A2A are implemented specifications | `README.md` lineage; `/.well-known/acp`, `/.well-known/agent-card.json`, `/a2a` in `docs/reference/openapi.md` |
+| `/ui` is read-only observability | `docs/adr/0025-the-hub-ui-is-the-observability-console.md` |
+| 125 verbs, 414 routes | §1 |
+
+---
+
+## 3. Task lifecycle (diagram 02)
+
+| Claim | Source |
+|---|---|
+| Twelve states | `src/mac/models.py` `class TaskState`: open, waiting, blocked, claimed, running, needs_review, needs_input, **stopped**, reviewing, completed, failed, cancelled |
+| `STOPPED` is not terminal | same file: "NOT terminal: stopped work is live work"; allocator only considers OPEN |
+| Three terminal states | `TERMINAL_TASK_STATES` = completed, failed, cancelled |
+| Non-terminal work is the default list view | `ACTIVE_TASK_STATES` comment in `src/mac/models.py` |
+| Hub still drives RUNNING → NEEDS_REVIEW → REVIEWING | `src/mac/services.py` `advance_default_review_workflow`; ADR 0016 is **Accepted** as a decision (2026-08-20) and is not yet the runtime |
+| CodeGraph is a hint, not a hard gate | `docs/adr/0031-codegraph-is-a-hint.md` Status: Accepted |
+| Native merge queue, "never land an untested tree" | `src/mac/native_merge_queue.py`; commit `2b49fb23` |
+| Failure causes are classified | `src/mac/review_failure_classifier.py`, `src/mac/attempt_failure_classifier.py` |
+
+Eleven became twelve since the `8b424c20` deck: `STOPPED` was added to
+`TaskState`. The live hub at capture had 4 tasks in that state (`mac task
+stats`, 2026-08-25).
+
+---
+
+## 4. Coordination (diagram 03)
+
+Unchanged in substance from the `8b424c20` audit. AgentBus is still a
+broadcast bus (`src/mac/agentbus_control.py`). Lifecycle verbs remain
+stand_down, abort, pause, resume, status. `abort` is still the destructive
+set. Inbox consumption for a CLI session that has no background slot is
+still `drain` / `pending` (`src/mac/agentbus_service.py`); `wait` still
+blocks. ADR 0026 is still Proposed.
+
+---
+
+## 5. Fleet and execution (diagram 04)
+
+| Claim | Source |
+|---|---|
+| macOS nodes are host installs under launchd | ADR 0015 **Accepted** |
+| Linux: native steward + containerized execution | ADR 0012 Accepted, implementation deferred; ADR 0015 narrows containers to Linux |
+| Five coding-agent routes, opencode first | `AGENT_PRIORITY` in `src/mac/coding_agent.py` |
+| Docker Engine/Moby is the only container runtime | ADR 0008 |
+| Secrets are handles | `README.md` Core Contracts |
+| Egress declared per project and per task | `mac project egress`, `mac task egress` in `docs/reference/cli.md` |
+
+---
+
+## 6. Measurement (diagram 05)
+
+Token-routing figures are **not re-measured**. They remain the seven days
+to 2026-08-19 from ADR 0017:
+
+| Claim | Source |
+|---|---|
+| 28,352 `llm.route` events; 481.8M input / 5.05M output; 64% streaming; 29.5% null `input_tokens`; 0 cached | ADR 0017, "Measured over the seven days to 2026-08-19" |
+| Cost is priced at read time | ADR 0017 `estimate_route_cost()` |
+
+Ledger census **is** re-measured. `mac task stats --json` against the live
+hub at capture 2026-08-25T00:08Z (counts only; no agent names):
+
+| state | count |
+|---|---|
+| blocked | 378 |
+| waiting | 29 |
+| open | 94 |
+| running | 1 |
+| failed | 2,160 |
+| cancelled | 3,565 |
+| completed | 728 |
+| reviewing | 18 |
+| needs_input | 22 |
+| needs_review | 1 |
+| stopped | 4 |
+
+The 165-of-355 permanently-dead blocked finding is still ADR 0018's
+2026-08-19 measurement. That dead-dependency query was **not** re-run.
+Blocked has grown from 355 to 378.
+
+ADR 0016 is no longer Proposed; the three open decisions on the slide are
+0029, 0017, and 0018. Sixteen ADRs remain Proposed overall (§7).
+
+---
+
+## 7. Statuses, stated precisely
+
+| ADR | Status in the file |
+|---|---|
+| 0001 vendored Hermes | **Superseded** (vendoring premise ended 2026-08-17) |
+| 0010 Fleet IDE cut-over | **Superseded** |
+| 0012 native steward + containerized execution | **Accepted; implementation deferred pending fleet measurement** |
+| 0015 macOS nodes are host installs | **Accepted** |
+| 0016 agents decide what a task needs | **Accepted** (accepted 2026-08-20); hub still drives the review workflow |
+| 0017 token spend metered at the router | **Proposed** |
+| 0018 task view is a graph | **Proposed** |
+| 0025 hub UI is the observability console | **Accepted** |
+| 0029 coding-route search path is a fleet contract | **Proposed** |
+| 0030 LangChain extracts before Qdrant | **Proposed** |
+| 0031 CodeGraph is a hint | **Accepted** |
+
+Also **Proposed**: 0002, 0003, 0005, 0006, 0020, 0021, 0022, 0023, 0024,
+0026, 0027, 0028. Sixteen Proposed in total.
+
+---
+
+## 8. Where the README (and generated help) is stale
+
+Noted because the deck contradicts them deliberately:
+
+- `README.md` still documents src/mac/_hermes as a vendored Hermes Agent
+  0.15.1 snapshot supplying "the agent loop, gateways, tools, plugins, and
+  skills". That directory does not exist at this commit. The vendored tree
+  was removed in `3ebde2dd`. The path is left unbackticked here because a
+  backticked repository path asserts that it exists
+  (`tests/test_guide_docs_are_true.py`).
+- The testing and linting sections of `README.md` still claim that path is
+  excluded from coverage and from Ruff. Nothing in `pyproject.toml` or the
+  `Makefile` references `_hermes`.
+- Current (non-archive) docs that still name the missing tree as if it were
+  present: `docs/audit.md`, `docs/home-consolidation.md`,
+  `docs/hermes-integration.md`, `docs/oneshot-isolation-gate-verification.md`,
+  `docs/reference/staged-module-integration-audit.md`. `docs/hermes-vendor-fate.md`
+  correctly says **removed**.
+- Generated `docs/reference/cli.md` `mac --help` text claims "0
+  administrative commands live under `mac admin`" while listing 54 groups
+  immediately below.
+
+**Not stale:** `mac-hermes = "mac.hermes_adapter:main"` in `pyproject.toml`
+and `src/mac/hermes_adapter.py` exist. The adapter is clean-room MAC code.
+`docs/hermes-retirement-premises.md` still records that both premises for
+retiring Hermes "neither holds as stated".
+
+The deck does not describe the vendored snapshot as present, and does not
+claim Hermes has been retired as an interaction boundary.
+
+---
+
+## 9. What landed since v1.1.0 (for the GitHub notes, not the slides)
+
+`git log --oneline v1.1.0..e8040fec` is 129 commits. The capabilities that
+are newly *true of this tree*, rather than merely newly committed:
+
+- Hub judgement replaces the semantic reviewer (`#644`).
+- OpenClaw identity and migrated cron jobs survive deploy (`#657`).
+- Operator-managed hub database is preserved (`#658`).
+- Docs-graph is a standing release gate (`#649`).
+- Native merge queue repair after a stuck GitHub queue (`#639`).
+- ADRs 0026–0031 exist as files; 0029 and 0030 are Proposed; 0031 is Accepted.
+- `STOPPED` is a task state; `judgement` is an admin group; CLI on coding-agent
+  shell paths (`#652`); sandboxes pin reviewed runtime digests (`#651`).
+
+Proposed ADRs are not listed as shipped capabilities.
+
+---
+
+## 10. Provenance of this directory
+
+| | |
+|---|---|
+| Commit described | `e8040fec1cda998fa0ef19eb3cec9a516537b247` |
+| Capture | 2026-08-25T00:08:16Z |
+| Directory | `docs/presentation/20260825T000816Z-e8040fec/` |
+| Previous sibling | `docs/presentation/20260820T011224Z-8b424c20/` |
+
+---
+
+## 11. Per-file decisions (inventory)
+
+Every row of `docs/reference/documentation-inventory.md` at `e8040fec`.
+Pinned decks under `docs/presentation/` are allowlisted and are not in this table.
+
+| Category | Source | Decision |
+|---|---|---|
+| supplemental reference | `activation-probe/calibration-spec.md` | not-changed against tree at this SHA |
+| supplemental reference | `activation-probe/classifier-spec.md` | not-changed against tree at this SHA |
+| supplemental reference | `activation-probe/integration-guide.md` | not-changed against tree at this SHA |
+| supplemental reference | `activation-probe/prototype-report.md` | not-changed against tree at this SHA |
+| supplemental reference | `activation-probe/runtime-selection.md` | not-changed against tree at this SHA |
+| architecture decision | `adr/0001-unify-hermes-runtime-into-mac.md` | not-changed; status in §7 |
+| architecture decision | `adr/0002-memory-store-at-scale.md` | not-changed; status in §7 |
+| architecture decision | `adr/0003-tokenhub-core-into-mac.md` | not-changed; status in §7 |
+| architecture decision | `adr/0004-task-ledger-vs-hermes-kanban.md` | not-changed; status in §7 |
+| architecture decision | `adr/0005-elastic-executor-tier-vs-static-fleet.md` | not-changed; status in §7 |
+| architecture decision | `adr/0006-acp-support.md` | not-changed; status in §7 |
+| architecture decision | `adr/0007-hermes-boundary-mood-nap-soul-memory.md` | not-changed; status in §7 |
+| architecture decision | `adr/0008-openshell-docker-engine-runtime.md` | not-changed; status in §7 |
+| architecture decision | `adr/0009-minimal-base-on-demand-layered-provisioning.md` | not-changed; status in §7 |
+| architecture decision | `adr/0010-fleet-ide-cutover-parity-matrix.md` | not-changed; status in §7 |
+| architecture decision | `adr/0011-hub-review-verification-scope.md` | not-changed; status in §7 |
+| architecture decision | `adr/0012-hybrid-native-steward-containerized-execution.md` | not-changed; status in §7 |
+| architecture decision | `adr/0013-authoritative-hub-allocator.md` | not-changed; status in §7 |
+| architecture decision | `adr/0014-visibility-is-not-a-dispatch-gate.md` | not-changed; status in §7 |
+| architecture decision | `adr/0015-macos-nodes-are-host-installs.md` | not-changed; status in §7 |
+| architecture decision | `adr/0016-agent-initiated-review.md` | not-changed; status in §7 |
+| architecture decision | `adr/0017-token-spend-is-metered-at-the-router.md` | not-changed; status in §7 |
+| architecture decision | `adr/0018-task-graph-progressive-disclosure.md` | not-changed; status in §7 |
+| architecture decision | `adr/0019-privilege-is-an-acl-on-a-resource-tree.md` | not-changed; status in §7 |
+| architecture decision | `adr/0020-a-running-task-is-not-editable.md` | not-changed; status in §7 |
+| architecture decision | `adr/0021-schema-changes-need-versioned-migrations.md` | not-changed; status in §7 |
+| architecture decision | `adr/0022-a-gate-returns-a-named-decision-not-a-boolean.md` | not-changed; status in §7 |
+| architecture decision | `adr/0023-one-skill-source-many-harness-plugins.md` | not-changed; status in §7 |
+| architecture decision | `adr/0024-the-dashboard-streams-the-bus-not-just-its-counts.md` | not-changed; status in §7 |
+| architecture decision | `adr/0025-the-hub-ui-is-the-observability-console.md` | not-changed; status in §7 |
+| architecture decision | `adr/0026-first-class-operations-emit-bus-events.md` | not-changed; status in §7 |
+| architecture decision | `adr/0027-upgrades-are-versioned-and-fail-closed.md` | not-changed; status in §7 |
+| architecture decision | `adr/0028-installation-is-a-package-not-a-push.md` | not-changed; status in §7 |
+| architecture decision | `adr/0029-the-route-search-path-is-a-fleet-contract.md` | not-changed; status in §7 |
+| architecture decision | `adr/0030-langchain-extracts-before-qdrant.md` | not-changed; status in §7 |
+| architecture decision | `adr/0031-codegraph-is-a-hint.md` | not-changed; status in §7 |
+| supplemental reference | `agent-lifecycle-proof.md` | not-changed against tree at this SHA |
+| historical archive | `archive/field-notes/assessment-2026-08-02.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-1b6783.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-21e771-worker3-tailscale-blocker.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-7023d6.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-83f38e.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-8bf378.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-97627e.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-a33145.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-a608f4.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-b07fbf.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-de3502.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-f6a813.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/assessment-task-f9cd72.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/closeout-dreamrepair-3dc2cf-openclaw-fleet-rollout.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/closeout-dreamrepair-5404b15-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/closeout-dreamrepair-965c6e89-openclaw-fleet-rollout.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/closeout-review-finalize-verify-prerequisite.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/closeout-task-9c83aa5b-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/contract-verify-environment-failure-finding.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/crash-incident-finding.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-dreamrepair-c8dd8037-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-dreamrepair-ecd3548-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-hgx-session-c0b2f9fd4e0b.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-hgx-session-c902fab4d55f.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-task-394db89d-slack.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-task-46eb6c-skill-env-prereqs.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-task-9c83aa5b-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-task-c3a30819-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/disposition-task-cc1dedb0-slack.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/dream-finding-3dc2cf.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/dream-finding-58afe2-openclaw-entrypoint-ready-token.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/dream-finding-6d1b5b.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/dream-finding-805aed7.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/dream-finding-965c6e89.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/dream-stalled-finalizer-recovery-finding.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/dream-triage-828e1ef4.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/findings-crash-1fc349e1-startup-selftest-attestation-gap.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/findings-crash-591645a3-startup-selftest-timeout.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/findings-crash-mac-agent-service-62021be0.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/findings-crash-service-unknown-crash-path.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/fleet-ide-workbench-plan.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/forensics-task-643b33ee1c7b4a4ab7a81bf8d5af34a4.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/forensics-task-a32a35e90ab0434e8c7766057b268bc6.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/haskell_migration.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dream-skill-generic-area-bucket.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dream-skill-tool_or_skill_name-actionability.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dream-tests-generic-area-bucket.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-394db89d-slack.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-477446f5-slack.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-4c4429b-scripts-openclaw.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-5404b15-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-71b00e8-slack.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-c8dd8037-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-cc1dedb0-slack.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-d94ad78-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-da0ac0f3-slack.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-dreamrepair-ffbc63f8-skill.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-predispatch-conflict-5a43ad.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-review-finalize-verify-prerequisite.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-task-2284f3-env-prerequisite-false-positive.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-task-b6ddd8-skill-env-prereqs.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-task-ed7b0b-new-file-staging-finalizer.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/investigation-task-f869c0-new-file-staging-finalizer.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/job-per-task-roles-spec-review.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/job-per-task-roles-spec.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/k8s-native-rewrite-plan.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/linear-bridge-spec-review.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/linear-bridge-spec.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/mac-task-bd-parity-audit.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/metadata-sync-assessment.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/prereq-task-029665.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/prereq-task-403ed263.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/prereq-task-e94f546c.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/prereq-task-fd2f34.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/provenance-dreamrepair-77fc3e59-slack.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/quickstart-gap-analysis.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/replace-hgx-session-c902fab4d55f.md` | not current behaviour (archive index) |
+| historical archive | `archive/field-notes/scaling-plan.md` | not current behaviour (archive index) |
+| historical archive | `archive/index.md` | not current behaviour (archive index) |
+| supplemental reference | `audit.md` | CHANGED finding: names missing `_hermes` tree (§8) |
+| supplemental reference | `authority-boundary.md` | not-changed against tree at this SHA |
+| book | `book/01-system.md` | not-changed; `make docs-check` executes examples |
+| book | `book/02-local-start.md` | not-changed; `make docs-check` executes examples |
+| book | `book/03-projects-and-tasks.md` | not-changed; `make docs-check` executes examples |
+| book | `book/04-machines-and-agents.md` | not-changed; `make docs-check` executes examples |
+| book | `book/05-evidence-review-completion.md` | not-changed; `make docs-check` executes examples |
+| book | `book/06-hermes-and-ide.md` | not-changed; `make docs-check` executes examples |
+| book | `book/07-repository-contracts.md` | not-changed; `make docs-check` executes examples |
+| book | `book/08-plans-and-dags.md` | not-changed; `make docs-check` executes examples |
+| book | `book/09-fleet-onboarding.md` | not-changed; `make docs-check` executes examples |
+| book | `book/10-identity-and-secrets.md` | not-changed; `make docs-check` executes examples |
+| book | `book/11-publication-and-refs.md` | not-changed; `make docs-check` executes examples |
+| book | `book/12-operations.md` | not-changed; `make docs-check` executes examples |
+| book | `book/13-deployment-topologies.md` | not-changed; `make docs-check` executes examples |
+| book | `book/14-images-and-cutover.md` | not-changed; `make docs-check` executes examples |
+| book | `book/15-sandboxed-runtimes.md` | not-changed; `make docs-check` executes examples |
+| book | `book/16-apis-and-integrations.md` | not-changed; `make docs-check` executes examples |
+| book | `book/17-learning-evals-scaling.md` | not-changed; `make docs-check` executes examples |
+| book | `book/18-capstone.md` | not-changed; `make docs-check` executes examples |
+| runbook | `break-glass-host-recovery.md` | not-changed against tree at this SHA |
+| supplemental reference | `c26-certifier-phase-profile-example.md` | not-changed against tree at this SHA |
+| supplemental reference | `client-bootstrap-contract.md` | not-changed against tree at this SHA |
+| supplemental reference | `coding-cli-credentials.md` | not-changed against tree at this SHA |
+| supplemental reference | `coding-route-ladder.md` | not-changed against tree at this SHA |
+| supplemental reference | `crash-diagnosis-and-repair.md` | not-changed against tree at this SHA |
+| supplemental reference | `dashboard-connection.md` | not-changed against tree at this SHA |
+| supplemental reference | `deploy-prerequisite-vs-phase1-audit.md` | not-changed against tree at this SHA |
+| supplemental reference | `dispatch-priority-bias-audit.md` | not-changed against tree at this SHA |
+| supplemental reference | `dream-repair-slack-lineage.md` | not-changed against tree at this SHA |
+| supplemental reference | `dreaming-rewrite.md` | not-changed against tree at this SHA |
+| supplemental reference | `env-config-reference.md` | not-changed against tree at this SHA |
+| runbook | `fleet-cutover-transaction-protocol.md` | not-changed against tree at this SHA |
+| supplemental reference | `fleet-directives.md` | not-changed against tree at this SHA |
+| runbook | `fleet-node-onboarding-checklist.md` | not-changed against tree at this SHA |
+| supplemental reference | `fleet-operational-learning.md` | not-changed against tree at this SHA |
+| supplemental reference | `fleet-registry-schema.md` | not-changed against tree at this SHA |
+| supplemental reference | `getting-started.md` | not-changed against tree at this SHA |
+| supplemental reference | `guide/01-architecture.md` | not-changed; `tests/test_guide_docs_are_true.py` |
+| supplemental reference | `guide/02-getting-started.md` | not-changed; `tests/test_guide_docs_are_true.py` |
+| supplemental reference | `guide/03-advanced.md` | not-changed; `tests/test_guide_docs_are_true.py` |
+| supplemental reference | `guide/04-ui.md` | not-changed; `tests/test_guide_docs_are_true.py` |
+| supplemental reference | `guide/05-developer-guide.md` | not-changed; `tests/test_guide_docs_are_true.py` |
+| supplemental reference | `guide/README.md` | not-changed; `tests/test_guide_docs_are_true.py` |
+| supplemental reference | `hermes-boundary.md` | not-changed against tree at this SHA |
+| supplemental reference | `hermes-integration.md` | CHANGED finding: names missing `_hermes` tree (§8) |
+| supplemental reference | `hermes-retirement-premises.md` | not-changed against tree at this SHA |
+| supplemental reference | `hermes-vendor-fate.md` | not-changed; correctly records removal |
+| supplemental reference | `hgx-elastic-capacity.md` | not-changed against tree at this SHA |
+| supplemental reference | `home-consolidation.md` | CHANGED finding: names missing `_hermes` tree (§8) |
+| runbook | `hub-availability.md` | not-changed against tree at this SHA |
+| supplemental reference | `hub-host-saturation-remediation.md` | not-changed against tree at this SHA |
+| supplemental reference | `human-interface-selector.md` | not-changed against tree at this SHA |
+| supplemental reference | `image-publication-and-qualification.md` | not-changed against tree at this SHA |
+| supplemental reference | `in-flight-agent-messages.md` | not-changed against tree at this SHA |
+| landing page | `index.md` | not-changed against tree at this SHA |
+| supplemental reference | `integration-authority-contract.md` | not-changed against tree at this SHA |
+| supplemental reference | `memory-tier-schema.md` | not-changed against tree at this SHA |
+| supplemental reference | `memory-tier-verification.md` | not-changed against tree at this SHA |
+| supplemental reference | `notifier-configuration-guide.md` | not-changed against tree at this SHA |
+| supplemental reference | `oneshot-isolation-gate-verification.md` | CHANGED finding: names missing `_hermes` tree (§8) |
+| supplemental reference | `openclaw-identities.md` | not-changed against tree at this SHA |
+| supplemental reference | `openshell-nemo-relay-e2e.md` | not-changed against tree at this SHA |
+| supplemental reference | `openshell-nemo-relay-integration.md` | not-changed against tree at this SHA |
+| supplemental reference | `openshell-sandbox.md` | not-changed against tree at this SHA |
+| runbook | `production-deployment.md` | not-changed against tree at this SHA |
+| generated reference | `reference/cli.md` | not-changed; CI `--check` on this SHA |
+| generated reference | `reference/documentation-inventory.md` | not-changed; CI `--check` on this SHA |
+| generated reference | `reference/openapi.md` | not-changed; CI `--check` on this SHA |
+| generated reference | `reference/staged-module-integration-audit.md` | not-changed; CI `--check` on this SHA |
+| supplemental reference | `repository-cicd-monitor.md` | not-changed against tree at this SHA |
+| supplemental reference | `repository-ref-hygiene.md` | not-changed against tree at this SHA |
+| supplemental reference | `repository-runtime-contract.md` | not-changed against tree at this SHA |
+| supplemental reference | `review-strategy-experiments.md` | not-changed against tree at this SHA |
+| supplemental reference | `review-tick-stall-diagnosis.md` | not-changed against tree at this SHA |
+| supplemental reference | `scientific-optimizer.md` | not-changed against tree at this SHA |
+| supplemental reference | `secrets-management-guide.md` | not-changed against tree at this SHA |
+| supplemental reference | `security/openshell-0.0.72-compatibility-review.mdx` | not-changed against tree at this SHA |
+| runbook | `soul-preservation-runbook.md` | not-changed against tree at this SHA |
+| supplemental reference | `structured-task-bodies.md` | not-changed against tree at this SHA |
+| historical archive | `superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md` | not current behaviour (archive index) |
+| historical archive | `superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md` | not current behaviour (archive index) |
+| historical archive | `superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md` | not current behaviour (archive index) |
+| runbook | `synchronized-fleet-cutover.md` | not-changed against tree at this SHA |
+| supplemental reference | `task-dependency-semantics.md` | not-changed against tree at this SHA |
+| supplemental reference | `task-throughput-observability.md` | not-changed against tree at this SHA |
+| supplemental reference | `testing-strategy.md` | not-changed against tree at this SHA |
+
+Root `README.md` is outside `docs/` and is the stale `_hermes` finding in §8.

--- a/docs/presentation/20260825T000816Z-e8040fec/README.md
+++ b/docs/presentation/20260825T000816Z-e8040fec/README.md
@@ -1,0 +1,90 @@
+# MAC capabilities deck — `e8040fec`
+
+A point-in-time capabilities deck for MAC, built by auditing the source and documentation at
+commit `e8040fec`, captured `2026-08-25T00:08:16Z`.
+
+## The deck
+
+**[MAC — What the control plane can do today (`e8040fec`)](https://docs.google.com/presentation/d/1cLzjGERKojHg0w1FOyUnlqlsVu_OZVM5b_kGc7T3fSw/edit)**
+
+13 slides, 16:9, speaker notes on every slide. Published as a native Google Slides presentation
+rather than committed as a binary — see "What is checked in, and what is not" below.
+
+## What is in this directory
+
+| File | Purpose |
+|---|---|
+| `AUDIT.md` | Every claim in the deck traced to a file, commit or generated reference |
+| `images/*.svg` | The five diagrams, hand-authored, and the durable source for them |
+| `build_deck.py` | Rebuilds the `.pptx` from the diagrams so it can be re-published |
+| `README.md` | This file |
+
+## What is checked in, and what is not
+
+**Checked in: text only.** The SVG diagram sources are the durable artifact — they diff, they
+review, and they regenerate everything else.
+
+**Not checked in: the rendered PNGs and the built `.pptx`.** Both are generated outputs, and
+committing them would put megabytes of opaque binary under `docs/` for no reviewable gain. It also
+breaks a gate: `tests/test_docs_no_operator_identity.py` greps every tracked file under `docs/` for
+fleet-identity tokens, and compressed image data eventually contains one by coincidence. Keeping
+`docs/` text-only means that gate keeps reading prose, which is the only place identity can
+actually leak.
+
+(Which token is deliberately not written here. Naming it would put it in a checked-in doc and trip
+the very gate this paragraph is about. Only the test file itself is exempt from the scan.)
+
+## This is a pinned artifact
+
+It describes `e8040fec` and nothing later, and is **not** updated as the code moves. Build a new
+sibling directory instead — see the convention in [`../README.md`](../README.md). An old deck should
+keep meaning what it meant when it was shown.
+
+Figures carry the date they were measured for the same reason. Token-routing numbers are still
+ADR 0017's seven days to 2026-08-19. The ledger census in `AUDIT.md` is from 2026-08-25.
+
+## Slides
+
+1. Title — commit and capture time
+2. What MAC is, and what it deliberately is not
+3. *Part one: the model*
+4. **One control plane, four objects** — the CLI as the object model, 125 verbs, six surfaces
+5. **A task is a state machine with receipts** — 12 states (STOPPED is new) and the four gates
+6. *Part two: coordination and execution*
+7. **A town square, not a switchboard** — the broadcast AgentBus, lifecycle verbs, dispatch, merge queue
+8. **A heterogeneous fleet, honestly modelled** — node classes, coding-agent routes, images, secrets
+9. *Part three: measurement*
+10. **The fleet measures itself** — what it measures, the 2026-08-25 census, ADRs 0029 / 0017 / 0018
+11. Scale at this commit
+12. Proposed, deferred, or stale — stated up front
+13. Provenance
+
+Slide 12 is deliberate. Sixteen ADRs are still Proposed; ADR 0016 is Accepted as a decision while
+the hub still drives review; ADR 0012 remains deferred; and the README still documents a vendored
+runtime that is not in the tree (`AUDIT.md` §8). A capabilities deck that omits those is marketing.
+
+## Rebuilding and re-publishing
+
+Render the diagrams to PNG with headless Chrome at 2× device scale:
+
+```console
+$ CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+$ cd docs/presentation/20260825T000816Z-e8040fec/images
+$ "$CHROME" --headless --disable-gpu --hide-scrollbars \
+    --force-device-scale-factor=2 --window-size=1520,900 \
+    --default-background-color=FFFFFF \
+    --screenshot=01-object-model.png "file://$PWD/01-object-model.svg"
+```
+
+Window sizes: `01` 1520×900 · `02` 1520×880 · `03` 1520×900 · `04` 1520×900 · `05` 1520×930.
+
+Then build the deck. `python-pptx` is deliberately **not** a repository dependency — this is a
+documentation artifact, not part of the shipped runtime:
+
+```console
+$ python3 -m venv /tmp/deckvenv && /tmp/deckvenv/bin/pip install python-pptx
+$ /tmp/deckvenv/bin/python docs/presentation/20260825T000816Z-e8040fec/build_deck.py
+```
+
+Publish with `scripts/publish-deck-to-slides.py` and `--expect-slides 13`. The rendered PNGs and the
+built `.pptx` are ignored by git, so a rebuild leaves the working tree clean.

--- a/docs/presentation/20260825T000816Z-e8040fec/build_deck.py
+++ b/docs/presentation/20260825T000816Z-e8040fec/build_deck.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Build the MAC capabilities deck for commit e8040fec as a 16:9 .pptx.
+
+This deck is a point-in-time artifact. It is pinned to the commit named in its
+directory and is NOT regenerated as the code moves — build a new timestamped
+directory instead, so an old deck keeps meaning what it meant when it was shown.
+
+Requires python-pptx, which is deliberately not a repository dependency:
+
+    python3 -m venv /tmp/deckvenv
+    /tmp/deckvenv/bin/pip install python-pptx
+    /tmp/deckvenv/bin/python build_deck.py
+
+Diagram PNGs are rendered from the SVGs beside them; see README.md for the exact
+render commands.
+
+Both the PNGs this reads and the .pptx it writes are gitignored: docs/ keeps only
+text, and the deck is published to Google Slides. README.md holds the link.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from struct import unpack
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Emu, Inches, Pt
+
+HERE = Path(__file__).resolve().parent
+IMAGES = HERE / "images"
+COMMIT = "e8040fec"
+CAPTURED = "2026-08-25T00:08:16Z"
+OUT = HERE / f"mac-capabilities-{COMMIT}.pptx"
+
+SLIDE_W = Inches(13.333)
+SLIDE_H = Inches(7.5)
+
+INK = RGBColor(0x1B, 0x25, 0x30)
+SLATE = RGBColor(0x2F, 0x3A, 0x45)
+GREY = RGBColor(0x5A, 0x6B, 0x7A)
+MUTED = RGBColor(0x8A, 0x98, 0xA6)
+WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+BLUE = RGBColor(0x2E, 0x6F, 0x9E)
+AMBER = RGBColor(0xB5, 0x65, 0x1D)
+SAND = RGBColor(0xF2, 0xC4, 0x8A)
+PALE = RGBColor(0xDC, 0xE5, 0xEC)
+GREEN = RGBColor(0x26, 0x55, 0x36)
+
+FONT = "Helvetica Neue"
+
+prs = Presentation()
+prs.slide_width = SLIDE_W
+prs.slide_height = SLIDE_H
+BLANK = prs.slide_layouts[6]
+
+
+def notes(slide, text: str) -> None:
+    slide.notes_slide.notes_text_frame.text = text.strip()
+
+
+def bg(slide, color) -> None:
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = color
+
+
+def textbox(slide, x, y, w, h, align=PP_ALIGN.LEFT):
+    box = slide.shapes.add_textbox(x, y, w, h)
+    tf = box.text_frame
+    tf.word_wrap = True
+    tf.paragraphs[0].alignment = align
+    return tf
+
+
+def line(tf, text, size, color, bold=False, space_before=0, space_after=6,
+         italic=False, first=False, mono=False):
+    p = tf.paragraphs[0] if first else tf.add_paragraph()
+    p.space_before = Pt(space_before)
+    p.space_after = Pt(space_after)
+    run = p.add_run()
+    run.text = text
+    run.font.size = Pt(size)
+    run.font.bold = bold
+    run.font.italic = italic
+    run.font.color.rgb = color
+    run.font.name = "Menlo" if mono else FONT
+    return p
+
+
+def add_image_slide(name: str, note: str):
+    """Full-bleed diagram slide: each diagram carries its own title."""
+    slide = prs.slides.add_slide(BLANK)
+    path = IMAGES / name
+    with open(path, "rb") as fh:
+        head = fh.read(33)
+    iw, ih = unpack(">II", head[16:24])
+    aspect = iw / ih
+
+    h, max_w = Inches(7.1), Inches(12.9)
+    w = Emu(int(h * aspect))
+    if w > max_w:
+        w = max_w
+        h = Emu(int(w / aspect))
+    slide.shapes.add_picture(
+        str(path), Emu(int((SLIDE_W - w) / 2)), Emu(int((SLIDE_H - h) / 2)),
+        width=w, height=h,
+    )
+    notes(slide, note)
+    return slide
+
+
+def section(kicker: str, title: str, subtitle: str, note: str) -> None:
+    slide = prs.slides.add_slide(BLANK)
+    bg(slide, SLATE)
+    tf = textbox(slide, Inches(0.9), Inches(2.6), Inches(11.5), Inches(2.4))
+    line(tf, kicker, 16, SAND, bold=True, first=True, space_after=10)
+    line(tf, title, 36, WHITE, bold=True, space_after=12)
+    line(tf, subtitle, 18, PALE)
+    notes(slide, note)
+
+
+# ------------------------------------------------------------------ slides
+
+def title_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    bg(slide, SLATE)
+    tf = textbox(slide, Inches(0.9), Inches(2.1), Inches(11.5), Inches(2.6))
+    line(tf, "MAC", 54, WHITE, bold=True, first=True, space_after=6)
+    line(tf, "What the control plane can do today", 30, PALE, space_after=18)
+    line(tf, "A multi-agent coordinator control plane, audited from its own source and documentation.",
+         17, MUTED)
+
+    tf2 = textbox(slide, Inches(0.9), Inches(5.5), Inches(11.5), Inches(1.4))
+    line(tf2, f"commit {COMMIT}   ·   captured {CAPTURED}", 16, SAND, bold=True, first=True,
+         space_after=4)
+    line(tf2, "Every claim in this deck is traced to a file or commit in AUDIT.md. Figures are dated because they age.",
+         13.5, MUTED)
+
+    notes(slide, f"""
+This deck describes MAC at commit {COMMIT} and nothing later. It was built by auditing the
+source and docs directly rather than from memory, and AUDIT.md traces every number back to the
+file or commit it came from.
+
+Open by saying what MAC is NOT: it is not a chat agent, not an IDE, and not a model. It is the
+durable operational record underneath a fleet of coding agents.
+""")
+
+
+def what_it_is() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    tf = textbox(slide, Inches(0.85), Inches(0.55), Inches(11.6), Inches(1.0))
+    line(tf, "What MAC is, and what it deliberately is not", 34, INK, bold=True, first=True,
+         space_after=4)
+    line(tf, "The boundary is the design. Everything MAC owns is something you would want to still be true after a crash.",
+         15, GREY)
+
+    tf2 = textbox(slide, Inches(0.85), Inches(1.85), Inches(5.6), Inches(5.0))
+    line(tf2, "It owns durable operational truth", 20, BLUE, bold=True, first=True, space_after=10)
+    for t in [
+        "Tasks, leases, routing, reviews, evidence.",
+        "Secrets as handles, runtime manifests, rollout state.",
+        "Machine and agent registry, capabilities and health.",
+        "Audit trails, and the publication record.",
+    ]:
+        line(tf2, "•  " + t, 15, SLATE, space_after=8)
+    line(tf2, "PostgreSQL is the authority — there is no offline replica and no ticket-file sync. "
+              "A .tickets/<id>.md file is an optional local convenience view and is explicitly not authoritative.",
+         14, GREY, space_before=10)
+
+    tf3 = textbox(slide, Inches(7.0), Inches(1.85), Inches(5.5), Inches(5.0))
+    line(tf3, "It does not own the conversation", 20, AMBER, bold=True, first=True, space_after=10)
+    for t in [
+        "Personality, chat, and messaging gateways belong to the human-facing runtime.",
+        "MAC sits underneath it and takes durable work from it.",
+        "The command-and-control dashboard was retired; /ui is read-only observability.",
+        "The console speaks on the bus like any other participant rather than mutating the control plane.",
+    ]:
+        line(tf3, "•  " + t, 15, SLATE, space_after=8)
+    line(tf3, "That boundary is why an agent going off the rails is a bus conversation, "
+              "not a privileged API call.", 14, GREY, space_before=10)
+
+    notes(slide, """
+The line to land: MAC owns what must survive a crash; the runtime above it owns what must feel
+like a conversation.
+
+The retirement of the command-and-control dashboard is worth calling out — it is the clearest
+signal of the direction of travel. The console can no longer mutate the control plane at all.
+""")
+
+
+def scale_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    tf = textbox(slide, Inches(0.85), Inches(0.55), Inches(11.6), Inches(1.0))
+    line(tf, "Scale, at this commit", 34, INK, bold=True, first=True, space_after=4)
+    line(tf, f"Counted directly in the tree at {COMMIT}, not estimated.", 15, GREY)
+
+    rows = [
+        ("205,258", "lines of Python under src/", "212 modules in src/mac"),
+        ("506", "test files under tests/", "plus fault-replay and contract suites"),
+        ("414", "HTTP routes", "generated from the live OpenAPI schema"),
+        ("125", "CLI verbs", "across project, task, agent and admin"),
+        ("18", "book chapters", "every shell example executed by make docs-check"),
+        ("31", "architecture decision records", "16 are Proposed, not shipped"),
+        ("5", "coding-agent routes", "opencode, pi, claude, codex, cursor"),
+    ]
+    tf2 = textbox(slide, Inches(0.85), Inches(1.8), Inches(11.6), Inches(5.2))
+    first = True
+    for num, label, note_ in rows:
+        p = tf2.paragraphs[0] if first else tf2.add_paragraph()
+        p.space_after = Pt(11)
+        r1 = p.add_run(); r1.text = f"{num:>10}   "
+        r1.font.size = Pt(23); r1.font.bold = True; r1.font.color.rgb = INK; r1.font.name = FONT
+        r2 = p.add_run(); r2.text = label
+        r2.font.size = Pt(17); r2.font.color.rgb = SLATE; r2.font.name = FONT
+        r3 = p.add_run(); r3.text = f"   — {note_}"
+        r3.font.size = Pt(14); r3.font.color.rgb = GREY; r3.font.name = FONT
+        first = False
+
+    notes(slide, """
+Do not read this table aloud. Use it to make one point: this is not a prototype, and the
+documentation is generated from the running system rather than written alongside it.
+
+The generated CLI and OpenAPI references are checked in CI, so a drifted doc fails the build.
+""")
+
+
+def honesty_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    tf = textbox(slide, Inches(0.85), Inches(0.55), Inches(11.6), Inches(1.0))
+    line(tf, "Proposed, deferred, or stale — stated up front", 34, INK, bold=True, first=True,
+         space_after=4)
+    line(tf, "A capabilities deck that only lists capabilities is marketing. These are the places the code and the claims do not yet meet.",
+         15, GREY)
+
+    items = [
+        ("Sixteen ADRs are still Proposed, including 0017, 0018 and 0029.",
+         "Token metering, the task graph, and the fleet-wide route ladder are designs with measured motivation — none of them has shipped. ADR 0016 is Accepted as a decision; the hub still drives RUNNING → NEEDS_REVIEW → REVIEWING."),
+        ("ADR 0012 is Accepted with implementation deferred.",
+         "The native-steward / containerized-execution split is a decision awaiting fleet measurement, and ADR 0015 has already narrowed its containerized half to Linux nodes only."),
+        ("The README still describes a runtime that was deleted.",
+         "It documents src/mac/_hermes as a vendored Hermes snapshot. That directory does not exist at this commit. Several current docs still name the path; the hermes-vendor-fate record already says it was removed."),
+        ("Generated CLI help claims zero admin commands.",
+         "mac --help prints '0 administrative commands live under mac admin' while the same generated reference lists 54 admin groups, including the new judgement group."),
+        ("Token attribution is not currently trustworthy.",
+         "29.5% of routes over the seven days to 2026-08-19 recorded no input token count, none reported cache hits, and cost is priced at read time rather than stored. ADR 0017 exists because of this. Those figures were not re-measured for this capture."),
+    ]
+    tf2 = textbox(slide, Inches(0.85), Inches(1.8), Inches(11.6), Inches(5.3))
+    first = True
+    for head, body in items:
+        line(tf2, head, 17.5, INK, bold=True, space_before=0 if first else 10, space_after=3,
+             first=first)
+        line(tf2, body, 14, GREY, space_after=2)
+        first = False
+
+    notes(slide, """
+This is the slide that earns the rest of the deck. In front of engineers, naming the five
+weakest points yourself is what makes the capability claims credible.
+
+The README staleness is a real finding from this audit and is worth fixing separately.
+""")
+
+
+def provenance_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    bg(slide, SLATE)
+    tf = textbox(slide, Inches(0.9), Inches(0.7), Inches(11.5), Inches(1.0))
+    line(tf, "Provenance", 34, WHITE, bold=True, first=True, space_after=4)
+    line(tf, "This deck is a pinned artifact, not a living document.", 16, PALE)
+
+    tf2 = textbox(slide, Inches(0.9), Inches(2.0), Inches(5.6), Inches(4.6))
+    line(tf2, "How to read it", 19, SAND, bold=True, first=True, space_after=8)
+    for t in [
+        f"It describes commit {COMMIT} and nothing later.",
+        "Figures carry the date they were measured, because they age.",
+        "AUDIT.md traces every claim to a file, commit or generated reference.",
+        "Diagrams are SVG sources; the PNGs are rendered from them.",
+    ]:
+        line(tf2, "•  " + t, 14.5, PALE, space_after=8)
+
+    tf3 = textbox(slide, Inches(7.0), Inches(2.0), Inches(5.5), Inches(4.6))
+    line(tf3, "Making the next one", 19, SAND, bold=True, first=True, space_after=8)
+    line(tf3, "Create a new sibling directory rather than editing this one:", 14.5, PALE,
+         space_after=8)
+    line(tf3, "docs/presentation/<UTC timestamp>-<short commit>/", 13.5, WHITE, mono=True,
+         space_after=10)
+    line(tf3, "The timestamp sorts, the commit pins, and neither collides. An old deck keeps "
+              "meaning what it meant when it was shown.", 14.5, PALE, space_after=8)
+    line(tf3, "See README.md in this directory for the exact render and build commands.",
+         14.5, MUTED)
+
+    notes(slide, """
+Close on the convention rather than a summary: decks are cheap to regenerate and are pinned to a
+commit, so nobody has to wonder whether a slide is still true — they can check the hash.
+""")
+
+
+# ------------------------------------------------------------------ build
+
+title_slide()
+what_it_is()
+
+section("PART ONE", "The model",
+        "Four objects, one ledger, and what must be true to move work between states.",
+        "Transition: everything MAC does is expressed against four nouns.")
+
+add_image_slide("01-object-model.png", """
+The CLI is not a wrapper over the object model — it IS the object model. project, task, agent,
+admin, 125 verbs.
+
+Two details worth pointing at: recovery is a first-class set of verbs rather than an incident
+runbook, and break-glass is grantable, listable and revocable, so an emergency leaves a record
+instead of an ambient permission. judgement is a new admin group: hourly process-quality
+authority over lifecycle gates, not a replacement for per-task review.
+
+The bottom band matters for integrators: six surfaces, one dispatch seam, and a contract test
+that proves the Python client and the hub agree about the route table.
+""")
+
+add_image_slide("02-task-lifecycle.png", """
+Eleven states became twelve: STOPPED is a live hold, not a terminal state, and it is excluded
+from dispatch because the allocator only considers OPEN tasks. Three terminal states remain.
+
+The four gates are the real content: a lease and fence authorize every mutation, evidence is typed
+and bound to one exact attempt, review must come from a different agent AND a different model, and
+landing goes through a speculative merge queue whose invariant is "never land an untested tree".
+
+CodeGraph is a hint when the tool and index exist (ADR 0031 Accepted), not a hard gate — the
+previous deck claimed it was mandatory.
+
+If asked why MAC built its own merge queue: GitHub's is organization-only, verified by API against
+the live repo — HTTP 422 on a user-owned repository.
+""")
+
+section("PART TWO", "Coordination and execution",
+        "How agents hear each other, and what actually runs the work.",
+        "Transition: the coordination model changed shape recently, and deliberately.")
+
+add_image_slide("03-coordination.png", """
+The headline: AgentBus became a broadcast bus. Point-to-point messages are no longer private,
+because an agent told "worker-2 already rebased that branch" cannot verify it without reading
+worker-2's stream.
+
+The motivating incidents are real and on the record — a `git add -A` moments from sweeping ~1,200
+lines of another agent's work into an unrelated commit, and a `git commit -a` that did.
+
+Note the human is a participant on the bus, not a controller above it, and that stand_down and
+abort are deliberately separate verbs. One carve-out: raw terminal streams stay participant-scoped
+because they carry credentials.
+""")
+
+add_image_slide("04-fleet-execution.png", """
+MAC does not pretend the fleet is homogeneous. macOS nodes are host installs under launchd — an
+earlier attempt to containerize them was superseded. Linux nodes run a native steward with
+containerized execution. Kubernetes and HGX provide elastic capacity.
+
+Five coding-agent routes, and the sandbox derives which are available from the router rather than
+hardcoding a list.
+
+The identity band is the one auditors care about: secrets are handles with audit records, output
+is redacted, and egress is declared per project and per task.
+""")
+
+section("PART THREE", "Measurement",
+        "The fleet instruments itself — and the instrumentation is currently indicting the design.",
+        "Transition: the most interesting capability is that MAC can prove itself wrong.")
+
+add_image_slide("05-measurement.png", """
+THE KEY SLIDE. Left: what MAC measures — review experiments with pre-registered arms and a blind
+treatment, a scientific optimizer that only ever emits a policy candidate, a dreaming pipeline
+where memory must SHRINK to be promoted, and operational learning that changes routing.
+
+Right: what those measurements actually found, dated. Token figures are still the seven days to
+2026-08-19: 29.5% of model routes recorded no input tokens; none reported cache hits. The ledger
+census is this capture: blocked 378 and growing. The 165-of-355 dead-dependency finding is from
+2026-08-19 and was not re-run.
+
+Bottom: three still-open ADRs with measured motivation — 0029 (route ladder), 0017 (token
+metering), 0018 (task graph). ADR 0016 is now Accepted as a decision; the hub still drives review.
+Sixteen ADRs remain Proposed.
+""")
+
+scale_slide()
+honesty_slide()
+provenance_slide()
+
+prs.save(OUT)
+print(f"wrote {OUT.name} — {len(prs.slides._sldIdLst)} slides")

--- a/docs/presentation/20260825T000816Z-e8040fec/images/01-object-model.svg
+++ b/docs/presentation/20260825T000816Z-e8040fec/images/01-object-model.svg
@@ -1,0 +1,175 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="900" viewBox="0 0 1520 900" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <rect width="1520" height="900" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">One control plane, four objects</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">The CLI is the object model, not a wrapper over one. 125 verbs across four nouns, and the same model is exposed through six surfaces.</text>
+
+  <!-- PROJECT -->
+  <rect x="40" y="104" width="342" height="470" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 114 a10 10 0 0 1 10 -10 h322 a10 10 0 0 1 10 10 v44 h-342 z" fill="#2E6F9E"/>
+  <text x="62" y="134" font-size="19" font-weight="700" fill="#FFFFFF">project</text>
+  <text x="290" y="134" font-size="15" font-weight="700" fill="#BBD7EA" text-anchor="end">9 verbs</text>
+  <text x="62" y="152" font-size="12.5" fill="#D6E6F2">a unit of work ownership</text>
+
+  <text x="62" y="186" font-size="13.5" fill="#2F3A45">Repositories, policy, and dispatch</text>
+  <text x="62" y="205" font-size="13.5" fill="#2F3A45">state. Project-level dispatch pause</text>
+  <text x="62" y="224" font-size="13.5" fill="#2F3A45">is a gate distinct from per-task</text>
+  <text x="62" y="243" font-size="13.5" fill="#2F3A45">staging.</text>
+
+  <text x="62" y="278" font-size="12" font-weight="700" fill="#2E6F9E">VERBS</text>
+  <text x="62" y="302" font-size="13.5" fill="#2F3A45">create · list · show · update</text>
+  <text x="62" y="324" font-size="13.5" fill="#2F3A45">delete · register</text>
+  <text x="62" y="346" font-size="13.5" font-weight="700" fill="#1B2530">pause · activate</text>
+  <text x="62" y="368" font-size="13.5" fill="#2F3A45">egress</text>
+
+  <rect x="62" y="392" width="298" height="162" rx="6" fill="#F4F6F8"/>
+  <text x="78" y="416" font-size="12" font-weight="700" fill="#2E6F9E">WHAT IT GUARANTEES</text>
+  <text x="78" y="438" font-size="12.5" fill="#2F3A45">A registered repository must satisfy</text>
+  <text x="78" y="456" font-size="12.5" fill="#2F3A45">a runtime contract before agents</text>
+  <text x="78" y="474" font-size="12.5" fill="#2F3A45">bootstrap on it, so work does not</text>
+  <text x="78" y="492" font-size="12.5" fill="#2F3A45">depend on accidental local state.</text>
+  <text x="78" y="516" font-size="12.5" fill="#2F3A45">Egress policy is declared per</text>
+  <text x="78" y="534" font-size="12.5" fill="#2F3A45">project and per task.</text>
+
+  <!-- TASK -->
+  <rect x="410" y="104" width="342" height="470" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M410 114 a10 10 0 0 1 10 -10 h322 a10 10 0 0 1 10 10 v44 h-342 z" fill="#2E6F9E"/>
+  <text x="432" y="134" font-size="19" font-weight="700" fill="#FFFFFF">task</text>
+  <text x="660" y="134" font-size="15" font-weight="700" fill="#BBD7EA" text-anchor="end">45 verbs</text>
+  <text x="432" y="152" font-size="12.5" fill="#D6E6F2">the thing agents claim, run, publish</text>
+
+  <text x="432" y="186" font-size="13.5" fill="#2F3A45">The durable ledger of record.</text>
+  <text x="432" y="205" font-size="13.5" fill="#2F3A45">State transitions, leases, history,</text>
+  <text x="432" y="224" font-size="13.5" fill="#2F3A45">evidence, dependencies, recovery —</text>
+  <text x="432" y="243" font-size="13.5" fill="#2F3A45">all in PostgreSQL.</text>
+
+  <text x="432" y="278" font-size="12" font-weight="700" fill="#2E6F9E">VERBS, BY WHAT THEY ARE FOR</text>
+  <text x="432" y="302" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">run:</tspan> claim · start · close · reopen</text>
+  <text x="432" y="324" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">prove:</tspan> evidence · submit-review · audit</text>
+  <text x="432" y="346" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">ask:</tspan> ask · answer · needs-input · wait</text>
+  <text x="432" y="368" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">explain:</tspan> why-unclaimed · throughput</text>
+
+  <rect x="432" y="392" width="298" height="162" rx="6" fill="#F4F6F8"/>
+  <text x="448" y="416" font-size="12" font-weight="700" fill="#2E6F9E">RECOVERY IS FIRST CLASS</text>
+  <text x="448" y="438" font-size="12.5" fill="#2F3A45">recover-stranded · recover-finalizer</text>
+  <text x="448" y="456" font-size="12.5" fill="#2F3A45">recover-stalled-finalizer</text>
+  <text x="448" y="480" font-size="12.5" fill="#2F3A45">break-glass · break-glass-list</text>
+  <text x="448" y="498" font-size="12.5" fill="#2F3A45">break-glass-revoke</text>
+  <text x="448" y="522" font-size="12.5" fill="#5A6B7A">Break-glass is grantable, listable</text>
+  <text x="448" y="540" font-size="12.5" fill="#5A6B7A">and revocable — never ambient.</text>
+
+  <!-- AGENT -->
+  <rect x="780" y="104" width="342" height="470" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M780 114 a10 10 0 0 1 10 -10 h322 a10 10 0 0 1 10 10 v44 h-342 z" fill="#2E6F9E"/>
+  <text x="802" y="134" font-size="19" font-weight="700" fill="#FFFFFF">agent</text>
+  <text x="1030" y="134" font-size="15" font-weight="700" fill="#BBD7EA" text-anchor="end">17 verbs</text>
+  <text x="802" y="152" font-size="12.5" fill="#D6E6F2">a worker on a machine</text>
+
+  <text x="802" y="186" font-size="13.5" fill="#2F3A45">Registry of what each worker can</text>
+  <text x="802" y="205" font-size="13.5" fill="#2F3A45">do: capabilities, resources, health,</text>
+  <text x="802" y="224" font-size="13.5" fill="#2F3A45">availability, and instance kind</text>
+  <text x="802" y="243" font-size="13.5" fill="#2F3A45">(static or fungible).</text>
+
+  <text x="802" y="278" font-size="12" font-weight="700" fill="#2E6F9E">VERBS</text>
+  <text x="802" y="302" font-size="13.5" fill="#2F3A45">create · list · show · update · delete</text>
+  <text x="802" y="324" font-size="13.5" font-weight="700" fill="#1B2530">hold · resume · heartbeat</text>
+  <text x="802" y="346" font-size="13.5" fill="#2F3A45">config · hardware · reflect · tell</text>
+  <text x="802" y="368" font-size="13.5" fill="#2F3A45">deregister · migrate</text>
+
+  <rect x="802" y="392" width="298" height="162" rx="6" fill="#F4F6F8"/>
+  <text x="818" y="416" font-size="12" font-weight="700" fill="#2E6F9E">VISIBILITY IS NOT A GATE</text>
+  <text x="818" y="438" font-size="12.5" fill="#2F3A45">ADR 0014 settled that agent</text>
+  <text x="818" y="456" font-size="12.5" fill="#2F3A45">visibility is a communication</text>
+  <text x="818" y="474" font-size="12.5" fill="#2F3A45">boundary, not a dispatch gate — so</text>
+  <text x="818" y="492" font-size="12.5" fill="#2F3A45">who may talk never decides who may</text>
+  <text x="818" y="510" font-size="12.5" fill="#2F3A45">work.</text>
+  <text x="818" y="534" font-size="12.5" fill="#5A6B7A">hardware reports a normalized</text>
+  <text x="818" y="552" font-size="12.5" fill="#5A6B7A">effective allocation per node.</text>
+
+  <!-- ADMIN -->
+  <rect x="1150" y="104" width="330" height="470" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M1150 114 a10 10 0 0 1 10 -10 h310 a10 10 0 0 1 10 10 v44 h-330 z" fill="#2F3A45"/>
+  <text x="1172" y="134" font-size="19" font-weight="700" fill="#FFFFFF">admin</text>
+  <text x="1458" y="134" font-size="15" font-weight="700" fill="#B7C4D0" text-anchor="end">54 groups</text>
+  <text x="1172" y="152" font-size="12.5" fill="#B7C4D0">everything an operator owns</text>
+
+  <text x="1172" y="186" font-size="13.5" fill="#2F3A45">Not a grab bag — each is its own</text>
+  <text x="1172" y="205" font-size="13.5" fill="#2F3A45">subcommand group with its own</text>
+  <text x="1172" y="224" font-size="13.5" fill="#2F3A45">verbs.</text>
+
+  <text x="1172" y="256" font-size="12" font-weight="700" fill="#2F3A45">WORK</text>
+  <text x="1172" y="278" font-size="13" fill="#2F3A45">dispatch · review · judgement</text>
+  <text x="1172" y="297" font-size="13" fill="#2F3A45">pull-request · workflow · plan</text>
+
+  <text x="1172" y="327" font-size="12" font-weight="700" fill="#2F3A45">LEARNING</text>
+  <text x="1172" y="349" font-size="13" fill="#2F3A45">memory · dream · nap · journal</text>
+  <text x="1172" y="368" font-size="13" fill="#2F3A45">optimizer · eval · curiosity</text>
+
+  <rect x="1172" y="392" width="286" height="162" rx="6" fill="#F4F6F8"/>
+  <text x="1188" y="416" font-size="12" font-weight="700" fill="#2F3A45">FLEET &amp; RUNTIME</text>
+  <text x="1188" y="438" font-size="12.5" fill="#2F3A45">fleet · machine · hgx · openshell</text>
+  <text x="1188" y="456" font-size="12.5" fill="#2F3A45">sandbox-image · runtime · rollout</text>
+  <text x="1188" y="480" font-size="12" font-weight="700" fill="#2F3A45">IDENTITY &amp; COMMS</text>
+  <text x="1188" y="502" font-size="12.5" fill="#2F3A45">secret · persona · binding</text>
+  <text x="1188" y="520" font-size="12.5" fill="#2F3A45">agentbus · directive · notifier</text>
+  <text x="1188" y="538" font-size="12.5" fill="#2F3A45">mcp · integrations · bridge</text>
+
+  <!-- SURFACES -->
+  <rect x="40" y="596" width="1440" height="272" rx="10" fill="#2F3A45"/>
+  <text x="64" y="632" font-size="20" font-weight="700" fill="#FFFFFF">The same object model, six ways in</text>
+  <text x="64" y="656" font-size="14" fill="#B7C4D0">Every surface goes through the same dispatch seam, and a contract test proves the client and the hub agree about the route table.</text>
+
+  <rect x="64" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="80" y="702" font-size="14" font-weight="700" fill="#FFFFFF">CLI</text>
+  <text x="80" y="726" font-size="12.5" fill="#C9D6E2">125 verbs. Generated</text>
+  <text x="80" y="744" font-size="12.5" fill="#C9D6E2">reference is checked</text>
+  <text x="80" y="762" font-size="12.5" fill="#C9D6E2">against the live parser,</text>
+  <text x="80" y="780" font-size="12.5" fill="#C9D6E2">so docs cannot drift.</text>
+  <text x="80" y="808" font-size="12.5" fill="#8FA5B8">--json works in any</text>
+  <text x="80" y="826" font-size="12.5" fill="#8FA5B8">position.</text>
+
+  <rect x="300" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="316" y="702" font-size="14" font-weight="700" fill="#FFFFFF">HTTP API</text>
+  <text x="316" y="726" font-size="12.5" fill="#C9D6E2">414 routes on FastAPI.</text>
+  <text x="316" y="744" font-size="12.5" fill="#C9D6E2">The route index is</text>
+  <text x="316" y="762" font-size="12.5" fill="#C9D6E2">generated from the live</text>
+  <text x="316" y="780" font-size="12.5" fill="#C9D6E2">OpenAPI schema.</text>
+  <text x="316" y="808" font-size="12.5" fill="#8FA5B8">Scoped bearer tokens:</text>
+  <text x="316" y="826" font-size="12.5" fill="#8FA5B8">read/write/agent/admin.</text>
+
+  <rect x="536" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="552" y="702" font-size="14" font-weight="700" fill="#FFFFFF">MCP server</text>
+  <text x="552" y="726" font-size="12.5" fill="#C9D6E2">Typed ledger tools for</text>
+  <text x="552" y="744" font-size="12.5" fill="#C9D6E2">coding agents, so they</text>
+  <text x="552" y="762" font-size="12.5" fill="#C9D6E2">stop parsing tables.</text>
+  <text x="552" y="790" font-size="12.5" fill="#8FA5B8">A test forbids it from</text>
+  <text x="552" y="808" font-size="12.5" fill="#8FA5B8">making its own requests,</text>
+  <text x="552" y="826" font-size="12.5" fill="#8FA5B8">so it cannot drift.</text>
+
+  <rect x="772" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="788" y="702" font-size="14" font-weight="700" fill="#FFFFFF">ACP + A2A</text>
+  <text x="788" y="726" font-size="12.5" fill="#C9D6E2">Agent Client Protocol</text>
+  <text x="788" y="744" font-size="12.5" fill="#C9D6E2">and A2A implemented as</text>
+  <text x="788" y="762" font-size="12.5" fill="#C9D6E2">specifications, not</text>
+  <text x="788" y="780" font-size="12.5" fill="#C9D6E2">vendored SDKs.</text>
+  <text x="788" y="808" font-size="12.5" fill="#8FA5B8">Served at /.well-known</text>
+  <text x="788" y="826" font-size="12.5" fill="#8FA5B8">agent cards.</text>
+
+  <rect x="1008" y="676" width="222" height="172" rx="7" fill="#3C4A57"/>
+  <text x="1024" y="702" font-size="14" font-weight="700" fill="#FFFFFF">Python client</text>
+  <text x="1024" y="726" font-size="12.5" fill="#C9D6E2">Contract-checked against</text>
+  <text x="1024" y="744" font-size="12.5" fill="#C9D6E2">the hub's real route</text>
+  <text x="1024" y="762" font-size="12.5" fill="#C9D6E2">table in CI.</text>
+  <text x="1024" y="790" font-size="12.5" fill="#8FA5B8">Tells you when the</text>
+  <text x="1024" y="808" font-size="12.5" fill="#8FA5B8">client is older than the</text>
+  <text x="1024" y="826" font-size="12.5" fill="#8FA5B8">hub it is talking to.</text>
+
+  <rect x="1244" y="676" width="214" height="172" rx="7" fill="#3C4A57"/>
+  <text x="1260" y="702" font-size="14" font-weight="700" fill="#FFFFFF">Console</text>
+  <text x="1260" y="726" font-size="12.5" fill="#C9D6E2">/ui is read-only</text>
+  <text x="1260" y="744" font-size="12.5" fill="#C9D6E2">observability. The</text>
+  <text x="1260" y="762" font-size="12.5" fill="#C9D6E2">command-and-control</text>
+  <text x="1260" y="780" font-size="12.5" fill="#C9D6E2">dashboard was retired.</text>
+  <text x="1260" y="808" font-size="12.5" fill="#8FA5B8">It speaks on the bus</text>
+  <text x="1260" y="826" font-size="12.5" fill="#8FA5B8">rather than mutating.</text>
+</svg>

--- a/docs/presentation/20260825T000816Z-e8040fec/images/02-task-lifecycle.svg
+++ b/docs/presentation/20260825T000816Z-e8040fec/images/02-task-lifecycle.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="880" viewBox="0 0 1520 880" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="fl" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#5A6B7A"/>
+    </marker>
+  </defs>
+  <rect width="1520" height="880" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">A task is a state machine with receipts</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">Twelve states in <tspan font-family="Menlo, Consolas, monospace" font-size="15">TaskState</tspan>, three of them terminal. What makes it a control plane rather than a queue is what must be true to move between them.</text>
+
+  <text x="40" y="114" font-size="13.5" font-weight="700" fill="#2E6F9E">THE PATH WORK TAKES WHEN IT GOES WELL</text>
+
+  <rect x="40" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="125" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">open</text>
+  <path d="M216 155 L 239 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="245" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="330" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">claimed</text>
+  <path d="M421 155 L 444 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="450" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="535" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">running</text>
+  <path d="M626 155 L 649 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="655" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="740" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">needs_review</text>
+  <text x="740" y="202" font-size="11.5" fill="#B5651D" text-anchor="middle">hub still drives this (ADR 0016 Accepted)</text>
+  <path d="M831 155 L 854 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="860" y="126" width="170" height="58" rx="8" fill="#E7F0F7" stroke="#2E6F9E" stroke-width="1.5"/>
+  <text x="945" y="161" font-size="16" font-weight="700" fill="#1B4E73" text-anchor="middle">reviewing</text>
+  <path d="M1036 155 L 1059 155" stroke="#5A6B7A" stroke-width="2" marker-end="url(#fl)"/>
+
+  <rect x="1065" y="126" width="170" height="58" rx="8" fill="#E3F0E7" stroke="#3E7C4F" stroke-width="2"/>
+  <text x="1150" y="155" font-size="16" font-weight="700" fill="#265536" text-anchor="middle">completed</text>
+  <text x="1150" y="173" font-size="11.5" fill="#3E7C4F" text-anchor="middle">terminal</text>
+
+  <text x="1260" y="146" font-size="13" fill="#5A6B7A">Terminal states are</text>
+  <text x="1260" y="164" font-size="13" fill="#5A6B7A">completed, failed and</text>
+  <text x="1260" y="182" font-size="13" fill="#5A6B7A">cancelled. Everything</text>
+  <text x="1260" y="200" font-size="13" fill="#5A6B7A">else still wants</text>
+  <text x="1260" y="218" font-size="13" fill="#5A6B7A">something from somebody</text>
+  <text x="1260" y="236" font-size="13" fill="#5A6B7A">— which is why that is</text>
+  <text x="1260" y="254" font-size="13" fill="#5A6B7A">the default list view.</text>
+
+  <text x="40" y="226" font-size="13.5" font-weight="700" fill="#8C3227">THE STATES THAT MEAN SOMETHING IS OWED</text>
+
+  <rect x="40" y="238" width="170" height="58" rx="8" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="125" y="264" font-size="15" font-weight="700" fill="#2F3A45" text-anchor="middle">waiting</text>
+  <text x="125" y="282" font-size="11.5" fill="#5A6B7A" text-anchor="middle">on a timer or window</text>
+
+  <rect x="245" y="238" width="170" height="58" rx="8" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="330" y="264" font-size="15" font-weight="700" fill="#2F3A45" text-anchor="middle">blocked</text>
+  <text x="330" y="282" font-size="11.5" fill="#5A6B7A" text-anchor="middle">on another task</text>
+
+  <rect x="450" y="238" width="170" height="58" rx="8" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="535" y="264" font-size="15" font-weight="700" fill="#2F3A45" text-anchor="middle">needs_input</text>
+  <text x="535" y="282" font-size="11.5" fill="#5A6B7A" text-anchor="middle">on a human answer</text>
+
+  <rect x="655" y="238" width="170" height="58" rx="8" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="740" y="264" font-size="15" font-weight="700" fill="#2F3A45" text-anchor="middle">stopped</text>
+  <text x="740" y="282" font-size="11.5" fill="#5A6B7A" text-anchor="middle">held by an operator</text>
+
+  <rect x="860" y="238" width="170" height="58" rx="8" fill="#FBF4F3" stroke="#DCBCB6"/>
+  <text x="945" y="264" font-size="15" font-weight="700" fill="#8C3227" text-anchor="middle">failed</text>
+  <text x="945" y="282" font-size="11.5" fill="#A9827B" text-anchor="middle">terminal</text>
+
+  <rect x="1065" y="238" width="170" height="58" rx="8" fill="#FBF4F3" stroke="#DCBCB6"/>
+  <text x="1150" y="264" font-size="15" font-weight="700" fill="#8C3227" text-anchor="middle">cancelled</text>
+  <text x="1150" y="282" font-size="11.5" fill="#A9827B" text-anchor="middle">terminal</text>
+
+  <text x="40" y="326" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">mac task ask / answer / needs-input</tspan> turn the human out-of-band question into a ledger state, so a task waiting on a person is visible rather than silently stalled.</text>
+  <text x="40" y="346" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">mac task why-unclaimed</tspan> explains a task that is ready but unassigned, because "nothing is happening" is the hardest fleet question to answer from a board.</text>
+
+  <!-- GATES -->
+  <text x="40" y="392" font-size="13.5" font-weight="700" fill="#2E6F9E">WHAT MUST BE TRUE TO MOVE — THE PART THAT IS NOT A QUEUE</text>
+
+  <rect x="40" y="406" width="345" height="288" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 416 a10 10 0 0 1 10 -10 h325 a10 10 0 0 1 10 10 v38 h-345 z" fill="#2E6F9E"/>
+  <text x="60" y="440" font-size="15.5" font-weight="700" fill="#FFFFFF">1 · CLAIM — leases and fences</text>
+  <text x="60" y="474" font-size="13" fill="#2F3A45">Every mutation is authorized by an exact</text>
+  <text x="60" y="493" font-size="13" fill="#2F3A45">lease and fence, not merely by an agent id,</text>
+  <text x="60" y="512" font-size="13" fill="#2F3A45">so two workers cannot claim one change.</text>
+  <text x="60" y="540" font-size="13" fill="#2F3A45">Lease expiry is the single liveness</text>
+  <text x="60" y="559" font-size="13" fill="#2F3A45">mechanism — a dead agent's work is</text>
+  <text x="60" y="578" font-size="13" fill="#2F3A45">reclaimed rather than lost.</text>
+  <text x="60" y="606" font-size="13" fill="#2F3A45">The dispatcher accounts for tenant pool</text>
+  <text x="60" y="625" font-size="13" fill="#2F3A45">policy, resources, capacity, stale</text>
+  <text x="60" y="644" font-size="13" fill="#2F3A45">heartbeats and expired leases.</text>
+  <text x="60" y="674" font-size="12.5" fill="#5A6B7A">Releasing a worker returns the lease.</text>
+
+  <rect x="405" y="406" width="345" height="288" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M405 416 a10 10 0 0 1 10 -10 h325 a10 10 0 0 1 10 10 v38 h-345 z" fill="#2E6F9E"/>
+  <text x="425" y="440" font-size="15.5" font-weight="700" fill="#FFFFFF">2 · PROVE — typed evidence</text>
+  <text x="425" y="474" font-size="13" fill="#2F3A45">Evidence rows are typed manifests bound to</text>
+  <text x="425" y="493" font-size="13" fill="#2F3A45">one exact attempt — repo_change,</text>
+  <text x="425" y="512" font-size="13" fill="#2F3A45">review_verdict, and their digests.</text>
+  <text x="425" y="540" font-size="13" fill="#2F3A45">CodeGraph is a hint when the index exists</text>
+  <text x="425" y="559" font-size="13" fill="#2F3A45">(ADR 0031), not a hard gate. Affected-test</text>
+  <text x="425" y="578" font-size="13" fill="#2F3A45">selection still decides what has to run.</text>
+  <text x="425" y="606" font-size="13" fill="#2F3A45">A short-retention command audit records</text>
+  <text x="425" y="625" font-size="13" fill="#2F3A45">what worker subprocesses really ran, so</text>
+  <text x="425" y="644" font-size="13" fill="#2F3A45">local shell history is never the evidence.</text>
+  <text x="425" y="674" font-size="12.5" fill="#5A6B7A">Evidence from one stage never authorizes a later one.</text>
+
+  <rect x="770" y="406" width="345" height="288" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M770 416 a10 10 0 0 1 10 -10 h325 a10 10 0 0 1 10 10 v38 h-345 z" fill="#2E6F9E"/>
+  <text x="790" y="440" font-size="15.5" font-weight="700" fill="#FFFFFF">3 · REVIEW — independence</text>
+  <text x="790" y="474" font-size="13" fill="#2F3A45">A reviewer must be a different agent or</text>
+  <text x="790" y="493" font-size="13" fill="#2F3A45">persona, and an approval of model-generated</text>
+  <text x="790" y="512" font-size="13" fill="#2F3A45">evidence must name a different model.</text>
+  <text x="790" y="540" font-size="13" fill="#2F3A45">The approval binds to the current executor</text>
+  <text x="790" y="559" font-size="13" fill="#2F3A45">evidence for that exact attempt.</text>
+  <text x="790" y="587" font-size="13" fill="#2F3A45">A blind arm physically removes the executor</text>
+  <text x="790" y="606" font-size="13" fill="#2F3A45">evidence file before the discovery pass,</text>
+  <text x="790" y="625" font-size="13" fill="#2F3A45">then restores it for adjudication.</text>
+  <text x="790" y="653" font-size="13" fill="#2F3A45">Reviews record what the reviewer said, not</text>
+  <text x="790" y="672" font-size="13" fill="#2F3A45">only which way it voted.</text>
+
+  <rect x="1135" y="406" width="345" height="288" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M1135 416 a10 10 0 0 1 10 -10 h325 a10 10 0 0 1 10 10 v38 h-345 z" fill="#2E6F9E"/>
+  <text x="1155" y="440" font-size="15.5" font-weight="700" fill="#FFFFFF">4 · LAND — the merge queue</text>
+  <text x="1155" y="474" font-size="13" fill="#2F3A45">Approved work lands through a pull request</text>
+  <text x="1155" y="493" font-size="13" fill="#2F3A45">the agent owns, not a push to main.</text>
+  <text x="1155" y="521" font-size="13" fill="#2F3A45">A native durable queue per (repository,</text>
+  <text x="1155" y="540" font-size="13" fill="#2F3A45">branch) tests entries speculatively, in a</text>
+  <text x="1155" y="559" font-size="13" fill="#2F3A45">Zuul-style train; a failure evicts the entry</text>
+  <text x="1155" y="578" font-size="13" fill="#2F3A45">and discards results projected behind it.</text>
+  <text x="1155" y="606" font-size="13" fill="#2F3A45">The speculation window is TCP congestion</text>
+  <text x="1155" y="625" font-size="13" fill="#2F3A45">control: floor 1, ceiling 4, additive growth,</text>
+  <text x="1155" y="644" font-size="13" fill="#2F3A45">halved on any failure.</text>
+  <text x="1155" y="674" font-size="12.5" font-weight="700" fill="#265536">Invariant: never land an untested tree.</text>
+
+  <rect x="40" y="716" width="1440" height="128" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="64" y="746" font-size="15.5" font-weight="700" fill="#1B2530">Recovery is a first-class verb, not an incident</text>
+  <text x="64" y="772" font-size="13.5" fill="#2F3A45">Stranded work, stalled finalizers and expired leases each have a named recovery path — <tspan font-family="Menlo, Consolas, monospace" font-size="13">recover-stranded</tspan>, <tspan font-family="Menlo, Consolas, monospace" font-size="13">recover-finalizer</tspan>, <tspan font-family="Menlo, Consolas, monospace" font-size="13">recover-stalled-finalizer</tspan> —</text>
+  <text x="64" y="794" font-size="13.5" fill="#2F3A45">because a fleet that cannot reclaim its own work degrades quietly. Break-glass override is grantable, listable and revocable, so an emergency leaves a record instead of</text>
+  <text x="64" y="816" font-size="13.5" fill="#2F3A45">an ambient permission. Failure causes are classified rather than free-text, which is what makes "why did this attempt die" answerable across thousands of tasks.</text>
+</svg>

--- a/docs/presentation/20260825T000816Z-e8040fec/images/03-coordination.svg
+++ b/docs/presentation/20260825T000816Z-e8040fec/images/03-coordination.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="900" viewBox="0 0 1520 900" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <rect width="1520" height="900" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">How agents coordinate: a town square, not a switchboard</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">AgentBus is a broadcast bus — every participant hears everything — because an agent that cannot hear its peers cannot avoid destroying their work.</text>
+
+  <!-- BUS VISUAL -->
+  <rect x="40" y="102" width="800" height="330" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+
+  <rect x="66" y="132" width="132" height="56" rx="7" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="132" y="156" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">agent</text>
+  <text x="132" y="175" font-size="11.5" fill="#5A6B7A" text-anchor="middle">macOS host</text>
+
+  <rect x="212" y="132" width="132" height="56" rx="7" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="278" y="156" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">agent</text>
+  <text x="278" y="175" font-size="11.5" fill="#5A6B7A" text-anchor="middle">Linux sandbox</text>
+
+  <rect x="358" y="132" width="132" height="56" rx="7" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="424" y="156" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">agent</text>
+  <text x="424" y="175" font-size="11.5" fill="#5A6B7A" text-anchor="middle">HGX node</text>
+
+  <rect x="504" y="132" width="132" height="56" rx="7" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="570" y="156" font-size="13.5" font-weight="700" fill="#1B4E73" text-anchor="middle">reviewer</text>
+  <text x="570" y="175" font-size="11.5" fill="#5A6B7A" text-anchor="middle">a peer, on request</text>
+
+  <rect x="650" y="132" width="164" height="56" rx="7" fill="#FDF6EE" stroke="#B5651D" stroke-width="2"/>
+  <text x="732" y="156" font-size="13.5" font-weight="700" fill="#7A430F" text-anchor="middle">human</text>
+  <text x="732" y="175" font-size="11.5" fill="#8A6438" text-anchor="middle">a participant, not a controller</text>
+
+  <line x1="132" y1="188" x2="132" y2="236" stroke="#2E6F9E" stroke-width="1.5"/>
+  <line x1="278" y1="188" x2="278" y2="236" stroke="#2E6F9E" stroke-width="1.5"/>
+  <line x1="424" y1="188" x2="424" y2="236" stroke="#2E6F9E" stroke-width="1.5"/>
+  <line x1="570" y1="188" x2="570" y2="236" stroke="#2E6F9E" stroke-width="1.5"/>
+  <line x1="732" y1="188" x2="732" y2="236" stroke="#B5651D" stroke-width="1.5"/>
+
+  <rect x="66" y="236" width="748" height="34" rx="6" fill="#2E6F9E"/>
+  <text x="440" y="259" font-size="15" font-weight="700" fill="#FFFFFF" text-anchor="middle">AgentBus — everyone hears it</text>
+
+  <line x1="440" y1="270" x2="440" y2="304" stroke="#2F3A45" stroke-width="1.5"/>
+  <rect x="300" y="304" width="280" height="50" rx="7" fill="#2F3A45"/>
+  <text x="440" y="326" font-size="14" font-weight="700" fill="#FFFFFF" text-anchor="middle">hub — keeps the ledger</text>
+  <text x="440" y="345" font-size="11.5" fill="#B7C4D0" text-anchor="middle">choreography is peer-to-peer; the record is central</text>
+
+  <text x="66" y="384" font-size="13" fill="#2F3A45"><tspan font-weight="700">Roll call</tspan> returns every agent on the bus with its capabilities — the prerequisite for an agent pulling</text>
+  <text x="66" y="403" font-size="13" fill="#2F3A45">work and judging for itself what it can take. Without a roster an agent can only wait to be assigned.</text>
+  <text x="66" y="422" font-size="13" fill="#2F3A45"><tspan font-weight="700">Traffic</tspan> returns everything being said, resumable by cursor. An inbox is scoped by <tspan font-style="italic">addressing</tspan>, not access.</text>
+
+  <!-- WHY -->
+  <rect x="860" y="102" width="620" height="330" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="884" y="134" font-size="17" font-weight="700" fill="#1B2530">Why private messages were abolished</text>
+  <text x="884" y="164" font-size="13.5" fill="#2F3A45">Two incidents are on the record where concurrent agents in one</text>
+  <text x="884" y="183" font-size="13.5" fill="#2F3A45">checkout nearly destroyed each other's work — a <tspan font-family="Menlo, Consolas, monospace" font-size="12.5">git add -A</tspan> moments</text>
+  <text x="884" y="202" font-size="13.5" fill="#2F3A45">from sweeping ~1,200 lines of another agent's half-finished work into an</text>
+  <text x="884" y="221" font-size="13.5" fill="#2F3A45">unrelated commit, and a <tspan font-family="Menlo, Consolas, monospace" font-size="12.5">git commit -a</tspan> that did.</text>
+  <text x="884" y="250" font-size="13.5" fill="#2F3A45">The only mitigation was a documented convention: a rule agents could</text>
+  <text x="884" y="269" font-size="13.5" fill="#2F3A45">follow but could not <tspan font-style="italic">verify</tspan>, because nothing told one agent what</text>
+  <text x="884" y="288" font-size="13.5" fill="#2F3A45">another was doing.</text>
+
+  <rect x="884" y="306" width="572" height="60" rx="6" fill="#FFFFFF" stroke="#9CC2D8"/>
+  <text x="900" y="330" font-size="13.5" font-style="italic" fill="#1B4E73">"An enforced silence would stop an agent from volunteering the one fact</text>
+  <text x="900" y="350" font-size="13.5" font-style="italic" fill="#1B4E73">that keeps another from destroying work."</text>
+
+  <text x="884" y="392" font-size="13" fill="#2F3A45"><tspan font-weight="700">One carve-out.</tspan> <tspan font-family="Menlo, Consolas, monospace" font-size="12.5">mac.debug.terminal.*</tspan> stays participant-scoped: those</text>
+  <text x="884" y="411" font-size="13" fill="#2F3A45">streams are raw terminal I/O including credentials, and a credential read</text>
+  <text x="884" y="425" font-size="13" fill="#2F3A45">off the bus cannot be un-read.</text>
+
+  <!-- THREE CARDS -->
+  <rect x="40" y="454" width="466" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="64" y="484" font-size="16" font-weight="700" fill="#1B2530">A closed, typed vocabulary</text>
+  <text x="64" y="510" font-size="13" fill="#2F3A45">Payloads were self-describing by convention only, so a</text>
+  <text x="64" y="529" font-size="13" fill="#2F3A45">malformed message was found by the consumer at turn time</text>
+  <text x="64" y="548" font-size="13" fill="#2F3A45">rather than by the producer at publish time.</text>
+  <text x="64" y="574" font-size="13" fill="#2F3A45">A schema registry now validates declared schemas at publish</text>
+  <text x="64" y="593" font-size="13" fill="#2F3A45">and warns on unknown ones, so experimentation stays open.</text>
+  <text x="64" y="622" font-size="12.5" fill="#5A6B7A">peer_message · peer_reply · media.share · error · task.claimed</text>
+  <text x="64" y="640" font-size="12.5" fill="#5A6B7A">task.progress · task.released · project.attention · git.*</text>
+
+  <rect x="527" y="454" width="466" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="551" y="484" font-size="16" font-weight="700" fill="#1B2530">Lifecycle verbs a human also speaks</text>
+  <text x="551" y="508" font-size="13" fill="#2F3A45">Requests on a channel everyone can see, which each agent</text>
+  <text x="551" y="527" font-size="13" fill="#2F3A45">observes and honours — never a privileged mutation.</text>
+
+  <rect x="551" y="540" width="112" height="32" rx="5" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="607" y="561" font-size="12.5" font-weight="700" fill="#1B4E73" text-anchor="middle">stand_down</text>
+  <rect x="671" y="540" width="80" height="32" rx="5" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="711" y="561" font-size="12.5" font-weight="700" fill="#1B4E73" text-anchor="middle">pause</text>
+  <rect x="759" y="540" width="86" height="32" rx="5" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="802" y="561" font-size="12.5" font-weight="700" fill="#1B4E73" text-anchor="middle">resume</text>
+  <rect x="853" y="540" width="80" height="32" rx="5" fill="#E7F0F7" stroke="#2E6F9E"/>
+  <text x="893" y="561" font-size="12.5" font-weight="700" fill="#1B4E73" text-anchor="middle">status</text>
+  <rect x="551" y="580" width="80" height="32" rx="5" fill="#FBE9E6" stroke="#C0392B"/>
+  <text x="591" y="601" font-size="12.5" font-weight="700" fill="#98291C" text-anchor="middle">abort</text>
+  <text x="645" y="601" font-size="12.5" fill="#8C3227">destructive — flagged so a UI cannot</text>
+  <text x="645" y="617" font-size="12.5" fill="#8C3227">put it behind the same control</text>
+
+  <text x="551" y="644" font-size="12.5" fill="#5A6B7A">Scopes: fleet · project · agent · task. A directive with no</text>
+  <text x="551" y="660" font-size="12.5" fill="#5A6B7A">target is refused — defaulting to the fleet is what does damage.</text>
+
+  <rect x="1014" y="454" width="466" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <text x="1038" y="484" font-size="16" font-weight="700" fill="#1B2530">Stand-down is not abort</text>
+  <text x="1038" y="510" font-size="13" fill="#2F3A45">Collapsing them is the mistake the vocabulary exists to</text>
+  <text x="1038" y="529" font-size="13" fill="#2F3A45">prevent. A single button labelled "stop" that means ABORT</text>
+  <text x="1038" y="548" font-size="13" fill="#2F3A45">destroys work in flight; one that means PAUSE does not stop</text>
+  <text x="1038" y="567" font-size="13" fill="#2F3A45">a runaway. Most off-the-rails moments want stand-down.</text>
+  <text x="1038" y="596" font-size="13" fill="#2F3A45">Both verbs ship, named honestly.</text>
+  <text x="1038" y="625" font-size="12.5" fill="#5A6B7A">A verb nobody understands fails where it is built rather than</text>
+  <text x="1038" y="643" font-size="12.5" fill="#5A6B7A">travelling the bus and being silently dropped — that is</text>
+  <text x="1038" y="661" font-size="12.5" fill="#5A6B7A">indistinguishable from a fleet that heard it and did nothing.</text>
+
+  <!-- BOTTOM -->
+  <rect x="40" y="688" width="712" height="180" rx="10" fill="#2F3A45"/>
+  <text x="64" y="720" font-size="17" font-weight="700" fill="#FFFFFF">Dispatch — matching work to capacity</text>
+  <text x="64" y="748" font-size="13.5" fill="#DCE5EC">The dispatcher matches open work to healthy, capable agents, accounting for</text>
+  <text x="64" y="768" font-size="13.5" fill="#DCE5EC">tenant pool policy, resources, capacity, stale heartbeats and expired leases.</text>
+  <text x="64" y="796" font-size="13.5" fill="#DCE5EC">Priority ages, so old work is not starved by a steady stream of new work.</text>
+  <text x="64" y="824" font-size="13" fill="#8FA5B8">Routing skips are logged with a reason class, which is what makes</text>
+  <text x="64" y="842" font-size="13" fill="#8FA5B8"><tspan font-family="Menlo, Consolas, monospace" font-size="12.5">mac task why-unclaimed</tspan> able to answer instead of guess.</text>
+
+  <rect x="768" y="688" width="712" height="180" rx="10" fill="#2F3A45"/>
+  <text x="792" y="720" font-size="17" font-weight="700" fill="#FFFFFF">The merge queue — because GitHub would not</text>
+  <text x="792" y="748" font-size="13.5" fill="#DCE5EC">GitHub merge queues are an organization-only feature, verified against the live</text>
+  <text x="792" y="768" font-size="13.5" fill="#DCE5EC">repository: adding the rule returns HTTP 422 on a user-owned repo. So for every</text>
+  <text x="792" y="788" font-size="13.5" fill="#DCE5EC">personal repository this is the only path, and mac grew its own.</text>
+  <text x="792" y="816" font-size="13.5" fill="#DCE5EC">Speculative Zuul-style train, AIMD window (floor 1, ceiling 4), eviction on</text>
+  <text x="792" y="836" font-size="13.5" fill="#DCE5EC">failure, and an entry that cannot progress is now required to say so.</text>
+</svg>

--- a/docs/presentation/20260825T000816Z-e8040fec/images/04-fleet-execution.svg
+++ b/docs/presentation/20260825T000816Z-e8040fec/images/04-fleet-execution.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="900" viewBox="0 0 1520 900" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <rect width="1520" height="900" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">A heterogeneous fleet, honestly modelled</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">mac does not pretend every machine is the same server class. Node classes differ by supervisor, isolation model and hardware, and the ADRs say which is which.</text>
+
+  <rect x="580" y="104" width="360" height="60" rx="9" fill="#2F3A45"/>
+  <text x="760" y="130" font-size="17" font-weight="700" fill="#FFFFFF" text-anchor="middle">hub</text>
+  <text x="760" y="150" font-size="12" fill="#B7C4D0" text-anchor="middle">ledger · capability registry · capacity · dispatch</text>
+
+  <path d="M700 164 L 270 214" stroke="#5A6B7A" stroke-width="1.5"/>
+  <path d="M760 164 L 760 214" stroke="#5A6B7A" stroke-width="1.5"/>
+  <path d="M820 164 L 1250 214" stroke="#5A6B7A" stroke-width="1.5"/>
+
+  <!-- macOS -->
+  <rect x="40" y="216" width="460" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 226 a10 10 0 0 1 10 -10 h440 a10 10 0 0 1 10 10 v40 h-460 z" fill="#2E6F9E"/>
+  <text x="62" y="252" font-size="16" font-weight="700" fill="#FFFFFF">macOS node</text>
+  <text x="478" y="252" font-size="12.5" fill="#BBD7EA" text-anchor="end">ADR 0015 · Accepted</text>
+  <text x="62" y="290" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">Host install under launchd.</tspan> Not a container.</text>
+  <text x="62" y="314" font-size="13.5" fill="#2F3A45">The earlier attempt ran the Linux-ELF OpenShell</text>
+  <text x="62" y="333" font-size="13.5" fill="#2F3A45">gateway inside a Linux container on Docker; that</text>
+  <text x="62" y="352" font-size="13.5" fill="#2F3A45">amendment was superseded.</text>
+  <text x="62" y="382" font-size="13" fill="#5A6B7A">Native toolchains, Apple silicon, and Xcode-bound</text>
+  <text x="62" y="400" font-size="13" fill="#5A6B7A">work are reachable because the agent is a host</text>
+  <text x="62" y="418" font-size="13" fill="#5A6B7A">process rather than a guest.</text>
+
+  <!-- Linux -->
+  <rect x="530" y="216" width="460" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M530 226 a10 10 0 0 1 10 -10 h440 a10 10 0 0 1 10 10 v40 h-460 z" fill="#2E6F9E"/>
+  <text x="552" y="252" font-size="16" font-weight="700" fill="#FFFFFF">Linux node</text>
+  <text x="968" y="252" font-size="12.5" fill="#BBD7EA" text-anchor="end">ADR 0008 / 0012</text>
+  <text x="552" y="290" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">Native steward under systemd</tspan>, with task</text>
+  <text x="552" y="309" font-size="13.5" fill="#2F3A45">execution in containers. The containerized half of</text>
+  <text x="552" y="328" font-size="13.5" fill="#2F3A45">ADR 0012 now applies to Linux only.</text>
+  <text x="552" y="358" font-size="13.5" fill="#2F3A45">OpenShell owns isolation — process trees,</text>
+  <text x="552" y="377" font-size="13.5" fill="#2F3A45">filesystem and network policy, sandbox lifecycle,</text>
+  <text x="552" y="396" font-size="13.5" fill="#2F3A45">and normalized action events.</text>
+  <text x="552" y="420" font-size="13" fill="#5A6B7A">Docker Engine / Moby is the only container runtime.</text>
+
+  <!-- K8s -->
+  <rect x="1020" y="216" width="460" height="212" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M1020 226 a10 10 0 0 1 10 -10 h440 a10 10 0 0 1 10 10 v40 h-460 z" fill="#2E6F9E"/>
+  <text x="1042" y="252" font-size="16" font-weight="700" fill="#FFFFFF">Kubernetes / HGX</text>
+  <text x="1458" y="252" font-size="12.5" fill="#BBD7EA" text-anchor="end">elastic capacity</text>
+  <text x="1042" y="290" font-size="13.5" fill="#2F3A45"><tspan font-weight="700">Pods under supervisord.</tspan> The runner carries</text>
+  <text x="1042" y="309" font-size="13.5" fill="#2F3A45">independent build and review paths, wrapped by</text>
+  <text x="1042" y="328" font-size="13.5" fill="#2F3A45">mac-owned test, evidence and publication gates.</text>
+  <text x="1042" y="358" font-size="13.5" fill="#2F3A45">HGX capacity is elastic: the fleet asks for more</text>
+  <text x="1042" y="377" font-size="13.5" fill="#2F3A45">workers when saturated rather than queueing behind</text>
+  <text x="1042" y="396" font-size="13.5" fill="#2F3A45">a fixed pool.</text>
+  <text x="1042" y="420" font-size="13" fill="#5A6B7A">GPU facts are part of the capability registry.</text>
+
+  <!-- EXECUTION -->
+  <rect x="40" y="452" width="900" height="238" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="64" y="484" font-size="17" font-weight="700" fill="#1B2530">What actually runs the work</text>
+  <text x="64" y="508" font-size="13.5" fill="#2F3A45">Five coding-agent routes, each with its own identity, discovered where it is</text>
+  <text x="64" y="527" font-size="13.5" fill="#2F3A45">installed. The sandbox derives its available agents from the router rather than</text>
+  <text x="64" y="546" font-size="13.5" fill="#2F3A45">hardcoding a list, so adding a route does not fork the image definition.</text>
+
+  <rect x="64" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="139" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">claude</text>
+  <rect x="228" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="303" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">codex</text>
+  <rect x="392" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="467" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">cursor</text>
+  <rect x="556" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="631" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">opencode</text>
+  <rect x="720" y="562" width="150" height="40" rx="6" fill="#FFFFFF" stroke="#2E6F9E"/>
+  <text x="795" y="588" font-size="14" font-weight="700" fill="#1B4E73" text-anchor="middle">pi</text>
+
+  <text x="64" y="632" font-size="13" fill="#2F3A45">A preflight sentinel proves the sandbox can actually launch the chosen agent before work is dispatched into it, and the</text>
+  <text x="64" y="651" font-size="13" fill="#2F3A45">MCP config the sandbox writes is asserted by test to launch mac's own ledger server — so the socket is never wired to nothing.</text>
+  <text x="64" y="675" font-size="13" fill="#5A6B7A">Sandbox policy changes are announced on the bus and acted on between tasks, not mid-flight.</text>
+
+  <!-- IMAGES -->
+  <rect x="964" y="452" width="516" height="238" rx="10" fill="#F4F6F8" stroke="#C9D2DA"/>
+  <text x="988" y="484" font-size="17" font-weight="700" fill="#1B2530">Images and rollout</text>
+  <text x="988" y="510" font-size="13.5" fill="#2F3A45">Runtime manifests are reproducible, with stable</text>
+  <text x="988" y="529" font-size="13.5" fill="#2F3A45">digests and secret-value checks.</text>
+  <text x="988" y="556" font-size="13.5" fill="#2F3A45">Images are qualified before use and carry a</text>
+  <text x="988" y="575" font-size="13.5" fill="#2F3A45"><tspan font-family="Menlo, Consolas, monospace" font-size="12.5">tested-&lt;inputs-sha&gt;</tspan> tag, so "which image was this</text>
+  <text x="988" y="594" font-size="13.5" fill="#2F3A45">proven against" is answerable from the tag alone.</text>
+  <text x="988" y="621" font-size="13.5" fill="#2F3A45">A synchronized cutover protocol moves the fleet</text>
+  <text x="988" y="640" font-size="13.5" fill="#2F3A45">between qualified versions as a transaction.</text>
+  <text x="988" y="668" font-size="13" fill="#265536" font-weight="700">A rollout can require a passing eval_run before promote.</text>
+
+  <!-- IDENTITY -->
+  <rect x="40" y="712" width="1440" height="156" rx="10" fill="#2F3A45"/>
+  <text x="64" y="744" font-size="17" font-weight="700" fill="#FFFFFF">Identity, secrets and blast radius</text>
+  <text x="64" y="772" font-size="13.5" fill="#DCE5EC"><tspan font-weight="700">Secrets are handles, not values.</tspan> Tenant-scoped secret handles carry audit records, and API and CLI output is redacted. Runtime manifests check that no</text>
+  <text x="64" y="792" font-size="13.5" fill="#DCE5EC">secret value was baked in. Review clones may inject HTTPS credentials into an individual git command, but never leave them in the checkout's origin URL or any evidence artifact.</text>
+  <text x="64" y="820" font-size="13.5" fill="#DCE5EC"><tspan font-weight="700">Scoped bearer tokens</tspan> separate read, write, agent, dispatch, secret and admin authority. <tspan font-weight="700">Egress policy</tspan> is declared per project and per task rather than assumed.</text>
+  <text x="64" y="848" font-size="13" fill="#8FA5B8">Tenants, users, Personas and platform bindings are modelled as records, which is what lets one hub serve more than one owner without sharing credentials.</text>
+</svg>

--- a/docs/presentation/20260825T000816Z-e8040fec/images/05-measurement.svg
+++ b/docs/presentation/20260825T000816Z-e8040fec/images/05-measurement.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1520" height="930" viewBox="0 0 1520 930" font-family="Helvetica Neue, Helvetica, Arial, sans-serif">
+  <rect width="1520" height="930" fill="#FFFFFF"/>
+
+  <text x="40" y="46" font-size="30" font-weight="700" fill="#1B2530">The fleet measures itself — including where it falls short</text>
+  <text x="40" y="76" font-size="16.5" fill="#5A6B7A">Every figure below is from this repository's own ledger, dated. The most useful capability mac has is that its instrumentation can indict its own design.</text>
+
+  <!-- WHAT IT MEASURES -->
+  <rect x="40" y="104" width="690" height="452" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M40 114 a10 10 0 0 1 10 -10 h670 a10 10 0 0 1 10 10 v42 h-690 z" fill="#2E6F9E"/>
+  <text x="62" y="142" font-size="17" font-weight="700" fill="#FFFFFF">What it measures</text>
+
+  <text x="62" y="186" font-size="14.5" font-weight="700" fill="#1B2530">Review experiments</text>
+  <text x="62" y="207" font-size="13" fill="#2F3A45">Pre-registered arms, propensity retained, deterministic assignment from</text>
+  <text x="62" y="225" font-size="13" fill="#2F3A45">(experiment_id, task_id, policy_version). A blind arm withholds executor</text>
+  <text x="62" y="243" font-size="13" fill="#2F3A45">evidence for an independent discovery pass.</text>
+
+  <text x="62" y="277" font-size="14.5" font-weight="700" fill="#1B2530">Scientific optimizer</text>
+  <text x="62" y="298" font-size="13" fill="#2F3A45">Policies, experiments, assignments, observations and decisions as durable</text>
+  <text x="62" y="316" font-size="13" fill="#2F3A45">tables. Emits a policy <tspan font-style="italic">candidate</tspan>; promotion stays an operator gate.</text>
+
+  <text x="62" y="350" font-size="14.5" font-weight="700" fill="#1B2530">Dreaming — memory that must shrink</text>
+  <text x="62" y="371" font-size="13" fill="#2F3A45">Copy-on-write runs, gated on provenance, contradiction reduction, privacy,</text>
+  <text x="62" y="389" font-size="13" fill="#2F3A45">retrieval quality, compression and win balance. A run whose output exceeds</text>
+  <text x="62" y="407" font-size="13" fill="#2F3A45">0.75× its input is quarantined; promotion retires the rows it supersedes.</text>
+
+  <text x="62" y="441" font-size="14.5" font-weight="700" fill="#1B2530">Fleet operational learning</text>
+  <text x="62" y="462" font-size="13" fill="#2F3A45">Repository-access outcomes are control inputs, not log lines: a proven</text>
+  <text x="62" y="480" font-size="13" fill="#2F3A45">success is preferred for later routing, a proven failure removes that agent</text>
+  <text x="62" y="498" font-size="13" fill="#2F3A45">from equivalent routing until a cooldown expires. Credentials are never stored.</text>
+
+  <text x="62" y="532" font-size="13" fill="#5A6B7A">Also: eval sets with scoring direction and regression thresholds · task throughput</text>
+  <text x="62" y="548" font-size="13" fill="#5A6B7A">observability · hub event-loop stall detection · classified attempt failures.</text>
+
+  <!-- WHAT IT MEASURED -->
+  <rect x="754" y="104" width="726" height="222" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M754 114 a10 10 0 0 1 10 -10 h706 a10 10 0 0 1 10 10 v42 h-726 z" fill="#2F3A45"/>
+  <text x="776" y="142" font-size="17" font-weight="700" fill="#FFFFFF">Model routing — 7 days to 2026-08-19 (unchanged)</text>
+
+  <text x="900" y="188" font-size="22" font-weight="700" fill="#1B2530" text-anchor="end">28,352</text>
+  <text x="916" y="188" font-size="13.5" fill="#2F3A45"><tspan font-family="Menlo, Consolas, monospace" font-size="12.5">llm.route</tspan> events recorded</text>
+
+  <text x="900" y="222" font-size="22" font-weight="700" fill="#1B2530" text-anchor="end">481.8M</text>
+  <text x="916" y="222" font-size="13.5" fill="#2F3A45">input tokens, against 5.05M output</text>
+
+  <text x="900" y="256" font-size="22" font-weight="700" fill="#C0392B" text-anchor="end">29.5%</text>
+  <text x="916" y="256" font-size="13.5" fill="#2F3A45">of routes recorded <tspan font-family="Menlo, Consolas, monospace" font-size="12.5">input_tokens = null</tspan></text>
+
+  <text x="900" y="290" font-size="22" font-weight="700" fill="#C0392B" text-anchor="end">0</text>
+  <text x="916" y="290" font-size="13.5" fill="#2F3A45">routes reported cached tokens at all</text>
+
+  <text x="776" y="316" font-size="12.5" fill="#5A6B7A">64% of routes stream. Cost is not stored — it is priced against a catalog at read time, and reports say "missing", never zero.</text>
+
+  <rect x="754" y="342" width="726" height="214" rx="10" fill="#FFFFFF" stroke="#C9D2DA" stroke-width="1.5"/>
+  <path d="M754 352 a10 10 0 0 1 10 -10 h706 a10 10 0 0 1 10 10 v42 h-726 z" fill="#2F3A45"/>
+  <text x="776" y="380" font-size="17" font-weight="700" fill="#FFFFFF">Ledger census — 2026-08-25 (live hub)</text>
+
+  <text x="776" y="418" font-size="13.5" fill="#2F3A45">blocked <tspan font-weight="700">378</tspan>   ·   waiting <tspan font-weight="700">29</tspan>   ·   open <tspan font-weight="700">94</tspan>   ·   running <tspan font-weight="700">1</tspan></text>
+  <text x="776" y="440" font-size="13.5" fill="#2F3A45">failed <tspan font-weight="700">2,160</tspan>   ·   cancelled <tspan font-weight="700">3,565</tspan>   ·   stopped <tspan font-weight="700">4</tspan></text>
+
+  <rect x="776" y="458" width="682" height="82" rx="7" fill="#FBF4F3" stroke="#DCBCB6"/>
+  <text x="884" y="490" font-size="24" font-weight="700" fill="#C0392B" text-anchor="end">165</text>
+  <text x="900" y="484" font-size="13.5" fill="#2F3A45">of 355 blocked tasks were permanently dead on 2026-08-19</text>
+  <text x="900" y="503" font-size="13.5" fill="#2F3A45">(ADR 0018). That dead-dep query was not re-run for this</text>
+  <text x="900" y="522" font-size="13.5" fill="#2F3A45">census; blocked has grown to 378, not shrunk.</text>
+
+  <!-- GAPS -->
+  <text x="40" y="596" font-size="14" font-weight="700" fill="#B5651D">OPEN DECISIONS AT THIS COMMIT — THREE THE MEASUREMENTS ARE FORCING (16 ADRs STILL PROPOSED)</text>
+
+  <rect x="40" y="610" width="466" height="292" rx="10" fill="#FDF6EE" stroke="#C08A4A"/>
+  <text x="62" y="640" font-size="15.5" font-weight="700" fill="#7A430F">ADR 0029 · Proposed</text>
+  <text x="62" y="662" font-size="14" font-weight="700" fill="#1B2530">The route search path is a fleet contract</text>
+  <text x="62" y="690" font-size="13" fill="#2F3A45">Coding-agent choice lived in per-worker environment:</text>
+  <text x="62" y="708" font-size="13" fill="#2F3A45">a pinned variable, an exported key, an edited unit</text>
+  <text x="62" y="726" font-size="13" fill="#2F3A45">file. No two hosts were obliged to agree.</text>
+  <text x="62" y="752" font-size="13" fill="#2F3A45">When one account exhausts, every worker rediscovers</text>
+  <text x="62" y="770" font-size="13" fill="#2F3A45">it independently, one wasted turn at a time.</text>
+  <text x="62" y="796" font-size="13" fill="#2F3A45">The decision is recorded; the ordered ladder is not</text>
+  <text x="62" y="814" font-size="13" fill="#2F3A45">yet the runtime search path on every host.</text>
+  <text x="62" y="846" font-size="12.5" fill="#7A430F" font-weight="700">Proposal: one fleet-wide ordered ladder, quota</text>
+  <text x="62" y="864" font-size="12.5" fill="#7A430F" font-weight="700">learning, and a bus event when a route is skipped.</text>
+
+  <rect x="527" y="610" width="466" height="292" rx="10" fill="#FDF6EE" stroke="#C08A4A"/>
+  <text x="549" y="640" font-size="15.5" font-weight="700" fill="#7A430F">ADR 0017 · Proposed</text>
+  <text x="549" y="662" font-size="14" font-weight="700" fill="#1B2530">Meter token spend at the router</text>
+  <text x="549" y="690" font-size="13" fill="#2F3A45">Usage lives as one observability event per request,</text>
+  <text x="549" y="708" font-size="13" fill="#2F3A45">with token counts inside a JSON text column.</text>
+  <text x="549" y="734" font-size="13" fill="#2F3A45">There is no token table and no cost column. Cost is</text>
+  <text x="549" y="752" font-size="13" fill="#2F3A45">computed at read time against a models catalog, and</text>
+  <text x="549" y="770" font-size="13" fill="#2F3A45">returns whether it could be priced at all.</text>
+  <text x="549" y="796" font-size="13" fill="#2F3A45">With 29.5% of routes reporting no input tokens and</text>
+  <text x="549" y="814" font-size="13" fill="#2F3A45">none reporting cache hits, spend cannot currently be</text>
+  <text x="549" y="832" font-size="13" fill="#2F3A45">attributed with confidence.</text>
+  <text x="549" y="864" font-size="12.5" fill="#7A430F" font-weight="700">Proposal: meter at the router, where the truth is,</text>
+  <text x="549" y="882" font-size="12.5" fill="#7A430F" font-weight="700">rather than trusting what the client reports.</text>
+
+  <rect x="1014" y="610" width="466" height="292" rx="10" fill="#FDF6EE" stroke="#C08A4A"/>
+  <text x="1036" y="640" font-size="15.5" font-weight="700" fill="#7A430F">ADR 0018 · Proposed</text>
+  <text x="1036" y="662" font-size="14" font-weight="700" fill="#1B2530">The task view is a graph, not a board</text>
+  <text x="1036" y="690" font-size="13" fill="#2F3A45">The console can say how many tasks are blocked. It</text>
+  <text x="1036" y="708" font-size="13" fill="#2F3A45">cannot say <tspan font-style="italic">what blocks them</tspan>, because the hub never</text>
+  <text x="1036" y="726" font-size="13" fill="#2F3A45">sends the edges — the client has no dependency field.</text>
+  <text x="1036" y="752" font-size="13" fill="#2F3A45">On a board, a task whose dependency lands in five</text>
+  <text x="1036" y="770" font-size="13" fill="#2F3A45">minutes and one that is permanently dead look</text>
+  <text x="1036" y="788" font-size="13" fill="#2F3A45">exactly the same.</text>
+  <text x="1036" y="820" font-size="12.5" font-style="italic" fill="#8C3227">"A state whose p50 dwell is measured in days is not a</text>
+  <text x="1036" y="838" font-size="12.5" font-style="italic" fill="#8C3227">queue, it is a graveyard."</text>
+  <text x="1036" y="864" font-size="12.5" fill="#7A430F" font-weight="700">Proposal: ship the dependency edges and present the</text>
+  <text x="1036" y="882" font-size="12.5" fill="#7A430F" font-weight="700">work as a graph under progressive disclosure.</text>
+</svg>

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -54,11 +54,12 @@ need to know, the failure message names it when it fires.
 
 | Directory | Commit | Deck | Subject |
 |---|---|---|---|
+| [`20260825T000816Z-e8040fec`](20260825T000816Z-e8040fec/README.md) | `e8040fec` | [Google Slides](https://docs.google.com/presentation/d/1cLzjGERKojHg0w1FOyUnlqlsVu_OZVM5b_kGc7T3fSw/edit) | What the control plane can do today — object model, twelve task states, coordination, fleet, measurement at v1.2.0 |
 | [`20260820T182340Z-bac50778`](20260820T182340Z-bac50778/README.md) | `bac50778` | [Google Slides](https://docs.google.com/presentation/d/1vzkNL3_IM-ophzQWUpJl3JE5L-X3MnEva8m6edeEOQk/edit) | How the control plane is put together — hub↔workers, the life of a task, inside the hub, with live console captures |
 | [`20260820T011224Z-8b424c20`](20260820T011224Z-8b424c20/README.md) | `8b424c20` | [Google Slides](https://docs.google.com/presentation/d/1DXgpB-3fy4IDLynGloaAP349BWrwoVSw8T46VyPdT3M/edit) | What the control plane can do today — object model, task lifecycle, coordination, fleet, measurement |
 
-Newest first. The two entries above were cut nine hours apart and disagree about ADR 0016's status,
-which is the convention working as intended rather than a defect: each is true of its own commit.
+Newest first. The `e8040fec` deck and the `8b424c20` deck disagree about ADR 0016's status and the
+task-state count, which is the convention working as intended: each is true of its own commit.
 
 ## Screenshots of a live fleet
 

--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 #: import it, so the number lives in exactly one place. It used to be copied by
 #: hand into four (pyproject, this package, the FastAPI app, the A2A card) with
 #: a comment on each asking the next person to keep them in sync.
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 __all__ = [
     "ControlPlane",


### PR DESCRIPTION
## Summary
- Pin a capabilities deck to `e8040fec` (thirteen slides, published to [Google Slides](https://docs.google.com/presentation/d/1cLzjGERKojHg0w1FOyUnlqlsVu_OZVM5b_kGc7T3fSw/edit)) with `AUDIT.md` tracing every count and the current-doc pass.
- Bump the single-sourced version `1.1.0` → `1.2.0` (129 commits since `v1.1.0`).
- Honest gaps stay on the deck: sixteen ADRs still Proposed, README still names a deleted Hermes snapshot, generated `mac --help` claims zero admin commands while listing 54.

After this lands on `main`: tag `v1.2.0` and `gh release create` from the audit, not the commit log.

## Test plan
- [x] Identity / guide / docs-graph / version-flag tests after staging
- [x] `make lint`
- [x] Executable book, accessibility, docs-graph, reference `--check`, strict mkdocs
- [ ] CI on this PR (Documentation + CI)
- [ ] Tag and GitHub release after merge