### PR TITLE
Provision a test database in run-sanity-tests.sh before the impact-map check

### DIFF
--- a/scripts/run-sanity-tests.sh
+++ b/scripts/run-sanity-tests.sh
@@ -14,6 +14,25 @@ if [ -z "${PY:-}" ]; then
     exit 2
 fi
 
+# Provision a test database before anything collects tests. The impact-map
+# check below runs `pytest --collect-only`, whose collection imports tests
+# calling test_dsn(); with no MAC_TEST_PG_URL they raise
+# TestPostgresUnavailable, collection returns zero node ids, and the check
+# fails before the exec below ever reaches run-contract-tests.sh, where
+# provisioning used to live only. Seen 2026-08-30: a task sandbox failed the
+# repository gate 0.5s in with "returned no node ids" regardless of its code.
+# The DSN survives the handoff: run-contract-tests.sh re-captures
+# MAC_TEST_PG_URL before its hermetic MAC_* sweep, so this also covers the
+# suite. Same helper contract as run-contract-tests.sh: an already-set DSN
+# wins, the helper finds a running server, a container engine, or installed
+# binaries, and says so on stderr when it cannot.
+if [ -z "${MAC_TEST_PG_URL:-}" ]; then
+    _pg_helper="$(dirname "$0")/start-test-postgres.sh"
+    if [ -x "$_pg_helper" ] && _pg_dsn=$("$_pg_helper"); then
+        eval "$_pg_dsn"
+    fi
+fi
+
 # Selection consults the committed impact map. A stale interned node id is a
 # pytest usage error (exit 4), not a test failure, so regeneration is a
 # prerequisite of this script -- the same shape as test-schema-migrations

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -13624,6 +13624,7 @@
     "retired": false,
     "sources": [
       "scripts/run-contract-tests.sh",
+      "scripts/run-sanity-tests.sh",
       "scripts/start-test-postgres.sh",
       "src/mac/services.py",
       "src/mac/test_support.py"


### PR DESCRIPTION
Task task_603f3016. The executor's preferred pre-push gate (run-sanity-tests.sh + test-policy.toml) runs `build-test-impact-map.py --check` before exec'ing run-contract-tests.sh. Collection imports tests calling test_dsn() (src/mac/test_support.py:48); with no MAC_TEST_PG_URL they raise TestPostgresUnavailable, collection yields zero node ids, and the gate dies in 0.5s with repository_test_failed regardless of code correctness. Seen live: task_5fcb6ff9 attempt 1 on agent_bullwinkle.

Fix: provision with the same start-test-postgres.sh helper contract run-contract-tests.sh uses (an already-set DSN wins). The exported DSN survives the handoff because run-contract-tests.sh re-captures MAC_TEST_PG_URL before its hermetic MAC_* sweep, so one provisioning covers both the check and the suite.

Verified: with MAC_TEST_PG_URL unset on a clean worktree, the impact-map check completes and the fail-fast preflight passes; env_config_registry.json regenerated for the new source reference.