### PR TITLE
Provision a test database in run-sanity-tests.sh before the impact-map check so task sandboxes stop failing the gate in 0.5s (task_603f301632794e0aafd4f5d3c804ede3)

### DIFF
--- a/scripts/run-sanity-tests.sh
+++ b/scripts/run-sanity-tests.sh
@@ -14,6 +14,18 @@ if [ -z "${PY:-}" ]; then
     exit 2
 fi
 
+# The impact-map check collects the suite, whose imports require a test DSN.
+# Provision it here so both collection and the contract runner below share it.
+if [ -z "${MAC_TEST_PG_URL:-}" ]; then
+    _pg_helper="scripts/start-test-postgres.sh"
+    if [ -x "$_pg_helper" ]; then
+        echo "run-sanity-tests.sh: provisioning PostgreSQL for impact-map collection" >&2
+        if _pg_dsn=$("$_pg_helper"); then
+            eval "$_pg_dsn"
+        fi
+    fi
+fi
+
 # Selection consults the committed impact map. A stale interned node id is a
 # pytest usage error (exit 4), not a test failure, so regeneration is a
 # prerequisite of this script -- the same shape as test-schema-migrations


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_603f301632794e0aafd4f5d3c804ede3`
- head: `ca568ca4c51a1db2f6017f86694b13fb244e188d`
- base at push: `2976182063d234476e4a686acc467cf9434db3b7`
