### PR TITLE
Pin macOS docs CI to PostgreSQL 17

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,10 +42,9 @@ jobs:
           # container; macOS runners have no container engine, so use the
           # Homebrew server that ships with the image.
           if [ "$RUNNER_OS" = "macOS" ]; then
-            formula=$(brew list --formula | grep -E '^postgresql(@[0-9]+)?$' | tail -1 || true)
-            if [ -z "$formula" ]; then
+            formula=postgresql@17
+            if ! brew list --versions "$formula" >/dev/null 2>&1; then
               brew install postgresql@17
-              formula=postgresql@17
             fi
             brew services start "$formula"
             echo "$(brew --prefix "$formula")/bin" >> "$GITHUB_PATH"

--- a/tests/test_documentation_book.py
+++ b/tests/test_documentation_book.py
@@ -111,3 +111,11 @@ def test_documentation_ci_covers_platforms_live_boundaries_and_versioning():
         'mike deploy --push --update-aliases "$version" latest',
     ):
         assert required in workflow
+
+
+def test_documentation_ci_uses_supported_postgres_on_macos():
+    workflow = (ROOT / ".github" / "workflows" / "docs.yml").read_text(encoding="utf-8")
+
+    assert "formula=postgresql@17" in workflow
+    assert 'brew list --versions "$formula"' in workflow
+    assert "grep -E '^postgresql(@[0-9]+)?$'" not in workflow


### PR DESCRIPTION
Task task_d6662cd7. The docs workflow previously selected any preinstalled Homebrew PostgreSQL formula; GitHub's macOS image can carry deprecated postgresql@14, producing the upstream-EOL warning and eventually breaking CI when Homebrew disables it. Pin the workflow to postgresql@17 while leaving unrelated runner formulas untouched, and add a regression contract.\n\nVerification: `eval "$(scripts/start-test-postgres.sh)" && .venv/bin/pytest -q tests/test_documentation_book.py` (8 passed).