### PR TITLE
Bind the OpenClaw gateway to loopback, not LAN

### DIFF
--- a/deploy/openclaw/install-openclaw-gateway.sh
+++ b/deploy/openclaw/install-openclaw-gateway.sh
@@ -1129,11 +1129,17 @@ if "telegram" in configured:
         },
     }
 
+# loopback, not lan/tailnet. The gateway runs in OpenShell's private netns
+# (host loopback is a different namespace; Tailscale lives on the supervisor).
+# Slack/Telegram are outbound; controlUi is off; advertised access is
+# sandbox_exec. bind=lan lets OpenShell publish 18789 onto every host NIC.
+# bind=tailnet looks for utun/tailscale0 inside the sandbox and fails closed
+# or is a no-op. Health/CLI already talk to ws://127.0.0.1:18789 in-sandbox.
 config = {
     "gateway": {
         "mode": "local",
         "port": int(os.environ.get("MAC_OPENCLAW_GATEWAY_PORT", "18789")),
-        "bind": "lan",
+        "bind": "loopback",
         "auth": {
             "mode": "token",
             "token": secret_ref("OPENCLAW_GATEWAY_TOKEN"),

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -2811,7 +2811,7 @@ def test_gateway_log_classifier_accepts_exact_recovered_rocky_startup(tmp_path):
         "Gateway target: ws://127.0.0.1:18789",
         "Source: local loopback",
         "Config: /home/sandbox/.config/mac-openclaw/openclaw.json",
-        "Bind: lan",
+        "Bind: loopback",
     ]
     result, summary = run_gateway_log_classifier(
         tmp_path,

--- a/tests/test_openclaw_gateway_deploy.py
+++ b/tests/test_openclaw_gateway_deploy.py
@@ -328,9 +328,21 @@ def test_prepare_rewrites_host_loopback_to_openshell_alias(tmp_path: Path) -> No
     policy = (mac_home / "openclaw" / "openclaw-policy.yaml").read_text(encoding="utf-8")
     assert "MAC_OPENCLAW_CONTROL_URL=http://host.openshell.internal:8789" in runtime
     assert "http://host.openshell.internal:8789/v1" in config
+    assert '"bind": "loopback"' in config
+    assert '"bind": "lan"' not in config
     assert "host: host.openshell.internal" in policy
     assert "127.0.0.1:8789" not in runtime
     assert "localhost:8789" not in runtime
+
+
+def test_installer_does_not_emit_lan_gateway_bind() -> None:
+    """bind=lan published 18789 onto every supervisor NIC. Chat is outbound;
+    operators use sandbox exec; OpenClaw's tailnet bind is not visible in the
+    sandbox netns. Loopback is the only reliable refuse.
+    """
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert '"bind": "loopback"' in text
+    assert '"bind": "lan"' not in text
 
 
 def test_prepare_renders_distinct_agentbus_and_model_router_ports(tmp_path: Path) -> None:
@@ -2445,6 +2457,7 @@ def test_prepare_supports_verified_headless_openclaw_runtime(tmp_path: Path) -> 
     config = json.loads((mac_home / "openclaw" / "managed" / "openclaw.json").read_text())
     runtime = (mac_home / "openclaw" / "managed" / "runtime.env").read_text()
     workspace = (mac_home / "openclaw" / "workspace" / "AGENTS.md").read_text()
+    assert config["gateway"]["bind"] == "loopback"
     assert config["channels"] == {}
     assert config["plugins"]["entries"]["slack"] == {"enabled": False}
     assert config["plugins"]["entries"]["telegram"] == {"enabled": False}

--- a/tests/test_openclaw_gateway_deploy.py
+++ b/tests/test_openclaw_gateway_deploy.py
@@ -91,7 +91,7 @@ if scenario in {"deferred", "tainted-deferral"}:
     print("Gateway target: ws://127.0.0.1:18789", file=sys.stderr)
     print("Source: local loopback", file=sys.stderr)
     print("Config: /home/sandbox/.config/mac-openclaw/openclaw.json", file=sys.stderr)
-    print("Bind: lan", file=sys.stderr)
+    print("Bind: loopback", file=sys.stderr)
     if scenario == "tainted-deferral":
         print("ERROR gateway database unavailable", file=sys.stderr)
     raise SystemExit(1)


### PR DESCRIPTION
## Summary
- OpenClaw was generated with `gateway.bind: lan` on 18789 — the same class of leak as hub `0.0.0.0`. The overlay is not a host firewall, and OpenShell can publish sandbox listen addresses onto every supervisor NIC.
- Bind is now `loopback`. `tailnet` is not reliable here: the gateway runs in OpenShell's private netns, so it cannot see the host Tailscale/utun interface. Slack/Telegram are outbound, Control UI is off, advertised access is `sandbox_exec`.
- `apply-cron-plan.mjs` already accepted `Bind: loopback`. Historical log fixtures that still say `Bind: lan` are unchanged.

## Test plan
- [ ] `eval "$(scripts/start-test-postgres.sh)" && uv run --extra dev pytest -q tests/test_openclaw_gateway_deploy.py::test_prepare_rewrites_host_loopback_to_openshell_alias tests/test_openclaw_gateway_deploy.py::test_prepare_supports_verified_headless_openclaw_runtime tests/test_openclaw_gateway_deploy.py::test_installer_does_not_emit_lan_gateway_bind`
- [ ] After deploy, `openclaw.json` has `"bind": "loopback"` and host `ss`/`lsof` does not show `*:18789`
- [ ] Slack/Telegram still connect (outbound Socket Mode / long poll)