### PR TITLE
Fix Darwin make install lockfile and use glab for GitLab remotes

### DIFF
--- a/docs/repository-ref-hygiene.md
+++ b/docs/repository-ref-hygiene.md
@@ -63,9 +63,11 @@ mac --json admin repo refs audit --repo . --remote origin --base-ref origin/main
 ```
 
 Audit reads current branch SHAs with `git ls-remote`, loads each task from the
-MAC ledger, checks open GitHub pull requests, and reports classification counts.
-It does not update or delete remote refs. Classifications include `active`,
-`blocked`, `deferred`, `superseded`, `quarantined`, `merged`, and `unknown`.
+MAC ledger, and checks open reviews on the selected remote. GitHub remotes use
+an authenticated `gh`; GitLab remotes use an authenticated `glab`. It reports
+classification counts without updating or deleting remote refs. Classifications
+include `active`, `blocked`, `deferred`, `superseded`, `quarantined`, `merged`,
+and `unknown`.
 
 Prune is also a dry-run unless `--execute` is supplied:
 
@@ -81,8 +83,8 @@ Execution fails closed unless all of these checks pass:
   disposition.
 - Its grace period has expired.
 - A completed branch is proven reachable from the selected canonical base ref.
-- GitHub pull-request state was successfully checked and no pull request is
-  open for the branch.
+- GitHub pull-request or GitLab merge-request state was successfully checked
+  and no review is open for the branch.
 - The remote SHA still equals the SHA observed by audit.
 
 Deletion is one atomic Git push guarded by a per-ref `--force-with-lease` for

--- a/observe/package-lock.json
+++ b/observe/package-lock.json
@@ -774,6 +774,26 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -3212,8 +3212,10 @@ def cmd_task_force_complete(args: argparse.Namespace) -> None:
     _print(_plane(args).force_complete_task(args.task_id, args.actor, args.reason or None))
 
 
-def _repository_open_pull_requests(repo: Path) -> tuple[Optional[Dict[str, str]], str]:
-    return query_open_pull_requests(repo, runner=subprocess.run)
+def _repository_open_pull_requests(
+    repo: Path, remote: str = "origin"
+) -> tuple[Optional[Dict[str, str]], str]:
+    return query_open_pull_requests(repo, remote=remote, runner=subprocess.run)
 
 
 def _repository_ref_audit(
@@ -3227,7 +3229,7 @@ def _repository_ref_audit(
     selected_tasks = set(args.task_ids or [])
     if selected_tasks:
         refs = [item for item in refs if item.task_id in selected_tasks]
-    open_prs, pr_warning = _repository_open_pull_requests(repo)
+    open_prs, pr_warning = _repository_open_pull_requests(repo, args.remote)
     result = audit_repository_refs_result(
         repo,
         refs,

--- a/src/mac/repository_hygiene.py
+++ b/src/mac/repository_hygiene.py
@@ -436,9 +436,10 @@ def _run(
 def query_open_pull_requests(
     repo: Path,
     *,
+    remote: str = "origin",
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
 ) -> tuple[Optional[Dict[str, str]], str]:
-    """Return open GitHub pull requests keyed by head branch.
+    """Return open pull or merge requests keyed by head branch.
 
     Failure is represented as ``(None, warning)`` rather than an empty mapping,
     because callers must distinguish "no open pull requests" from "the check
@@ -446,8 +447,24 @@ def query_open_pull_requests(
     """
 
     try:
-        result = runner(
-            [
+        cwd = str(Path(repo).expanduser().resolve())
+        if not _REMOTE_NAME_RE.fullmatch(str(remote or "")):
+            return None, "pull request state could not be verified: invalid git remote name"
+        remote_result = runner(
+            ["git", "remote", "get-url", remote],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        parsed_remote = (
+            _canonical_git_remote(remote_result.stdout) if remote_result.returncode == 0 else None
+        )
+        host = parsed_remote[0] if parsed_remote else ""
+        if host == "github.com" or host.endswith(".github.com"):
+            provider = "GitHub"
+            command = [
                 "gh",
                 "pr",
                 "list",
@@ -457,33 +474,58 @@ def query_open_pull_requests(
                 "1000",
                 "--json",
                 "headRefName,number,url",
-            ],
-            cwd=str(Path(repo).expanduser().resolve()),
+            ]
+            branch_field, number_field, url_field = "headRefName", "number", "url"
+            review_label = "PR"
+        elif host == "gitlab.com" or any(
+            label == "gitlab" or label.startswith("gitlab-") for label in host.split(".")
+        ):
+            provider = "GitLab"
+            command = [
+                "glab",
+                "mr",
+                "list",
+                "--state",
+                "opened",
+                "--per-page",
+                "1000",
+                "--output",
+                "json",
+            ]
+            branch_field, number_field, url_field = "source_branch", "iid", "web_url"
+            review_label = "MR"
+        else:
+            return None, "pull request state could not be verified: unsupported repository host"
+        result = runner(
+            command,
+            cwd=cwd,
             capture_output=True,
             text=True,
             timeout=60,
             check=False,
         )
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        return None, "GitHub pull request state could not be verified"
+        return None, "pull request state could not be verified"
     if result.returncode != 0:
-        return None, "GitHub pull request state could not be verified"
+        return None, "%s pull request state could not be verified" % provider
     try:
         payload = json.loads(result.stdout or "[]")
     except json.JSONDecodeError:
-        return None, "GitHub pull request state returned malformed JSON"
+        return None, "%s pull request state returned malformed JSON" % provider
     if not isinstance(payload, list):
-        return None, "GitHub pull request state returned an invalid response"
+        return None, "%s pull request state returned an invalid response" % provider
     heads: Dict[str, str] = {}
     for item in payload:
         if not isinstance(item, dict):
             continue
-        branch = str(item.get("headRefName") or "").strip()
+        branch = str(item.get(branch_field) or "").strip()
         if not branch:
             continue
-        url = str(item.get("url") or "").strip()
-        number = str(item.get("number") or "").strip()
-        heads[branch] = url or (("PR #%s" % number) if number else "open pull request")
+        url = str(item.get(url_field) or "").strip()
+        number = str(item.get(number_field) or "").strip()
+        heads[branch] = url or (
+            ("%s #%s" % (review_label, number)) if number else "open pull request"
+        )
     return heads, ""
 
 

--- a/src/mac/repository_ref_reconciler.py
+++ b/src/mac/repository_ref_reconciler.py
@@ -404,7 +404,7 @@ class RepositoryRefReconciler:
         )
         refresh_remote_base_ref(repo, remote, base_ref)
         refs = list_managed_remote_refs(repo, remote)
-        open_pull_requests, pr_warning = query_open_pull_requests(repo)
+        open_pull_requests, pr_warning = query_open_pull_requests(repo, remote=remote)
         audit_result = audit_repository_refs_result(
             repo,
             refs,

--- a/tests/cli/test_cli_repo_refs.py
+++ b/tests/cli/test_cli_repo_refs.py
@@ -175,7 +175,9 @@ def test_repo_refs_audit_dry_run_and_execute(tmp_path, monkeypatch):
 
     branch = "mac/agent_worker/%s-lease_%s" % (task["id"], "d" * 18)
     _git(repo, "push", "origin", "HEAD:refs/heads/%s" % branch)
-    monkeypatch.setattr(cli, "_repository_open_pull_requests", lambda _repo: ({}, ""))
+    monkeypatch.setattr(
+        cli, "_repository_open_pull_requests", lambda _repo, _remote="origin": ({}, "")
+    )
 
     rc, audit, error = _run(
         tmp_path,
@@ -245,7 +247,7 @@ def test_repo_refs_execute_requires_pull_request_verification(tmp_path, monkeypa
     monkeypatch.setattr(
         cli,
         "_repository_open_pull_requests",
-        lambda _repo: (None, "pull request state unavailable"),
+        lambda _repo, _remote="origin": (None, "pull request state unavailable"),
     )
 
     rc, result, error = _run(
@@ -272,11 +274,15 @@ def test_open_pull_request_probe_parses_and_validates_output(tmp_path, monkeypat
         {"headRefName": "", "number": 14, "url": "https://example/pr/14"},
         "invalid",
     ]
-    monkeypatch.setattr(
-        cli.subprocess,
-        "run",
-        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0, json.dumps(payload), ""),
-    )
+
+    def fake_run(argv, **kwargs):
+        if argv == ["git", "remote", "get-url", "origin"]:
+            return subprocess.CompletedProcess(
+                argv, 0, "https://github.com/example/project.git\n", ""
+            )
+        return subprocess.CompletedProcess(argv, 0, json.dumps(payload), "")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
     heads, warning = cli._repository_open_pull_requests(tmp_path)
 
@@ -299,6 +305,10 @@ def test_open_pull_request_probe_parses_and_validates_output(tmp_path, monkeypat
 )
 def test_open_pull_request_probe_fails_closed(tmp_path, monkeypatch, behavior, warning):
     def fake_run(*args, **kwargs):
+        if args[0] == ["git", "remote", "get-url", "origin"]:
+            return subprocess.CompletedProcess(
+                args[0], 0, "https://github.com/example/project.git\n", ""
+            )
         if behavior == "raise":
             raise FileNotFoundError
         if behavior == "failure":
@@ -324,7 +334,7 @@ def test_repository_ref_audit_filters_tasks_and_reports_warning(tmp_path, monkey
     monkeypatch.setattr(
         cli,
         "_repository_open_pull_requests",
-        lambda _repo: (None, "PR state unavailable"),
+        lambda _repo, _remote="origin": (None, "PR state unavailable"),
     )
     monkeypatch.setattr(
         cli,

--- a/tests/test_npm_lockfile_optional_packages.py
+++ b/tests/test_npm_lockfile_optional_packages.py
@@ -1,0 +1,40 @@
+"""Lockfiles must name every optionalDependency they declare.
+
+`npm ci` fails closed when a parent lists an optional package that has no
+`packages` entry — even on a machine that will never install that binding.
+Darwin `make install` hit this for `@rolldown/binding-linux-arm64-musl@1.2.4`
+in observe/package-lock.json while ide/ and desktop/ were complete.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCKFILES = (
+    ROOT / "observe" / "package-lock.json",
+    ROOT / "ide" / "package-lock.json",
+    ROOT / "desktop" / "package-lock.json",
+)
+
+
+@pytest.mark.parametrize("lockfile", LOCKFILES, ids=lambda path: path.parent.name)
+def test_optional_dependencies_have_packages_entries(lockfile: Path):
+    document = json.loads(lockfile.read_text(encoding="utf-8"))
+    packages = document.get("packages") or {}
+    assert isinstance(packages, dict)
+    missing = []
+    for parent, meta in packages.items():
+        if not isinstance(meta, dict):
+            continue
+        optional = meta.get("optionalDependencies") or {}
+        if not isinstance(optional, dict):
+            continue
+        for name, version in optional.items():
+            key = "node_modules/%s" % name
+            if key not in packages:
+                missing.append("%s optional %s@%s has no %s entry" % (parent, name, version, key))
+    assert missing == []

--- a/tests/test_repository_hygiene.py
+++ b/tests/test_repository_hygiene.py
@@ -657,10 +657,12 @@ def test_prune_normalizes_remote_revalidation_failure(tmp_path):
     assert "secret" not in str(exc_info.value)
 
 
-def test_query_open_pull_requests_uses_distinct_failure_state(tmp_path):
+def test_query_open_pull_requests_uses_github_schema(tmp_path):
     payload = '[{"headRefName":"branch","number":7,"url":"https://example.invalid/pull/7"}]'
 
     def success(argv, **kwargs):
+        if argv == ["git", "remote", "get-url", "origin"]:
+            return _cp(argv, stdout="git@github.com:example/project.git\n")
         assert argv[:4] == ["gh", "pr", "list", "--state"]
         assert kwargs["cwd"] == str(tmp_path.resolve())
         return _cp(argv, stdout=payload)
@@ -669,12 +671,72 @@ def test_query_open_pull_requests_uses_distinct_failure_state(tmp_path):
     assert warning == ""
     assert heads == {"branch": "https://example.invalid/pull/7"}
 
+
+def test_query_open_pull_requests_uses_gitlab_schema_without_github_flags(tmp_path):
+    payload = (
+        '[{"source_branch":"branch","iid":7,"web_url":"https://example.invalid/merge_requests/7"}]'
+    )
+
+    def success(argv, **kwargs):
+        if argv == ["git", "remote", "get-url", "origin"]:
+            return _cp(
+                argv,
+                stdout="ssh://git@gitlab-master.nvidia.com:12051/example/project.git\n",
+            )
+        assert argv == [
+            "glab",
+            "mr",
+            "list",
+            "--state",
+            "opened",
+            "--per-page",
+            "1000",
+            "--output",
+            "json",
+        ]
+        assert "--jq" not in argv
+        assert kwargs["cwd"] == str(tmp_path.resolve())
+        return _cp(argv, stdout=payload)
+
+    heads, warning = query_open_pull_requests(tmp_path, runner=success)
+    assert warning == ""
+    assert heads == {"branch": "https://example.invalid/merge_requests/7"}
+
+
+def test_query_open_pull_requests_uses_distinct_failure_state(tmp_path):
+    def failed_review_query(argv, **kwargs):
+        if argv == ["git", "remote", "get-url", "origin"]:
+            return _cp(argv, stdout="https://github.com/example/project.git\n")
+        return _cp(argv, returncode=1)
+
     heads, warning = query_open_pull_requests(
         tmp_path,
-        runner=lambda *args, **kwargs: _cp([], returncode=1),
+        runner=failed_review_query,
     )
     assert heads is None
     assert "could not be verified" in warning
+
+
+def test_query_open_pull_requests_fails_closed_for_unknown_origin(tmp_path):
+    heads, warning = query_open_pull_requests(
+        tmp_path,
+        runner=lambda argv, **kwargs: _cp(
+            argv, stdout="ssh://git@example.invalid/team/project.git\n"
+        ),
+    )
+    assert heads is None
+    assert "unsupported repository host" in warning
+
+
+def test_query_open_pull_requests_reads_the_selected_remote(tmp_path):
+    def success(argv, **kwargs):
+        if argv == ["git", "remote", "get-url", "upstream"]:
+            return _cp(argv, stdout="https://github.com/example/project.git\n")
+        return _cp(argv, stdout="[]")
+
+    heads, warning = query_open_pull_requests(tmp_path, remote="upstream", runner=success)
+    assert warning == ""
+    assert heads == {}
 
 
 def test_verify_repository_remote_accepts_transport_equivalence(tmp_path):

--- a/tests/test_repository_ref_reconciler.py
+++ b/tests/test_repository_ref_reconciler.py
@@ -107,7 +107,7 @@ def _install_success_fakes(monkeypatch, *, pr_warning=""):
     monkeypatch.setattr(
         rrr,
         "query_open_pull_requests",
-        lambda _repo: (None, pr_warning) if pr_warning else ({}, ""),
+        lambda _repo, **_kwargs: (None, pr_warning) if pr_warning else ({}, ""),
     )
     monkeypatch.setattr(
         rrr,


### PR DESCRIPTION
## Summary
- `make install` failed on Darwin at `observe && npm ci` because `rolldown@1.2.4` lists `@rolldown/binding-linux-arm64-musl` as optional without a lockfile `packages` entry. npm 11 requires that entry even on machines that will never install the binding. The CLI link step already succeeded; this is `install-gui`.
- `query_open_pull_requests` always ran `gh pr list` with GitHub JSON fields. That work existed uncommitted in `opencode/task_26e524c4-gitlab-review-checks` and had no GitHub PR. GitHub remotes keep `gh`; GitLab remotes (including `gitlab-master.nvidia.com`) use `glab mr list` and the GitLab schema; unknown hosts fail closed.

## Test plan
- [x] `cd observe && npm ci --no-audit --no-fund` on Darwin
- [x] `pytest tests/test_npm_lockfile_optional_packages.py tests/test_repository_hygiene.py tests/test_repository_ref_reconciler.py tests/cli/test_cli_repo_refs.py` (90 passed)
- [ ] `make install` from a clean checkout after merge