### PR TITLE
Release v1.3.4

### DIFF
--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 #: import it, so the number lives in exactly one place. It used to be copied by
 #: hand into four (pyproject, this package, the FastAPI app, the A2A card) with
 #: a comment on each asking the next person to keep them in sync.
-__version__ = "1.3.3"
+__version__ = "1.3.4"
 
 __all__ = [
     "ControlPlane",


### PR DESCRIPTION
Bump the single-sourced MAC version after the v1.3.4 documentation audit/deck landed in #705 and candidate CI at e78a7ba7 passed.\n\nRelease deck: https://docs.google.com/presentation/d/1uPIlC_TYrp3XHd4ARIbrdxNjPiYgAE7pjdi2n_2FUD8/edit\n\nRelease notes are sourced from docs/presentation/20260831T143751Z-e78a7ba7/AUDIT.md.