### PR TITLE
Map OpenClaw installer changes to their tests

### DIFF
--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -127,6 +127,19 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
     ),
     "deploy/fleet-node-rollback-supervisor.py": ("tests/test_fleet_node_rollback_supervisor.py",),
     "deploy/fleet-node-substrate-adopt.py": ("tests/test_fleet_node_substrate_adopt.py",),
+    # Shell + the out-of-process Python validator it calls. Neither lives under
+    # src/, so the coverage map cannot attribute them; without this contract a
+    # probe-timing change forced the whole-repo 90% floor (47 minutes) and
+    # failed at 89.9969% displayed as 90.00%.
+    "deploy/openclaw/install-openclaw-gateway.sh": (
+        "tests/test_dream_cycle_runner.py",
+        "tests/test_fleet_node_generated_rollback.py",
+        "tests/test_fleet_node_phase1_quiesce.py",
+        "tests/test_openclaw_fleet_upgrade_control.py",
+        "tests/test_openclaw_gateway_cold_start.py",
+        "tests/test_openclaw_gateway_deploy.py",
+        "tests/test_script_job_home.py",
+    ),
     "docs/env-config-reference.md": ("tests/test_env_config.py",),
     "scripts/generate-env-config-registry.py": ("tests/test_env_config.py",),
     # The documentation site's nav. It is a .yml, so it was "opaque" and forced
@@ -138,6 +151,10 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
     "scripts/run-contract-tests.sh": ("tests/test_contract_test_runner.py",),
     "scripts/select-sanity-tests.py": ("tests/test_resolve_impacted_tests.py",),
     "scripts/test-checkpoint.py": ("tests/test_test_checkpoint.py",),
+    "scripts/validate-openclaw-channel-status.py": (
+        "tests/test_openclaw_channel_status.py",
+        "tests/test_openclaw_gateway_deploy.py",
+    ),
     "src/mac/data/env_config_registry.json": ("tests/test_env_config.py",),
     # Source entry points the coverage map cannot attribute because they run
     # only out-of-process — a git-invoked askpass helper, or an installed

--- a/tests/test_infrastructure_coverage.py
+++ b/tests/test_infrastructure_coverage.py
@@ -214,6 +214,10 @@ def test_openshell_supervisor_contracts(tmp_path, monkeypatch, capsys):
 
     monkeypatch.setenv("MAC_OPENSHELL_POLICY", "~/policy.yaml")
     assert module.default_policy_path("agent").name == "policy.yaml"
+    monkeypatch.delenv("MAC_OPENSHELL_POLICY", raising=False)
+    default_policy = module.default_policy_path("agent_rocky")
+    assert default_policy.name == "rocky-policy.yaml"
+    assert default_policy.parent.name == "openshell"
     monkeypatch.setenv("MAC_OPENSHELL_CHILD", "python -m worker")
     assert module.default_child_argv() == ["python", "-m", "worker"]
     monkeypatch.delenv("MAC_OPENSHELL_CHILD")

--- a/tests/test_mac_paths.py
+++ b/tests/test_mac_paths.py
@@ -37,6 +37,8 @@ def test_defaults_match_legacy_literals(clean_home):
     assert mac_paths.fleets_config() == home / ".mac" / "fleets.yaml"
     assert mac_paths.ledger_db() == home / ".mac" / "mac.db"
     assert mac_paths.journal_dir() == home / ".mac" / "journal"
+    assert mac_paths.backups_dir() == home / ".mac" / "backups"
+    assert mac_paths.archive_dir() == home / ".mac" / "archive"
     assert mac_paths.gateway_env_file() == home / ".mac" / "openclaw" / ".env"
     assert mac_paths.dream_logs_dir() == home / ".mac" / "openclaw" / "dream_logs"
     assert mac_paths.openclaw_home() == home / ".mac" / "openclaw"
@@ -48,6 +50,8 @@ def test_mac_home_relocates_all_derived_paths_together(clean_home, monkeypatch):
     assert mac_paths.mac_home() == root
     assert mac_paths.ledger_db() == root / "mac.db"
     assert mac_paths.journal_dir() == root / "journal"
+    assert mac_paths.backups_dir() == root / "backups"
+    assert mac_paths.archive_dir() == root / "archive"
     assert mac_paths.fleets_config() == root / "fleets.yaml"
     assert mac_paths.openclaw_home() == root / "openclaw"
     # Phase 2 (2026-08-21): the gateway home now relocates WITH MAC_HOME, which

--- a/tests/test_resolve_impacted_tests.py
+++ b/tests/test_resolve_impacted_tests.py
@@ -212,6 +212,46 @@ def test_fleet_installer_contract_includes_every_direct_test_owner():
     assert direct_owners <= set(R.PATH_TEST_CONTRACTS["deploy/fleet-node-install.sh"])
 
 
+def test_openclaw_installer_contract_includes_every_direct_test_owner():
+    direct_owners = {
+        path.relative_to(ROOT).as_posix()
+        for path in (ROOT / "tests").rglob("test_*.py")
+        if "install-openclaw-gateway.sh" in path.read_text(encoding="utf-8")
+    }
+    direct_owners.discard("tests/test_resolve_impacted_tests.py")
+
+    assert direct_owners <= set(
+        R.PATH_TEST_CONTRACTS["deploy/openclaw/install-openclaw-gateway.sh"]
+    )
+
+
+def test_openclaw_channel_validator_resolves_by_contract(repo, policy, impact_map):
+    """scripts/*.py is opaque to the coverage map. The validator must resolve
+    to its reviewed tests instead of forcing the whole-repo coverage floor."""
+    for owner in R.PATH_TEST_CONTRACTS["scripts/validate-openclaw-channel-status.py"]:
+        target = repo / owner
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("def test_x():\n    assert True\n", encoding="utf-8")
+    for owner in R.PATH_TEST_CONTRACTS["deploy/openclaw/install-openclaw-gateway.sh"]:
+        target = repo / owner
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists():
+            target.write_text("def test_x():\n    assert True\n", encoding="utf-8")
+    result = _resolve(
+        repo,
+        policy,
+        impact_map,
+        [
+            "deploy/openclaw/install-openclaw-gateway.sh",
+            "scripts/validate-openclaw-channel-status.py",
+        ],
+    )
+    assert result["mode"] == "focused"
+    assert result["reason"] == "impact_hybrid_scope"
+    assert "tests/test_openclaw_channel_status.py" in result["tests"]
+    assert "tests/test_openclaw_gateway_deploy.py" in result["tests"]
+
+
 def test_documentation_only_selects_no_tests(repo, policy, impact_map):
     result = _resolve(repo, policy, impact_map, ["docs/guide.md", "README rename.md"])
     assert result["mode"] == "focused"


### PR DESCRIPTION
## Summary
- `4785e087` was opaque to impact selection (`install-openclaw-gateway.sh` and `validate-openclaw-channel-status.py` live outside `src/`), so mainline ran the whole-repo 90% floor for 47 minutes and failed at 89.9969% (printed as 90.00%).
- Add reviewed path contracts so those files select their existing OpenClaw tests instead of the full suite, plus a ratchet that every test mentioning the installer stays in the contract.

## Test plan
- [x] `pytest tests/test_resolve_impacted_tests.py` (37 passed)
- [x] `resolve-impacted-tests.py --base 4785e087^` is `focused` (57 tests)
- [ ] mainline on this merge is focused, not a 47-minute full floor