### PR TITLE
Make hub-verify inject a reachable test Postgres DSN (task_321b8e8d)

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -542,8 +542,10 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HUB_UPGRADE_REQUIRED_CHECKS` | bool | consumer-defined | hub | Hub setting: hub upgrade required checks. |
 | `MAC_HUB_URL` | str | consumer-defined | hub | Hub setting: hub url. |
 | `MAC_HUB_VERIFY_IMAGE` | str | consumer-defined | hub | Hub setting: hub verify image. |
-| `MAC_HUB_VERIFY_PG_HOST` | str | consumer-defined | hub | Hostname substituted for `127.0.0.1`/`localhost`/`::1` in the hub-verify test DSN. Default `host.docker.internal`. Does not select the live hub database. |
-| `MAC_HUB_VERIFY_PG_URL` | str | consumer-defined | hub | Dedicated test Postgres DSN injected into the hub-verify OpenShell sandbox as `MAC_TEST_PG_URL`. Never the live hub database. Loopback hosts are rewritten to `host.docker.internal` (or `MAC_HUB_VERIFY_PG_HOST`) so the sandbox can reach Postgres on the hub. If unset, hub-verify runs `scripts/start-test-postgres.sh` from the cloned repo and rewrites that DSN the same way. |
+| `MAC_HUB_VERIFY_PG_DATADIR` | str | consumer-defined | hub | Data directory for the dedicated hub-verify Postgres started by `scripts/start-test-postgres.sh`. Defaults to a temp `mac-hubverify-pgdata` directory, never the live hub cluster. |
+| `MAC_HUB_VERIFY_PG_HOST` | str | consumer-defined | hub | Hostname substituted for `127.0.0.1`/`localhost`/`::1` in the hub-verify test DSN. Default `host.openshell.internal` (OpenShell's host-bridge alias). Does not select the live hub Postgres. |
+| `MAC_HUB_VERIFY_PG_PORT` | int | consumer-defined | hub | Port passed to `scripts/start-test-postgres.sh` when hub-verify provisions a dedicated test DSN. Default 55432 so the helper does not attach to the live hub listener on 5432. |
+| `MAC_HUB_VERIFY_PG_URL` | str | consumer-defined | hub | Dedicated test Postgres DSN injected into the hub-verify OpenShell sandbox as `MAC_TEST_PG_URL`. Never the live hub Postgres (same host and port, not merely the same database name). Loopback hosts are rewritten to `host.openshell.internal` (or `MAC_HUB_VERIFY_PG_HOST` / `MAC_OPENSHELL_HOST_ALIAS`) so the sandbox can reach Postgres on the hub. If unset, hub-verify runs `scripts/start-test-postgres.sh` on a dedicated port (default 55432) and rewrites that DSN the same way. |
 | `MAC_HUB_VERIFY_RUNNER` | str | consumer-defined | hub | Hub setting: hub verify runner. |
 | `MAC_HUB_VERIFY_TIMEOUT` | int | consumer-defined | hub | Hub setting: hub verify timeout. |
 | `MAC_HUMAN` | str | consumer-defined | core | Core setting: human. |

--- a/scripts/generate-env-config-registry.py
+++ b/scripts/generate-env-config-registry.py
@@ -124,16 +124,27 @@ CONSUMER_DEFAULTS = {
 CURATED_DESCRIPTIONS = {
     "MAC_HUB_VERIFY_PG_URL": (
         "Dedicated test Postgres DSN injected into the hub-verify OpenShell "
-        "sandbox as `MAC_TEST_PG_URL`. Never the live hub database. Loopback "
-        "hosts are rewritten to `host.docker.internal` (or "
-        "`MAC_HUB_VERIFY_PG_HOST`) so the sandbox can reach Postgres on the hub. "
-        "If unset, hub-verify runs `scripts/start-test-postgres.sh` from the "
-        "cloned repo and rewrites that DSN the same way."
+        "sandbox as `MAC_TEST_PG_URL`. Never the live hub Postgres (same host "
+        "and port, not merely the same database name). Loopback hosts are "
+        "rewritten to `host.openshell.internal` (or `MAC_HUB_VERIFY_PG_HOST` / "
+        "`MAC_OPENSHELL_HOST_ALIAS`) so the sandbox can reach Postgres on the "
+        "hub. If unset, hub-verify runs `scripts/start-test-postgres.sh` on a "
+        "dedicated port (default 55432) and rewrites that DSN the same way."
     ),
     "MAC_HUB_VERIFY_PG_HOST": (
         "Hostname substituted for `127.0.0.1`/`localhost`/`::1` in the "
-        "hub-verify test DSN. Default `host.docker.internal`. Does not select "
-        "the live hub database."
+        "hub-verify test DSN. Default `host.openshell.internal` (OpenShell's "
+        "host-bridge alias). Does not select the live hub Postgres."
+    ),
+    "MAC_HUB_VERIFY_PG_PORT": (
+        "Port passed to `scripts/start-test-postgres.sh` when hub-verify "
+        "provisions a dedicated test DSN. Default 55432 so the helper does not "
+        "attach to the live hub listener on 5432."
+    ),
+    "MAC_HUB_VERIFY_PG_DATADIR": (
+        "Data directory for the dedicated hub-verify Postgres started by "
+        "`scripts/start-test-postgres.sh`. Defaults to a temp "
+        "`mac-hubverify-pgdata` directory, never the live hub cluster."
     ),
     "MAC_DEPLOY_GATEWAY_PROBE_FATAL": (
         "Set `1` to make a failed OpenClaw gateway/channel probe fail the node, "

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -6446,7 +6446,18 @@
   },
   {
     "default": null,
-    "description": "Hostname substituted for `127.0.0.1`/`localhost`/`::1` in the hub-verify test DSN. Default `host.docker.internal`. Does not select the live hub database.",
+    "description": "Data directory for the dedicated hub-verify Postgres started by `scripts/start-test-postgres.sh`. Defaults to a temp `mac-hubverify-pgdata` directory, never the live hub cluster.",
+    "family": "hub",
+    "name": "MAC_HUB_VERIFY_PG_DATADIR",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Hostname substituted for `127.0.0.1`/`localhost`/`::1` in the hub-verify test DSN. Default `host.openshell.internal` (OpenShell's host-bridge alias). Does not select the live hub Postgres.",
     "family": "hub",
     "name": "MAC_HUB_VERIFY_PG_HOST",
     "retired": false,
@@ -6457,7 +6468,18 @@
   },
   {
     "default": null,
-    "description": "Dedicated test Postgres DSN injected into the hub-verify OpenShell sandbox as `MAC_TEST_PG_URL`. Never the live hub database. Loopback hosts are rewritten to `host.docker.internal` (or `MAC_HUB_VERIFY_PG_HOST`) so the sandbox can reach Postgres on the hub. If unset, hub-verify runs `scripts/start-test-postgres.sh` from the cloned repo and rewrites that DSN the same way.",
+    "description": "Port passed to `scripts/start-test-postgres.sh` when hub-verify provisions a dedicated test DSN. Default 55432 so the helper does not attach to the live hub listener on 5432.",
+    "family": "hub",
+    "name": "MAC_HUB_VERIFY_PG_PORT",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Dedicated test Postgres DSN injected into the hub-verify OpenShell sandbox as `MAC_TEST_PG_URL`. Never the live hub Postgres (same host and port, not merely the same database name). Loopback hosts are rewritten to `host.openshell.internal` (or `MAC_HUB_VERIFY_PG_HOST` / `MAC_OPENSHELL_HOST_ALIAS`) so the sandbox can reach Postgres on the hub. If unset, hub-verify runs `scripts/start-test-postgres.sh` on a dedicated port (default 55432) and rewrites that DSN the same way.",
     "family": "hub",
     "name": "MAC_HUB_VERIFY_PG_URL",
     "retired": false,
@@ -9072,7 +9094,8 @@
     "name": "MAC_OPENSHELL_HOST_ALIAS",
     "retired": false,
     "sources": [
-      "src/mac/executor_sandbox.py"
+      "src/mac/executor_sandbox.py",
+      "src/mac/services.py"
     ],
     "type": "str"
   },
@@ -13495,7 +13518,8 @@
     "name": "MAC_TEST_PG_CONTAINER",
     "retired": false,
     "sources": [
-      "scripts/start-test-postgres.sh"
+      "scripts/start-test-postgres.sh",
+      "src/mac/services.py"
     ],
     "type": "str"
   },
@@ -13506,7 +13530,8 @@
     "name": "MAC_TEST_PG_DATADIR",
     "retired": false,
     "sources": [
-      "scripts/start-test-postgres.sh"
+      "scripts/start-test-postgres.sh",
+      "src/mac/services.py"
     ],
     "type": "str"
   },
@@ -13517,7 +13542,8 @@
     "name": "MAC_TEST_PG_DB",
     "retired": false,
     "sources": [
-      "scripts/start-test-postgres.sh"
+      "scripts/start-test-postgres.sh",
+      "src/mac/services.py"
     ],
     "type": "str"
   },
@@ -13561,7 +13587,8 @@
     "name": "MAC_TEST_PG_PORT",
     "retired": false,
     "sources": [
-      "scripts/start-test-postgres.sh"
+      "scripts/start-test-postgres.sh",
+      "src/mac/services.py"
     ],
     "type": "int"
   },

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1119,7 +1119,14 @@ def hub_verification_unavailable_reason(output: str) -> Optional[str]:
     return None
 
 
-_HUB_VERIFY_SANDBOX_PG_HOST = "host.docker.internal"
+# OpenShell injects this hosts entry; ``host.docker.internal`` is Docker
+# Desktop and is not present in a hub-verify sandbox. Keep in lockstep with
+# ``executor_sandbox._OPENSHELL_HOST_ALIAS_DEFAULT``.
+_HUB_VERIFY_SANDBOX_PG_HOST = "host.openshell.internal"
+_HUB_VERIFY_PG_PORT = "55432"
+_HUB_VERIFY_PG_DB = "mac_hubverify"
+_HUB_VERIFY_PG_CONTAINER = "mac-hubverify-postgres"
+_LOOPBACK_PG_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "0.0.0.0"})
 
 
 def parse_start_test_postgres_export(stdout: str) -> str:
@@ -1132,6 +1139,50 @@ def parse_start_test_postgres_export(stdout: str) -> str:
     return ""
 
 
+def _pg_url_authority(dsn: str) -> Optional[Tuple[str, int]]:
+    parsed = urllib.parse.urlsplit((dsn or "").strip())
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        return None
+    return host, int(parsed.port or 5432)
+
+
+def _hub_verify_pg_shares_live_server(candidate: str, live: str) -> bool:
+    """True when *candidate* is the live hub Postgres process, even if the
+    database name or role differs.
+
+    ``start-test-postgres.sh`` will happily emit ``...@127.0.0.1:5432/mac_test``
+    when the hub is already listening on 5432. Exact-string comparison against
+    ``MAC_DATABASE_URL`` (a different database on that same server) would then
+    inject the live cluster into the sandbox.
+    """
+
+    if not candidate or not live:
+        return False
+    if candidate.strip() == live.strip():
+        return True
+    left = _pg_url_authority(candidate)
+    right = _pg_url_authority(live)
+    if left is None or right is None:
+        return False
+    left_host, left_port = left
+    right_host, right_port = right
+    if left_port != right_port:
+        return False
+    if left_host == right_host:
+        return True
+    return left_host in _LOOPBACK_PG_HOSTS or right_host in _LOOPBACK_PG_HOSTS
+
+
+def _hub_verify_sandbox_pg_host(*, sandbox_host: str = "") -> str:
+    return (
+        sandbox_host
+        or os.environ.get("MAC_HUB_VERIFY_PG_HOST")
+        or os.environ.get("MAC_OPENSHELL_HOST_ALIAS")
+        or ""
+    ).strip() or _HUB_VERIFY_SANDBOX_PG_HOST
+
+
 def hub_verify_sandbox_pg_url(
     raw: str,
     *,
@@ -1140,8 +1191,9 @@ def hub_verify_sandbox_pg_url(
 ) -> Optional[str]:
     """Return a test DSN the OpenShell hub-verify sandbox can use.
 
-    Refuses the live hub database. Rewrites loopback hosts to
-    ``host.docker.internal`` (override with ``MAC_HUB_VERIFY_PG_HOST``) so a
+    Refuses the live hub Postgres (same host+port, not merely the same DSN).
+    Rewrites loopback hosts to ``host.openshell.internal`` (override with
+    ``MAC_HUB_VERIFY_PG_HOST`` or ``MAC_OPENSHELL_HOST_ALIAS``) so a dedicated
     Postgres started on the hub is reachable from inside the sandbox.
     """
 
@@ -1149,14 +1201,12 @@ def hub_verify_sandbox_pg_url(
     live = (live_database_url or "").strip()
     if not candidate:
         return None
-    if live and candidate == live:
+    if _hub_verify_pg_shares_live_server(candidate, live):
         return None
-    host = (sandbox_host or os.environ.get("MAC_HUB_VERIFY_PG_HOST") or "").strip()
-    if not host:
-        host = _HUB_VERIFY_SANDBOX_PG_HOST
+    host = _hub_verify_sandbox_pg_host(sandbox_host=sandbox_host)
     parsed = urllib.parse.urlsplit(candidate)
     hostname = (parsed.hostname or "").strip().lower()
-    if hostname in {"127.0.0.1", "localhost", "::1"}:
+    if hostname in _LOOPBACK_PG_HOSTS:
         username = parsed.username or ""
         password = parsed.password
         userinfo = username
@@ -1170,9 +1220,42 @@ def hub_verify_sandbox_pg_url(
         candidate = urllib.parse.urlunsplit(
             (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
         )
-        if live and candidate == live:
+        if _hub_verify_pg_shares_live_server(candidate, live):
             return None
     return candidate
+
+
+def _hub_verify_start_test_postgres(repo_root: Path) -> str:
+    helper = repo_root / "scripts" / "start-test-postgres.sh"
+    if not helper.is_file():
+        return ""
+    env = dict(os.environ)
+    env.pop("MAC_TEST_PG_URL", None)
+    env["MAC_TEST_PG_PORT"] = (
+        os.environ.get("MAC_HUB_VERIFY_PG_PORT") or _HUB_VERIFY_PG_PORT
+    ).strip() or _HUB_VERIFY_PG_PORT
+    env["MAC_TEST_PG_DB"] = _HUB_VERIFY_PG_DB
+    env["MAC_TEST_PG_CONTAINER"] = _HUB_VERIFY_PG_CONTAINER
+    env["MAC_TEST_PG_DATADIR"] = os.environ.get("MAC_HUB_VERIFY_PG_DATADIR") or os.path.join(
+        tempfile.gettempdir(), "mac-hubverify-pgdata"
+    )
+    try:
+        proc = subprocess.run(
+            ["bash", str(helper)],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=90,
+            check=False,
+            env=env,
+        )
+    except Exception:  # noqa: BLE001 - missing helper must not abort verify
+        return ""
+    # 0 is success; ``returncode or 1`` would turn a successful helper into a
+    # miss and leave the sandbox without MAC_TEST_PG_URL (observed after #682).
+    if getattr(proc, "returncode", 1) != 0:
+        return ""
+    return parse_start_test_postgres_export(proc.stdout or "")
 
 
 def hub_verify_test_pg_url(repo_root: Path) -> Optional[str]:
@@ -1180,23 +1263,7 @@ def hub_verify_test_pg_url(repo_root: Path) -> Optional[str]:
 
     explicit = (os.environ.get("MAC_HUB_VERIFY_PG_URL") or "").strip()
     live = (os.environ.get("MAC_DATABASE_URL") or os.environ.get("MAC_DB") or "").strip()
-    raw = explicit
-    if not raw:
-        helper = repo_root / "scripts" / "start-test-postgres.sh"
-        if helper.is_file():
-            try:
-                proc = subprocess.run(
-                    ["bash", str(helper)],
-                    cwd=str(repo_root),
-                    capture_output=True,
-                    text=True,
-                    timeout=90,
-                    check=False,
-                )
-            except Exception:  # noqa: BLE001 - missing helper must not abort verify
-                proc = None
-            if proc is not None and int(proc.returncode or 1) == 0:
-                raw = parse_start_test_postgres_export(proc.stdout or "")
+    raw = explicit or _hub_verify_start_test_postgres(repo_root)
     return hub_verify_sandbox_pg_url(raw, live_database_url=live)
 
 
@@ -27239,7 +27306,7 @@ class ControlPlane:
             # commands instead of preserving the image ENV. Pass the
             # sandbox-owned runtime path explicitly; never inherit the
             # control-plane host's PATH. MAC_TEST_PG_URL is a dedicated
-            # test DSN (never the live hub database).
+            # test DSN on host.openshell.internal (never the live hub Postgres).
             for value in hub_verify_sandbox_env_pairs(test_pg_url=test_pg_url):
                 argv += ["--env", value]
             argv += [

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -13920,7 +13920,7 @@ def test_hub_verify_sandbox_injects_dedicated_test_pg_url(cp, monkeypatch):
     from mac import services as services_mod
 
     captured = []
-    dsn = "postgresql://mac_test@host.docker.internal:5432/mac_test"
+    dsn = "postgresql://mac_test@host.openshell.internal:55432/mac_hubverify"
 
     def fake_run(argv, **kwargs):
         captured.append(list(argv))

--- a/tests/test_hub_verify_pg_url.py
+++ b/tests/test_hub_verify_pg_url.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 from mac.openshell_runtime import SANDBOX_BASE_PATH
 from mac.services import (
     hub_verify_sandbox_env_pairs,
     hub_verify_sandbox_pg_url,
+    hub_verify_test_pg_url,
     parse_start_test_postgres_export,
 )
 
@@ -17,7 +21,7 @@ def test_parse_start_test_postgres_export() -> None:
 
 def test_hub_verify_rewrites_loopback_for_sandbox() -> None:
     got = hub_verify_sandbox_pg_url("postgresql://tester@127.0.0.1:5432/mac_test")
-    assert got == "postgresql://tester@host.docker.internal:5432/mac_test"
+    assert got == "postgresql://tester@host.openshell.internal:5432/mac_test"
 
 
 def test_hub_verify_refuses_live_hub_database() -> None:
@@ -28,6 +32,37 @@ def test_hub_verify_refuses_live_hub_database() -> None:
 def test_hub_verify_refuses_explicit_dsn_that_is_the_live_hub() -> None:
     live = "postgresql://mac@100.72.16.110:5432/mac"
     assert hub_verify_sandbox_pg_url(live, live_database_url=live) is None
+
+
+def test_hub_verify_refuses_same_server_different_database() -> None:
+    live = "postgresql://mac@127.0.0.1:5432/mac"
+    assert (
+        hub_verify_sandbox_pg_url(
+            "postgresql://tester@127.0.0.1:5432/mac_test",
+            live_database_url=live,
+        )
+        is None
+    )
+
+
+def test_hub_verify_refuses_loopback_when_live_is_tailscale_same_port() -> None:
+    live = "postgresql://mac@100.72.16.110:5432/mac"
+    assert (
+        hub_verify_sandbox_pg_url(
+            "postgresql://jkh@127.0.0.1:5432/mac_hubverify",
+            live_database_url=live,
+        )
+        is None
+    )
+
+
+def test_hub_verify_allows_dedicated_port_on_loopback() -> None:
+    live = "postgresql://mac@127.0.0.1:5432/mac"
+    got = hub_verify_sandbox_pg_url(
+        "postgresql://tester@127.0.0.1:55432/mac_hubverify",
+        live_database_url=live,
+    )
+    assert got == "postgresql://tester@host.openshell.internal:55432/mac_hubverify"
 
 
 def test_hub_verify_host_override() -> None:
@@ -44,6 +79,46 @@ def test_hub_verify_env_pairs_include_path_and_optional_dsn() -> None:
     assert "PATH=%s" % SANDBOX_BASE_PATH in pairs
     assert not any(item.startswith("MAC_TEST_PG_URL=") for item in pairs)
     injected = hub_verify_sandbox_env_pairs(
-        test_pg_url="postgresql://mac_test@host.docker.internal:5432/mac_test"
+        test_pg_url="postgresql://mac_test@host.openshell.internal:55432/mac_hubverify"
     )
-    assert "MAC_TEST_PG_URL=postgresql://mac_test@host.docker.internal:5432/mac_test" in injected
+    assert (
+        "MAC_TEST_PG_URL=postgresql://mac_test@host.openshell.internal:55432/mac_hubverify"
+        in injected
+    )
+
+
+def test_hub_verify_test_pg_url_runs_helper_on_dedicated_port(tmp_path: Path, monkeypatch) -> None:
+    """Helper exit 0 must inject a rewritten DSN on a non-live port.
+
+    ``returncode or 1`` treats 0 as failure, which is how #682 shipped a helper
+    that never injected MAC_TEST_PG_URL.
+    """
+
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "scripts" / "start-test-postgres.sh").write_text("#!/bin/bash\n", encoding="utf-8")
+    captured: dict[str, object] = {}
+
+    def fake_run(argv, **kwargs):
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="export MAC_TEST_PG_URL=postgresql://me@127.0.0.1:55432/mac_hubverify\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("mac.services.subprocess.run", fake_run)
+    monkeypatch.delenv("MAC_HUB_VERIFY_PG_URL", raising=False)
+    monkeypatch.delenv("MAC_HUB_VERIFY_PG_PORT", raising=False)
+    monkeypatch.delenv("MAC_HUB_VERIFY_PG_HOST", raising=False)
+    monkeypatch.delenv("MAC_OPENSHELL_HOST_ALIAS", raising=False)
+    monkeypatch.setenv("MAC_DATABASE_URL", "postgresql://mac@127.0.0.1:5432/mac")
+    monkeypatch.setenv("MAC_TEST_PG_URL", "postgresql://mac@127.0.0.1:5432/mac")
+    got = hub_verify_test_pg_url(repo)
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["MAC_TEST_PG_PORT"] == "55432"
+    assert env["MAC_TEST_PG_DB"] == "mac_hubverify"
+    assert env.get("MAC_TEST_PG_URL") in (None, "")
+    assert got == "postgresql://me@host.openshell.internal:55432/mac_hubverify"


### PR DESCRIPTION
## Summary
- Hub-verify still left OpenShell sandboxes without `MAC_TEST_PG_URL` after #682: a successful `start-test-postgres.sh` exits 0, and `returncode or 1` treated that as failure so the DSN was never injected.
- Rewrite loopback DSNs to `host.openshell.internal` (OpenShell's host-bridge alias), not `host.docker.internal`.
- Provision the helper on dedicated port 55432 / database `mac_hubverify` and refuse any DSN that shares host+port with the live hub Postgres.

## Test plan
- [x] `tests/test_hub_verify_pg_url.py` and the hub-verify control-plane injection tests
- [x] `scripts/generate-env-config-registry.py` is current
- [ ] Merge, then restart/redeploy the hub on `aa5649e1`+this commit so live hub-verify picks up the helper
- [ ] Confirm a subsequent repo-change review produces a hub-verify verdict instead of `hub_verify_unavailable` / unset `MAC_TEST_PG_URL`