### PR TITLE
Add transactional release workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ CONSOLE_SCRIPTS = mac mac-hermes mac-agent mac-firecrawl-gateway mac-hub-upgrade
 	install install-cli install-gui uninstall uninstall-cli \
 	build build-cli build-gui package package-cli package-gui publish \
 	clean clean-cli clean-gui distclean run-gui \
-	install-hooks setup deploy test coverage test-api test-cli test-local-console test-systemd-local-console test-ui test-schema-migrations cli-coverage lint lint-fix lint-local-console format-local-console \
+	install-hooks setup deploy release test coverage test-api test-cli test-local-console test-systemd-local-console test-ui test-schema-migrations cli-coverage lint lint-fix lint-local-console format-local-console \
 	test-portfolio impact-map fault-replay sanity-test compatibility-test postgres-schema \
 	docs docs-install docs-serve docs-test docs-build docs-check docs-accessibility docs-graph docs-lab docs-reference env-reference \
 	ide-install ide-run ide-dev ide-check ide-build ide-preview ide-package \
@@ -240,6 +240,9 @@ deploy: require-python ## Deploy to an already configured fleet hub.
 		exit 2; \
 	fi
 	$(PYTHON) setup.py $(if $(HUB),--hub $(HUB),) $(ARGS)
+
+release: ## Create a tagged GitHub release (BUMP=patch; FLEET=<name> deploys it).
+	scripts/release.sh $(BUMP) $(if $(FLEET),--fleet $(FLEET),)
 
 # ---------------------------------------------------------------------------
 # Tests and quality gates.

--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,9 @@ deploy: require-python ## Deploy to an already configured fleet hub.
 	fi
 	$(PYTHON) setup.py $(if $(HUB),--hub $(HUB),) $(ARGS)
 
-release: ## Create a tagged GitHub release (BUMP=patch; FLEET=<name> deploys it).
-	scripts/release.sh $(BUMP) $(if $(FLEET),--fleet $(FLEET),)
+release: ## Create a tagged GitHub release (RELEASE_DOCS=dir; FLEET=<name> deploys it).
+	@if [ -z "$(RELEASE_DOCS)" ]; then echo "usage: make release RELEASE_DOCS=docs/presentation/<release-dir> [BUMP=patch] [FLEET=<name>]"; exit 2; fi
+	scripts/release.sh $(BUMP) --docs-dir "$(RELEASE_DOCS)" $(if $(FLEET),--fleet $(FLEET),)
 
 # ---------------------------------------------------------------------------
 # Tests and quality gates.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,12 +2,13 @@
 # Create an immutable MAC release from main and optionally roll it out.
 set -euo pipefail
 
-usage() { echo 'usage: scripts/release.sh [major|minor|patch] [--fleet NAME]'; }
+usage() { echo 'usage: scripts/release.sh [major|minor|patch] --docs-dir DIR [--fleet NAME]'; }
 die() { echo "release: $*" >&2; exit 1; }
 
-bump=patch; fleet=""
+bump=patch; fleet=""; docs_dir=""
 while (($#)); do case "$1" in
   major|minor|patch) bump="$1";;
+  --docs-dir) shift; (($#)) || die '--docs-dir requires a path'; docs_dir="$1";;
   --fleet) shift; (($#)) || die '--fleet requires a name'; fleet="$1";;
   -h|--help) usage; exit 0;;
   *) die "unknown argument: $1";;
@@ -25,9 +26,17 @@ case "$bump" in major) major=$((major+1)); minor=0; patch=0;; minor) minor=$((mi
 version="$major.$minor.$patch"; tag="v$version"; branch="release/$tag"
 git rev-parse -q --verify "refs/tags/$tag" >/dev/null && die "$tag already exists"
 
-# A pinned audit/deck is the human-authored release gate; its presence is
-# verified here, while docs-check verifies that it is reachable and valid.
-git ls-files 'docs/presentation/*/AUDIT.md' | grep -q . || die 'no pinned release audit exists'
+# A release must carry its own audited documentation and rebuildable deck, not
+# merely point at a prior release's artifacts.  Content remains deliberately
+# human-authored, but this command proves it was updated before it can tag.
+[ -n "$docs_dir" ] || die '--docs-dir is required for every release'
+[ -f "$docs_dir/README.md" ] || die "$docs_dir lacks README.md"
+[ -f "$docs_dir/AUDIT.md" ] || die "$docs_dir lacks AUDIT.md"
+[ -f "$docs_dir/build_deck.py" ] || die "$docs_dir lacks build_deck.py"
+git diff --quiet "v$current"..HEAD -- "$docs_dir" && die "$docs_dir was not updated since v$current"
+grep -Fq "$tag" "$docs_dir/AUDIT.md" || die "$docs_dir/AUDIT.md does not identify $tag"
+python3 scripts/generate-docs-reference.py --write
+python3 "$docs_dir/build_deck.py"
 python3 - "$version" <<'PY'
 from pathlib import Path
 import re, sys
@@ -39,7 +48,7 @@ PY
 make lint
 make test
 make docs-check
-git add src/mac/__init__.py
+git add src/mac/__init__.py docs
 git commit -m "Release $tag"
 git switch -c "$branch"
 git push --set-upstream origin "$branch"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Create an immutable MAC release from main and optionally roll it out.
+set -euo pipefail
+
+usage() { echo 'usage: scripts/release.sh [major|minor|patch] [--fleet NAME]'; }
+die() { echo "release: $*" >&2; exit 1; }
+
+bump=patch; fleet=""
+while (($#)); do case "$1" in
+  major|minor|patch) bump="$1";;
+  --fleet) shift; (($#)) || die '--fleet requires a name'; fleet="$1";;
+  -h|--help) usage; exit 0;;
+  *) die "unknown argument: $1";;
+esac; shift; done
+
+command -v gh >/dev/null || die 'gh is required'
+gh auth status >/dev/null 2>&1 || die 'gh is not authenticated'
+git diff --quiet && git diff --cached --quiet || die 'working tree is not clean'
+[ "$(git branch --show-current)" = main ] || die 'release must start from main'
+git fetch origin --tags --prune
+git diff --quiet HEAD origin/main || die 'local main differs from origin/main'
+current="$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*' | sed 's/^v//')"
+IFS=. read -r major minor patch <<<"$current"
+case "$bump" in major) major=$((major+1)); minor=0; patch=0;; minor) minor=$((minor+1)); patch=0;; patch) patch=$((patch+1));; esac
+version="$major.$minor.$patch"; tag="v$version"; branch="release/$tag"
+git rev-parse -q --verify "refs/tags/$tag" >/dev/null && die "$tag already exists"
+
+# A pinned audit/deck is the human-authored release gate; its presence is
+# verified here, while docs-check verifies that it is reachable and valid.
+git ls-files 'docs/presentation/*/AUDIT.md' | grep -q . || die 'no pinned release audit exists'
+python3 - "$version" <<'PY'
+from pathlib import Path
+import re, sys
+p=Path('src/mac/__init__.py'); text=p.read_text(encoding='utf-8')
+text, n=re.subn(r'__version__ = "[^"]+"', f'__version__ = "{sys.argv[1]}"', text, count=1)
+if n != 1: raise SystemExit('single version declaration not found')
+p.write_text(text, encoding='utf-8')
+PY
+make lint
+make test
+make docs-check
+git add src/mac/__init__.py
+git commit -m "Release $tag"
+git switch -c "$branch"
+git push --set-upstream origin "$branch"
+pr_url="$(gh pr create --base main --head "$branch" --title "Release $tag" --body "Prepare $tag from a gated main commit.")"
+gh pr checks "$pr_url" --watch --fail-fast
+gh pr merge "$pr_url" --squash --delete-branch
+git switch main
+git pull --ff-only origin main
+git tag -a "$tag" -m "Release $tag"
+git push origin "$tag"
+gh run watch "$(gh run list --workflow release.yml --branch "$tag" --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
+if [ -n "$fleet" ]; then make deploy HUB="$fleet"; fi
+echo "release: $tag is published"

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,17 +1,36 @@
 """The single-command release workflow must retain its safe ordering."""
+
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "release.sh"
 
+
 def test_release_workflow_requires_gates_then_pr_tag_artifact_and_optional_rollout():
     text = SCRIPT.read_text(encoding="utf-8")
-    required = ['make lint', 'make test', 'make docs-check', 'git switch -c "$branch"', 'gh pr checks "$pr_url" --watch --fail-fast', 'gh pr merge "$pr_url" --squash --delete-branch', 'git pull --ff-only origin main', 'git tag -a "$tag"', 'git push origin "$tag"', 'gh run watch', 'make deploy HUB="$fleet"']
+    required = [
+        "make lint",
+        "make test",
+        "make docs-check",
+        'git switch -c "$branch"',
+        'gh pr checks "$pr_url" --watch --fail-fast',
+        'gh pr merge "$pr_url" --squash --delete-branch',
+        "git pull --ff-only origin main",
+        'git tag -a "$tag"',
+        'git push origin "$tag"',
+        "gh run watch",
+        'make deploy HUB="$fleet"',
+    ]
     missing = [item for item in required if item not in text]
     assert not missing, missing
-    assert text.index('gh pr merge "$pr_url"') < text.index('git tag -a "$tag"') < text.index('make deploy HUB="$fleet"')
+    assert (
+        text.index('gh pr merge "$pr_url"')
+        < text.index('git tag -a "$tag"')
+        < text.index('make deploy HUB="$fleet"')
+    )
+
 
 def test_makefile_exposes_release_target():
     text = (ROOT / "Makefile").read_text(encoding="utf-8")
-    assert 'release: ## Create a tagged GitHub release' in text
-    assert 'scripts/release.sh $(BUMP)' in text
+    assert "release: ## Create a tagged GitHub release" in text
+    assert "scripts/release.sh $(BUMP)" in text

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -12,6 +12,9 @@ def test_release_workflow_requires_gates_then_pr_tag_artifact_and_optional_rollo
         "make lint",
         "make test",
         "make docs-check",
+        "--docs-dir is required for every release",
+        "scripts/generate-docs-reference.py --write",
+        'python3 "$docs_dir/build_deck.py"',
         'git switch -c "$branch"',
         'gh pr checks "$pr_url" --watch --fail-fast',
         'gh pr merge "$pr_url" --squash --delete-branch',
@@ -33,4 +36,5 @@ def test_release_workflow_requires_gates_then_pr_tag_artifact_and_optional_rollo
 def test_makefile_exposes_release_target():
     text = (ROOT / "Makefile").read_text(encoding="utf-8")
     assert "release: ## Create a tagged GitHub release" in text
-    assert "scripts/release.sh $(BUMP)" in text
+    assert "RELEASE_DOCS=docs/presentation" in text
+    assert 'scripts/release.sh $(BUMP) --docs-dir "$(RELEASE_DOCS)"' in text

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,17 @@
+"""The single-command release workflow must retain its safe ordering."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "release.sh"
+
+def test_release_workflow_requires_gates_then_pr_tag_artifact_and_optional_rollout():
+    text = SCRIPT.read_text(encoding="utf-8")
+    required = ['make lint', 'make test', 'make docs-check', 'git switch -c "$branch"', 'gh pr checks "$pr_url" --watch --fail-fast', 'gh pr merge "$pr_url" --squash --delete-branch', 'git pull --ff-only origin main', 'git tag -a "$tag"', 'git push origin "$tag"', 'gh run watch', 'make deploy HUB="$fleet"']
+    missing = [item for item in required if item not in text]
+    assert not missing, missing
+    assert text.index('gh pr merge "$pr_url"') < text.index('git tag -a "$tag"') < text.index('make deploy HUB="$fleet"')
+
+def test_makefile_exposes_release_target():
+    text = (ROOT / "Makefile").read_text(encoding="utf-8")
+    assert 'release: ## Create a tagged GitHub release' in text
+    assert 'scripts/release.sh $(BUMP)' in text


### PR DESCRIPTION
Ports NanoLang release methodology into MAC as scripts/release.sh and make release. The workflow gates lint/test/docs, creates and merges a release PR, tags the landed main commit, waits for the tag-triggered artifact workflow, and deploys only when FLEET=<name> is explicitly supplied.\n\nValidation: tests/test_release_workflow.py (2 passed), bash -n. `make lint` validates new code but remains nonzero due pre-existing formatting drift in tests/test_deploy_agent_configs.py.