### PR TITLE
Publish runtime wheel with releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release artifacts
+
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+
+permissions:
+  contents: write
+
+jobs:
+  wheel:
+    name: Build and publish Python wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39
+      - name: Set up Python
+        run: uv python install 3.11
+      - name: Build and verify wheel
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          make package-cli PYTHON="$(uv python find 3.11)"
+          wheel="$(find dist -maxdepth 1 -name 'mac-*.whl' -print -quit)"
+          test -n "$wheel"
+          version="${RELEASE_TAG#v}"
+          case "$(basename "$wheel")" in
+            "mac-${version}-"*.whl) ;;
+            *) echo "wheel $wheel does not match release $RELEASE_TAG" >&2; exit 1 ;;
+          esac
+          uv venv --python 3.11 /tmp/mac-release-smoke
+          uv pip install --python /tmp/mac-release-smoke/bin/python \
+            "${wheel}[postgres,relay]"
+          /tmp/mac-release-smoke/bin/python -c \
+            'import mac, mac.task_executor; print(mac.__version__)'
+      - name: Create release if needed and attach wheel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh release view "$RELEASE_TAG" >/dev/null 2>&1 || \
+            gh release create "$RELEASE_TAG" --verify-tag \
+              --title "mac $RELEASE_TAG" --generate-notes
+          gh release upload "$RELEASE_TAG" dist/mac-*.whl --clobber

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ GUI_PACKAGE ?= dist/mac-hub-ui.tar.gz
 DESKTOP_NODE_MODULES_STAMP := desktop/node_modules/.package-lock.json
 
 # Console scripts declared in pyproject.toml [project.scripts]; keep in sync.
-CONSOLE_SCRIPTS = mac mac-hermes mac-agent mac-firecrawl-gateway mac-hub-upgrade-supervisor mac-k8s-orchestrator mac-k8s-bootstrap mac-task-runner mac-webdav-server mac-evidence mac-hermes-gateway mac-schema-migrate
+CONSOLE_SCRIPTS = mac mac-hermes mac-agent mac-firecrawl-gateway mac-hub-upgrade-supervisor mac-k8s-orchestrator mac-k8s-bootstrap mac-task-runner mac-webdav-server mac-evidence mac-openshell-supervisor mac-openshell-collector mac-git-askpass mac-router mac-pg-backup mac-schema-migrate
 
 .PHONY: help require-python require-npm require-uv \
 	install install-cli install-gui uninstall uninstall-cli \

--- a/skills/cut-a-release/SKILL.md
+++ b/skills/cut-a-release/SKILL.md
@@ -199,7 +199,16 @@ Land it the way all work lands here — through a pull request, not a push to
 
 ```bash
 git tag vX.Y.Z && git push origin vX.Y.Z
-gh release create vX.Y.Z --title "mac vX.Y.Z" --notes-file notes.md
+```
+
+The tag-triggered `Release artifacts` workflow builds the exact-version wheel,
+installs it into a clean environment, proves `mac.task_executor` imports, then
+creates the GitHub release when necessary and attaches the wheel. Wait for that
+workflow to pass before calling the release complete. If release notes need more
+than the generated changelog, update the release after publication:
+
+```bash
+gh release edit vX.Y.Z --title "mac vX.Y.Z" --notes-file notes.md
 ```
 
 Write the notes from the deck's `AUDIT.md`, not from the commit log. The log

--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -58,6 +58,24 @@ def test_make_dry_run_builds_both_supported_surfaces() -> None:
     assert "npm run build" in result.stdout
 
 
+def test_package_cli_verifies_the_current_console_script_contract() -> None:
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    scripts = makefile.split("CONSOLE_SCRIPTS = ", 1)[1].splitlines()[0].split()
+
+    assert "mac-hermes-gateway" not in scripts
+    assert {
+        "mac",
+        "mac-agent",
+        "mac-evidence",
+        "mac-git-askpass",
+        "mac-openshell-collector",
+        "mac-openshell-supervisor",
+        "mac-pg-backup",
+        "mac-router",
+        "mac-schema-migrate",
+    } <= set(scripts)
+
+
 def test_gui_launcher_selects_auth_without_printing_the_token() -> None:
     makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
     deploy = (ROOT / "deploy" / "deploy-mac-fleet.sh").read_text(encoding="utf-8")

--- a/tests/test_release_artifacts.py
+++ b/tests/test_release_artifacts.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def test_release_tags_publish_an_importable_version_matched_wheel() -> None:
+    raw = WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(raw)
+
+    assert workflow[True]["push"]["tags"] == ["v[0-9]+.[0-9]+.[0-9]+"]
+    assert workflow["permissions"]["contents"] == "write"
+    assert "make package-cli" in raw
+    assert '"mac-${version}-"*.whl' in raw
+    assert '"${wheel}[postgres,relay]"' in raw
+    assert "import mac, mac.task_executor" in raw
+    assert 'gh release upload "$RELEASE_TAG" dist/mac-*.whl --clobber' in raw
+
+
+def test_release_wheel_is_built_from_the_tag_checkout() -> None:
+    raw = WORKFLOW.read_text(encoding="utf-8")
+    checkout = raw.index("actions/checkout@")
+    build = raw.index("make package-cli")
+    upload = raw.index("gh release upload")
+
+    assert checkout < build < upload


### PR DESCRIPTION
## Summary
- publish the exact-version `mac` wheel as a GitHub release asset on every SemVer tag
- install the wheel into a clean environment and prove `mac.task_executor` imports before upload
- repair `package-cli`'s stale console-script inventory so the release gate is executable
- update the release skill to wait for artifact publication

## Context
Releases v1.3.3 and v1.3.4 have no attached artifacts even though `make package-cli` builds a wheel. The Linux executor outage observed while releasing the backlog is related but distinct: push deploy installs editable source, and the failed workers were still running the pre-#703 copied-interpreter configuration. This PR closes the release artifact gap; deploying current main remains the fleet repair.

## Verification
- `make lint`
- `make package-cli`
- `eval "$(scripts/start-test-postgres.sh)" && uv run --extra dev pytest -q tests/test_release_artifacts.py tests/test_makefile_contract.py tests/test_report_repository_routing.py` (36 passed)
- `scripts/run-sanity-tests.sh --changed-file Makefile --changed-file .github/workflows/release.yml --changed-file tests/test_release_artifacts.py --changed-file tests/test_makefile_contract.py --changed-file skills/cut-a-release/SKILL.md`
