### PR TITLE
Recover report execution after host Python upgrades

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -12069,21 +12069,12 @@ install_mac_agent_wrapper() {
   local executor_py="${4:-$MAC_HOME/bin/mac-task-executor.py}"
   local crash_observer="${5:-$MAC_HOME/bin/mac-crash-observer}"
   local install_aliases="${6:-1}"
-  local report_python="$MAC_HOME/venv/bin/mac-report-python"
   mkdir -p \
     "$(dirname "$wrapper")" \
     "$(dirname "$selftest")" \
     "$(dirname "$executor")" \
     "$(dirname "$executor_py")" \
     "$(dirname "$crash_observer")"
-  # venv/bin/python is normally a symlink. A retarget between attestation and
-  # exec would select an unapproved interpreter, so install a real immutable-by-
-  # identity launcher within the venv and attest/invoke this exact file.
-  local resolved_python
-  resolved_python="$("$VENV/bin/python" -c 'import os, sys; print(os.path.realpath(sys.executable))')"
-  [ -f "$resolved_python" ] || die "resolved worker Python is missing: $resolved_python"
-  install -m 0755 "$resolved_python" "${report_python}.new"
-  mv -f "${report_python}.new" "$report_python"
   # Deliberately run outside the MAC virtualenv: it must remain usable when a
   # broken MAC import graph is the reason the worker cannot start.
   install -m 0755 "$SRC_DIR/deploy/mac-crash-observer.py" "$crash_observer"

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -1067,12 +1067,12 @@ def build_mac_env(
     values.setdefault("MAC_WORKER_POLL_INTERVAL", "2")
     values.setdefault("MAC_WORKER_LEASE_SECONDS", "900")
     values.setdefault("MAC_WORKER_EXECUTOR", str(cfg.paths.mac_home / "bin" / "mac-task-executor"))
-    # Report executors use deployment-owned, no-follow artifacts. The Python
-    # binary is a real file copied beside the venv launchers (not the mutable
-    # venv/bin/python symlink); the task wrapper must exec these exact paths.
-    values["MAC_TASK_EXECUTOR_PYTHON"] = str(
-        cfg.paths.mac_home / "venv" / "bin" / "mac-report-python"
-    )
+    # Registration resolves this venv launcher to the current base interpreter,
+    # execute-probes it, and sends that exact file identity to the hub for
+    # approval. Do not copy the interpreter into the venv: Homebrew Python
+    # binaries retain a versioned Cellar dylib reference, so a routine patch
+    # upgrade left the copy executable but unloadable before MAC could run.
+    values["MAC_TASK_EXECUTOR_PYTHON"] = str(cfg.paths.mac_home / "venv" / "bin" / "python")
     values["MAC_TASK_EXECUTOR_SCRIPT"] = str(cfg.paths.mac_home / "bin" / "mac-task-executor.py")
     values["MAC_SELF_UPDATE_REPO"] = str(cfg.paths.mac_home / "src" / "mac")
     values.setdefault("MAC_AGENT_STARTUP_SELF_TEST", "1")

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -661,7 +661,35 @@ def _read_only_report_executor_attestation(
             _read_only_report_extra_create_argv(require_approval=False)
         if not _read_only_report_environment_passthrough_valid():
             return None
-        python_candidate = (os.environ.get("MAC_TASK_EXECUTOR_PYTHON") or sys.executable).strip()
+        configured_python = (os.environ.get("MAC_TASK_EXECUTOR_PYTHON") or "").strip()
+        python_candidate = configured_python or sys.executable
+        # A persistent venv can outlive its base interpreter. Homebrew patch
+        # upgrades exposed this with a copied Mach-O launcher that still
+        # existed but referenced a removed Cellar framework. Execute-probe the
+        # configured candidate; if it is stale, recover through the interpreter
+        # already running this worker. The resolved file and digest below are
+        # still what the hub approves, so task execution cannot retarget a
+        # symlink after approval.
+        probe = subprocess.run(
+            [python_candidate, "-c", "import mac"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
+        if probe.returncode != 0 and configured_python:
+            python_candidate = sys.executable
+            probe = subprocess.run(
+                [python_candidate, "-c", "import mac"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+                check=False,
+            )
+        if probe.returncode != 0:
+            return None
         python_path, python_sha256 = nofollow_regular_file_identity(
             Path(python_candidate).expanduser().resolve(strict=True)
         )

--- a/tests/test_report_repository_routing.py
+++ b/tests/test_report_repository_routing.py
@@ -720,7 +720,26 @@ def test_deployed_report_wrapper_execs_only_approved_absolute_artifacts():
     assert '. "$HOME/.mac/mac.env"' not in block
     assert 'exec "$MAC_TASK_EXECUTOR_PYTHON" "$MAC_TASK_EXECUTOR_SCRIPT"' in block
     assert 'exec "$HOME/.mac/venv/bin/python"' not in block
-    assert 'install -m 0755 "$resolved_python" "${report_python}.new"' in installer
+    assert "mac-report-python" not in installer
+
+
+def test_stale_configured_report_python_falls_back_to_running_interpreter(
+    report_boundary_env, tmp_path, monkeypatch
+):
+    executor, _policy = report_boundary_env
+    stale_python = tmp_path / "removed-python-launcher"
+    stale_python.write_text("#!/bin/sh\nexit 127\n", encoding="utf-8")
+    stale_python.chmod(0o755)
+    monkeypatch.setenv("MAC_TASK_EXECUTOR_PYTHON", str(stale_python))
+
+    attestation = worker._read_only_report_executor_attestation([str(executor)])
+
+    assert attestation is not None
+    assert attestation["python_path"] == str(Path(sys.executable).resolve())
+    assert worker._apply_read_only_report_executor_approval(
+        _marker_resources(attestation), os.environ
+    )
+    assert os.environ["MAC_TASK_EXECUTOR_PYTHON"] == str(Path(sys.executable).resolve())
 
 
 def test_model_sandbox_never_receives_fleet_hub_credentials(report_boundary_env, monkeypatch):


### PR DESCRIPTION
Task task_eb30d8b7. Persistent MAC venvs can outlive their base interpreter after Homebrew, package-manager, image, or version-manager updates. The copied `mac-report-python` binary retained Rocky's removed Python 3.14.6 Cellar dylib and aborted before Python while the current 3.14.7 interpreter was healthy.\n\nStop copying the interpreter into the venv. Configure the normal venv launcher, execute-probe it during report-executor attestation, and fall back to the already-running worker interpreter when the configured launcher is stale. The fallback's resolved no-follow path and digest remain the exact artifacts the hub approves, preserving the anti-retargeting boundary.\n\nVerification: `tests/test_report_repository_routing.py` (27 passed), `make lint` clean, shell syntax clean.