### PR TITLE
Discover mesh hub IPv4 when Tailscale is off the SSH PATH

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -48,11 +48,6 @@ readonly RECOVERY_POLICY
 MAC_LAUNCHD_TX_RECOVERY_POLICY="$RECOVERY_POLICY"
 export MAC_LAUNCHD_TX_RECOVERY_POLICY
 
-# Non-interactive SSH PATH is typically /usr/bin:/bin. Mesh bind looks up
-# `tailscale ip -4`; Darwin keeps that binary off the default PATH.
-PATH="/usr/local/bin:/opt/homebrew/bin:/Applications/Tailscale.app/Contents/MacOS:$PATH"
-export PATH
-
 # The outer controller acquires this fence before it copies or mutates any
 # managed state.  Re-check it in-band before this transaction's first write,
 # then renew it throughout long package/image installs.  A controller whose

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -48,6 +48,11 @@ readonly RECOVERY_POLICY
 MAC_LAUNCHD_TX_RECOVERY_POLICY="$RECOVERY_POLICY"
 export MAC_LAUNCHD_TX_RECOVERY_POLICY
 
+# Non-interactive SSH PATH is typically /usr/bin:/bin. Mesh bind looks up
+# `tailscale ip -4`; Darwin keeps that binary off the default PATH.
+PATH="/usr/local/bin:/opt/homebrew/bin:/Applications/Tailscale.app/Contents/MacOS:$PATH"
+export PATH
+
 # The outer controller acquires this fence before it copies or mutates any
 # managed state.  Re-check it in-band before this transaction's first write,
 # then renew it throughout long package/image installs.  A controller whose

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -638,7 +638,8 @@
       "src/mac/dispatch.py",
       "src/mac/gitops.py",
       "src/mac/ide_launcher.py",
-      "src/mac/local_console.py"
+      "src/mac/local_console.py",
+      "src/mac/mesh_bind.py"
     ],
     "type": "str"
   },
@@ -3080,7 +3081,8 @@
     "retired": false,
     "sources": [
       "deploy/deploy-mac-fleet.sh",
-      "deploy/fleet-node-install.sh"
+      "deploy/fleet-node-install.sh",
+      "src/mac/mesh_bind.py"
     ],
     "type": "str"
   },
@@ -4464,7 +4466,8 @@
     "retired": false,
     "sources": [
       "deploy/deploy-mac-fleet.sh",
-      "deploy/fleet-node-install.sh"
+      "deploy/fleet-node-install.sh",
+      "src/mac/mesh_bind.py"
     ],
     "type": "str"
   },
@@ -6429,6 +6432,7 @@
       "src/mac/k8s/job_executor.py",
       "src/mac/k8s/runner.py",
       "src/mac/local_console.py",
+      "src/mac/mesh_bind.py",
       "src/mac/openshell_collector.py",
       "src/mac/openshell_supervisor.py",
       "src/mac/worker.py"
@@ -13861,6 +13865,7 @@
       "src/mac/k8s/orchestrator.py",
       "src/mac/k8s/runner.py",
       "src/mac/local_console.py",
+      "src/mac/mesh_bind.py",
       "src/mac/openshell_collector.py",
       "src/mac/worker.py"
     ],

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -17,10 +17,10 @@ import secrets
 import shlex
 import sys
 import urllib.parse
-from typing import Dict, Mapping, MutableMapping, Optional, Sequence
+from typing import Callable, Dict, Mapping, MutableMapping, Optional, Sequence
 
 from mac.providers import ROUTER_PROVIDERS, router_secret_name, upstream_provider_env_vars
-from mac.mesh_bind import MeshBindError, deploy_mac_bind_host
+from mac.mesh_bind import MeshBindError, deploy_mac_bind_host, lookup_tailscale_ipv4, overlay_ipv4_from_url
 
 
 DEFAULT_WORKER_CAPABILITIES = (
@@ -880,6 +880,7 @@ def build_mac_env(
     cfg: DeployEnvConfig,
     *,
     environ: Optional[Mapping[str, str]] = None,
+    lookup: Optional[Callable[..., str]] = None,
 ) -> Dict[str, str]:
     env = os.environ if environ is None else environ
     values: Dict[str, str] = dict(existing)
@@ -896,10 +897,13 @@ def build_mac_env(
         )
     _ensure_secret_values(values)
     values.update(_path_values(cfg))
-    tailscale_ip = (
-        (env.get("MAC_TAILSCALE_IP") or "").strip()
-        or (values.get("MAC_TAILSCALE_IP") or "").strip()
-    )
+    finder = lookup or lookup_tailscale_ipv4
+    tailscale_ip = finder(environ=env)
+    if not tailscale_ip:
+        existing_ip = str(values.get("MAC_TAILSCALE_IP") or "").strip()
+        tailscale_ip = existing_ip or overlay_ipv4_from_url(cfg.control.hub_url)
+    if tailscale_ip:
+        values["MAC_TAILSCALE_IP"] = tailscale_ip
     try:
         values["MAC_BIND_HOST"] = deploy_mac_bind_host(
             cfg.control.bind_host,

--- a/src/mac/mesh_bind.py
+++ b/src/mac/mesh_bind.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import ipaddress
 import socket
 import subprocess
+import urllib.parse
 from typing import Callable, List, Mapping, Optional, Sequence
 
 MESH_PROVIDERS = frozenset({"tailscale", "headscale"})
@@ -22,6 +23,20 @@ TAILSCALE_CGNAT_V4 = ipaddress.ip_network("100.64.0.0/10")
 TAILSCALE_ULA_V6 = ipaddress.ip_network("fd7a:115c:a1e0::/48")
 UNSPECIFIED_HOSTS = frozenset({"0.0.0.0", "::", "*", "[::]"})
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost", ""})
+# Non-interactive SSH PATH is often /usr/bin:/bin:/usr/sbin:/sbin. Darwin
+# installs Tailscale under /usr/local/bin or Tailscale.app, not that PATH.
+TAILSCALE_IPV4_BINARIES = (
+    "tailscale",
+    "/usr/local/bin/tailscale",
+    "/opt/homebrew/bin/tailscale",
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+)
+_HUB_URL_ENV_KEYS = (
+    "MAC_DEPLOY_HUB_URL",
+    "MAC_HUB_URL",
+    "MAC_URL",
+    "MAC_API_URL",
+)
 
 RunCommand = Callable[..., subprocess.CompletedProcess[str]]
 
@@ -104,30 +119,77 @@ def hosts_include_non_loopback(hosts: Sequence[str]) -> bool:
     return any(not is_loopback_host(host) for host in hosts)
 
 
+def overlay_ipv4_from_host(host: str) -> str:
+    """Return ``host`` when it is a Tailscale CGNAT IPv4, else empty."""
+    text = str(host or "").strip().strip("[]")
+    if not text:
+        return ""
+    if text.count(":") == 1 and "." in text:
+        text = text.split(":", 1)[0]
+    ip = _parse_ip(text)
+    if ip is None or ip.version != 4 or ip not in TAILSCALE_CGNAT_V4:
+        return ""
+    return str(ip)
+
+
+def overlay_ipv4_from_url(url: str) -> str:
+    try:
+        host = urllib.parse.urlparse(str(url or "")).hostname or ""
+    except ValueError:
+        return ""
+    return overlay_ipv4_from_host(host)
+
+
+def overlay_ipv4_from_ssh_target(target: str) -> str:
+    text = str(target or "").strip()
+    if not text:
+        return ""
+    if "@" in text:
+        text = text.rsplit("@", 1)[1]
+    return overlay_ipv4_from_host(text)
+
+
 def lookup_tailscale_ipv4(
     *,
     environ: Optional[Mapping[str, str]] = None,
     run: Optional[RunCommand] = None,
 ) -> str:
-    """Prefer a live ``tailscale ip -4``; fall back to ``MAC_TAILSCALE_IP``."""
+    """Live ``tailscale ip -4``, then env/URL/SSH-target CGNAT fallbacks.
+
+    Deploy SSH sessions do not put Homebrew or Tailscale.app on PATH, so the
+    CLI lookup is empty unless an absolute binary exists. The fleet already
+    knows the overlay address as ``MAC_DEPLOY_TARGET`` / the hub URL.
+    """
     env = environ or {}
     runner = run or subprocess.run
-    try:
-        completed = runner(
-            ["tailscale", "ip", "-4"],
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False,
-        )
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        completed = None
-    if completed is not None and completed.returncode == 0:
+    for binary in TAILSCALE_IPV4_BINARIES:
+        try:
+            completed = runner(
+                [binary, "ip", "-4"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=False,
+            )
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+            continue
+        if completed.returncode != 0:
+            continue
         live = (completed.stdout or "").strip().splitlines()
-        if live and _parse_ip(live[0].strip()):
-            return live[0].strip()
-    fallback = str(env.get("MAC_TAILSCALE_IP") or "").strip()
-    return fallback if _parse_ip(fallback) else ""
+        if live:
+            token = live[0].strip()
+            # The CLI names the live overlay address, including Headscale
+            # prefixes that are not CGNAT. URL/SSH fallbacks stay CGNAT-only.
+            if _parse_ip(token):
+                return token
+    raw = str(env.get("MAC_TAILSCALE_IP") or "").strip()
+    if _parse_ip(raw):
+        return raw
+    for key in _HUB_URL_ENV_KEYS:
+        found = overlay_ipv4_from_url(str(env.get(key) or "").strip())
+        if found:
+            return found
+    return overlay_ipv4_from_ssh_target(str(env.get("MAC_DEPLOY_TARGET") or "").strip())
 
 
 def mesh_bind_problems(

--- a/tests/test_mesh_bind.py
+++ b/tests/test_mesh_bind.py
@@ -13,6 +13,8 @@ from mac.mesh_bind import (
     deploy_mac_bind_host,
     is_allowed_mesh_bind_host,
     lookup_tailscale_ipv4,
+    overlay_ipv4_from_ssh_target,
+    overlay_ipv4_from_url,
     parse_bind_hosts,
     runtime_bind_error,
     serve_bind_hosts,
@@ -146,6 +148,44 @@ def test_lookup_falls_back_to_env_when_cli_missing() -> None:
     )
 
 
+def test_lookup_tries_well_known_tailscale_binaries() -> None:
+    def fake_run(args, **_kwargs):
+        if args[0] == "tailscale":
+            raise FileNotFoundError("tailscale")
+        if args[0] == "/usr/local/bin/tailscale":
+            return SimpleNamespace(returncode=0, stdout="100.64.0.4\n")
+        raise FileNotFoundError(args[0])
+
+    assert lookup_tailscale_ipv4(environ={}, run=fake_run) == "100.64.0.4"
+
+
+def test_lookup_uses_deploy_target_and_hub_url_when_cli_missing() -> None:
+    def fake_run(*_args, **_kwargs):
+        raise FileNotFoundError("tailscale")
+
+    assert (
+        lookup_tailscale_ipv4(
+            environ={"MAC_DEPLOY_TARGET": "jkh@100.64.9.9"},
+            run=fake_run,
+        )
+        == "100.64.9.9"
+    )
+    assert (
+        lookup_tailscale_ipv4(
+            environ={"MAC_DEPLOY_HUB_URL": "http://100.64.8.8:8789"},
+            run=fake_run,
+        )
+        == "100.64.8.8"
+    )
+
+
+def test_overlay_parsers_accept_cgnat_only() -> None:
+    assert overlay_ipv4_from_ssh_target("jkh@100.64.1.2:22") == "100.64.1.2"
+    assert overlay_ipv4_from_url("http://100.64.1.3:8789") == "100.64.1.3"
+    assert overlay_ipv4_from_ssh_target("jkh@10.0.0.5") == ""
+    assert overlay_ipv4_from_url("http://example.test:8789") == ""
+
+
 def test_bind_sockets_loopback_ephemeral() -> None:
     sockets = bind_sockets(["127.0.0.1"], 0)
     try:
@@ -213,6 +253,36 @@ def test_build_mac_env_expands_mesh_hub_bind(tmp_path) -> None:
         {},
         cfg,
         environ={"MAC_TAILSCALE_IP": "100.64.0.1", "MAC_API_ALLOW_OPEN": "1"},
+        lookup=lambda environ=None: (environ or {}).get("MAC_TAILSCALE_IP") or "",
     )
     assert values["MAC_BIND_HOST"] == "127.0.0.1,100.64.0.1"
     assert values["MAC_NETWORK_PROVIDER"] == "tailscale"
+    assert values["MAC_TAILSCALE_IP"] == "100.64.0.1"
+
+
+def test_build_mac_env_discovers_overlay_ip_from_hub_url(tmp_path) -> None:
+    from mac import deploy_env
+
+    cfg = deploy_env.DeployEnvConfig(
+        paths=deploy_env.DeployPaths(tmp_path / "mac.env", tmp_path / ".mac", tmp_path),
+        control=deploy_env.ControlConfig(
+            port="8789",
+            hub_url="http://100.64.0.9:8789",
+            hub_token="hub-token",
+            bind_host="0.0.0.0",
+            supervisor_kind="systemd",
+            network_provider="tailscale",
+        ),
+        gateway=deploy_env.GatewayConfig("", "", "", ""),
+        worker=deploy_env.WorkerConfig("loop", "python", "", "", "0"),
+        services=deploy_env.SharedServicesConfig("", "6333", "", "3002"),
+        identity=deploy_env.DeployIdentity("hub", "hub", "fleet"),
+    )
+    values = deploy_env.build_mac_env(
+        {},
+        cfg,
+        environ={"MAC_API_ALLOW_OPEN": "1"},
+        lookup=lambda environ=None: "",
+    )
+    assert values["MAC_BIND_HOST"] == "127.0.0.1,100.64.0.9"
+    assert values["MAC_TAILSCALE_IP"] == "100.64.0.9"


### PR DESCRIPTION
## Summary
- v1.3.2 phase-2 on the Darwin hub failed closed while rewriting `MAC_BIND_HOST=0.0.0.0`: `write-mac-env` never called the live overlay lookup, and non-interactive SSH PATH is `/usr/bin:/bin`, so `tailscale ip -4` is missing even though `/usr/local/bin/tailscale` works.
- Look up well-known Tailscale binaries, then CGNAT addresses already present as `MAC_DEPLOY_HUB_URL` / `MAC_DEPLOY_TARGET`, persist `MAC_TAILSCALE_IP`, and prepend those PATHs in the node installer.

## Test plan
- [x] `pytest tests/test_mesh_bind.py tests/test_deploy_env_edges.py tests/test_deploy_direct_hub_readiness.py`
- [ ] CI sanity / contract as selected by the impact map
- [ ] After merge: recover the aborted v1.3.2 cohort (`--recovery-policy rollback`) and deploy the follow-up release to the hub and workers