### PR TITLE
Drop leftover work-package task triggers that blocked every claim

### DIFF
--- a/src/mac/data/postgres/migrations/0003_drop_leftover_work_package_triggers.sql
+++ b/src/mac/data/postgres/migrations/0003_drop_leftover_work_package_triggers.sql
@@ -1,0 +1,57 @@
+-- Authorized legacy prune drops work_package_* TABLES CASCADE. That does not
+-- drop trigger functions that live on `tasks` and only *query* those tables.
+-- Observed 2026-08-27 on the live hub after
+-- MAC_DEPLOY_AUTHORIZE_LEGACY_SCHEMA_PRUNE=1: every claim_task_v2 failed with
+-- `relation "work_package_assignment_audit" does not exist` because
+-- trg_work_package_task_claim_authority was still attached to tasks.
+--
+-- IF EXISTS / CASCADE so this is a no-op on a fresh database and on a hub
+-- whose operator already ran migrations/2026-08-17-drop-work-package-tables.sql.
+
+DROP TRIGGER IF EXISTS trg_work_package_expiry_task_detach_guard ON tasks;
+DROP TRIGGER IF EXISTS trg_work_package_task_claim_authority ON tasks;
+
+DROP FUNCTION IF EXISTS trg_evidence_attempt_links_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_evidence_attempt_package_identity() CASCADE;
+DROP FUNCTION IF EXISTS trg_evidence_attempt_verification_identity() CASCADE;
+DROP FUNCTION IF EXISTS trg_evidence_attempt_verifications_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_execution_cohort_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_execution_cohort_configuration_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_assignment_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_fence_monotonic() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_initial_state() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_inputs_open() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_invariants() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_repository_matches() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_certification_job_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_certification_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_controller_outcome_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_controller_station_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_current_epoch_status() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_epochs_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_expiry_node_guard() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_expiry_repair_authority() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_expiry_repairs_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_expiry_task_detach_guard() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_finalization_outcome_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_history_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_landing_attempt_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_landing_intent_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_landing_receipt_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_landing_stream_invariants() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_lineage_carry_forward_evidence() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_node_candidate_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_node_lineage_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_plan_versions_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_publication_finalization_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_ref_retirement_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_station_attempt_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_claim_authority() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_link_candidate_state() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_link_executable_insert() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_links_identity_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_links_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_wip_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_packages_current_epoch_coherent() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_packages_initial_state() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_packages_state_transition() CASCADE;

--- a/src/mac/data/postgres/schema.sql
+++ b/src/mac/data/postgres/schema.sql
@@ -2976,3 +2976,60 @@ CREATE INDEX IF NOT EXISTS idx_dream_entries_run
     ON dream_candidate_entries (run_id);
 CREATE INDEX IF NOT EXISTS idx_dream_runs_state
     ON dream_runs (state, created_at);
+-- Authorized legacy prune drops work_package_* TABLES CASCADE. That does not
+-- drop trigger functions that live on `tasks` and only *query* those tables.
+-- Observed 2026-08-27 on the live hub after
+-- MAC_DEPLOY_AUTHORIZE_LEGACY_SCHEMA_PRUNE=1: every claim_task_v2 failed with
+-- `relation "work_package_assignment_audit" does not exist` because
+-- trg_work_package_task_claim_authority was still attached to tasks.
+--
+-- IF EXISTS / CASCADE so this is a no-op on a fresh database and on a hub
+-- whose operator already ran migrations/2026-08-17-drop-work-package-tables.sql.
+
+DROP TRIGGER IF EXISTS trg_work_package_expiry_task_detach_guard ON tasks;
+DROP TRIGGER IF EXISTS trg_work_package_task_claim_authority ON tasks;
+
+DROP FUNCTION IF EXISTS trg_evidence_attempt_links_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_evidence_attempt_package_identity() CASCADE;
+DROP FUNCTION IF EXISTS trg_evidence_attempt_verification_identity() CASCADE;
+DROP FUNCTION IF EXISTS trg_evidence_attempt_verifications_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_execution_cohort_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_execution_cohort_configuration_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_assignment_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_fence_monotonic() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_initial_state() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_inputs_open() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_invariants() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_batch_repository_matches() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_certification_job_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_certification_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_controller_outcome_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_controller_station_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_current_epoch_status() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_epochs_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_expiry_node_guard() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_expiry_repair_authority() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_expiry_repairs_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_expiry_task_detach_guard() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_finalization_outcome_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_history_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_landing_attempt_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_landing_intent_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_landing_receipt_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_landing_stream_invariants() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_lineage_carry_forward_evidence() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_node_candidate_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_node_lineage_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_plan_versions_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_publication_finalization_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_ref_retirement_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_station_attempt_append_only() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_claim_authority() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_link_candidate_state() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_link_executable_insert() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_links_identity_immutable() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_task_links_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_package_wip_lifecycle() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_packages_current_epoch_coherent() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_packages_initial_state() CASCADE;
+DROP FUNCTION IF EXISTS trg_work_packages_state_transition() CASCADE;

--- a/src/mac/schema_migrations.py
+++ b/src/mac/schema_migrations.py
@@ -58,6 +58,64 @@ LEGACY_PRUNABLE_TABLES = frozenset(
         "work_packages",
     }
 )
+# Trigger functions that lived on surviving tables (notably `tasks`) and only
+# *queried* the prunable relations. DROP TABLE ... CASCADE does not remove
+# them. The 2026-08-27 fleet outage was every claim failing with
+# `relation "work_package_assignment_audit" does not exist`.
+LEGACY_PRUNABLE_FUNCTIONS = frozenset(
+    {
+        "trg_evidence_attempt_links_immutable",
+        "trg_evidence_attempt_package_identity",
+        "trg_evidence_attempt_verification_identity",
+        "trg_evidence_attempt_verifications_immutable",
+        "trg_execution_cohort_append_only",
+        "trg_execution_cohort_configuration_append_only",
+        "trg_work_package_assignment_immutable",
+        "trg_work_package_batch_fence_monotonic",
+        "trg_work_package_batch_initial_state",
+        "trg_work_package_batch_inputs_open",
+        "trg_work_package_batch_invariants",
+        "trg_work_package_batch_repository_matches",
+        "trg_work_package_certification_job_lifecycle",
+        "trg_work_package_certification_lifecycle",
+        "trg_work_package_controller_outcome_append_only",
+        "trg_work_package_controller_station_lifecycle",
+        "trg_work_package_current_epoch_status",
+        "trg_work_package_epochs_lifecycle",
+        "trg_work_package_expiry_node_guard",
+        "trg_work_package_expiry_repair_authority",
+        "trg_work_package_expiry_repairs_immutable",
+        "trg_work_package_expiry_task_detach_guard",
+        "trg_work_package_finalization_outcome_append_only",
+        "trg_work_package_history_immutable",
+        "trg_work_package_landing_attempt_lifecycle",
+        "trg_work_package_landing_intent_lifecycle",
+        "trg_work_package_landing_receipt_lifecycle",
+        "trg_work_package_landing_stream_invariants",
+        "trg_work_package_lineage_carry_forward_evidence",
+        "trg_work_package_node_candidate_lifecycle",
+        "trg_work_package_node_lineage_immutable",
+        "trg_work_package_plan_versions_immutable",
+        "trg_work_package_publication_finalization_lifecycle",
+        "trg_work_package_ref_retirement_append_only",
+        "trg_work_package_station_attempt_append_only",
+        "trg_work_package_task_claim_authority",
+        "trg_work_package_task_link_candidate_state",
+        "trg_work_package_task_link_executable_insert",
+        "trg_work_package_task_links_identity_immutable",
+        "trg_work_package_task_links_lifecycle",
+        "trg_work_package_wip_lifecycle",
+        "trg_work_packages_current_epoch_coherent",
+        "trg_work_packages_initial_state",
+        "trg_work_packages_state_transition",
+    }
+)
+LEGACY_PRUNABLE_TASK_TRIGGERS = frozenset(
+    {
+        "trg_work_package_expiry_task_detach_guard",
+        "trg_work_package_task_claim_authority",
+    }
+)
 FORMER_STARTUP_ENSURE_COLUMNS = frozenset(
     {
         ("agents", "installed_packages"),
@@ -177,6 +235,18 @@ MIGRATIONS: tuple[Migration, ...] = (
            AND to_regclass(current_schema() || '.dream_candidate_entries') IS NOT NULL
         """,
     ),
+    Migration(
+        "0003_drop_leftover_work_package_triggers",
+        _load_sql(MIGRATION_PATH / "0003_drop_leftover_work_package_triggers.sql"),
+        """
+        SELECT to_regprocedure(
+                   current_schema() || '.trg_work_package_task_claim_authority()'
+               ) IS NULL
+           AND to_regprocedure(
+                   current_schema() || '.trg_work_package_expiry_task_detach_guard()'
+               ) IS NULL
+        """,
+    ),
 )
 
 
@@ -250,6 +320,21 @@ def _later_migration_tables(migrations: Sequence[Migration]) -> set[str]:
     for migration in migrations[1:]:
         tables.update(_table_bodies(migration.sql))
     return tables
+
+
+def _drop_legacy_prunable_functions(cur: Any) -> None:
+    """Drop leftover work-package trigger functions on surviving tables.
+
+    ``DROP TABLE ... CASCADE`` removes triggers that live ON the dropped
+    table. It does not remove triggers on ``tasks`` whose function body
+    still queries the dropped table, and those leftovers abort every
+    ``claim_task`` with a missing-relation error.
+    """
+
+    for trigger_name in sorted(LEGACY_PRUNABLE_TASK_TRIGGERS):
+        cur.execute("DROP TRIGGER IF EXISTS %s ON tasks" % trigger_name)
+    for function_name in sorted(LEGACY_PRUNABLE_FUNCTIONS):
+        cur.execute("DROP FUNCTION IF EXISTS %s() CASCADE" % function_name)
 
 
 def _legacy_prune_plan(cur: Any, relations: Iterable[str]) -> dict[str, Any]:
@@ -664,6 +749,7 @@ def apply_migrations(
                                 )
                             legacy_prune = locked_plan
                             cur.execute("DROP TABLE %s CASCADE" % quoted)
+                            _drop_legacy_prunable_functions(cur)
                             baseline_proof = _prove_baseline(
                                 cur,
                                 migrations[0].sql,

--- a/tests/test_humans_model.py
+++ b/tests/test_humans_model.py
@@ -436,7 +436,7 @@ def _apply_versioned_humans_repair(store) -> None:
         start,
     )
     repair = Migration(
-        "0003_test_humans_repair",
+        "0004_test_humans_repair",
         MIGRATIONS[0].sql[start:end],
         """
         SELECT to_regclass(current_schema() || '.humans') IS NOT NULL

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -499,6 +499,7 @@ def test_schema_migration_authority_is_separate_from_legacy_receipts() -> None:
     assert [migration.migration_id for migration in MIGRATIONS] == [
         "0001_postgresql_authority_baseline",
         "0002_dream_candidate_store",
+        "0003_drop_leftover_work_package_triggers",
     ]
     expected_checksums = {
         "0001_postgresql_authority_baseline": (
@@ -506,6 +507,9 @@ def test_schema_migration_authority_is_separate_from_legacy_receipts() -> None:
         ),
         "0002_dream_candidate_store": (
             "597a14ee40fa1d5d28fd05daa1ae2adf53518690e5f6f3e55b9c0598107b62f9"
+        ),
+        "0003_drop_leftover_work_package_triggers": (
+            "bde53a11681f213e107703925e690b2694dc7a95d242b0df943f442be53f0a1d"
         ),
     }
     for migration in MIGRATIONS:

--- a/tests/test_schema_migrations.py
+++ b/tests/test_schema_migrations.py
@@ -48,7 +48,11 @@ EXPECTED_LEGACY_PRUNABLE_TABLES = {
 
 
 def test_legacy_prune_allowlist_is_exact_and_has_no_runtime_sql_users() -> None:
-    from mac.schema_migrations import LEGACY_PRUNABLE_TABLES
+    from mac.schema_migrations import (
+        LEGACY_PRUNABLE_FUNCTIONS,
+        LEGACY_PRUNABLE_TABLES,
+        LEGACY_PRUNABLE_TASK_TRIGGERS,
+    )
 
     assert LEGACY_PRUNABLE_TABLES == EXPECTED_LEGACY_PRUNABLE_TABLES
     root = Path(__file__).resolve().parents[1]
@@ -58,6 +62,27 @@ def test_legacy_prune_allowlist_is_exact_and_has_no_runtime_sql_users() -> None:
     assert (
         set(re.findall(r"DROP TABLE IF EXISTS\s+(\w+)\s+CASCADE", historical_drop))
         == LEGACY_PRUNABLE_TABLES
+    )
+    assert (
+        set(re.findall(r"DROP FUNCTION IF EXISTS\s+(\w+)\s*\(\)\s+CASCADE", historical_drop))
+        == LEGACY_PRUNABLE_FUNCTIONS
+    )
+    migration_drop = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "mac"
+        / "data"
+        / "postgres"
+        / "migrations"
+        / "0003_drop_leftover_work_package_triggers.sql"
+    ).read_text(encoding="utf-8")
+    assert (
+        set(re.findall(r"DROP FUNCTION IF EXISTS\s+(\w+)\s*\(\)\s+CASCADE", migration_drop))
+        == LEGACY_PRUNABLE_FUNCTIONS
+    )
+    assert (
+        set(re.findall(r"DROP TRIGGER IF EXISTS\s+(\w+)\s+ON tasks", migration_drop))
+        == LEGACY_PRUNABLE_TASK_TRIGGERS
     )
 
     runtime_root = root / "src" / "mac"

--- a/tests/test_schema_migrations_live.py
+++ b/tests/test_schema_migrations_live.py
@@ -47,6 +47,64 @@ def _install_unversioned_legacy_tables(store, *, include_unknown: bool = False) 
         )
         if include_unknown:
             conn.execute("CREATE TABLE unknown_legacy_extra (id INTEGER PRIMARY KEY)")
+        _install_leftover_work_package_task_triggers(conn)
+
+
+def _install_leftover_work_package_task_triggers(conn) -> None:
+    """Reproduce the live-hub leftover: a tasks trigger that queries a dropped table.
+
+    DROP TABLE work_package_assignment_audit CASCADE does not remove this.
+    """
+
+    conn.execute(
+        """
+        CREATE OR REPLACE FUNCTION trg_work_package_task_claim_authority()
+        RETURNS trigger AS $$
+        BEGIN
+            PERFORM 1 FROM work_package_assignment_audit LIMIT 1;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    conn.execute(
+        """
+        CREATE OR REPLACE FUNCTION trg_work_package_expiry_task_detach_guard()
+        RETURNS trigger AS $$
+        BEGIN
+            IF OLD.lease_id IS NOT NULL AND NEW.lease_id IS NULL THEN
+                PERFORM 1 FROM work_package_assignment_audit LIMIT 1;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+        """
+    )
+    conn.execute("DROP TRIGGER IF EXISTS trg_work_package_task_claim_authority ON tasks")
+    conn.execute(
+        """
+        CREATE TRIGGER trg_work_package_task_claim_authority
+        BEFORE UPDATE ON tasks
+        FOR EACH ROW EXECUTE FUNCTION trg_work_package_task_claim_authority()
+        """
+    )
+    conn.execute("DROP TRIGGER IF EXISTS trg_work_package_expiry_task_detach_guard ON tasks")
+    conn.execute(
+        """
+        CREATE TRIGGER trg_work_package_expiry_task_detach_guard
+        BEFORE UPDATE ON tasks
+        FOR EACH ROW EXECUTE FUNCTION trg_work_package_expiry_task_detach_guard()
+        """
+    )
+
+
+def _function_exists(store, name: str) -> bool:
+    row = store.query_one(
+        "SELECT 1 AS ok FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+        "WHERE n.nspname = current_schema() AND p.proname = ?",
+        (name,),
+    )
+    return row is not None
 
 
 def _relation_exists(store, relation: str) -> bool:
@@ -96,7 +154,7 @@ def test_known_existing_schema_requires_and_accepts_explicit_baseline(pg_dsn: st
 
 def test_explicit_upgrade_applies_in_order_and_proves_postcondition(pg_dsn: str) -> None:
     upgrade = Migration(
-        "0003_upgrade_probe",
+        "0004_upgrade_probe",
         "CREATE TABLE migration_upgrade_probe (id INTEGER PRIMARY KEY)",
         "SELECT to_regclass('migration_upgrade_probe') IS NOT NULL",
     )
@@ -105,13 +163,13 @@ def test_explicit_upgrade_applies_in_order_and_proves_postcondition(pg_dsn: str)
         store.apply_migrations(applied_by="pytest:bootstrap")
         result = store.apply_migrations(applied_by="pytest:upgrade", migrations=chain)
 
-        assert result["applied"] == ["0003_upgrade_probe"]
-        assert result["current_version"] == "0003_upgrade_probe"
+        assert result["applied"] == ["0004_upgrade_probe"]
+        assert result["current_version"] == "0004_upgrade_probe"
         assert (
-            store.query_one("SELECT migration_id FROM schema_migrations WHERE ordinal = 3")[
+            store.query_one("SELECT migration_id FROM schema_migrations WHERE ordinal = 4")[
                 "migration_id"
             ]
-            == "0003_upgrade_probe"
+            == "0004_upgrade_probe"
         )
 
 
@@ -173,7 +231,7 @@ def test_schema_version_rejects_inconsistency_and_verification_detects_tampering
 
 def test_missing_or_out_of_order_ledger_is_refused(pg_dsn: str) -> None:
     upgrade = Migration(
-        "0003_order_probe",
+        "0004_order_probe",
         "CREATE TABLE migration_order_probe (id INTEGER PRIMARY KEY)",
         "SELECT to_regclass('migration_order_probe') IS NOT NULL",
     )
@@ -190,7 +248,7 @@ def test_missing_or_out_of_order_ledger_is_refused(pg_dsn: str) -> None:
 
 def test_failed_migration_rolls_back_ddl_and_receipt(pg_dsn: str) -> None:
     broken = Migration(
-        "0003_rollback_probe",
+        "0004_rollback_probe",
         "CREATE TABLE migration_rollback_probe (id INTEGER PRIMARY KEY)",
         "SELECT FALSE",
     )
@@ -237,7 +295,7 @@ def test_read_only_startup_refuses_fresh_and_behind_databases(pg_dsn: str) -> No
         store.apply_migrations(applied_by="pytest:old-binary", migrations=MIGRATIONS[:1])
         status = store.migration_status()
         assert status["status"] == "pending"
-        assert status["pending"] == [MIGRATIONS[1].migration_id]
+        assert status["pending"] == [migration.migration_id for migration in MIGRATIONS[1:]]
         with pytest.raises(StoreError, match="behind this binary"):
             store.verify_schema()
 
@@ -259,7 +317,7 @@ def test_partial_or_empty_authority_is_refused(pg_dsn: str) -> None:
 
 def test_pending_migration_without_postcondition_is_refused(pg_dsn: str) -> None:
     missing_proof = Migration(
-        "0003_missing_proof",
+        "0004_missing_proof",
         "CREATE TABLE migration_missing_proof (id INTEGER PRIMARY KEY)",
     )
     with _fresh_store(pg_dsn) as store:
@@ -324,6 +382,8 @@ def test_legacy_prune_requires_separate_authority_and_accepts_rows(pg_dsn: str) 
         assert result["legacy_schema_prune"]["table_names"] == sorted(LEGACY_PRUNABLE_TABLES)
         assert result["legacy_schema_prune"]["total_rows"] == len(LEGACY_PRUNABLE_TABLES) + 1
         assert not any(_relation_exists(store, table) for table in LEGACY_PRUNABLE_TABLES)
+        assert not _function_exists(store, "trg_work_package_task_claim_authority")
+        assert not _function_exists(store, "trg_work_package_expiry_task_detach_guard")
         assert store.verify_schema()["status"] == "verified"
 
 
@@ -351,7 +411,7 @@ def test_failure_after_legacy_drop_rolls_back_tables_rows_and_ledger(pg_dsn: str
     from mac.schema_migrations import LEGACY_PRUNABLE_TABLES
 
     broken = Migration(
-        "0003_legacy_prune_rollback_probe",
+        "0004_legacy_prune_rollback_probe",
         "CREATE TABLE legacy_prune_rollback_probe (id INTEGER PRIMARY KEY)",
         "SELECT FALSE",
     )
@@ -373,3 +433,24 @@ def test_failure_after_legacy_drop_rolls_back_tables_rows_and_ledger(pg_dsn: str
         )
         assert not _relation_exists(store, "schema_migrations")
         assert not _relation_exists(store, "legacy_prune_rollback_probe")
+
+
+def test_upgrade_drops_leftover_work_package_task_triggers(pg_dsn: str) -> None:
+    """A hub already on 0002 still has the tasks triggers after table prune."""
+
+    with _fresh_store(pg_dsn) as store:
+        store.apply_migrations(
+            applied_by="pytest:through-0002",
+            migrations=MIGRATIONS[:2],
+        )
+        with store._pool.connection() as conn:
+            _install_leftover_work_package_task_triggers(conn)
+        assert _function_exists(store, "trg_work_package_task_claim_authority")
+        assert _function_exists(store, "trg_work_package_expiry_task_detach_guard")
+
+        result = store.apply_migrations(applied_by="pytest:drop-leftovers")
+
+        assert result["applied"] == ["0003_drop_leftover_work_package_triggers"]
+        assert not _function_exists(store, "trg_work_package_task_claim_authority")
+        assert not _function_exists(store, "trg_work_package_expiry_task_detach_guard")
+        assert store.verify_schema()["status"] == "verified"


### PR DESCRIPTION
## Summary
- Authorized legacy prune dropped `work_package_*` tables `CASCADE` but left `tasks` triggers whose functions still queried those tables. Live hub symptom: every `claim_task_v2` failed with `relation "work_package_assignment_audit" does not exist`.
- Adds `0003_drop_leftover_work_package_triggers` so a hub already at `0002` heals on the next migrate (`IF EXISTS` is a no-op once the functions are gone).
- Prune now also drops the same leftover task triggers and functions, matching `migrations/2026-08-17-drop-work-package-tables.sql`.

Live containment already ran on the hub: the two `tasks` triggers and 44 leftover functions were dropped, and workers resumed claiming (`claim_failure_count` on recent dispatch rounds is 0). This PR is the durable repair so the next deploy cannot recreate the hole.

## Test plan
- [x] `make test-schema-migrations` (211 passed)
- [x] `tests/test_humans_model.py` (37 passed; probe id moved to `0004_test_humans_repair`)
- [x] `scripts/run-contract-tests.sh` — 11098 passed; the only failures are pre-existing stale `test_impact_map.json` node ids from the prune commit already on `main` (`test_committed_impact_map_has_no_stale_node_ids` / `test_committed_impact_map_ids_actually_collect`)
- [ ] After merge: deploy so live `schema_version` records `0003` (functions already dropped; migration is a no-op)

Ledger: `task_9a4cbe52`