### PR TITLE
Label failed-run coverage as partial

### DIFF
--- a/scripts/coverage-policy.py
+++ b/scripts/coverage-policy.py
@@ -202,6 +202,14 @@ def main(argv: list[str] | None = None) -> int:
         "--changed-lines",
         help="diff mode: JSON file mapping source path -> [line numbers] (overrides --base)",
     )
+    parser.add_argument(
+        "--partial",
+        action="store_true",
+        help=(
+            "label an incomplete measurement and skip floor enforcement; "
+            "the caller's test failure remains authoritative"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -217,6 +225,8 @@ def main(argv: list[str] | None = None) -> int:
             result = evaluate_diff(coverage_doc, policy_doc, changed)
         else:
             result = evaluate(coverage_doc, policy_doc)
+        if args.partial:
+            result["partial"] = True
     except (
         OSError,
         KeyError,
@@ -233,24 +243,28 @@ def main(argv: list[str] | None = None) -> int:
     elif result.get("mode") == "diff":
         statement = result["statements"]
         print(
-            "diff coverage safety: statements "
+            ("partial diff coverage (tests failed): " if args.partial else "diff coverage safety: ")
+            + "statements "
             f"{statement['covered']}/{statement['relevant']} changed lines "
             f"({statement['percent']:.2f}%, floor {statement['safety_floor']:.2f}%); "
             f"uncovered branches on changed lines: {result['branches']['uncovered_on_changed_lines']}"
         )
-        for failure in result["failures"]:
-            print(f"coverage-policy: {failure}", file=sys.stderr)
+        if not args.partial:
+            for failure in result["failures"]:
+                print(f"coverage-policy: {failure}", file=sys.stderr)
     else:
         statement = result["statements"]
         branch = result["branches"]
         print(
-            "coverage safety: statements "
+            ("partial coverage (tests failed): " if args.partial else "coverage safety: ")
+            + "statements "
             f"{statement['covered']}/{statement['total']} ({statement['percent']:.2f}%, floor {statement['safety_floor']:.2f}%); "
             f"branches {branch['covered']}/{branch['total']} ({branch['percent']:.2f}%, floor {branch['safety_floor']:.2f}%)"
         )
-        for failure in result["failures"]:
-            print(f"coverage-policy: {failure}", file=sys.stderr)
-    return 0 if result["status"] == "pass" else 1
+        if not args.partial:
+            for failure in result["failures"]:
+                print(f"coverage-policy: {failure}", file=sys.stderr)
+    return 0 if args.partial or result["status"] == "pass" else 1
 
 
 if __name__ == "__main__":

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -743,7 +743,15 @@ PYCAP
     fi
     if [ "$combine_status" -eq 0 ] && [ "$json_status" -eq 0 ]; then
         "$PY" -m coverage report || report_status=$?
-        "$PY" scripts/coverage-policy.py --coverage-json "$coverage_json" || policy_status=$?
+        coverage_policy_args=""
+        if [ "$pytest_status" -ne 0 ]; then
+            coverage_policy_args="--partial"
+        fi
+        # A failed pytest phase leaves an incomplete measurement (and can
+        # suppress the serial phase). Label it as partial; pytest_status below
+        # remains the gate result rather than a misleading coverage failure.
+        "$PY" scripts/coverage-policy.py --coverage-json "$coverage_json" \
+            $coverage_policy_args || policy_status=$?
     fi
     if [ -s "$coverage_json" ]; then
         coverage_publish="coverage.json.tmp.$$"

--- a/tests/test_coverage_policy.py
+++ b/tests/test_coverage_policy.py
@@ -179,6 +179,26 @@ def test_main_fail_exit_one(policy_mod, tmp_path, capsys):
     assert "statement coverage" in captured.err
 
 
+def test_main_partial_labels_measurement_and_skips_floor_failure(policy_mod, tmp_path, capsys):
+    coverage_path, policy_path = _write_inputs(
+        tmp_path, _coverage_doc(covered_lines=10), _policy_doc()
+    )
+    code = policy_mod.main(
+        [
+            "--coverage-json",
+            str(coverage_path),
+            "--policy",
+            str(policy_path),
+            "--partial",
+        ]
+    )
+    assert code == 0
+    captured = capsys.readouterr()
+    assert captured.out.startswith("partial coverage (tests failed): statements 10/100")
+    assert "coverage safety:" not in captured.out
+    assert captured.err == ""
+
+
 def test_main_json_output(policy_mod, tmp_path, capsys):
     coverage_path, policy_path = _write_inputs(tmp_path, _coverage_doc(), _policy_doc())
     code = policy_mod.main(


### PR DESCRIPTION
Task task_877b8d14. When pytest fails, the resulting coverage is incomplete (including suppression of the serial phase), but the gate previously printed an authoritative-looking `coverage safety:` line and evaluated floors before exiting with pytest_status. This labels the measurement `partial coverage (tests failed)`, suppresses floor diagnostics for that incomplete measurement, and leaves pytest_status authoritative. Complete runs remain byte-for-byte unchanged.\n\nVerification: `eval "$(scripts/start-test-postgres.sh)" && .venv/bin/pytest -q tests/test_contract_test_runner.py tests/test_coverage_policy.py` (54 passed).