### PR TITLE
Add mac agentbus traffic/roll-call CLI commands

### DIFF
--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -6076,6 +6076,71 @@ def cmd_agentbus_broadcast(args: argparse.Namespace) -> None:
     )
 
 
+def cmd_agentbus_traffic(args: argparse.Namespace) -> None:
+    """Read the whole bus as ``agent_id`` hears it, not just what is addressed to it.
+
+    ``read``/``wait``/``drain`` answer "has anyone said anything to me" on one
+    known stream or inbox. This is the fleet activity firehose -- point-to-point
+    AND group traffic across every stream the agent may hear, the thing an
+    operator actually wants when asking "what is the fleet doing right now".
+    The read endpoint has existed since 2026-08-17 with no CLI command calling
+    it, which is the whole reason nobody used it from a terminal.
+
+    Without --follow this is one page, like ``broadcast``. With --follow it
+    polls forever, printing each new batch as it arrives, until interrupted --
+    the tail-mode counterpart to ``wait``'s single-shot exit-on-first-message.
+    """
+    import time as _time
+
+    cp = _plane(args)
+    include_addressed = not args.exclude_addressed
+    cursor = args.after_cursor or ""
+    if not args.follow:
+        traffic = cp.read_agentbus_traffic(
+            args.agent_id,
+            cursor,
+            args.limit,
+            include_addressed=include_addressed,
+        )
+        _print(traffic)
+        return
+    interval = max(0.1, float(args.poll_interval_seconds))
+    try:
+        while True:
+            traffic = cp.read_agentbus_traffic(
+                args.agent_id,
+                cursor,
+                args.limit,
+                include_addressed=include_addressed,
+            )
+            if traffic:
+                for item in traffic:
+                    entry = item.to_dict() if hasattr(item, "to_dict") else item
+                    _print(entry)
+                    next_cursor = entry.get("cursor") if hasattr(entry, "get") else None
+                    if next_cursor:
+                        cursor = str(next_cursor)
+            _time.sleep(interval)
+    except KeyboardInterrupt:
+        return
+
+
+def cmd_agentbus_roll_call(args: argparse.Namespace) -> None:
+    """Who is on the bus right now, and what each of them can do.
+
+    One-shot fleet roster as ``agent_id`` (the identity the CLI session
+    authenticates as -- reused for authorization only, the roster itself is
+    not scoped to it). Pairs with ``traffic`` for "what is the fleet doing":
+    this answers who is out there, traffic answers what they are saying.
+    """
+    _print(
+        _plane(args).agentbus_roll_call(
+            args.agent_id,
+            include_departed=args.include_departed,
+        )
+    )
+
+
 def cmd_agentbus_publish(args: argparse.Namespace) -> None:
     _print(
         _plane(args).publish_agentbus_content(
@@ -11075,6 +11140,37 @@ def build_parser() -> argparse.ArgumentParser:
     )
     bus_broadcast.add_argument("--project")
     _set(cmd_agentbus_broadcast, bus_broadcast)
+
+    bus_traffic = agentbus.add_parser(
+        "traffic",
+        help="watch fleet activity: the whole bus, not just what is addressed to you",
+        description=(
+            "Point-to-point AND group traffic across every stream this agent "
+            "may hear, not just its own inbox or one known stream -- the "
+            "thing an operator actually wants when asking 'what is the fleet "
+            "doing right now'. Without --follow this is one page; with "
+            "--follow it polls and prints forever until interrupted."
+        ),
+    )
+    bus_traffic.add_argument("agent_id", help="identity to authenticate and listen as")
+    bus_traffic.add_argument("--after-cursor", default="")
+    bus_traffic.add_argument("--limit", type=int, default=100)
+    bus_traffic.add_argument(
+        "--exclude-addressed",
+        action="store_true",
+        help="drop chunks already addressed to this agent (it handles those via inbox/wait)",
+    )
+    bus_traffic.add_argument("--follow", action="store_true", help="poll and tail forever")
+    bus_traffic.add_argument("--poll-interval-seconds", type=float, default=2.0)
+    _set(cmd_agentbus_traffic, bus_traffic)
+
+    bus_roll_call = agentbus.add_parser(
+        "roll-call",
+        help="who is on the bus right now, and what each of them can do",
+    )
+    bus_roll_call.add_argument("agent_id", help="identity to authenticate as")
+    bus_roll_call.add_argument("--include-departed", action="store_true")
+    _set(cmd_agentbus_roll_call, bus_roll_call)
 
     bus_publish = agentbus.add_parser("publish")
     bus_publish.add_argument("sender_agent_id")

--- a/src/mac/dispatch.py
+++ b/src/mac/dispatch.py
@@ -1736,6 +1736,39 @@ class RemoteDispatch:
             )
         )
 
+    def read_agentbus_traffic(
+        self,
+        agent_id: str,
+        after_cursor: str = "",
+        limit: int = 100,
+        *,
+        include_addressed: bool = True,
+    ) -> List[_Dictish]:
+        return _wrap_list(
+            self._get(
+                "/agents/%s/agentbus/traffic" % quote(agent_id, safe=""),
+                after_cursor=after_cursor,
+                limit=limit,
+                include_addressed=include_addressed,
+            )
+        )
+
+    def agentbus_roll_call(
+        self,
+        agent_id: str,
+        *,
+        include_departed: bool = False,
+    ) -> _Dictish:
+        # The route is agent-scoped for authorization only (an agent connects
+        # to the bus as itself, same as read_agentbus_traffic); the roster it
+        # returns is fleet-wide, not filtered to agent_id.
+        return _Dictish(
+            self._get(
+                "/agents/%s/agentbus/roll-call" % quote(agent_id, safe=""),
+                include_departed=include_departed,
+            )
+        )
+
     # -- Inbox (task_7faf8e56) ----------------------------------------------
     #
     # RemoteDispatch wrapped the entire agentbus surface EXCEPT the inbox, and

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -18872,8 +18872,14 @@ class ControlPlane:
 
     # AgentBus broadcast channel: fleet-readable typed events.
 
-    def agentbus_roll_call(self, *args: Any, **kwargs: Any) -> JsonDict:
-        return self.agentbus_broadcast.roll_call(*args, **kwargs)
+    def agentbus_roll_call(self, agent_id: str = "", *, include_departed: bool = False) -> JsonDict:
+        # agent_id is accepted-and-ignored here so CLI call sites are
+        # identical in local and hub (RemoteDispatch) mode: the hub route is
+        # agent-scoped for authorization only (POST /agents/{id}/...), and
+        # in-process ControlPlane calls carry no per-caller identity to
+        # authorize against.
+        del agent_id
+        return self.agentbus_broadcast.roll_call(include_departed=include_departed)
 
     def publish_agentbus_broadcast(self, *args: Any, **kwargs: Any) -> JsonDict:
         agent_id = self._positional_or_kw(args, kwargs, "agent_id", 0)

--- a/tests/cli/test_cli_extended.py
+++ b/tests/cli/test_cli_extended.py
@@ -9,7 +9,7 @@ Covers:
   - observability: list, prune
   - rollout extended: verify-artifact, health
   - nap extended: cycle, due
-  - agentbus extended: publish, repo-update, artifact-publish
+  - agentbus extended: publish, repo-update, artifact-publish, traffic, roll-call
   - secret: access (with trusted machine)
   - task extended: detect-beads, detect-ticketing
 
@@ -519,6 +519,55 @@ def test_agentbus_publish_event(tmp_path):
         '{"msg": "hello"}',
     )
     assert rc == 0
+
+
+def test_agentbus_traffic_reads_the_whole_bus_not_just_the_inbox(tmp_path):
+    """agentbus traffic surfaces the message as the listener, not just the sender's echo."""
+    sender = _make_agent(tmp_path, "traffic-sender", agent_id="agent_traffic_sender")
+    listener = _make_agent(tmp_path, "traffic-listener", agent_id="agent_traffic_listener")
+
+    rc, _sent = _run(
+        tmp_path,
+        "admin",
+        "agentbus",
+        "publish",
+        sender["id"],
+        "--recipient-agent-id",
+        listener["id"],
+        "--payload",
+        '{"msg": "hello"}',
+    )
+    assert rc == 0
+
+    rc, traffic = _run(tmp_path, "admin", "agentbus", "traffic", listener["id"])
+    assert rc == 0
+    assert len(traffic) == 1
+    assert traffic[0]["from_agent_id"] == sender["id"]
+    assert traffic[0]["addressed_to_me"] is True
+
+    # --exclude-addressed drops messages already addressed to the listener --
+    # it handles those via inbox/wait, not the firehose.
+    rc, filtered = _run(
+        tmp_path, "admin", "agentbus", "traffic", listener["id"], "--exclude-addressed"
+    )
+    assert rc == 0
+    assert filtered == []
+
+    # The sender never sees its own write echoed back.
+    rc, sender_view = _run(tmp_path, "admin", "agentbus", "traffic", sender["id"])
+    assert rc == 0
+    assert sender_view == []
+
+
+def test_agentbus_roll_call_lists_registered_agents(tmp_path):
+    """agentbus roll-call answers who is on the bus, authenticating as any registered agent."""
+    agent = _make_agent(tmp_path, "roll-call-agent", agent_id="agent_roll_call")
+
+    rc, roster = _run(tmp_path, "admin", "agentbus", "roll-call", agent["id"])
+
+    assert rc == 0
+    assert roster["schema"].startswith("mac.agentbus")
+    assert agent["id"] in {entry["id"] for entry in roster["agents"]}
 
 
 def test_agent_reflect_publishes_self_description(tmp_path):

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -637,6 +637,57 @@ def test_remote_dispatch_read_agentbus_chunks_passes_agent_id():
     assert "limit=5" in url
 
 
+def test_remote_dispatch_read_agentbus_traffic_hits_agent_scoped_route():
+    """`mac agentbus traffic` in hub mode — the firehose route, agent-scoped
+    for auth the same way the inbox is (an agent connects to the bus as
+    itself)."""
+    from mac.http_client import HubClient
+
+    fake = _FakeTransport(
+        response_for={
+            ("GET", "/agents/agent_rocky/agentbus/traffic"): [
+                {"from_agent_id": "agent_peer", "addressed_to_me": True}
+            ]
+        }
+    )
+    disp = RemoteDispatch(HubClient("http://hub:8789", token="tok", transport=fake))
+    traffic = disp.read_agentbus_traffic(
+        "agent_rocky", "2026-01-01T00:00:00Z::chunk_1", 25, include_addressed=False
+    )
+    assert [item.to_dict() for item in traffic] == [
+        {"from_agent_id": "agent_peer", "addressed_to_me": True}
+    ]
+    method, url, _body, token = fake.calls[-1]
+    assert method == "GET"
+    assert "/agents/agent_rocky/agentbus/traffic" in url
+    assert "after_cursor=2026-01-01T00%3A00%3A00Z" in url
+    assert "limit=25" in url
+    assert "include_addressed=false" in url
+    assert token == "tok"
+
+
+def test_remote_dispatch_agentbus_roll_call_hits_agent_scoped_route():
+    """`mac agentbus roll-call` in hub mode -- agent_id authorizes, the roster
+    returned is fleet-wide, not filtered to it."""
+    from mac.http_client import HubClient
+
+    fake = _FakeTransport(
+        response_for={
+            ("GET", "/agents/agent_rocky/agentbus/roll-call"): {
+                "schema": "mac.agentbus.roll_call.v1",
+                "agents": [{"id": "agent_rocky"}, {"id": "agent_peer"}],
+            }
+        }
+    )
+    disp = RemoteDispatch(HubClient("http://hub:8789", token="tok", transport=fake))
+    roster = disp.agentbus_roll_call("agent_rocky", include_departed=True)
+    assert roster.to_dict()["agents"] == [{"id": "agent_rocky"}, {"id": "agent_peer"}]
+    method, url, _body, _token = fake.calls[-1]
+    assert method == "GET"
+    assert "/agents/agent_rocky/agentbus/roll-call" in url
+    assert "include_departed=true" in url
+
+
 def test_remote_dispatch_project_repository_wrappers_hit_hub_paths():
     from mac.http_client import HubClient
 


### PR DESCRIPTION
## Summary
- The read-side HTTP API for the fleet activity firehose has existed since 2026-08-17 (`ControlPlane.read_agentbus_traffic`/`agentbus_roll_call`, routes `GET /agents/{agent_id}/agentbus/{traffic,roll-call}`) with no CLI command ever calling it -- the exact same gap `mac agentbus broadcast` closed for the separate typed-event channel (its own docstring: "it existed with no way to read it from the CLI, which is most of why nobody read it").
- `mac agentbus traffic <agent_id> [--follow] [--after-cursor ...] [--exclude-addressed]` reads the whole bus as `agent_id` hears it -- point-to-point AND group traffic, not just its own inbox or one known stream. `--follow` polls and tails forever until interrupted, the tail-mode counterpart to `agentbus wait`'s single-shot exit-on-first-message.
- `mac agentbus roll-call <agent_id> [--include-departed]` is a one-shot fleet roster.
- Both take an existing registered `agent_id` (positional, matching the `broadcast`/`wait`/`read` convention) rather than inventing a dedicated "viewer" identity for v1 -- the hub route is agent-scoped for authorization only (`assert_actor`), the same way the inbox already is.

## Also fixed
- `RemoteDispatch` had no `read_agentbus_traffic`/`agentbus_roll_call` wrappers at all -- hub mode (every fleet agent) would have raised "not yet supported in hub mode". Added both.
- Gave `ControlPlane.agentbus_roll_call` an explicit `agent_id`-accepted-and-ignored signature (was `*args/**kwargs` passthrough straight to a keyword-only `roll_call()`) so the CLI call site is identical in local and hub mode.

## Verification
- New tests: `test_agentbus_traffic_reads_the_whole_bus_not_just_the_inbox`, `test_agentbus_roll_call_lists_registered_agents` (full CLI harness, `tests/cli/test_cli_extended.py`), `test_remote_dispatch_read_agentbus_traffic_hits_agent_scoped_route`, `test_remote_dispatch_agentbus_roll_call_hits_agent_scoped_route` (`tests/test_dispatch.py`)
- `tests/cli/` + `tests/test_dispatch.py`: 716 passed, 1 pre-existing unrelated failure (`test_the_table_never_exceeds_the_terminal`, reproduces identically with this branch's changes stashed out -- a task-table terminal-width issue, nothing to do with agentbus)
- `ruff check` on all changed files -- clean
- Manual `--help` smoke test on both new subcommands, confirmed reachable via the existing `agentbus` -> `admin agentbus` re-parenting