### PR TITLE
Add AgentFabric presentation authoring package under docs/presentations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,10 @@ mac-evidence.json
 # See docs/presentation/README.md.
 docs/presentation/*/images/*.png
 docs/presentation/*/*.pptx
+
+# Generated AgentFabric presentation members. The authoring package under
+# docs/presentations/ keeps only text; the .pptx/.docx and all QA output are
+# reproducible from it via regenerate.sh.
+docs/presentations/*/*.pptx
+docs/presentations/*/*.docx
+/_build/

--- a/docs/presentations/agentfabric-overview/README.md
+++ b/docs/presentations/agentfabric-overview/README.md
@@ -1,0 +1,53 @@
+# AgentFabric overview — authoring package
+
+This is the reproducible authoring package for the AgentFabric technical/marketing
+overview: a `presentation` member (20-slide deck) and a `narrative` member (long-form
+document) built from one reviewed source of claims.
+
+The audience assumption is stated in the deck and must not drift: **a highly technical
+reader who is new both to AgentFabric and to fleet-scale multi-agent / multi-model
+orchestration.** Nothing in either member may assume prior product knowledge.
+
+Narrative order, which is deliberate:
+
+| Slides | What it argues |
+| --- | --- |
+| 1–5 | Marketing first: what the system does, why a chat window is not an operating model, the four properties it guarantees, and the end-to-end loop |
+| 6–10 | Technology re-use: where AgentFabric leverages NVIDIA technology, where it leverages open source, the five mechanisms it adds anyway, and the containment boundary |
+| 11–19 | How the machine actually runs: actors and their single authority each, task lifecycle, bus coordination, fleet shape, model routing and spend, evidence, measured surface area, and stated limits |
+| 20 | Close and adoption path |
+
+Diagrams and flows carry the argument. Bullet lists are used in one place on purpose —
+the NVIDIA and open-source project inventories on slides 7 and 8 — because a list of
+load-bearing dependencies is the point of those slides.
+
+## Read in this order
+
+1. [current deliverables](current-deliverables.md) — what exists right now
+2. [deck specification](deck-specification.md) — slide-by-slide presentation authority
+3. [narrative specification](narrative-specification.md) — long-form structure authority
+4. [source notes](source-notes.md) — the factual ledger every claim traces to
+5. [QA ledger](qa-ledger.md) — what was checked, and how to re-check it
+6. [SKILL.md](SKILL.md) — the regeneration workflow
+
+Model-facing inputs: [deck-authoring prompt](prompts/deck-authoring-prompt.md) and
+[image prompts](prompts/image-prompts.md).
+
+## Builders
+
+| File | Role |
+| --- | --- |
+| [`build_deck.py`](build_deck.py) | deterministic `python-pptx` deck; native shapes only, no raster diagrams |
+| [`build_narrative.py`](build_narrative.py) | deterministic `python-docx` narrative member |
+| [`render_slides.py`](render_slides.py) | slide rasterizer, contact sheet, and text-frame overlap report |
+| [`publish_google_workspace.py`](publish_google_workspace.py) | optional publication; requires explicit authorization |
+| [`regenerate.sh`](regenerate.sh) / [`regenerate_python.sh`](regenerate_python.sh) | regeneration entry points |
+
+Every diagram in the deck is built from native PowerPoint shapes, so the deck stays
+editable and legible after a Google Slides import. There is no `assets/` directory and no
+generated hero imagery: a mechanism diagram is preferred over decoration everywhere the
+two compete.
+
+Generated `.pptx` / `.docx` artifacts are build outputs. Regenerate them; do not treat a
+stale copy as authority. Publication to any external location requires explicit
+authorization from the owner of that location.

--- a/docs/presentations/agentfabric-overview/SKILL.md
+++ b/docs/presentations/agentfabric-overview/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: agentfabric-overview-presentation
+description: Regenerate or extend the AgentFabric overview document pair (20-slide deck plus prose narrative) from this authoring package. Read before editing any file in docs/presentations/agentfabric-overview/.
+---
+
+# AgentFabric overview presentation
+
+This package produces two members of one document pair from source: a 20-slide
+presentation and a prose narrative. Both are generated; neither is hand-edited.
+If you find yourself editing the `.pptx` or the `.docx`, stop — edit the builder.
+
+## Sources of truth, in precedence order
+
+| File | Owns |
+| --- | --- |
+| `source-notes.md` | every factual claim, its authority in the tree, and its implemented / decided / proposed status |
+| `deck-specification.md` | slide order, per-slide visual form, required claims, prohibitions |
+| `narrative-specification.md` | narrative section order and depth |
+| `build_deck.py` | the deck; the only way slides are produced |
+| `build_narrative.py` | the narrative; the only way the document is produced |
+| `render_slides.py` | PNG rendering, geometry checks, text-frame overlap detection |
+| `verify_pair.py` | pair invariants: slide count, notes coverage, heading spine, manifest honesty |
+| `qa-ledger.md` | what was run, when, and what it said |
+
+A claim that is not in `source-notes.md` does not go on a slide. If you need a new
+claim, add it there **with its authority first**, then use it.
+
+## Regenerating
+
+```console
+docs/presentations/agentfabric-overview/regenerate.sh
+```
+
+That runs, in order: `build_deck.py`, `build_narrative.py`, `render_slides.py`,
+`verify_pair.py`. It requires `python-pptx`, `python-docx`, `lxml`, and `Pillow`
+importable from `$OBJ_DIR/doc-toolchain`, `.venv`, or `python3`; it will not
+install them for you. Set `AGENTFABRIC_DECK_SKIP_RENDER=1` to skip rendering
+while iterating on prose.
+
+Generated artifacts (`agentfabric-overview.pptx`, `agentfabric-overview.docx`)
+live beside the builders. QA output — rendered PNGs, contact sheet, manifest,
+acceptance record — lands in the ignored `_build/agentfabric-overview/`.
+
+## Rules that are not negotiable
+
+1. **Diagrams are native shapes.** Every diagram is built from PowerPoint
+   shapes, connectors, and text frames so the deck stays editable after a Google
+   Slides import. No raster diagrams, no decorative hero imagery, no image-only
+   slides.
+2. **Speaker notes on every slide.** `verify_pair.py` fails the build otherwise.
+   Notes carry the mechanism and the qualifications that do not fit on the slide.
+3. **Bullets are for inventories only.** Lists are allowed where the content
+   genuinely is a list of NVIDIA or OSS projects. Everywhere else, use a diagram
+   or a flow.
+4. **Status is never blurred.** Implemented, decided-but-not-yet-runtime, and
+   proposed stay visibly distinct, and each item's placement traces to an ADR's
+   own status line.
+5. **No invented numbers.** No ROI, productivity, throughput, or maturity
+   figures. Counted figures carry their command and their measurement date, and
+   are re-measured on every regeneration rather than carried forward.
+6. **Re-use is stated as re-use.** A dependency is named as a dependency; a
+   design reference is named as a reference. NemoClaw is a reference, not the
+   deployed gateway.
+7. **Publication requires explicit authorization.** `publish_google_workspace.py`
+   has no default destination and requires `--slides-id` and `--authorized-by`.
+   Do not publish, and do not record a published location in the manifest,
+   without that authorization from the repository owner.
+
+## Extending the deck
+
+Adding or reordering slides means changing three files together:
+`deck-specification.md` (the contract), `build_deck.py` (the implementation), and
+`verify_pair.py`'s `EXPECTED_SLIDES` (the gate). Update `qa-ledger.md` with the
+run that proved it, and re-measure any count you touched.
+
+Keep the narrative in step: if a claim changes on a slide, the corresponding
+narrative section changes in the same commit. Divergence between the two members
+on a shared claim is a defect, not a stylistic difference.

--- a/docs/presentations/agentfabric-overview/build_deck.py
+++ b/docs/presentations/agentfabric-overview/build_deck.py
@@ -1,0 +1,1551 @@
+#!/usr/bin/env python3
+"""Build the AgentFabric overview deck with python-pptx.
+
+Deterministic, no LLM calls, no plugin runtime. The primitive shape vocabulary
+(`shape`, `text`, `pill`, `chip`, `line`, `arrow`, `footer`, `title`, `wash`,
+`labeled_card`) is inherited from the authoring package this directory was
+seeded from; every diagram here is drawn with native PowerPoint shapes so the
+mechanism stays readable, editable, and diffable after a Google Slides import.
+
+`deck-specification.md` is the narrative authority for this file and
+`source-notes.md` is its factual ledger. Slide order follows the specification:
+marketing first, then reused technology, then actors and roles.
+
+Usage:
+    python3 build_deck.py
+Environment overrides:
+    AGENTFABRIC_DECK_SOURCE, AGENTFABRIC_REPO, AGENTFABRIC_DECK_OUTPUT
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import MSO_ANCHOR, MSO_AUTO_SIZE, PP_ALIGN
+from pptx.oxml.ns import qn
+from pptx.util import Emu, Pt
+
+HERE = Path(__file__).resolve().parent
+SOURCE = Path(os.environ.get("AGENTFABRIC_DECK_SOURCE", str(HERE)))
+REPO = Path(os.environ.get("AGENTFABRIC_REPO", str(SOURCE.parents[2])))
+
+
+def _obj_dir() -> Path:
+    return Path(os.environ.get("OBJ_DIR") or (REPO / "_build"))
+
+
+OUT = Path(
+    os.environ.get("AGENTFABRIC_DECK_OUTPUT")
+    or (REPO / "docs" / "presentations" / "agentfabric-overview" / "agentfabric-overview.pptx")
+)
+
+W, H, TOTAL = 1280, 720, 20
+PX = 9525  # EMU per px at 96dpi.
+BRAND = "AGENTFABRIC"
+
+C = {
+    "ink": "#101317",
+    "panel": "#23282F",
+    "steel": "#65707C",
+    "fog": "#EEF1F3",
+    "white": "#FFFFFF",
+    "orange": "#FF6B35",
+    "orange2": "#FF9B66",
+    "blue": "#72B7D6",
+    "green": "#76B900",  # NVIDIA green: reserved for reused NVIDIA technology.
+    "green2": "#7BC6A4",
+    "red": "#F47C7C",
+    "line": "#D8DEE3",
+    "muted": "#AAB3BC",
+    "code": "#1A1F26",
+    "codeline": "#333B45",
+}
+FONT = "Helvetica Neue"
+MONO = "Courier New"
+
+_GEOMETRY = {
+    "rect": MSO_SHAPE.RECTANGLE,
+    "roundRect": MSO_SHAPE.ROUNDED_RECTANGLE,
+    "ellipse": MSO_SHAPE.OVAL,
+    "chevron": MSO_SHAPE.CHEVRON,
+}
+_RADIUS = {"rounded-xl": 0.14, "rounded-lg": 0.09, "rounded-full": 0.5}
+_ALIGN = {"left": PP_ALIGN.LEFT, "center": PP_ALIGN.CENTER, "right": PP_ALIGN.RIGHT}
+
+
+def _rgb(hex_color: str) -> RGBColor:
+    return RGBColor.from_string(hex_color.lstrip("#"))
+
+
+def _px(v: float) -> Emu:
+    return Emu(round(v * PX))
+
+
+def _set_alpha(fill, opacity: float) -> None:
+    solid_fill = fill.fore_color._xFill
+    srgb = solid_fill.find(qn("a:srgbClr"))
+    if srgb is None:
+        return
+    for existing in srgb.findall(qn("a:alpha")):
+        srgb.remove(existing)
+    alpha = solid_fill.makeelement(qn("a:alpha"), {"val": str(round(opacity * 100000))})
+    srgb.append(alpha)
+
+
+def shape(slide, geometry, x, y, w, h, fill, **opts):
+    sp = slide.shapes.add_shape(_GEOMETRY[geometry], _px(x), _px(y), _px(w), _px(h))
+    sp.shadow.inherit = False
+    if fill == "none":
+        sp.fill.background()
+    else:
+        sp.fill.solid()
+        sp.fill.fore_color.rgb = _rgb(fill)
+        opacity = opts.get("opacity")
+        if opacity is not None:
+            _set_alpha(sp.fill, opacity)
+    stroke = opts.get("stroke", "none")
+    if stroke in (None, "none"):
+        sp.line.fill.background()
+    else:
+        sp.line.color.rgb = _rgb(stroke)
+        sp.line.width = Pt(opts.get("strokeWidth") or 1)
+    radius_key = opts.get("radius")
+    if radius_key and geometry == "roundRect":
+        sp.adjustments[0] = _RADIUS.get(radius_key, 0.05)
+    return sp
+
+
+def text(slide, value, x, y, w, h, size=28, color=C["ink"], bold=False, **opts):
+    box = slide.shapes.add_textbox(_px(x), _px(y), _px(w), _px(h))
+    tf = box.text_frame
+    tf.word_wrap = True
+    tf.vertical_anchor = MSO_ANCHOR.TOP
+    tf.margin_left = tf.margin_right = tf.margin_top = tf.margin_bottom = Emu(0)
+    tf.text = value
+    align = _ALIGN.get(opts.get("align"))
+    font_name = opts.get("font", FONT)
+    italic = opts.get("italic", False)
+    for para in tf.paragraphs:
+        if align is not None:
+            para.alignment = align
+        for run in para.runs:
+            run.font.name = font_name
+            run.font.size = Pt(size)
+            run.font.bold = bold
+            run.font.italic = italic
+            run.font.color.rgb = _rgb(color)
+    if opts.get("fit"):
+        tf.auto_size = MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE
+    return box
+
+
+def mono(slide, value, x, y, w, h, size=12, color=C["fog"], bold=False):
+    return text(slide, value, x, y, w, h, size, color, bold, font=MONO)
+
+
+def line(slide, x, y, w, h=4, color=C["orange"]):
+    return shape(slide, "rect", x, y, w, h, color)
+
+
+def dot(slide, x, y, d, color, stroke="none"):
+    return shape(
+        slide,
+        "ellipse",
+        x,
+        y,
+        d,
+        d,
+        color,
+        stroke=stroke,
+        strokeWidth=0 if stroke == "none" else 2,
+    )
+
+
+def pill(slide, label, x, y, w, fill=C["orange"], color=C["white"], size=13):
+    shape(slide, "roundRect", x, y, w, 32, fill, radius="rounded-full")
+    text(slide, label, x + 10, y + 6, w - 20, 20, size, color, True, align="center", fit=True)
+
+
+def chip(slide, label, x, y, w, fill=C["panel"], color=C["fog"], size=13):
+    shape(slide, "roundRect", x, y, w, 34, fill, radius="rounded-lg")
+    text(slide, label, x + 12, y + 7, w - 24, 20, size, color, True, fit=True)
+
+
+def labeled_card(
+    slide,
+    x,
+    y,
+    w,
+    h,
+    fill,
+    heading,
+    body,
+    heading_color,
+    body_color,
+    heading_size=20,
+    body_size=15,
+    **opts,
+):
+    """A rounded cell whose copy lives in the shape text frame, so Google cannot overflow it."""
+    sp = shape(slide, "roundRect", x, y, w, h, fill, radius="rounded-xl", **opts)
+    tf = sp.text_frame
+    tf.word_wrap = True
+    tf.vertical_anchor = MSO_ANCHOR.MIDDLE
+    tf.margin_left = tf.margin_right = _px(18)
+    tf.margin_top = tf.margin_bottom = _px(18)
+    lines = [heading, *body.split("\n")]
+    for i, entry in enumerate(lines):
+        para = tf.paragraphs[0] if i == 0 else tf.add_paragraph()
+        para.alignment = PP_ALIGN.CENTER
+        para.text = entry
+        if i == 0:
+            para.space_after = Pt(10)
+        for run in para.runs:
+            run.font.name = FONT
+            run.font.size = Pt(heading_size if i == 0 else body_size)
+            run.font.bold = True
+            run.font.color.rgb = _rgb(heading_color if i == 0 else body_color)
+    tf.auto_size = MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE
+    return sp
+
+
+def caption_bar(slide, value, y=648, fill="#FFF0E8", color=C["ink"]):
+    shape(slide, "roundRect", 70, y, 1140, 36, fill, radius="rounded-full")
+    text(slide, value, 90, y + 8, 1100, 22, 13, color, True, align="center", fit=True)
+
+
+def wash(slide, x=0, y=0, w=W, h=H, opacity=0.35):
+    return shape(slide, "rect", x, y, w, h, C["ink"], opacity=opacity)
+
+
+def title(slide, value, sub, dark, n, tag=None):
+    # Reserved header band (y=28-252). Title boxes are taller than the type they
+    # hold so Google's Arial substitution cannot paint into the subtitle.
+    ink = C["white"] if dark else C["ink"]
+    muted = C["muted"] if dark else C["steel"]
+    pill(
+        slide,
+        BRAND,
+        70,
+        28,
+        148,
+        C["white"] if dark else C["ink"],
+        C["ink"] if dark else C["white"],
+    )
+    if tag:
+        tag_w = max(188, 32 + len(tag) * 9)
+        pill(slide, tag, 230, 28, tag_w, C["orange"], C["ink"], 12)
+    text(slide, str(n).zfill(2), 1170, 32, 40, 22, 13, ink, True, align="right")
+    long = len(value) > 46
+    t_size = 32 if long else 38
+    text(slide, value, 70, 78, 1140, 84, t_size, ink, True, fit=True)
+    if sub:
+        text(slide, sub, 72, 168, 1100, 68, 17, muted, False, fit=True)
+    line(slide, 70, 248, 88, 6, C["orange"])
+
+
+def footer(slide, n, dark=False):
+    # Footer lives below y=696 so bottom captions ending at y=684 cannot collide.
+    text(slide, BRAND, 70, 698, 170, 16, 11, C["muted"] if dark else C["steel"], True)
+    line(slide, 1080, 704, 120, 3, C["panel"] if dark else C["line"])
+    line(slide, 1080, 704, max(8, 120 * n / TOTAL), 3, C["orange"])
+
+
+def arrow(slide, x1, y, x2, color=C["orange"]):
+    line(slide, x1, y, max(4, x2 - x1 - 13), 4, color)
+    shape(slide, "chevron", x2 - 19, y - 8, 19, 20, color)
+
+
+def down_arrow(slide, x, y1, y2, color=C["orange"]):
+    shape(slide, "rect", x, y1, 4, max(4, y2 - y1 - 12), color)
+    sp = slide.shapes.add_shape(MSO_SHAPE.CHEVRON, _px(x - 8), _px(y2 - 14), _px(20), _px(18))
+    sp.shadow.inherit = False
+    sp.rotation = 90
+    sp.fill.solid()
+    sp.fill.fore_color.rgb = _rgb(color)
+    sp.line.fill.background()
+    return sp
+
+
+def notes(slide, lines):
+    slide.notes_slide.notes_text_frame.text = "\n".join(lines)
+
+
+def section(slide, kicker, headline, body, n):
+    """Full-bleed divider: one kicker, one headline, one sentence of scope."""
+    pill(slide, BRAND, 70, 48, 148, C["white"], C["ink"])
+    text(slide, kicker, 70, 168, 700, 30, 15, C["orange2"], True)
+    text(slide, headline, 70, 208, 900, 150, 46, C["white"], True, fit=True)
+    line(slide, 74, 384, 120, 8, C["orange"])
+    text(slide, body, 74, 414, 760, 110, 20, C["fog"], False, fit=True)
+    footer(slide, n, True)
+
+
+def stage_flow(slide, labels, y, x0=70, width=1140, height=44, dark=False, accent=None):
+    """A left-to-right chevron flow. Diagram, not prose: labels are one or two words."""
+    accent = accent or C["orange"]
+    n = len(labels)
+    step = width / n
+    body_w = step - 12
+    for i, label in enumerate(labels):
+        x = x0 + i * step
+        fill = accent if i == 0 else (C["panel"] if not dark else C["white"])
+        color = C["ink"] if i == 0 or dark else C["white"]
+        shape(slide, "chevron", x, y, body_w, height, fill)
+        text(
+            slide,
+            label,
+            x + 8,
+            y + (height - 22) / 2,
+            body_w - 30,
+            22,
+            13,
+            color,
+            True,
+            align="center",
+            fit=True,
+        )
+
+
+def build() -> Path:
+    p = Presentation()
+    p.slide_width = _px(W)
+    p.slide_height = _px(H)
+    blank = p.slide_layouts[6]
+
+    def add_slide(bg=C["white"]):
+        s = p.slides.add_slide(blank)
+        shape(s, "rect", 0, 0, W, H, bg)
+        return s
+
+    # ------------------------------------------------------------------ part 0
+    # 01 - cover
+    s = add_slide(C["ink"])
+    # Hero: a hub with a fleet around it, drawn natively. No raster, no text in art.
+    shape(s, "ellipse", 900, 250, 220, 220, C["panel"], stroke=C["orange"], strokeWidth=2)
+    text(s, "HUB", 940, 340, 140, 30, 18, C["orange"], True, align="center")
+    fleet = [(760, 170), (1140, 170), (700, 400), (1180, 400), (760, 560), (1140, 560)]
+    for fx, fy in fleet:
+        dot(s, fx, fy, 56, C["panel"], C["blue"])
+        arrow(s, min(fx + 56, 1010), fy + 26, max(fx + 70, 902), C["steel"])
+    pill(s, BRAND, 70, 55, 148, C["white"], C["ink"])
+    text(
+        s,
+        "One control plane\nfor a fleet of\nAI agents.",
+        70,
+        140,
+        560,
+        220,
+        44,
+        C["white"],
+        True,
+        fit=True,
+    )
+    line(s, 74, 402, 112, 7, C["orange"])
+    text(
+        s,
+        "AgentFabric turns a conversation into durable work, dispatches it across a heterogeneous"
+        " fleet of agents and models, and keeps the receipts.",
+        74,
+        428,
+        520,
+        130,
+        19,
+        C["fog"],
+        False,
+        fit=True,
+    )
+    text(
+        s,
+        "MULTI-AGENT, MULTI-MODEL ORCHESTRATION AT SCALE",
+        74,
+        580,
+        560,
+        28,
+        14,
+        C["orange2"],
+        True,
+        fit=True,
+    )
+    notes(
+        s,
+        [
+            "Audience assumption: highly technical, but new both to AgentFabric and to fleet-scale agent orchestration. Nothing in this deck assumes prior product knowledge.",
+            "Order of the deck: what the system does (1-5), what it reuses and why (6-10), then who the actors are and how the machine actually runs (11-19).",
+            "Every quantified figure traces to source-notes.md, which cites the control-plane tree it was measured from. No modeled ROI or productivity numbers appear anywhere in this deck.",
+        ],
+    )
+
+    # 02 - what it does
+    s = add_slide(C["white"])
+    title(
+        s,
+        "Ask once. The fabric carries it to production.",
+        "A request becomes a durable task, the task is leased to an agent that can actually do it, the"
+        " result is reviewed by a different agent, and every step leaves evidence.",
+        False,
+        2,
+        tag="WHAT IT DOES",
+    )
+    stage_flow(
+        s,
+        ["ASK", "DURABLE TASK", "LEASE + DISPATCH", "EXECUTE", "INDEPENDENT REVIEW", "PUBLISH"],
+        300,
+    )
+    cards2 = [
+        ("NOTHING IS LOST", "A task outlives the\nchat, the agent, and\nthe machine.", C["orange"]),
+        ("NOTHING IS BLIND", "Cost, timing, and\nprovenance are recorded\nper step.", C["blue"]),
+        (
+            "NOTHING SELF-APPROVES",
+            "The agent that did the\nwork does not accept\nthe work.",
+            C["green2"],
+        ),
+    ]
+    for i, (head, body, color) in enumerate(cards2):
+        x = 70 + i * 386
+        labeled_card(
+            s,
+            x,
+            396,
+            368,
+            200,
+            C["fog"],
+            head,
+            body,
+            C["ink"],
+            C["steel"],
+            19,
+            15,
+            stroke=color,
+            strokeWidth=2,
+        )
+    caption_bar(s, "The unit of truth is a task in a ledger, not a message in a transcript.")
+    footer(s, 2)
+    notes(
+        s,
+        [
+            "This is the marketing frame, and it is also literally the pipeline: ask, durable task, lease, execute, independent review, publish.",
+            "'Independent review' is a separate agent invocation under control-plane-owned gates, not the executing agent grading itself.",
+            "Mechanism for each of these three claims appears later: the ledger and its state machine on slide 13, measurement on slide 17, and the review gates on slides 12-13.",
+        ],
+    )
+
+    # 03 - the problem
+    s = add_slide(C["fog"])
+    title(
+        s,
+        "A chat window is not an operating model.",
+        "One human supervising one agent works. The same pattern at fleet scale loses work, repeats"
+        " work, and cannot answer what any of it cost.",
+        False,
+        3,
+        tag="THE PROBLEM",
+    )
+    shape(
+        s,
+        "roundRect",
+        70,
+        300,
+        520,
+        296,
+        C["white"],
+        radius="rounded-xl",
+        stroke=C["line"],
+        strokeWidth=1,
+    )
+    text(s, "ONE AGENT", 100, 326, 300, 26, 15, C["steel"], True)
+    dot(s, 100, 380, 64, C["orange"])
+    text(s, "human", 96, 456, 72, 22, 13, C["steel"], True, align="center")
+    arrow(s, 168, 410, 300)
+    dot(s, 300, 380, 64, C["panel"])
+    text(s, "agent", 296, 456, 72, 22, 13, C["steel"], True, align="center")
+    arrow(s, 368, 410, 500)
+    dot(s, 470, 380, 64, C["blue"])
+    text(s, "result", 466, 456, 72, 22, 13, C["steel"], True, align="center")
+    text(
+        s,
+        "Supervision is the human. It works, and it does not scale.",
+        100,
+        516,
+        460,
+        56,
+        15,
+        C["ink"],
+        True,
+        fit=True,
+    )
+
+    shape(s, "roundRect", 620, 300, 590, 296, C["ink"], radius="rounded-xl")
+    text(s, "FORTY AGENTS", 650, 326, 340, 26, 15, C["orange2"], True)
+    for i in range(8):
+        for j in range(4):
+            dot(s, 654 + i * 62, 366 + j * 44, 26, C["panel"] if (i + j) % 3 else C["red"])
+    text(
+        s,
+        "Same pattern, no system of record: duplicated effort, stranded work,\n"
+        'unattributed spend, and no answer to "who approved this?"',
+        650,
+        526,
+        540,
+        56,
+        15,
+        C["fog"],
+        True,
+        fit=True,
+    )
+    footer(s, 3)
+    notes(
+        s,
+        [
+            "The failure is structural, not a tooling gap: conversation is ephemeral state, and a fleet needs durable state with ownership, ordering, and receipts.",
+            "The red nodes on the right are illustrative of failure classes (stranded, duplicated, unattributed), not a measured failure rate. Do not attach a percentage to this slide.",
+            "Real ledger census figures, when quoted, come from source-notes.md and carry the date they were measured.",
+        ],
+    )
+
+    # 04 - what you get
+    s = add_slide(C["ink"])
+    title(
+        s,
+        "Four properties the fabric guarantees.",
+        "These are the reasons to put a control plane underneath agents at all, rather than scaling"
+        " prompts and hoping.",
+        True,
+        4,
+        tag="WHY IT MATTERS",
+    )
+    props = [
+        (
+            "DURABLE TRUTH",
+            "Tasks, leases, reviews,\nsecrets, and audit trails\nsurvive every restart.",
+            C["orange"],
+        ),
+        (
+            "HONEST HETEROGENEITY",
+            "Different machines,\nOSes, agents, and models\nare modelled, not hidden.",
+            C["blue"],
+        ),
+        (
+            "EVIDENCE BY DEFAULT",
+            "Build, test, review, and\npublication decisions are\nnamed and stored.",
+            C["green2"],
+        ),
+        (
+            "SPEND VISIBILITY",
+            "Model calls are recorded\nas route events and\npriced at read time.",
+            C["orange2"],
+        ),
+    ]
+    for i, (head, body, color) in enumerate(props):
+        x = 70 + i * 290
+        labeled_card(
+            s,
+            x,
+            300,
+            272,
+            240,
+            C["panel"],
+            head,
+            body,
+            color,
+            C["fog"],
+            18,
+            14,
+            stroke=color,
+            strokeWidth=2,
+        )
+    text(
+        s,
+        "A fleet you cannot audit is a fleet you cannot trust with a repository.",
+        70,
+        576,
+        1140,
+        40,
+        22,
+        C["white"],
+        True,
+        align="center",
+        fit=True,
+    )
+    footer(s, 4, True)
+    notes(
+        s,
+        [
+            "Durable truth: the control plane owns tasks, leases, routing, reviews, evidence, secret handles, runtime manifests, rollout state, and audit trails.",
+            "Honest heterogeneity: node classes differ by design (host installs versus containerized execution), and the dispatcher matches work to capability rather than pretending the fleet is uniform.",
+            "Spend visibility: usage is recorded where routing happens, one event per model call, and cost is priced at read time - so re-pricing history does not require re-running work. Enforcing metering at the router (rather than trusting the caller to report usage) is an accepted-in-principle but still proposed decision; today a streamed route that did not request usage is recorded as a coverage gap.",
+        ],
+    )
+
+    # 05 - end to end
+    s = add_slide(C["white"])
+    title(
+        s,
+        "One request, end to end.",
+        "The same path every piece of work takes. Read it left to right; the annotations under each"
+        " hand-off are what the control plane writes down.",
+        False,
+        5,
+        tag="THE LOOP",
+    )
+    lanes = [
+        ("HUMAN", "asks in chat", C["orange"]),
+        ("GATEWAY", "conversation, memory", C["blue"]),
+        ("HUB", "task + lease", C["ink"]),
+        ("WORKER", "sandboxed execution", C["panel"]),
+        ("REVIEWER", "independent decision", C["green2"]),
+        ("PUBLISH", "merge queue, receipts", C["orange2"]),
+    ]
+    for i, (head, sub, color) in enumerate(lanes):
+        x = 70 + i * 192
+        shape(
+            s,
+            "roundRect",
+            x,
+            300,
+            172,
+            96,
+            C["fog"],
+            radius="rounded-xl",
+            stroke=color,
+            strokeWidth=2,
+        )
+        text(s, head, x + 14, 322, 144, 24, 15, C["ink"], True, align="center", fit=True)
+        text(s, sub, x + 14, 350, 144, 34, 12, C["steel"], False, align="center", fit=True)
+        if i < len(lanes) - 1:
+            arrow(s, x + 172, 346, x + 192)
+        down_arrow(s, x + 84, 400, 452, C["line"])
+    records = [
+        "intent",
+        "identity",
+        "ledger row,\nstate, owner",
+        "action events,\ntoken spend",
+        "named gate\ndecision",
+        "provenance,\nevidence pointer",
+    ]
+    for i, record in enumerate(records):
+        x = 70 + i * 192
+        shape(s, "roundRect", x, 452, 172, 96, C["ink"], radius="rounded-lg")
+        text(s, record, x + 14, 474, 144, 60, 13, C["fog"], True, align="center", fit=True)
+    text(s, "WHAT GETS WRITTEN DOWN", 70, 566, 400, 26, 14, C["steel"], True)
+    caption_bar(
+        s, "Every arrow crosses a boundary the control plane owns; nothing advances on trust alone."
+    )
+    footer(s, 5)
+    notes(
+        s,
+        [
+            "This slide is the whole system in one picture; slides 12 through 17 expand each lane.",
+            "The gateway owns conversation, personality, and memory. It deliberately does not own operational truth - that separation is the core architectural decision.",
+            "'Named gate decision' is literal: gates return a named decision rather than a boolean, so a refusal is explainable after the fact.",
+        ],
+    )
+
+    # ------------------------------------------------------------------ part 1
+    # 06 - divider: reuse
+    s = add_slide(C["ink"])
+    section(
+        s,
+        "PART ONE",
+        "Built on the stack, not instead of it.",
+        "Isolation, observability, inference, containers, scheduling, and coding agents already exist"
+        " and are maintained by people whose full-time job they are. AgentFabric integrates them and"
+        " spends its own code on the one thing none of them provide: durable operational truth.",
+        6,
+    )
+    notes(
+        s,
+        [
+            "Framing for the engineering audience: the interesting question is not what was written, it is what was deliberately not written.",
+            "Each reuse claim on the next three slides names the project and the boundary. Lineage (learned from) is stated separately from integration (depends on) on purpose.",
+        ],
+    )
+
+    # 07 - NVIDIA technology
+    s = add_slide(C["white"])
+    title(
+        s,
+        "Where AgentFabric leverages NVIDIA technology.",
+        "Four NVIDIA projects carry four hard problems: confinement, observability, elastic GPU"
+        " capacity, and a reference conversational runtime.",
+        False,
+        7,
+        tag="NVIDIA STACK",
+    )
+    shape(s, "roundRect", 70, 296, 1140, 74, C["ink"], radius="rounded-xl")
+    text(s, "AGENTFABRIC CONTROL PLANE", 90, 314, 500, 30, 18, C["white"], True)
+    text(
+        s,
+        "tasks · leases · routing · reviews · evidence · audit",
+        700,
+        320,
+        490,
+        26,
+        14,
+        C["muted"],
+        False,
+        align="right",
+        fit=True,
+    )
+    nv = [
+        (
+            "NVIDIA OpenShell",
+            "EXECUTION SECURITY",
+            "Landlock filesystem policy,\nseccomp syscall filter,\ndeny-by-default L7 egress.\nOne guardrail authority.",
+        ),
+        (
+            "NVIDIA NeMo Relay",
+            "OBSERVABILITY",
+            "Request, task, tool, and\nmodel activity mapped into\nRelay scopes when the\n`relay` extra is enabled.",
+        ),
+        (
+            "NVIDIA HGX",
+            "ELASTIC CAPACITY",
+            "Bounded, receipt-bearing\nautoscaling of provider\nsessions from durable\nprovisioning demand.",
+        ),
+        (
+            "NVIDIA NemoClaw",
+            "REFERENCE INTEGRATION",
+            "Compatibility and design\nreference for the\nconversational agent\nboundary.",
+        ),
+    ]
+    for i, (name, role, body) in enumerate(nv):
+        x = 70 + i * 290
+        shape(
+            s,
+            "roundRect",
+            x,
+            404,
+            272,
+            214,
+            C["fog"],
+            radius="rounded-xl",
+            stroke=C["green"],
+            strokeWidth=2,
+        )
+        down_arrow(s, x + 134, 370, 404, C["green"])
+        text(s, name, x + 16, 424, 240, 30, 16, C["ink"], True, align="center", fit=True)
+        text(s, role, x + 16, 456, 240, 22, 11, C["green"], True, align="center", fit=True)
+        line(s, x + 106, 484, 60, 3, C["green"])
+        text(s, body, x + 16, 500, 240, 104, 12, C["steel"], False, align="center", fit=True)
+    footer(s, 7)
+    notes(
+        s,
+        [
+            "OpenShell is the security boundary: process trees, filesystem and network policy, sandbox lifecycle, and normalized action-event collection integrate with it rather than reimplementing isolation. The design goal is exactly one guardrail authority, the policy file, instead of two competing ones.",
+            "NeMo Relay is optional and enabled through a packaging extra; observability is mapped into it rather than invented.",
+            "HGX capacity is operator-side and bounded: read-only status and plan commands are separate from an explicit execute, and provider work never runs on a dispatcher or HTTP thread.",
+            "NemoClaw is reference material for the conversational boundary, not the deployed implementation of it. That distinction is deliberate and is recorded in source-notes.md.",
+        ],
+    )
+
+    # 08 - OSS technology
+    s = add_slide(C["fog"])
+    title(
+        s,
+        "Where AgentFabric leverages open source.",
+        "Bullets, here, on purpose: this is the list of projects doing load-bearing work, grouped by"
+        " the problem each one already solved.",
+        False,
+        8,
+        tag="OSS STACK",
+    )
+    groups = [
+        (
+            "STATE",
+            C["orange"],
+            ["PostgreSQL", "SQLite (local)", "Alembic-style\nversioned migrations"],
+        ),
+        ("SERVICE", C["blue"], ["FastAPI", "Uvicorn", "Pydantic", "httpx"]),
+        (
+            "EXECUTION",
+            C["green2"],
+            ["Docker Engine / Moby", "Kubernetes", "OpenClaw", "Codex CLI · OpenCode"],
+        ),
+        ("PROTOCOL", C["orange2"], ["ACP", "A2A agent cards", "MCP", "OCSF event streams"]),
+    ]
+    for i, (head, color, items) in enumerate(groups):
+        x = 70 + i * 290
+        shape(
+            s,
+            "roundRect",
+            x,
+            300,
+            272,
+            320,
+            C["white"],
+            radius="rounded-xl",
+            stroke=color,
+            strokeWidth=2,
+        )
+        text(s, head, x + 20, 322, 232, 28, 16, C["ink"], True, fit=True)
+        line(s, x + 20, 356, 46, 4, color)
+        for j, item in enumerate(items):
+            dot(s, x + 22, 384 + j * 58, 10, color)
+            text(s, item, x + 44, 376 + j * 58, 208, 48, 14, C["steel"], True, fit=True)
+    caption_bar(
+        s,
+        "Every box above is a dependency, not a fork. The control plane owns none of these problems.",
+    )
+    footer(s, 8)
+    notes(
+        s,
+        [
+            "PostgreSQL is the authority for fleet deployments; the local development path is SQLite, and schema changes require versioned migrations with fail-closed authority.",
+            "Coding executors are plural and pluggable - the route ladder on slide 16 orders them - because no single coding agent is uniformly best or uniformly available.",
+            "Protocols are implemented specifications, not aspirations: ACP and A2A endpoints and agent cards are served by the hub, MCP is a client of the same API rather than a second implementation, and OCSF is the event vocabulary produced under sandboxed execution.",
+            "Hermes Agent is lineage rather than dependency: the fleet learned from its loop, gateways, and skills, and the in-tree snapshot was removed. Say 'learned from', not 'built on', for that one.",
+        ],
+    )
+
+    # 09 - what AgentFabric adds
+    s = add_slide(C["ink"])
+    title(
+        s,
+        "What AgentFabric adds that nothing above provides.",
+        "Reuse is the default. These five mechanisms are the parts that had to be built, because"
+        " they are the parts that make agent output trustworthy.",
+        True,
+        9,
+        tag="UNIQUE POWERS",
+    )
+    powers = [
+        (
+            "DURABLE LEDGER",
+            "A task is a state machine\nwith an owner, a lease,\ndependencies, and history.",
+        ),
+        (
+            "NAMED GATES",
+            "A gate returns a named\ndecision, not a boolean.\nRefusals are explainable.",
+        ),
+        (
+            "ROUTE LADDER",
+            "Ordered, capability-matched\nselection across coding\nagents and models.",
+        ),
+        (
+            "EVIDENCE CLOSURE",
+            "Build, test, review, and\npublication artifacts are\npointers, kept with the task.",
+        ),
+        (
+            "BREAK-GLASS",
+            "Recovery is a granted,\nlistable, revocable\nauthorization with a reason.",
+        ),
+    ]
+    for i, (head, body) in enumerate(powers):
+        x = 70 + i * 231
+        shape(
+            s,
+            "roundRect",
+            x,
+            300,
+            213,
+            250,
+            C["panel"],
+            radius="rounded-xl",
+            stroke=C["orange"],
+            strokeWidth=2,
+        )
+        text(s, str(i + 1).zfill(2), x + 20, 320, 60, 26, 14, C["orange"], True)
+        text(s, head, x + 20, 352, 176, 56, 16, C["white"], True, fit=True)
+        line(s, x + 20, 414, 44, 3, C["orange"])
+        text(s, body, x + 20, 432, 176, 100, 13, C["fog"], False, fit=True)
+    text(
+        s,
+        "Agent output is a candidate. These five mechanisms are how it earns the right to land.",
+        70,
+        580,
+        1140,
+        40,
+        21,
+        C["orange2"],
+        True,
+        align="center",
+        fit=True,
+    )
+    footer(s, 9, True)
+    notes(
+        s,
+        [
+            "This is the anti-reinvention slide's counterweight: the deck is explicit that reuse is preferred, so it must be equally explicit about the parts that are genuinely ours.",
+            "Leases are what make concurrency safe: a claim is time-bounded and recoverable, so a dead worker does not strand work forever - there are explicit recovery verbs for stranded and stalled work.",
+            "Break-glass exists because recovery paths that are undocumented become undocumented root access. Granting, listing, and revoking are all first-class and reason-bearing.",
+            "Precision on named gates: the review gate returns a named decision today; making that the contract for every gate is an accepted-in-principle proposal rather than a finished refactor. Say it that way if asked.",
+        ],
+    )
+
+    # 10 - trust boundary
+    s = add_slide(C["white"])
+    title(
+        s,
+        "The trust boundary, drawn explicitly.",
+        "Agents run with wide latitude inside a narrow box. The box - not the agent's good"
+        " judgement - is what makes autonomous execution acceptable.",
+        False,
+        10,
+        tag="CONTAINMENT",
+    )
+    shape(
+        s,
+        "roundRect",
+        70,
+        296,
+        700,
+        324,
+        C["fog"],
+        radius="rounded-xl",
+        stroke=C["orange"],
+        strokeWidth=2,
+    )
+    text(s, "INSIDE THE SANDBOX", 96, 316, 400, 26, 15, C["orange"], True)
+    inside = [
+        "Agent process tree, owned and reaped",
+        "Read-only and read-write paths, allow-listed",
+        "Syscall filter; never runs as root",
+        "Declared egress hosts, per project and per task",
+        "Secret handles resolved at use, never printed",
+    ]
+    for i, item in enumerate(inside):
+        dot(s, 96, 360 + i * 48, 12, C["orange"])
+        text(s, item, 122, 352 + i * 48, 620, 36, 15, C["ink"], True, fit=True)
+    shape(s, "roundRect", 800, 296, 410, 324, C["ink"], radius="rounded-xl")
+    text(s, "NEVER CROSSES", 826, 316, 340, 26, 15, C["red"], True)
+    outside = [
+        "Undeclared network destinations",
+        "Raw credential values",
+        "Another project's repository",
+        "Self-approval of its own work",
+    ]
+    for i, item in enumerate(outside):
+        shape(s, "rect", 826, 366 + i * 58, 26, 4, C["red"])
+        text(s, item, 866, 352 + i * 58, 320, 44, 15, C["fog"], True, fit=True)
+    caption_bar(
+        s,
+        "Deny-by-default egress and secrets-as-handles are policy, enforced by the sandbox, not conventions.",
+    )
+    footer(s, 10)
+    notes(
+        s,
+        [
+            "The containment model is OpenShell's, configured by a control-plane-authored policy: filesystem via Landlock, syscalls via seccomp, network via an L7 proxy that is deny-by-default.",
+            "Secrets are handles: work references a secret by name and the value is resolved at use, so a transcript, a log, or an evidence bundle never carries the value.",
+            "'Never self-approves' is an authority boundary rather than a sandbox control, and it is the one item on the right that the control plane enforces itself.",
+        ],
+    )
+
+    # ------------------------------------------------------------------ part 2
+    # 11 - divider: actors
+    s = add_slide(C["ink"])
+    section(
+        s,
+        "PART TWO",
+        "Actors, roles, and who is allowed to decide.",
+        "The rest of the deck is the machine itself: the cast of actors, the life of one task, how"
+        " agents coordinate without a switchboard, how the fleet is shaped, and how models and money"
+        " are routed and measured.",
+        11,
+    )
+    notes(
+        s,
+        [
+            "Transition point. A decision audience can stop here; an engineering audience should stay for slides 12 through 17.",
+            "The organizing idea for this half: every actor has exactly one kind of authority, and no actor holds two that would let it grade its own work.",
+        ],
+    )
+
+    # 12 - the cast
+    s = add_slide(C["white"])
+    title(
+        s,
+        "The cast, and the one authority each actor holds.",
+        "Roles are separated so that the ability to do work, the ability to accept work, and the"
+        " ability to change the rules never live in the same place.",
+        False,
+        12,
+        tag="ACTORS",
+    )
+    cast = [
+        ("REQUESTER", "states intent", C["orange"]),
+        ("GATEWAY AGENT", "conversation + memory", C["blue"]),
+        ("HUB", "durable truth", C["ink"]),
+        ("DISPATCHER", "matches work to capability", C["panel"]),
+        ("WORKER", "runs one leased task", C["steel"]),
+        ("CODING EXECUTOR", "edits the repository", C["orange2"]),
+        ("REVIEWER AGENT", "returns a named decision", C["green2"]),
+        ("OPERATOR", "grants, revokes, recovers", C["red"]),
+    ]
+    for i, (head, role, color) in enumerate(cast):
+        col, row = i % 4, i // 4
+        x = 70 + col * 290
+        y = 300 + row * 168
+        shape(
+            s,
+            "roundRect",
+            x,
+            y,
+            272,
+            148,
+            C["fog"],
+            radius="rounded-xl",
+            stroke=color,
+            strokeWidth=2,
+        )
+        shape(s, "rect", x + 20, y + 24, 40, 4, color)
+        text(s, head, x + 20, y + 44, 232, 30, 17, C["ink"], True, fit=True)
+        text(s, role, x + 20, y + 84, 232, 44, 14, C["steel"], True, fit=True)
+    footer(s, 12)
+    notes(
+        s,
+        [
+            "The gateway agent is a stock conversational runtime under a control-plane-authored sandbox policy; it owns personality, memory, and channels, and holds no operational authority.",
+            "Worker and coding executor are separate actors on purpose: the worker is the leased, supervised process; the executor is whichever coding agent the route ladder selected for it.",
+            "The reviewer is a different invocation from the one that produced the work. The operator is the only actor that can grant recovery authority, and every grant is recorded with its reason.",
+            "Missing from this list, deliberately: any actor that can both execute and accept. That combination does not exist in the model.",
+        ],
+    )
+
+    # 13 - life of a task
+    s = add_slide(C["fog"])
+    title(
+        s,
+        "The life of one task.",
+        "A task is a state machine, not a status string. Terminal states are reached by decision,"
+        " and the path is stored with the task.",
+        False,
+        13,
+        tag="LIFECYCLE",
+    )
+    stage_flow(
+        s, ["OPEN", "WAITING", "CLAIMED", "RUNNING", "NEEDS REVIEW", "REVIEWING", "COMPLETED"], 300
+    )
+    gates = [
+        ("DEPENDENCY", "unfinished dependency\nholds the task"),
+        ("LEASE", "one owner, time-bounded,\nrecoverable"),
+        ("EVIDENCE", "build and test output\nbefore review"),
+        ("ACCEPTANCE", "an independent named\ndecision"),
+    ]
+    for i, (head, body) in enumerate(gates):
+        x = 70 + i * 290
+        shape(
+            s,
+            "roundRect",
+            x,
+            396,
+            272,
+            132,
+            C["white"],
+            radius="rounded-xl",
+            stroke=C["orange"],
+            strokeWidth=2,
+        )
+        text(s, f"GATE {i + 1}", x + 20, 414, 232, 22, 12, C["orange"], True)
+        text(s, head, x + 20, 438, 232, 26, 16, C["ink"], True, fit=True)
+        text(s, body, x + 20, 468, 232, 46, 13, C["steel"], False, fit=True)
+        down_arrow(s, x + 134, 348, 396, C["line"])
+    others = ["BLOCKED", "NEEDS INPUT", "STOPPED", "FAILED", "CANCELLED"]
+    text(s, "ALSO TERMINAL OR HELD:", 70, 552, 290, 24, 13, C["steel"], True)
+    for i, label in enumerate(others):
+        chip(s, label, 380 + i * 166, 546, 158, C["ink"], C["fog"], 12)
+    caption_bar(s, "Failure keeps its evidence. A failed task is a record, not a deletion.")
+    footer(s, 13)
+    notes(
+        s,
+        [
+            "The state set is larger than the happy path shown here; the held and terminal states are listed along the bottom so the diagram stays readable while remaining complete about the vocabulary.",
+            "Holds are not states: a staged task carries a hold flag and is released, which is why 'dispatchable' is a function of dependencies, capability, lease, and project pause rather than a single field.",
+            "Recovery verbs exist for stranded and stalled work precisely because leases expire while a real process may or may not still be alive.",
+        ],
+    )
+
+    # 14 - coordination
+    s = add_slide(C["ink"])
+    title(
+        s,
+        "Coordination is a town square, not a switchboard.",
+        "Agents broadcast on a shared bus and act on what they hear. The hub does not sit in the"
+        " middle of every conversation - it sits underneath the durable consequences.",
+        True,
+        14,
+        tag="COORDINATION",
+    )
+    shape(s, "roundRect", 430, 396, 420, 76, C["orange"], radius="rounded-full")
+    text(
+        s, "AGENTBUS  ·  BROADCAST", 450, 418, 380, 32, 20, C["ink"], True, align="center", fit=True
+    )
+    participants = ["GATEWAY", "WORKER", "REVIEWER", "OPERATOR", "DISPATCHER"]
+    for i, label in enumerate(participants):
+        x = 70 + i * 231
+        shape(
+            s,
+            "roundRect",
+            x,
+            300,
+            213,
+            62,
+            C["panel"],
+            radius="rounded-lg",
+            stroke=C["blue"],
+            strokeWidth=1,
+        )
+        text(s, label, x + 16, 318, 181, 26, 14, C["fog"], True, align="center", fit=True)
+        down_arrow(s, x + 106, 366, 396, C["blue"])
+    verbs = ["stand down", "abort", "pause", "resume", "status"]
+    text(s, "LIFECYCLE VERBS ON THE BUS", 70, 512, 400, 26, 14, C["muted"], True)
+    for i, label in enumerate(verbs):
+        chip(s, label, 70 + i * 231, 548, 213, C["white"], C["ink"], 13)
+    text(
+        s,
+        "Broadcast for intent and interruption. Ledger for consequence.",
+        70,
+        604,
+        1140,
+        34,
+        18,
+        C["orange2"],
+        True,
+        align="center",
+        fit=True,
+    )
+    footer(s, 14, True)
+    notes(
+        s,
+        [
+            "The bus is a broadcast medium: a message is heard by the fleet rather than addressed through a central router, which is what makes an interruption like 'stand down' cheap and immediate.",
+            "The durable consequence of anything heard on the bus still lands in the ledger. The bus is not the system of record and must not be described as one.",
+            "Operational learning is recorded as secret-free memories, so repeated failures against the same credential pattern change future routing instead of being retried blindly.",
+        ],
+    )
+
+    # 15 - fleet shape
+    s = add_slide(C["white"])
+    title(
+        s,
+        "A heterogeneous fleet, modelled honestly.",
+        "Node classes differ because the work differs. The dispatcher matches a task to a node that"
+        " can actually run it, then leases it.",
+        False,
+        15,
+        tag="FLEET",
+    )
+    nodes = [
+        (
+            "macOS HOST",
+            "launchd-managed host\ninstall; Apple toolchain\nwork stays native.",
+            C["blue"],
+        ),
+        (
+            "LINUX NODE",
+            "native steward plus\ncontainerized execution\nunder Docker Engine.",
+            C["orange"],
+        ),
+        (
+            "KUBERNETES",
+            "one orchestrator folds\nclaim, launch, and stuck-\nJob reconciliation.",
+            C["green2"],
+        ),
+        (
+            "HGX SESSION",
+            "bounded elastic capacity,\nonboarded by explicit\noperator receipt.",
+            C["green"],
+        ),
+    ]
+    shape(s, "roundRect", 70, 296, 1140, 68, C["ink"], radius="rounded-xl")
+    text(
+        s,
+        "DISPATCHER  ·  capability match, then lease",
+        90,
+        314,
+        700,
+        32,
+        18,
+        C["white"],
+        True,
+        fit=True,
+    )
+    for i, (head, body, color) in enumerate(nodes):
+        x = 70 + i * 290
+        down_arrow(s, x + 134, 364, 398, color)
+        shape(
+            s,
+            "roundRect",
+            x,
+            398,
+            272,
+            200,
+            C["fog"],
+            radius="rounded-xl",
+            stroke=color,
+            strokeWidth=2,
+        )
+        text(s, head, x + 20, 420, 232, 30, 17, C["ink"], True, fit=True)
+        line(s, x + 20, 456, 46, 4, color)
+        text(s, body, x + 20, 476, 232, 100, 14, C["steel"], False, fit=True)
+    caption_bar(
+        s,
+        "Capability, egress, and secrets are declared per node and per task - not assumed uniform.",
+    )
+    footer(s, 15)
+    notes(
+        s,
+        [
+            "macOS nodes are host installs under launchd by decision, not by omission; containerized execution is narrowed to Linux, where the container story is honest.",
+            "Docker Engine / Moby is the single container runtime, so the sandbox policy has one enforcement path to reason about.",
+            "HGX capacity is fungible and bounded: onboarding a provider session is an explicit operator action with a durable receipt, which keeps the machine-onboarding trust boundary intact.",
+        ],
+    )
+
+    # 16 - multi-model routing
+    s = add_slide(C["fog"])
+    title(
+        s,
+        "Many models, one ordered route, one meter.",
+        "Multi-model is a routing problem with a cost consequence. The ladder decides who does the"
+        " work; the meter records what it cost.",
+        False,
+        16,
+        tag="MODELS + MONEY",
+    )
+    text(s, "ROUTE LADDER  ·  ordered, capability-filtered", 70, 296, 600, 26, 14, C["steel"], True)
+    ladder = ["opencode", "pi", "claude", "codex", "cursor"]
+    for i, label in enumerate(ladder):
+        x = 70 + i * 231
+        fill = C["orange"] if i == 0 else C["white"]
+        color = C["ink"]
+        shape(
+            s,
+            "roundRect",
+            x,
+            330,
+            213,
+            62,
+            fill,
+            radius="rounded-lg",
+            stroke=C["orange"] if i == 0 else C["line"],
+            strokeWidth=2,
+        )
+        text(
+            s, f"{i + 1}. {label}", x + 16, 348, 181, 26, 15, color, True, align="center", fit=True
+        )
+        if i < len(ladder) - 1:
+            arrow(s, x + 213, 359, x + 231, C["steel"])
+    shape(s, "roundRect", 70, 424, 550, 200, C["ink"], radius="rounded-xl")
+    text(s, "RECORDED AT THE ROUTER", 96, 446, 400, 26, 15, C["orange2"], True)
+    meter = [
+        "one route event per model call",
+        "input, output, and streaming state",
+        "attributed to task, project, and agent",
+    ]
+    for i, item in enumerate(meter):
+        dot(s, 96, 492 + i * 42, 10, C["orange"])
+        text(s, item, 120, 484 + i * 42, 480, 34, 14, C["fog"], True, fit=True)
+    shape(
+        s,
+        "roundRect",
+        660,
+        424,
+        550,
+        200,
+        C["white"],
+        radius="rounded-xl",
+        stroke=C["blue"],
+        strokeWidth=2,
+    )
+    text(s, "PRICED AT READ TIME", 686, 446, 400, 26, 15, C["blue"], True)
+    priced = [
+        "history re-prices without re-running",
+        "cost per task, project, and outcome",
+        "coverage gaps are measured, not averaged away",
+    ]
+    for i, item in enumerate(priced):
+        dot(s, 686, 492 + i * 42, 10, C["blue"])
+        text(s, item, 710, 484 + i * 42, 480, 34, 14, C["ink"], True, fit=True)
+    footer(s, 16)
+    notes(
+        s,
+        [
+            "The ladder is ordered and filtered by capability and availability; the first entry is the current default coding route, and the order is a fleet contract rather than a per-worker preference.",
+            "Recording happens where routing happens, which is the only place that sees every model call regardless of which agent made it. The router currently captures usage the caller reported; making the router itself the meter is a proposed decision, not a shipped one.",
+            "Pricing at read time means a price-table change re-values history instead of invalidating it. Coverage is itself measured - the proposal that owns this quantified the unmetered fraction rather than averaging it away - so quote that figure from source-notes.md with its date.",
+        ],
+    )
+
+    # 17 - evidence and measurement
+    s = add_slide(C["ink"])
+    title(
+        s,
+        "The fleet measures itself.",
+        "Timing, spend, decisions, and provenance are recorded per step, which is what makes the"
+        ' question "where did the day go?" answerable at all.',
+        True,
+        17,
+        tag="EVIDENCE",
+    )
+    stage_flow(
+        s,
+        ["ROUTE EVENT", "ACTION EVENT", "GATE DECISION", "EVIDENCE POINTER", "AUDIT TRAIL"],
+        300,
+        dark=True,
+    )
+    cols = [
+        ("PER TASK", "state history, owner,\nlease, dependencies"),
+        ("PER STEP", "timing, tokens,\nexit decision"),
+        ("PER RELEASE", "provenance pin and\nevidence closure"),
+    ]
+    for i, (head, body) in enumerate(cols):
+        x = 70 + i * 386
+        shape(
+            s,
+            "roundRect",
+            x,
+            396,
+            368,
+            160,
+            C["panel"],
+            radius="rounded-xl",
+            stroke=C["blue"],
+            strokeWidth=1,
+        )
+        text(s, head, x + 24, 418, 320, 28, 16, C["blue"], True, fit=True)
+        text(s, body, x + 24, 452, 320, 76, 15, C["fog"], False, fit=True)
+    text(
+        s,
+        "Evidence indexes what happened. It does not, by itself, authorize a release.",
+        70,
+        584,
+        1140,
+        40,
+        20,
+        C["orange2"],
+        True,
+        align="center",
+        fit=True,
+    )
+    footer(s, 17, True)
+    notes(
+        s,
+        [
+            "The distinction on the bottom line matters and is easy to get wrong in a deck: the ledger and its pointers are an index of evidence, while acceptance and publication remain explicit decisions by an authorized actor.",
+            "Action events arrive as a normalized stream from sandboxed execution, so 'what did the agent actually do' is not reconstructed from a transcript.",
+            "Ledger census and token figures quoted in conversation must carry the date they were measured; source-notes.md holds the measured values and their dates.",
+        ],
+    )
+
+    # 18 - scale
+    s = add_slide(C["white"])
+    title(
+        s,
+        "Scale of the implementation.",
+        "Surface area, not maturity: what exists in the tree this package was audited against.",
+        False,
+        18,
+        tag="SCALE",
+    )
+    facts = [
+        ("221", "control-plane\nmodules"),
+        ("435", "HTTP\nroutes"),
+        ("458", "CLI leaf\ncommands"),
+        ("12", "task\nstates"),
+    ]
+    for i, (num, label) in enumerate(facts):
+        x = 70 + i * 290
+        text(s, num, x, 316, 272, 76, 52, C["orange"] if i == 0 else C["ink"], True, align="center")
+        line(s, x + 96, 404, 80, 4, C["line"])
+        text(s, label, x, 424, 272, 60, 17, C["steel"], True, align="center", fit=True)
+    pairs = [
+        ("5", "coding-agent routes on the ladder"),
+        ("4", "object groups: project, task, agent, admin"),
+        ("2", "dispatch targets: fleet nodes and Kubernetes"),
+    ]
+    for i, (num, label) in enumerate(pairs):
+        x = 70 + i * 386
+        shape(s, "roundRect", x, 500, 368, 110, C["fog"], radius="rounded-xl")
+        text(s, num, x + 24, 526, 60, 56, 32, C["orange"], True)
+        text(s, label, x + 96, 526, 250, 62, 15, C["ink"], True, fit=True)
+    caption_bar(
+        s,
+        "Every figure here is a count from the audited tree, recorded with its source in source-notes.md.",
+    )
+    footer(s, 18)
+    notes(
+        s,
+        [
+            "These counts describe surface area only. They are not a maturity claim and must be re-measured, not carried forward, when this package is regenerated.",
+            "The CLI is the object model: project, task, agent, and admin. The HTTP API, the Python client, and the MCP server are clients of that same surface rather than parallel implementations.",
+        ],
+    )
+
+    # 19 - stated honestly
+    s = add_slide(C["fog"])
+    title(
+        s,
+        "Stated honestly: implemented, decided, proposed.",
+        "A deck that blurs these three is marketing. The distinction is kept here so an engineering"
+        " reviewer can trust the rest of it.",
+        False,
+        19,
+        tag="LIMITS",
+    )
+    columns = [
+        (
+            "IMPLEMENTED",
+            C["green2"],
+            [
+                "Durable ledger, leases, recovery",
+                "Sandboxed execution and egress policy",
+                "Independent review gates",
+                "Route events, priced at read time",
+            ],
+        ),
+        (
+            "DECIDED, NOT YET RUNTIME",
+            C["orange"],
+            [
+                "Agent-initiated review scope",
+                "Native steward plus containerized\nexecution on Linux",
+            ],
+        ),
+        (
+            "PROPOSED",
+            C["steel"],
+            [
+                "Metering enforced at the router",
+                "Route-search-path contract",
+                "Task view as a graph",
+                "Retrieval and extraction pipeline",
+            ],
+        ),
+    ]
+    for i, (head, color, items) in enumerate(columns):
+        x = 70 + i * 386
+        shape(
+            s,
+            "roundRect",
+            x,
+            300,
+            368,
+            320,
+            C["white"],
+            radius="rounded-xl",
+            stroke=color,
+            strokeWidth=2,
+        )
+        text(s, head, x + 24, 322, 320, 50, 16, C["ink"], True, fit=True)
+        line(s, x + 24, 376, 46, 4, color)
+        for j, item in enumerate(items):
+            dot(s, x + 24, 408 + j * 56, 10, color)
+            text(s, item, x + 48, 400 + j * 56, 296, 48, 14, C["steel"], True, fit=True)
+    footer(s, 19)
+    notes(
+        s,
+        [
+            "Placement of each item traces to the architecture-decision record that owns it, with that record's own status line as the authority - see source-notes.md.",
+            "'Decided, not yet runtime' is the category most decks omit. An accepted decision whose implementation is deferred is neither a shipped capability nor a proposal.",
+        ],
+    )
+
+    # 20 - close
+    s = add_slide(C["ink"])
+    pill(s, BRAND, 70, 48, 148, C["white"], C["ink"])
+    text(s, "Reuse the stack.\nOwn the truth.", 70, 150, 700, 160, 46, C["white"], True, fit=True)
+    line(s, 74, 336, 120, 8, C["orange"])
+    text(
+        s,
+        "NVIDIA OpenShell for confinement. NeMo Relay for observability. HGX for capacity. Postgres,"
+        " Kubernetes, and the best available coding agents for execution. AgentFabric for the one"
+        " thing none of them do: durable, auditable operational truth across the whole fleet.",
+        74,
+        366,
+        660,
+        170,
+        19,
+        C["fog"],
+        False,
+        fit=True,
+    )
+    steps = [
+        ("START", "one repository,\none project, one\nreal workload"),
+        ("GROW", "add node classes\nand coding routes\nas work demands"),
+        ("MEASURE", "read cost and\nthroughput before\nadding capacity"),
+    ]
+    for i, (head, body) in enumerate(steps):
+        y = 300 + i * 116
+        shape(
+            s,
+            "roundRect",
+            790,
+            y,
+            420,
+            100,
+            C["panel"],
+            radius="rounded-xl",
+            stroke=C["orange"],
+            strokeWidth=1,
+        )
+        text(s, head, 814, y + 20, 120, 26, 15, C["orange"], True)
+        text(s, body, 940, y + 18, 250, 66, 13, C["fog"], False, fit=True)
+    text(s, str(TOTAL), 1162, 698, 48, 16, 12, C["muted"], True, align="right")
+    notes(
+        s,
+        [
+            "Close on the adoption path, not the vision: one project and one real workload first, because the fabric's value shows up when a second agent has to trust the first one's output.",
+            "For mechanism questions, return to slides 7 through 10 (reuse and containment) and 12 through 17 (actors, lifecycle, coordination, fleet, routing, evidence).",
+            "The authority for every claim in this deck is source-notes.md; the narrative member carries the same claims in prose at greater depth.",
+        ],
+    )
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    p.save(str(OUT))
+    return OUT
+
+
+def _capability_manifest(pptx_path: Path) -> dict:
+    return {
+        "schema": "agentfabric/document-pair-manifest@1",
+        "ecosystem": "google-workspace",
+        "members": {
+            "presentation": {
+                "local_artifact": str(pptx_path),
+                "published_location": None,
+                "publication_authorized": False,
+                "access": {
+                    "audience": "organization",
+                    "principals": [],
+                    "permission": "view",
+                    "link_sharing": "organization-restricted",
+                },
+            }
+        },
+        "authoring_package": {
+            "root": str(SOURCE),
+            "elements": {
+                "deck_specification": "deck-specification.md",
+                "narrative_specification": "narrative-specification.md",
+                "factual_ledger": "source-notes.md",
+                "generation_prompts": "prompts",
+                "build_source": "build_deck.py",
+                "regeneration_entry_point": "regenerate.sh",
+                "deliverable_links": "current-deliverables.md",
+                "qa_record": "qa-ledger.md",
+            },
+        },
+    }
+
+
+def main() -> None:
+    out = build()
+    slide_count = len(Presentation(str(out)).slides)
+    print(f"built {slide_count} slides -> {out}")
+    manifest_path = _obj_dir() / "agentfabric-overview" / "capability-manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(_capability_manifest(out), indent=2) + "\n", encoding="utf-8"
+    )
+    print(f"capability manifest -> {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/presentations/agentfabric-overview/build_narrative.py
+++ b/docs/presentations/agentfabric-overview/build_narrative.py
@@ -1,0 +1,761 @@
+#!/usr/bin/env python3
+"""Build the AgentFabric overview narrative member with python-docx.
+
+Structure authority: narrative-specification.md. Factual authority: source-notes.md.
+The narrative and the deck must not diverge on a shared claim.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from docx import Document
+from docx.enum.text import WD_LINE_SPACING
+from docx.oxml.ns import qn
+from docx.shared import Inches, Pt, RGBColor
+
+HERE = Path(__file__).resolve().parent
+SOURCE = Path(os.environ.get("AGENTFABRIC_DECK_SOURCE", str(HERE)))
+REPO = Path(os.environ.get("AGENTFABRIC_REPO", str(SOURCE.parents[2])))
+
+
+def _obj_dir() -> Path:
+    return Path(os.environ.get("OBJ_DIR") or (REPO / "_build"))
+
+
+OUT = Path(os.environ.get("AGENTFABRIC_NARRATIVE_OUTPUT") or (SOURCE / "agentfabric-overview.docx"))
+PPTX = Path(os.environ.get("AGENTFABRIC_DECK_OUTPUT") or (SOURCE / "agentfabric-overview.pptx"))
+INK = RGBColor(0x10, 0x13, 0x17)
+STEEL = RGBColor(0x65, 0x70, 0x7C)
+
+
+def _set_run_font(run, *, name: str, size: Pt, color=INK, bold=False, italic=False):
+    run.font.name = name
+    run.font.size = size
+    run.font.color.rgb = color
+    run.bold = bold
+    run.italic = italic
+    rpr = run._element.get_or_add_rPr()
+    rfonts = rpr.get_or_add_rFonts()
+    rfonts.set(qn("w:ascii"), name)
+    rfonts.set(qn("w:hAnsi"), name)
+    rfonts.set(qn("w:cs"), name)
+
+
+def heading(doc: Document, level: int, text: str) -> None:
+    paragraph = doc.add_heading(text, level=level)
+    for run in paragraph.runs:
+        _set_run_font(run, name="Calibri", size=Pt(22 - (level * 2)), color=INK, bold=True)
+
+
+def body(doc: Document, text: str, *, italic: bool = False) -> None:
+    paragraph = doc.add_paragraph()
+    paragraph.paragraph_format.space_after = Pt(10)
+    paragraph.paragraph_format.line_spacing_rule = WD_LINE_SPACING.SINGLE
+    run = paragraph.add_run(text)
+    _set_run_font(run, name="Calibri", size=Pt(12), color=INK, italic=italic)
+
+
+def bullets(doc: Document, items: list[str]) -> None:
+    for item in items:
+        paragraph = doc.add_paragraph(style="List Bullet")
+        paragraph.paragraph_format.space_after = Pt(4)
+        run = paragraph.add_run(item)
+        _set_run_font(run, name="Calibri", size=Pt(11), color=INK)
+
+
+def code(doc: Document, text: str) -> None:
+    paragraph = doc.add_paragraph()
+    paragraph.paragraph_format.space_before = Pt(6)
+    paragraph.paragraph_format.space_after = Pt(10)
+    paragraph.paragraph_format.left_indent = Inches(0.25)
+    run = paragraph.add_run(text)
+    _set_run_font(run, name="Courier New", size=Pt(9), color=STEEL)
+
+
+def write_manifest(pptx_path: Path, docx_path: Path) -> Path:
+    manifest = {
+        "schema": "agentfabric/document-pair-manifest@1",
+        "members": {
+            "presentation": {
+                "local_artifact": str(pptx_path),
+                "published_location": None,
+                "publication_authorized": False,
+            },
+            "narrative": {
+                "local_artifact": str(docx_path),
+                "published_location": None,
+                "publication_authorized": False,
+            },
+        },
+        "authoring_package": {
+            "root": str(SOURCE),
+            "elements": {
+                "deck_specification": "deck-specification.md",
+                "narrative_specification": "narrative-specification.md",
+                "factual_ledger": "source-notes.md",
+                "generation_prompts": "prompts",
+                "deck_build_source": "build_deck.py",
+                "narrative_build_source": "build_narrative.py",
+                "regeneration_entry_point": "regenerate.sh",
+                "deliverable_links": "current-deliverables.md",
+                "qa_record": "qa-ledger.md",
+            },
+        },
+    }
+    path = _obj_dir() / "agentfabric-overview" / "document-pair-manifest.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def build() -> Path:  # noqa: PLR0915 - one linear document, written in order
+    doc = Document()
+    section = doc.sections[0]
+    section.page_width = Inches(8.5)
+    section.page_height = Inches(11)
+    section.left_margin = Inches(1)
+    section.right_margin = Inches(1)
+    section.top_margin = Inches(1)
+    section.bottom_margin = Inches(1)
+    core = doc.core_properties
+    core.title = "AgentFabric: one control plane for a fleet of AI agents"
+    core.author = "AgentFabric maintainers"
+    core.subject = "Narrative member of the AgentFabric overview document pair"
+
+    # ---------------------------------------------------------------- part 1
+    heading(doc, 1, "AgentFabric: one control plane for a fleet of AI agents")
+    body(
+        doc,
+        "This is the narrative member of the AgentFabric overview. It accompanies the "
+        "20-slide presentation built from deck-specification.md, carries the same claims "
+        "in prose at greater depth, and shares one factual ledger with it: "
+        "source-notes.md. Where the two members disagree on a shared claim, one of them "
+        "is wrong and must be corrected rather than reconciled by the reader.",
+    )
+    body(
+        doc,
+        "The reader this is written for is highly technical and completely unfamiliar with "
+        "both AgentFabric and the requirements of running many agents and many models at "
+        "once. Nothing here assumes prior product knowledge. AgentFabric is the "
+        "presentation name for the control plane whose repository, CLI, and modules are "
+        "named mac; they are the same system.",
+    )
+
+    heading(doc, 2, "What problem this solves")
+    body(
+        doc,
+        "One engineer supervising one coding agent works. The human reads the diff, "
+        "notices the wrong turn, and re-steers. Supervision is the human, and it is "
+        "genuinely sufficient at that scale. The interesting failure appears when the same "
+        "pattern is multiplied: several dozen agents, several models, several machine "
+        "classes, and work that outlives any single conversation.",
+    )
+    body(
+        doc,
+        "At that point the missing piece is not a better prompt or a smarter agent. It is "
+        "that a conversation is ephemeral state. A transcript has no owner, no ordering, "
+        "no dependency edges, no lease, and no receipt. Two agents can start the same "
+        "work; an agent can stop mid-flight and take the only record of what it was doing "
+        "with it; the money spent on model calls cannot be attributed to the work it paid "
+        "for; and nobody can answer, afterwards, who approved a change. Those are not "
+        "tooling gaps, they are consequences of using a chat log as a system of record.",
+    )
+    body(
+        doc,
+        "AgentFabric's position is that a fleet of agents needs the same thing any other "
+        "distributed system needs: durable state with ownership, ordering, and evidence. "
+        "The unit of truth is a task in a ledger, not a message in a transcript. Agents "
+        "become participants in a control plane rather than the control plane itself.",
+    )
+
+    heading(doc, 2, "Who this document is for, and what it does not claim")
+    body(
+        doc,
+        "This narrative is for an engineer evaluating adoption, an architect reviewing the "
+        "control model, or a manager who wants the deck's claims traced to their source. "
+        "It states no return-on-investment figure, no productivity multiple, and no "
+        "throughput projection, because none of those are measured. Counted figures "
+        "describe surface area and carry the command and the date that produced them. "
+        "Where a capability is decided but not yet running, or proposed but not yet "
+        "decided, it is labelled as such in the same sentence that describes it.",
+    )
+
+    # ---------------------------------------------------------------- part 2
+    heading(doc, 1, "What the system does")
+    heading(doc, 2, "Ask once, and the fabric carries it to production")
+    body(
+        doc,
+        "The externally visible behaviour is a single pipeline: a request becomes a "
+        "durable task; the task is leased to an agent that can actually do it; the agent "
+        "executes inside a sandbox; a different agent reviews the result; and publication "
+        "leaves provenance behind. Ask, durable task, lease and dispatch, execute, "
+        "independent review, publish. Every stage is a boundary owned by the control "
+        "plane, and nothing advances because a participant asserts it should.",
+    )
+    heading(doc, 2, "The three consequences worth stating plainly")
+    body(
+        doc,
+        "First, nothing is lost. A task outlives the chat that produced it, the agent that "
+        "claimed it, and the machine that ran it, because the task is a row with a state, "
+        "an owner, a lease, dependencies, and history rather than a paragraph in a "
+        "transcript.",
+    )
+    body(
+        doc,
+        "Second, nothing is blind. Timing, model usage, gate decisions, and provenance are "
+        'recorded per step, which is what makes the question "where did the day go, and '
+        'what did it cost?" answerable at all.',
+    )
+    body(
+        doc,
+        "Third, nothing self-approves. The agent that produced the work does not hold the "
+        "authority to accept it. Review is a separate invocation under control-plane-owned "
+        "gates. This is an authority boundary rather than a sandbox control, and it is the "
+        "single property that makes autonomous agent output safe to merge.",
+    )
+    heading(doc, 2, "One request, end to end")
+    body(
+        doc,
+        "Read the loop as six hand-offs, each of which writes something down. A human "
+        "states intent in a chat channel. The gateway agent owns that conversation, its "
+        "personality, and its memory, and it records identity - deliberately nothing else, "
+        "because it holds no operational authority. The hub converts intent into a ledger "
+        "row with a state and an owner, and issues a time-bounded lease. A worker executes "
+        "the leased task inside a sandbox, emitting normalized action events and model "
+        "route events as it goes. A reviewer, which is a different invocation, returns a "
+        "named decision. Publication records provenance and an evidence pointer.",
+    )
+    body(
+        doc,
+        "The separation between the second and third hand-off is the core architectural "
+        "decision of the system: conversation, personality, memory, and channels belong to "
+        "the human-facing runtime, while tasks, leases, routing, reviews, evidence, secret "
+        "handles, runtime manifests, rollout state, and audit trails belong to the control "
+        "plane. Authority: README.md and docs/authority-boundary.md.",
+    )
+
+    # ---------------------------------------------------------------- part 3
+    heading(doc, 1, "Built on the stack, not instead of it")
+    heading(doc, 2, "Why re-use is the design position")
+    body(
+        doc,
+        "Isolation, observability, inference capacity, container runtimes, scheduling, and "
+        "coding agents all already exist, and each is maintained by people for whom it is "
+        "a full-time job. Re-implementing any of them would produce a worse version of "
+        "something already available, and would spend the project's budget on the parts of "
+        "the problem that are already solved. For an engineering reader the interesting "
+        "question about AgentFabric is therefore not what was written; it is what was "
+        "deliberately not written.",
+    )
+    body(
+        doc,
+        "The rule this package follows when describing re-use is that lineage and "
+        "integration are stated separately. A project AgentFabric depends on is named as a "
+        "dependency; a project AgentFabric learned from or stays compatible with is named "
+        "as a reference. Blurring the two would misrepresent both.",
+    )
+
+    heading(doc, 2, "Where AgentFabric leverages NVIDIA technology")
+    heading(doc, 3, "NVIDIA OpenShell - the execution security boundary")
+    body(
+        doc,
+        "OpenShell is the confinement authority. Filesystem policy is enforced with "
+        "Landlock, syscalls are filtered with seccomp, and network egress goes through an "
+        "L7 proxy that is deny-by-default; sandbox lifecycle and the collection of "
+        "normalized action events are OpenShell's too. AgentFabric authors the policy and "
+        "integrates with the sandbox rather than implementing isolation, and the design "
+        "goal is exactly one guardrail authority - the policy file - instead of two "
+        "competing ones. Authority: src/mac/openshell_service.py, "
+        "src/mac/executor_sandbox.py, src/mac/sandbox_egress.py, "
+        "src/mac/openshell_collector.py, docs/openshell-sandbox.md, and ADR 0008, which "
+        "makes Docker Engine/Moby OpenShell's only container runtime so that there is a "
+        "single enforcement path to reason about.",
+    )
+    heading(doc, 3, "NVIDIA NeMo Relay - optional observability")
+    body(
+        doc,
+        "Request, task, tool, and model activity is mapped into NeMo Relay scopes when the "
+        "relay packaging extra is enabled, which pins nemo-relay==0.3.0. Observability is "
+        "mapped into an existing system rather than invented, and it is optional: the "
+        "control plane's own event stream remains the durable record. Authority: "
+        "src/mac/relay_observability.py, pyproject.toml, "
+        "docs/openshell-nemo-relay-integration.md.",
+    )
+    heading(doc, 3, "NVIDIA HGX - bounded elastic capacity")
+    body(
+        doc,
+        "HGX provides provider-session capacity beyond the statically owned fleet. Two "
+        "properties matter more than the capacity itself: it is bounded, and onboarding a "
+        "session is an explicit operator action that leaves a durable receipt, which keeps "
+        "the machine-onboarding trust boundary intact. Read-only status and planning are "
+        "separate from an explicit execute step, and provider work never runs on a "
+        "dispatcher or HTTP thread. An automatically scaling elastic executor tier beyond "
+        "this operator-driven path is a proposal, not a shipped capability. Authority: "
+        "docs/hgx-elastic-capacity.md and ADR 0005 (Proposed).",
+    )
+    heading(doc, 3, "NVIDIA NemoClaw - a reference, not a deployment")
+    body(
+        doc,
+        "NemoClaw is a compatibility and design reference for the conversational agent "
+        "boundary. It is named because the boundary AgentFabric draws around a "
+        "human-facing runtime was designed to remain compatible with it, and it is "
+        "explicitly not presented as the deployed gateway implementation. Authority: "
+        "README.md and docs/hermes-boundary.md.",
+    )
+
+    heading(doc, 2, "Where AgentFabric leverages open source")
+    body(
+        doc,
+        "This is the one place a list is the honest form, because the content is an "
+        "inventory of load-bearing dependencies grouped by the problem each one already "
+        "solved.",
+    )
+    heading(doc, 3, "State")
+    bullets(
+        doc,
+        [
+            "PostgreSQL - the authority for fleet deployments; the test suite runs against "
+            "Postgres because that is what the fleet runs.",
+            "SQLite - the local development and test path only.",
+            "Versioned schema migrations - schema changes are migrations with fail-closed "
+            "authority, not an append-only helper list (src/mac/schema_migrations.py).",
+        ],
+    )
+    heading(doc, 3, "Service")
+    bullets(
+        doc,
+        [
+            "FastAPI and Uvicorn - the HTTP control surface.",
+            "Pydantic - request, response, and configuration models.",
+            "httpx - outbound HTTP, including agent-to-hub traffic.",
+        ],
+    )
+    heading(doc, 3, "Execution")
+    bullets(
+        doc,
+        [
+            "Docker Engine / Moby - the single container runtime under OpenShell (ADR 0008).",
+            "Kubernetes - one of two dispatch targets; a single orchestrator folds claim, "
+            "launch, and stuck-Job reconciliation (src/mac/k8s/runner.py).",
+            "OpenClaw - the conversational runtime under a control-plane-authored sandbox policy.",
+            "OpenAI Codex CLI and OpenCode - coding executors on the route ladder, "
+            "selected per task rather than fixed.",
+        ],
+    )
+    heading(doc, 3, "Protocol")
+    bullets(
+        doc,
+        [
+            "ACP - agent client protocol endpoints served by the hub (src/mac/acp/).",
+            "A2A agent cards - published capability descriptions (src/mac/a2a/card.py).",
+            "MCP - the MCP server is a client of the same HTTP surface, not a second "
+            "implementation (src/mac/mcp_server.py).",
+            "OCSF - the event vocabulary for normalized action events produced under "
+            "sandboxed execution (src/mac/openshell_collector.py).",
+        ],
+    )
+    body(
+        doc,
+        "Every entry above is a dependency, not a fork. The control plane owns none of "
+        "those problems, and each protocol is an implemented specification rather than an "
+        "aspiration - which is what allows a foreign agent implementation to participate "
+        "without a bespoke adapter.",
+    )
+
+    heading(doc, 2, "What AgentFabric adds anyway")
+    body(
+        doc,
+        "Re-use is the default, which obliges the project to be equally explicit about the "
+        "parts that had to be built. These five mechanisms are what make agent output "
+        "trustworthy, and none of the projects above provides them.",
+    )
+    heading(doc, 3, "A durable task ledger")
+    body(
+        doc,
+        "A task is a state machine with an owner, a lease, dependencies, and history, "
+        "persisted in Postgres. Twelve states are defined - open, waiting, blocked, "
+        "claimed, running, needs_review, needs_input, stopped, reviewing, completed, "
+        "failed, cancelled - of which completed, failed, and cancelled are terminal. "
+        "Authority: TaskState and TERMINAL_TASK_STATES in src/mac/models.py, ADR 0004.",
+    )
+    heading(doc, 3, "Named gate decisions")
+    body(
+        doc,
+        "A gate returns a named decision rather than a boolean, so a refusal is "
+        "explainable after the fact instead of appearing as a failed run. The review gate "
+        "works this way today (ADR 0011, Accepted); generalizing the contract to every "
+        "gate in the system is an accepted-in-principle proposal (ADR 0022, Proposed) "
+        "rather than a finished refactor.",
+    )
+    heading(doc, 3, "An ordered coding-route ladder")
+    body(
+        doc,
+        "Coding executors are plural and pluggable, and selection is an ordered, "
+        "capability-filtered ladder rather than a per-worker environment preference. The "
+        "current order is opencode, pi, claude, codex, cursor. The order is a fleet "
+        "contract, and the reason opencode is first is credential durability rather than "
+        "model quality - it keeps a long-lived credential file that can be provisioned to "
+        "a worker, where an expiring OAuth session cannot. Do not read the ladder as a "
+        "quality ranking. Authority: AGENT_PRIORITY in src/mac/coding_agent.py and "
+        "docs/coding-route-ladder.md.",
+    )
+    heading(doc, 3, "Evidence closure")
+    body(
+        doc,
+        "Build, test, review, and publication artifacts are kept as pointers with the task, "
+        "so a completed task carries the numbered evidence that justified it: lint and "
+        "format output, test output, the push, and the merge request. A code executor "
+        "cannot push or open a merge request without passing that gate, and a task whose "
+        "tests fail is routed to review with its full output rather than silently retried. "
+        "Authority: AGENTS.md (the mac.worker_evidence.v1 manifest) and "
+        "src/mac/observability_service.py.",
+    )
+    heading(doc, 3, "Break-glass recovery")
+    body(
+        doc,
+        "Recovery from a wedged host is a granted, listable, revocable authorization that "
+        "carries a reason, exposed as mac task break-glass, break-glass-list, and "
+        "break-glass-revoke. This mechanism exists because an undocumented recovery path "
+        "becomes undocumented root access: making the grant first-class is what keeps it "
+        "auditable. Authority: docs/break-glass-host-recovery.md.",
+    )
+
+    heading(doc, 2, "The trust boundary")
+    heading(doc, 3, "What runs inside the sandbox")
+    body(
+        doc,
+        "An agent runs with wide latitude inside a narrow box: its process tree is owned "
+        "and reaped, read-only and read-write paths are allow-listed through Landlock, "
+        "syscalls are filtered, it never runs as root, egress hosts are declared per "
+        "project and per task, and secrets are handles resolved at use. The box - not the "
+        "agent's good judgement - is what makes autonomous execution acceptable.",
+    )
+    heading(doc, 3, "What never crosses it")
+    body(
+        doc,
+        "Four things never cross the boundary: an undeclared network destination, a raw "
+        "credential value, another project's repository, and an agent's approval of its own "
+        "work. The first three are enforced by the sandbox and the secret store - work "
+        "references a secret by name and the value is resolved at use, so a transcript, a "
+        "log, or an evidence bundle never carries it. The fourth is an authority boundary "
+        "the control plane enforces itself. Authority: docs/openshell-sandbox.md, "
+        "docs/secrets-management-guide.md, docs/authority-boundary.md.",
+    )
+
+    # ---------------------------------------------------------------- part 4
+    heading(doc, 1, "Actors, roles, and who is allowed to decide")
+    heading(doc, 2, "The cast, and the single-authority rule")
+    body(
+        doc,
+        "Roles are separated so that the ability to do work, the ability to accept work, "
+        "and the ability to change the rules never live in the same place. Every actor "
+        "holds exactly one kind of authority.",
+    )
+    heading(doc, 3, "Requester")
+    body(doc, "States intent, in natural language, in a channel. Holds no authority beyond that.")
+    heading(doc, 3, "Gateway agent")
+    body(
+        doc,
+        "A stock conversational runtime - OpenClaw in the deployed path - running under a "
+        "control-plane-authored sandbox policy. Owns personality, memory, and channels; "
+        "owns no operational truth.",
+    )
+    heading(doc, 3, "Hub")
+    body(
+        doc,
+        "The control plane itself: the ledger, leases, routing, reviews, evidence, secret "
+        "handles, and audit trails. It is the only durable authority, and it is the only "
+        "actor whose state survives everything else.",
+    )
+    heading(doc, 3, "Dispatcher")
+    body(
+        doc,
+        "Matches ready work to a node that can actually run it, then leases it. "
+        "Dispatchability is a function of dependencies, worker capability, lease state, and "
+        "project pause - not a single field.",
+    )
+    heading(doc, 3, "Worker")
+    body(
+        doc,
+        "Runs exactly one leased task as a supervised, sandboxed process tree, and reports "
+        "evidence. A worker holds a lease, never an approval.",
+    )
+    heading(doc, 3, "Coding executor")
+    body(
+        doc,
+        "Whichever coding agent the route ladder selected for this task. It edits the "
+        "repository inside the worker's sandbox. Worker and executor are separate actors "
+        "on purpose: the supervision is ours, the coding agent is replaceable.",
+    )
+    heading(doc, 3, "Reviewer agent")
+    body(
+        doc,
+        "A different invocation from the one that produced the work, returning a named "
+        'decision. This is the mechanism behind "nothing self-approves".',
+    )
+    heading(doc, 3, "Operator")
+    body(
+        doc,
+        "The human with rule-changing authority: grants and revokes recovery "
+        "authorizations, pauses projects, onboards nodes and provider sessions. Every grant "
+        "is recorded with its reason.",
+    )
+    body(
+        doc,
+        "Deliberately absent from this list is any actor that can both perform work and accept it.",
+    )
+
+    heading(doc, 2, "The life of one task")
+    heading(doc, 3, "A state machine, not a status string")
+    body(
+        doc,
+        "The happy path runs open, waiting, claimed, running, needs_review, reviewing, "
+        "completed. Blocked, needs_input, and stopped are held states; failed and cancelled "
+        "are terminal. A failed task keeps its evidence: it is a record, not a deletion, "
+        "which is what allows a later reviewer to distinguish a flaky environment from a "
+        "wrong approach.",
+    )
+    heading(doc, 3, "The four gates")
+    body(
+        doc,
+        "Gate one is dependency: an unfinished dependency holds the task. Gate two is the "
+        "lease: one owner, time-bounded, recoverable. Gate three is evidence: build and "
+        "test output exist before review is possible. Gate four is acceptance: an "
+        "independent, named decision.",
+    )
+    heading(doc, 3, "Holds are flags, not states")
+    body(
+        doc,
+        "A staged task carries metadata.no_dispatch=true and is released by removing that "
+        "key, rather than by moving through a state. Keeping holds out of the state machine "
+        'is why "dispatchable" can remain a computed predicate instead of a field somebody '
+        "has to remember to update. Authority: AGENTS.md and src/mac/task_lifecycle.py.",
+    )
+    heading(doc, 3, "Recovery of stranded and stalled work")
+    body(
+        doc,
+        "Leases expire while a real process may or may not still be alive, so recovery is "
+        "explicit rather than implied: there are verbs for stranded and stalled work, and "
+        "cancelling a task revokes the lease and aborts the running executor rather than "
+        "marking a row and hoping.",
+    )
+
+    heading(doc, 2, "Coordination without a switchboard")
+    heading(doc, 3, "Broadcast for intent, ledger for consequence")
+    body(
+        doc,
+        "Agents coordinate on a shared broadcast bus - the AgentBus - and act on what they "
+        "hear. The hub does not sit in the middle of every conversation; it sits underneath "
+        "the durable consequences. That is what makes an interruption such as stand down, "
+        "abort, pause, resume, or status cheap and immediate across the whole fleet. The "
+        "bus is not the system of record, and must never be described as one: anything "
+        "heard on the bus that has a durable consequence lands in the ledger. Authority: "
+        "src/mac/agentbus_service.py, src/mac/agentbus_control.py.",
+    )
+    heading(doc, 3, "Operational learning as secret-free memory")
+    body(
+        doc,
+        "Repository-access outcomes are recorded as secret-free memories, and reviewer "
+        "routing prefers recent success while temporarily avoiding a recent authentication "
+        "failure. Only the credential source name, redacted host, operation, outcome, "
+        "classified failure, and remediation are stored - never a credential value or "
+        "authenticated URL. The effect is that a failing credential pattern changes future "
+        "routing instead of being retried blindly. Authority: "
+        "docs/fleet-operational-learning.md.",
+    )
+
+    heading(doc, 2, "The fleet, modelled honestly")
+    body(
+        doc,
+        "Node classes differ because the work differs, and the dispatcher matches a task to "
+        "a node that can actually run it rather than pretending the fleet is uniform. "
+        "Capability, egress, and secrets are declared per node and per task.",
+    )
+    heading(doc, 3, "macOS hosts")
+    body(
+        doc,
+        "Host installs managed by launchd, by decision rather than omission: Apple "
+        "toolchain work stays native because the container story on macOS is not honest "
+        "(ADR 0015, Accepted).",
+    )
+    heading(doc, 3, "Linux nodes")
+    body(
+        doc,
+        "Containerized execution under Docker Engine/Moby. The pairing of a native node "
+        "steward with containerized task execution is accepted with implementation deferred "
+        "pending fleet measurement (ADR 0012), and the deck says so rather than claiming it "
+        "as running.",
+    )
+    heading(doc, 3, "Kubernetes")
+    body(
+        doc,
+        "One of two dispatch targets. A single orchestrator folds claim, launch, and "
+        "stuck-Job reconciliation, so a stuck Job is reconciled by the same component that "
+        "created it (src/mac/k8s/runner.py).",
+    )
+    heading(doc, 3, "HGX provider sessions")
+    body(
+        doc,
+        "Bounded elastic capacity, onboarded by explicit operator receipt, resolved by "
+        "immutable session ID rather than display name. Fleet targets always resolve from "
+        "~/.mac/fleets.yaml, which is the source of truth after host swaps.",
+    )
+
+    heading(doc, 2, "Models and money")
+    heading(doc, 3, "The ordered ladder decides who does the work")
+    body(
+        doc,
+        "Multi-model operation is a routing problem with a cost consequence. The ladder is "
+        "ordered and filtered by capability and availability, and it is a fleet contract "
+        "rather than a per-worker preference - which is the point of the proposal to make "
+        "the route search path itself contractual (ADR 0029, Proposed).",
+    )
+    heading(doc, 3, "Recording happens where routing happens")
+    body(
+        doc,
+        "Every model call produces one route event carrying input and output token counts "
+        "and streaming state, attributed to a task, project, or agent. The router is the "
+        "only place that sees every call regardless of which agent made it, which is why "
+        "that is where recording belongs.",
+    )
+    body(
+        doc,
+        "Being precise about the current state matters here, because this is the claim a "
+        "deck most easily overstates. Today the router captures the usage the caller "
+        "reported; making the router itself the meter, so that a client which does not ask "
+        "for usage cannot produce an unmetered call, is a proposal (ADR 0017). That "
+        "proposal quantifies the gap rather than hiding it: over the seven days to "
+        "2026-08-19, on 28,352 route events, 8,352 routes (29.5 per cent) recorded a null "
+        "input-token count, 5,948 were flagged as streamed without usage, and 2,474 were "
+        "attributed to nothing.",
+    )
+    heading(doc, 3, "Pricing at read time")
+    body(
+        doc,
+        "Cost is not stored. Route events are priced at read time against a models catalog, "
+        "so a price-table change re-values history instead of invalidating it, and cost per "
+        "task, project, and outcome is a query rather than a re-run. Coverage is itself "
+        "measured, so a gap is visible rather than averaged away. Authority: "
+        "estimate_route_cost() in src/mac/scientific_optimizer.py and "
+        "src/mac/models_catalog.py.",
+    )
+
+    heading(doc, 2, "Evidence")
+    heading(doc, 3, "What is recorded, and at what granularity")
+    body(
+        doc,
+        "Per task: state history, owner, lease, and dependencies. Per step: timing, token "
+        "usage, and the exit decision. Per release: a provenance pin and evidence closure. "
+        'Action events arrive as a normalized stream from sandboxed execution, so "what did '
+        'the agent actually do" is read rather than reconstructed from a transcript.',
+    )
+    heading(doc, 3, "An index is not an authorization")
+    body(
+        doc,
+        "This distinction is easy to lose in a slide and is worth stating carefully: the "
+        "ledger and its pointers form an index of evidence. Acceptance and publication "
+        "remain explicit decisions by an authorized actor. Evidence explains what happened; "
+        "it does not, by itself, authorize a release.",
+    )
+
+    # ---------------------------------------------------------------- part 5
+    heading(doc, 1, "Scope, honestly stated")
+    heading(doc, 2, "Measured surface area")
+    body(
+        doc,
+        "The following counts describe the audited tree - jordanhubbard/mac at 2976182, "
+        "measured 2026-08-30. They are surface area, not maturity, and they must be "
+        "re-measured rather than carried forward when this package is regenerated. Each "
+        "figure's command is recorded in source-notes.md.",
+    )
+    code(
+        doc,
+        "221  control-plane modules       ls src/mac/*.py | wc -l\n"
+        "435  HTTP route declarations     grep route decorators under src/mac\n"
+        "458  CLI leaf commands           walk mac.cli.build_parser()\n"
+        "  4  first-class CLI objects     project, task, agent, admin\n"
+        " 12  task states                 TaskState in src/mac/models.py\n"
+        "  5  coding routes               AGENT_PRIORITY in src/mac/coding_agent.py\n"
+        "  2  dispatch targets            fleet nodes, Kubernetes",
+    )
+    body(
+        doc,
+        "The CLI is the object model, and the HTTP API, the Python client, and the MCP "
+        "server are clients of that same surface rather than parallel implementations. That "
+        "is why the object count, not the command count, is the meaningful figure.",
+    )
+    heading(doc, 2, "Implemented")
+    body(
+        doc,
+        "The durable ledger with leases and recovery, sandboxed execution with "
+        "deny-by-default egress policy, independent review gates, and per-route "
+        "observability events priced at read time are implemented and in use.",
+    )
+    heading(doc, 2, "Decided, not yet runtime")
+    body(
+        doc,
+        "Agent-initiated review scope is accepted (ADR 0016). The pairing of a native node "
+        "steward with containerized execution on Linux is accepted with implementation "
+        "deferred pending fleet measurement (ADR 0012). This is the category most decks "
+        "omit: an accepted decision whose implementation is deferred is neither a shipped "
+        "capability nor a proposal, and collapsing it into either one is what makes an "
+        "architecture document untrustworthy.",
+    )
+    heading(doc, 2, "Proposed")
+    body(
+        doc,
+        "Metering enforced at the router (ADR 0017), the route-search-path contract "
+        "(ADR 0029), the task view as a graph under progressive disclosure (ADR 0018), and "
+        "the retrieval and extraction pipeline (ADR 0030) are proposals. Each ADR's own "
+        "status line is the authority for its placement here.",
+    )
+
+    # ---------------------------------------------------------------- part 6
+    heading(doc, 1, "How to adopt it")
+    heading(doc, 2, "Start with one project and one real workload")
+    body(
+        doc,
+        "Register one repository as a project, create real tasks in the ledger, and let the "
+        "fleet claim them. One real workload exercises the parts that matter - leases, "
+        "gates, evidence, and review - in a way that a demonstration task does not, because "
+        "the fabric's value appears exactly when a second agent has to trust the first "
+        "one's output.",
+    )
+    heading(doc, 2, "Grow node classes and coding routes as work demands")
+    body(
+        doc,
+        "Add a node class when the work needs it - a macOS host for Apple toolchain work, a "
+        "Linux node or Kubernetes for containerized execution, an HGX session for bounded "
+        "extra capacity - and add a coding route when a task class needs a different "
+        "executor. Both are declarations, not forks.",
+    )
+    heading(doc, 2, "Measure before adding capacity")
+    body(
+        doc,
+        "Read cost and throughput from the ledger before buying more of anything. The "
+        "reason to put a control plane underneath agents at all is that it can answer that "
+        "question; a fleet that cannot be audited is a fleet that cannot be trusted with a "
+        "repository, and it also cannot be sized.",
+    )
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    doc.save(str(OUT))
+    return OUT
+
+
+def main() -> None:
+    out = build()
+    document = Document(str(out))
+    headings = [p for p in document.paragraphs if p.style.name.startswith("Heading")]
+    print(f"built narrative -> {out} ({len(headings)} headings)")
+    if not PPTX.is_file():
+        raise SystemExit(f"presentation artifact missing: {PPTX}")
+    manifest = write_manifest(PPTX, out)
+    print(f"document-pair manifest -> {manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/presentations/agentfabric-overview/current-deliverables.md
+++ b/docs/presentations/agentfabric-overview/current-deliverables.md
@@ -1,0 +1,75 @@
+# Current deliverables — AgentFabric overview
+
+Status of the two members of this document pair, as of the last recorded
+regeneration.
+
+**Built from:** `jordanhubbard/mac` at `2976182`, 2026-08-30.
+
+## Members
+
+| Member | Local artifact | Published location | Publication authorized |
+| --- | --- | --- | --- |
+| Presentation | `docs/presentations/agentfabric-overview/agentfabric-overview.pptx` — 20 slides, speaker notes on every slide | none | no |
+| Narrative | `docs/presentations/agentfabric-overview/agentfabric-overview.docx` — 67 headings, six parts | none | no |
+
+Neither member has been published. There is no Google Slides or Google Docs
+resource for this package, and `publish_google_workspace.py` has no default
+destination: publishing requires `--slides-id` and `--authorized-by`, supplied by
+the repository owner. Do not record a published location here until a
+publication receipt exists in `_build/agentfabric-overview/publish-receipt.json`.
+
+## Generated artifacts
+
+Both members and all QA output are build products, reproduced by
+`regenerate.sh`, and are gitignored — the authoring package is the durable
+artifact. QA output lands in `_build/agentfabric-overview/`:
+
+| Artifact | Contents |
+| --- | --- |
+| `document-pair-manifest.json` | member paths, publication authorization state, package element map |
+| `acceptance.json` | slide count, notes coverage, narrative heading spine, pass/fail |
+| `rendered-slides/slide-01.png` … `slide-20.png` | 1280 × 720 renderings used for visual review |
+| `contact-sheet.png` | all 20 slides on one sheet |
+
+## Deck structure
+
+Marketing first, then mechanism, then limits.
+
+1. One control plane for a fleet of AI agents
+2. Ask once. The fabric carries it to production
+3. A chat window is not an operating model
+4. Four properties the fabric guarantees
+5. One request, end to end
+6. Part one — built on the stack, not instead of it
+7. Where AgentFabric leverages NVIDIA technology
+8. Where AgentFabric leverages open source
+9. What AgentFabric adds that nothing above provides
+10. The trust boundary, drawn explicitly
+11. Part two — actors, roles, and who is allowed to decide
+12. The cast, and the one authority each actor holds
+13. The life of one task
+14. Coordination is a town square, not a switchboard
+15. A heterogeneous fleet, modelled honestly
+16. Many models, one ordered route, one meter
+17. The fleet measures itself
+18. Scale of the implementation
+19. Stated honestly: implemented, decided, proposed
+20. Reuse the stack. Own the truth
+
+## Narrative structure
+
+Six parts, matching the deck's claim order: framing and the problem; what the
+system does; built on the stack (NVIDIA re-use, OSS re-use, what AgentFabric
+adds, the trust boundary); actors, lifecycle, coordination, fleet, models, and
+evidence; scope stated honestly; and how to adopt it.
+
+## Known limitations of this edition
+
+- Counts on slide 18 are surface area measured on the commit above. They must be
+  re-measured on regeneration, not carried forward.
+- Metering is described as recording at the router with pricing at read time.
+  Enforcement at the router is a proposal (ADR 0017) and the coverage gap is
+  quoted with its measurement window; see `source-notes.md`.
+- Slide rendering uses Liberation Sans or DejaVu Sans when Arial is unavailable,
+  so rendered PNG metrics are indicative rather than pixel-identical to
+  PowerPoint on macOS.

--- a/docs/presentations/agentfabric-overview/deck-specification.md
+++ b/docs/presentations/agentfabric-overview/deck-specification.md
@@ -1,0 +1,84 @@
+# Deck specification — AgentFabric overview
+
+This file is the presentation authority. `build_deck.py` realizes it; where the two
+disagree, this file is wrong or the builder is wrong, and one of them must change in the
+same commit. Factual claims trace to [source-notes.md](source-notes.md).
+
+## Audience and contract
+
+- Highly technical reader, new to AgentFabric **and** new to fleet-scale multi-agent /
+  multi-model orchestration. No prior product knowledge is assumed anywhere.
+- Marketing before mechanism: what the system does and why it matters comes first; the
+  machine comes second.
+- Technology re-use is the thesis. Every capability that already exists in NVIDIA or
+  open-source projects is named as an integration, not re-described as an invention. The
+  mechanisms AgentFabric genuinely adds get their own slide and are not diluted.
+- Visual first. A mechanism diagram beats a bullet list. Bullet lists appear only where
+  the list itself is the content: the NVIDIA project inventory (7) and the open-source
+  project inventory (8).
+- Speaker notes on every slide, stating the mechanism behind the claim and the limits of
+  the claim. The deck is forwarded without narration.
+- No invented ROI, productivity, or throughput numbers. No roadmap item presented as
+  shipped.
+
+## Visual system
+
+- 1280 × 720, 20 slides. Ink `#101317`, orange `#F5601A`, panel `#EDF0F2`, fog `#B9C0C8`.
+- Native shapes only: chevron flows, round-rect panels, chips, connectors, arrows. No
+  raster diagrams and no decorative hero images — the deck must remain editable and
+  legible after a Google Slides import.
+- Every slide carries a section tag pill, a headline, one supporting sentence, and a
+  bottom caption bar that states the takeaway in one line.
+- Section dividers (6, 11) are the only text-dominant slides.
+
+## Slides
+
+### Part 0 — what it does (1–5)
+
+| # | Title | Visual | Must say |
+| --- | --- | --- | --- |
+| 1 | One control plane for a fleet of AI agents. | hub-and-fleet topology | AgentFabric turns a conversation into durable work, dispatches it across a heterogeneous fleet of agents and models, and keeps the receipts. |
+| 2 | Ask once. The fabric carries it to production. | ASK → DURABLE TASK → LEASE + DISPATCH → EXECUTE → INDEPENDENT REVIEW → PUBLISH chevron flow, plus three consequence panels | Nothing is lost; nothing is blind; nothing self-approves. The unit of truth is a task in a ledger, not a message in a transcript. |
+| 3 | A chat window is not an operating model. | one-agent supervision diagram beside a forty-agent field with no system of record | The failure at fleet scale is structural — lost work, duplicated work, unattributed spend, no answer to "who approved this?" The failure field is illustrative, not a measured failure rate. |
+| 4 | Four properties the fabric guarantees. | four panels | Durable truth, honest heterogeneity, evidence by default, spend visibility. |
+| 5 | One request, end to end. | six-lane flow (human → gateway → hub → worker → reviewer → publish) with a "what gets written down" row beneath each hand-off | Every arrow crosses a boundary the control plane owns. The gateway owns conversation, personality, and memory and deliberately holds no operational authority. |
+
+### Part 1 — built on the stack (6–10)
+
+| # | Title | Visual | Must say |
+| --- | --- | --- | --- |
+| 6 | Built on the stack, not instead of it. | section divider | Isolation, observability, inference, containers, scheduling, and coding agents already exist and are maintained by people whose full-time job they are. |
+| 7 | Where AgentFabric leverages NVIDIA technology. | control-plane bar over four project columns | OpenShell → execution security (Landlock, seccomp, deny-by-default L7 egress, one guardrail authority). NeMo Relay → optional observability mapping. HGX → bounded, receipt-bearing elastic capacity. NemoClaw → compatibility and design reference for the conversational boundary, not the deployed implementation. |
+| 8 | Where AgentFabric leverages open source. | four labelled columns of project bullets | STATE: PostgreSQL, SQLite (local), versioned migrations. SERVICE: FastAPI, Uvicorn, Pydantic, httpx. EXECUTION: Docker Engine / Moby, Kubernetes, OpenClaw, Codex CLI · OpenCode. PROTOCOL: ACP, A2A agent cards, MCP, OCSF event streams. Every box is a dependency, not a fork. |
+| 9 | What AgentFabric adds that nothing above provides. | five numbered mechanism cards | Durable ledger, named gates, route ladder, evidence closure, break-glass. Agent output is a candidate; these five are how it earns the right to land. |
+| 10 | The trust boundary, drawn explicitly. | inside-the-sandbox panel beside a never-crosses panel | Owned and reaped process tree, allow-listed paths, syscall filter, declared egress, secrets as handles resolved at use. Never crosses: undeclared destinations, raw credential values, another project's repository, self-approval. |
+
+### Part 2 — actors and mechanism (11–19)
+
+| # | Title | Visual | Must say |
+| --- | --- | --- | --- |
+| 11 | Actors, roles, and who is allowed to decide. | section divider | Every actor holds exactly one kind of authority; no actor holds two that would let it grade its own work. |
+| 12 | The cast, and the one authority each actor holds. | eight actor cards | Requester, gateway agent, hub, dispatcher, worker, coding executor, reviewer agent, operator. |
+| 13 | The life of one task. | state flow with four numbered gates and a held/terminal chip row | A task is a state machine, not a status string. Gates: dependency, lease, evidence, acceptance. A failed task is a record, not a deletion. |
+| 14 | Coordination is a town square, not a switchboard. | broadcast bus with five participants and a lifecycle-verb row | Broadcast for intent and interruption; ledger for consequence. The bus is not the system of record. |
+| 15 | A heterogeneous fleet, modelled honestly. | dispatcher bar over four node classes | macOS host install, Linux node with containerized execution, Kubernetes, HGX session. Capability, egress, and secrets are declared per node and per task. |
+| 16 | Many models, one ordered route, one meter. | ordered route ladder plus metered/priced panels | The ladder decides who does the work; the meter records what it cost. Metered at the router, priced at read time, attribution gaps reported rather than hidden. |
+| 17 | The fleet measures itself. | evidence flow into per-task / per-step / per-release panels | Evidence indexes what happened; it does not by itself authorize a release. |
+| 18 | Scale of the implementation. | measured counts | Surface area, not maturity. Every figure is a count from the audited tree, recorded with its command in source-notes.md. |
+| 19 | Stated honestly: implemented, decided, proposed. | three-column ledger | The "decided, not yet runtime" column is mandatory. A deck that blurs the three is marketing. |
+
+### Close (20)
+
+| # | Title | Visual | Must say |
+| --- | --- | --- | --- |
+| 20 | Reuse the stack. Own the truth. | closing statement plus START / GROW / MEASURE adoption steps | One project and one real workload first. The fabric's value appears when a second agent has to trust the first one's output. |
+
+## Prohibitions
+
+- Do not describe NemoClaw as the deployed gateway implementation.
+- Do not describe the AgentBus as the system of record.
+- Do not present slide 18's counts as maturity, or carry them forward without
+  re-measuring.
+- Do not move an item from "decided" to "implemented" without an authority in
+  source-notes.md.
+- Do not add a slide whose only content is a headline over an image.

--- a/docs/presentations/agentfabric-overview/narrative-specification.md
+++ b/docs/presentations/agentfabric-overview/narrative-specification.md
@@ -1,0 +1,71 @@
+# Narrative specification — AgentFabric overview
+
+This file is the authority for the narrative member (`build_narrative.py` →
+`agentfabric-overview.docx`). The narrative is prose, not slide fragments: a reader who
+has only this document must be able to reconstruct how the system works. It carries the
+same claims as the deck at greater depth and must not diverge from it on a shared claim.
+Factual claims trace to [source-notes.md](source-notes.md).
+
+## Contract
+
+- Same audience as the deck: highly technical, new to AgentFabric and to fleet-scale
+  multi-agent / multi-model orchestration.
+- Same order as the deck: what it does, then what it re-uses and why, then actors and
+  mechanism.
+- Written in complete paragraphs. Lists are permitted only for the NVIDIA and open-source
+  project inventories.
+- Every mechanism claim names its authority in the control-plane tree (module, document,
+  or CLI surface).
+- Implemented, decided-but-not-yet-runtime, and proposed are kept distinct in wording, not
+  merely in one summary section.
+- No invented ROI, productivity, or throughput figures. Counts are surface area and carry
+  the command that produced them.
+
+## Structure
+
+Heading levels are meaningful: level 1 is a part, level 2 is a section, level 3 is a
+mechanism. No level may be skipped.
+
+1. **AgentFabric: one control plane for a fleet of AI agents** (L1)
+   - What problem this solves (L2) — conversation is ephemeral state; a fleet needs
+     durable state with ownership, ordering, and receipts.
+   - Who this document is for (L2) — and what it deliberately does not claim.
+2. **What the system does** (L1)
+   - Ask once, and the fabric carries it to production (L2) — the six-stage pipeline.
+   - The three consequences (L2) — nothing is lost, nothing is blind, nothing
+     self-approves.
+   - One request, end to end (L2) — the six boundaries and what is written down at each.
+3. **Built on the stack, not instead of it** (L1)
+   - Why re-use is the design position (L2).
+   - Where AgentFabric leverages NVIDIA technology (L2) — OpenShell (L3), NeMo Relay (L3),
+     HGX (L3), NemoClaw as reference rather than deployment (L3).
+   - Where AgentFabric leverages open source (L2) — state, service, execution, protocol
+     (one L3 each).
+   - What AgentFabric adds anyway (L2) — durable ledger, named gates, route ladder,
+     evidence closure, break-glass (one L3 each).
+   - The trust boundary (L2) — what runs inside the sandbox (L3), what never crosses (L3).
+4. **Actors, roles, and who is allowed to decide** (L1)
+   - The cast and its single-authority rule (L2), one L3 per actor.
+   - The life of one task (L2) — the state machine (L3), the four gates (L3), holds versus
+     states (L3), recovery of stranded and stalled work (L3).
+   - Coordination without a switchboard (L2) — broadcast for intent, ledger for
+     consequence (L3), operational learning as secret-free memory (L3).
+   - The fleet, modelled honestly (L2) — one L3 per node class.
+   - Models and money (L2) — the ordered route ladder (L3), metering at the router (L3),
+     pricing at read time (L3).
+   - Evidence (L2) — what is recorded per task, per step, and per release (L3); why an
+     index is not an authorization (L3).
+5. **Scope, honestly stated** (L1)
+   - Measured surface area (L2) — counts with their commands.
+   - Implemented (L2) / Decided, not yet runtime (L2) / Proposed (L2).
+6. **How to adopt it** (L1)
+   - Start with one project and one real workload (L2).
+   - Grow node classes and coding routes as work demands (L2).
+   - Measure before adding capacity (L2).
+
+## Prohibitions
+
+- Do not restate the deck's caption lines as the narrative's argument; the narrative owes
+  the reader the mechanism, not the slogan.
+- Do not describe the AgentBus as durable state, or evidence as release authority.
+- Do not promote a decided-but-unimplemented item into the implemented sections.

--- a/docs/presentations/agentfabric-overview/prompts/deck-authoring-prompt.md
+++ b/docs/presentations/agentfabric-overview/prompts/deck-authoring-prompt.md
@@ -1,0 +1,61 @@
+# Deck authoring prompt — AgentFabric overview
+
+Use this when asking a model to draft or revise slide content for this package.
+It encodes the constraints the specifications impose, so that a draft arrives in
+a form `build_deck.py` can implement without re-litigating the ground rules.
+
+## The brief
+
+You are writing for an audience that is highly technical and completely
+unfamiliar with both AgentFabric and the requirements of multi-agent,
+multi-model orchestration at fleet scale. Assume they can read a state machine
+and a trust boundary; assume they have never heard of this system, and do not
+assume they accept that orchestration needs a control plane at all — earn that.
+
+Order is marketing first, then mechanism:
+
+1. What the system does, in outcomes a reader can check.
+2. Why chat-only orchestration does not scale to a fleet.
+3. Where AgentFabric leverages NVIDIA technology, and where it leverages open
+   source — with the boundary each one owns.
+4. What AgentFabric adds that none of those provide.
+5. Who the actors are and which single authority each one holds.
+6. How one task lives, how agents coordinate, how the fleet and the models are
+   modelled, and what evidence is left behind.
+7. What is implemented, what is decided but not yet running, and what is
+   proposed.
+
+## Form constraints
+
+- Prefer a diagram or a flow to a bullet list. A slide that could be a flow and
+  is instead six bullets is a rejected draft.
+- Bullets are allowed for one purpose: naming high-profile NVIDIA or OSS
+  projects AgentFabric is built on. Name the project and the boundary it owns.
+- Every diagram must be expressible in native shapes: rectangles, rounded
+  rectangles, chevrons, chips, connectors, arrows, and text frames. If a visual
+  needs an illustration to work, it is the wrong visual.
+- Each slide carries: a claim as its title, one visual that proves it, and
+  speaker notes that give the mechanism plus any qualification.
+- Titles are sentences that assert something. "Coordination is a town square,
+  not a switchboard" is a title; "Coordination" is not.
+
+## Factual constraints
+
+- Every claim must exist in `source-notes.md` with an authority in the tree. If
+  a claim is not there, add it there first or drop it.
+- Re-use is stated as re-use: a dependency is named as a dependency, a design
+  reference as a reference. NemoClaw is a reference, not the deployed gateway.
+  Unbounded elastic capacity is a proposal, not a shipped capability.
+- Never blur status. An accepted decision whose implementation is deferred is
+  neither shipped nor proposed, and gets its own label.
+- No ROI, productivity, throughput, or maturity numbers. Counted figures carry
+  the command and date that produced them, and describe surface area only.
+- Do not overstate metering: route events record what the caller reported today;
+  enforcing metering at the router is a proposal, and the coverage gap is
+  published with its measurement window.
+
+## Output shape
+
+Return, per slide: the number, the title claim, the visual as a described
+layout, the text that appears inside the visual, and two or three speaker notes.
+Do not return prose paragraphs intended to be pasted onto a slide.

--- a/docs/presentations/agentfabric-overview/prompts/image-prompts.md
+++ b/docs/presentations/agentfabric-overview/prompts/image-prompts.md
@@ -1,0 +1,21 @@
+# Image prompts — intentionally empty
+
+This package generates no images, and there is no `assets/` directory.
+
+Every diagram in the AgentFabric overview deck is built from native PowerPoint
+shapes in `build_deck.py`: rounded rectangles, chevrons, chips, connectors,
+arrows, and text frames. That is a deliberate constraint rather than a
+limitation of the toolchain:
+
+- The deck survives a Google Slides import as an editable object graph, so a
+  reviewer can move a box or fix a label without regenerating an image.
+- A diagram that renders as text and shapes stays searchable, diffable in the
+  builder, and legible when projected badly.
+- A generated illustration cannot be traced to an authority in
+  `source-notes.md`, so it can only carry mood — and this deck earns attention
+  with mechanism instead.
+
+If a future slide genuinely needs a raster asset, add the prompt here, record
+why a native diagram could not carry the claim, and note the decision in
+`qa-ledger.md`. Do not add decorative hero imagery or image-only slides;
+`deck-specification.md` prohibits both.

--- a/docs/presentations/agentfabric-overview/publish_google_workspace.py
+++ b/docs/presentations/agentfabric-overview/publish_google_workspace.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Publish the AgentFabric overview pair to Google Workspace without persisting tokens.
+
+Obtains a bearer token with `gcloud auth print-access-token` immediately before
+use. The token stays in process memory and is never printed, logged, or written
+to a receipt. Updates an existing Slides resource in place and creates a Google
+Doc from the local .docx when no Doc ID is supplied.
+
+Publication is never implicit. The target Slides ID must be passed explicitly and
+`--authorized-by` must name the person who authorized this publication; there is
+no default destination, because a deck copied from another project must not be
+able to overwrite that project's published artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree
+
+HERE = Path(__file__).resolve().parent
+DOC_NAME = "AgentFabric — One Control Plane for a Fleet of AI Agents (narrative)"
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+SLIDES_GOOGLE = "application/vnd.google-apps.presentation"
+DOCS_GOOGLE = "application/vnd.google-apps.document"
+DRIVE = "https://www.googleapis.com/drive/v3"
+UPLOAD = "https://www.googleapis.com/upload/drive/v3"
+
+
+def _ssl() -> ssl.SSLContext:
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
+
+
+def _token() -> str:
+    result = subprocess.run(
+        ["gcloud", "auth", "print-access-token"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = (
+            result.stderr or result.stdout or "gcloud auth print-access-token failed"
+        ).strip()
+        raise SystemExit(message)
+    token = result.stdout.strip()
+    if not token or token.count(".") < 2 and not token.startswith("ya29."):
+        # Still accept opaque tokens; refuse empty.
+        if not token:
+            raise SystemExit("gcloud returned an empty access token")
+    return token
+
+
+def _request(
+    token: str,
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    data: bytes | None = None,
+    raw: bool = False,
+) -> tuple[int, dict[str, str], bytes]:
+    request_headers = {"Authorization": f"Bearer {token}"}
+    if headers:
+        request_headers.update(headers)
+    request = urllib.request.Request(url, data=data, method=method, headers=request_headers)
+    try:
+        with urllib.request.urlopen(request, context=_ssl()) as response:
+            body = response.read()
+            return response.status, dict(response.headers), body
+    except urllib.error.HTTPError as error:
+        detail = error.read()[:800]
+        raise SystemExit(
+            f"Drive API {method} {url.split('?', 1)[0]} failed: {error.code} {detail!r}"
+        ) from None
+
+
+def _json(token: str, method: str, url: str, payload: dict | None = None) -> dict:
+    data = None
+    headers = {}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json; charset=UTF-8"
+    status, _headers, body = _request(token, method, url, headers=headers, data=data)
+    if not body:
+        return {"http_status": status}
+    parsed = json.loads(body.decode("utf-8"))
+    parsed["http_status"] = status
+    return parsed
+
+
+def _resumable_update(token: str, file_id: str, path: Path, source_mime: str) -> dict:
+    meta_url = (
+        f"{UPLOAD}/files/{urllib.parse.quote(file_id)}?uploadType=resumable&supportsAllDrives=true"
+    )
+    start_headers = {
+        "Content-Type": "application/json; charset=UTF-8",
+        "X-Upload-Content-Type": source_mime,
+        "X-Upload-Content-Length": str(path.stat().st_size),
+    }
+    start_data = json.dumps({}).encode("utf-8")
+    _status, response_headers, _body = _request(
+        token, "PATCH", meta_url, headers=start_headers, data=start_data
+    )
+    location = response_headers.get("Location") or response_headers.get("location")
+    if not location:
+        raise SystemExit("Drive resumable update did not return a Location header")
+    media = path.read_bytes()
+    _status, _headers, body = _request(
+        token,
+        "PUT",
+        location,
+        headers={"Content-Type": source_mime, "Content-Length": str(len(media))},
+        data=media,
+    )
+    return json.loads(body.decode("utf-8")) if body else {}
+
+
+def _resumable_create(
+    token: str, *, name: str, parents: list[str], source_mime: str, google_mime: str, path: Path
+) -> dict:
+    meta_url = f"{UPLOAD}/files?uploadType=resumable&supportsAllDrives=true"
+    metadata = {"name": name, "mimeType": google_mime, "parents": parents}
+    start_headers = {
+        "Content-Type": "application/json; charset=UTF-8",
+        "X-Upload-Content-Type": source_mime,
+        "X-Upload-Content-Length": str(path.stat().st_size),
+    }
+    _status, response_headers, _body = _request(
+        token, "POST", meta_url, headers=start_headers, data=json.dumps(metadata).encode("utf-8")
+    )
+    location = response_headers.get("Location") or response_headers.get("location")
+    if not location:
+        raise SystemExit("Drive resumable create did not return a Location header")
+    media = path.read_bytes()
+    _status, _headers, body = _request(
+        token,
+        "PUT",
+        location,
+        headers={"Content-Type": source_mime, "Content-Length": str(len(media))},
+        data=media,
+    )
+    return json.loads(body.decode("utf-8")) if body else {}
+
+
+def _ensure_org_reader(token: str, file_id: str) -> dict:
+    listed = _json(
+        token,
+        "GET",
+        f"{DRIVE}/files/{urllib.parse.quote(file_id)}/permissions"
+        "?fields=permissions(id,type,domain,role,allowFileDiscovery)&supportsAllDrives=true",
+    )
+    permissions = listed.get("permissions") or []
+    already = any(
+        item.get("type") == "domain"
+        and item.get("domain") == "nvidia.com"
+        and item.get("role") == "reader"
+        for item in permissions
+        if isinstance(item, dict)
+    )
+    if not already:
+        _json(
+            token,
+            "POST",
+            f"{DRIVE}/files/{urllib.parse.quote(file_id)}/permissions?supportsAllDrives=true",
+            {
+                "type": "domain",
+                "domain": "nvidia.com",
+                "role": "reader",
+                "allowFileDiscovery": False,
+            },
+        )
+        listed = _json(
+            token,
+            "GET",
+            f"{DRIVE}/files/{urllib.parse.quote(file_id)}/permissions"
+            "?fields=permissions(id,type,domain,role,allowFileDiscovery)&supportsAllDrives=true",
+        )
+    public = [
+        {
+            "type": item.get("type"),
+            "domain": item.get("domain"),
+            "role": item.get("role"),
+            "allowFileDiscovery": item.get("allowFileDiscovery"),
+        }
+        for item in (listed.get("permissions") or [])
+        if isinstance(item, dict)
+    ]
+    return {"permissions": public}
+
+
+def _export(token: str, file_id: str, *, kind: str, dest: Path) -> int:
+    if kind == "pptx":
+        url = f"https://docs.google.com/presentation/d/{urllib.parse.quote(file_id)}/export/pptx"
+    elif kind == "docx":
+        url = f"{DRIVE}/files/{urllib.parse.quote(file_id)}/export?" + urllib.parse.urlencode(
+            {"mimeType": DOCX_MIME}
+        )
+    else:
+        raise SystemExit(f"unknown export kind {kind}")
+    _status, _headers, body = _request(token, "GET", url)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_bytes(body)
+    return len(body)
+
+
+def _pptx_pages(path: Path) -> tuple[int, int]:
+    with zipfile.ZipFile(path) as archive:
+        slides = [
+            name
+            for name in archive.namelist()
+            if name.startswith("ppt/slides/slide") and name.endswith(".xml")
+        ]
+        notes = [
+            name
+            for name in archive.namelist()
+            if name.startswith("ppt/notesSlides/notesSlide") and name.endswith(".xml")
+        ]
+    return len(slides), len(notes)
+
+
+def _docx_headings(path: Path) -> int:
+    with zipfile.ZipFile(path) as archive:
+        root = ElementTree.fromstring(archive.read("word/document.xml"))
+    w = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+    count = 0
+    for para in root.iter(f"{w}p"):
+        style = para.find(f"{w}pPr/{w}pStyle")
+        if style is not None:
+            value = style.attrib.get(f"{w}val", "")
+            if value.lower().startswith("heading"):
+                count += 1
+    return count
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--slides-id",
+        required=True,
+        help="Google Slides file to update in place; there is deliberately no default",
+    )
+    parser.add_argument(
+        "--authorized-by",
+        required=True,
+        help="who authorized this publication; recorded in the receipt",
+    )
+    parser.add_argument("--doc-id", default="", help="update this Google Doc in place when set")
+    parser.add_argument(
+        "--pptx",
+        default=str(HERE / "agentfabric-overview.pptx"),
+    )
+    parser.add_argument(
+        "--docx",
+        default=str(HERE / "agentfabric-overview.docx"),
+    )
+    args = parser.parse_args()
+    pptx = Path(args.pptx)
+    docx = Path(args.docx)
+    if not pptx.is_file() or not docx.is_file():
+        raise SystemExit("local PPTX and DOCX must both exist before publication")
+
+    token = _token()
+    slides_meta = _json(
+        token,
+        "GET",
+        f"{DRIVE}/files/{urllib.parse.quote(args.slides_id)}"
+        "?fields=id,name,mimeType,parents,version,capabilities/canEdit&supportsAllDrives=true",
+    )
+    if slides_meta.get("mimeType") != SLIDES_GOOGLE:
+        raise SystemExit(
+            f"slides resource is not a Google presentation: {slides_meta.get('mimeType')}"
+        )
+    if not (slides_meta.get("capabilities") or {}).get("canEdit"):
+        raise SystemExit("authenticated principal cannot edit the existing Slides resource")
+    parents = [str(item) for item in (slides_meta.get("parents") or []) if item]
+    if not parents:
+        raise SystemExit(
+            "existing Slides file has no parent folder; refusing to create an unrooted Doc"
+        )
+
+    updated_slides = _resumable_update(token, args.slides_id, pptx, PPTX_MIME)
+    slides_access = _ensure_org_reader(token, args.slides_id)
+
+    if args.doc_id:
+        updated_doc = _resumable_update(token, args.doc_id, docx, DOCX_MIME)
+        doc_id = args.doc_id
+        renamed = _json(
+            token,
+            "PATCH",
+            f"{DRIVE}/files/{urllib.parse.quote(doc_id)}?supportsAllDrives=true",
+            {"name": DOC_NAME},
+        )
+        if renamed.get("name"):
+            updated_doc["name"] = renamed["name"]
+    else:
+        updated_doc = _resumable_create(
+            token,
+            name=DOC_NAME,
+            parents=parents,
+            source_mime=DOCX_MIME,
+            google_mime=DOCS_GOOGLE,
+            path=docx,
+        )
+        doc_id = str(updated_doc.get("id") or "")
+        if not doc_id:
+            raise SystemExit("Drive create did not return a document id")
+    doc_access = _ensure_org_reader(token, doc_id)
+
+    export_root = HERE.parents[2] / "_build" / "agentfabric-overview"
+    exported_pptx = export_root / "published-export.pptx"
+    exported_docx = export_root / "published-export.docx"
+    pptx_bytes = _export(token, args.slides_id, kind="pptx", dest=exported_pptx)
+    docx_bytes = _export(token, doc_id, kind="docx", dest=exported_docx)
+    local_slides, local_notes = _pptx_pages(pptx)
+    exported_slides, exported_notes = _pptx_pages(exported_pptx)
+    local_headings = _docx_headings(docx)
+    exported_headings = _docx_headings(exported_docx)
+
+    receipt = {
+        "authorized_by": args.authorized_by,
+        "slides_id": args.slides_id,
+        "slides_url": f"https://docs.google.com/presentation/d/{args.slides_id}/edit",
+        "slides_version": updated_slides.get("version") or slides_meta.get("version"),
+        "slides_mime": updated_slides.get("mimeType") or SLIDES_GOOGLE,
+        "doc_id": doc_id,
+        "doc_url": f"https://docs.google.com/document/d/{doc_id}/edit",
+        "doc_name": updated_doc.get("name"),
+        "exported_pptx_bytes": pptx_bytes,
+        "exported_docx_bytes": docx_bytes,
+        "local_slides": local_slides,
+        "exported_slides": exported_slides,
+        "local_notes": local_notes,
+        "exported_notes": exported_notes,
+        "local_headings": local_headings,
+        "exported_headings": exported_headings,
+        "slides_access": slides_access,
+        "doc_access": doc_access,
+    }
+    receipt_path = export_root / "publish-receipt.json"
+    receipt_path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
+    json.dump(receipt, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    if exported_slides != local_slides or exported_notes != local_notes:
+        raise SystemExit("exported Slides page or notes count does not match the local PPTX")
+    if exported_headings < 1:
+        raise SystemExit("exported Google Doc has no headings")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/presentations/agentfabric-overview/qa-ledger.md
+++ b/docs/presentations/agentfabric-overview/qa-ledger.md
@@ -1,0 +1,83 @@
+# QA ledger — AgentFabric overview
+
+What was run, what it said. Append a dated entry per regeneration; do not edit
+past entries. An entry without a command and its output is not evidence.
+
+---
+
+## 2026-08-30 — initial AgentFabric edition
+
+Package created by adapting the Literate-AI `docs/presentations/` authoring
+package to AgentFabric, then replacing the deck, the narrative, and all
+specifications. Built against `jordanhubbard/mac` at `2976182`.
+
+### Build
+
+```
+docs/presentations/agentfabric-overview/regenerate.sh
+```
+
+- `build_deck.py` — `built 20 slides -> docs/presentations/agentfabric-overview/agentfabric-overview.pptx`
+- `build_narrative.py` — `built narrative -> docs/presentations/agentfabric-overview/agentfabric-overview.docx (67 headings)`
+- `render_slides.py` — 20 PNGs plus contact sheet, `no text-frame overlaps detected`
+- `verify_pair.py` — `pair verified: 20 slides, notes on all of them, 67 narrative headings`
+
+### Gates
+
+| Gate | Result |
+| --- | --- |
+| Slide count matches specification (20) | pass |
+| Speaker notes present on every slide (20/20) | pass |
+| Text-frame overlap detection | pass — none detected |
+| Narrative heading spine, no skipped levels | pass — 67 headings, 0 skips |
+| Manifest claims no unauthorized publication | pass — both members `publication_authorized: false`, `published_location: null` |
+| Stale-source references (`literate`, `litai`, `component://`, case-insensitive) | pass — the only remaining matches are the provenance notes in this ledger |
+| Native diagrams only, no `assets/` directory | pass — package contains no images |
+| No invented ROI / productivity / throughput figures | pass — reviewed slide-by-slide against `source-notes.md` |
+| `make lint` (ruff check + format --check) | pass for this package (14 files, check clean, format clean). The repository-wide run also reports 15 pre-existing unformatted files under `tests/`, none of them touched here |
+| `scripts/run-contract-tests.sh` | documentation contract and environment registry pass; 11,136 tests pass, 44 fail. All 44 are the merge-queue / git-publication families the runner itself warns about on a host with git 2.34.1 (`git merge-tree` requires ≥ 2.38); unrelated to this package, which adds no runtime code paths |
+| `scripts/test-docs.py` fence contract | pass — `console` fences only under `docs/`; a `bash` fence in `SKILL.md` was rejected and changed |
+| `scripts/generate-docs-reference.py --write` | regenerated; `docs/reference/documentation-inventory.md` now lists the nine package documents |
+
+### Defects found and fixed during this pass
+
+1. **Slide 13 overlap.** The terminal/held chip row collided with the
+   `ALSO TERMINAL OR HELD:` label. Chips were shifted right and narrowed; the
+   re-render reports no overlaps.
+2. **Linux font fallback missing.** `render_slides.py` only searched macOS font
+   paths and silently fell back to PIL's bitmap default, producing an unreadable
+   contact sheet. Liberation Sans and DejaVu Sans paths were added.
+3. **Slide 18 counts were inherited, not measured.** The copied deck's figures
+   (219 modules, 430 routes, 125 CLI verbs) did not match the tree. Re-measured
+   to 221 modules, 435 routes, 458 CLI leaf commands, 12 task states; commands
+   recorded in `source-notes.md`.
+4. **Metering was overstated.** The deck claimed every model call is metered at
+   the router and listed router-side metering as implemented. ADR 0017 is
+   *Proposed* and quantifies a 29.5 per cent unmetered fraction over the seven
+   days to 2026-08-19. Slides 4, 16, and 19 now say route events are recorded and
+   priced at read time, with enforcement listed as proposed and the coverage gap
+   quoted with its window.
+5. **Named gates were overstated.** Slide 9's claim now carries a speaker note
+   distinguishing the implemented review gate (ADR 0011, Accepted) from the
+   general contract (ADR 0022, Proposed).
+6. **Publisher pointed at another project's deck.** `publish_google_workspace.py`
+   defaulted to the Literate-AI Slides ID and named the Literate-AI narrative.
+   The default was removed; `--slides-id` and `--authorized-by` are now required.
+7. **Regeneration referenced a missing verifier.** Both regenerate scripts called
+   `scripts/verify_document_pair.py` and a `components/literate-ai-overview/`
+   component file, neither of which exists in this repository. Replaced with the
+   package-local `verify_pair.py`; the unused Codex `build_deck.mjs` fallback path
+   was removed.
+
+### Visual review
+
+Contact sheet inspected at `_build/agentfabric-overview/contact-sheet.png`.
+Confirmed: marketing-first opening, NVIDIA and OSS re-use inventories, unique
+mechanisms, trust boundary, actor roles, task lifecycle, AgentBus coordination,
+heterogeneous fleet, route ladder, evidence flow, honest status columns, adoption
+close. No slide is bullets-only except the two deliberate project inventories.
+
+### Publication
+
+Not published, not authorized. No Google Slides or Docs resource exists for this
+package.

--- a/docs/presentations/agentfabric-overview/regenerate.sh
+++ b/docs/presentations/agentfabric-overview/regenerate.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Entry point for regenerating the AgentFabric overview pair. Everything is built
+# by the pinned python-pptx / python-docx toolchain; generated artifacts land in
+# this directory and QA output lands in the ignored OBJ_DIR.
+
+source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(git -C "$source_dir" rev-parse --show-toplevel)"
+obj_dir="${OBJ_DIR:-$repo_dir/_build}"
+
+exec env OBJ_DIR="$obj_dir" "$source_dir/regenerate_python.sh" "$@"

--- a/docs/presentations/agentfabric-overview/regenerate_python.sh
+++ b/docs/presentations/agentfabric-overview/regenerate_python.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(git -C "$source_dir" rev-parse --show-toplevel)"
+obj_dir="${OBJ_DIR:-$repo_dir/_build}"
+check_only=0
+if [[ "${1:-}" == "--check" ]]; then
+  check_only=1
+fi
+
+python_bin=""
+for candidate in \
+  "$obj_dir/doc-toolchain/bin/python3" \
+  "$obj_dir/doc-toolchain/bin/python" \
+  "$obj_dir/doc-toolchain/Scripts/python.exe"
+do
+  if [[ -x "$candidate" ]]; then
+    python_bin="$candidate"
+    break
+  fi
+done
+if [[ -z "$python_bin" && -x "$repo_dir/.venv/bin/python3" ]]; then
+  python_bin="$repo_dir/.venv/bin/python3"
+fi
+if [[ -z "$python_bin" ]]; then
+  python_bin="python3"
+fi
+
+if ! "$python_bin" -c "import pptx, docx, PIL, lxml" >/dev/null 2>&1; then
+  echo "Authoring toolchain is not importable for ${python_bin}." >&2
+  echo "Install python-pptx, python-docx, lxml, and Pillow into a virtualenv and point" >&2
+  echo "OBJ_DIR/doc-toolchain (or .venv) at it; this script will not pip-install for you." >&2
+  exit 2
+fi
+
+if [[ "$check_only" -eq 1 ]]; then
+  printf '%s\n' "$python_bin"
+  exit 0
+fi
+
+build_dir="$obj_dir/agentfabric-overview"
+mkdir -p "$build_dir"
+
+(
+  cd "$source_dir"
+  AGENTFABRIC_DECK_SOURCE="$source_dir" \
+  AGENTFABRIC_REPO="$repo_dir" \
+  OBJ_DIR="$obj_dir" \
+  "$python_bin" build_deck.py
+  AGENTFABRIC_DECK_SOURCE="$source_dir" \
+  AGENTFABRIC_REPO="$repo_dir" \
+  OBJ_DIR="$obj_dir" \
+  "$python_bin" build_narrative.py
+  if [[ "${AGENTFABRIC_DECK_SKIP_RENDER:-}" != "1" ]]; then
+    AGENTFABRIC_DECK_SOURCE="$source_dir" \
+    AGENTFABRIC_REPO="$repo_dir" \
+    OBJ_DIR="$obj_dir" \
+    "$python_bin" render_slides.py
+  fi
+)
+
+pptx="${AGENTFABRIC_DECK_OUTPUT:-$source_dir/agentfabric-overview.pptx}"
+docx="${AGENTFABRIC_NARRATIVE_OUTPUT:-$source_dir/agentfabric-overview.docx}"
+echo "PPTX: $pptx"
+echo "DOCX: $docx"
+
+AGENTFABRIC_DECK_SOURCE="$source_dir" \
+AGENTFABRIC_REPO="$repo_dir" \
+OBJ_DIR="$obj_dir" \
+"$python_bin" "$source_dir/verify_pair.py"
+echo "Acceptance report: $build_dir/acceptance.json"

--- a/docs/presentations/agentfabric-overview/render_slides.py
+++ b/docs/presentations/agentfabric-overview/render_slides.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Rasterize the overview PPTX with Pillow for visual QA.
+
+LibreOffice is not required. This is a layout inspection aid: it draws fills, strokes,
+images, and text from python-pptx shapes. It is not a pixel-identical PowerPoint
+renderer. Output lives under ignored _build/.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE, MSO_SHAPE_TYPE
+
+HERE = Path(__file__).resolve().parent
+SOURCE = Path(os.environ.get("AGENTFABRIC_DECK_SOURCE", str(HERE)))
+REPO = Path(os.environ.get("AGENTFABRIC_REPO", str(SOURCE.parents[2])))
+PPTX = Path(os.environ.get("AGENTFABRIC_DECK_OUTPUT") or (SOURCE / "agentfabric-overview.pptx"))
+OUT_DIR = Path(os.environ.get("OBJ_DIR") or (REPO / "_build")) / "agentfabric-overview"
+EMU_PER_PX = 9525
+W, H = 1280, 720
+COLS = 5
+
+
+def _px(value) -> int:
+    return int(round(int(value) / EMU_PER_PX))
+
+
+def _rgb(color) -> tuple[int, int, int] | None:
+    if color is None:
+        return None
+    try:
+        return (int(color[0]), int(color[1]), int(color[2]))
+    except (TypeError, IndexError, ValueError):
+        return None
+
+
+def _fill_rgba(shape) -> tuple[int, int, int, int] | None:
+    fill = getattr(shape, "fill", None)
+    if fill is None:
+        return None
+    try:
+        ftype = fill.type
+    except (ValueError, AttributeError):
+        return None
+    if ftype is None:
+        return None
+    try:
+        fore = fill.fore_color.rgb
+    except (AttributeError, TypeError, ValueError):
+        return None
+    rgb = _rgb(fore)
+    if rgb is None:
+        return None
+    alpha = 255
+    try:
+        srgb = fill.fore_color._xFill.find(
+            "{http://schemas.openxmlformats.org/drawingml/2006/main}srgbClr"
+        )
+        if srgb is not None:
+            node = srgb.find("{http://schemas.openxmlformats.org/drawingml/2006/main}alpha")
+            if node is not None:
+                alpha = round(int(node.get("val", "100000")) / 100000 * 255)
+    except (AttributeError, TypeError, ValueError):
+        pass
+    return (*rgb, alpha)
+
+
+def _line_rgb(shape) -> tuple[int, int, int] | None:
+    line = getattr(shape, "line", None)
+    if line is None:
+        return None
+    try:
+        return _rgb(line.color.rgb)
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _font(size_pt: float, bold: bool) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    size = max(8, int(round(size_pt * 96 / 72)))
+    candidates = [
+        "/System/Library/Fonts/Supplemental/Arial Bold.ttf"
+        if bold
+        else "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/System/Library/Fonts/Supplemental/Courier New Bold.ttf"
+        if bold
+        else "/System/Library/Fonts/Supplemental/Courier New.ttf",
+        "/Library/Fonts/Arial.ttf",
+        "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf"
+        if bold
+        else "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
+        if bold
+        else "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    ]
+    for path in candidates:
+        if Path(path).is_file():
+            try:
+                return ImageFont.truetype(path, size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def _wrap(draw: ImageDraw.ImageDraw, text: str, font, max_width: int) -> list[str]:
+    lines: list[str] = []
+    for paragraph in text.split("\n"):
+        if not paragraph:
+            lines.append("")
+            continue
+        words = paragraph.split(" ")
+        current = ""
+        for word in words:
+            trial = word if not current else f"{current} {word}"
+            if draw.textlength(trial, font=font) <= max_width or not current:
+                current = trial
+            else:
+                lines.append(current)
+                current = word
+        lines.append(current)
+    return lines or [""]
+
+
+def _draw_shape(base: Image.Image, shape) -> None:
+    overlay = Image.new("RGBA", base.size, (0, 0, 0, 0))
+    draw = ImageDraw.Draw(overlay)
+    x, y = _px(shape.left), _px(shape.top)
+    w, h = max(1, _px(shape.width)), max(1, _px(shape.height))
+    box = [x, y, x + w, y + h]
+    fill = _fill_rgba(shape)
+    stroke = _line_rgb(shape)
+    outline = stroke
+    if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+        from io import BytesIO
+
+        picture = Image.open(BytesIO(shape.image.blob)).convert("RGBA")
+        picture = picture.resize((w, h), Image.Resampling.LANCZOS)
+        overlay.paste(picture, (x, y), picture)
+        base.alpha_composite(overlay)
+        return
+    if fill:
+        auto = getattr(shape, "auto_shape_type", None)
+        if auto == MSO_SHAPE.OVAL:
+            draw.ellipse(box, fill=fill, outline=outline)
+        elif auto == MSO_SHAPE.CHEVRON:
+            pts = [
+                (x, y),
+                (x + w - max(6, w // 4), y),
+                (x + w, y + h // 2),
+                (x + w - max(6, w // 4), y + h),
+                (x, y + h),
+                (x + max(6, w // 4), y + h // 2),
+            ]
+            draw.polygon(pts, fill=fill, outline=outline)
+        elif auto == MSO_SHAPE.ROUNDED_RECTANGLE:
+            radius = max(2, min(w, h) // 8)
+            draw.rounded_rectangle(box, radius=radius, fill=fill, outline=outline)
+        else:
+            draw.rectangle(box, fill=fill, outline=outline)
+    base.alpha_composite(overlay)
+    if shape.has_text_frame:
+        _draw_text(base, shape, x, y, w, h)
+
+
+def _draw_text(base: Image.Image, shape, x: int, y: int, w: int, h: int) -> None:
+    draw = ImageDraw.Draw(base)
+    cursor_y = y
+    for paragraph in shape.text_frame.paragraphs:
+        runs = list(paragraph.runs)
+        raw = paragraph.text
+        if not raw and not runs:
+            continue
+        size = 14.0
+        bold = False
+        color = (16, 19, 23, 255)
+        if runs:
+            font_size = runs[0].font.size
+            if font_size is not None:
+                size = font_size.pt
+            bold = bool(runs[0].font.bold)
+            try:
+                rgb = _rgb(runs[0].font.color.rgb)
+                if rgb:
+                    color = (*rgb, 255)
+            except (AttributeError, TypeError, ValueError):
+                pass
+        font = _font(size, bold)
+        lines = _wrap(draw, raw, font, max(8, w - 4))
+        align = str(getattr(paragraph, "alignment", "") or "")
+        for line in lines:
+            if cursor_y > y + h:
+                break
+            width = draw.textlength(line, font=font) if line else 0
+            tx = x
+            if "CENTER" in align:
+                tx = x + max(0, (w - int(width)) // 2)
+            elif "RIGHT" in align:
+                tx = x + max(0, w - int(width))
+            draw.text((tx, cursor_y), line, font=font, fill=color)
+            cursor_y += int(size * 96 / 72) + 2
+
+
+def text_box_overlaps(slide, page: int) -> list[str]:
+    """Report pairs of text-bearing shapes whose frames overlap.
+
+    Geometry-escape only checks the slide edge. Painted overflow and colliding
+    titles are a separate defect; this is a layout-inspection aid, not an oracle.
+    """
+    boxes: list[tuple[str, int, int, int, int]] = []
+    for shape in slide.shapes:
+        if not getattr(shape, "has_text_frame", False):
+            continue
+        raw = (shape.text_frame.text or "").strip()
+        if not raw:
+            continue
+        x, y, w, h = _px(shape.left), _px(shape.top), _px(shape.width), _px(shape.height)
+        boxes.append((raw.splitlines()[0][:40], x, y, x + w, y + h))
+    hits: list[str] = []
+    for i, (a, ax0, ay0, ax1, ay1) in enumerate(boxes):
+        for b, bx0, by0, bx1, by1 in boxes[i + 1 :]:
+            if ax0 < bx1 - 4 and bx0 < ax1 - 4 and ay0 < by1 - 4 and by0 < ay1 - 4:
+                hits.append(f"slide {page}: {a!r} overlaps {b!r}")
+    return hits
+
+
+def render_slide(slide) -> Image.Image:
+    canvas = Image.new("RGBA", (W, H), (255, 255, 255, 255))
+    for shape in slide.shapes:
+        try:
+            _draw_shape(canvas, shape)
+        except Exception:
+            continue
+    return canvas.convert("RGB")
+
+
+def contact_sheet(images: list[Image.Image]) -> Image.Image:
+    thumb_w, thumb_h = 240, 135
+    rows = (len(images) + COLS - 1) // COLS
+    sheet = Image.new("RGB", (COLS * thumb_w, rows * thumb_h), (238, 241, 243))
+    for index, image in enumerate(images):
+        thumb = image.resize((thumb_w, thumb_h), Image.Resampling.LANCZOS)
+        col, row = index % COLS, index // COLS
+        sheet.paste(thumb, (col * thumb_w, row * thumb_h))
+    return sheet
+
+
+def main() -> None:
+    if not PPTX.is_file():
+        raise SystemExit(f"missing presentation: {PPTX}")
+    presentation = Presentation(str(PPTX))
+    slides_dir = OUT_DIR / "rendered-slides"
+    slides_dir.mkdir(parents=True, exist_ok=True)
+    rendered: list[Image.Image] = []
+    overlap_hits: list[str] = []
+    for index, slide in enumerate(presentation.slides, start=1):
+        overlap_hits.extend(text_box_overlaps(slide, index))
+        image = render_slide(slide)
+        rendered.append(image)
+        path = slides_dir / f"slide-{index:02d}.png"
+        image.save(path, "PNG")
+        print(f"rendered {path}")
+    sheet = contact_sheet(rendered)
+    sheet_path = OUT_DIR / "contact-sheet.png"
+    sheet.save(sheet_path, "PNG")
+    print(f"contact sheet {sheet_path}")
+    if overlap_hits:
+        print(f"{len(overlap_hits)} text-frame overlap(s):")
+        for hit in overlap_hits:
+            print(f"  {hit}")
+    else:
+        print("no text-frame overlaps detected")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/presentations/agentfabric-overview/source-notes.md
+++ b/docs/presentations/agentfabric-overview/source-notes.md
@@ -1,0 +1,144 @@
+# Source notes — AgentFabric overview
+
+This is the factual ledger for both members of this package. Every claim in the deck and
+the narrative must appear here with an authority inside the control-plane tree, and every
+counted figure must carry the command that produced it and the date it was measured.
+
+If a claim is not in this file, it does not belong in the deck.
+
+**Audited tree:** `jordanhubbard/mac` at `2976182`, measured 2026-08-30.
+
+## Identity and framing
+
+| Claim | Authority | Status |
+| --- | --- | --- |
+| AgentFabric is a multi-agent coordinator control plane that owns durable operational truth; human-facing runtimes own conversation, personality, memory, and messaging gateways | `README.md`, `docs/authority-boundary.md` | implemented |
+| The control plane owns tasks, leases, routing, reviews, evidence, secret handles, runtime manifests, rollout state, and audit trails | `README.md`, `src/mac/models.py`, `src/mac/task_lifecycle.py` | implemented |
+| The gateway (conversational runtime) holds no operational authority | `docs/hermes-boundary.md`, `docs/authority-boundary.md` | implemented |
+
+"AgentFabric" is the presentation name for this control plane; the repository, CLI, and
+modules use `mac`. The deck never claims the two are different systems.
+
+## NVIDIA technology re-use (slide 7)
+
+| Project | Role in AgentFabric | Authority |
+| --- | --- | --- |
+| NVIDIA OpenShell | execution security: Landlock filesystem policy, seccomp syscall filter, deny-by-default L7 egress, sandbox lifecycle, normalized action events. One guardrail authority, not two competing ones. | `src/mac/openshell_service.py`, `src/mac/executor_sandbox.py`, `src/mac/sandbox_egress.py`, `src/mac/openshell_collector.py`, `docs/openshell-sandbox.md`, ADR 0008 (Accepted) |
+| NVIDIA NeMo Relay | optional observability: request, task, tool, and model activity mapped into Relay scopes, enabled through the `relay` packaging extra (`nemo-relay==0.3.0`) | `src/mac/relay_observability.py`, `pyproject.toml` (`[project.optional-dependencies] relay`), `docs/openshell-nemo-relay-integration.md`, `docs/openshell-nemo-relay-e2e.md` |
+| NVIDIA HGX | bounded elastic provider-session capacity; onboarding is an explicit operator action with a durable receipt | `docs/hgx-elastic-capacity.md`, `AGENTS.md` (`hgx list` / `hgx ssh` transport), ADR 0005 (Proposed — the elastic tier beyond the operator-driven path is a proposal) |
+| NVIDIA NemoClaw | compatibility and design reference for the conversational agent boundary; **not** the deployed gateway implementation | `README.md`, `docs/hermes-boundary.md` |
+
+The deck must state the HGX and NemoClaw qualifications. Presenting NemoClaw as the
+deployed gateway, or unbounded elastic capacity as shipped, is a factual error.
+
+## Open-source re-use (slide 8)
+
+| Group | Projects | Authority |
+| --- | --- | --- |
+| State | PostgreSQL (fleet authority), SQLite (local development), versioned migrations | `CLAUDE.md` ("the test suite runs against PostgreSQL, not SQLite, because that is what the fleet runs"), `src/mac/schema_migrations.py`, ADR 0021 (Proposed — the migration *policy* is proposed; versioned migrations exist) |
+| Service | FastAPI, Uvicorn, Pydantic, httpx | `pyproject.toml`, `src/mac/api.py`, `src/mac/http_routes/` |
+| Execution | Docker Engine / Moby, Kubernetes, OpenClaw, OpenAI Codex CLI, OpenCode | ADR 0008 (Accepted), `src/mac/k8s/runner.py`, `src/mac/coding_agent.py`, `docs/openclaw-identities.md` |
+| Protocol | ACP, A2A agent cards, MCP, OCSF event streams | `src/mac/acp/protocol.py`, `src/mac/a2a/card.py`, `src/mac/mcp_server.py`, `src/mac/openshell_collector.py`, ADR 0006 (Proposed — ACP *support scope*) |
+
+Every entry is a dependency, not a fork. The MCP server and the Python client are clients
+of the same HTTP surface rather than parallel implementations (`src/mac/mcp_server.py`).
+
+## Mechanisms AgentFabric adds (slide 9)
+
+| Mechanism | Authority | Status |
+| --- | --- | --- |
+| Durable task ledger: a task is a state machine with an owner, a lease, dependencies, and history | `src/mac/models.py` (`TaskState`), `src/mac/task_lifecycle.py`, `docs/task-dependency-semantics.md`, ADR 0004 (Accepted) | implemented |
+| Named gate decisions rather than booleans, so refusals are explainable | ADR 0022 (Proposed as a general contract), `docs/adr/0011-hub-review-verification-scope.md` (Accepted) for the review gate | review gate implemented; the general contract is a proposal |
+| Ordered, capability-filtered coding-route ladder | `src/mac/coding_agent.py` (`AGENT_PRIORITY`), `docs/coding-route-ladder.md` | implemented |
+| Evidence closure: build, test, review, and publication artifacts kept as pointers with the task | `AGENTS.md` (`mac.worker_evidence.v1` manifest), `src/mac/observability_service.py` | implemented |
+| Break-glass: recovery is a granted, listable, revocable, reason-bearing authorization | `mac task break-glass` / `break-glass-list` / `break-glass-revoke`, `docs/break-glass-host-recovery.md` | implemented |
+
+The route ladder order is `("opencode", "pi", "claude", "codex", "cursor")` —
+`src/mac/coding_agent.py:111`. opencode is first for credential durability, not model
+quality; the module comment states this. Do not present the order as a quality ranking.
+
+## Containment (slide 10)
+
+| Claim | Authority |
+| --- | --- |
+| Agent process tree is owned and reaped; syscall filter applied; never runs as root | `src/mac/executor_sandbox.py`, `src/mac/worker.py`, `docs/openshell-sandbox.md` |
+| Read-only and read-write paths are allow-listed via Landlock | `src/mac/openshell_service.py`, `src/mac/executor_sandbox.py` |
+| Egress is deny-by-default with declared hosts per project and per task | `src/mac/sandbox_egress.py` |
+| Secrets are handles resolved at use and never printed | `docs/secrets-management-guide.md` |
+| An agent never accepts its own work | `docs/adr/0011-hub-review-verification-scope.md`, `docs/authority-boundary.md` |
+
+"Never self-approves" is an authority boundary enforced by the control plane, not a
+sandbox control. The deck says so.
+
+## Actors, lifecycle, coordination, fleet (slides 12–15)
+
+| Claim | Authority |
+| --- | --- |
+| Eight actors, one authority each: requester, gateway agent, hub, dispatcher, worker, coding executor, reviewer agent, operator | `docs/authority-boundary.md`, `src/mac/services.py`, `src/mac/worker.py` |
+| 12 task states | `src/mac/models.py` (`TaskState`): open, waiting, blocked, claimed, running, needs_review, needs_input, stopped, reviewing, completed, failed, cancelled |
+| Terminal states are completed, failed, cancelled | `src/mac/models.py` (`TERMINAL_TASK_STATES`) |
+| A hold is a flag (`metadata.no_dispatch=true`), not a state; `mac task release` removes the key | `AGENTS.md`, `src/mac/task_lifecycle.py` |
+| Leases are time-bounded and recoverable; recovery verbs exist for stranded and stalled work | `src/mac/task_lifecycle.py`, `AGENTS.md` |
+| AgentBus is a broadcast medium with lifecycle verbs (stand down, abort, pause, resume, status); the ledger, not the bus, is the system of record | `src/mac/agentbus_service.py`, `src/mac/agentbus_control.py`, `src/mac/agentbus_broadcast.py`, ADR 0026 (Proposed — *first-class operations emit bus events*) |
+| Operational learning is recorded as secret-free memories that bias future routing | `AGENTS.md` ("Fleet Operational Learning"), `docs/fleet-operational-learning.md` |
+| macOS nodes are host installs by decision | ADR 0015 (Accepted), `docs/adr/0015-macos-nodes-are-host-installs.md` |
+| Docker Engine / Moby is the only container runtime | ADR 0008 (Accepted) |
+| Kubernetes dispatch folds claim, launch, and stuck-Job reconciliation into one orchestrator | `src/mac/k8s/runner.py` |
+| HGX sessions are onboarded by explicit operator action with a durable receipt | `docs/hgx-elastic-capacity.md`, `AGENTS.md` |
+| Fleet targets resolve from `~/.mac/fleets.yaml`, which is the source of truth | `AGENTS.md` ("Fleet Host Resolution") |
+
+## Models and money (slide 16)
+
+| Claim | Authority | Status |
+| --- | --- | --- |
+| One route event per model call, carrying input, output, and streaming state, attributed to task, project, or agent | `src/mac/observability_service.py` (`llm.route` events), ADR 0017 | implemented |
+| Cost is priced at read time against a models catalog, so a price-table change re-values history | `estimate_route_cost()` in `src/mac/scientific_optimizer.py`, `src/mac/models_catalog.py` | implemented |
+| Metering **enforced** at the router rather than trusted from the caller | ADR 0017 (**Proposed**) | proposed |
+| Coverage gaps are measured, not averaged away | ADR 0017 quantifies them: over the seven days to 2026-08-19, on 28,352 `llm.route` events, 8,352 routes (29.5%) recorded `input_tokens = null`, 5,948 were flagged `stream_no_usage`, and 2,474 routes were attributed to nothing | measured, dated |
+
+Any spend figure quoted from this package must carry its measurement date. The deck must
+not say "every model call is metered at the router" — today the router captures what the
+caller reported, and the gap is quantified above.
+
+## Measured surface area (slide 18)
+
+Counts describe surface area, not maturity. Re-measure on every regeneration; do not carry
+these forward.
+
+| Figure | Value | Command (repository root, `2976182`, 2026-08-30) |
+| --- | --- | --- |
+| control-plane modules | 221 | `ls src/mac/*.py \| wc -l` |
+| HTTP route declarations | 435 | `grep -rhoE "@(app\|router)\.(get\|post\|put\|patch\|delete)\(" src/mac \| wc -l` |
+| CLI leaf commands | 458 | walk `mac.cli.build_parser()` and count parsers with no subparser map |
+| top-level CLI groups | 4 objects (`project`, `task`, `agent`, `admin`) plus `help` | `mac.cli.build_parser()` subparser map |
+| task states | 12 | `TaskState` in `src/mac/models.py` |
+| coding routes on the ladder | 5 | `AGENT_PRIORITY` in `src/mac/coding_agent.py` |
+| dispatch targets | 2 (fleet nodes, Kubernetes) | `src/mac/k8s/runner.py` plus the fleet dispatcher path |
+
+## Implemented / decided / proposed (slide 19)
+
+Placement is taken from each ADR's own status line.
+
+| Column | Item | Authority |
+| --- | --- | --- |
+| Implemented | durable ledger, leases, recovery | ADR 0004 (Accepted), `src/mac/task_lifecycle.py` |
+| Implemented | sandboxed execution and egress policy | ADR 0008 (Accepted), `src/mac/sandbox_egress.py` |
+| Implemented | independent review gates | ADR 0011 (Accepted) |
+| Implemented | route events, priced at read time | `src/mac/observability_service.py`, `estimate_route_cost()` |
+| Decided, not yet runtime | agent-initiated review scope | ADR 0016 (Accepted 2026-08-20) |
+| Decided, not yet runtime | native steward plus containerized execution on Linux | ADR 0012 (**Accepted; implementation deferred pending fleet measurement**) |
+| Proposed | metering enforced at the router | ADR 0017 (Proposed) |
+| Proposed | route-search-path contract | ADR 0029 (Proposed) |
+| Proposed | task view as a graph | ADR 0018 (Proposed) |
+| Proposed | retrieval and extraction pipeline | ADR 0030 (Proposed) |
+
+## Prohibited claims
+
+- No ROI, productivity, or throughput percentages. None are measured, so none may appear.
+- The forty-agent failure field on slide 3 is illustrative of failure classes, not a
+  measured failure rate.
+- Evidence indexes what happened; it does not authorize a release. Acceptance and
+  publication remain explicit decisions by an authorized actor.
+- The AgentBus is not the system of record.
+- No claim that the full fleet matrix has been qualified; node classes are configuration
+  evidence, not qualification evidence.

--- a/docs/presentations/agentfabric-overview/verify_pair.py
+++ b/docs/presentations/agentfabric-overview/verify_pair.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Verify the AgentFabric overview document pair before it is shown to anyone.
+
+Checks the two generated members against the invariants the specifications
+require: the deck's slide count, speaker notes on every slide, a heading spine in
+the narrative with no skipped levels, and a document-pair manifest that does not
+claim publication authorization it does not have.
+
+Exits non-zero with the failing invariant named. Writes an acceptance record to
+$OBJ_DIR/agentfabric-overview/acceptance.json.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree
+
+HERE = Path(__file__).resolve().parent
+SOURCE = Path(os.environ.get("AGENTFABRIC_DECK_SOURCE", str(HERE)))
+REPO = Path(os.environ.get("AGENTFABRIC_REPO", str(SOURCE.parents[2])))
+OBJ = Path(os.environ.get("OBJ_DIR") or (REPO / "_build"))
+PPTX = Path(os.environ.get("AGENTFABRIC_DECK_OUTPUT") or (SOURCE / "agentfabric-overview.pptx"))
+DOCX = Path(
+    os.environ.get("AGENTFABRIC_NARRATIVE_OUTPUT") or (SOURCE / "agentfabric-overview.docx")
+)
+MANIFEST = OBJ / "agentfabric-overview" / "document-pair-manifest.json"
+
+EXPECTED_SLIDES = 20
+W = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+A = "{http://schemas.openxmlformats.org/drawingml/2006/main}"
+
+
+def _deck_counts(path: Path) -> tuple[int, int, int]:
+    with zipfile.ZipFile(path) as archive:
+        slides = sorted(
+            name
+            for name in archive.namelist()
+            if name.startswith("ppt/slides/slide") and name.endswith(".xml")
+        )
+        notes = sorted(
+            name
+            for name in archive.namelist()
+            if name.startswith("ppt/notesSlides/notesSlide") and name.endswith(".xml")
+        )
+        with_text = 0
+        for name in notes:
+            root = ElementTree.fromstring(archive.read(name))
+            if any((node.text or "").strip() for node in root.iter(f"{A}t")):
+                with_text += 1
+    return len(slides), len(notes), with_text
+
+
+def _narrative_headings(path: Path) -> tuple[int, list[str]]:
+    with zipfile.ZipFile(path) as archive:
+        root = ElementTree.fromstring(archive.read("word/document.xml"))
+    levels: list[int] = []
+    texts: list[str] = []
+    for para in root.iter(f"{W}p"):
+        style = para.find(f"{W}pPr/{W}pStyle")
+        if style is None:
+            continue
+        value = style.attrib.get(f"{W}val", "").lower()
+        if not value.startswith("heading"):
+            continue
+        digits = "".join(ch for ch in value if ch.isdigit())
+        if not digits:
+            continue
+        levels.append(int(digits))
+        texts.append("".join(node.text or "" for node in para.iter(f"{W}t")))
+    skipped = [
+        texts[index] for index in range(1, len(levels)) if levels[index] > levels[index - 1] + 1
+    ]
+    return len(levels), skipped
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in (PPTX, DOCX, MANIFEST):
+        if not path.is_file():
+            failures.append(f"missing artifact: {path}")
+    if failures:
+        for failure in failures:
+            print(f"FAIL {failure}", file=sys.stderr)
+        return 1
+
+    slides, notes, notes_with_text = _deck_counts(PPTX)
+    headings, skipped = _narrative_headings(DOCX)
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    members = manifest.get("members", {})
+
+    if slides != EXPECTED_SLIDES:
+        failures.append(f"deck has {slides} slides, specification requires {EXPECTED_SLIDES}")
+    if notes_with_text != slides:
+        failures.append(f"{slides - notes_with_text} slide(s) carry no speaker notes")
+    if headings < 40:
+        failures.append(f"narrative has only {headings} headings; the spine looks truncated")
+    if skipped:
+        failures.append(f"narrative skips heading levels at: {skipped[:3]}")
+    for name, member in members.items():
+        if member.get("publication_authorized") and not member.get("published_location"):
+            failures.append(f"{name} claims publication authorization with no published location")
+
+    record = {
+        "deck": {"slides": slides, "notes_slides": notes, "notes_with_text": notes_with_text},
+        "narrative": {"headings": headings, "skipped_levels": skipped},
+        "manifest": str(MANIFEST),
+        "passed": not failures,
+        "failures": failures,
+    }
+    out = OBJ / "agentfabric-overview" / "acceptance.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+    for failure in failures:
+        print(f"FAIL {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    print(
+        f"pair verified: {slides} slides, notes on all of them, "
+        f"{headings} narrative headings -> {out}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/reference/documentation-inventory.md
+++ b/docs/reference/documentation-inventory.md
@@ -194,6 +194,15 @@ marked `historical archive` and must not be read as current behaviour.
 | supplemental reference | [`openshell-nemo-relay-e2e.md`](../openshell-nemo-relay-e2e.md) | OpenShell + NeMo Relay: container-contract verification |
 | supplemental reference | [`openshell-nemo-relay-integration.md`](../openshell-nemo-relay-integration.md) | OpenShell + NeMo Relay integration |
 | supplemental reference | [`openshell-sandbox.md`](../openshell-sandbox.md) | Running Hermes under the OpenShell sandbox |
+| supplemental reference | [`presentations/agentfabric-overview/README.md`](../presentations/agentfabric-overview/README.md) | AgentFabric overview — authoring package |
+| supplemental reference | [`presentations/agentfabric-overview/SKILL.md`](../presentations/agentfabric-overview/SKILL.md) | AgentFabric overview presentation |
+| supplemental reference | [`presentations/agentfabric-overview/current-deliverables.md`](../presentations/agentfabric-overview/current-deliverables.md) | Current deliverables — AgentFabric overview |
+| supplemental reference | [`presentations/agentfabric-overview/deck-specification.md`](../presentations/agentfabric-overview/deck-specification.md) | Deck specification — AgentFabric overview |
+| supplemental reference | [`presentations/agentfabric-overview/narrative-specification.md`](../presentations/agentfabric-overview/narrative-specification.md) | Narrative specification — AgentFabric overview |
+| supplemental reference | [`presentations/agentfabric-overview/prompts/deck-authoring-prompt.md`](../presentations/agentfabric-overview/prompts/deck-authoring-prompt.md) | Deck authoring prompt — AgentFabric overview |
+| supplemental reference | [`presentations/agentfabric-overview/prompts/image-prompts.md`](../presentations/agentfabric-overview/prompts/image-prompts.md) | Image prompts — intentionally empty |
+| supplemental reference | [`presentations/agentfabric-overview/qa-ledger.md`](../presentations/agentfabric-overview/qa-ledger.md) | QA ledger — AgentFabric overview |
+| supplemental reference | [`presentations/agentfabric-overview/source-notes.md`](../presentations/agentfabric-overview/source-notes.md) | Source notes — AgentFabric overview |
 | runbook | [`production-deployment.md`](../production-deployment.md) | Production Deployment |
 | generated reference | [`reference/cli.md`](../reference/cli.md) | Command-line reference |
 | generated reference | [`reference/documentation-inventory.md`](../reference/documentation-inventory.md) | Documentation inventory |


### PR DESCRIPTION
Adapts the Literate-AI presentation-authoring boilerplate into an AgentFabric document pair: a 20-slide marketing-first deck and a prose narrative, both generated from pinned python-pptx / python-docx builders with native editable diagrams, speaker notes on every slide, and a pair verifier.

Claims are sourced from the control-plane tree; implemented, decided-but-not-yet- runtime, and proposed capabilities are kept distinct (notably: route usage is recorded at the router and priced at read time, while router-enforced metering remains proposed).