### PR TITLE
Make the contract gate fail fast without git >= 2.38

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -120,6 +120,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_CONTINUITY_MIN_SCORE` | str | consumer-defined | core | Core setting: continuity min score. |
 | `MAC_CONTINUITY_TOKEN_BUDGET` | str | consumer-defined | core | Core setting: continuity token budget. |
 | `MAC_CONTRACT_DESCRIPTION` | str | consumer-defined | core | Core setting: contract description. |
+| `MAC_CONTRACT_GIT` | str | consumer-defined | core | Core setting: contract git. |
 | `MAC_CONTRACT_MARKER` | str | consumer-defined | core | Core setting: contract marker. |
 | `MAC_CONTRACT_RUNTIME_VENV` | str | consumer-defined | core | Core setting: contract runtime venv. |
 | `MAC_CONTRACT_SNAPSHOT` | str | consumer-defined | core | Core setting: contract snapshot. |

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -82,6 +82,16 @@ _MAC_CONTRACT_RUNTIME_VENV_REQUESTED="${MAC_CONTRACT_RUNTIME_VENV:-}"
 # unset", pointing at the CI provisioning step rather than at this line.
 _MAC_TEST_PG_URL_REQUESTED="${MAC_TEST_PG_URL:-}"
 _MAC_COVERAGE_DIR=""
+# The merge-gate suite and the production merge queue both call
+# `git merge-tree --write-tree`, which only exists in git >= 2.38. Resolve
+# a usable git the same way the interpreter is resolved below: honour an
+# explicit override and a task-local toolchain bin dir, and capture both
+# BEFORE the hermetic MAC_* sweep unsets every MAC_-prefixed var (exactly
+# like _MAC_CONTRACT_RUNTIME_VENV_REQUESTED). MAC_CONTRACT_GIT names a git
+# binary directly; MAC_TOOLCHAIN_BIN is a task-local bin dir whose ./git is
+# preferred over the ambient PATH git. Empty/unset => the PATH git.
+_MAC_CONTRACT_GIT_REQUESTED="${MAC_CONTRACT_GIT:-}"
+_MAC_TOOLCHAIN_BIN_REQUESTED="${MAC_TOOLCHAIN_BIN:-}"
 
 # Fleet executors inherit deployment/task environment. Keep repository tests
 # hermetic so they exercise the checked-out code, not the live agent runtime.
@@ -175,18 +185,79 @@ git config --global --add safe.directory '*' >/dev/null 2>&1 || true
 
 # The merge-gate suite (and the production merge queue) uses
 # `git merge-tree --write-tree`, added in git 2.38. On an older git the
-# git-publication/merge-queue tests fail with an opaque rc=129 — lead the log
-# with the actual cause so a fleet host running distro git (e.g. 2.34 on the
-# GKE pod image) is diagnosable from the first line of the failure output.
-_git_ver="$(git version 2>/dev/null | sed -E 's/^git version ([0-9]+)\.([0-9]+).*/\1 \2/')"
-if [ -n "${_git_ver}" ]; then
-    _git_major="${_git_ver%% *}"
-    _git_minor="${_git_ver#* }"
-    if [ "${_git_major:-0}" -lt 2 ] || { [ "${_git_major:-0}" -eq 2 ] && [ "${_git_minor:-0}" -lt 38 ]; }; then
-        echo "run-contract-tests.sh: WARNING: $(git version) < 2.38 —" \
-             "merge-gate tests (and the production merge queue) WILL fail;" \
-             "upgrade git on this host" >&2
+# git-publication/merge-queue tests fail with an opaque rc=129, so a fleet host
+# running distro git (e.g. 2.34 on the Ubuntu-22.04 / GKE pod image) used to
+# burn a whole gate run and report a misleading generic test failure. Resolve a
+# usable git the same way the interpreter is resolved below — prefer an explicit
+# override, then a task-local toolchain bin dir, then the ambient PATH git — and
+# FAIL FAST with a distinct, classified status BEFORE paying for the full suite
+# when none is >= 2.38. Existing hosts that already ship git >= 2.38 keep the
+# byte-identical fast path (the resolved git's own dir is re-exported onto PATH
+# so every test subprocess sees exactly the git resolved here).
+_MAC_GIT_REQUIRED_MAJOR=2
+_MAC_GIT_REQUIRED_MINOR=38
+# Exit status reserved for the git-toolchain prerequisite: distinct from the
+# interpreter/pytest statuses so the dispatcher can classify it as environment
+# at the source instead of inferring it from a truncated log.
+_MAC_GIT_PREREQ_EXIT=3
+# Print "MAJOR MINOR" for the given git binary, or nothing if it cannot report.
+_git_ver_of() {
+    "$1" version 2>/dev/null | sed -E 's/^git version ([0-9]+)\.([0-9]+).*/\1 \2/'
+}
+# 0 if the given git binary reports >= the required floor, non-zero otherwise.
+_git_meets_floor() {
+    _gmf_ver="$(_git_ver_of "$1")"
+    [ -n "${_gmf_ver}" ] || return 1
+    _gmf_major="${_gmf_ver%% *}"
+    _gmf_minor="${_gmf_ver#* }"
+    if [ "${_gmf_major:-0}" -lt "$_MAC_GIT_REQUIRED_MAJOR" ]; then
+        return 1
     fi
+    if [ "${_gmf_major:-0}" -eq "$_MAC_GIT_REQUIRED_MAJOR" ] \
+        && [ "${_gmf_minor:-0}" -lt "$_MAC_GIT_REQUIRED_MINOR" ]; then
+        return 1
+    fi
+    return 0
+}
+# Resolve the candidate git in override precedence order. An explicit
+# MAC_CONTRACT_GIT names the binary directly; MAC_TOOLCHAIN_BIN supplies a
+# task-local bin dir whose ./git is preferred over the ambient PATH git; the
+# PATH git is the default.
+_mac_git=""
+if [ -n "$_MAC_CONTRACT_GIT_REQUESTED" ] && [ -x "$_MAC_CONTRACT_GIT_REQUESTED" ]; then
+    _mac_git="$_MAC_CONTRACT_GIT_REQUESTED"
+elif [ -n "$_MAC_TOOLCHAIN_BIN_REQUESTED" ] && [ -x "$_MAC_TOOLCHAIN_BIN_REQUESTED/git" ]; then
+    _mac_git="$_MAC_TOOLCHAIN_BIN_REQUESTED/git"
+else
+    _mac_git="$(command -v git || true)"
+fi
+# If the preferred override is present but too old, still consider whether the
+# ambient PATH git satisfies the floor — the override is a hint, not a downgrade.
+if [ -n "$_mac_git" ] && ! _git_meets_floor "$_mac_git"; then
+    _mac_path_git="$(command -v git || true)"
+    if [ -n "$_mac_path_git" ] && [ "$_mac_path_git" != "$_mac_git" ] \
+        && _git_meets_floor "$_mac_path_git"; then
+        _mac_git="$_mac_path_git"
+    fi
+fi
+if [ -z "$_mac_git" ] || ! _git_meets_floor "$_mac_git"; then
+    # Report the full version string (patch level included) so the diagnostic
+    # names exactly the git that was found, e.g. "2.34.1" on Ubuntu-22.04.
+    _mac_git_found="$("${_mac_git:-git}" version 2>/dev/null | sed -E 's/^git version //')"
+    [ -n "$_mac_git_found" ] || _mac_git_found="none"
+    echo "run-contract-tests.sh: FATAL: git ${_mac_git_found} < ${_MAC_GIT_REQUIRED_MAJOR}.${_MAC_GIT_REQUIRED_MINOR} required for merge-gate tests and the production merge queue; provide a modern git via MAC_CONTRACT_GIT=/path/to/git or MAC_TOOLCHAIN_BIN=<dir with ./git> (this gate will NOT run the suite on an unusable git)" >&2
+    exit "$_MAC_GIT_PREREQ_EXIT"
+fi
+# Export the resolved git's directory at the FRONT of PATH so every test
+# subprocess resolves the same git this gate validated. Only prepend when the
+# resolved git is NOT already the one the ambient PATH resolves to: on a host
+# whose PATH git already satisfies the floor (no override in play) PATH is left
+# byte-identical; when an override/toolchain git was chosen it is pushed to the
+# front so subprocesses see it instead of the older PATH git.
+_mac_git_dir="$(CDPATH= cd -- "$(dirname -- "$_mac_git")" && pwd)"
+if [ "$_mac_git" != "$(command -v git || true)" ]; then
+    PATH="${_mac_git_dir}:${PATH}"
+    export PATH
 fi
 
 # Resolve a usable interpreter instead of assuming a repo-local .venv. Local

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -1412,6 +1412,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: contract git.",
+    "family": "core",
+    "name": "MAC_CONTRACT_GIT",
+    "retired": false,
+    "sources": [
+      "scripts/run-contract-tests.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: contract marker.",
     "family": "core",
     "name": "MAC_CONTRACT_MARKER",
@@ -13793,6 +13804,7 @@
     "name": "MAC_TOOLCHAIN_BIN",
     "retired": false,
     "sources": [
+      "scripts/run-contract-tests.sh",
       "src/mac/executor_sandbox.py"
     ],
     "type": "str"

--- a/tests/test_contract_test_runner.py
+++ b/tests/test_contract_test_runner.py
@@ -881,3 +881,167 @@ def test_contract_runner_nested_invocation_never_checkpoints(tmp_path):
     assert completed.returncode == 0
     assert _checkpoint_calls(calls, "plan") == []
     assert _checkpoint_calls(calls, "record") == []
+
+
+# --- Environment-prerequisite git-toolchain resolution (merge-gate floor) ---
+#
+# The merge-gate suite and the production merge queue call
+# `git merge-tree --write-tree`, which only exists in git >= 2.38. On a host
+# whose only git is older (2.34.1 is stock Ubuntu-22.04 / the GKE pod image) the
+# runner must NOT warn-and-run — it must resolve a modern git from an explicit
+# override (MAC_CONTRACT_GIT) or a task-local toolchain bin dir
+# (MAC_TOOLCHAIN_BIN) and, failing that, fail fast with a distinct, actionable
+# status BEFORE paying for the whole suite. These tests stage a FAKE git on
+# PATH the same way the module stages a fake python3 — never a real downgrade.
+
+
+def _fake_git_body(version: str) -> str:
+    """A git stub that reports ``version`` for ``git version`` and otherwise
+    behaves as a no-op success. It never shells out to a real git, so it cannot
+    perform a real downgrade of the host toolchain."""
+    return (
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        f"  version|--version) printf 'git version {version}\\n' ; exit 0 ;;\n"
+        "esac\n"
+        # config/init calls the runner makes on the hermetic HOME must succeed.
+        "exit 0\n"
+    )
+
+
+def _stage_git_runner(
+    tmp_path: Path,
+    *,
+    path_git_version: str | None,
+    override_git_version: str | None = None,
+    toolchain_git_version: str | None = None,
+    use_toolchain_env: bool = False,
+) -> tuple[Path, dict[str, str], Path]:
+    """Stage a throwaway repo running the REAL runner with a fake git on PATH
+    (and, optionally, an override/toolchain git) plus a fake python3 so the gate
+    can proceed past interpreter resolution when git resolves. Returns the repo,
+    the env, and the python-call log path."""
+    repo = tmp_path / "repo"
+    (repo / "scripts").mkdir(parents=True)
+    (repo / "pyproject.toml").write_text("[project]\nname='fake'\n", encoding="utf-8")
+    (repo / "scripts" / "run-contract-tests.sh").write_text(
+        RUNNER.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    (repo / "scripts" / "run-contract-tests.sh").chmod(0o755)
+
+    path_bin = tmp_path / "pathbin"
+    path_bin.mkdir()
+    log_path = tmp_path / "python.log"
+    # A python3 that both passes _py_can_run_suite and runs the gate to green,
+    # and logs its pytest phases so we can assert the suite actually ran.
+    _write_exec(
+        path_bin / "python3",
+        "#!/bin/sh\n"
+        'printf \'%s\\n\' "$*" >> "$FAKE_PY_LOG"\n' + _GOOD_PY_BODY.split("\n", 1)[1],
+    )
+    if path_git_version is not None:
+        _write_exec(path_bin / "git", _fake_git_body(path_git_version))
+
+    env = {
+        "PATH": f"{path_bin}:/usr/bin:/bin",
+        "HOME": str(tmp_path / "home"),
+        "MAC_CONTRACT_RUNTIME_VENV": str(tmp_path / "nonexistent-runtime-venv"),
+        "FAKE_PY_LOG": str(log_path),
+    }
+    (tmp_path / "home").mkdir()
+
+    if override_git_version is not None:
+        override_git = tmp_path / "override" / "git"
+        _write_exec(override_git, _fake_git_body(override_git_version))
+        env["MAC_CONTRACT_GIT"] = str(override_git)
+    if toolchain_git_version is not None:
+        toolchain_bin = tmp_path / "toolchain"
+        _write_exec(toolchain_bin / "git", _fake_git_body(toolchain_git_version))
+        if use_toolchain_env:
+            env["MAC_TOOLCHAIN_BIN"] = str(toolchain_bin)
+
+    for marker in (
+        "PYTEST_CURRENT_TEST",
+        "PYTEST_XDIST_WORKER",
+        "PYTEST_XDIST_WORKER_COUNT",
+        "PYTEST_XDIST_TESTRUNUID",
+    ):
+        env.pop(marker, None)
+    return repo, env, log_path
+
+
+def _run_git_runner(repo: Path, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(repo / "scripts" / "run-contract-tests.sh")],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_contract_runner_resolves_override_git_over_older_path_git(tmp_path):
+    """MAC_CONTRACT_GIT (a modern git) must win over an older PATH git: the gate
+    resolves it, does NOT fail fast, and runs the suite. The old PATH git alone
+    would have failed the merge-gate floor."""
+    repo, env, log_path = _stage_git_runner(
+        tmp_path, path_git_version="2.34.1", override_git_version="2.42.0"
+    )
+    completed = _run_git_runner(repo, env)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "FATAL: git" not in completed.stderr
+    calls = log_path.read_text(encoding="utf-8").splitlines() if log_path.exists() else []
+    assert any("-m pytest" in c or "-m coverage run -m pytest" in c for c in calls), (
+        "the suite must run once a modern git is resolved: " + completed.stderr
+    )
+
+
+def test_contract_runner_resolves_toolchain_bin_git_over_older_path_git(tmp_path):
+    """MAC_TOOLCHAIN_BIN/git (a modern git captured before the MAC_* sweep) must
+    be preferred over an older PATH git and let the gate proceed."""
+    repo, env, log_path = _stage_git_runner(
+        tmp_path,
+        path_git_version="2.34.1",
+        toolchain_git_version="2.39.5",
+        use_toolchain_env=True,
+    )
+    completed = _run_git_runner(repo, env)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "FATAL: git" not in completed.stderr
+    calls = log_path.read_text(encoding="utf-8").splitlines() if log_path.exists() else []
+    assert any("-m pytest" in c or "-m coverage run -m pytest" in c for c in calls)
+
+
+def test_contract_runner_fails_fast_when_only_old_git_present(tmp_path):
+    """With only git 2.34.1 on PATH and no override, the gate must exit non-zero
+    with a distinct status and a single first-line diagnostic naming the found
+    version, the required version, and the override — BEFORE any pytest phase."""
+    repo, env, log_path = _stage_git_runner(tmp_path, path_git_version="2.34.1")
+    completed = _run_git_runner(repo, env)
+
+    assert completed.returncode == 3, completed.stdout + completed.stderr
+    first_line = completed.stderr.splitlines()[0]
+    assert "FATAL" in first_line
+    assert "2.34.1" in first_line
+    assert "2.38" in first_line
+    assert "MAC_CONTRACT_GIT" in first_line
+    # The full suite must NOT have started: no python pytest phase was logged.
+    calls = log_path.read_text(encoding="utf-8").splitlines() if log_path.exists() else []
+    assert not any("-m pytest" in c for c in calls), (
+        "fail-fast must abort before the suite runs: " + "\n".join(calls)
+    )
+
+
+def test_contract_runner_modern_path_git_runs_without_fail_fast(tmp_path):
+    """A host that already ships git >= 2.38 keeps the unchanged fast path: the
+    gate proceeds to the suite and emits no git-prerequisite diagnostic."""
+    repo, env, log_path = _stage_git_runner(tmp_path, path_git_version="2.39.5")
+    completed = _run_git_runner(repo, env)
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert "FATAL: git" not in completed.stderr
+    calls = log_path.read_text(encoding="utf-8").splitlines() if log_path.exists() else []
+    assert any("-m pytest" in c or "-m coverage run -m pytest" in c for c in calls)


### PR DESCRIPTION
Task task_5fcb6ff9. Salvages agent_bullwinkle's preserved WIP from attempt 1 after attempt 2 started from the new base and incorrectly concluded there were no changes. Resolves a git >=2.38 executable via MAC_CONTRACT_GIT or the task-local toolchain bin captured before the hermetic MAC_* sweep; exports it on PATH; and exits 3 with an actionable environment-prerequisite diagnostic before pytest when none exists. Adds focused modern-git, override, task-local toolchain, and old-git regression coverage.\n\nVerification: `eval "$(scripts/start-test-postgres.sh)" && .venv/bin/pytest -q tests/test_contract_test_runner.py` (34 passed).