### PR TITLE
Restore Ruff formatting gate before v1.3.4

### DIFF
--- a/deploy/fleet-prerequisite-receipts.py
+++ b/deploy/fleet-prerequisite-receipts.py
@@ -264,9 +264,10 @@ def _validate_tool_version_check(value: dict[str, Any]) -> dict[str, Any]:
     if check["kind"] != "tool-version":
         raise PrerequisiteError("tool version check kind is invalid")
     _absolute_path(check["path"])
-    if not isinstance(check["minimum_version"], str) or re.fullmatch(
-        r"[0-9]+(?:\.[0-9]+){1,3}", check["minimum_version"]
-    ) is None:
+    if (
+        not isinstance(check["minimum_version"], str)
+        or re.fullmatch(r"[0-9]+(?:\.[0-9]+){1,3}", check["minimum_version"]) is None
+    ):
         raise PrerequisiteError("tool minimum_version is invalid")
     return check
 

--- a/deploy/openclaw/run-script-cron-job.py
+++ b/deploy/openclaw/run-script-cron-job.py
@@ -632,7 +632,9 @@ def calendar_day_key(now: Optional[float] = None) -> str:
 
 
 def delivery_receipt_path(output_dir: str, job: dict) -> Path:
-    return Path(output_dir).expanduser() / ("%s.last-success.json" % _slug(job.get("name") or "job"))
+    return Path(output_dir).expanduser() / (
+        "%s.last-success.json" % _slug(job.get("name") or "job")
+    )
 
 
 def already_delivered_today(job: dict, output_dir: str, *, now: Optional[float] = None) -> bool:

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -20,7 +20,12 @@ import urllib.parse
 from typing import Callable, Dict, Mapping, MutableMapping, Optional, Sequence
 
 from mac.providers import ROUTER_PROVIDERS, router_secret_name, upstream_provider_env_vars
-from mac.mesh_bind import MeshBindError, deploy_mac_bind_host, lookup_tailscale_ipv4, overlay_ipv4_from_url
+from mac.mesh_bind import (
+    MeshBindError,
+    deploy_mac_bind_host,
+    lookup_tailscale_ipv4,
+    overlay_ipv4_from_url,
+)
 
 
 DEFAULT_WORKER_CAPABILITIES = (

--- a/src/mac/mesh_bind.py
+++ b/src/mac/mesh_bind.py
@@ -239,8 +239,7 @@ def deploy_mac_bind_host(
     for host in explicit:
         if not is_allowed_mesh_bind_host(host, mesh_ips=(mesh_ip,) if mesh_ip else ()):
             raise MeshBindError(
-                "mesh hub bind refused: %r is not loopback or Tailscale/Headscale"
-                % host
+                "mesh hub bind refused: %r is not loopback or Tailscale/Headscale" % host
             )
     if any(is_unspecified_host(host) for host in requested_hosts):
         if not mesh_ip or not _parse_ip(mesh_ip):
@@ -251,8 +250,7 @@ def deploy_mac_bind_host(
     if mesh_ip:
         if not is_allowed_mesh_bind_host(mesh_ip, mesh_ips=(mesh_ip,)):
             raise MeshBindError(
-                "mesh hub bind refused: Tailscale IP %r is not a usable listen address"
-                % mesh_ip
+                "mesh hub bind refused: Tailscale IP %r is not a usable listen address" % mesh_ip
             )
         return format_bind_hosts(["127.0.0.1", mesh_ip])
     return "127.0.0.1"
@@ -334,7 +332,5 @@ def runtime_bind_error(
     """Message for create_app. None when the configured bind is legal."""
     hosts = parse_bind_hosts(bind_host)
     mesh_ips = [mesh_ip] if mesh_ip.strip() else []
-    problems = mesh_bind_problems(
-        hosts, network_provider=network_provider, mesh_ips=mesh_ips
-    )
+    problems = mesh_bind_problems(hosts, network_provider=network_provider, mesh_ips=mesh_ips)
     return "; ".join(problems) if problems else None

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -6110,9 +6110,7 @@ class MacWorker(
             # all (ADR 0015): its kernel cannot enforce Landlock, so a probe
             # sandbox never starts and leaves a restarting container behind.
             host_install = sys.platform in REPORT_REPOSITORY_HOST_INSTALL_PLATFORMS
-            sandboxed = not host_install and _env_truthy(
-                os.environ.get("MAC_OPENSHELL_SANDBOX")
-            )
+            sandboxed = not host_install and _env_truthy(os.environ.get("MAC_OPENSHELL_SANDBOX"))
 
             def _verify(choice: Any) -> bool:
                 try:

--- a/tests/test_contract_test_runner.py
+++ b/tests/test_contract_test_runner.py
@@ -936,8 +936,7 @@ def _stage_git_runner(
     # and logs its pytest phases so we can assert the suite actually ran.
     _write_exec(
         path_bin / "python3",
-        "#!/bin/sh\n"
-        'printf \'%s\\n\' "$*" >> "$FAKE_PY_LOG"\n' + _GOOD_PY_BODY.split("\n", 1)[1],
+        '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$FAKE_PY_LOG"\n' + _GOOD_PY_BODY.split("\n", 1)[1],
     )
     if path_git_version is not None:
         _write_exec(path_bin / "git", _fake_git_body(path_git_version))

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -1066,10 +1066,7 @@ def test_daemon_and_openclaw_timeouts_are_forwarded_only_when_set():
     # parsers on the node. The controller must omit the assignment unless the
     # operator actually set a value.
     deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
-    assert (
-        'if [ -n "${MAC_DEPLOY_DAEMON_QUIESCENCE_TIMEOUT_SECONDS:-}" ]; then'
-        in deploy
-    )
+    assert 'if [ -n "${MAC_DEPLOY_DAEMON_QUIESCENCE_TIMEOUT_SECONDS:-}" ]; then' in deploy
     assert "add_remote_env MAC_DEPLOY_DAEMON_QUIESCENCE_TIMEOUT_SECONDS" in deploy
     assert 'if [ -n "${MAC_OPENCLAW_VERIFY_STARTUP_TIMEOUT:-}" ]; then' in deploy
     assert "add_remote_env MAC_OPENCLAW_VERIFY_STARTUP_TIMEOUT" in deploy

--- a/tests/test_dream_cycle_runner.py
+++ b/tests/test_dream_cycle_runner.py
@@ -97,8 +97,7 @@ def test_kslug_process_note_is_not_a_transcript() -> None:
 def test_choose_reply_prefers_kslug_transcript_over_preamble() -> None:
     transcript = (
         ":tv: _KSLUG NIGHTLY NEWS_ :tv:\n"
-        "_DAN GREEN:_ Good evening, Santa Cruz. I'm Dan Green. "
-        + ("Item from the wire. " * 40)
+        "_DAN GREEN:_ Good evening, Santa Cruz. I'm Dan Green. " + ("Item from the wire. " * 40)
     )
     payload = {
         "text": "The KSLUG skill and SPEC aren't accessible in this sandbox.",
@@ -151,8 +150,7 @@ def test_kslug_prompt_includes_host_runner_contract(tmp_path: Path) -> None:
     captured = {}
     transcript = (
         ":tv: _KSLUG NIGHTLY NEWS_ :tv:\n"
-        "_DAN GREEN:_ Good evening, Santa Cruz. I'm Dan Green. "
-        + ("Local wire copy. " * 40)
+        "_DAN GREEN:_ Good evening, Santa Cruz. I'm Dan Green. " + ("Local wire copy. " * 40)
     )
     job = {
         "name": "kslug-nightly-news",
@@ -171,8 +169,7 @@ def test_kslug_prompt_includes_host_runner_contract(tmp_path: Path) -> None:
         home_channel_target="channel:C0HOME",
         script_runner=lambda *_args: ("wire", ""),
         agent_runner=lambda _bin, prompt, **_kwargs: (
-            captured.update(prompt=prompt)
-            or json.dumps({"text": transcript})
+            captured.update(prompt=prompt) or json.dumps({"text": transcript})
         ),
         deliver_runner=lambda *_args, **_kwargs: None,
     )

--- a/tests/test_fleet_upgrade_service.py
+++ b/tests/test_fleet_upgrade_service.py
@@ -232,9 +232,10 @@ def test_upgrade_arm_skips_operator_held_and_virtual_agents(tmp_path: Path):
     )
     assert fenced == [worker.id]
     assert armed["state"] == "hub_applying"
-    assert cp.get_agent(worker.id).dispatch_hold_reason == "fleet_upgrade:%s:hub_cutover" % upgrade[
-        "id"
-    ]
+    assert (
+        cp.get_agent(worker.id).dispatch_hold_reason
+        == "fleet_upgrade:%s:hub_cutover" % upgrade["id"]
+    )
     assert cp.get_agent(session.id).dispatch_hold_reason == "interactive session"
     assert cp.get_agent(operator.id).dispatch_hold is False
 

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -105,7 +105,9 @@ def test_snapshot_prefers_openclaw_workspace_when_root_has_no_soul(tmp_path):
     _make_agent_home(workspace)
     root = tmp_path / "journal"
 
-    m = journal.snapshot(home=home, root=root, date="2026-08-26", agent_id="natasha", run_hook=False)
+    m = journal.snapshot(
+        home=home, root=root, date="2026-08-26", agent_id="natasha", run_hook=False
+    )
 
     dest = root / "2026-08-26"
     assert (dest / "SOUL.md").read_text().startswith("# SOUL")

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3483,9 +3483,7 @@ def test_worker_route_probe_stays_on_the_host_unless_the_sandbox_is_opted_into(
         # host branch resolves binaries on the host and passes None.
         resolver_kinds.append("host" if which is None else "sandbox")
         return (
-            choice
-            if accept(choice)
-            else coding_agent.CodingAgentChoice(agent="", available=False)
+            choice if accept(choice) else coding_agent.CodingAgentChoice(agent="", available=False)
         )
 
     def record_sandbox_verification(verified_choice):

--- a/tests/test_worker_contract_edges.py
+++ b/tests/test_worker_contract_edges.py
@@ -11,6 +11,7 @@ from mac import worker
 def _completed(returncode=0, stdout="", stderr=""):
     return subprocess.CompletedProcess([], returncode, stdout, stderr)
 
+
 def test_verification_contract_dispatches_all_evidence_types() -> None:
     sha = "a" * 40
     anchor = {


### PR DESCRIPTION
Task task_c8b32b6b. Release preflight found origin/main red under the mandatory `make lint` gate: Ruff check passed, but format --check reported 12 committed files. Applied only the repository's canonical `make lint-fix` formatter.\n\nVerification: `make lint` passes (1177 files already formatted).