### PR TITLE
Reconcile against canonical HEAD before assuming a repo_change is still required

### DIFF
--- a/skills/agentbus-context/SKILL.md
+++ b/skills/agentbus-context/SKILL.md
@@ -18,7 +18,7 @@ existed; nothing read it.
 
 ## Step zero of every task
 
-Before your first edit, answer three questions:
+Before your first edit, answer four questions:
 
 1. **Has this task's work already been published?** If `git.merged` names your
    task, the change is in the trunk. Verify against the repository, say so in
@@ -31,6 +31,14 @@ Before your first edit, answer three questions:
    `task.claimed` from another agent in this repository means you are not
    alone in it. If a peer says they own a file you were about to change,
    believe them.
+4. **Is the requested change still absent in THIS tree?** Starting on HEAD is
+   placement, not a validity decision. Adjacent `git.merged` / `git.pushed`
+   events for other tasks are facts to re-read, not proof this defect is gone.
+   Record `canonical_reconcile` in evidence with `still_valid`,
+   `already_satisfied`, or `needs_restatement`. Do not treat another task's
+   merge as already published for this task. `already_satisfied` and
+   `needs_restatement` use `evidence_type=no_change` and must not open a pull
+   request.
 
 When MAC runs you as a fleet worker, the answers are already in your prompt: a
 section headed **"AgentBus context"**, gathered by the worker before your task
@@ -58,6 +66,12 @@ checked out by hand), ask the hub yourself:
 | `sandbox.policy_changed` / `sandbox.policy_published` | the guardrail moved | the worker holds new work itself; you do not need to act mid-task |
 
 ## Traps
+
+**Starting on HEAD is not a validity decision.** Workspace prep places you on
+the current canonical tip. That does not mean the described change is gone.
+A sibling landing that touched the same files is a reason to re-read HEAD,
+not a reason to skip the look or to auto-cancel. Record `canonical_reconcile`
+before you edit.
 
 **`git.merged` carries a `tree_sha`, and that is the field you match on.**
 Every merge in this fleet is a *squash*: the commit sha in the event was minted

--- a/src/mac/bus_task_context.py
+++ b/src/mac/bus_task_context.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, Iterable, List, Optional, Sequence
 
+from mac.canonical_reconcile import sibling_landings_from_bus
+
 BUS_TASK_CONTEXT_SCHEMA = "mac.bus_task_context.v1"
 
 #: How many events reach the coding agent.
@@ -280,6 +282,10 @@ def derive_signals(entries: Sequence[Dict[str, Any]], focus: Dict[str, str]) -> 
         "already_published": already_published,
         "canonical_advanced": canonical_advanced,
         "peer_activity": peers[:10],
+        # Same-repo landings that are not THIS task. Facts to re-read HEAD.
+        # Never treated as already_published — a sibling merge is not proof
+        # the described defect is gone.
+        "sibling_landings": sibling_landings_from_bus({"events": list(entries)}, task_id=task_id),
     }
 
 
@@ -362,6 +368,26 @@ def render_bus_context_section(context: Optional[Dict[str, Any]]) -> str:
             "- PEERS ACTIVE in this repository: %s. If one of them says they own "
             "a file you were about to change, believe them." % held
         )
+    siblings = signals.get("sibling_landings")
+    if isinstance(siblings, list) and siblings:
+        lines.append(
+            "- RECENT LANDINGS in this repository (not this task). Re-read HEAD. "
+            "Do not treat these as already_published for this task:"
+        )
+        for item in siblings[:6]:
+            if not isinstance(item, dict):
+                continue
+            pr = item.get("pr_number")
+            pr_bit = (" pr #%s" % pr) if pr not in (None, "", 0) else ""
+            lines.append(
+                "    [%s]%s task=%s sha=%s"
+                % (
+                    _text(item.get("event_type")) or "git",
+                    pr_bit,
+                    _text(item.get("task_id")) or "?",
+                    (_text(item.get("sha")) or "?")[:12],
+                )
+            )
     lines.append("- Events (newest first):")
     for entry in context["events"]:
         payload = entry.get("payload") if isinstance(entry.get("payload"), dict) else {}

--- a/src/mac/canonical_reconcile.py
+++ b/src/mac/canonical_reconcile.py
@@ -1,0 +1,422 @@
+"""Force a look at canonical HEAD before assuming a repo_change is still required.
+
+Workspace prep already places the agent on the current canonical tip. That is
+placement, not a validity decision. AgentBus ``already_published`` is keyed to
+THIS task's merge (the duplicate-PR failure). Adjacent landings on the same
+files are not proof the described defect is gone — nanolang #107/#108 is the
+counterexample: a release PR touched ``scripts/release.sh`` and the direct-push
+bug was still on HEAD.
+
+This module is the recorded look:
+
+* extract likely paths from the task title/description
+* list recent commits that touched them (or the branch, if no paths)
+* render those facts into the executor prompt
+* validate that repository evidence carries a decision matching the evidence type
+
+Auto-cancel is intentionally absent. The host refuses a repo_change that never
+did this reconcile; it does not guess that the work is obsolete.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+CANONICAL_RECONCILE_SCHEMA = "mac.canonical_reconcile.v1"
+RECONCILE_DECISIONS = frozenset({"still_valid", "already_satisfied", "needs_restatement"})
+NO_CHANGE_DECISIONS = frozenset({"already_satisfied", "needs_restatement"})
+REPO_CHANGE_DECISIONS = frozenset({"still_valid"})
+RECENT_COMMIT_LIMIT = 15
+
+_BACKTICK_PATH = re.compile(r"`([^`]+)`")
+_SLASH_PATH = re.compile(r"(?<![\w./-])((?:[A-Za-z0-9_.-]+/){1,}[A-Za-z0-9_.-]+)")
+_GIT_SHA = re.compile(r"^[0-9a-fA-F]{7,64}$")
+_SKIP_PATH_PREFIXES = (
+    "http://",
+    "https://",
+    "git@",
+    "ssh://",
+    "git://",
+    "file://",
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def implicated_paths(title: str, description: str) -> List[str]:
+    """Path-like tokens the task statement is likely talking about."""
+
+    blob = "%s\n%s" % (title or "", description or "")
+    found: List[str] = []
+    seen = set()
+    for match in _BACKTICK_PATH.finditer(blob):
+        _remember_path(found, seen, match.group(1), from_backtick=True)
+    for match in _SLASH_PATH.finditer(blob):
+        _remember_path(found, seen, match.group(1), from_backtick=False)
+    return found
+
+
+def _remember_path(
+    found: List[str],
+    seen: set[str],
+    raw: str,
+    *,
+    from_backtick: bool,
+) -> None:
+    path = _text(raw).strip(".,;:()[]{}<>\"'")
+    if not path or path in seen:
+        return
+    lowered = path.lower()
+    if any(lowered.startswith(prefix) for prefix in _SKIP_PATH_PREFIXES):
+        return
+    if "://" in path or path.startswith("git@"):
+        return
+    if "/" not in path:
+        # Bare filenames only from backticks (`release.sh`, `Makefile`).
+        if not from_backtick or "." not in path:
+            return
+    seen.add(path)
+    found.append(path)
+
+
+def expected_head_sha_from_task(task: Optional[Mapping[str, Any]]) -> str:
+    snapshot = reconcile_snapshot_from_task(task)
+    return _text(snapshot.get("head_sha"))
+
+
+def reconcile_snapshot_from_task(task: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+    task = task if isinstance(task, Mapping) else {}
+    metadata = task.get("metadata") if isinstance(task.get("metadata"), Mapping) else {}
+    runtime = metadata.get("runtime") if isinstance(metadata.get("runtime"), Mapping) else {}
+    snapshot = runtime.get("canonical_reconcile")
+    return dict(snapshot) if isinstance(snapshot, Mapping) else {}
+
+
+def _git(
+    worktree: Path, args: Sequence[str], *, timeout: float = 15.0
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+        env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+    )
+
+
+def recent_commits_touching(
+    worktree: Optional[Path],
+    paths: Sequence[str],
+    *,
+    limit: int = RECENT_COMMIT_LIMIT,
+) -> List[Dict[str, Any]]:
+    """Recent commits on the prepared HEAD, optionally restricted to *paths*."""
+
+    if worktree is None or not Path(worktree).is_dir():
+        return []
+    root = Path(worktree)
+    argv = [
+        "log",
+        "-n",
+        str(max(1, min(int(limit), 50))),
+        "--format=%H\t%s",
+        "--",
+    ]
+    existing = [path for path in paths if path]
+    if existing:
+        argv.extend(existing)
+    try:
+        proc = _git(root, argv)
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    commits: List[Dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        sha, sep, subject = line.partition("\t")
+        sha = sha.strip()
+        if not _GIT_SHA.match(sha):
+            continue
+        commits.append(
+            {
+                "sha": sha,
+                "subject": subject.strip(),
+                "paths": _commit_paths(root, sha, existing),
+            }
+        )
+    return commits
+
+
+def _commit_paths(worktree: Path, sha: str, implicated: Sequence[str]) -> List[str]:
+    try:
+        proc = _git(worktree, ["diff-tree", "--no-commit-id", "--name-only", "-r", sha])
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    names = [_text(line) for line in proc.stdout.splitlines() if _text(line)]
+    if not implicated:
+        return names[:20]
+    implicated_set = set(implicated)
+    return [name for name in names if name in implicated_set] or names[:20]
+
+
+def sibling_landings_from_bus(
+    context: Optional[Mapping[str, Any]],
+    *,
+    task_id: str,
+) -> List[Dict[str, Any]]:
+    """Same-repo merges/pushes that are not THIS task's landing.
+
+    Facts for the prompt. Never treated as ``already_published``.
+    """
+
+    if not isinstance(context, Mapping):
+        return []
+    events = context.get("events")
+    if not isinstance(events, list):
+        return []
+    mine = _text(task_id)
+    landings: List[Dict[str, Any]] = []
+    seen = set()
+    for entry in events:
+        if not isinstance(entry, Mapping):
+            continue
+        event_type = _text(entry.get("event_type"))
+        if event_type not in {"git.merged", "git.pushed", "git.pr_opened"}:
+            continue
+        if mine and _text(entry.get("task_id")) == mine:
+            continue
+        payload = entry.get("payload") if isinstance(entry.get("payload"), Mapping) else {}
+        key = (
+            event_type,
+            _text(entry.get("task_id")),
+            _text(payload.get("pr_number") or payload.get("sha") or payload.get("branch")),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        paths = _payload_paths(payload)
+        landings.append(
+            {
+                "event_type": event_type,
+                "task_id": _text(entry.get("task_id")),
+                "agent_id": _text(entry.get("agent_id")),
+                "pr_number": payload.get("pr_number"),
+                "sha": _text(
+                    payload.get("sha") or payload.get("head_sha") or payload.get("tree_sha")
+                ),
+                "branch": _text(payload.get("branch") or payload.get("canonical_branch")),
+                "paths": paths,
+                "relevance": _text(entry.get("relevance")),
+            }
+        )
+        if len(landings) >= 10:
+            break
+    return landings
+
+
+def _payload_paths(payload: Mapping[str, Any]) -> List[str]:
+    for key in ("paths", "files", "files_changed"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [_text(item) for item in value if _text(item)][:20]
+    return []
+
+
+def build_reconcile_snapshot(
+    worktree: Optional[Path],
+    task: Mapping[str, Any],
+    *,
+    head_sha: str,
+    canonical_branch: str,
+    bus_context: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    title = _text(task.get("title"))
+    description = _text(task.get("description"))
+    paths = implicated_paths(title, description)
+    return {
+        "schema": CANONICAL_RECONCILE_SCHEMA,
+        "head_sha": _text(head_sha),
+        "canonical_branch": _text(canonical_branch) or "main",
+        "implicated_paths": paths,
+        "recent_commits": recent_commits_touching(worktree, paths),
+        "sibling_landings": sibling_landings_from_bus(bus_context, task_id=_text(task.get("id"))),
+    }
+
+
+def render_reconcile_section(task: Optional[Mapping[str, Any]]) -> str:
+    """Prompt facts. Empty unless workspace prep attached a snapshot."""
+
+    snapshot = reconcile_snapshot_from_task(task)
+    if not snapshot:
+        return ""
+    head = _text(snapshot.get("head_sha")) or "unknown"
+    branch = _text(snapshot.get("canonical_branch")) or "main"
+    lines = [
+        "Canonical HEAD reconcile (required before you edit):",
+        "- You are on %s at %s. Starting on HEAD is placement, not proof the "
+        "task is still valid." % (branch, head[:12] if head != "unknown" else head),
+        "- Confirm the requested change is still absent in THIS tree. Adjacent "
+        "landings on the same files are not proof the defect is gone.",
+        "- Record canonical_reconcile in mac-evidence.json with decision "
+        "still_valid | already_satisfied | needs_restatement, this HEAD sha, "
+        "and a reason.",
+        "- still_valid: implement (evidence_type=repo_change).",
+        "- already_satisfied: do not re-implement; evidence_type=no_change; "
+        "cite this HEAD. Do not open a pull request.",
+        "- needs_restatement: the statement no longer matches the tree; "
+        "evidence_type=no_change; do not invent a different change.",
+    ]
+    paths = (
+        snapshot.get("implicated_paths")
+        if isinstance(snapshot.get("implicated_paths"), list)
+        else []
+    )
+    if paths:
+        lines.append(
+            "- Likely paths from the task statement: %s" % ", ".join(str(p) for p in paths[:12])
+        )
+    commits = (
+        snapshot.get("recent_commits") if isinstance(snapshot.get("recent_commits"), list) else []
+    )
+    if commits:
+        lines.append("- Recent commits that touched those paths (newest first):")
+        for item in commits[:8]:
+            if not isinstance(item, Mapping):
+                continue
+            touched = item.get("paths") if isinstance(item.get("paths"), list) else []
+            extra = (" " + ",".join(str(p) for p in touched[:4])) if touched else ""
+            lines.append(
+                "    %s %s%s"
+                % ((_text(item.get("sha")) or "?")[:12], _text(item.get("subject")), extra)
+            )
+    landings = (
+        snapshot.get("sibling_landings")
+        if isinstance(snapshot.get("sibling_landings"), list)
+        else []
+    )
+    if landings:
+        lines.append(
+            "- RECENT LANDINGS in this repository (not this task). Re-read HEAD. "
+            "Do not treat these as already_published for this task:"
+        )
+        for item in landings[:6]:
+            if not isinstance(item, Mapping):
+                continue
+            pr = item.get("pr_number")
+            pr_bit = (" pr #%s" % pr) if pr not in (None, "", 0) else ""
+            lines.append(
+                "    [%s]%s task=%s sha=%s"
+                % (
+                    _text(item.get("event_type")) or "git",
+                    pr_bit,
+                    _text(item.get("task_id")) or "?",
+                    (_text(item.get("sha")) or "?")[:12],
+                )
+            )
+    return "\n".join(lines)
+
+
+def _reconcile_block(manifest: Mapping[str, Any]) -> Dict[str, Any]:
+    block = manifest.get("canonical_reconcile")
+    return dict(block) if isinstance(block, Mapping) else {}
+
+
+def reconcile_evidence_problems(
+    manifest: Mapping[str, Any],
+    evidence_type: str,
+    expected_head_sha: str,
+) -> List[str]:
+    """Host gate. Empty expected_head_sha means this run did not prepare a snapshot."""
+
+    expected = _text(expected_head_sha)
+    if not expected:
+        return []
+    kind = _text(evidence_type).lower()
+    if kind not in {"repo_change", "no_change"}:
+        return []
+    block = _reconcile_block(manifest)
+    problems: List[str] = []
+    if not block:
+        problems.append(
+            "repository evidence requires canonical_reconcile "
+            "(still_valid | already_satisfied | needs_restatement) against prepared HEAD"
+        )
+        return problems
+    decision = _text(block.get("decision")).lower()
+    if decision not in RECONCILE_DECISIONS:
+        problems.append(
+            "canonical_reconcile.decision must be still_valid, already_satisfied, "
+            "or needs_restatement"
+        )
+    if not _text(block.get("reason")):
+        problems.append("canonical_reconcile.reason is required")
+    cited = _text(block.get("head_sha"))
+    if cited and not _GIT_SHA.match(cited):
+        problems.append("canonical_reconcile.head_sha must be a git SHA")
+    elif cited and not head_sha_matches(cited, expected):
+        problems.append("canonical_reconcile.head_sha must match the prepared canonical HEAD")
+    elif not cited:
+        problems.append("canonical_reconcile.head_sha is required")
+    if kind == "repo_change" and decision and decision not in REPO_CHANGE_DECISIONS:
+        problems.append("repo_change evidence requires canonical_reconcile.decision=still_valid")
+    if kind == "no_change" and decision and decision not in NO_CHANGE_DECISIONS:
+        problems.append(
+            "no_change evidence requires canonical_reconcile.decision="
+            "already_satisfied or needs_restatement"
+        )
+    return problems
+
+
+def head_sha_matches(cited: str, expected: str) -> bool:
+    left = _text(cited).lower()
+    right = _text(expected).lower()
+    if not left or not right:
+        return False
+    if left == right:
+        return True
+    # Permit abbreviated citations of the prepared SHA.
+    n = min(len(left), len(right))
+    return n >= 7 and (left.startswith(right[:n]) or right.startswith(left[:n]))
+
+
+def is_no_change_reconcile(manifest: Mapping[str, Any]) -> bool:
+    kind = _text(manifest.get("evidence_type")).lower()
+    decision = _text(_reconcile_block(manifest).get("decision")).lower()
+    return kind == "no_change" and decision in NO_CHANGE_DECISIONS
+
+
+def host_still_valid_reconcile(
+    task: Optional[Mapping[str, Any]],
+    existing: Optional[Mapping[str, Any]] = None,
+    *,
+    reason: str = "",
+) -> Dict[str, Any]:
+    """Fill still_valid when the host is publishing a repo_change.
+
+    The look is the snapshot attached at worktree prep. Host rescue of a
+    missing/incomplete agent manifest still needs a decision that cites that
+    HEAD, or submit refuses. Do not invent already_satisfied here.
+    """
+    block = dict(existing) if isinstance(existing, Mapping) else {}
+    if _text(block.get("decision")).lower() in RECONCILE_DECISIONS:
+        return block
+    snapshot = reconcile_snapshot_from_task(task)
+    head = _text(block.get("head_sha")) or _text(snapshot.get("head_sha"))
+    if not head:
+        return block
+    block["decision"] = "still_valid"
+    block["head_sha"] = head
+    if not _text(block.get("reason")):
+        block["reason"] = reason or (
+            "repository change finalized against prepared canonical HEAD %s" % head[:12]
+        )
+    return block

--- a/src/mac/evidence_validators.py
+++ b/src/mac/evidence_validators.py
@@ -13,6 +13,7 @@ import subprocess
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Optional
 
+from mac.canonical_reconcile import reconcile_evidence_problems
 from mac.fleet_learning import (
     AUTH_FAILURE_CLASSES,
     classify_repository_access_failure,
@@ -166,6 +167,9 @@ class EvidenceValidationContext:
     repo_coupled: bool = False
     # mac-wjy3: a task whose contract requires tests must record a tests list.
     require_tests: bool = False
+    # Prepared canonical HEAD the worker attached. Empty means this run did
+    # not snapshot a worktree (unit tests of bare manifests stay fail-open).
+    expected_reconcile_head_sha: str = ""
 
 
 class EvidenceValidator:
@@ -479,20 +483,30 @@ def validate_evidence_type(
     allow_empty_repo_change: bool = False,
     repo_coupled: bool = False,
     require_tests: bool = False,
+    expected_reconcile_head_sha: str = "",
 ) -> List[str]:
     typed = VerificationManifest.parse(manifest)
     validator = VALIDATORS.get(str(evidence_type or "").strip().lower())
     if validator is None:
         return ["unsupported verification.evidence_type: %s" % evidence_type]
-    return validator.validate(
+    problems = validator.validate(
         typed,
         EvidenceValidationContext(
             passed_check_count=passed_check_count,
             allow_empty_repo_change=allow_empty_repo_change,
             repo_coupled=repo_coupled,
             require_tests=require_tests,
+            expected_reconcile_head_sha=expected_reconcile_head_sha,
         ),
     )
+    problems.extend(
+        reconcile_evidence_problems(
+            typed.raw,
+            str(evidence_type or "").strip().lower(),
+            expected_reconcile_head_sha,
+        )
+    )
+    return problems
 
 
 def _manifest_list(value: Any) -> List[Any]:

--- a/src/mac/executor-policy.txt
+++ b/src/mac/executor-policy.txt
@@ -14,6 +14,13 @@ worktree (rebase before publishing), and whether a peer holds a lease on
 related work. A context that says TRUNCATED is incomplete; query the hub rather
 than treating what you were shown as the whole story.
 
+Before editing a repository task, read the Canonical HEAD reconcile section
+when present. Starting on HEAD is placement, not proof the task is still
+valid. Adjacent landings on the same files are not proof the defect is gone.
+Record canonical_reconcile.decision (still_valid, already_satisfied, or
+needs_restatement) against that HEAD. already_satisfied and needs_restatement
+use evidence_type=no_change and must not open a pull request.
+
 The prepared task worktree is the worker's only writable repository checkout;
 registered source checkouts remain read-only except for explicit
 source-remediation tasks. The worker owns analysis, edits, task-local bootstrap,

--- a/src/mac/executor_finalizer.py
+++ b/src/mac/executor_finalizer.py
@@ -342,6 +342,11 @@ from mac.bus_task_context import (  # noqa: E402
     already_published as bus_already_published,
     bus_context_from_task,
 )
+from mac.canonical_reconcile import (  # noqa: E402
+    head_sha_matches,
+    host_still_valid_reconcile,
+    is_no_change_reconcile,
+)
 from mac.executor_hub_io import (  # noqa: E402,F401 - compatibility re-exports
     broadcast_event,
     utcnow,
@@ -804,6 +809,141 @@ def _read_executor_evidence_payload(task_workspace: Path) -> Dict[str, Any]:
     return loaded if isinstance(loaded, dict) else {}
 
 
+def _canonical_reconcile_from_evidence(evidence: Mapping[str, Any]) -> Dict[str, Any]:
+    block = evidence.get("canonical_reconcile") if isinstance(evidence, Mapping) else None
+    return dict(block) if isinstance(block, dict) else {}
+
+
+def _stamp_canonical_reconcile(manifest: Dict[str, Any], block: Mapping[str, Any]) -> None:
+    if block:
+        manifest["canonical_reconcile"] = dict(block)
+
+
+def _finalize_no_change_reconcile(
+    task_workspace: Path,
+    task: Dict[str, Any],
+    worktree_path: Path,
+    agent_evidence: Mapping[str, Any],
+    *,
+    task_id: Optional[str],
+) -> bool:
+    """Accept already_satisfied / needs_restatement without commit, push, or PR.
+
+    Returns True when evidence was written and the caller must stop.
+    """
+    if not is_no_change_reconcile(agent_evidence):
+        return False
+    reconcile_block = _canonical_reconcile_from_evidence(agent_evidence)
+    status = _git(["status", "--porcelain"], worktree_path)
+    tracked_lines, untracked_paths, staged_new_paths = _split_porcelain_status(status.stdout)
+    dirty = bool(tracked_lines or untracked_paths or staged_new_paths)
+    head_sha = _git(["rev-parse", "HEAD"], worktree_path).stdout.strip()
+    base_sha = _repository_prepared_base(task)
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"], worktree_path).stdout.strip() or "HEAD"
+    reason = str(
+        agent_evidence.get("reason")
+        or agent_evidence.get("no_change_reason")
+        or reconcile_block.get("reason")
+        or ""
+    ).strip()
+    decision = str(reconcile_block.get("decision") or "").strip().lower()
+    moved = bool(base_sha and head_sha and not head_sha_matches(head_sha, base_sha))
+    if dirty or moved:
+        problem = (
+            "no_change canonical_reconcile requires a clean worktree at the prepared HEAD"
+            if dirty
+            else "no_change canonical_reconcile requires HEAD to match the prepared base"
+        )
+        manifest = {
+            "schema": "mac.worker_evidence.v1",
+            "status": "fail",
+            "evidence_type": "no_change",
+            "reason": reason or problem,
+            "summary": problem,
+            "problems": [problem],
+            "canonical_reconcile": reconcile_block,
+            "repo": {
+                "head_sha": head_sha,
+                "base_sha": base_sha,
+                "pushed": False,
+                "remote_ref": "refs/heads/" + branch if branch != "HEAD" else "",
+                "dirty": dirty,
+                "files_changed": [],
+            },
+            "push": {
+                "returncode": 1,
+                "status": "skipped",
+                "reason": problem,
+            },
+            "checks": [
+                {
+                    "name": "canonical_head_matches_prepared_base",
+                    "returncode": 1,
+                    "status": "fail",
+                    "stderr": problem,
+                }
+            ],
+        }
+        (task_workspace / "mac-evidence.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        emit_telemetry(
+            "finalizer_completed",
+            task_id=task_id,
+            level="warning",
+            all_ok=False,
+            pushed=False,
+            head_sha=head_sha,
+        )
+        return True
+    if not reason:
+        reason = "requested change is already present at canonical HEAD"
+    stamped = dict(reconcile_block) if reconcile_block else {}
+    stamped.setdefault("decision", decision)
+    stamped.setdefault("head_sha", head_sha)
+    stamped.setdefault("reason", reason)
+    manifest = {
+        "schema": "mac.worker_evidence.v1",
+        "status": "complete",
+        "evidence_type": "no_change",
+        "reason": reason,
+        "summary": reason,
+        "canonical_reconcile": stamped,
+        "repo": {
+            "head_sha": head_sha,
+            "base_sha": base_sha,
+            "pushed": False,
+            "remote_ref": "refs/heads/" + branch if branch != "HEAD" else "",
+            "dirty": False,
+            "files_changed": [],
+        },
+        "push": {
+            "returncode": 0,
+            "status": "skipped",
+            "reason": "canonical_reconcile %s; no publication" % (decision or "no_change"),
+        },
+        "checks": [
+            {
+                "name": "canonical_head_matches_prepared_base",
+                "returncode": 0,
+                "status": "pass",
+            }
+        ],
+    }
+    (task_workspace / "mac-evidence.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    emit_telemetry(
+        "finalizer_completed",
+        task_id=task_id,
+        level="info",
+        all_ok=True,
+        pushed=False,
+        head_sha=head_sha,
+    )
+    return True
+
+
 def _preserve_executor_state_before_refusal(
     task_workspace: Path,
     task: Dict[str, Any],
@@ -1124,6 +1264,7 @@ def _write_partial_finalizer_evidence(
     files_changed: Optional[List[str]] = None,
     bootstrap: Optional[Dict[str, Any]] = None,
     tests: Optional[Dict[str, Any]] = None,
+    canonical_reconcile: Optional[Mapping[str, Any]] = None,
 ) -> None:
     manifest: Dict[str, Any] = {
         "schema": "mac.worker_evidence.v1",
@@ -1156,6 +1297,7 @@ def _write_partial_finalizer_evidence(
     }
     if bootstrap is not None:
         manifest["bootstrap"] = bootstrap
+    _stamp_canonical_reconcile(manifest, canonical_reconcile or {})
     (task_workspace / "mac-evidence.json").write_text(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
@@ -1236,6 +1378,16 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
         return
     task_id = str(task.get("id") or "") or None
     emit_telemetry("finalizer_started", task_id=task_id)
+    agent_evidence = _read_executor_evidence_payload(task_workspace)
+    reconcile_block = _canonical_reconcile_from_evidence(agent_evidence)
+    if _finalize_no_change_reconcile(
+        task_workspace,
+        task,
+        worktree_path,
+        agent_evidence,
+        task_id=task_id,
+    ):
+        return
     progress: Dict[str, Any] = {
         "head_sha": "",
         "base_sha": _repository_prepared_base(task),
@@ -1257,6 +1409,7 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
             files_changed=list(progress["files_changed"]),
             bootstrap=progress["bootstrap"],
             tests=progress["tests"],
+            canonical_reconcile=reconcile_block,
         )
 
     with _FinalizerPhaseContext(
@@ -1575,6 +1728,8 @@ def run_deterministic_git_finalizer(task_workspace: Path, task: Dict[str, Any]) 
     recovery_log = _load_harness_recovery_log(task_workspace)
     if recovery_log:
         manifest["recovery"] = recovery_log
+    stamped = host_still_valid_reconcile(task, reconcile_block)
+    _stamp_canonical_reconcile(manifest, stamped)
     with _FinalizerPhaseContext(
         task_workspace,
         task_id,

--- a/src/mac/executor_prompt.py
+++ b/src/mac/executor_prompt.py
@@ -71,6 +71,7 @@ from mac.bus_task_context import (
     bus_context_from_task,
     render_bus_context_section,
 )
+from mac.canonical_reconcile import render_reconcile_section
 from mac.models import (
     metadata_declares_read_only_report_repository,
     metadata_declares_report_deliverable,
@@ -860,7 +861,7 @@ def build_task_prompt(
     evidence_contract = (
         "This is a read-only repository report. Evidence must use evidence_type=operator_result; repository mutation, commit, push, and host finalization are forbidden."
         if metadata_declares_read_only_report_repository(metadata)
-        else "Evidence contract: repository tasks use evidence_type=repo_change; operator_result is reserved for work without a repository contract. The deterministic host owns final tests, cleanliness, canonical freshness, and publication."
+        else "Evidence contract: repository tasks use evidence_type=repo_change when the requested change is still absent in this tree; already_satisfied and needs_restatement use evidence_type=no_change and must not open a pull request. operator_result is reserved for work without a repository contract. The deterministic host owns final tests, cleanliness, canonical freshness, and publication."
     )
     parts = [
         "You are running as a MAC fleet worker. Complete the assigned task from first principles.",
@@ -891,6 +892,9 @@ def build_task_prompt(
     bus_section = render_bus_context_section(bus_context_from_task(task))
     if bus_section:
         parts.append(bus_section)
+    reconcile_section = render_reconcile_section(task)
+    if reconcile_section:
+        parts.append(reconcile_section)
     integration_section = _cooperative_integration_section(task)
     if integration_section:
         parts.append(integration_section)

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -209,6 +209,7 @@ from mac.agentbus_control import (
 from mac.action_event_service import ActionEventService
 from mac.agentbus_broadcast import BroadcastService
 from mac.agentbus_service import AgentBusService
+from mac.canonical_reconcile import expected_head_sha_from_task
 from mac.deploy_service import DeployService
 from mac.directive_service import DirectiveService
 from mac import evidence_blobs
@@ -26704,6 +26705,9 @@ class ControlPlane:
             allow_empty_repo_change=self._allows_empty_repo_change_evidence(task, evidence_type),
             repo_coupled=self._task_is_repo_coupled(task),
             require_tests=self._task_requires_tests(task),
+            expected_reconcile_head_sha=expected_head_sha_from_task(
+                {"id": task.id, "metadata": task.metadata}
+            ),
         )
         problems.extend(self._required_changed_file_problems(task, manifest))
         return problems

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -47,6 +47,12 @@ from mac.bus_task_context import (
     bus_context_from_task,
     task_focus as bus_task_focus,
 )
+from mac.canonical_reconcile import (
+    build_reconcile_snapshot,
+    expected_head_sha_from_task,
+    host_still_valid_reconcile,
+    reconcile_evidence_problems,
+)
 from mac.agentbus_control import (
     DEBUG_TERMINAL_INPUT_SCHEMA,
     DEBUG_TERMINAL_OPEN_CONTENT_TYPE,
@@ -4096,6 +4102,7 @@ class MacWorker(
         # is written, because task.json is what the coding agent is handed --
         # afterwards would be too late for the agent that has to act on it.
         self._attach_bus_task_context(task, task_dir, repository_context)
+        self._attach_canonical_reconcile(task, task_dir, repository_context)
         (task_dir / "task.json").write_text(
             json.dumps({"task": task, "lease": lease}, indent=2, sort_keys=True),
             encoding="utf-8",
@@ -4173,6 +4180,64 @@ class MacWorker(
             },
         )
         return context
+
+    def _attach_canonical_reconcile(
+        self,
+        task: JsonDict,
+        task_dir: Path,
+        repository_context: Optional[JsonDict],
+    ) -> JsonDict:
+        """Record the look at canonical HEAD that placement is not a validity decision.
+
+        Adjacent landings on the same files are facts to re-read, not proof the
+        described defect is gone. The snapshot is what the prompt renders and
+        what submit later requires the evidence to answer.
+        """
+        repo = repository_context if isinstance(repository_context, dict) else {}
+        worktree_raw = str(repo.get("repository_worktree") or "").strip()
+        worktree = Path(worktree_raw).expanduser() if worktree_raw else None
+        if worktree is None or not worktree.is_dir():
+            return {}
+        head_sha = str(repo.get("repository_base_sha") or "").strip()
+        canonical_branch = str(repo.get("repository_canonical_branch") or "").strip()
+        metadata = task.get("metadata") if isinstance(task.get("metadata"), dict) else {}
+        runtime = metadata.get("runtime") if isinstance(metadata.get("runtime"), dict) else {}
+        bus_context = (
+            runtime.get("bus_context") if isinstance(runtime.get("bus_context"), dict) else {}
+        )
+        snapshot = build_reconcile_snapshot(
+            worktree,
+            task,
+            head_sha=head_sha,
+            canonical_branch=canonical_branch,
+            bus_context=bus_context,
+        )
+        try:
+            (task_dir / "canonical-reconcile.json").write_text(
+                json.dumps(snapshot, indent=2, sort_keys=True, default=str),
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
+        metadata = task.setdefault("metadata", {})
+        if isinstance(metadata, dict):
+            runtime = metadata.setdefault("runtime", {})
+            if isinstance(runtime, dict):
+                runtime["canonical_reconcile"] = snapshot
+        self._observe_log(
+            "worker.canonical_reconcile.attached",
+            subject_type="task",
+            subject_id=str(task.get("id") or ""),
+            detail={
+                "agent_id": self.agent_id,
+                "head_sha": snapshot.get("head_sha"),
+                "canonical_branch": snapshot.get("canonical_branch"),
+                "implicated_paths": list(snapshot.get("implicated_paths") or [])[:12],
+                "recent_commits": len(snapshot.get("recent_commits") or []),
+                "sibling_landings": len(snapshot.get("sibling_landings") or []),
+            },
+        )
+        return snapshot
 
     def _review_task_payload(self, task_dir: Path) -> JsonDict:
         loaded = json.loads((task_dir / "task.json").read_text(encoding="utf-8"))
@@ -4730,6 +4795,16 @@ class MacWorker(
             "tests": tests,
             "checks": checks,
         }
+        existing_reconcile = {}
+        try:
+            loaded = json.loads((task_dir / "mac-evidence.json").read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            loaded = {}
+        if isinstance(loaded, dict) and isinstance(loaded.get("canonical_reconcile"), dict):
+            existing_reconcile = loaded["canonical_reconcile"]
+        stamped = host_still_valid_reconcile(task, existing_reconcile)
+        if stamped:
+            manifest["canonical_reconcile"] = stamped
         if problems:
             manifest["problems"] = problems
         return manifest
@@ -4924,6 +4999,13 @@ class MacWorker(
             if evidence_type == "review_verdict":
                 problems.extend(_worker_review_verdict_executor_repo_problems(task_dir, manifest))
             problems.extend(_worker_required_changed_file_problems(task_payload, manifest))
+            problems.extend(
+                reconcile_evidence_problems(
+                    manifest,
+                    evidence_type,
+                    expected_head_sha_from_task(task_payload),
+                )
+            )
 
         serialized_context = _load_repository_context(task_dir)
         trusted_read_only_context = _trusted_read_only_repository_context(task_payload)

--- a/tests/test_bus_task_context.py
+++ b/tests/test_bus_task_context.py
@@ -184,6 +184,12 @@ def test_a_merge_of_someone_elses_task_is_not_my_work_landing():
     assert already_published(context) is None
     # ...but it IS a canonical advance, which is a different fact about it.
     assert context["events"], "a peer's merge onto my base branch is still relevant"
+    siblings = context["signals"]["sibling_landings"]
+    assert siblings
+    assert siblings[0]["task_id"] == "task_theirs"
+    rendered = render_bus_context_section(context)
+    assert "RECENT LANDINGS" in rendered
+    assert "ALREADY LANDED" not in rendered
 
 
 def test_it_answers_whether_the_canonical_tip_moved():

--- a/tests/test_canonical_reconcile.py
+++ b/tests/test_canonical_reconcile.py
@@ -1,0 +1,337 @@
+"""Canonical HEAD reconcile is a recorded look, not an auto-kill."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from mac import executor_finalizer as finalizer
+from mac.canonical_reconcile import (
+    build_reconcile_snapshot,
+    expected_head_sha_from_task,
+    head_sha_matches,
+    implicated_paths,
+    reconcile_evidence_problems,
+    render_reconcile_section,
+    sibling_landings_from_bus,
+)
+from mac.executor_prompt import build_task_prompt
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True, check=False)
+
+
+def test_implicated_paths_take_backticks_and_slash_tokens_not_urls():
+    paths = implicated_paths(
+        "stop `scripts/release.sh` from pushing main",
+        "See https://github.com/acme/widgets/blob/main/scripts/release.sh and src/mac/cli.py.",
+    )
+    assert "scripts/release.sh" in paths
+    assert "src/mac/cli.py" in paths
+    assert not any(item.startswith("https://") for item in paths)
+
+
+def test_implicated_paths_ignore_version_tokens_without_slash():
+    assert implicated_paths("Release v3.4.11", "bump the version") == []
+
+
+def test_sibling_landings_exclude_this_task_and_are_not_already_published():
+    context = {
+        "events": [
+            {
+                "event_type": "git.merged",
+                "task_id": "task_mine",
+                "payload": {"sha": "aaa", "pr_number": 1},
+            },
+            {
+                "event_type": "git.merged",
+                "task_id": "task_theirs",
+                "payload": {"sha": "bbb", "pr_number": 107},
+            },
+        ]
+    }
+    landings = sibling_landings_from_bus(context, task_id="task_mine")
+    assert len(landings) == 1
+    assert landings[0]["task_id"] == "task_theirs"
+    assert landings[0]["pr_number"] == 107
+
+
+def test_reconcile_evidence_fail_open_without_prepared_head():
+    assert (
+        reconcile_evidence_problems(
+            {"evidence_type": "repo_change"},
+            "repo_change",
+            "",
+        )
+        == []
+    )
+
+
+def test_repo_change_without_decision_fails_when_head_is_expected():
+    problems = reconcile_evidence_problems(
+        {"evidence_type": "repo_change"},
+        "repo_change",
+        "abcdef1234567890",
+    )
+    assert any("canonical_reconcile" in item for item in problems)
+
+
+def test_still_valid_allows_repo_change_against_prepared_head():
+    manifest = {
+        "evidence_type": "repo_change",
+        "canonical_reconcile": {
+            "decision": "still_valid",
+            "head_sha": "abcdef1234567890",
+            "reason": "scripts/release.sh still pushes origin main",
+        },
+    }
+    assert reconcile_evidence_problems(manifest, "repo_change", "abcdef1234567890") == []
+    assert head_sha_matches("abcdef1", "abcdef1234567890")
+
+
+def test_already_satisfied_allows_no_change_and_rejects_repo_change():
+    manifest = {
+        "evidence_type": "no_change",
+        "canonical_reconcile": {
+            "decision": "already_satisfied",
+            "head_sha": "abcdef1234567890",
+            "reason": "the requested push path is already a PR flow",
+        },
+    }
+    assert reconcile_evidence_problems(manifest, "no_change", "abcdef1234567890") == []
+    assert reconcile_evidence_problems(manifest, "repo_change", "abcdef1234567890")
+
+
+def test_needs_restatement_is_a_no_change_decision():
+    manifest = {
+        "evidence_type": "no_change",
+        "canonical_reconcile": {
+            "decision": "needs_restatement",
+            "head_sha": "abcdef1234567890",
+            "reason": "the statement names a file that no longer exists",
+        },
+    }
+    assert reconcile_evidence_problems(manifest, "no_change", "abcdef1234567890") == []
+
+
+def test_render_reconcile_section_empty_without_snapshot():
+    assert render_reconcile_section({"id": "t1", "title": "x"}) == ""
+
+
+def test_render_and_prompt_include_reconcile_facts_when_snapshot_attached(tmp_path):
+    task = {
+        "id": "task_a0d06a48",
+        "title": "stop `scripts/release.sh` from pushing main",
+        "description": "git push origin main is still there",
+        "metadata": {
+            "execution_contract": {"type": "repository"},
+            "runtime": {
+                "canonical_reconcile": {
+                    "schema": "mac.canonical_reconcile.v1",
+                    "head_sha": "abc1234567890def",
+                    "canonical_branch": "main",
+                    "implicated_paths": ["scripts/release.sh"],
+                    "recent_commits": [
+                        {
+                            "sha": "def4567890ab",
+                            "subject": "Release v3.4.11",
+                            "paths": ["scripts/release.sh"],
+                        }
+                    ],
+                    "sibling_landings": [
+                        {
+                            "event_type": "git.merged",
+                            "task_id": "task_other",
+                            "pr_number": 107,
+                            "sha": "eee111222333",
+                        }
+                    ],
+                }
+            },
+        },
+    }
+    section = render_reconcile_section(task)
+    assert "Canonical HEAD reconcile" in section
+    assert "still_valid" in section
+    assert "already_satisfied" in section
+    assert "needs_restatement" in section
+    assert "scripts/release.sh" in section
+    assert "Do not treat these as already_published" in section
+    prompt = build_task_prompt(task, tmp_path / "task.json")
+    assert "Canonical HEAD reconcile" in prompt
+    assert "repository tasks use evidence_type=repo_change" in prompt
+
+
+def test_non_repo_prompt_omits_reconcile_when_no_snapshot(tmp_path):
+    prompt = build_task_prompt(
+        {"id": "t1", "title": "answer a question", "metadata": {}},
+        tmp_path / "task.json",
+    )
+    assert "Canonical HEAD reconcile" not in prompt
+
+
+def test_host_still_valid_fills_missing_decision_from_snapshot():
+    from mac.canonical_reconcile import host_still_valid_reconcile
+
+    task = {"metadata": {"runtime": {"canonical_reconcile": {"head_sha": "abcdef1234567890"}}}}
+    stamped = host_still_valid_reconcile(task, {})
+    assert stamped["decision"] == "still_valid"
+    assert stamped["head_sha"] == "abcdef1234567890"
+
+
+def test_host_still_valid_does_not_override_already_satisfied():
+    from mac.canonical_reconcile import host_still_valid_reconcile
+
+    existing = {
+        "decision": "already_satisfied",
+        "head_sha": "abcdef1234567890",
+        "reason": "already a PR flow",
+    }
+    assert host_still_valid_reconcile({"metadata": {}}, existing)["decision"] == "already_satisfied"
+    task = {"metadata": {"runtime": {"canonical_reconcile": {"head_sha": "deadbeefcafebabe"}}}}
+    assert expected_head_sha_from_task(task) == "deadbeefcafebabe"
+
+
+def test_snapshot_lists_recent_commits_on_implicated_paths(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.email", "t@t")
+    _git(repo, "config", "user.name", "t")
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    (scripts / "release.sh").write_text("git push origin main\n", encoding="utf-8")
+    _git(repo, "add", "scripts/release.sh")
+    _git(repo, "commit", "-m", "add release.sh")
+    head = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    snapshot = build_reconcile_snapshot(
+        repo,
+        {
+            "id": "task_mine",
+            "title": "fix `scripts/release.sh`",
+            "description": "",
+        },
+        head_sha=head,
+        canonical_branch="main",
+        bus_context={"events": []},
+    )
+    assert snapshot["schema"] == "mac.canonical_reconcile.v1"
+    assert snapshot["implicated_paths"] == ["scripts/release.sh"]
+    assert snapshot["recent_commits"]
+    assert snapshot["recent_commits"][0]["sha"] == head
+
+
+def _seed_worktree(tmp_path: Path):
+    origin = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", str(origin))
+    work = tmp_path / "work"
+    _git(tmp_path, "clone", str(origin), str(work))
+    _git(work, "config", "user.email", "t@t")
+    _git(work, "config", "user.name", "t")
+    (work / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-m", "init")
+    _git(work, "branch", "-M", "main")
+    _git(work, "push", "origin", "main")
+    return origin, work
+
+
+def test_finalizer_no_change_already_satisfied_does_not_open_a_pr(tmp_path, monkeypatch):
+    origin, work = _seed_worktree(tmp_path)
+    head = _git(work, "rev-parse", "HEAD").stdout.strip()
+    monkeypatch.setenv("MAC_TASK_REPO_WORKTREE", str(work))
+    monkeypatch.setenv("MAC_TASK_REPO_BASE_SHA", head)
+    monkeypatch.setenv("MAC_TASK_REPO_LEASE_ID", "lease-test")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "mac-evidence.json").write_text(
+        json.dumps(
+            {
+                "schema": "mac.worker_evidence.v1",
+                "status": "complete",
+                "evidence_type": "no_change",
+                "reason": "HEAD already uses gh pr create",
+                "canonical_reconcile": {
+                    "decision": "already_satisfied",
+                    "head_sha": head,
+                    "reason": "HEAD already uses gh pr create",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    opened = {"called": False}
+
+    def _should_not_open(*_args, **_kwargs):
+        opened["called"] = True
+        return {"opened": True, "number": 99}
+
+    monkeypatch.setattr(finalizer, "open_task_pull_request", _should_not_open)
+    task = {
+        "id": "task_satisfied",
+        "metadata": {
+            "publication_target": "git://main",
+            "origin": {
+                "repository_contract": {
+                    "canonical_remote_url": origin.as_uri(),
+                    "test": {"command": "true"},
+                }
+            },
+        },
+    }
+    finalizer.run_deterministic_git_finalizer(ws, task)
+    manifest = json.loads((ws / "mac-evidence.json").read_text(encoding="utf-8"))
+    assert manifest["evidence_type"] == "no_change"
+    assert manifest["status"] == "complete"
+    assert manifest["repo"]["pushed"] is False
+    assert manifest["push"]["status"] == "skipped"
+    assert not opened["called"]
+    assert manifest["canonical_reconcile"]["decision"] == "already_satisfied"
+    names = {item["name"]: item["status"] for item in manifest["checks"]}
+    assert names["canonical_head_matches_prepared_base"] == "pass"
+
+
+def test_finalizer_rejects_no_change_when_the_tree_is_dirty(tmp_path, monkeypatch):
+    origin, work = _seed_worktree(tmp_path)
+    head = _git(work, "rev-parse", "HEAD").stdout.strip()
+    (work / "README.md").write_text("hello\ndirty\n", encoding="utf-8")
+    monkeypatch.setenv("MAC_TASK_REPO_WORKTREE", str(work))
+    monkeypatch.setenv("MAC_TASK_REPO_BASE_SHA", head)
+    monkeypatch.setenv("MAC_TASK_REPO_LEASE_ID", "lease-test")
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / "mac-evidence.json").write_text(
+        json.dumps(
+            {
+                "schema": "mac.worker_evidence.v1",
+                "status": "complete",
+                "evidence_type": "no_change",
+                "reason": "already done",
+                "canonical_reconcile": {
+                    "decision": "already_satisfied",
+                    "head_sha": head,
+                    "reason": "already done",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    task = {
+        "id": "task_dirty",
+        "metadata": {
+            "publication_target": "git://main",
+            "origin": {
+                "repository_contract": {
+                    "canonical_remote_url": origin.as_uri(),
+                    "test": {"command": "true"},
+                }
+            },
+        },
+    }
+    finalizer.run_deterministic_git_finalizer(ws, task)
+    manifest = json.loads((ws / "mac-evidence.json").read_text(encoding="utf-8"))
+    assert manifest["status"] == "fail"
+    assert manifest["repo"]["pushed"] is False
+    assert any("clean worktree" in item for item in manifest["problems"])

--- a/tests/test_evidence_validators.py
+++ b/tests/test_evidence_validators.py
@@ -861,3 +861,68 @@ def test_tests_list_with_one_item_passes_require_tests():
         )
         == []
     )
+
+
+def test_reconcile_is_not_required_without_prepared_head_sha():
+    assert (
+        validate_evidence_type(
+            "repo_change",
+            _repo_manifest(),
+            passed_check_count=_passed_check_count,
+        )
+        == []
+    )
+
+
+def test_repo_change_requires_still_valid_when_prepared_head_is_set():
+    problems = validate_evidence_type(
+        "repo_change",
+        _repo_manifest(),
+        passed_check_count=_passed_check_count,
+        expected_reconcile_head_sha="abcdef1234567890",
+    )
+    assert any("canonical_reconcile" in item for item in problems)
+
+    ok = _repo_manifest(
+        canonical_reconcile={
+            "decision": "still_valid",
+            "head_sha": "abcdef1234567890",
+            "reason": "the requested change is still absent",
+        }
+    )
+    assert (
+        validate_evidence_type(
+            "repo_change",
+            ok,
+            passed_check_count=_passed_check_count,
+            expected_reconcile_head_sha="abcdef1234567890",
+        )
+        == []
+    )
+
+
+def test_no_change_already_satisfied_passes_when_prepared_head_is_set():
+    manifest = _repo_manifest(
+        evidence_type="no_change",
+        repo={
+            "head_sha": "abcdef1234567890",
+            "dirty": False,
+            "pushed": False,
+            "files_changed": [],
+        },
+        reason="already present at HEAD",
+        canonical_reconcile={
+            "decision": "already_satisfied",
+            "head_sha": "abcdef1234567890",
+            "reason": "already present at HEAD",
+        },
+    )
+    assert (
+        validate_evidence_type(
+            "no_change",
+            manifest,
+            passed_check_count=_passed_check_count,
+            expected_reconcile_head_sha="abcdef1234567890",
+        )
+        == []
+    )

--- a/tests/test_worker_bus_context.py
+++ b/tests/test_worker_bus_context.py
@@ -21,6 +21,7 @@ that: a rare terminal event buried under a page of chatter is still found.
 from __future__ import annotations
 
 import json
+import subprocess
 from urllib.parse import parse_qs, urlparse
 
 import pytest
@@ -146,6 +147,60 @@ def test_the_prompt_the_agent_is_given_names_what_it_must_not_redo(tmp_path):
     assert "AgentBus context" in prompt
     assert "ALREADY LANDED" in prompt
     assert "do NOT open a second pull request" in prompt
+
+
+def test_the_prompt_names_canonical_head_reconcile_when_the_worker_attaches_it(tmp_path):
+    from mac.executor_prompt import build_task_prompt
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "release.sh").write_text("git push origin main\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, capture_output=True, check=True)
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    client = _Client(
+        [
+            _event(
+                11,
+                "git.merged",
+                task_id="task_theirs",
+                payload={
+                    "repository": REPO_CONTEXT["repository_canonical_remote"],
+                    "canonical_branch": "main",
+                    "sha": "peerlanded",
+                    "pr_number": 107,
+                },
+            )
+        ]
+    )
+    instance = _worker(tmp_path, client)
+    task = _task()
+    task["title"] = "stop `scripts/release.sh` from pushing main"
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    repo_context = dict(REPO_CONTEXT)
+    repo_context["repository_worktree"] = str(repo)
+    repo_context["repository_base_sha"] = head
+    instance._attach_bus_task_context(task, task_dir, repo_context)
+    instance._attach_canonical_reconcile(task, task_dir, repo_context)
+
+    snapshot = task["metadata"]["runtime"]["canonical_reconcile"]
+    assert snapshot["head_sha"] == head
+    assert "scripts/release.sh" in snapshot["implicated_paths"]
+    on_disk = json.loads((task_dir / "canonical-reconcile.json").read_text(encoding="utf-8"))
+    assert on_disk["head_sha"] == head
+    prompt = build_task_prompt(task, task_dir / "task.json")
+    assert "Canonical HEAD reconcile" in prompt
+    assert "still_valid" in prompt
+    assert "already_satisfied" in prompt
+    assert "RECENT LANDINGS" in prompt or "sibling" in json.dumps(snapshot)
 
 
 def test_the_workers_own_echo_is_not_fed_back_to_it(tmp_path):


### PR DESCRIPTION
## Summary
- Repository workers now attach a recorded look at the prepared canonical HEAD (implicated paths, recent commits, same-repo sibling landings) and the executor prompt requires a `canonical_reconcile` decision: `still_valid`, `already_satisfied`, or `needs_restatement`.
- `already_satisfied` / `needs_restatement` are legal `no_change` outcomes: clean tree, no PR, no attempt burned. Sibling `git.merged` events are facts to re-read, never `already_published` for this task.
- The host refuses a `repo_change` that never did this reconcile when a snapshot was attached; executor policy and the AgentBus skill carry the same instruction into every sandbox.

Closes `task_a0d06a48`.

## Test plan
- [x] `tests/test_canonical_reconcile.py` (path extract, snapshot, evidence matrix, no_change finalizer skips PR)
- [x] `tests/test_bus_task_context.py` sibling landings are not `already_published`
- [x] `tests/test_evidence_validators.py` require reconcile only when prepared HEAD is set
- [x] `tests/test_worker.py` host rescue still submits `repo_change` with host-stamped `still_valid`
- [ ] Deploy to the rocky fleet and confirm workers heartbeat / can claim