### PR TITLE
Release v1.3.2

### DIFF
--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 #: import it, so the number lives in exactly one place. It used to be copied by
 #: hand into four (pyproject, this package, the FastAPI app, the A2A card) with
 #: a comment on each asking the next person to keep them in sync.
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 __all__ = [
     "ControlPlane",


### PR DESCRIPTION
## Summary
- Bump the single-sourced `mac.__version__` to **1.3.2**.
- Patch on [v1.3.1](https://github.com/jordanhubbard/mac/releases/tag/v1.3.1). Capability surface is unchanged; the [v1.3.0 capabilities deck](https://docs.google.com/presentation/d/1yOOzFqRVwhY6opljcPEzfkzQmdjwylsxi1_hFO_8wJ0/edit) still describes it.
- Includes already-merged [#686](https://github.com/jordanhubbard/mac/pull/686) (mesh hub bind refuse) and [#687](https://github.com/jordanhubbard/mac/pull/687) (OpenClaw loopback bind).

## Test plan
- [ ] `uv run --extra dev python -c 'from mac import __version__; assert __version__ == "1.3.2"'`
- [ ] After merge: tag `v1.3.2` and `gh release create`