### PR TITLE
Resolve psql/pg_restore off PATH during live backup verify

### DIFF
--- a/src/mac/pg_backup.py
+++ b/src/mac/pg_backup.py
@@ -352,8 +352,15 @@ def dump(
     verify_detail: Dict[str, object] = {"performed": False}
     verified = False
     if verify:
+        # Pass the caller's runner, not `run`. `run` is always a callable
+        # (`_default_runner` on the live path), and `_binary_for` treats any
+        # non-None runner as a model that must keep using bare names. Passing
+        # `_default_runner` made verify_restore invoke argv[0]="psql" /
+        # "pg_restore", which FileNotFoundError'd under launchd PATH
+        # (task_0393627c). The live path's runner is None, so `_binary_for`
+        # resolves via pg_binary(); a test FakePg still arrives as `runner`.
         verify_detail = verify_restore(
-            dsn, destination, verify_tables=verify_tables, now=now, runner=run
+            dsn, destination, verify_tables=verify_tables, now=now, runner=runner
         )
         verified = bool(verify_detail.get("ok"))
 

--- a/tests/test_pg_backup.py
+++ b/tests/test_pg_backup.py
@@ -325,3 +325,35 @@ def test_dump_succeeds_while_the_live_table_is_churning(tmp_path):
     res = pg_backup.dump(DSN, tmp_path / "b", now=_now(), runner=Churning())
     assert res.verified is True
     assert json.loads(res.manifest.read_text())["restore_verified"] is True
+
+
+def test_live_dump_resolves_psql_and_pg_restore_when_they_are_off_path(tmp_path, monkeypatch):
+    """dump(verify=True) on the live path must not pass _default_runner into
+    verify_restore. That made _binary_for return the bare name ``psql``, which
+    FileNotFoundError'd under launchd PATH (task_0393627c / rocky 2026-08-28).
+    """
+
+    install = tmp_path / "opt" / "postgresql@17" / "bin"
+    install.mkdir(parents=True)
+    for name in ("pg_dump", "pg_restore", "psql"):
+        binary = install / name
+        binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        binary.chmod(binary.stat().st_mode | stat.S_IXUSR)
+
+    empty = tmp_path / "path-without-postgres"
+    empty.mkdir()
+    monkeypatch.setattr(pg_backup, "_PG_BIN_SEARCH", (str(install),))
+    monkeypatch.setenv("PATH", str(empty))
+
+    fake = FakePg()
+    monkeypatch.setattr(pg_backup, "_default_runner", fake)
+    res = pg_backup.dump(DSN, tmp_path / "live", now=_now(), runner=None)
+
+    assert res.verified is True
+    invoked = [Path(argv[0]) for argv in fake.calls]
+    names = {path.name for path in invoked}
+    assert {"pg_dump", "pg_restore", "psql"} <= names
+    for path in invoked:
+        if path.name in {"pg_dump", "pg_restore", "psql"}:
+            assert path.is_absolute(), path
+            assert path.parent == install, path


### PR DESCRIPTION
## Summary
- `dump()` passed `_default_runner` into `verify_restore`, so `_binary_for` returned the bare name `psql`/`pg_restore` instead of the Homebrew path.
- Launchd PATH on rocky has no Homebrew; restore-verify then FileNotFoundError'd after `pg_dump` succeeded (`task_0393627c`).
- Live path now passes `runner=None` so `pg_binary()` resolves; FakePg tests still inject a modelled runner.

## Test plan
- [x] `uv run --extra dev pytest -q tests/test_pg_backup.py tests/test_backup_authority_matches_backend.py` (26 passed)
- [ ] After merge: rocky scheduled `mac-pg-backup` restore-verifies without `psql` FileNotFoundError