### PR TITLE
Deliver KSLUG transcripts as Slack presentation blocks

### DIFF
--- a/deploy/openclaw/run-script-cron-job.py
+++ b/deploy/openclaw/run-script-cron-job.py
@@ -64,6 +64,10 @@ MAX_SCRIPT_OUTPUT = 20000
 DEFAULT_SCRIPT_TIMEOUT = 300.0
 DEFAULT_AGENT_TIMEOUT = 300.0
 SCRIPT_OUTPUT_HEADING = "## Script Output"
+# OpenClaw Slack's buildSlackPresentationBlocks truncates each type=text block
+# at the Block Kit section mrkdwn cap. Chunk here so a 4k+ KSLUG transcript is
+# not silently cut after the runner already counted it as delivered.
+SLACK_SECTION_TEXT_MAX = 3000
 
 # Nightly #localnews (kslug-nightly-news) has historically leaked process notes
 # into Slack when the workspace skill / AgentFS SPEC were missing. The host
@@ -538,6 +542,11 @@ def message_args(
     ``json.dumps`` escapes the newlines, so the token crossing the boundary has
     none while the body survives intact. ``--message`` keeps a single-line
     summary because the CLI requires it.
+
+    OpenClaw Slack (2026.6.11) renders ``presentation.title`` and
+    ``presentation.blocks`` into Block Kit. A top-level ``{"text": body}`` is
+    ignored, so Slack posted only the ``--message`` banner. The body must be
+    ``{"blocks": [{"type": "text", "text": ...}, ...]}``.
     """
     return [
         message_bin,
@@ -551,8 +560,36 @@ def message_args(
         "--message",
         summary_line(text),
         "--presentation",
-        json.dumps({"text": text}),
+        json.dumps({"blocks": presentation_text_blocks(text)}),
     ]
+
+
+def presentation_text_blocks(text: str, *, limit: int = SLACK_SECTION_TEXT_MAX) -> list:
+    """Split ``text`` into Slack presentation ``type=text`` blocks.
+
+    Empty input yields no blocks: the CLI still has ``--message``. Chunks stay
+    at or under ``limit`` so OpenClaw does not truncate mid-broadcast.
+    """
+    body = str(text or "")
+    if not body:
+        return []
+    if limit <= 0:
+        limit = SLACK_SECTION_TEXT_MAX
+    chunks = []
+    remaining = body
+    while remaining:
+        if len(remaining) <= limit:
+            chunks.append(remaining)
+            break
+        window = remaining[:limit]
+        cut = window.rfind("\n")
+        if cut < limit // 2:
+            chunks.append(remaining[:limit])
+            remaining = remaining[limit:]
+        else:
+            chunks.append(remaining[: cut + 1])
+            remaining = remaining[cut + 1 :]
+    return [{"type": "text", "text": chunk} for chunk in chunks if chunk]
 
 
 def summary_line(text: str, *, limit: int = 200) -> str:

--- a/tests/test_dream_cycle_runner.py
+++ b/tests/test_dream_cycle_runner.py
@@ -252,9 +252,33 @@ def test_the_multi_line_body_survives_the_escaping() -> None:
 
     body = "first line\nsecond line\nthird line"
     args = runner.message_args("/bin/openclaw-message", "slack", "C0123ABC", body, account="a")
-    presentation = args[args.index("--presentation") + 1]
+    presentation = _json.loads(args[args.index("--presentation") + 1])
 
-    assert _json.loads(presentation)["text"] == body
+    assert "text" not in presentation
+    assert presentation["blocks"] == [{"type": "text", "text": body}]
+    assert "".join(block["text"] for block in presentation["blocks"]) == body
+    assert args[args.index("--message") + 1] == "first line"
+
+
+def test_presentation_chunks_long_transcripts_without_argv_newlines() -> None:
+    """A KSLUG-length body must keep every character and stay sandbox-safe."""
+    import json as _json
+
+    body = ("local wire copy from the collector. " * 80) + "\n" + ("dan green closer. " * 80)
+    assert len(body) > runner.SLACK_SECTION_TEXT_MAX
+    args = runner.message_args("/bin/openclaw-message", "slack", "C0123ABC", body)
+    assert not any("\n" in part or "\r" in part for part in args)
+    presentation = _json.loads(args[args.index("--presentation") + 1])
+    blocks = presentation["blocks"]
+    assert all(block["type"] == "text" for block in blocks)
+    assert all(len(block["text"]) <= runner.SLACK_SECTION_TEXT_MAX for block in blocks)
+    assert "".join(block["text"] for block in blocks) == body
+    assert "dan green closer" in "".join(block["text"] for block in blocks)
+
+
+def test_presentation_text_blocks_empty_input_is_no_blocks() -> None:
+    assert runner.presentation_text_blocks("") == []
+    assert runner.presentation_text_blocks("   ") == [{"type": "text", "text": "   "}]
 
 
 def test_the_summary_line_is_never_empty() -> None:


### PR DESCRIPTION
## Summary
- Host script jobs (KSLUG nightly news) posted only the first line to Slack because `--message` is the banner and `--presentation {"text": body}` is ignored by OpenClaw Slack.
- Send the body as `presentation.blocks` of `type=text`, chunked at the Block Kit 3000-character section cap, so the sandbox argv still has no raw newlines.

## Test plan
- [x] `pytest tests/test_dream_cycle_runner.py` (32 passed)
- [ ] After merge, copy `deploy/openclaw/run-script-cron-job.py` to Rocky `~/.mac/bin/mac-cron-script-runner` (or the next OpenClaw install) so 06:00 PDT actually posts the show.