### PR TITLE
Stop a slow-but-healthy OpenClaw startup from failing the whole node deploy

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -11084,8 +11084,13 @@ run_bounded_node_phase() {
               || ! jobs -pr | awk -v wanted="${phase_pids[scan]}" \
                 '$0 == wanted { found=1 } END { exit(found ? 0 : 1) }'; }; then
           # The child died before publishing its atomic status (for example,
-          # SIGKILL). Reap it and synthesize a controller failure instead of
-          # polling a receipt that can never appear.
+          # SIGKILL, or a `jobs -pr` race against a child that already
+          # exited). Reap it and synthesize a controller failure instead of
+          # polling a receipt that can never appear. Say so explicitly: an
+          # unexplained status=125 with no matching phase-log error reads as
+          # a mysterious phase failure rather than what it is -- the
+          # controller lost track of the child, not a real command failure.
+          echo "==> ${phase_agents[scan]}: ${phase} child exited without publishing its status file (status=125 synthesized); this is a controller/job-control condition, not necessarily a command failure inside the phase -- retry" >&2
           wait "${phase_pids[scan]}" 2>/dev/null || true
           phase_statuses[scan]=125
           phase_active[scan]=0
@@ -11122,6 +11127,7 @@ run_bounded_node_phase() {
           && { ! kill -0 "${phase_pids[scan]}" 2>/dev/null \
             || ! jobs -pr | awk -v wanted="${phase_pids[scan]}" \
               '$0 == wanted { found=1 } END { exit(found ? 0 : 1) }'; }; then
+        echo "==> ${phase_agents[scan]}: ${phase} child exited without publishing its status file (status=125 synthesized); this is a controller/job-control condition, not necessarily a command failure inside the phase -- retry" >&2
         wait "${phase_pids[scan]}" 2>/dev/null || true
         phase_statuses[scan]=125
         phase_active[scan]=0

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -14506,12 +14506,23 @@ else
 fi
 
 if [ "${MAC_CHAT_GATEWAY_IMPL:-openclaw}" = "openclaw" ]; then
-  if [ "$SUPERVISOR_KIND" = "systemd" ]; then
-    wait_for_gateway_ready_log "$LOG_DIR/openclaw-gateway-journal.txt"
-    classify_gateway_logs "$LOG_DIR/openclaw-gateway-journal.txt"
-  else
-    wait_for_gateway_ready_log "$LOG_DIR/openclaw-gateway.log"
-    classify_gateway_logs "$LOG_DIR/openclaw-gateway.log"
+  # classify_gateway_logs exits nonzero on any actionable finding, which the
+  # script's error trap otherwise turns straight into a fatal node failure.
+  # A slow-but-healthy OpenClaw startup routinely logs its own transient
+  # ERROR/Exception lines while retrying (that is what the classifier is
+  # built to catch); that must not fail the whole node any more than the
+  # readiness probe above does, for the same "chat gateway failure may not
+  # stop task execution" reason (see gateway_probe_is_fatal). Honor the same
+  # switch here instead of letting classify_gateway_logs decide unilaterally.
+  gateway_log="$LOG_DIR/openclaw-gateway.log"
+  [ "$SUPERVISOR_KIND" = "systemd" ] && gateway_log="$LOG_DIR/openclaw-gateway-journal.txt"
+  wait_for_gateway_ready_log "$gateway_log"
+  if ! classify_gateway_logs "$gateway_log"; then
+    handle_failed_openclaw_successor "OpenClaw gateway log contains actionable errors"
+    if gateway_probe_is_fatal; then
+      exit 1
+    fi
+    note_gateway_degraded "OpenClaw gateway log contains actionable errors"
   fi
 elif [ "$SUPERVISOR_KIND" = "systemd" ]; then
   classify_gateway_logs "$LOG_DIR/hermes-gateway-journal.txt"

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -2772,6 +2772,31 @@ def test_pure_worker_deploy_requires_openshell_and_github_credentials(tmp_path):
     assert '*" --fail-closed "*' in deploy
 
 
+def test_gateway_log_classifier_failure_is_non_fatal_by_default_for_openclaw():
+    # Regression: a slow-but-healthy OpenClaw startup on 2026-09-01 logged its
+    # own transient ERROR lines while retrying, classify_gateway_logs exited
+    # 1 on that actionable finding, and the script's error trap turned it
+    # straight into a fatal node failure -- exactly the "gateway probe fails
+    # the whole fleet" incident gateway_probe_is_fatal was built to prevent
+    # for the readiness check, except this second check bypassed it entirely.
+    script = deploy_script_text()
+    call_site = script.split(
+        'if [ "${MAC_CHAT_GATEWAY_IMPL:-openclaw}" = "openclaw" ]; then\n'
+        "  # classify_gateway_logs exits nonzero",
+        1,
+    )[1].split("log \"verifying hub health", 1)[0]
+
+    assert "if ! classify_gateway_logs " in call_site
+    assert "handle_failed_openclaw_successor " in call_site
+    assert "if gateway_probe_is_fatal; then" in call_site
+    assert "note_gateway_degraded " in call_site
+    # The old form let classify_gateway_logs's own SystemExit(1) propagate
+    # unguarded straight into the script's error trap.
+    assert re.search(
+        r'^\s*classify_gateway_logs "\$gateway_log"\s*$', call_site, re.MULTILINE
+    ) is None
+
+
 def test_fleet_deploy_treats_unconfigured_discord_startup_as_benign():
     script = deploy_script_text()
     classifier = script.split("classify_gateway_logs() {", 1)[1].split(

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -709,6 +709,54 @@ run_bounded_node_phase {shlex.quote(str(specs))} stdin-proof stdin_draining_work
         assert f"worker{number}: stdin-proof passed" in result.stdout
 
 
+def test_bounded_node_phase_explains_a_child_that_dies_without_publishing_status(tmp_path):
+    # Regression for a 2026-09-01 fleet deploy: bullwinkle's phase1-prepare
+    # reported "status 125" with an otherwise-empty log, which reads as a
+    # mysterious phase failure. That status is synthesized by the controller
+    # when it loses track of a child (kill -0/`jobs -pr` race, or the child
+    # was killed externally) -- it is not necessarily a command failure
+    # inside the phase. The controller must say so explicitly.
+    deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    bounded = (
+        "run_bounded_node_phase() {"
+        + deploy.split("run_bounded_node_phase() {", 1)[1].split(
+            "\n}\n\npreflight_probe_helper_source", 1
+        )[0]
+        + "\n}"
+    )
+    specs = tmp_path / "selected-specs"
+    specs.write_text("victim|fixture\n", encoding="utf-8")
+    snippet = f"""set -euo pipefail
+TMPDIR_LOCAL={shlex.quote(str(tmp_path))}
+NODE_PARALLELISM=1
+BOUNDED_NODE_PHASE_AGGREGATE_FAILURES=0
+stable_worker_agent_id() {{ printf '%s\n' "$1"; }}
+persist_bounded_phase_failure_evidence() {{ return 1; }}
+self_destructing_worker() {{
+  # Simulate a child that dies before it can write its own status file.
+  # $$ is inherited from the parent shell inside a subshell -- BASHPID is
+  # the subshell's own pid, the one that must die here.
+  kill -9 $BASHPID
+}}
+{bounded}
+run_bounded_node_phase {shlex.quote(str(specs))} die-before-status self_destructing_worker
+"""
+    result = subprocess.run(
+        ["bash", "-c", snippet],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert (
+        "victim: die-before-status child exited without publishing its status "
+        "file (status=125 synthesized)" in result.stderr
+    )
+    assert "controller/job-control condition" in result.stderr
+    assert "ERROR: victim: die-before-status failed with status 125" in result.stderr
+
+
 def test_legacy_hub_bootstrap_preflights_onboarding_before_phase1():
     deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
     legacy = deploy.split("legacy_hub_bootstrap() {", 1)[1].split(


### PR DESCRIPTION
## Summary
- `classify_gateway_logs()` unconditionally `raise SystemExit(1)` on any actionable finding in the OpenClaw gateway log, and that propagated straight into the script's error trap as a fatal node failure -- ignoring `gateway_probe_is_fatal` (default off), even though every other OpenClaw-failure site in `fleet-node-install.sh` already routes through `handle_failed_openclaw_successor`/`note_gateway_degraded` specifically so a degraded chat gateway cannot fail task execution (see the 2026-08-11 incident comment above `gateway_probe_is_fatal`). Now the OpenClaw call site honors the same switch.
- `run_bounded_node_phase`'s "child died before publishing its status file" path (status=125, synthesized when a `kill -0`/`jobs -pr` race loses track of a child) now logs explicitly what happened, instead of surfacing as a bare, unexplained `status 125` with an empty phase log.

## Root cause
Observed live bootstrapping the fleet onto PR #708 on 2026-09-01: rocky's (hub) OpenClaw gateway was healthy seconds after the 180s readiness probe gave up (Slack connected, `[gateway] ready` logged), but the deploy still failed at `apply-phase2` and left the whole 3-node cohort ("rocky","natasha","bullwinkle") retained under dispatch hold for roll-forward repair. A same-day retry then hit the second issue on bullwinkle's `phase1-prepare`.

## Verification
- New regression tests: `test_gateway_log_classifier_failure_is_non_fatal_by_default_for_openclaw` (static), `test_bounded_node_phase_explains_a_child_that_dies_without_publishing_status` (executes the real bash function with a self-killing worker fixture)
- `uv run --extra dev pytest tests/ -k "deploy or gateway or openclaw"` -- 993 passed
- `ruff check` on both changed test files -- clean

Fixes task_3b884d2e.