### PR TITLE
Add bounded local continuation under hub supervision

### DIFF
--- a/docs/adr/0033-local-continuation-hub-supervision.md
+++ b/docs/adr/0033-local-continuation-hub-supervision.md
@@ -1,0 +1,76 @@
+# ADR 0033: Agents continue locally under independent hub supervision
+
+- Status: **Accepted**
+- Date: 2026-08-25
+- Decision owner: MAC fleet owner
+- Related: [ADR 0013](0013-authoritative-hub-allocator.md) — the hub remains the
+  task and lease authority
+- Related: [ADR 0023](0023-one-skill-source-many-harness-plugins.md) — only the
+  hub sends an addressed stall nudge
+- Related: [ADR 0026](0026-first-class-operations-emit-bus-events.md) — agents
+  announce coarse progress; they do not stream private reasoning
+- Related: [ADR 0032](0032-cli-session-hooks-not-tmux.md) — harness hooks are the
+  live I/O boundary for interactive CLI sessions
+
+## Context
+
+A hub-only recovery nudge solves duplicate supervision: peers do not all prod a
+silent session. It should not also make the hub responsible for every ordinary
+next turn. A healthy worker already knows that its previous iteration finished
+and can schedule its next one without a round trip.
+
+The opposite extreme is also wrong. A perpetual local mind that chooses work,
+keeps working after losing its lease, or treats its own timer as authority can
+conflict with another agent and spend tokens while explicitly waiting for CI,
+review, or a human.
+
+The useful part of a persistent microharness is local continuation and bounded
+backoff. The useful part of MAC is independent authority and recovery.
+
+## Decision
+
+**A healthy agent schedules its own next iteration. Every iteration re-enters
+through the hub's heartbeat, hold, claim, task-state, and lease checks.**
+
+The local continuation policy has four outcomes:
+
+1. Real work or progress schedules an immediate next iteration.
+2. An empty iteration schedules exponential backoff with a small cap.
+3. A transient iteration failure schedules the same bounded recovery backoff.
+4. An explicit hub hold is waiting, not progress: local wakes stay at the cap
+   until the hub releases the hold.
+
+The worker's timer is a wake-up mechanism, not authority. It does not preserve a
+claim across iterations, select work outside the ledger, edit a running task, or
+override a hold. The existing lease renewal thread and subprocess timeout remain
+the local watchdogs while an executor is active. If the worker process crashes,
+hangs past that timeout, loses its lease, or stops producing progress, the hub's
+independent liveness and ADR 0023 stall recovery still apply.
+
+Workers emit `task.progress` only at coarse execution boundaries:
+`execution_started` and `execution_finished`. Tool thoughts, chain-of-thought,
+and per-token activity are never published. These events let the hub distinguish
+productive work from a heartbeat-only stall without creating a firehose.
+
+Interactive Claude, Codex, Cursor, OpenCode, and Pi sessions use the same policy
+at their own turn boundary once ADR 0032 hooks are installed. The fleet worker
+implementation does not wrap those CLIs in tmux or introduce another session
+protocol.
+
+## Consequences
+
+- Productive agents continue without waiting for a hub nudge.
+- Empty queues and transient faults do not hot-poll.
+- A durable hold suspends speculative work and token use.
+- The hub can still recover a dead local loop because liveness, ownership, and
+  addressed nudging remain independent of that loop.
+- Local continuation is a small deterministic state machine with focused tests,
+  rather than prompt language every harness may interpret differently.
+
+## Not this ADR
+
+- Autonomous interest selection while idle.
+- Peer-to-peer stall nudges.
+- Removing leases, heartbeats, subprocess timeouts, or hub stall detection.
+- Streaming private model reasoning to AgentBus.
+- Implementing the harness hook adapters accepted by ADR 0032.

--- a/docs/archive/index.md
+++ b/docs/archive/index.md
@@ -39,6 +39,7 @@ to their retained sources.
 - [ADR 0029: The coding-route search path is a fleet contract, not per-worker environment](../adr/0029-the-route-search-path-is-a-fleet-contract.md) — `adr/0029-the-route-search-path-is-a-fleet-contract.md`
 - [ADR 0030: LangChain extracts meaning on the agent; hub Qdrant only stores the extract](../adr/0030-langchain-extracts-before-qdrant.md) — `adr/0030-langchain-extracts-before-qdrant.md`
 - [ADR 0032: CLI sessions use each harness's hooks, not tmux, for recording and AgentBus injection](../adr/0032-cli-session-hooks-not-tmux.md) — `adr/0032-cli-session-hooks-not-tmux.md`
+- [ADR 0033: Agents continue locally under independent hub supervision](../adr/0033-local-continuation-hub-supervision.md) — `adr/0033-local-continuation-hub-supervision.md`
 - [Autonomous Project Routing and Review/Fix Loop Implementation Plan](../superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md) — `superpowers/plans/2026-05-31-autonomous-project-routing-review-fix-loop.md`
 - [Autonomous Project Routing and Review/Fix Loop Design](../superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md) — `superpowers/specs/2026-05-31-autonomous-review-fix-loop-design.md`
 - [K8s bootstrap fleet registration — design](../superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md) — `superpowers/specs/2026-06-04-k8s-bootstrap-fleet-registration-design.md`

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -47,6 +47,7 @@ marked `historical archive` and must not be read as current behaviour.
 | architecture decision | [`adr/0029-the-route-search-path-is-a-fleet-contract.md`](../adr/0029-the-route-search-path-is-a-fleet-contract.md) | ADR 0029: The coding-route search path is a fleet contract, not per-worker environment |
 | architecture decision | [`adr/0030-langchain-extracts-before-qdrant.md`](../adr/0030-langchain-extracts-before-qdrant.md) | ADR 0030: LangChain extracts meaning on the agent; hub Qdrant only stores the extract |
 | architecture decision | [`adr/0032-cli-session-hooks-not-tmux.md`](../adr/0032-cli-session-hooks-not-tmux.md) | ADR 0032: CLI sessions use each harness's hooks, not tmux, for recording and AgentBus injection |
+| architecture decision | [`adr/0033-local-continuation-hub-supervision.md`](../adr/0033-local-continuation-hub-supervision.md) | ADR 0033: Agents continue locally under independent hub supervision |
 | supplemental reference | [`agent-lifecycle-proof.md`](../agent-lifecycle-proof.md) | Agent Lifecycle Proof |
 | historical archive | [`archive/field-notes/assessment-2026-08-02.md`](../archive/field-notes/assessment-2026-08-02.md) | Can MAC do work? — fleet assessment, 2026-08-02 |
 | historical archive | [`archive/field-notes/assessment-task-1b6783.md`](../archive/field-notes/assessment-task-1b6783.md) | Assessment: task_1b67831356c347c3a91d782982f47d1c |

--- a/src/mac/agent_inner_loop.py
+++ b/src/mac/agent_inner_loop.py
@@ -1,0 +1,116 @@
+"""Bounded local continuation policy for persistent MAC workers.
+
+The worker owns *when to try again*; the hub still owns *whether it may work*.
+Every wake therefore returns to the normal heartbeat, hold, claim, and lease
+checks instead of carrying authority across iterations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+PROGRESS_STATUSES = frozenset(
+    {
+        "blocked",
+        "completed",
+        "decomposed",
+        "failed",
+        "needs_review",
+        "review_nudge_invalid",
+        "review_verdict_failed",
+        "stale_result",
+        "submitted_for_review",
+    }
+)
+WAITING_STATUSES = frozenset({"held"})
+TERMINAL_STATUSES = frozenset({"self_update_restart"})
+
+
+@dataclass(frozen=True)
+class InnerLoopDecision:
+    """One local scheduling decision, with no task or lease authority."""
+
+    mode: str
+    delay_seconds: float
+    streak: int
+    reason: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema": "mac.agent_inner_loop.v1",
+            "mode": self.mode,
+            "delay_seconds": self.delay_seconds,
+            "streak": self.streak,
+            "reason": self.reason,
+        }
+
+
+class PersistentAgentLoop:
+    """Schedule immediate continuation or a bounded self-wake.
+
+    Productive iterations continue immediately. Empty and failed iterations
+    back off exponentially to avoid hot polling. A durable hub hold is treated
+    as explicit waiting and stays at the cap until the hub releases it.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_delay_seconds: float,
+        max_delay_seconds: float,
+    ) -> None:
+        self.base_delay_seconds = max(0.0, float(base_delay_seconds))
+        self.max_delay_seconds = max(self.base_delay_seconds, float(max_delay_seconds))
+        self._empty_streak = 0
+        self._error_streak = 0
+
+    def observe(self, status: str) -> InnerLoopDecision:
+        normalized = str(status or "error").strip().lower()
+        if normalized in TERMINAL_STATUSES:
+            self._reset()
+            return InnerLoopDecision("stopped", 0.0, 0, normalized)
+        if normalized in WAITING_STATUSES:
+            self._empty_streak = 0
+            self._error_streak = 0
+            return InnerLoopDecision(
+                "waiting",
+                self.max_delay_seconds,
+                0,
+                normalized,
+            )
+        if normalized == "no_task":
+            self._error_streak = 0
+            self._empty_streak += 1
+            return InnerLoopDecision(
+                "idle",
+                self._bounded_delay(self._empty_streak),
+                self._empty_streak,
+                normalized,
+            )
+        if normalized == "error":
+            self._empty_streak = 0
+            self._error_streak += 1
+            return InnerLoopDecision(
+                "recovering",
+                self._bounded_delay(self._error_streak),
+                self._error_streak,
+                normalized,
+            )
+
+        self._reset()
+        return InnerLoopDecision(
+            "continuing",
+            0.0,
+            0,
+            normalized if normalized in PROGRESS_STATUSES else "work_observed",
+        )
+
+    def _bounded_delay(self, streak: int) -> float:
+        if self.base_delay_seconds == 0:
+            return 0.0
+        exponent = min(max(0, streak - 1), 30)
+        return min(self.max_delay_seconds, self.base_delay_seconds * (2**exponent))
+
+    def _reset(self) -> None:
+        self._empty_streak = 0
+        self._error_streak = 0

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -68,7 +68,9 @@ from mac.agentbus_control import (
     debug_terminal_output_payload,
     reflect_result_payload,
 )
+from mac.agent_inner_loop import PersistentAgentLoop
 from mac.env_config import resolve_hub_agent
+from mac.session_nudge import NUDGE_TOPIC
 
 # Shared with the hub's checksum helper on purpose: if the two ever computed the
 # digest differently the worker would rewrite its policy on every sweep and
@@ -918,6 +920,14 @@ class MacWorker(
         # signature rejections can never drive a rotation loop.
         self._last_attestation_heal_at = 0.0
         self.poll_interval_seconds = float(poll_interval_seconds)
+        self._inner_loop_wake = threading.Event()
+        self._inner_loop = PersistentAgentLoop(
+            base_delay_seconds=self.poll_interval_seconds,
+            max_delay_seconds=min(
+                5.0,
+                max(self.poll_interval_seconds, self.poll_interval_seconds * 8.0),
+            ),
+        )
         self.allowed_projects = list(allowed_projects or [])
         self.required_metadata = dict(required_metadata or {})
         self.claim_only_canary_tasks = bool(claim_only_canary_tasks)
@@ -1022,6 +1032,7 @@ class MacWorker(
     def stop(self) -> None:
         """Signal the run loop to exit after the current task."""
         self._stop = True
+        self._inner_loop_wake.set()
 
     def run_forever(self, max_iterations: Optional[int] = None) -> List[WorkerRunResult]:
         """Loop run_once() with sleep on empty. Bounded by max_iterations for tests.
@@ -1062,15 +1073,27 @@ class MacWorker(
                         level="error",
                         detail={"error": str(exc), "iteration": iterations},
                     )
-                    results.append(WorkerRunResult(status="error", error=str(exc)))
+                    outcome = WorkerRunResult(status="error", error=str(exc))
+                    results.append(outcome)
                     if max_iterations is None:
-                        time.sleep(self.poll_interval_seconds)
+                        decision = self._inner_loop.observe(outcome.status)
+                        self._inner_loop_wake.wait(decision.delay_seconds)
+                        self._inner_loop_wake.clear()
                     continue
-                if outcome.status in {"no_task", "held"}:
-                    if max_iterations is None:
-                        time.sleep(self.poll_interval_seconds)
-                    continue
-                results.append(outcome)
+                if outcome.status not in {"no_task", "held"}:
+                    results.append(outcome)
+                if max_iterations is None:
+                    decision = self._inner_loop.observe(outcome.status)
+                    self._observe_log(
+                        "worker.inner_loop.%s" % decision.mode,
+                        level="debug",
+                        subject_type="agent",
+                        subject_id=self.agent_id,
+                        detail=decision.to_dict(),
+                    )
+                    if decision.delay_seconds > 0:
+                        self._inner_loop_wake.wait(decision.delay_seconds)
+                        self._inner_loop_wake.clear()
         finally:
             self._restore_signal_handlers(prior_handlers)
             self._stop_delivery_drain_thread()
@@ -1514,6 +1537,16 @@ class MacWorker(
                     task_dir = self._prepare_task_workspace(task, lease)
                 else:
                     raise
+            self._emit_bus_event(
+                "task.progress",
+                task_id=task_id,
+                project=str(task.get("project") or "") or None,
+                payload={
+                    "schema": "mac.agent_inner_loop.progress.v1",
+                    "phase": "execution_started",
+                    "continuation": "local",
+                },
+            )
             started = time.monotonic()
             execution = self._execute_with_lease_renewal(task, lease, task_dir)
             duration_ms = (time.monotonic() - started) * 1000.0
@@ -1531,6 +1564,17 @@ class MacWorker(
                 subject_type="task",
                 subject_id=task_id,
                 detail={"returncode": execution.returncode, "summary": execution.summary},
+            )
+            self._emit_bus_event(
+                "task.progress",
+                task_id=task_id,
+                project=str(task.get("project") or "") or None,
+                payload={
+                    "schema": "mac.agent_inner_loop.progress.v1",
+                    "phase": "execution_finished",
+                    "returncode": execution.returncode,
+                    "duration_ms": round(duration_ms, 3),
+                },
             )
             if not self._assignment_is_current(task_id, lease_id):
                 return self._stale_result(
@@ -2718,6 +2762,25 @@ class MacWorker(
                 result = self._handle_reflect_request_stream(stream)
                 processed.append(stream_id)
                 self._save_agentbus_control_state(processed)
+                continue
+            if topic == NUDGE_TOPIC and content_type == "application/json":
+                # A hub nudge is an independent recovery signal, not task
+                # authority. Wake the local scheduler; the normal heartbeat,
+                # hold, claim, task-state, and lease checks still decide
+                # whether this worker may do anything.
+                processed.append(stream_id)
+                self._save_agentbus_control_state(processed)
+                self._inner_loop_wake.set()
+                self._observe_log(
+                    "worker.inner_loop.hub_nudge_received",
+                    level="info",
+                    subject_type="task",
+                    subject_id=str(stream.get("task_id") or "") or None,
+                    detail={
+                        "agent_id": self.agent_id,
+                        "stream_id": stream_id,
+                    },
+                )
                 continue
             # Directable peer/directive handling (task_c6f02f06). Default OFF:
             # when MAC_WORKER_DIRECTABLE is unset these branches are not entered

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -356,6 +356,35 @@ class WorkerRunResult:
         return asdict(self)
 
 
+def _emit_task_progress(
+    worker: Any,
+    task: JsonDict,
+    phase: str,
+    **payload: Any,
+) -> None:
+    """Emit a coarse progress boundary when the host supports AgentBus.
+
+    ``execute_assignment`` is intentionally reusable by small harnesses in
+    tests and K8s adapters. Those hosts implement the execution contract but
+    do not necessarily mix in worker observability, so progress remains
+    best-effort rather than becoming a new execution prerequisite.
+    """
+
+    emit = getattr(worker, "_emit_bus_event", None)
+    if not callable(emit):
+        return
+    emit(
+        "task.progress",
+        task_id=str(task.get("id") or "") or None,
+        project=str(task.get("project") or "") or None,
+        payload={
+            "schema": "mac.agent_inner_loop.progress.v1",
+            "phase": phase,
+            **payload,
+        },
+    )
+
+
 def _build_willing_media_routes(host: str, hardware: Optional[JsonDict]) -> List[JsonDict]:
     """All media routes this host is configured (willing) to serve: catalog-
     derived + GPU-gated (advertised_media_routes returns [] off-GPU). One server
@@ -1537,15 +1566,11 @@ class MacWorker(
                     task_dir = self._prepare_task_workspace(task, lease)
                 else:
                     raise
-            self._emit_bus_event(
-                "task.progress",
-                task_id=task_id,
-                project=str(task.get("project") or "") or None,
-                payload={
-                    "schema": "mac.agent_inner_loop.progress.v1",
-                    "phase": "execution_started",
-                    "continuation": "local",
-                },
+            _emit_task_progress(
+                self,
+                task,
+                "execution_started",
+                continuation="local",
             )
             started = time.monotonic()
             execution = self._execute_with_lease_renewal(task, lease, task_dir)
@@ -1565,16 +1590,12 @@ class MacWorker(
                 subject_id=task_id,
                 detail={"returncode": execution.returncode, "summary": execution.summary},
             )
-            self._emit_bus_event(
-                "task.progress",
-                task_id=task_id,
-                project=str(task.get("project") or "") or None,
-                payload={
-                    "schema": "mac.agent_inner_loop.progress.v1",
-                    "phase": "execution_finished",
-                    "returncode": execution.returncode,
-                    "duration_ms": round(duration_ms, 3),
-                },
+            _emit_task_progress(
+                self,
+                task,
+                "execution_finished",
+                returncode=execution.returncode,
+                duration_ms=round(duration_ms, 3),
             )
             if not self._assignment_is_current(task_id, lease_id):
                 return self._stale_result(

--- a/tests/test_agent_inner_loop.py
+++ b/tests/test_agent_inner_loop.py
@@ -1,0 +1,49 @@
+from mac.agent_inner_loop import PersistentAgentLoop
+
+
+def test_productive_iteration_continues_immediately_and_resets_backoff():
+    loop = PersistentAgentLoop(base_delay_seconds=1, max_delay_seconds=5)
+
+    assert [loop.observe("no_task").delay_seconds for _ in range(4)] == [1, 2, 4, 5]
+
+    decision = loop.observe("submitted_for_review")
+    assert decision.mode == "continuing"
+    assert decision.delay_seconds == 0
+    assert decision.to_dict()["schema"] == "mac.agent_inner_loop.v1"
+
+    assert loop.observe("no_task").delay_seconds == 1
+
+
+def test_explicit_hub_hold_suspends_at_cap_without_accumulating_a_streak():
+    loop = PersistentAgentLoop(base_delay_seconds=0.5, max_delay_seconds=4)
+
+    decision = loop.observe("held")
+
+    assert decision.mode == "waiting"
+    assert decision.delay_seconds == 4
+    assert decision.streak == 0
+    assert loop.observe("no_task").delay_seconds == 0.5
+
+
+def test_errors_back_off_but_a_successful_wake_recovers_immediately():
+    loop = PersistentAgentLoop(base_delay_seconds=2, max_delay_seconds=5)
+
+    assert [loop.observe("error").delay_seconds for _ in range(3)] == [2, 4, 5]
+    assert loop.observe("completed").delay_seconds == 0
+    assert loop.observe("error").delay_seconds == 2
+
+
+def test_zero_delay_keeps_bounded_test_workers_deterministic():
+    loop = PersistentAgentLoop(base_delay_seconds=0, max_delay_seconds=0)
+
+    assert loop.observe("no_task").delay_seconds == 0
+    assert loop.observe("error").delay_seconds == 0
+
+
+def test_restart_is_terminal_for_the_local_loop():
+    loop = PersistentAgentLoop(base_delay_seconds=1, max_delay_seconds=5)
+
+    decision = loop.observe("self_update_restart")
+
+    assert decision.mode == "stopped"
+    assert decision.delay_seconds == 0

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2612,11 +2612,27 @@ def test_mac_worker_run_forever_drains_queue_then_reports_offline(tmp_path: Path
         poll_interval_seconds=0.0,
         attestation_key=cp._agent_attestation_key(agent.id),
     )
+    emitted_progress = []
+    emit_bus_event = worker._emit_bus_event
+
+    def capture_bus_event(event_type, **kwargs):
+        if event_type == "task.progress":
+            emitted_progress.append((kwargs.get("task_id"), kwargs.get("payload", {}).get("phase")))
+        emit_bus_event(event_type, **kwargs)
+
+    worker._emit_bus_event = capture_bus_event
     # max_iterations bounds the loop so the test doesn't hang.
     results = worker.run_forever(max_iterations=5)
 
     submitted = [r for r in results if r.status == "submitted_for_review"]
     assert {r.task["id"] for r in submitted} == set(task_ids)
+    # Assert the worker's boundary emissions before the hub's documented
+    # per-agent rate limiting/coalescing can collapse adjacent progress events.
+    assert set(emitted_progress) == {
+        (task_id, phase)
+        for task_id in task_ids
+        for phase in ("execution_started", "execution_finished")
+    }
     # After the loop the worker marks itself offline (best-effort heartbeat).
     refreshed = cp.get_agent(agent.id)
     assert refreshed.status == "offline"

--- a/tests/test_worker_additional_edges.py
+++ b/tests/test_worker_additional_edges.py
@@ -216,6 +216,29 @@ def test_agentbus_control_filters_and_handlers(monkeypatch, tmp_path) -> None:
     assert saved
 
 
+def test_agentbus_hub_nudge_wakes_local_inner_loop(monkeypatch, tmp_path) -> None:
+    client = _Client()
+    instance = _instance(tmp_path, client)
+    client.get_value = [
+        {
+            "id": "hub-nudge",
+            "recipient_agent_id": "agent",
+            "topic": worker.NUDGE_TOPIC,
+            "content_type": "application/json",
+            "task_id": "task-1",
+        }
+    ]
+    monkeypatch.setattr(instance, "_load_agentbus_control_state", lambda: [])
+    saved = []
+    monkeypatch.setattr(
+        instance, "_save_agentbus_control_state", lambda state: saved.append(list(state))
+    )
+
+    assert instance._process_agentbus_control() is None
+    assert instance._inner_loop_wake.is_set()
+    assert saved == [["hub-nudge"]]
+
+
 def test_control_stream_handler_exception_paths(monkeypatch, tmp_path) -> None:
     client = _Client()
     instance = _instance(tmp_path, client)


### PR DESCRIPTION
## Summary
- add a deterministic local continuation/backoff policy while retaining hub task and lease authority
- wake the local scheduler on addressed hub nudges and publish coarse task execution progress
- record ADR 0033 and cover worker integration and minimal harness behavior

## Test plan
- [x] `make lint`
- [x] focused inner-loop/worker tests (105 passed)
- [x] full `make test` executed: all hybrid tests passed; 11,447 passed overall with 14 pre-existing Darwin portability/timing failures tracked as `task_50410fb9`
- [x] tracked-content search confirms no CodeGraph references were restored