### PR TITLE
Declare and provision git >= 2.38 for fleet worker/runner hosts so the authoritative gate stops running distro git 2.34.1 (task_7d2049429ec8496c8bd98e470302f78b)

### DIFF
--- a/.mac/project.yaml
+++ b/.mac/project.yaml
@@ -20,6 +20,8 @@ toolchain:
     - initdb
     - pg_ctl
     - postgres
+  minimum_versions:
+    git: "2.38"
 bootstrap:
   command: python3 scripts/bootstrap-project.py
   creates:

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     MAC_BIND_HOST=0.0.0.0 \
     MAC_PORT=8789
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends git && \
+    python3 -c "import re,subprocess; v=tuple(map(int,re.search(r'[0-9]+(?:\.[0-9]+)+',subprocess.check_output(['git','version'],text=True)).group().split('.')[:2])); assert v >= (2,38), v" && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN printf '%s\n' 'mac:x:10001:' >> /etc/group && \
     printf '%s\n' 'mac:x:10001:10001:MAC service:/var/lib/mac:/usr/sbin/nologin' >> /etc/passwd && \
     mkdir -p /var/lib/mac && \

--- a/Dockerfile.codex-runner
+++ b/Dockerfile.codex-runner
@@ -5,6 +5,7 @@ USER root
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git ca-certificates curl nodejs npm && \
+    python3 -c "import re,subprocess; v=tuple(map(int,re.search(r'[0-9]+(?:\.[0-9]+)+',subprocess.check_output(['git','version'],text=True)).group().split('.')[:2])); assert v >= (2,38), v" && \
     npm install -g @openai/codex && \
     npm install -g opencode-ai && \
     npm cache clean --force && \

--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -7305,11 +7305,18 @@ openshell_checks = (
     if openshell_required
     else [path_check("openshell-disabled-state", mac_home)]
 )
+git_cli = next(
+    (str(Path(candidate).resolve()) for candidate in (shutil.which("git"), "/opt/homebrew/bin/git", "/usr/local/bin/git", "/usr/bin/git") if candidate and Path(candidate).is_file()),
+    None,
+)
+if git_cli is None:
+    raise SystemExit("git >= 2.38 prerequisite is unavailable")
 
 checks = {
     "machine-onboarding": [
         path_check("mac-cli", mac_bin, executable=True),
         path_check("github-cli", github_cli, executable=True),
+        {"name": "git-cli", "kind": "tool-version", "path": git_cli, "minimum_version": "2.38"},
     ],
     # The controller reached this node through the route identity sealed into
     # the contract. Prove the other half of the route by dialing the selected

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -9334,6 +9334,20 @@ install_github_cli() {
   log "verified onboarded GitHub CLI at $existing"
 }
 
+verify_git_version() {
+  local git_bin="" version=""
+  git_bin="$(onboarded_command_path git 2>/dev/null || true)"
+  [ -n "$git_bin" ] || die "Git >= 2.38 is missing; complete node onboarding before phase 2"
+  version="$("$git_bin" version 2>/dev/null)" || die "onboarded Git is not executable"
+  "$PY" - "$version" <<'PY' || die "Git >= 2.38 is required for merge-tree --write-tree"
+import re
+import sys
+match = re.search(r"[0-9]+(?:\.[0-9]+)+", sys.argv[1])
+raise SystemExit(0 if match and tuple(map(int, match.group().split(".")[:2])) >= (2, 38) else 1)
+PY
+  log "verified onboarded $version"
+}
+
 normalize_hermes_redaction_env() {
   "$PY" - "$LOG_DIR/hermes-redaction-normalization.json" "$(mac_gateway_home)/config.yaml" "$(mac_gateway_home)/.env" <<'PY'
 import json
@@ -10796,6 +10810,7 @@ else
   ensure_dns_resolution
   ensure_venv_support
   install_github_cli
+  verify_git_version
   configure_github_https_credentials
   install_github_review_key
 fi

--- a/deploy/fleet-prerequisite-receipts.py
+++ b/deploy/fleet-prerequisite-receipts.py
@@ -24,6 +24,7 @@ import os
 import re
 import socket
 import stat
+import subprocess
 import sys
 import tempfile
 import time
@@ -255,6 +256,21 @@ def _validate_path_check(value: dict[str, Any]) -> dict[str, Any]:
     return check
 
 
+def _validate_tool_version_check(value: dict[str, Any]) -> dict[str, Any]:
+    check = _exact_dict(
+        value, frozenset({"name", "kind", "path", "minimum_version"}), "tool version check"
+    )
+    _safe_name(check["name"], "check name")
+    if check["kind"] != "tool-version":
+        raise PrerequisiteError("tool version check kind is invalid")
+    _absolute_path(check["path"])
+    if not isinstance(check["minimum_version"], str) or re.fullmatch(
+        r"[0-9]+(?:\.[0-9]+){1,3}", check["minimum_version"]
+    ) is None:
+        raise PrerequisiteError("tool minimum_version is invalid")
+    return check
+
+
 def _validate_loopback_host(value: Any) -> str:
     if not isinstance(value, str) or value not in {"127.0.0.1", "::1", "localhost"}:
         raise PrerequisiteError("network checks are restricted to loopback")
@@ -384,6 +400,8 @@ def _validate_contract(value: Any) -> dict[str, Any]:
         kind = raw.get("kind")
         if kind == "path":
             check = _validate_path_check(raw)
+        elif kind == "tool-version":
+            check = _validate_tool_version_check(raw)
         elif kind == "tcp":
             check = _validate_tcp_check(raw)
         elif kind == "http":
@@ -495,6 +513,34 @@ def _probe_tcp(check: dict[str, Any]) -> dict[str, Any]:
     return {"connected": True, "elapsed_ms": int((time.monotonic() - started) * 1000)}
 
 
+def _probe_tool_version(check: dict[str, Any]) -> dict[str, Any]:
+    path = _absolute_path(check["path"])
+    try:
+        metadata = os.lstat(path)
+        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+            raise PrerequisiteError(f"tool version check {check['name']} is not a regular file")
+        output = subprocess.run(
+            [str(path), "version"],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+            env={"PATH": "/usr/bin:/bin", "HOME": "/"},
+        ).stdout
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise PrerequisiteError(f"tool version check {check['name']} failed") from exc
+    match = re.search(r"[0-9]+(?:\.[0-9]+)+", output)
+    if match is None:
+        raise PrerequisiteError(f"tool version check {check['name']} output is invalid")
+    detected = tuple(int(part) for part in match.group().split("."))
+    required = tuple(int(part) for part in check["minimum_version"].split("."))
+    width = max(len(detected), len(required))
+    if detected + (0,) * (width - len(detected)) < required + (0,) * (width - len(required)):
+        raise PrerequisiteError(f"tool version check {check['name']} is below minimum")
+    return {"version": match.group(), "minimum_version": check["minimum_version"]}
+
+
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
         raise urllib.error.HTTPError(req.full_url, code, "redirect refused", headers, fp)
@@ -531,6 +577,8 @@ def verify_contract(contract: Any, *, now: float | None = None) -> dict[str, Any
     for check in parsed["checks"]:
         if check["kind"] == "path":
             observation = _probe_path(check)
+        elif check["kind"] == "tool-version":
+            observation = _probe_tool_version(check)
         elif check["kind"] == "tcp":
             observation = _probe_tcp(check)
         else:
@@ -579,7 +627,7 @@ def validate_receipt(value: Any) -> dict[str, Any]:
         if name in seen:
             raise PrerequisiteError("receipt check names must be unique")
         seen.add(name)
-        if check["kind"] not in {"path", "tcp", "http"}:
+        if check["kind"] not in {"path", "tool-version", "tcp", "http"}:
             raise PrerequisiteError("receipt check kind is unsupported")
         _digest(check["evidence_sha256"], "receipt evidence digest")
     return json.loads(_canonical(receipt))

--- a/deploy/openshell/mac-hermes.Containerfile
+++ b/deploy/openshell/mac-hermes.Containerfile
@@ -106,6 +106,7 @@ RUN printf '%s\n' 'deb http://deb.debian.org/debian bookworm-backports main' > /
     && chmod 0755 /usr/local/bin/mac-verify-bash-contract \
     && /usr/local/bin/mac-verify-bash-contract \
     && apt-get install -y --no-install-recommends iproute2 iptables git procps make cmake ninja-build build-essential libssl-dev openjdk-17-jre-headless clang llvm lld \
+    && python3 -c "import re,subprocess; v=tuple(map(int,re.search(r'[0-9]+(?:\.[0-9]+)+',subprocess.check_output(['git','version'],text=True)).group().split('.')[:2])); assert v >= (2,38), v" \
     && apt-get install -y --no-install-recommends postgresql postgresql-client \
     && apt-get install -y --no-install-recommends -t bookworm-backports qemu-system-misc \
     && command -v ps >/dev/null \

--- a/docs/repository-runtime-contract.md
+++ b/docs/repository-runtime-contract.md
@@ -19,6 +19,8 @@ toolchain:
     - python3
     - git
     - gh
+  minimum_versions:
+    git: "2.38"
 bootstrap:
   command: python3 scripts/bootstrap-project.py
   creates:
@@ -45,6 +47,9 @@ evidence:
 - `toolchain.required_commands`: commands that must exist before bootstrap can
   run. Keep this list small and portable. Project bootstrap scripts should fail
   loudly when a required command is still missing.
+- `toolchain.minimum_versions`: minimum dotted versions for commands in
+  `required_commands`. Fleet prerequisite receipts verify these floors before
+  phase 2; mac requires Git 2.38 for `merge-tree --write-tree`.
 - `bootstrap.command`: an idempotent command run from the repository root to
   create the local build/test environment.
 - `bootstrap.creates`: relative paths expected after bootstrap. These are used

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -102,6 +102,7 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         "tests/test_gatewayless_worker_selftest_crash.py",
         "tests/test_generated_artifact_guards_always_run.py",
         "tests/test_github_review_key_install.py",
+        "tests/test_git_toolchain_floor.py",
         "tests/test_hermes_prompt_bridge_inert.py",
         "tests/test_hub_does_not_log_on_the_event_loop.py",
         "tests/test_hub_upgrade_supervisor.py",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -1761,6 +1761,20 @@ def _contract_string_list(value: Any, field: str, *, required: bool = True) -> L
     return strings
 
 
+def _contract_version_mapping(value: Any, field: str) -> Dict[str, str]:
+    if value is None:
+        return {}
+    mapping = _contract_mapping(value, field)
+    result: Dict[str, str] = {}
+    for command, version in mapping.items():
+        name = _contract_string(command, "%s command" % field)
+        minimum = _contract_string(version, "%s.%s" % (field, name))
+        if re.fullmatch(r"[0-9]+(?:\.[0-9]+){1,3}", minimum) is None:
+            raise ValidationError("%s.%s must be a dotted numeric version" % (field, name))
+        result[name] = minimum
+    return result
+
+
 def _contract_relative_paths(value: Any, field: str) -> List[str]:
     paths = _contract_string_list(value, field, required=False)
     for raw_path in paths:
@@ -1997,6 +2011,10 @@ def _normalize_repository_contract(raw: Any, contract_path: str) -> JsonDict:
             "required_commands": _contract_string_list(
                 toolchain.get("required_commands"),
                 "repository runtime contract.toolchain.required_commands",
+            ),
+            "minimum_versions": _contract_version_mapping(
+                toolchain.get("minimum_versions"),
+                "repository runtime contract.toolchain.minimum_versions",
             ),
         },
         "bootstrap": {

--- a/tests/test_fleet_prerequisite_receipts.py
+++ b/tests/test_fleet_prerequisite_receipts.py
@@ -104,6 +104,36 @@ def test_path_verifier_seals_only_secret_free_digests(tmp_path: Path) -> None:
     assert "#!/bin/sh" not in encoded
 
 
+def test_tool_version_verifier_enforces_minimum_without_sealing_output(tmp_path: Path) -> None:
+    tool = tmp_path / "git"
+    tool.write_text("#!/bin/sh\nprintf 'git version 2.38.1 secret-output\\n'\n", encoding="utf-8")
+    tool.chmod(0o700)
+    contract = {
+        "schema": receipts.CONTRACT_SCHEMA,
+        "participant": "machine-onboarding",
+        "agent_id": AGENT,
+        "node_identity_sha256": IDENTITY,
+        "checks": [
+            {
+                "name": "git-cli",
+                "kind": "tool-version",
+                "path": str(tool),
+                "minimum_version": "2.38",
+            }
+        ],
+    }
+
+    receipt = receipts.verify_contract(contract, now=1000.0)
+
+    assert receipt["status"] == "ready"
+    assert receipt["checks"][0]["kind"] == "tool-version"
+    assert "secret-output" not in json.dumps(receipt)
+
+    contract["checks"][0]["minimum_version"] = "2.39"
+    with pytest.raises(receipts.PrerequisiteError, match="below minimum"):
+        receipts.verify_contract(contract, now=1000.0)
+
+
 @pytest.mark.parametrize("change", ["mode", "digest", "symlink"])
 def test_path_verifier_rejects_drift_and_indirection(tmp_path: Path, change: str) -> None:
     tool = tmp_path / "tool"

--- a/tests/test_git_toolchain_floor.py
+++ b/tests/test_git_toolchain_floor.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import yaml
+
+from mac.services import _normalize_repository_contract
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_git_minimum_and_provisioning_assets_are_guarded() -> None:
+    contract = yaml.safe_load((ROOT / ".mac/project.yaml").read_text(encoding="utf-8"))
+    minimum = tuple(map(int, contract["toolchain"]["minimum_versions"]["git"].split(".")))
+    assert minimum >= (2, 38)
+
+    for relative in (
+        "Dockerfile",
+        "Dockerfile.codex-runner",
+        "deploy/openshell/mac-hermes.Containerfile",
+    ):
+        text = (ROOT / relative).read_text(encoding="utf-8")
+        assert "git" in text
+        assert "v >= (2,38)" in text
+
+    installer = (ROOT / "deploy/fleet-node-install.sh").read_text(encoding="utf-8")
+    assert "verify_git_version" in installer
+    assert "Git >= 2.38" in installer
+
+
+def test_machine_onboarding_receipt_declares_git_floor() -> None:
+    deploy = (ROOT / "deploy/deploy-mac-fleet.sh").read_text(encoding="utf-8")
+    assert '"kind": "tool-version"' in deploy
+    assert '"minimum_version": "2.38"' in deploy
+
+
+def test_repository_contract_normalizes_minimum_versions() -> None:
+    raw = yaml.safe_load((ROOT / ".mac/project.yaml").read_text(encoding="utf-8"))
+    normalized = _normalize_repository_contract(raw, ".mac/project.yaml")
+    assert normalized["toolchain"]["minimum_versions"] == {"git": "2.38"}


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_7d2049429ec8496c8bd98e470302f78b`
- head: `42cf8b65e0444d7b78627636b21eed71ffd94322`
- base at push: `2976182063d234476e4a686acc467cf9434db3b7`
