### PR TITLE
Release v1.3.3

### DIFF
--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 #: import it, so the number lives in exactly one place. It used to be copied by
 #: hand into four (pyproject, this package, the FastAPI app, the A2A card) with
 #: a comment on each asking the next person to keep them in sync.
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 __all__ = [
     "ControlPlane",


### PR DESCRIPTION
## Summary
- Bump the single-sourced `mac.__version__` to **1.3.3**.
- Patch on [v1.3.2](https://github.com/jordanhubbard/mac/releases/tag/v1.3.2). Capability surface is unchanged; the [v1.3.0 capabilities deck](https://docs.google.com/presentation/d/1yOOzFqRVwhY6opljcPEzfkzQmdjwylsxi1_hFO_8wJ0/edit) still describes it.
- Includes already-merged [#689](https://github.com/jordanhubbard/mac/pull/689): Darwin fleet deploy can discover the Tailscale IPv4 when `tailscale` is off the SSH PATH, so mesh hubs rewrite `0.0.0.0` instead of failing closed.

## Test plan
- [ ] `uv run --extra dev python -c 'from mac import __version__; assert __version__ == "1.3.3"'`
- [ ] After merge: tag `v1.3.3` and `gh release create`
- [ ] Deploy to the hub and workers after the aborted v1.3.2 cohort is recovered