### PR TITLE
Fix v1.3.0 deck slide-12 defects still open on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,13 @@ vacuum. It has learned from, interoperates with, or substantially relies on the
 following projects. The relationship is stated explicitly so that an
 integration or protocol influence is not mistaken for copied source:
 
-- **[Hermes Agent](https://github.com/NousResearch/hermes-agent) — vendored
-  runtime:** `src/mac/_hermes` is a pruned, MAC-modified snapshot of Hermes
-  Agent 0.15.1 at
-  [`b1a25404b`](https://github.com/NousResearch/hermes-agent/commit/b1a25404b638bfbd79ce4d08b49afc0ee1361528).
-  It supplies the agent loop, gateways, tools, plugins, and skills. The
-  snapshot contract — the pin and prune policy — is
-  [ADR 0001](docs/adr/0001-unify-hermes-runtime-into-mac.md); the standalone
-  deploy/hermes/SNAPSHOT.md it once named was removed with the inactive
-  snapshot.
+- **[Hermes Agent](https://github.com/NousResearch/hermes-agent) — lineage,
+  not a vendored tree:** MAC learned from Hermes Agent's loop, gateways, and
+  skills. The in-tree snapshot of that runtime was removed in PR #377
+  (`3ebde2dd`); see [the vendor-fate record](docs/hermes-vendor-fate.md).
+  Live fleet chat uses stock OpenClaw. First-party `mac.hermes_adapter` is
+  clean-room MAC code, not a copy of that snapshot. ADR 0001 is superseded
+  on the vendoring premise.
 - **[NVIDIA OpenShell](https://github.com/NVIDIA/OpenShell) — execution
   security foundation:** MAC's agent process trees, filesystem/network policy,
   sandbox lifecycle, and normalized action-event collection integrate with
@@ -81,9 +79,8 @@ integration or protocol influence is not mistaken for copied source:
 
 This is a direct-lineage and architectural acknowledgement, not an exhaustive
 transitive dependency list. Python and Node dependencies remain documented in
-their manifests and lockfiles; additional skill- and plugin-level notices are
-kept with the vendored Hermes files that require them. Each upstream project
-remains subject to its own license.
+their manifests and lockfiles. Each upstream project remains subject to its
+own license.
 
 ## Core Contracts
 
@@ -207,9 +204,8 @@ and the `/dashboard/*` routes require a bearer token, so an unauthenticated
 browser gets `403` there; `/ui` is the front door.
 
 `make test` runs the complete hermetic pytest suite with statement, branch, and
-Python-subprocess coverage for MAC-owned `src/mac` code. Vendored Hermes
-internals under `src/mac/_hermes` are excluded. Coverage is a regression safety
-floor rather than a target for generating tests; see
+Python-subprocess coverage for MAC-owned `src/mac` code. Coverage is a
+regression safety floor rather than a target for generating tests; see
 [the test portfolio strategy](docs/testing-strategy.md). Use `make coverage`
 for the same full-suite report, `make test-portfolio` to audit redundant
 execution, and `make fault-replay` to prove tests detect known historical bugs.
@@ -230,9 +226,7 @@ logic errors and undefined names, plus syntax errors). Formatting is in the
 same gate, so `make lint-fix` cannot rewrite files `make lint` never mentioned.
 Widen `[tool.ruff.lint].select` as the codebase is cleaned up. Ruff is a
 dev-only tool pinned in the `dev` extra and fetched on demand with
-`uv run --with ruff`; it is not a runtime dependency. The vendored
-Hermes runtime under `src/mac/_hermes` keeps its own upstream lint discipline
-and is excluded.
+`uv run --with ruff`; it is not a runtime dependency.
 
 The common lifecycle is deliberately conventional:
 

--- a/docs/archive/field-notes/canary-v1.3.1.md
+++ b/docs/archive/field-notes/canary-v1.3.1.md
@@ -3,4 +3,4 @@
 
 # v1.3.1 fleet canary
 
-At 2026-08-28T21:49:27Z, task `task_d894080c2eac4d6e92a288e8ec9f23e4` was executed by agent `agent_rocky` as the post-deploy canary for hub version 1.3.1 at git SHA `7e1f0735`.
+At 2026-08-28T21:49:27Z, task `task_d894080c2eac4d6e92a288e8ec9f23e4` was executed by the hub worker as the post-deploy canary for hub version 1.3.1 at git SHA `7e1f0735`.

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -30,10 +30,13 @@ are structural, and they are the ones worth acting on.
 
 ### Scale at a glance
 
+The `_hermes/` row is a **2026-07-24 measurement**. That tree was deleted in
+PR #377 (`3ebde2dd`). It is not present in current checkouts.
+
 | Category | Files | Lines of code | Notes |
 |---|---:|---:|---|
 | First-party MAC code (`src/mac/`, excl. `_hermes/`) | ~200 modules + 5 sub-packages | **~185,000** | The code this repository owns and must maintain. |
-| Vendored runtime (`src/mac/_hermes/`) | — | **~443,000** | Pinned snapshot of `NousResearch/hermes-agent`; excluded from coverage. |
+| Vendored runtime (`src/mac/_hermes/`, **removed**) | — | **~443,000** | Historical: pinned snapshot of `NousResearch/hermes-agent`. |
 | Tests (`tests/`) | 445 | **~200,600** | 6,883 test functions → 8,555 collected nodes. |
 | **Total tracked (excl. `.venv`/`dist`/caches)** | **~1,329** | — | The 10,826 raw `.py` count is inflated by `.venv` and `__pycache__`. |
 
@@ -50,7 +53,7 @@ surface.**
 | Duplication | Moderate — naming collisions, two HTTP-route paths, ledger sprawl | Medium |
 | God-class | `services.py` = one 26,433-line `ControlPlane` (719 methods) | **High** |
 | Test debt | 37 `_edges` coverage-companion modules; only 25% of files parametrized | **High** |
-| Vendored surface | ~443K LOC pinned; most of it dormant but correctly quarantined | Low (by design) |
+| Vendored surface | Historical ~443K LOC; tree removed in PR #377 | Low (closed) |
 
 > **Verification note (added after the initial pass).** Every dead-code candidate below was
 > checked against the full reference graph *and git history* before any action. The result
@@ -120,13 +123,24 @@ handler.
 
 ---
 
-## 4. Vendored runtime — `src/mac/_hermes/`
+## 4. Vendored runtime — removed after this audit
 
-`src/mac/_hermes/` is a **vendored, integrity-pinned snapshot** of
+!!! warning "The in-tree Hermes snapshot is gone"
+    This section is a 2026-07-24 measurement of a tree that was **deleted** in
+    PR #377 (`3ebde2dd`, 2026-08-17). It is not a current inventory. See
+    [the vendor-fate record](hermes-vendor-fate.md). First-party modules named
+    `hermes_*` remain; they are clean-room MAC code, not that snapshot.
+
+The figures below described the then-vendored snapshot of
+`https://github.com/NousResearch/hermes-agent.git`. They are retained as
+evidence of why the tree was removed (it was larger than first-party MAC).
+
+### Historical measurement (2026-07-24)
+
+`src/mac/_hermes/` was a **vendored, integrity-pinned snapshot** of
 `https://github.com/NousResearch/hermes-agent.git` (commit `b1a25404…`, vendored
-`2026-05-31`), per `src/mac/_hermes/SNAPSHOT_PIN` and ADR 0001
-(`docs/adr/0001-unify-hermes-runtime-into-mac.md`). It is ~443K LOC — **more than twice the
-size of all first-party code** — and is deliberately quarantined:
+`2026-05-31`), per ADR 0001. It was ~443K LOC — **more than twice the
+size of all first-party code** — and was deliberately quarantined:
 
 - **Excluded from coverage** (`pyproject.toml:130-132`: "do not count vendored Hermes
   internals against this repository's threshold").

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -542,6 +542,8 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HUB_UPGRADE_REQUIRED_CHECKS` | bool | consumer-defined | hub | Hub setting: hub upgrade required checks. |
 | `MAC_HUB_URL` | str | consumer-defined | hub | Hub setting: hub url. |
 | `MAC_HUB_VERIFY_IMAGE` | str | consumer-defined | hub | Hub setting: hub verify image. |
+| `MAC_HUB_VERIFY_PG_HOST` | str | consumer-defined | hub | Hostname substituted for `127.0.0.1`/`localhost`/`::1` in the hub-verify test DSN. Default `host.docker.internal`. Does not select the live hub database. |
+| `MAC_HUB_VERIFY_PG_URL` | str | consumer-defined | hub | Dedicated test Postgres DSN injected into the hub-verify OpenShell sandbox as `MAC_TEST_PG_URL`. Never the live hub database. Loopback hosts are rewritten to `host.docker.internal` (or `MAC_HUB_VERIFY_PG_HOST`) so the sandbox can reach Postgres on the hub. If unset, hub-verify runs `scripts/start-test-postgres.sh` from the cloned repo and rewrites that DSN the same way. |
 | `MAC_HUB_VERIFY_RUNNER` | str | consumer-defined | hub | Hub setting: hub verify runner. |
 | `MAC_HUB_VERIFY_TIMEOUT` | int | consumer-defined | hub | Hub setting: hub verify timeout. |
 | `MAC_HUMAN` | str | consumer-defined | core | Core setting: human. |

--- a/docs/hermes-integration.md
+++ b/docs/hermes-integration.md
@@ -74,9 +74,10 @@ Relevant environment:
 - `HERMES_HOME`: Hermes state directory; defaults to `~/.hermes`.
 - `ACC_DIR`: legacy ACC data directory for migration references; defaults to
   `~/.acc`.
-- `MAC_HERMES_AGENT_DIR` / `HERMES_AGENT_DIR`: explicit external Hermes checkout
-  to inspect for legacy shim compatibility. Normal fleet deployment uses the
-  vendored runtime under `src/mac/_hermes`.
+- `MAC_HERMES_AGENT_DIR` / `HERMES_AGENT_DIR`: optional path to an *external*
+  Hermes checkout for legacy shim inspection. Fleet deployment does not vendor
+  a Hermes tree; the in-tree snapshot was removed (see
+  [the vendor-fate record](hermes-vendor-fate.md)). Normal chat uses OpenClaw.
 - `MAC_HERMES_APPLY_SLACK_ACCOUNT_SHIM=0`: disable the startup shim patcher
   when `MAC_HERMES_AGENT_DIR` points at an explicit checkout. It is enabled by
   default only for explicit checkout paths.
@@ -98,11 +99,12 @@ Relevant environment:
 - `MAC_HERMES_SYNC_SLACK_HOME_CHANNELS=0`: preserve existing home-channel files
   without discovery.
 
-The default deployment runs MAC's vendored Hermes snapshot. The explicit-checkout
-shim settings above remain only for compatibility with an operator-managed
-external checkout. In the normal topology the gateway receives its model,
-provider, base URL, and hub-facing token from fleet deploy; upstream provider
-credentials remain on the hub behind the in-mac router.
+The default fleet chat runtime is stock OpenClaw, not a vendored Hermes
+snapshot (removed in PR #377). The explicit-checkout shim settings above remain
+only for compatibility with an operator-managed external Hermes checkout. In
+the normal topology the gateway receives its model, provider, base URL, and
+hub-facing token from fleet deploy; upstream provider credentials remain on
+the hub behind the in-mac router.
 
 ## Creating Tasks
 

--- a/docs/home-consolidation.md
+++ b/docs/home-consolidation.md
@@ -1,8 +1,9 @@
 # Home-Directory Consolidation: Analysis & Plan
 
 Status: **plan** (approved target = single authoritative root under `$HOME`).
-Scope: first-party MAC only (`src/mac/` excluding the vendored `src/mac/_hermes/`
-snapshot, `deploy/`, `scripts/`, `Makefile`). Every claim below is grounded in
+Scope: first-party MAC only (`src/mac/`, `deploy/`, `scripts/`, `Makefile`).
+The former in-tree Hermes snapshot is gone (PR #377); do not exclude a path
+that is no longer in the tree. Every claim below is grounded in
 `file:line` evidence gathered by a three-way exploration of the `.mac`,
 `.hermes`, and `.openclaw`/`.nemoclaw` namespaces.
 
@@ -251,8 +252,8 @@ runner's dependency on `~/.hermes/scripts`.
 
 - Fleet-wide blast radius: home resolution runs in every worker + the hub +
   deploy. Phase 0 must be backward-compatible and land as a coordinated epoch.
-- Vendored gateway code (`src/mac/_hermes/`, OpenClaw upstream) expects its
-  internal home layout; we relocate the *root* via `HERMES_HOME`, never rename
-  the gateway's internal structure.
+- OpenClaw (and any remaining external Hermes home) expects its internal
+  home layout; we relocate the *root* via `HERMES_HOME` / the OpenClaw home
+  under `$MAC_HOME/openclaw`, never rename the gateway's internal structure.
 - Secrets migration is the highest-care step — verify perms and that no secret
   is duplicated or dropped; do it with checksums and a reversible backup.

--- a/docs/oneshot-isolation-gate-verification.md
+++ b/docs/oneshot-isolation-gate-verification.md
@@ -1,5 +1,12 @@
 # Oneshot isolation — contract gate verification
 
+!!! warning "Historical verification of a removed tree"
+    This record described a fix in the vendored Hermes snapshot. That snapshot
+    was deleted in PR #377 (`3ebde2dd`). It is not a current operating
+    contract; see [the vendor-fate record](hermes-vendor-fate.md). The
+    reconciled regression module named below may still exist; the source path
+    it originally guarded does not.
+
 Verification record for the `hermes -z` one-shot session-isolation area after
 the stale characterization tests were reconciled with the applied fix. This
 document captures the operational evidence that the repository contract gate is

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -54,7 +54,7 @@ The objects mac models. Start here:
 Everything else:
   admin  fleet, runtime and control-plane administration
 
-0 administrative commands live under `mac admin` (`mac admin help` lists them).
+54 administrative commands live under `mac admin` (`mac admin help` lists them).
 They moved: `mac fleet ...` is now `mac admin fleet ...`, and the old spelling says so.
 
 Run `mac help --all` to see every command in one list.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -76,8 +76,8 @@ transaction or equivalent durable evidence.
   rollback are covered and proven in the live fleet.
 - [x] The current `main` source commit is deployed and attested on the hub,
   every configured worker, and every subsequently registered fleet member.
-  Verified `060acc500ab99e30bc01cfccf7eef2232108b4e4` on rocky, natasha, and
-  bullwinkle after typed cohort `20260827T060057Z` (`make deploy HUB=rocky`
+  Verified `060acc500ab99e30bc01cfccf7eef2232108b4e4` on the hub, worker-1, and
+  gpu-worker after typed cohort `20260827T060057Z` (`make deploy HUB=<hub>`
   with hold-adoptions after a retained roll-forward). Hub `/health` ok;
   workers idle and unheld; `HERMES_HOME=$MAC_HOME/openclaw`.
 - [x] A failed or interrupted fleet deployment can safely resume without
@@ -110,7 +110,7 @@ transaction or equivalent durable evidence.
   Live receipt `kslug-nightly-news.last-success.json` delivered
   `2026-08-26T22:23:31Z` to `slack:C0AH1QJCT7F`; later runs skipped
   `already_delivered_today`. Launchd job `kslug-nightly-news` (`0 6 * * *`)
-  reinstalled on rocky in deploy `20260827T060057Z` at `060acc50`.
+  reinstalled on the hub in deploy `20260827T060057Z` at `060acc50`.
 - [ ] Scheduled automation fails closed: failed collectors cannot become agent
   prose, repeated unchanged results are suppressed, DMs are allowed, and
   channel broadcasts are limited to the configured destination.
@@ -140,3 +140,34 @@ transaction or equivalent durable evidence.
 6. Implement hierarchical sandbox ACL feedback and profile placement.
 7. Revisit dream-cycle analysis only after the higher-priority proofs are
    durable.
+
+## Known defects from the v1.3.0 capabilities deck (slide 12)
+
+Source: [MAC capabilities at `d8d491d6`](https://docs.google.com/presentation/d/1yOOzFqRVwhY6opljcPEzfkzQmdjwylsxi1_hFO_8wJ0/edit?slide=id.p12),
+captured 2026-08-28. Items stay unchecked until they meet the completion rule
+above. Large ADRs are held `--no-dispatch` until hub-verify can land
+repository work (`task_321b8e8d`).
+
+- [ ] Default `mac --help` reports the real `mac admin` subcommand count, not
+      zero. Ledger `task_2d33cc69`.
+- [ ] Current docs no longer describe the deleted Hermes snapshot as present.
+      Ledger `task_a0fc238b`. Fate record: `docs/hermes-vendor-fate.md`.
+- [ ] Token spend is metered at the router and persisted (ADR 0017). 29.5% of
+      `llm.route` events over the seven days to 2026-08-19 recorded no input
+      tokens; cost is priced at read time. Ledger `task_b0750aee` (successor to
+      failed `task_45927341`).
+- [ ] The task view is a graph under progressive disclosure (ADR 0018): the hub
+      sends dependency edges so the console can show *what* blocks a task.
+      Ledger `task_bdf11b3f`.
+- [ ] The coding-route search path is a fleet contract, not per-worker
+      environment (ADR 0029). Ledger `task_198bf6ab`.
+- [ ] CLI sessions use each harness's hooks for AgentBus inject/record, not
+      tmux and not a prompt-level `agentbus wait` (ADR 0032). Ledger
+      `task_13a1f7fe`.
+- [ ] ADR 0012 (native steward + containerized execution) stays deferred until
+      a fleet measurement exists. ADR 0015 already narrowed the containerized
+      half to Linux. Ledger `task_3a48fd75`.
+- [ ] Hub-verify OpenShell sandboxes receive a dedicated test Postgres DSN
+      (not the live hub database) so a repository canary can complete.
+      Ledger `task_321b8e8d`. Blocked the v1.3.1 canary `task_d894080c` /
+      PR #681.

--- a/scripts/generate-env-config-registry.py
+++ b/scripts/generate-env-config-registry.py
@@ -122,6 +122,19 @@ CONSUMER_DEFAULTS = {
 # sentence is fine for a setting whose name says what it does; an escape hatch
 # needs its default, its blast radius, and the one case for turning it on.
 CURATED_DESCRIPTIONS = {
+    "MAC_HUB_VERIFY_PG_URL": (
+        "Dedicated test Postgres DSN injected into the hub-verify OpenShell "
+        "sandbox as `MAC_TEST_PG_URL`. Never the live hub database. Loopback "
+        "hosts are rewritten to `host.docker.internal` (or "
+        "`MAC_HUB_VERIFY_PG_HOST`) so the sandbox can reach Postgres on the hub. "
+        "If unset, hub-verify runs `scripts/start-test-postgres.sh` from the "
+        "cloned repo and rewrites that DSN the same way."
+    ),
+    "MAC_HUB_VERIFY_PG_HOST": (
+        "Hostname substituted for `127.0.0.1`/`localhost`/`::1` in the "
+        "hub-verify test DSN. Default `host.docker.internal`. Does not select "
+        "the live hub database."
+    ),
     "MAC_DEPLOY_GATEWAY_PROBE_FATAL": (
         "Set `1` to make a failed OpenClaw gateway/channel probe fail the node, "
         "and therefore the whole deploy cohort; unset or `0` records the failure, "

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -333,6 +333,16 @@ def _subparsers_of(parser: argparse.ArgumentParser) -> Optional[argparse._SubPar
     return None
 
 
+def _admin_command_count(action: argparse._SubParsersAction) -> int:
+    """Distinct subcommands under `mac admin`, aliases collapsed, excluding help."""
+
+    admin_parser = action.choices.get("admin")
+    admin_action = _subparsers_of(admin_parser) if admin_parser is not None else None
+    if admin_action is None:
+        return 0
+    return len([name for name, _ in _distinct_subcommands(admin_action) if name != "help"])
+
+
 def _distinct_subcommands(
     action: argparse._SubParsersAction,
 ) -> List[Tuple[str, argparse.ArgumentParser]]:
@@ -745,9 +755,13 @@ def _top_level_help_text(action: argparse._SubParsersAction, *, show_all: bool =
                 _format_rows([("admin", "fleet, runtime and control-plane administration")])
             )
             lines.append("")
+        # Count the admin *group's* subcommands. After re-parenting, the
+        # top-level leftover set is empty, so `len(registered - {"admin"})`
+        # printed "0 administrative commands" while `mac admin help` listed
+        # fifty-odd groups (v1.3.0 deck slide 12).
         lines.append(
             "%d administrative commands live under `mac admin` "
-            "(`mac admin help` lists them)." % len(registered - {"admin"})
+            "(`mac admin help` lists them)." % _admin_command_count(action)
         )
         lines.append(
             "They moved: `mac fleet ...` is now `mac admin fleet ...`, and the "

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -1646,6 +1646,7 @@
       "src/mac/pg_backup_scheduler.py",
       "src/mac/router_service.py",
       "src/mac/schema_migrations.py",
+      "src/mac/services.py",
       "src/mac/store.py",
       "src/mac/worker.py",
       "src/mac/worker_credentials.py"
@@ -1669,6 +1670,7 @@
       "src/mac/mac_paths.py",
       "src/mac/router_service.py",
       "src/mac/schema_migrations.py",
+      "src/mac/services.py",
       "src/mac/store.py",
       "src/mac/worker.py",
       "src/mac/worker_credentials.py"
@@ -6436,6 +6438,28 @@
     "description": "Hub setting: hub verify image.",
     "family": "hub",
     "name": "MAC_HUB_VERIFY_IMAGE",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Hostname substituted for `127.0.0.1`/`localhost`/`::1` in the hub-verify test DSN. Default `host.docker.internal`. Does not select the live hub database.",
+    "family": "hub",
+    "name": "MAC_HUB_VERIFY_PG_HOST",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Dedicated test Postgres DSN injected into the hub-verify OpenShell sandbox as `MAC_TEST_PG_URL`. Never the live hub database. Loopback hosts are rewritten to `host.docker.internal` (or `MAC_HUB_VERIFY_PG_HOST`) so the sandbox can reach Postgres on the hub. If unset, hub-verify runs `scripts/start-test-postgres.sh` from the cloned repo and rewrites that DSN the same way.",
+    "family": "hub",
+    "name": "MAC_HUB_VERIFY_PG_URL",
     "retired": false,
     "sources": [
       "src/mac/services.py"

--- a/src/mac/hermes_startup.py
+++ b/src/mac/hermes_startup.py
@@ -1233,10 +1233,10 @@ def apply_hermes_gateway_runtime_shim_report(
     """Report the per-agent gateway provider/model override.
 
     ADR 0001 hu-03/hu-04: the override is now **owned, in-process code**
-    (``mac.agent_provider``, called by the vendored gateway in ``src/mac/_hermes``).
-    The old runtime string-surgery of a cloned upstream tree is gone, so there is
-    no shim to "miss" — when an override is configured the in-process gateway
-    always honors it. The ``gateway_runtime_shim_*`` field names are retained for
+    (``mac.agent_provider``). The vendored gateway snapshot that used to live
+    in-tree was removed; there is no shim to "miss" — when an override is
+    configured the in-process gateway always honors it. The
+    ``gateway_runtime_shim_*`` field names are retained for
     dashboard/report-schema compatibility but now reflect the owned decision.
     ``agent_dir`` is accepted and ignored (no upstream checkout is consulted).
     """
@@ -1258,7 +1258,7 @@ def apply_hermes_gateway_runtime_shim_report(
         "gateway_runtime_shim_patch": {
             "obsolete": True,
             "applied": False,
-            "note": "in-process via mac.agent_provider (vendored gateway); no string surgery",
+            "note": "in-process via mac.agent_provider (no vendored gateway); no string surgery",
             "error": "",
         },
         "provider_decision": provider_decision,
@@ -1277,9 +1277,9 @@ def _slack_activation_report(
     env_token_present = bool(os.environ.get("SLACK_BOT_TOKEN"))
     explicit_config = _config_explicitly_enables_slack(hermes_home / "config.yaml")
     # ADR 0001 hu-04: multi-workspace Slack support (activation from
-    # slack_accounts.json) is now baked into the vendored gateway — the former
-    # out-of-tree multi-slack-mvp patch. So an account file is sufficient; there
-    # is no upstream-checkout "shim" to apply. Shim field names are retained for
+    # slack_accounts.json) is owned in-process — the former out-of-tree
+    # multi-slack-mvp patch. An account file is sufficient; there is no
+    # upstream-checkout "shim" to apply. Shim field names are retained for
     # report-schema compatibility and report as effectively present.
     activation_source = "not_configured"
     can_activate = False
@@ -1296,7 +1296,7 @@ def _slack_activation_report(
     _obsolete_patch = {
         "obsolete": True,
         "applied": False,
-        "note": "vendored gateway (no upstream-checkout shim)",
+        "note": "in-process gateway (no upstream-checkout shim)",
         "error": "",
     }
     return {

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1119,6 +1119,97 @@ def hub_verification_unavailable_reason(output: str) -> Optional[str]:
     return None
 
 
+_HUB_VERIFY_SANDBOX_PG_HOST = "host.docker.internal"
+
+
+def parse_start_test_postgres_export(stdout: str) -> str:
+    """Read the DSN from ``scripts/start-test-postgres.sh`` stdout."""
+
+    for line in (stdout or "").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("export MAC_TEST_PG_URL="):
+            return stripped.split("=", 1)[1].strip().strip("'\"")
+    return ""
+
+
+def hub_verify_sandbox_pg_url(
+    raw: str,
+    *,
+    live_database_url: str = "",
+    sandbox_host: str = "",
+) -> Optional[str]:
+    """Return a test DSN the OpenShell hub-verify sandbox can use.
+
+    Refuses the live hub database. Rewrites loopback hosts to
+    ``host.docker.internal`` (override with ``MAC_HUB_VERIFY_PG_HOST``) so a
+    Postgres started on the hub is reachable from inside the sandbox.
+    """
+
+    candidate = (raw or "").strip()
+    live = (live_database_url or "").strip()
+    if not candidate:
+        return None
+    if live and candidate == live:
+        return None
+    host = (sandbox_host or os.environ.get("MAC_HUB_VERIFY_PG_HOST") or "").strip()
+    if not host:
+        host = _HUB_VERIFY_SANDBOX_PG_HOST
+    parsed = urllib.parse.urlsplit(candidate)
+    hostname = (parsed.hostname or "").strip().lower()
+    if hostname in {"127.0.0.1", "localhost", "::1"}:
+        username = parsed.username or ""
+        password = parsed.password
+        userinfo = username
+        if password is not None:
+            userinfo = "%s:%s" % (username, password)
+        netloc = host
+        if parsed.port:
+            netloc = "%s:%s" % (host, parsed.port)
+        if userinfo:
+            netloc = "%s@%s" % (userinfo, netloc)
+        candidate = urllib.parse.urlunsplit(
+            (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
+        )
+        if live and candidate == live:
+            return None
+    return candidate
+
+
+def hub_verify_test_pg_url(repo_root: Path) -> Optional[str]:
+    """Dedicated test DSN for the hub-verify sandbox, never the live hub DB."""
+
+    explicit = (os.environ.get("MAC_HUB_VERIFY_PG_URL") or "").strip()
+    live = (os.environ.get("MAC_DATABASE_URL") or os.environ.get("MAC_DB") or "").strip()
+    raw = explicit
+    if not raw:
+        helper = repo_root / "scripts" / "start-test-postgres.sh"
+        if helper.is_file():
+            try:
+                proc = subprocess.run(
+                    ["bash", str(helper)],
+                    cwd=str(repo_root),
+                    capture_output=True,
+                    text=True,
+                    timeout=90,
+                    check=False,
+                )
+            except Exception:  # noqa: BLE001 - missing helper must not abort verify
+                proc = None
+            if proc is not None and int(proc.returncode or 1) == 0:
+                raw = parse_start_test_postgres_export(proc.stdout or "")
+    return hub_verify_sandbox_pg_url(raw, live_database_url=live)
+
+
+def hub_verify_sandbox_env_pairs(*, test_pg_url: Optional[str] = None) -> List[str]:
+    """``--env`` values for a hub-verify OpenShell create."""
+
+    pairs = ["HOME=/tmp", "PATH=%s" % SANDBOX_BASE_PATH]
+    dsn = (test_pg_url or "").strip()
+    if dsn:
+        pairs.append("MAC_TEST_PG_URL=%s" % dsn)
+    return pairs
+
+
 def _hub_review_failure_excerpt(output: str, *, head: int = 2000, tail: int = 1500) -> str:
     """Keep the head AND the tail of a rejected verification's output.
 
@@ -27129,6 +27220,7 @@ class ControlPlane:
             argv = [openshell, "sandbox", "create", "--no-auto-providers"]
             if policy:
                 argv += ["--policy", policy]
+            test_pg_url = hub_verify_test_pg_url(tmp / "repo")
             argv += [
                 "--name",
                 name,
@@ -27142,14 +27234,15 @@ class ControlPlane:
                 "mac.keep=false",
                 "--from",
                 image,
-                "--env",
-                "HOME=/tmp",
-                # OpenShell's supervisor resets PATH on fresh create/exec
-                # commands instead of preserving the image ENV. Pass the
-                # sandbox-owned runtime path explicitly; never inherit the
-                # control-plane host's PATH.
-                "--env",
-                "PATH=%s" % SANDBOX_BASE_PATH,
+            ]
+            # OpenShell's supervisor resets PATH on fresh create/exec
+            # commands instead of preserving the image ENV. Pass the
+            # sandbox-owned runtime path explicitly; never inherit the
+            # control-plane host's PATH. MAC_TEST_PG_URL is a dedicated
+            # test DSN (never the live hub database).
+            for value in hub_verify_sandbox_env_pairs(test_pg_url=test_pg_url):
+                argv += ["--env", value]
+            argv += [
                 "--upload",
                 "%s:%s" % (str(tmp / "repo.tgz"), "/sandbox"),
                 "--",

--- a/tests/cli/test_cli_first_class_surface.py
+++ b/tests/cli/test_cli_first_class_surface.py
@@ -31,6 +31,7 @@ Two properties are asserted here, and the second matters as much as the first:
 from __future__ import annotations
 
 import argparse
+import re
 
 import pytest
 
@@ -258,6 +259,10 @@ def test_top_level_help_is_only_the_first_class_objects(parser, capsys):
         assert name in out
     assert "Getting started:" not in out, "administrative groups are back at the top level"
     assert "mac admin help" in out
+    assert "0 administrative commands live under" not in out
+    match = re.search(r"(\d+) administrative commands live under", out)
+    assert match is not None, out
+    assert int(match.group(1)) >= 20, out
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -13907,6 +13907,36 @@ def test_hub_verify_sandbox_command_whitelists_uploaded_repo_for_git(cp, monkeyp
     # Lost-.git uploads still fail fast with a distinguishable message.
     assert "rev-parse --is-inside-work-tree" in inner
     assert "not a usable git repo after upload" in inner
+    assert not any(value.startswith("MAC_TEST_PG_URL=") for value in env_values)
+
+
+def test_hub_verify_sandbox_injects_dedicated_test_pg_url(cp, monkeypatch):
+    """Hub-verify must pass a test DSN into the sandbox. Observed live on
+    task_d894080c: the OpenShell sandbox had no MAC_TEST_PG_URL, start-test-postgres
+    could not provision inside --no-auto-providers, and review retried as
+    hub_verify_unavailable."""
+    import subprocess as _subprocess
+
+    from mac import services as services_mod
+
+    captured = []
+    dsn = "postgresql://mac_test@host.docker.internal:5432/mac_test"
+
+    def fake_run(argv, **kwargs):
+        captured.append(list(argv))
+        if "rev-parse" in argv and "HEAD" in argv:
+            return _subprocess.CompletedProcess(argv, 0, stdout=("a" * 40) + "\n", stderr="")
+        return _subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(services_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(services_mod, "hub_verify_test_pg_url", lambda repo_root: dsn)
+    rc, _out = cp._hub_verify_run_contract_test(
+        "git@github.com:org/repo.git", "task/branch", "a" * 40, ""
+    )
+    assert rc == 0
+    create = next(a for a in captured if "create" in a and "--upload" in a)
+    env_values = [create[index + 1] for index, value in enumerate(create[:-1]) if value == "--env"]
+    assert "MAC_TEST_PG_URL=%s" % dsn in env_values
 
 
 def test_hub_verify_blocking_guard_returns_waiting_not_agent_nudge(cp, monkeypatch):

--- a/tests/test_hub_verify_evidence_window.py
+++ b/tests/test_hub_verify_evidence_window.py
@@ -79,7 +79,7 @@ def _fake_run(monkeypatch):
         done = lambda rc, out="", err="": subprocess.CompletedProcess(argv, rc, out, err)
         if argv[0] == "git" and "rev-parse" in argv:
             return done(0, HEAD_SHA + "\n")
-        if argv[0] in ("git", "tar"):
+        if argv[0] in ("git", "tar", "bash"):
             return done(0)
         if "delete" in argv:
             return done(0)

--- a/tests/test_hub_verify_pg_url.py
+++ b/tests/test_hub_verify_pg_url.py
@@ -1,0 +1,49 @@
+"""Hub-verify must not point OpenShell sandboxes at the live hub database."""
+
+from __future__ import annotations
+
+from mac.openshell_runtime import SANDBOX_BASE_PATH
+from mac.services import (
+    hub_verify_sandbox_env_pairs,
+    hub_verify_sandbox_pg_url,
+    parse_start_test_postgres_export,
+)
+
+
+def test_parse_start_test_postgres_export() -> None:
+    stdout = "warning: skip me\nexport MAC_TEST_PG_URL=postgresql://me@127.0.0.1:5432/mac_test\n"
+    assert parse_start_test_postgres_export(stdout) == "postgresql://me@127.0.0.1:5432/mac_test"
+
+
+def test_hub_verify_rewrites_loopback_for_sandbox() -> None:
+    got = hub_verify_sandbox_pg_url("postgresql://tester@127.0.0.1:5432/mac_test")
+    assert got == "postgresql://tester@host.docker.internal:5432/mac_test"
+
+
+def test_hub_verify_refuses_live_hub_database() -> None:
+    live = "postgresql://mac@127.0.0.1:5432/mac"
+    assert hub_verify_sandbox_pg_url(live, live_database_url=live) is None
+
+
+def test_hub_verify_refuses_explicit_dsn_that_is_the_live_hub() -> None:
+    live = "postgresql://mac@100.72.16.110:5432/mac"
+    assert hub_verify_sandbox_pg_url(live, live_database_url=live) is None
+
+
+def test_hub_verify_host_override() -> None:
+    got = hub_verify_sandbox_pg_url(
+        "postgresql://tester@localhost:5432/mac_test",
+        sandbox_host="hub.internal",
+    )
+    assert got == "postgresql://tester@hub.internal:5432/mac_test"
+
+
+def test_hub_verify_env_pairs_include_path_and_optional_dsn() -> None:
+    pairs = hub_verify_sandbox_env_pairs()
+    assert "HOME=/tmp" in pairs
+    assert "PATH=%s" % SANDBOX_BASE_PATH in pairs
+    assert not any(item.startswith("MAC_TEST_PG_URL=") for item in pairs)
+    injected = hub_verify_sandbox_env_pairs(
+        test_pg_url="postgresql://mac_test@host.docker.internal:5432/mac_test"
+    )
+    assert "MAC_TEST_PG_URL=postgresql://mac_test@host.docker.internal:5432/mac_test" in injected


### PR DESCRIPTION
## Summary
- Put the still-open v1.3.0 capabilities-deck (slide 12) items on `docs/roadmap.md` with ledger IDs.
- `mac --help` now reports the real `mac admin` subcommand count instead of zero (`task_2d33cc69`).
- Current docs no longer describe the deleted Hermes snapshot as present (`task_a0fc238b`).
- Hub-verify OpenShell sandboxes get a dedicated test Postgres DSN (never the live hub database) so a repository canary can finish (`task_321b8e8d`). Loopback hosts are rewritten to `host.docker.internal`.

Large ADRs from the same slide (0017, 0018, 0029, 0032) and the ADR 0012 deferral stay filed `--no-dispatch` until this hub-verify fix is merged **and deployed**. Do not release the held backlog on merge alone.

## Test plan
- [x] `tests/test_hub_verify_pg_url.py` (rewrite loopback, refuse live DSN, env pairs)
- [x] `test_hub_verify_sandbox_command_whitelists_uploaded_repo_for_git`
- [x] `test_hub_verify_sandbox_injects_dedicated_test_pg_url`
- [x] `tests/test_hub_verify_evidence_window.py`
- [x] `test_top_level_help_is_only_the_first_class_objects`
- [x] `test_docs_carry_no_operator_identity`
- [x] `scripts/generate-docs-reference.py --check` and env-registry `--check`
- [ ] GitHub CI on this PR
- [ ] After merge: deploy to the fleet, then one repository canary through hub-verify