### PR TITLE
Repair autonomous integration gates

### DIFF
--- a/docs/reference/openapi.md
+++ b/docs/reference/openapi.md
@@ -386,6 +386,7 @@ request and response definitions.
 | `POST` | `/tasks/{task_id}/review-outcomes` | Record Review Outcome |
 | `POST` | `/tasks/{task_id}/reviews` | Request Review |
 | `POST` | `/tasks/{task_id}/start` | Start Task |
+| `POST` | `/tasks/{task_id}/stop` | Stop Task |
 | `POST` | `/tasks/{task_id}/submit-for-review` | Submit For Review |
 | `GET` | `/tasks/{task_id}/summary` | Task Summary |
 | `GET` | `/tasks/{task_id}/transcript` | Get Task Transcript |

--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -6180,6 +6180,15 @@ def create_app(
         # OPEN so it can be retried or reconciled. Counterpart to force-complete.
         return cp.reopen_task(task_id, body.actor, body.reason).to_dict()
 
+    @app.post("/tasks/{task_id}/stop")
+    def stop_task(
+        task_id: str,
+        body: TaskRecoveryRequest,
+        principal: TokenPrincipal = Depends(_get_principal),
+    ) -> Dict[str, Any]:
+        principal.require_admin()
+        return cp.stop_task(task_id, actor=body.actor, reason=body.reason).to_dict()
+
     @app.post("/tasks/{task_id}/ask")
     def ask_task(
         task_id: str,

--- a/src/mac/canonical_reconcile.py
+++ b/src/mac/canonical_reconcile.py
@@ -407,10 +407,17 @@ def host_still_valid_reconcile(
     HEAD, or submit refuses. Do not invent already_satisfied here.
     """
     block = dict(existing) if isinstance(existing, Mapping) else {}
-    if _text(block.get("decision")).lower() in RECONCILE_DECISIONS:
+    decision = _text(block.get("decision")).lower()
+    if decision in NO_CHANGE_DECISIONS:
         return block
     snapshot = reconcile_snapshot_from_task(task)
-    head = _text(block.get("head_sha")) or _text(snapshot.get("head_sha"))
+    # For repo_change the host finalizer is the authority: it operates on the
+    # worktree prepared from this snapshot and may rebase it before testing and
+    # pushing. An agent can accidentally cite its sandbox HEAD (or a sibling
+    # checkout); preserving that valid-looking but wrong SHA makes successful
+    # work fail the evidence gate after publication. Stamp the prepared
+    # canonical HEAD, while no_change decisions above remain agent-authored.
+    head = _text(snapshot.get("head_sha")) or _text(block.get("head_sha"))
     if not head:
         return block
     block["decision"] = "still_valid"

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -6457,6 +6457,7 @@
     "name": "MAC_HUB_VERIFY_IMAGE",
     "retired": false,
     "sources": [
+      "src/mac/deploy_env.py",
       "src/mac/services.py"
     ],
     "type": "str"

--- a/src/mac/deploy_env.py
+++ b/src/mac/deploy_env.py
@@ -1030,6 +1030,13 @@ def build_mac_env(
         values.pop("MAC_WORKER_DEPLOY_GENERATION", None)
         values.pop("MAC_WORKER_DEPLOY_BARRIER_FILE", None)
     openshell_explicitly_disabled = _apply_openshell_deploy_config(values, env)
+    runtime_image = (env.get("MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE") or "").strip()
+    if cfg.identity.is_hub and runtime_image:
+        # Hub verification executes untrusted repository tests in the same
+        # reviewed runtime family as workers. Never retain the pre-publication
+        # localhost/mac-hermes:net fallback: OpenShell interprets it as a local
+        # registry reference and every review fails before a test starts.
+        values["MAC_HUB_VERIFY_IMAGE"] = runtime_image
     openshell_active = any(
         (
             _enabled(str(env.get("MAC_DEPLOY_OPENSHELL_ENABLED") or "")),

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -795,6 +795,16 @@ class RemoteDispatch:
         body = _drop_none({"actor": actor, "reason": reason})
         return _Dictish(self._post("/tasks/%s/reopen" % quote(task_id, safe=""), body))
 
+    def stop_task(
+        self,
+        task_id: str,
+        *,
+        actor: str,
+        reason: Optional[str] = None,
+    ) -> _Dictish:
+        body = _drop_none({"actor": actor, "reason": reason})
+        return _Dictish(self._post("/tasks/%s/stop" % quote(task_id, safe=""), body))
+
     def update_task(self, task_id: str, **fields: Any) -> _Dictish:
         return _Dictish(self._put("/tasks/%s" % quote(task_id, safe=""), _drop_none(dict(fields))))
 

--- a/src/mac/review_service.py
+++ b/src/mac/review_service.py
@@ -34,6 +34,7 @@ from mac.models import (
     TaskState,
     TransitionError,
     ValidationError,
+    ensure_json_object,
     json_dumps,
     json_loads,
     new_id,
@@ -582,15 +583,25 @@ class ReviewService:
                 error=str((rejected_feedback or {}).get("feedback") or "") or None,
             )
             refund_attempt = bool(classification.is_infrastructure)
+            metadata = ensure_json_object(reviewed_task.metadata)
+            infrastructure_failures = int(metadata.get("review_infrastructure_failure_count") or 0)
+            if refund_attempt:
+                infrastructure_failures += 1
             effective_attempts = reviewed_task.attempt_count - (1 if refund_attempt else 0)
             exhausted = effective_attempts >= reviewed_task.max_attempts
-            transition_target = TaskState.BLOCKED.value if exhausted else TaskState.OPEN.value
+            infrastructure_exhausted = refund_attempt and infrastructure_failures >= 3
+            transition_target = (
+                TaskState.BLOCKED.value
+                if exhausted or infrastructure_exhausted
+                else TaskState.OPEN.value
+            )
             transition_detail = {
                 "review_id": review_id,
                 "review_status": status_value,
                 "reason": "review rejected after max attempts" if exhausted else "review rejected",
                 "review_failure_class": classification.failure_class,
                 "review_failure_is_infrastructure": classification.is_infrastructure,
+                "review_infrastructure_failure_count": infrastructure_failures,
             }
             if refund_attempt:
                 # Name the refund in the transition detail so the ledger shows
@@ -601,6 +612,12 @@ class ReviewService:
                 )
             if exhausted:
                 transition_detail["manual_repair_required"] = True
+            if infrastructure_exhausted:
+                transition_detail["manual_repair_required"] = True
+                transition_detail["reason"] = (
+                    "review harness failed %d consecutive times; operator repair required"
+                    % infrastructure_failures
+                )
         with self.store.transaction() as conn:
             locked_task = conn.execute(
                 """
@@ -645,6 +662,8 @@ class ReviewService:
                     rejected_feedback,
                     history,
                 )
+                if refund_attempt:
+                    metadata["review_infrastructure_failure_count"] = infrastructure_failures
                 conn.execute(
                     "UPDATE tasks SET metadata = ?, updated_at = ? WHERE id = ?",
                     (json_dumps(metadata), now, review.task_id),

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -27207,7 +27207,19 @@ class ControlPlane:
         # on the hub -- observed live on 2026-08-11.
         auth_url, auth_env = _gitops.askpass_remote_auth(remote_url)
         openshell = (os.environ.get("MAC_OPENSHELL_BIN") or "openshell").strip() or "openshell"
-        image = (os.environ.get("MAC_HUB_VERIFY_IMAGE") or "localhost/mac-hermes:net").strip()
+        image = (os.environ.get("MAC_HUB_VERIFY_IMAGE") or "").strip()
+        if not image:
+            return 1, (
+                "hub verification is unavailable: MAC_HUB_VERIFY_IMAGE must name "
+                "the deployment-approved immutable OpenShell runtime image"
+            )
+        if not re.fullmatch(
+            r"ghcr\.io/jordanhubbard/mac-openshell-runtime@sha256:[0-9a-f]{64}", image
+        ):
+            return 1, (
+                "hub verification is unavailable: MAC_HUB_VERIFY_IMAGE is not "
+                "the immutable repository-owned OpenShell runtime image"
+            )
         policy = (os.environ.get("MAC_OPENSHELL_POLICY") or "").strip()
         try:
             # 1200s could not cover even a scoped run once cloning, uploading

--- a/tests/api/test_api_route_coverage.py
+++ b/tests/api/test_api_route_coverage.py
@@ -1417,6 +1417,7 @@ def _path_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> str:
         ("DELETE", "/tasks/{task_id}"): {"task_id": "delete_task_id"},
         ("POST", "/tasks/{task_id}/transition"): {"task_id": "transition_task_id"},
         ("POST", "/tasks/{task_id}/reopen"): {"task_id": "reopen_task_id"},
+        ("POST", "/tasks/{task_id}/stop"): {"task_id": "reopen_task_id"},
         ("POST", "/tasks/{task_id}/ask"): {"task_id": "ask_task_id"},
         ("POST", "/tasks/{task_id}/answer"): {"task_id": "answer_task_id"},
         ("POST", "/tasks/{task_id}/force-complete"): {"task_id": "force_complete_task_id"},
@@ -2009,6 +2010,10 @@ def _case_for(method: str, path_template: str, ctx: Mapping[str, Any]) -> Reques
         ("POST", "/tasks/{task_id}/reopen"): {
             "actor": "operator",
             "reason": "route coverage reopen",
+        },
+        ("POST", "/tasks/{task_id}/stop"): {
+            "actor": "operator",
+            "reason": "route coverage stop",
         },
         ("POST", "/tasks/{task_id}/ask"): {
             "actor": "operator",

--- a/tests/test_canonical_reconcile.py
+++ b/tests/test_canonical_reconcile.py
@@ -194,6 +194,26 @@ def test_host_still_valid_does_not_override_already_satisfied():
     assert expected_head_sha_from_task(task) == "deadbeefcafebabe"
 
 
+def test_host_still_valid_corrects_agent_head_to_prepared_snapshot():
+    from mac.canonical_reconcile import host_still_valid_reconcile
+
+    task = {"metadata": {"runtime": {"canonical_reconcile": {"head_sha": "a" * 40}}}}
+    stamped = host_still_valid_reconcile(
+        task,
+        {
+            "decision": "still_valid",
+            "head_sha": "b" * 40,
+            "reason": "agent inspected its sandbox checkout",
+        },
+    )
+
+    assert stamped == {
+        "decision": "still_valid",
+        "head_sha": "a" * 40,
+        "reason": "agent inspected its sandbox checkout",
+    }
+
+
 def test_snapshot_lists_recent_commits_on_implicated_paths(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -13881,6 +13881,10 @@ def test_hub_verify_sandbox_command_whitelists_uploaded_repo_for_git(cp, monkeyp
         return _subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
 
     monkeypatch.setattr(services_mod.subprocess, "run", fake_run)
+    monkeypatch.setenv(
+        "MAC_HUB_VERIFY_IMAGE",
+        "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64,
+    )
     rc, out = cp._hub_verify_run_contract_test(
         "git@github.com:org/repo.git", "task/branch", "a" * 40, ""
     )
@@ -13930,6 +13934,10 @@ def test_hub_verify_sandbox_injects_dedicated_test_pg_url(cp, monkeypatch):
 
     monkeypatch.setattr(services_mod.subprocess, "run", fake_run)
     monkeypatch.setattr(services_mod, "hub_verify_test_pg_url", lambda repo_root: dsn)
+    monkeypatch.setenv(
+        "MAC_HUB_VERIFY_IMAGE",
+        "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64,
+    )
     rc, _out = cp._hub_verify_run_contract_test(
         "git@github.com:org/repo.git", "task/branch", "a" * 40, ""
     )

--- a/tests/test_deploy_env_edges.py
+++ b/tests/test_deploy_env_edges.py
@@ -317,6 +317,24 @@ def test_repository_ref_reconciler_defaults_to_daily_prune_on_hub_only(tmp_path)
     assert "MAC_CLIENT_PRINCIPALS_FILE" not in spoke
 
 
+def test_hub_verify_uses_the_deployment_approved_runtime_image(tmp_path):
+    runtime = "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64
+
+    hub = deploy_env.build_mac_env(
+        {"MAC_HUB_VERIFY_IMAGE": "localhost/mac-hermes:net"},
+        _cfg(tmp_path),
+        environ={"MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE": runtime},
+    )
+    spoke = deploy_env.build_mac_env(
+        {},
+        _cfg(tmp_path, agent="spoke", manager="hub"),
+        environ={"MAC_DEPLOY_OPENSHELL_RUNTIME_IMAGE": runtime},
+    )
+
+    assert hub["MAC_HUB_VERIFY_IMAGE"] == runtime
+    assert "MAC_HUB_VERIFY_IMAGE" not in spoke
+
+
 def test_spoke_env_removes_stale_local_control_plane_configuration(tmp_path):
     spoke = deploy_env.build_mac_env(
         {

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -1393,6 +1393,56 @@ def test_remote_dispatch_task_close_uses_api_transition_shape(monkeypatch):
     }
 
 
+def test_remote_dispatch_task_stop_uses_admin_stop_route(monkeypatch):
+    import io
+    import json as _json
+    import sys
+
+    from mac.cli import main
+    from mac.http_client import HubClient
+
+    monkeypatch.delenv("MAC_DB", raising=False)
+    monkeypatch.setenv("MAC_DEPLOY_ENV_FILE", "/dev/null")
+    fake = _FakeTransport(
+        response_for={("POST", "/tasks/task_xyz/stop"): {"id": "task_xyz", "state": "stopped"}}
+    )
+    orig_init = HubClient.__init__
+    monkeypatch.setattr(
+        HubClient,
+        "__init__",
+        lambda self, base_url, *, token=None, transport=None: orig_init(
+            self, base_url, token=token, transport=fake
+        ),
+    )
+
+    out = io.StringIO()
+    old = sys.stdout
+    sys.stdout = out
+    try:
+        rc = main(
+            [
+                "--hub-url",
+                "http://hub.example:8789",
+                "task",
+                "stop",
+                "task_xyz",
+                "--reason",
+                "integration recovery",
+                "--actor",
+                "operator",
+            ]
+        )
+    finally:
+        sys.stdout = old
+
+    assert rc == 0
+    assert _json.loads(out.getvalue()) == {"id": "task_xyz", "state": "stopped"}
+    method, url, payload, _token = fake.calls[0]
+    assert method == "POST"
+    assert url == "http://hub.example:8789/tasks/task_xyz/stop"
+    assert payload == {"actor": "operator", "reason": "integration recovery"}
+
+
 def test_dictish_supports_attribute_access():
     d = _Dictish({"id": "lease_42", "agent_id": "agent_x"})
     assert d.id == "lease_42"  # noqa: E501 — matches typed-object access pattern

--- a/tests/test_hub_verify_evidence_window.py
+++ b/tests/test_hub_verify_evidence_window.py
@@ -91,6 +91,10 @@ def _fake_run(monkeypatch):
 
 def _capture(monkeypatch):
     _fake_run(monkeypatch)
+    monkeypatch.setenv(
+        "MAC_HUB_VERIFY_IMAGE",
+        "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64,
+    )
     plane = types.SimpleNamespace()  # no _hub_verify_runner -> the real path
     return ControlPlane._hub_verify_run_contract_test(
         plane, "https://example.invalid/r.git", "b", HEAD_SHA, "scripts/run-contract-tests.sh"
@@ -126,6 +130,10 @@ def test_the_blind_tail_that_caused_this_would_still_fail(monkeypatch):
 def test_a_genuinely_dead_harness_is_still_unavailable(monkeypatch):
     """#522 must survive this fix: no gate ran, so there is no verdict to sign."""
     monkeypatch.setattr(gitops, "askpass_remote_auth", lambda url: (url, {}), raising=False)
+    monkeypatch.setenv(
+        "MAC_HUB_VERIFY_IMAGE",
+        "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64,
+    )
 
     def run(argv, **kwargs):
         done = lambda rc, out="", err="": subprocess.CompletedProcess(argv, rc, out, err)
@@ -142,6 +150,21 @@ def test_a_genuinely_dead_harness_is_still_unavailable(monkeypatch):
     )
 
     assert hub_verification_unavailable_reason(output) == "ssh exited with status"
+
+
+def test_hub_verify_refuses_the_obsolete_local_hermes_image(monkeypatch):
+    monkeypatch.setenv("MAC_HUB_VERIFY_IMAGE", "localhost/mac-hermes:net")
+
+    rc, output = ControlPlane._hub_verify_run_contract_test(
+        types.SimpleNamespace(),
+        "https://example.invalid/r.git",
+        "b",
+        HEAD_SHA,
+        "true",
+    )
+
+    assert rc == 1
+    assert "immutable repository-owned OpenShell runtime image" in output
 
 
 def test_the_excerpt_survives_the_second_truncation_on_the_way_to_the_worker(

--- a/tests/test_review_attempt_refund.py
+++ b/tests/test_review_attempt_refund.py
@@ -151,23 +151,24 @@ def test_semantic_rejection_still_spends_the_attempt(cp):
     assert after.state == TaskState.OPEN.value
 
 
-def test_repeated_harness_failures_never_exhaust_the_budget(cp):
-    """The whole task_4ce995cb shape: three harness rejections, still alive.
-
-    Previously this reached attempt_count 3/3 and went terminal with
-    failure_class "scope".  The task must remain retryable instead.
-    """
+def test_repeated_harness_failures_stop_after_three_refunded_attempts(cp):
+    """Harness failures refund work attempts, but cannot retry forever."""
     executor, reviewer, task, review, ev = _drive_to_review(cp, "three-strikes")
 
     for round_index, feedback in enumerate((HARNESS_588_ERRORS, HARNESS_UTF8, HARNESS_588_ERRORS)):
         _reject_with(cp, review, reviewer, task, feedback, ev)
         current = cp.get_task(task.id)
-        assert current.state == TaskState.OPEN.value, "round %d left the task in %s" % (
+        expected = TaskState.BLOCKED.value if round_index == 2 else TaskState.OPEN.value
+        assert current.state == expected, "round %d left the task in %s" % (
             round_index,
             current.state,
         )
         assert current.attempt_count == 0
         assert current.attempt_count < current.max_attempts
+        assert current.metadata["review_infrastructure_failure_count"] == round_index + 1
+
+        if current.state == TaskState.BLOCKED.value:
+            break
 
         # Next attempt: re-claim (which spends an attempt again) and re-review.
         # After a reacquire the control plane requires the current lease_id, so
@@ -188,7 +189,7 @@ def test_repeated_harness_failures_never_exhaust_the_budget(cp):
         review = cp.request_review(task.id, reviewer.id, actor="manual")
 
     final = cp.get_task(task.id)
-    assert final.state not in {TaskState.FAILED.value, TaskState.BLOCKED.value}
+    assert final.state == TaskState.BLOCKED.value
 
 
 def test_the_transition_says_why_the_attempt_was_refunded(cp):


### PR DESCRIPTION
## Summary
- make hub verification use the deployment-approved immutable OpenShell runtime instead of the obsolete `localhost/mac-hermes:net`
- correct `canonical_reconcile.head_sha` at the host finalizer boundary when an agent cites a non-prepared checkout
- add the missing hub API and `RemoteDispatch.stop_task` surface
- stop infrastructure-review retries after three refunded failures instead of reimplementing forever

## Root causes observed
- Rocky had no `MAC_HUB_VERIFY_IMAGE`; `ControlPlane._hub_verify_run_contract_test` silently defaulted to `localhost/mac-hermes:net`, which OpenShell treated as a localhost registry reference and failed before tests began.
- The finalizer preserved a syntactically valid agent-authored reconcile SHA even though the host had the authoritative prepared snapshot. The evidence validator then correctly rejected the mismatched SHA.
- Infrastructure review failures refunded attempts without any separate ceiling, allowing the same task to be implemented and rejected indefinitely.
- `ControlPlane.stop_task` existed, but hub mode had neither a stop route nor a `RemoteDispatch` wrapper, so operators could not use the documented corrective action.

## Verification
- `make lint`
- 120 focused tests covering review refunds, deploy env, canonical reconciliation, hub verification, RemoteDispatch/CLI stop, and every API route
- full sanity gate advanced through the generated-artifact checks; the focused suite covers the changed integration boundaries
