### PR TITLE
Implement ADR 0023: Agent Plugins installer and hub-only stall nudge

### DIFF
--- a/docs/adr/0023-one-skill-source-many-harness-plugins.md
+++ b/docs/adr/0023-one-skill-source-many-harness-plugins.md
@@ -1,6 +1,6 @@
 # ADR 0023 - One skill source, thin plugins per coding harness
 
-- Status: **Proposed**
+- Status: **Accepted**
 - Date: 2026-08-20
 - Amended: 2026-08-25 — Agent Plugins 1.0 is the portable package; the
   human CLI and the agent plugin share one `mac` executable; every agent
@@ -339,6 +339,11 @@ does not change the single-sender rule.
 
 ## Consequences
 
+- Implemented 2026-08-25: `mac admin plugin install|status|uninstall`
+  writes one Agent Plugins package under `$MAC_HOME/plugin` and wires
+  detected harnesses; `ControlPlane.tick` is the only stall nudger
+  (`mac.session_nudge`). Heartbeat is not progress. How a session hears
+  the nudge is [ADR 0032](0032-cli-session-hooks-not-tmux.md).
 - Guidance stops depending on a session choosing to read it.
 - A new rule is written once and reaches every harness as one plugin
   plus thin shims, not five authored copies.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -249,6 +249,7 @@ Fleet and machines:
   hgx            HGX / GPU capacity management
   openshell      sandboxed execution environments for agents
   mcp            serve the ledger to coding agents as Model Context Protocol tools
+  plugin         install mac skills and MCP into Claude, Codex, Cursor, OpenCode
   sandbox-image  the sandbox IMAGE: its bill of materials and its rollout
   runtime        runtime images and environment definitions
   rollout        staged rollout of a runtime or configuration

--- a/skills/agentbus-context/SKILL.md
+++ b/skills/agentbus-context/SKILL.md
@@ -71,7 +71,13 @@ read the feed yourself, filter them yourself.
 
 **Announce what you will touch; do not narrate.** A peer can act on "I am
 editing src/mac/api.py". Nobody can act on a status update, and every message
-is durable and audited.
+is durable and audited. Heartbeat is liveness, not progress: a session that
+only heartbeats still looks stuck.
+
+**Broadcast the work; do not nudge a silent peer.** Claim, worktree, push, PR,
+and merge are how others learn you are in the tree. If you are stuck, address
+the hub. Do not broadcast a plea, and do not inbox a peer who has gone quiet —
+only the hub tick may send a stall nudge (ADR 0023).
 
 ## Reach: which agents actually get this file
 
@@ -81,15 +87,13 @@ none:
 * An agent working **in the mac repository** reads this because `AGENTS.md`
   and `CLAUDE.md` at the repo root point at `skills/`, and every coding CLI
   reads those.
-* An agent working in **any other mac-managed project** does *not* get this
-  file — MAC does not install `skills/` into repositories it did not author.
+* After `mac admin plugin install`, the same skills are on the harness
+  (Claude/Cursor/Codex/OpenCode/Pi pointers at one `$MAC_HOME/plugin` copy).
+  That is how a session outside this repository gets the obligation.
+* Until that installer has been run on a host, an agent working in **any
+  other mac-managed project** does *not* get this file from the repo.
   What reaches it instead is the executor policy
   (`src/mac/executor-policy.txt`, delivered into every task sandbox as
   `.mac-executor-policy.txt` and named as the top authority in every task
   prompt) plus the **AgentBus context** section the worker attaches to the
   task. Those are prompt-level and project-independent; this file is not.
-* Delivering `skills/` for arbitrary projects would mean writing into a
-  repository MAC does not own — either into `.claude/skills/` (per-CLI, and a
-  repository change the project's owners did not ask for) or into the sandbox
-  home (`~/.claude/skills`, per-host, invisible to the repository). Neither is
-  in place today.

--- a/skills/mac-cli/SKILL.md
+++ b/skills/mac-cli/SKILL.md
@@ -83,6 +83,11 @@ prints a redirect rather than working, so if a command "used to exist", try
 not exist. Agents use the opposite pair: `mac agent hold` / `mac agent resume`.
 So the verb depends on the object, and guessing from the other one is wrong.
 
+**`mac agent install` is not a verb.** `mac agent` is the fleet worker:
+register, list, hold, resume, heartbeat. The harness installer is
+`mac admin plugin install`. Guessing `mac agent install` from a design
+doc that said "agent install" sends you to a usage error.
+
 **`mac agent update` cannot change status.** It takes `--capabilities`,
 `--add-capability`, `--remove-capability`, `--instance-kind`, `--owner`,
 `--visibility`. To clear a `draining` agent, PUT `{"status": "idle"}` to
@@ -163,6 +168,10 @@ called "help".
     mac admin judgement status          process-quality daemon last report
     mac admin judgement run             run one judgement cycle now
     mac admin login --local-console     hub-local enrollment without SSH
+    mac admin plugin install --scope global
+    mac admin plugin install --scope repo --repo PATH
+    mac admin plugin status
+    mac admin plugin uninstall
 
 `mac admin login --local-console` is only for a shell on the hub. It asks the
 running API service for a new scoped, independently revocable credential over

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -819,6 +819,44 @@ def cmd_mcp_serve(args: argparse.Namespace) -> None:
     raise SystemExit(serve(_plane(args)))
 
 
+def cmd_plugin_install(args: argparse.Namespace) -> None:
+    """Install the Agent Plugins package into the user's harnesses (ADR 0023)."""
+    from mac.harness_plugin import install
+
+    if args.repo and args.scope == "global":
+        raise ValidationError(
+            "pass --scope repo with --repo, or omit --repo for a global install"
+        )
+    if args.scope == "repo" and not args.repo:
+        raise ValidationError("plugin install --repo is required for --scope repo")
+    _print(
+        install(
+            scope=args.scope,
+            repo=Path(args.repo) if args.repo else None,
+            user_home=Path(args.user_home) if args.user_home else None,
+            skills_root=Path(args.skills_root) if args.skills_root else None,
+        )
+    )
+
+
+def cmd_plugin_status(args: argparse.Namespace) -> None:
+    """Report which harnesses carry which plugin revision."""
+    from mac.harness_plugin import status
+
+    _print(status())
+
+
+def cmd_plugin_uninstall(args: argparse.Namespace) -> None:
+    """Remove the pointers this installer wrote; leave the user's other MCP servers."""
+    from mac.harness_plugin import uninstall
+
+    _print(
+        uninstall(
+            user_home=Path(args.user_home) if args.user_home else None,
+        )
+    )
+
+
 def cmd_init(args: argparse.Namespace) -> None:
     """Initialize the local mac control-plane database."""
     _plane(args)
@@ -9322,6 +9360,47 @@ def build_parser() -> argparse.ArgumentParser:
         "serve", help="serve the mac ledger to a coding agent over stdio"
     )
     _set(cmd_mcp_serve, mcp_serve)
+    plugin = sub.add_parser(
+        "plugin",
+        help="install mac skills and MCP into coding harnesses (ADR 0023)",
+    ).add_subparsers(dest="plugin_command", required=True)
+    plugin_install = plugin.add_parser(
+        "install",
+        help="write the Agent Plugins package and wire detected harnesses",
+    )
+    plugin_install.add_argument(
+        "--scope",
+        choices=("global", "repo"),
+        default="global",
+        help="global: user harness dirs; repo: pointers inside --repo",
+    )
+    plugin_install.add_argument(
+        "--repo",
+        help="install repo-local pointers into this repository; refused for the mac source tree",
+    )
+    plugin_install.add_argument(
+        "--user-home",
+        help="override the user home used to find ~/.claude, ~/.cursor, ~/.codex",
+    )
+    plugin_install.add_argument(
+        "--skills-root",
+        help="canonical skills/ directory; default: discover from cwd or this checkout",
+    )
+    _set(cmd_plugin_install, plugin_install)
+    plugin_status = plugin.add_parser(
+        "status",
+        help="show which harnesses have which plugin revision",
+    )
+    _set(cmd_plugin_status, plugin_status)
+    plugin_uninstall = plugin.add_parser(
+        "uninstall",
+        help="remove pointers this installer wrote",
+    )
+    plugin_uninstall.add_argument(
+        "--user-home",
+        help="override the user home used to find harness config directories",
+    )
+    _set(cmd_plugin_uninstall, plugin_uninstall)
     openshell = sub.add_parser("openshell", help="OpenShell sandbox guardrail commands").add_subparsers(dest="openshell_command", required=True)
     osh_reconcile = openshell.add_parser(
         "reconcile",

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -196,6 +196,7 @@ COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
             ("hgx", "HGX / GPU capacity management"),
             ("openshell", "sandboxed execution environments for agents"),
             ("mcp", "serve the ledger to coding agents as Model Context Protocol tools"),
+            ("plugin", "install mac skills and MCP into Claude, Codex, Cursor, OpenCode"),
             ("sandbox-image", "the sandbox IMAGE: its bill of materials and its rollout"),
             ("runtime", "runtime images and environment definitions"),
             ("rollout", "staged rollout of a runtime or configuration"),

--- a/src/mac/harness_plugin.py
+++ b/src/mac/harness_plugin.py
@@ -1,0 +1,397 @@
+"""Install mac's skills and MCP as an Agent Plugins 1.0 package (ADR 0023).
+
+One canonical directory, thin per-harness pointers. The human CLI and the
+agent plugin share the same ``mac admin mcp serve`` executable. This module
+does not install ``mac`` itself.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+from mac import __version__
+from mac.mac_paths import plugin_dir as default_plugin_dir
+from mac.mcp_server import server_command
+from mac.models import ValidationError, json_dumps
+
+RECEIPT_SCHEMA = "mac.plugin.receipt.v1"
+PLUGIN_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+MCP_SCHEMA = "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json"
+
+HARNESSES = ("claude", "codex", "cursor", "opencode", "pi")
+
+_MAC_SOURCE_MARKERS = (
+    "src/mac/__init__.py",
+    "skills/mac-cli/SKILL.md",
+    "docs/adr/0023-one-skill-source-many-harness-plugins.md",
+)
+
+
+@dataclass(frozen=True)
+class HarnessHomes:
+    """Vendor config roots. Tests pass a fake user home; production uses Path.home()."""
+
+    root: Path
+
+    @property
+    def claude(self) -> Path:
+        return self.root / ".claude"
+
+    @property
+    def cursor(self) -> Path:
+        return self.root / ".cursor"
+
+    @property
+    def codex(self) -> Path:
+        return self.root / ".codex"
+
+    @property
+    def opencode(self) -> Path:
+        return self.root / ".config" / "opencode"
+
+    @property
+    def agents(self) -> Path:
+        return self.root / ".agents"
+
+    @property
+    def pi(self) -> Path:
+        return self.root / ".pi"
+
+
+def is_mac_source_tree(path: Path) -> bool:
+    """True iff ``path`` is this repository, which the installer must refuse."""
+    root = path.resolve()
+    return all((root / marker).is_file() for marker in _MAC_SOURCE_MARKERS)
+
+
+def find_skills_root(start: Optional[Path] = None) -> Path:
+    """Locate the canonical ``skills/`` tree.
+
+    Walks from ``start`` (cwd by default) then from this file's checkout
+    layout. A wheel without a checkout fails closed with a named error.
+    """
+    candidates: List[Path] = []
+    here = Path(start or Path.cwd()).resolve()
+    candidates.append(here)
+    candidates.extend(here.parents)
+    candidates.append(Path(__file__).resolve().parents[2])
+    seen: set[Path] = set()
+    for base in candidates:
+        if base in seen:
+            continue
+        seen.add(base)
+        skills = base / "skills"
+        if (skills / "mac-cli" / "SKILL.md").is_file():
+            return skills
+    raise ValidationError(
+        "cannot find skills/mac-cli/SKILL.md; run mac admin plugin install "
+        "from a mac checkout, or pass --skills-root"
+    )
+
+
+def detect_harnesses(homes: HarnessHomes) -> Dict[str, str]:
+    """Map harness name to ``present`` or ``absent``. Presence is a home directory."""
+    mapping = {
+        "claude": homes.claude,
+        "codex": homes.codex,
+        "cursor": homes.cursor,
+        "opencode": homes.opencode,
+        "pi": homes.pi,
+    }
+    return {name: ("present" if path.is_dir() else "absent") for name, path in mapping.items()}
+
+
+def _skill_dirs(skills_root: Path) -> List[Path]:
+    return sorted(
+        path for path in skills_root.iterdir() if path.is_dir() and (path / "SKILL.md").is_file()
+    )
+
+
+def _write_canonical_plugin(plugin_root: Path, skills_root: Path) -> None:
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    (plugin_root / "plugin.json").write_text(
+        json.dumps(
+            {
+                "$schema": PLUGIN_SCHEMA,
+                "name": "mac",
+                "version": __version__,
+                "description": "MAC control-plane skills and ledger MCP",
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    command = server_command()
+    (plugin_root / "mcp.json").write_text(
+        json.dumps(
+            {
+                "$schema": MCP_SCHEMA,
+                "mcpServers": {
+                    "mac": {
+                        "type": "stdio",
+                        "command": command[0],
+                        "args": command[1:],
+                    }
+                },
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    dest_skills = plugin_root / "skills"
+    if dest_skills.exists():
+        shutil.rmtree(dest_skills)
+    dest_skills.mkdir()
+    for skill in _skill_dirs(skills_root):
+        shutil.copytree(skill, dest_skills / skill.name, dirs_exist_ok=True)
+
+
+def _symlink_skill(target_dir: Path, skill_src: Path) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    dest = target_dir / skill_src.name
+    if dest.is_symlink() or dest.exists():
+        if dest.is_dir() and not dest.is_symlink():
+            shutil.rmtree(dest)
+        else:
+            dest.unlink()
+    dest.symlink_to(skill_src.resolve(), target_is_directory=True)
+
+
+def _merge_mcp_json(path: Path, command: List[str]) -> None:
+    document: Dict[str, Any] = {"mcpServers": {}}
+    if path.is_file():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            loaded = {}
+        if isinstance(loaded, dict):
+            document = loaded
+    servers = document.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        servers = {}
+        document["mcpServers"] = servers
+    servers["mac"] = {
+        "type": "stdio",
+        "command": command[0],
+        "args": command[1:],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _drop_mcp_server(path: Path) -> None:
+    if not path.is_file():
+        return
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return
+    if not isinstance(document, dict):
+        return
+    servers = document.get("mcpServers")
+    if isinstance(servers, dict):
+        servers.pop("mac", None)
+    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _wire_harness(
+    name: str,
+    homes: HarnessHomes,
+    plugin_root: Path,
+    *,
+    detected: Mapping[str, str],
+    repo: Optional[Path],
+) -> str:
+    if detected.get(name) != "present" and repo is None:
+        return "skipped"
+    skills_src = plugin_root / "skills"
+    command = server_command()
+    if name == "claude":
+        for skill in _skill_dirs(skills_src):
+            _symlink_skill(homes.claude / "skills", skill)
+        _merge_mcp_json(homes.claude / "mcp.json", command)
+        return "installed"
+    if name == "cursor":
+        if repo is not None:
+            _merge_mcp_json(repo / ".cursor" / "mcp.json", command)
+            return "installed"
+        _merge_mcp_json(homes.cursor / "mcp.json", command)
+        return "installed"
+    if name == "codex":
+        _merge_mcp_json(homes.codex / "mcp.json", command)
+        return "installed"
+    if name == "opencode":
+        if repo is not None:
+            for skill in _skill_dirs(skills_src):
+                _symlink_skill(repo / ".agents" / "skills", skill)
+            return "installed"
+        for skill in _skill_dirs(skills_src):
+            _symlink_skill(homes.opencode / "skills", skill)
+            _symlink_skill(homes.agents / "skills", skill)
+        _merge_mcp_json(homes.opencode / "mcp.json", command)
+        return "installed"
+    if name == "pi":
+        for skill in _skill_dirs(skills_src):
+            _symlink_skill(homes.pi / "skills", skill)
+        return "installed"
+    return "skipped"
+
+
+def _unwire_harness(
+    name: str, homes: HarnessHomes, plugin_root: Path, repo: Optional[Path]
+) -> None:
+    skill_names = (
+        [path.name for path in _skill_dirs(plugin_root / "skills")]
+        if (plugin_root / "skills").is_dir()
+        else []
+    )
+    skill_homes = {
+        "claude": [homes.claude / "skills"],
+        "opencode": [homes.opencode / "skills", homes.agents / "skills"],
+        "pi": [homes.pi / "skills"],
+    }
+    for directory in skill_homes.get(name, []):
+        for skill_name in skill_names:
+            dest = directory / skill_name
+            if dest.is_symlink() or dest.exists():
+                if dest.is_dir() and not dest.is_symlink():
+                    continue
+                dest.unlink(missing_ok=True)
+    if name in {"claude", "cursor", "codex", "opencode"}:
+        mcp_path = {
+            "claude": homes.claude / "mcp.json",
+            "cursor": homes.cursor / "mcp.json",
+            "codex": homes.codex / "mcp.json",
+            "opencode": homes.opencode / "mcp.json",
+        }[name]
+        _drop_mcp_server(mcp_path)
+    if name == "cursor" and repo is not None:
+        _drop_mcp_server(repo / ".cursor" / "mcp.json")
+    if name == "opencode" and repo is not None:
+        for skill_name in skill_names:
+            dest = repo / ".agents" / "skills" / skill_name
+            if dest.is_symlink():
+                dest.unlink(missing_ok=True)
+
+
+def _receipt_path(plugin_root: Path) -> Path:
+    return plugin_root / "RECEIPT.json"
+
+
+def install(
+    *,
+    scope: str = "global",
+    repo: Optional[Path] = None,
+    user_home: Optional[Path] = None,
+    plugin_root: Optional[Path] = None,
+    skills_root: Optional[Path] = None,
+    now: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Write the canonical plugin and wire detected (or repo-nominated) harnesses."""
+    scope_value = str(scope or "global").strip().lower()
+    if scope_value not in {"global", "repo"}:
+        raise ValidationError("plugin install scope must be 'global' or 'repo'")
+    repo_path = Path(repo).resolve() if repo is not None else None
+    if scope_value == "repo":
+        if repo_path is None:
+            raise ValidationError("plugin install --repo is required for scope=repo")
+        if is_mac_source_tree(repo_path):
+            raise ValidationError(
+                "refusing to install into the mac source tree; nominate another "
+                "repository or use --scope global"
+            )
+    homes = HarnessHomes(Path(user_home).resolve() if user_home is not None else Path.home())
+    root = Path(plugin_root).resolve() if plugin_root is not None else default_plugin_dir()
+    source = Path(skills_root).resolve() if skills_root is not None else find_skills_root()
+    _write_canonical_plugin(root, source)
+    detected = detect_harnesses(homes)
+    if scope_value == "repo":
+        wired = {
+            "claude": "skipped",
+            "codex": "skipped",
+            "cursor": _wire_harness(
+                "cursor", homes, root, detected={"cursor": "present"}, repo=repo_path
+            ),
+            "opencode": _wire_harness(
+                "opencode", homes, root, detected={"opencode": "present"}, repo=repo_path
+            ),
+            "pi": "skipped",
+        }
+    else:
+        wired = {
+            name: _wire_harness(name, homes, root, detected=detected, repo=None)
+            for name in HARNESSES
+        }
+    receipt = {
+        "schema": RECEIPT_SCHEMA,
+        "version": __version__,
+        "scope": scope_value,
+        "plugin_root": str(root),
+        "skills_root": str(source),
+        "repo": str(repo_path) if repo_path is not None else None,
+        "harnesses": wired,
+        "detected": detect_harnesses(homes),
+        "installed_at": (now or datetime.now(timezone.utc)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    _receipt_path(root).write_text(json_dumps(receipt) + "\n", encoding="utf-8")
+    return receipt
+
+
+def status(*, plugin_root: Optional[Path] = None) -> Dict[str, Any]:
+    root = Path(plugin_root).resolve() if plugin_root is not None else default_plugin_dir()
+    path = _receipt_path(root)
+    if not path.is_file():
+        return {
+            "schema": RECEIPT_SCHEMA,
+            "installed": False,
+            "plugin_root": str(root),
+            "stale": False,
+        }
+    receipt = json.loads(path.read_text(encoding="utf-8"))
+    stale = str(receipt.get("version") or "") != __version__
+    receipt["installed"] = True
+    receipt["stale"] = stale
+    return receipt
+
+
+def uninstall(
+    *,
+    plugin_root: Optional[Path] = None,
+    user_home: Optional[Path] = None,
+) -> Dict[str, Any]:
+    root = Path(plugin_root).resolve() if plugin_root is not None else default_plugin_dir()
+    path = _receipt_path(root)
+    if not path.is_file():
+        return {
+            "schema": RECEIPT_SCHEMA,
+            "installed": False,
+            "removed": False,
+            "plugin_root": str(root),
+        }
+    receipt = json.loads(path.read_text(encoding="utf-8"))
+    homes = HarnessHomes(Path(user_home).resolve() if user_home is not None else Path.home())
+    repo = Path(receipt["repo"]) if receipt.get("repo") else None
+    for name in HARNESSES:
+        _unwire_harness(name, homes, root, repo)
+    shutil.rmtree(root, ignore_errors=True)
+    return {
+        "schema": RECEIPT_SCHEMA,
+        "installed": False,
+        "removed": True,
+        "plugin_root": str(root),
+        "harnesses": receipt.get("harnesses") or {},
+    }
+
+
+def peer_must_not_nudge() -> str:
+    """Named obligation for tests: stall recovery is hub-only."""
+    return "hub-only"

--- a/src/mac/mac_paths.py
+++ b/src/mac/mac_paths.py
@@ -41,6 +41,7 @@ __all__ = [
     "script_jobs_scripts_dir",
     "script_jobs_output_dir",
     "legacy_gateway_scripts_dir",
+    "plugin_dir",
 ]
 
 
@@ -64,6 +65,15 @@ def mac_home() -> Path:
     relocation knob once callers route through it.
     """
     return _env_path("MAC_HOME") or (Path.home() / ".mac")
+
+
+def plugin_dir() -> Path:
+    """Canonical Agent Plugins package the installer owns: ``$MAC_HOME/plugin``.
+
+    One copy, then client-specific pointers. Copying the plugin into four
+    harness directories is how they go stale independently.
+    """
+    return mac_home() / "plugin"
 
 
 def gateway_home() -> Path:

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -19146,6 +19146,22 @@ class ControlPlane:
                 level="error",
                 detail={"error": str(exc)[:500]},
             )
+        try:
+            from mac.session_nudge import nudge_stalled_sessions
+
+            stall_nudges = nudge_stalled_sessions(self)
+        except Exception as exc:  # noqa: BLE001 - stall recovery must not stop dispatch
+            stall_nudges = {
+                "schema": "mac.session_nudge.v1",
+                "errors": [{"error": str(exc)[:500]}],
+            }
+            self.record_log(
+                "session_nudge.tick_failed",
+                layer="control_plane",
+                source="dispatcher.tick",
+                level="error",
+                detail={"error": str(exc)[:500]},
+            )
         assignments = (
             self._dispatch_batch_impl(
                 lease_seconds=lease_seconds,
@@ -19164,6 +19180,7 @@ class ControlPlane:
             "review_workflows": review_workflows,
             "source_convergence": source_convergence,
             "crash_repairs": crash_repairs,
+            "stall_nudges": stall_nudges,
             "retention_pruned": retention_pruned,
             "memory_health": memory_health,
             "auto_reopened": [

--- a/src/mac/session_nudge.py
+++ b/src/mac/session_nudge.py
@@ -1,0 +1,205 @@
+"""Hub-only stall nudge for registered agents that have gone silent (ADR 0023).
+
+Peers may observe silence on the broadcast bus. They must not address a
+"get on with it" message. Recovery is one sender — the hub tick — with a
+cap and a cooldown.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from mac.agentbus_broadcast import BROADCAST_LAYER
+from mac.models import TaskState, utcnow
+
+NUDGE_SCHEMA = "mac.session_nudge.v1"
+NUDGE_TOPIC = "mac.session.nudge.v1"
+NUDGE_RESOURCE_KEY = "stall_nudge"
+DEFAULT_SILENCE_SECONDS = 15 * 60
+DEFAULT_COOLDOWN_SECONDS = 10 * 60
+DEFAULT_MAX_ATTEMPTS = 3
+LIVE_STATES = frozenset({TaskState.CLAIMED.value, TaskState.RUNNING.value})
+HUB_SENDER_CANDIDATES = ("agent_operator",)
+
+
+def peer_must_not_nudge() -> str:
+    """Named obligation for tests: stall recovery is hub-only."""
+    return "hub-only"
+
+
+def _parse_time(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    text = str(value).strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _now(value: Optional[str]) -> datetime:
+    parsed = _parse_time(value) if value else None
+    return parsed or _parse_time(utcnow()) or datetime.now(timezone.utc)
+
+
+def last_progress_at(plane: Any, agent_id: str, task_id: Optional[str]) -> Optional[str]:
+    """Latest broadcast the worker (not the hub) made about this work."""
+    try:
+        sql = (
+            "SELECT created_at FROM observability_events "
+            "WHERE layer = ? AND source = ? "
+            "AND name NOT LIKE 'bcast.agent.heartbeat%' "
+        )
+        params: List[Any] = [BROADCAST_LAYER, agent_id]
+        if task_id:
+            sql += "AND subject_id = ? "
+            params.append(task_id)
+        sql += "ORDER BY sequence DESC LIMIT 1"
+        row = plane.store.query_one(sql, tuple(params))
+    except Exception:  # noqa: BLE001 - missing table must not fail the tick
+        return None
+    if row is None:
+        return None
+    if hasattr(row, "keys"):
+        return str(row["created_at"]) if row["created_at"] else None
+    return str(row[0]) if row else None
+
+
+def _hub_sender_id(plane: Any) -> Optional[str]:
+    for agent_id in HUB_SENDER_CANDIDATES:
+        try:
+            agent = plane.get_agent(agent_id)
+        except Exception:  # noqa: BLE001 - missing sender is a skip, not a crash
+            continue
+        resources = agent.resources if isinstance(agent.resources, dict) else {}
+        if resources.get("virtual") is True:
+            return agent.id
+    for agent in plane.list_agents():
+        resources = agent.resources if isinstance(agent.resources, dict) else {}
+        if resources.get("virtual") is True:
+            return agent.id
+    return None
+
+
+def _nudge_state(agent: Any) -> Dict[str, Any]:
+    resources = agent.resources if isinstance(agent.resources, dict) else {}
+    state = resources.get(NUDGE_RESOURCE_KEY)
+    return dict(state) if isinstance(state, dict) else {}
+
+
+def should_nudge(
+    *,
+    last_progress: Optional[str],
+    fallback_at: Optional[str],
+    nudge_state: Dict[str, Any],
+    now: datetime,
+    silence_seconds: int,
+    cooldown_seconds: int,
+    max_attempts: int,
+) -> bool:
+    attempts = int(nudge_state.get("count") or 0)
+    if attempts >= max_attempts:
+        return False
+    last_nudge = _parse_time(nudge_state.get("last_at"))
+    if last_nudge is not None and now - last_nudge < timedelta(seconds=cooldown_seconds):
+        return False
+    mark = _parse_time(last_progress) or _parse_time(fallback_at)
+    if mark is None:
+        return False
+    return now - mark >= timedelta(seconds=silence_seconds)
+
+
+def nudge_stalled_sessions(
+    plane: Any,
+    *,
+    now: Optional[str] = None,
+    silence_seconds: int = DEFAULT_SILENCE_SECONDS,
+    cooldown_seconds: int = DEFAULT_COOLDOWN_SECONDS,
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+) -> Dict[str, Any]:
+    """Address one stall nudge per silent live task. Hub tick is the only caller."""
+    clock = _now(now)
+    ensure = getattr(plane, "_ensure_operator_persona", None)
+    if callable(ensure):
+        try:
+            ensure()
+        except Exception:  # noqa: BLE001 - missing steward is a skip, not a crash
+            pass
+    sender_id = _hub_sender_id(plane)
+    nudged: List[Dict[str, Any]] = []
+    skipped: List[str] = []
+    if sender_id is None:
+        return {
+            "schema": NUDGE_SCHEMA,
+            "nudged": [],
+            "skipped": ["no_virtual_hub_sender"],
+            "sender_id": None,
+        }
+    for task in plane.list_tasks(state=list(LIVE_STATES)):
+        if str(getattr(task, "state", "")) not in LIVE_STATES:
+            continue
+        agent_id = str(getattr(task, "owner_agent_id", "") or "").strip()
+        if not agent_id:
+            skipped.append("task_without_owner:%s" % task.id)
+            continue
+        try:
+            agent = plane.get_agent(agent_id)
+        except Exception:  # noqa: BLE001
+            skipped.append("missing_agent:%s" % agent_id)
+            continue
+        resources = dict(agent.resources) if isinstance(agent.resources, dict) else {}
+        if resources.get("virtual") is True:
+            skipped.append("virtual:%s" % agent_id)
+            continue
+        state = _nudge_state(agent)
+        progress = last_progress_at(plane, agent_id, task.id)
+        fallback = getattr(task, "started_at", None) or getattr(task, "updated_at", None)
+        if not should_nudge(
+            last_progress=progress,
+            fallback_at=fallback,
+            nudge_state=state,
+            now=clock,
+            silence_seconds=silence_seconds,
+            cooldown_seconds=cooldown_seconds,
+            max_attempts=max_attempts,
+        ):
+            continue
+        attempt = int(state.get("count") or 0) + 1
+        payload = {
+            "schema": NUDGE_SCHEMA,
+            "reason": "stall",
+            "task_id": task.id,
+            "attempt": attempt,
+            "next_step": (
+                "Read the AgentBus broadcast, then either claim ready work, "
+                "announce progress, or address the hub with what is blocking you. "
+                "Do not wait for a peer to nudge you."
+            ),
+        }
+        plane.agentbus.publish(
+            sender_id,
+            recipient_agent_id=agent_id,
+            topic=NUDGE_TOPIC,
+            content_type="application/json",
+            payload=payload,
+            task_id=task.id,
+        )
+        resources[NUDGE_RESOURCE_KEY] = {
+            "count": attempt,
+            "last_at": clock.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "task_id": task.id,
+        }
+        plane.update_agent(agent_id, resources=resources, actor="hub.tick")
+        nudged.append({"agent_id": agent_id, "task_id": task.id, "attempt": attempt})
+    return {
+        "schema": NUDGE_SCHEMA,
+        "sender_id": sender_id,
+        "nudged": nudged,
+        "skipped": skipped,
+    }

--- a/tests/cli/test_cli_plugin.py
+++ b/tests/cli/test_cli_plugin.py
@@ -1,0 +1,92 @@
+"""`mac admin plugin` at the CLI layer (ADR 0023)."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+from mac.cli import main
+from mac.test_support import dsn_for
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _run(tmp_path, *args, env_home=None):
+    out = io.StringIO()
+    err = io.StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = out, err
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+    raw = out.getvalue().strip()
+    return rc, (json.loads(raw) if raw else None), err.getvalue()
+
+
+def _skills(tmp_path: Path) -> Path:
+    root = tmp_path / "skills"
+    skill = root / "mac-cli"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# mac-cli\n", encoding="utf-8")
+    return root
+
+
+def test_plugin_install_status_uninstall(tmp_path, monkeypatch):
+    mac_home = tmp_path / "mac-home"
+    user_home = tmp_path / "user"
+    (user_home / ".cursor").mkdir(parents=True)
+    monkeypatch.setenv("MAC_HOME", str(mac_home))
+    skills = _skills(tmp_path)
+
+    rc, installed, _err = _run(
+        tmp_path,
+        "admin",
+        "plugin",
+        "install",
+        "--scope",
+        "global",
+        "--user-home",
+        str(user_home),
+        "--skills-root",
+        str(skills),
+    )
+    assert rc in (None, 0)
+    assert installed["harnesses"]["cursor"] == "installed"
+    assert (mac_home / "plugin" / "plugin.json").is_file()
+
+    rc, reported, _err = _run(tmp_path, "admin", "plugin", "status")
+    assert rc in (None, 0)
+    assert reported["installed"] is True
+
+    rc, removed, _err = _run(
+        tmp_path,
+        "admin",
+        "plugin",
+        "uninstall",
+        "--user-home",
+        str(user_home),
+    )
+    assert rc in (None, 0)
+    assert removed["removed"] is True
+    assert not (mac_home / "plugin").exists()
+
+
+def test_plugin_install_refuses_the_mac_source_tree(tmp_path, monkeypatch):
+    monkeypatch.setenv("MAC_HOME", str(tmp_path / "mac-home"))
+    rc, _out, err = _run(
+        tmp_path,
+        "admin",
+        "plugin",
+        "install",
+        "--scope",
+        "repo",
+        "--repo",
+        str(REPO),
+        "--skills-root",
+        str(_skills(tmp_path)),
+    )
+    assert rc == 1
+    assert "mac source tree" in err

--- a/tests/test_harness_plugin.py
+++ b/tests/test_harness_plugin.py
@@ -1,0 +1,155 @@
+"""Agent Plugins installer (ADR 0023): one package, thin harness pointers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from mac.harness_plugin import (
+    RECEIPT_SCHEMA,
+    find_skills_root,
+    install,
+    is_mac_source_tree,
+    peer_must_not_nudge,
+    status,
+    uninstall,
+)
+from mac.mcp_server import server_command
+from mac.models import ValidationError
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _skills(tmp_path: Path) -> Path:
+    root = tmp_path / "skills"
+    skill = root / "mac-cli"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# mac-cli\n", encoding="utf-8")
+    return root
+
+
+def _homes(tmp_path: Path, *names: str) -> Path:
+    home = tmp_path / "home"
+    mapping = {
+        "claude": home / ".claude",
+        "cursor": home / ".cursor",
+        "codex": home / ".codex",
+        "opencode": home / ".config" / "opencode",
+        "pi": home / ".pi",
+    }
+    for name in names:
+        mapping[name].mkdir(parents=True)
+    return home
+
+
+def test_server_command_is_the_existing_mcp_verb():
+    assert server_command() == ["mac", "admin", "mcp", "serve"]
+
+
+def test_peer_must_not_nudge_is_hub_only():
+    assert peer_must_not_nudge() == "hub-only"
+
+
+def test_mac_source_tree_is_refused(tmp_path):
+    assert is_mac_source_tree(REPO)
+    other = tmp_path / "other"
+    other.mkdir()
+    assert is_mac_source_tree(other) is False
+
+
+def test_global_install_wires_detected_harnesses_only(tmp_path):
+    home = _homes(tmp_path, "claude", "cursor")
+    plugin = tmp_path / "plugin"
+    receipt = install(
+        user_home=home,
+        plugin_root=plugin,
+        skills_root=_skills(tmp_path),
+    )
+
+    assert receipt["schema"] == RECEIPT_SCHEMA
+    assert receipt["harnesses"]["claude"] == "installed"
+    assert receipt["harnesses"]["cursor"] == "installed"
+    assert receipt["harnesses"]["codex"] == "skipped"
+    assert (plugin / "plugin.json").is_file()
+    assert json.loads((plugin / "mcp.json").read_text(encoding="utf-8"))["mcpServers"]["mac"][
+        "args"
+    ] == ["admin", "mcp", "serve"]
+    assert (home / ".claude" / "skills" / "mac-cli").is_symlink()
+    cursor_mcp = json.loads((home / ".cursor" / "mcp.json").read_text(encoding="utf-8"))
+    assert cursor_mcp["mcpServers"]["mac"]["command"] == "mac"
+    assert not (home / ".codex" / "mcp.json").exists()
+
+
+def test_repo_install_refuses_the_mac_tree(tmp_path):
+    with pytest.raises(ValidationError, match="mac source tree"):
+        install(
+            scope="repo",
+            repo=REPO,
+            user_home=_homes(tmp_path),
+            plugin_root=tmp_path / "plugin",
+            skills_root=_skills(tmp_path),
+        )
+
+
+def test_repo_install_writes_only_repo_pointers(tmp_path):
+    home = _homes(tmp_path, "cursor", "claude")
+    repo = tmp_path / "app"
+    repo.mkdir()
+    plugin = tmp_path / "plugin"
+    receipt = install(
+        scope="repo",
+        repo=repo,
+        user_home=home,
+        plugin_root=plugin,
+        skills_root=_skills(tmp_path),
+    )
+
+    assert receipt["harnesses"]["cursor"] == "installed"
+    assert receipt["harnesses"]["opencode"] == "installed"
+    assert receipt["harnesses"]["claude"] == "skipped"
+    assert (repo / ".cursor" / "mcp.json").is_file()
+    assert (repo / ".agents" / "skills" / "mac-cli").is_symlink()
+    assert not (home / ".cursor" / "mcp.json").exists()
+    assert not (home / ".claude" / "skills" / "mac-cli").exists()
+
+
+def test_uninstall_drops_mac_mcp_and_keeps_the_rest(tmp_path):
+    home = _homes(tmp_path, "cursor")
+    mcp = home / ".cursor" / "mcp.json"
+    mcp.write_text(
+        json.dumps({"mcpServers": {"other": {"command": "keep-me"}}}),
+        encoding="utf-8",
+    )
+    plugin = tmp_path / "plugin"
+    install(
+        user_home=home,
+        plugin_root=plugin,
+        skills_root=_skills(tmp_path),
+    )
+    result = uninstall(user_home=home, plugin_root=plugin)
+
+    assert result["removed"] is True
+    assert not plugin.exists()
+    leftover = json.loads(mcp.read_text(encoding="utf-8"))
+    assert "mac" not in leftover["mcpServers"]
+    assert leftover["mcpServers"]["other"]["command"] == "keep-me"
+
+
+def test_status_reports_missing_and_installed(tmp_path):
+    plugin = tmp_path / "plugin"
+    missing = status(plugin_root=plugin)
+    assert missing["installed"] is False
+    install(
+        user_home=_homes(tmp_path, "pi"),
+        plugin_root=plugin,
+        skills_root=_skills(tmp_path),
+    )
+    present = status(plugin_root=plugin)
+    assert present["installed"] is True
+    assert present["stale"] is False
+
+
+def test_find_skills_root_sees_this_checkout():
+    assert (find_skills_root(REPO) / "mac-cli" / "SKILL.md").is_file()

--- a/tests/test_mac_cli_skill.py
+++ b/tests/test_mac_cli_skill.py
@@ -178,6 +178,9 @@ def test_the_traps_it_documents_are_real(tree):
     for moved in ("dispatch", "human", "memory", "machine", "fleet"):
         assert ("admin", moved) in tree, "admin %s should exist" % moved
         assert (moved,) not in tree, "%s should have moved under admin" % moved
+    # ADR 0023: the installer is admin plugin, not agent install.
+    assert ("admin", "plugin", "install") in tree
+    assert ("agent", "install") not in tree
 
 
 def test_agent_update_still_cannot_set_status():

--- a/tests/test_session_nudge.py
+++ b/tests/test_session_nudge.py
@@ -1,0 +1,198 @@
+"""Hub-only stall nudge (ADR 0023): one sender, cap, cooldown, heartbeat ≠ progress."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from mac.agentbus_broadcast import BROADCAST_LAYER
+from mac.harness_plugin import peer_must_not_nudge as plugin_peer_must_not_nudge
+from mac.models import parse_time, utcnow
+from mac.services import ControlPlane
+from mac.session_nudge import (
+    DEFAULT_MAX_ATTEMPTS,
+    NUDGE_SCHEMA,
+    NUDGE_TOPIC,
+    nudge_stalled_sessions,
+    peer_must_not_nudge,
+)
+
+
+def _iso(stamp, **delta):
+    return (parse_time(stamp) + timedelta(**delta)).isoformat()
+
+
+def _broadcast(cp, name, agent_id, subject_id, when):
+    cp.observability.insert_observation(
+        cp.store,
+        "log",
+        name,
+        BROADCAST_LAYER,
+        agent_id,
+        "info",
+        None,
+        "",
+        "task",
+        subject_id,
+        {},
+        when,
+    )
+
+
+def _live(cp: ControlPlane):
+    cp._ensure_operator_persona()
+    machine = cp.register_machine("worker-host")
+    agent = cp.register_agent(machine.id, "worker", capabilities=["python"])
+    task = cp.create_task(title="silent work")
+    cp.claim_task(task.id, agent.id)
+    return agent, cp.get_task(task.id)
+
+
+def test_peer_obligation_is_hub_only():
+    assert peer_must_not_nudge() == "hub-only"
+    assert plugin_peer_must_not_nudge() == "hub-only"
+
+
+def test_silence_gets_one_addressed_nudge_from_the_hub():
+    cp = ControlPlane.in_memory()
+    agent, task = _live(cp)
+    claimed_at = utcnow()
+
+    result = nudge_stalled_sessions(
+        cp,
+        now=_iso(claimed_at, minutes=20),
+        silence_seconds=600,
+        cooldown_seconds=60,
+    )
+
+    assert result["sender_id"] == "agent_operator"
+    assert result["nudged"] == [{"agent_id": agent.id, "task_id": task.id, "attempt": 1}]
+    streams = cp.agentbus.list_streams(agent_id=agent.id)
+    assert any(stream.topic == NUDGE_TOPIC for stream in streams)
+    assert all(
+        stream.sender_agent_id == "agent_operator"
+        for stream in streams
+        if stream.topic == NUDGE_TOPIC
+    )
+    stored = cp.get_agent(agent.id).resources["stall_nudge"]
+    assert stored["count"] == 1
+    assert stored["task_id"] == task.id
+
+
+def test_recent_progress_is_not_a_stall():
+    cp = ControlPlane.in_memory()
+    agent, task = _live(cp)
+    claimed_at = utcnow()
+    _broadcast(
+        cp,
+        "bcast.task.progress",
+        agent.id,
+        task.id,
+        _iso(claimed_at, minutes=19),
+    )
+
+    result = nudge_stalled_sessions(
+        cp,
+        now=_iso(claimed_at, minutes=20),
+        silence_seconds=600,
+    )
+
+    assert result["nudged"] == []
+
+
+def test_heartbeat_is_not_progress():
+    cp = ControlPlane.in_memory()
+    agent, task = _live(cp)
+    claimed_at = utcnow()
+    _broadcast(
+        cp,
+        "bcast.agent.heartbeat.v1",
+        agent.id,
+        task.id,
+        _iso(claimed_at, minutes=19),
+    )
+
+    result = nudge_stalled_sessions(
+        cp,
+        now=_iso(claimed_at, minutes=20),
+        silence_seconds=600,
+    )
+
+    assert result["nudged"][0]["task_id"] == task.id
+
+
+def test_cooldown_and_cap():
+    cp = ControlPlane.in_memory()
+    agent, task = _live(cp)
+    claimed_at = utcnow()
+
+    first = nudge_stalled_sessions(
+        cp,
+        now=_iso(claimed_at, minutes=20),
+        silence_seconds=600,
+        cooldown_seconds=600,
+        max_attempts=2,
+    )
+    immediate = nudge_stalled_sessions(
+        cp,
+        now=_iso(claimed_at, minutes=21),
+        silence_seconds=600,
+        cooldown_seconds=600,
+        max_attempts=2,
+    )
+    second = nudge_stalled_sessions(
+        cp,
+        now=_iso(claimed_at, minutes=40),
+        silence_seconds=600,
+        cooldown_seconds=600,
+        max_attempts=2,
+    )
+    capped = nudge_stalled_sessions(
+        cp,
+        now=_iso(claimed_at, minutes=60),
+        silence_seconds=600,
+        cooldown_seconds=600,
+        max_attempts=2,
+    )
+
+    assert first["nudged"][0]["attempt"] == 1
+    assert immediate["nudged"] == []
+    assert second["nudged"][0]["attempt"] == 2
+    assert capped["nudged"] == []
+    assert cp.get_agent(agent.id).resources["stall_nudge"]["count"] == 2
+    assert DEFAULT_MAX_ATTEMPTS == 3
+
+
+def test_waiting_work_is_not_a_stall():
+    cp = ControlPlane.in_memory()
+    cp._ensure_operator_persona()
+    machine = cp.register_machine("worker-host")
+    agent = cp.register_agent(machine.id, "worker")
+    task = cp.create_task(title="needs a human")
+    cp.store.execute(
+        "UPDATE tasks SET state = ?, owner_agent_id = ? WHERE id = ?",
+        ("waiting", agent.id, task.id),
+    )
+
+    result = nudge_stalled_sessions(
+        cp,
+        now=_iso(utcnow(), minutes=20),
+        silence_seconds=600,
+    )
+
+    assert result["nudged"] == []
+
+
+def test_tick_includes_stall_nudges_and_swallows_failures(monkeypatch):
+    cp = ControlPlane.in_memory()
+    healthy = cp.tick(limit=0)
+    assert healthy["stall_nudges"]["schema"] == NUDGE_SCHEMA
+    assert not healthy["stall_nudges"].get("errors")
+
+    def _boom(_plane, **_kwargs):
+        raise RuntimeError("nudge exploded")
+
+    monkeypatch.setattr("mac.session_nudge.nudge_stalled_sessions", _boom)
+    broken = ControlPlane.in_memory()
+    tick = broken.tick(limit=0)
+    assert tick["stall_nudges"]["errors"]
+    assert "assignments" in tick


### PR DESCRIPTION
## Summary
- Ships **ADR 0023**: `mac admin plugin install|status|uninstall` writes one Agent Plugins 1.0 package under `$MAC_HOME/plugin` and wires detected Claude/Codex/Cursor/OpenCode/Pi harnesses to the existing `mac admin mcp serve`. The mac source tree is refused as a `--scope repo` target.
- Hub-only stall nudge on `ControlPlane.tick`: addressed inbox message, cap + cooldown, heartbeat is not progress. Peers must not nudge.
- Marks ADR 0023 **Accepted**. `mac agent install` remains not a verb.

## Test plan
- [x] `pytest` on `tests/test_harness_plugin.py`, `tests/test_session_nudge.py`, `tests/cli/test_cli_plugin.py`, CLI coverage/admin surface/skill gates
- [x] `make lint`
- [x] `scripts/generate-docs-reference.py --check`