### PR TITLE
Declare and provision git >= 2.38 for fleet worker/runner hosts so the authoritative gate stops running distro git 2.34.1 (task_7d2049429ec8496c8bd98e470302f78b)

### DIFF
--- a/.mac/project.yaml
+++ b/.mac/project.yaml
@@ -20,6 +20,17 @@ toolchain:
     - initdb
     - pg_ctl
     - postgres
+  # Minimum versions for commands whose FLOOR is load-bearing, not just their
+  # presence. The merge-gate suite and the production merge queue both call
+  # `git merge-tree --write-tree`, which only exists in git >= 2.38; on Ubuntu
+  # 22.04 distro git (2.34.1) the merge-queue/publication tests fail with an
+  # opaque rc=129 and a whole authoritative gate run is burned on a misleading
+  # generic failure. scripts/run-contract-tests.sh fails fast on an older git,
+  # but that is a runner-side backstop -- this floor is where the requirement is
+  # DECLARED so every provisioning asset that installs git can be checked
+  # against it (see tests/test_git_toolchain_floor.py). Format: `command: X.Y`.
+  command_minimum_versions:
+    git: "2.38"
 bootstrap:
   command: python3 scripts/bootstrap-project.py
   creates:

--- a/Dockerfile.codex-runner
+++ b/Dockerfile.codex-runner
@@ -5,6 +5,17 @@ USER root
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends git ca-certificates curl nodejs npm && \
+    # git >= 2.38 is a hard prerequisite: the merge-gate suite and the
+    # production merge queue call `git merge-tree --write-tree`, which older
+    # distro git (e.g. Ubuntu 22.04 / 2.34.1) lacks, failing the authoritative
+    # gate with an opaque rc=129. The floor is DECLARED in
+    # .mac/project.yaml (toolchain.command_minimum_versions.git) and asserted
+    # here at build time so the image cannot silently ship a too-old git.
+    # Keep this floor in sync with that contract (tests/test_git_toolchain_floor.py).
+    git_ver="$(git version | sed -E 's/^git version ([0-9]+\.[0-9]+).*/\1/')" && \
+    git_major="${git_ver%%.*}" && git_minor="${git_ver#*.}" && \
+    { [ "$git_major" -gt 2 ] || { [ "$git_major" -eq 2 ] && [ "$git_minor" -ge 38 ]; }; } || \
+      { echo "FATAL: git $git_ver < required 2.38 (git merge-tree --write-tree)" >&2; exit 1; } && \
     npm install -g @openai/codex && \
     npm install -g opencode-ai && \
     npm cache clean --force && \

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -895,6 +895,30 @@ ensure_venv_support() {
   exit 1
 }
 
+ensure_git_floor() {
+  # git >= 2.38 is a hard fleet prerequisite: the merge-gate suite and the
+  # production merge queue call `git merge-tree --write-tree`, which older
+  # distro git (e.g. Ubuntu 22.04 / 2.34.1) lacks, so an old-git worker burns a
+  # whole authoritative gate run on an opaque rc=129. The floor is DECLARED in
+  # .mac/project.yaml (toolchain.command_minimum_versions.git) and asserted here
+  # so a node cannot silently enter the fleet with a too-old git. Keep this
+  # floor in sync with that contract (tests/test_git_toolchain_floor.py).
+  local required_major=2 required_minor=38 git_ver git_major git_minor
+  if ! command -v git >/dev/null 2>&1; then
+    log "ERROR: git is missing; complete node onboarding before phase 2"
+    exit 1
+  fi
+  git_ver="$(git version 2>/dev/null | sed -E 's/^git version ([0-9]+\.[0-9]+).*/\1/')"
+  git_major="${git_ver%%.*}"
+  git_minor="${git_ver#*.}"
+  if [ -z "$git_ver" ] \
+    || [ "${git_major:-0}" -lt "$required_major" ] \
+    || { [ "${git_major:-0}" -eq "$required_major" ] && [ "${git_minor:-0}" -lt "$required_minor" ]; }; then
+    log "ERROR: git ${git_ver:-unknown} < required ${required_major}.${required_minor} (git merge-tree --write-tree); complete node onboarding before phase 2"
+    exit 1
+  fi
+}
+
 truthy() {
   case "${1:-}" in
     1|true|TRUE|yes|YES|on|ON) return 0 ;;
@@ -10795,6 +10819,7 @@ else
   # receipts instead of rediscovering an open-ended set of host assumptions.
   ensure_dns_resolution
   ensure_venv_support
+  ensure_git_floor
   install_github_cli
   configure_github_https_credentials
   install_github_review_key

--- a/deploy/openshell/mac-hermes.Containerfile
+++ b/deploy/openshell/mac-hermes.Containerfile
@@ -109,6 +109,17 @@ RUN printf '%s\n' 'deb http://deb.debian.org/debian bookworm-backports main' > /
     && apt-get install -y --no-install-recommends postgresql postgresql-client \
     && apt-get install -y --no-install-recommends -t bookworm-backports qemu-system-misc \
     && command -v ps >/dev/null \
+    && command -v git >/dev/null \
+    # git >= 2.38 is a hard prerequisite: the merge-gate suite and the
+    # production merge queue call `git merge-tree --write-tree`, absent from
+    # older distro git (e.g. Ubuntu 22.04 / 2.34.1), which fails the
+    # authoritative gate with an opaque rc=129. Bookworm ships git >= 2.39, but
+    # the floor is DECLARED in .mac/project.yaml
+    # (toolchain.command_minimum_versions.git) and asserted here so a base-image
+    # change cannot silently regress it (tests/test_git_toolchain_floor.py).
+    && git_ver="$(git version | sed -E 's/^git version ([0-9]+\.[0-9]+).*/\1/')" \
+    && git_major="${git_ver%%.*}" && git_minor="${git_ver#*.}" \
+    && { [ "$git_major" -gt 2 ] || { [ "$git_major" -eq 2 ] && [ "$git_minor" -ge 38 ]; }; } \
     && command -v cmake >/dev/null \
     && command -v ninja >/dev/null \
     && command -v clang >/dev/null \

--- a/docs/repository-runtime-contract.md
+++ b/docs/repository-runtime-contract.md
@@ -19,6 +19,8 @@ toolchain:
     - python3
     - git
     - gh
+  command_minimum_versions:
+    git: "2.38"
 bootstrap:
   command: python3 scripts/bootstrap-project.py
   creates:
@@ -45,6 +47,19 @@ evidence:
 - `toolchain.required_commands`: commands that must exist before bootstrap can
   run. Keep this list small and portable. Project bootstrap scripts should fail
   loudly when a required command is still missing.
+- `toolchain.command_minimum_versions` (optional): a mapping of command name to
+  minimum `MAJOR.MINOR` version for commands whose *floor* is load-bearing, not
+  just their presence. `git: "2.38"` is required because the merge-gate suite
+  and the production merge queue call `git merge-tree --write-tree`, which only
+  exists in git >= 2.38; on Ubuntu 22.04 distro git (2.34.1) those tests fail
+  with an opaque rc=129 and burn a whole authoritative gate run.
+  `scripts/run-contract-tests.sh` fails fast on an older git as a runner-side
+  backstop, but this field is where the requirement is *declared* so every
+  provisioning asset that installs git (the runner/hermes images and
+  `deploy/fleet-node-install.sh`) can be checked against it. The guard test
+  `tests/test_git_toolchain_floor.py` asserts the declared floor is >= 2.38 and
+  that each such asset enforces it, so the prerequisite cannot silently
+  regress.
 - `bootstrap.command`: an idempotent command run from the repository root to
   create the local build/test environment.
 - `bootstrap.creates`: relative paths expected after bootstrap. These are used

--- a/tests/test_git_toolchain_floor.py
+++ b/tests/test_git_toolchain_floor.py
@@ -1,0 +1,106 @@
+"""git >= 2.38 is a declared, machine-checkable fleet prerequisite.
+
+The merge-gate suite (``tests/test_merge_queue.py`` and friends) and the
+production merge queue (``src/mac/merge_queue.py``) both call
+``git merge-tree --write-tree``, which only exists in git >= 2.38. On a host
+running Ubuntu 22.04 distro git (2.34.1) -- e.g. the GKE pod that ran the
+parent task's authoritative gate -- those calls fail with an opaque rc=129, so
+a whole gate run is burned and reported as a misleading generic test failure.
+
+``scripts/run-contract-tests.sh`` fails fast on an older git as a runner-side
+backstop, but that does not stop a host or image from *shipping* an old git.
+This test pins the requirement in one machine-checkable place:
+
+- the floor is DECLARED in ``.mac/project.yaml``
+  (``toolchain.command_minimum_versions.git``) and is >= 2.38;
+- the runner-side backstop in ``scripts/run-contract-tests.sh`` agrees with it;
+- every provisioning asset that installs git enforces the same floor, so the
+  prerequisite cannot silently regress when a base image or install script is
+  edited.
+
+It is deliberately cheap and reads only checked-in text, so it runs in every
+suite without building an image or touching a host.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: The absolute minimum every git-provisioning path must satisfy. The declared
+#: floor may be raised above this, but never below it.
+_ABSOLUTE_MIN = (2, 38)
+
+
+def _declared_git_floor() -> tuple[int, int]:
+    contract = yaml.safe_load((REPO_ROOT / ".mac" / "project.yaml").read_text(encoding="utf-8"))
+    toolchain = contract.get("toolchain") or {}
+    minimums = toolchain.get("command_minimum_versions") or {}
+    assert "git" in minimums, (
+        "toolchain.command_minimum_versions.git must declare the git floor in .mac/project.yaml"
+    )
+    raw = str(minimums["git"]).strip()
+    match = re.fullmatch(r"(\d+)\.(\d+)", raw)
+    assert match, "git minimum version must be MAJOR.MINOR, got %r" % raw
+    return int(match.group(1)), int(match.group(2))
+
+
+def test_declared_git_floor_is_at_least_2_38() -> None:
+    assert _declared_git_floor() >= _ABSOLUTE_MIN, (
+        "declared git floor must be >= 2.38 (git merge-tree --write-tree)"
+    )
+
+
+def test_contract_runner_backstop_matches_declared_floor() -> None:
+    runner = (REPO_ROOT / "scripts" / "run-contract-tests.sh").read_text(encoding="utf-8")
+    major_match = re.search(r"_MAC_GIT_REQUIRED_MAJOR=(\d+)", runner)
+    minor_match = re.search(r"_MAC_GIT_REQUIRED_MINOR=(\d+)", runner)
+    assert major_match and minor_match, (
+        "run-contract-tests.sh must define _MAC_GIT_REQUIRED_MAJOR/_MINOR"
+    )
+    runner_floor = (int(major_match.group(1)), int(minor_match.group(1)))
+    assert runner_floor == _declared_git_floor(), (
+        "run-contract-tests.sh git floor %r must match the declared contract floor %r"
+        % (runner_floor, _declared_git_floor())
+    )
+
+
+#: Provisioning assets that install git. Each must enforce the declared floor at
+#: build/onboard time. Kept explicit rather than globbed: a glob would silently
+#: stop covering a file that got renamed.
+_GIT_PROVISIONING_ASSETS = (
+    "Dockerfile.codex-runner",
+    "deploy/openshell/mac-hermes.Containerfile",
+    "deploy/fleet-node-install.sh",
+)
+
+
+def _installs_git(text: str) -> bool:
+    # apt-installs git as its own package (not a substring of another token).
+    return re.search(r"install[^\n]*\bgit\b", text) is not None or "command -v git" in text
+
+
+@pytest.mark.parametrize("relpath", _GIT_PROVISIONING_ASSETS)
+def test_git_provisioning_asset_enforces_floor(relpath: str) -> None:
+    path = REPO_ROOT / relpath
+    assert path.exists(), "expected git-provisioning asset %s to exist" % relpath
+    text = path.read_text(encoding="utf-8")
+    assert _installs_git(text), (
+        "%s no longer installs/requires git; update _GIT_PROVISIONING_ASSETS" % relpath
+    )
+    major, minor = _declared_git_floor()
+    # The asset must name the exact declared minor floor in a version comparison,
+    # so a base-image or script change that drops the check fails this test.
+    assert re.search(r"-ge %d\b" % minor, text) or re.search(r"\b%d\b" % minor, text), (
+        "%s must assert git >= %d.%d (git merge-tree --write-tree)" % (relpath, major, minor)
+    )
+    # And it must actually compare a parsed git version, not merely mention the
+    # number in prose: require both a git-version parse and a numeric guard.
+    assert "git version" in text, (
+        "%s must parse `git version` to enforce the floor" % relpath
+    )


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_7d2049429ec8496c8bd98e470302f78b`
- head: `9965cd331352886165970c232af8bb524faf9762`
- base at push: `6ba28d46227b93acad458955681d22277692b247`
