### PR TITLE
Expand empty schema-migration arg arrays under bash nounset

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -11112,8 +11112,12 @@ PY_SCHEMA_PREFLIGHT
   write_schema_migration_receipt \
     backup_required "$preflight" "" "" "$quiescence"
   log "creating restore-verified PostgreSQL backup before schema migration"
+  # ${a[@]+"${a[@]}"} rather than "${a[@]}": under `set -u`, bash 3.2 (macOS
+  # hub hosts) treats expanding an empty array as unbound. backup_args is
+  # empty for a versioned authority with pending migrations; only `fresh`
+  # appends --allow-empty-authority.
   "$VENV/bin/mac-pg-backup" --json --dsn "$dsn" --out "$backup_dir" \
-    "${backup_args[@]}" > "$backup"
+    ${backup_args[@]+"${backup_args[@]}"} > "$backup"
   "$PY" - "$backup" <<'PY_SCHEMA_BACKUP_PROOF'
 import json
 import sys
@@ -11132,7 +11136,7 @@ PY_SCHEMA_BACKUP_PROOF
   log "applying explicit transactional PostgreSQL schema migrations"
   if ! "$VENV/bin/mac-schema-migrate" --database-url "$dsn" \
       --applied-by "fleet-deploy:${DEPLOY_REV}:${DEPLOY_GENERATION}" \
-      "${baseline_args[@]}" > "$migration"; then
+      ${baseline_args[@]+"${baseline_args[@]}"} > "$migration"; then
     write_schema_migration_receipt \
       migration_failed_backup_retained "$preflight" "$backup" "" "$quiescence"
     die "PostgreSQL schema migration failed transactionally; backup retained at $(cat "$backup")"

--- a/tests/test_deploy_schema_migrations.py
+++ b/tests/test_deploy_schema_migrations.py
@@ -115,3 +115,18 @@ def test_spokes_never_backup_or_migrate_postgresql() -> None:
     assert first_command == "control_plane_enabled || return 0"
     assert '"$VENV/bin/mac-pg-backup"' in body
     assert '"$VENV/bin/mac-schema-migrate"' in body
+
+
+def test_empty_backup_and_baseline_args_expand_under_nounset() -> None:
+    """Versioned pending migrations leave both arrays empty; Darwin bash 3.2
+    with `set -u` aborts `"${empty[@]}"` (rocky 2026-08-28 deploy of #671)."""
+    body = _migration_function(_installer())
+
+    assert "local -a baseline_args=() backup_args=()" in body
+    assert '    ${backup_args[@]+"${backup_args[@]}"} > "$backup"' in body
+    assert '      ${baseline_args[@]+"${baseline_args[@]}"} > "$migration"' in body
+    unsafe = body.replace('${backup_args[@]+"${backup_args[@]}"}', "").replace(
+        '${baseline_args[@]+"${baseline_args[@]}"}', ""
+    )
+    assert '"${backup_args[@]}"' not in unsafe
+    assert '"${baseline_args[@]}"' not in unsafe


### PR DESCRIPTION
## Summary
- Rocky's apply of `24914df4` died at `backup_args[@]: unbound variable` on macOS bash 3.2 (`set -u`) before it could backup or apply `0003_drop_leftover_work_package_triggers`.
- `backup_args` / `baseline_args` stay empty on a versioned hub with pending migrations; `"${empty[@]}"` is unbound on Darwin. Use the same `${a[@]+"${a[@]}"}` form the installer already uses for `CONTAINER_RUNTIME_PATHS`.
- Natasha and bullwinkle already applied `24914df4`; this unblocks the hub retry (`task_0f6b3af5`).

## Test plan
- [x] `uv run --extra dev pytest -q tests/test_deploy_schema_migrations.py` (7 passed)
- [x] `/bin/bash` 3.2: `"${arr[@]}"` exits 127 under `set -u`; `${arr[@]+"${arr[@]}"}` does not
- [ ] `make deploy HUB=rocky` after merge: schema receipt `migrated`, `agent_rocky` idle/healthy