### PR TITLE
v1.3.1: stop portfolio false-red and pin Darwin process_e2e serial

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     env:
       MAC_SECRET_KEY: ci-test-key-with-at-least-32-characters-of-entropy
     steps:
@@ -359,16 +360,17 @@ jobs:
         with:
           name: test-portfolio
           path: .test-portfolio/
-      - name: Commit the refreshed impact map to main
+      - name: Open a PR for the refreshed impact map
         # The producer of the committed map is this job: a green whole-repo
-        # portfolio run with MAC_TEST_REBUILD_MAP=1. It used to run only on a
-        # nightly schedule, so a merge that deleted tests left interned node
-        # ids stranded until the next cron -- and every subsequent PR's
-        # always_run guards failed. Push-to-main is therefore part of the
-        # same dependency: if main moved, regenerate. [skip ci] keeps the
-        # data-only commit from re-triggering CI (and the image republish
-        # path). The rebase-retry loop tolerates a racing push to main.
+        # portfolio run with MAC_TEST_REBUILD_MAP=1. Branch protection rejects
+        # `git push origin HEAD:main` (GH013), and that rejection used to fail
+        # this job — so a red main meant "git was not allowed to push", not
+        # "the product is red". Land the refresh on a bot-owned branch as a
+        # pull request. The map is already uploaded as the test-portfolio
+        # artifact; a blocked push or PR must not fail the job.
         if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           map=src/mac/data/test_impact_map.json
@@ -378,20 +380,23 @@ jobs:
           fi
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          branch=ci/impact-map-refresh
+          git checkout -B "$branch"
           git add "$map"
-          git commit -m "chore(test-selection): refresh committed impact map [skip ci]" \
+          git commit -m "chore(test-selection): refresh committed impact map" \
             -m "Rebuilt from the portfolio coverage run at ${GITHUB_SHA}."
-          for attempt in 1 2 3 4 5; do
-            if git push origin HEAD:main; then
-              echo "pushed refreshed impact map"
-              exit 0
-            fi
-            echo "push rejected (attempt ${attempt}); rebasing onto origin/main"
-            git fetch origin main
-            git rebase origin/main
-          done
-          echo "failed to push refreshed impact map after retries" >&2
-          exit 1
+          if ! git push origin "HEAD:refs/heads/${branch}" --force; then
+            echo "::warning::could not push ${branch}; map is in the test-portfolio artifact"
+            exit 0
+          fi
+          if gh pr view "$branch" --json number --jq .number >/dev/null 2>&1; then
+            echo "updated existing impact-map PR"
+            exit 0
+          fi
+          gh pr create --base main --head "$branch" \
+            --title "chore(test-selection): refresh committed impact map" \
+            --body "Portfolio job rebuilt \`src/mac/data/test_impact_map.json\` from ${GITHUB_SHA}. Opened because branch protection forbids pushing the refresh directly to main." \
+            || echo "::warning::could not open PR; branch ${branch} was pushed"
 
   container-contract:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -1240,6 +1245,7 @@ jobs:
       - postgres-contract
       - publication-scope
       - docker
+      - portfolio
     if: always() && failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -1150,6 +1150,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_TEST_PORTFOLIO_OUTPUT` | str | consumer-defined | core | Core setting: test portfolio output. |
 | `MAC_TEST_REBUILD_MAP` | bool | consumer-defined | core | Core setting: test rebuild map. |
 | `MAC_TEST_SELECT_BASE` | str | consumer-defined | core | Core setting: test select base. |
+| `MAC_TEST_SERIAL_SLICE` | str | consumer-defined | core | Core setting: test serial slice. |
 | `MAC_TEST_STALL_TIMEOUT` | int | consumer-defined | core | Core setting: test stall timeout. |
 | `MAC_TICK_BLOCKING_HUB_VERIFY` | str | consumer-defined | core | Core setting: tick blocking hub verify. |
 | `MAC_TICK_RUNS_REVIEW_SWEEP` | str | consumer-defined | core | Core setting: tick runs review sweep. |

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -140,6 +140,7 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
     "mkdocs.yml": ("tests/test_docs_accessibility.py",),
     "scripts/resolve-impacted-tests.py": ("tests/test_resolve_impacted_tests.py",),
     "scripts/run-contract-tests.sh": ("tests/test_contract_test_runner.py",),
+    "scripts/serial_slice_plugin.py": ("tests/test_contract_test_runner.py",),
     "scripts/select-sanity-tests.py": ("tests/test_resolve_impacted_tests.py",),
     "scripts/test-checkpoint.py": ("tests/test_test_checkpoint.py",),
     "src/mac/data/env_config_registry.json": ("tests/test_env_config.py",),

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -59,7 +59,11 @@ _HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 # sides of generated artifacts so a generator or generated-output-only change
 # cannot silently bypass its drift test.
 PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
-    ".github/workflows/ci.yml": ("tests/test_deployment_image_artifact.py",),
+    ".github/workflows/ci.yml": (
+        "tests/test_deployment_image_artifact.py",
+        "tests/test_red_main_is_surfaced.py",
+        "tests/test_portfolio_ci_does_not_push_main.py",
+    ),
     "deploy/deploy-mac-fleet.sh": (
         "tests/test_deploy_schema_migrations.py",
         "tests/test_deploy_fleet_drain.py",

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -503,6 +503,27 @@ PYCAP
     # loadscope (which keeps a module's tests + module-scoped fixtures on one
     # worker).
     _SERIAL_MARK="process_e2e or postgres or container_contract or docker_e2e"
+    # Pin the protected marker slice to one process. PYTEST_ADDOPTS is unset
+    # above, but an explicit `-n 0` is what keeps a future pyproject addopts
+    # (or a leaked `-n auto`) from making process_e2e concurrent after we split
+    # it off. The plugin drops coverage's subprocess patch for children:
+    # tracing docker/sudo/launchctl blows sub-second process-group deadlines
+    # on Darwin after a wide xdist bulk phase. The parent pytest process is
+    # still measured by `coverage run`.
+    _mac_run_serial_pytest() {
+        export MAC_TEST_SERIAL_SLICE=1
+        _serial_status=0
+        _serial_pypath="$(cd "$(dirname "$0")" && pwd)${PYTHONPATH:+:$PYTHONPATH}"
+        if [ "${1:-}" = "coverage" ]; then
+            PYTHONPATH="$_serial_pypath" "$PY" -m coverage run -m pytest -n 0 \
+                -p serial_slice_plugin -m "$_SERIAL_MARK" || _serial_status=$?
+        else
+            PYTHONPATH="$_serial_pypath" "$PY" -m pytest -n 0 \
+                -p serial_slice_plugin -m "$_SERIAL_MARK" || _serial_status=$?
+        fi
+        unset MAC_TEST_SERIAL_SLICE
+        return "$_serial_status"
+    }
 
     # Every invocation owns a separate coverage namespace. Multiple agents and
     # local actors routinely test the same checkout concurrently; sharing the
@@ -619,7 +640,7 @@ PYCAP
             "$PY" -m pytest -n "$_MAC_TEST_JOBS" --dist loadscope \
                 -m "not ($_SERIAL_MARK)" || pytest_status=$?
             if [ "$pytest_status" -eq 0 ]; then
-                "$PY" -m pytest -m "$_SERIAL_MARK" || pytest_status=$?
+                _mac_run_serial_pytest || pytest_status=$?
             fi
         else
             # Nested/serial single-owner run. A nested empty selection (exit 5)
@@ -653,7 +674,7 @@ PYCAP
             "$PY" -m pytest -n "$_MAC_TEST_JOBS" --dist loadscope \
                 -m "not ($_SERIAL_MARK)" || triage_status=$?
             if [ "$triage_status" -eq 0 ]; then
-                "$PY" -m pytest -m "$_SERIAL_MARK" || triage_status=$?
+                _mac_run_serial_pytest || triage_status=$?
             fi
         else
             "$PY" -m pytest || triage_status=$?
@@ -689,7 +710,7 @@ PYCAP
         "$PY" -m coverage run -m pytest -n "$_MAC_TEST_JOBS" --dist loadscope \
             -m "not ($_SERIAL_MARK)" || pytest_status=$?
         if [ "$pytest_status" -eq 0 ]; then
-            "$PY" -m coverage run -m pytest -m "$_SERIAL_MARK" || pytest_status=$?
+            _mac_run_serial_pytest coverage || pytest_status=$?
         fi
     else
         # Nested/serial single-owner run under coverage. A nested empty

--- a/scripts/serial_slice_plugin.py
+++ b/scripts/serial_slice_plugin.py
@@ -1,0 +1,17 @@
+"""Loaded only for the contract runner's serial marker slice.
+
+Coverage's ``patch = ["subprocess"]`` traces docker/sudo/launchctl children.
+After a wide xdist bulk phase that overhead blows sub-second process-group
+deadlines, especially on Darwin. The parent pytest process remains measured
+by ``coverage run``; this plugin drops the child-tracing env so the serial
+slice exercises the product, not the tracer.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def pytest_configure(config) -> None:  # noqa: ARG001
+    os.environ.pop("COVERAGE_PROCESS_START", None)
+    os.environ.pop("COVERAGE_PROCESS_CONFIG", None)

--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 #: import it, so the number lives in exactly one place. It used to be copied by
 #: hand into four (pyproject, this package, the FastAPI app, the A2A card) with
 #: a comment on each asking the next person to keep them in sync.
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 __all__ = [
     "ControlPlane",

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -13606,6 +13606,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: test serial slice.",
+    "family": "core",
+    "name": "MAC_TEST_SERIAL_SLICE",
+    "retired": false,
+    "sources": [
+      "scripts/run-contract-tests.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: test stall timeout.",
     "family": "core",
     "name": "MAC_TEST_STALL_TIMEOUT",

--- a/tests/test_contract_test_runner.py
+++ b/tests/test_contract_test_runner.py
@@ -34,7 +34,7 @@ def _run_with_fake_python(
     fake_python = bin_dir / "python3"
     fake_python.write_text(
         """#!/bin/sh
-printf 'PYTEST_ADDOPTS=%s\tDISABLE=%s\tCOVERAGE_FILE=%s\tSKIPFILE=%s\t%s\n' "${PYTEST_ADDOPTS-<unset>}" "${MAC_TEST_DISABLE_GROUPS-<unset>}" "${COVERAGE_FILE-<unset>}" "${MAC_TEST_CHECKPOINT_SKIP_FILE-<unset>}" "$*" >> "$FAKE_PY_LOG"
+printf 'PYTEST_ADDOPTS=%s\tDISABLE=%s\tCOVERAGE_FILE=%s\tSKIPFILE=%s\tSERIAL=%s\t%s\n' "${PYTEST_ADDOPTS-<unset>}" "${MAC_TEST_DISABLE_GROUPS-<unset>}" "${COVERAGE_FILE-<unset>}" "${MAC_TEST_CHECKPOINT_SKIP_FILE-<unset>}" "${MAC_TEST_SERIAL_SLICE-<unset>}" "$*" >> "$FAKE_PY_LOG"
 case "$*" in
     *os.cpu_count*)
         # The runner computes its headroom-aware default worker count with a
@@ -192,7 +192,11 @@ def test_contract_runner_defaults_to_headroom_workers_and_protects_serial_phase(
     # saturating every core; the serial phase stays unparallelised.
     assert "-n 6 --dist loadscope" in pytest_calls[0]
     assert "not (process_e2e or postgres or container_contract or docker_e2e)" in pytest_calls[0]
-    assert "-n " not in pytest_calls[1]
+    assert "SERIAL=<unset>" in pytest_calls[0]
+    assert "-n 0" in pytest_calls[1]
+    assert "-p serial_slice_plugin" in pytest_calls[1]
+    assert "--dist" not in pytest_calls[1]
+    assert "SERIAL=1" in pytest_calls[1]
     assert "-m process_e2e or postgres or container_contract or docker_e2e" in pytest_calls[1]
     assert all(line.startswith("PYTEST_ADDOPTS=<unset>\t") for line in pytest_calls)
 
@@ -221,7 +225,9 @@ def test_contract_runner_fast_mode_skips_coverage_and_policy(tmp_path):
     assert len(pytest_calls) == 2
     assert "-n 6 --dist loadscope" in pytest_calls[0]
     assert "not (process_e2e or postgres or container_contract or docker_e2e)" in pytest_calls[0]
-    assert "-n " not in pytest_calls[1]
+    assert "-n 0" in pytest_calls[1]
+    assert "-p serial_slice_plugin" in pytest_calls[1]
+    assert "--dist" not in pytest_calls[1]
     assert "-m process_e2e or postgres or container_contract or docker_e2e" in pytest_calls[1]
     # No coverage pipeline runs at all.
     assert not any("-m coverage combine" in line for line in calls)

--- a/tests/test_portfolio_ci_does_not_push_main.py
+++ b/tests/test_portfolio_ci_does_not_push_main.py
@@ -1,0 +1,73 @@
+"""Portfolio CI must not fail main by pushing to a protected branch.
+
+The job used to ``git push origin HEAD:main`` after rebuilding
+``src/mac/data/test_impact_map.json``. Branch protection returns GH013, the
+job went red, and a red main meant "git was not allowed to push" rather than
+"the product is red". Landing the refresh is a pull request; a blocked push
+must not fail the job. The map is already uploaded as an artifact.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+@pytest.fixture(scope="module")
+def workflow():
+    return yaml.safe_load(CI.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def portfolio_job(workflow):
+    return workflow["jobs"]["portfolio"]
+
+
+def test_portfolio_job_exists(workflow):
+    assert "portfolio" in workflow["jobs"]
+
+
+def _map_refresh_script(portfolio_job) -> str:
+    for step in portfolio_job["steps"]:
+        run = str(step.get("run") or "")
+        if "gh pr create" in run or "impact-map-refresh" in run:
+            return run
+    raise AssertionError("portfolio job has no impact-map refresh step")
+
+
+def test_portfolio_does_not_push_to_protected_main(portfolio_job):
+    script = _map_refresh_script(portfolio_job)
+
+    assert "HEAD:main" not in script
+    assert "git push origin HEAD:main" not in script
+    assert "refs/heads/main" not in script or "github.ref" in script
+
+
+def test_portfolio_lands_the_map_via_a_pull_request(portfolio_job):
+    script = _map_refresh_script(portfolio_job)
+
+    assert "gh pr create" in script
+    assert "ci/impact-map-refresh" in script
+    assert portfolio_job["permissions"].get("contents") == "write"
+    assert portfolio_job["permissions"].get("pull-requests") == "write"
+
+
+def test_a_blocked_map_push_does_not_fail_the_job(portfolio_job):
+    """The artifact is already uploaded. GH013 must not paint main red."""
+    script = _map_refresh_script(portfolio_job)
+
+    assert "exit 1" not in script
+    assert "could not push" in script
+    assert "test-portfolio" in script
+
+
+def test_report_main_red_watches_portfolio_now_that_it_cannot_false_red(workflow):
+    watched = set(workflow["jobs"]["report-main-red"]["needs"])
+
+    assert "portfolio" in watched

--- a/tests/test_red_main_is_surfaced.py
+++ b/tests/test_red_main_is_surfaced.py
@@ -32,7 +32,7 @@ CI = ROOT / ".github" / "workflows" / "ci.yml"
 #: Jobs whose failure must reach a person. These are the ones that do NOT run
 #: on pull requests, so a failure here is invisible until something says so.
 #: If a job like this is added to CI, add it here too.
-MAIN_ONLY_CRITICAL = {"docker", "mainline", "publication-scope"}
+MAIN_ONLY_CRITICAL = {"docker", "mainline", "publication-scope", "portfolio"}
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_resolve_impacted_tests.py
+++ b/tests/test_resolve_impacted_tests.py
@@ -235,6 +235,15 @@ def test_fleet_installer_contract_includes_every_direct_test_owner():
     assert direct_owners <= set(R.PATH_TEST_CONTRACTS["deploy/fleet-node-install.sh"])
 
 
+def test_ci_workflow_contract_owns_portfolio_and_red_main_guards():
+    owners = R.PATH_TEST_CONTRACTS[".github/workflows/ci.yml"]
+    assert "tests/test_deployment_image_artifact.py" in owners
+    assert "tests/test_red_main_is_surfaced.py" in owners
+    assert "tests/test_portfolio_ci_does_not_push_main.py" in owners
+    for owner in owners:
+        assert (ROOT / owner).is_file(), owner
+
+
 def test_documentation_only_selects_no_tests(repo, policy, impact_map):
     result = _resolve(repo, policy, impact_map, ["docs/guide.md", "README rename.md"])
     assert result["mode"] == "focused"

--- a/tests/test_shared_service_launchd_lifecycle.py
+++ b/tests/test_shared_service_launchd_lifecycle.py
@@ -17,6 +17,21 @@ ROOT = Path(__file__).resolve().parents[1]
 LAUNCHD_LIFECYCLE = ROOT / "deploy" / "lib" / "launchd-lifecycle.sh"
 
 
+def _without_coverage_tracing(env: dict[str, str]) -> dict[str, str]:
+    cleaned = dict(env)
+    cleaned.pop("COVERAGE_PROCESS_START", None)
+    cleaned.pop("COVERAGE_PROCESS_CONFIG", None)
+    return cleaned
+
+
+@pytest.fixture(autouse=True)
+def _drop_coverage_subprocess_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """launchd helpers inherit os.environ; coverage's subprocess patch wraps
+    sudo/launchctl and blows the 1-second command deadlines."""
+    monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
+    monkeypatch.delenv("COVERAGE_PROCESS_CONFIG", raising=False)
+
+
 @pytest.mark.parametrize(
     ("installer_name", "label", "health_assignment", "wrapper_call"),
     (
@@ -399,7 +414,7 @@ while :; do sleep 5; done
             str(LAUNCHD_LIFECYCLE),
             str(worker),
         ],
-        env={**os.environ, "CHILD_PID_FILE": str(child_pid)},
+        env=_without_coverage_tracing({**os.environ, "CHILD_PID_FILE": str(child_pid)}),
         check=False,
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary
- Portfolio CI no longer `git push origin HEAD:main` (GH013 was painting main red). It opens `ci/impact-map-refresh` as a PR; a blocked push does not fail the job. `report-main-red` now watches `portfolio` now that it cannot false-red.
- The contract runner pins the serial marker slice at `-n 0` and loads `serial_slice_plugin` so coverage subprocess tracing does not wrap docker/sudo/launchctl children after a wide xdist bulk phase (Darwin `process_e2e` timeouts).
- Version bump to **1.3.1**. Capability surface is unchanged from the v1.3.0 deck.

## Test plan
- [x] `ruff check` on changed Python
- [x] focused pytest: contract runner, portfolio CI contract, red-main, impact resolver, makefile, image-publish, hermes vendor fate, version skew, bounded launchd runner, OpenClaw prepare, phase1 timeout (108 + 26 passed)
- [ ] CI mainline on this PR
- [ ] tag `v1.3.1` after merge and deploy to rocky/natasha/bullwinkle over Tailscale MagicDNS

Ledger: `task_367d0950`, `task_1746351d`, `task_e00b069b`