### PR TITLE
Harden release documentation gates for v1.3.5

### DIFF
--- a/docs/book/05-evidence-review-completion.md
+++ b/docs/book/05-evidence-review-completion.md
@@ -23,10 +23,11 @@ MAC_DB="$DOCS_DB" MAC_API_ALLOW_OPEN=1 \
   --port "$DOCS_PORT" >"$TMPDIR/mac-docs-hub.log" 2>&1 &
 hub_pid=$!
 trap 'kill "$hub_pid" 2>/dev/null || true; wait "$hub_pid" 2>/dev/null || true' EXIT
-for attempt in 1 2 3 4 5; do
+for attempt in $(seq 1 30); do
   curl --fail --silent "$DOCS_HUB_URL/health" >/dev/null && break
   sleep 1
 done
+curl --fail --silent "$DOCS_HUB_URL/health" >/dev/null
 mac --hub-url "$DOCS_HUB_URL" admin machine register lifecycle-host \
   --machine-id machine_lifecycle
 writer_registration="$(mac --hub-url "$DOCS_HUB_URL" --json agent register \

--- a/docs/book/17-learning-evals-scaling.md
+++ b/docs/book/17-learning-evals-scaling.md
@@ -3,7 +3,7 @@ schema: mac.docs.chapter.v1
 chapter: 17
 title: Learning, Evals, and Scaling
 audiences: [operator, integrator, contributor]
-timeout_seconds: 60
+timeout_seconds: 120
 ---
 
 # Learning, Evals, and Scaling

--- a/docs/book/18-capstone.md
+++ b/docs/book/18-capstone.md
@@ -26,10 +26,11 @@ MAC_DB="$DOCS_DB" MAC_API_ALLOW_OPEN=1 \
   --port "$DOCS_PORT" >"$TMPDIR/mac-docs-hub.log" 2>&1 &
 hub_pid=$!
 trap 'kill "$hub_pid" 2>/dev/null || true; wait "$hub_pid" 2>/dev/null || true' EXIT
-for attempt in 1 2 3 4 5; do
+for attempt in $(seq 1 30); do
   curl --fail --silent "$DOCS_HUB_URL/health" >/dev/null && break
   sleep 1
 done
+curl --fail --silent "$DOCS_HUB_URL/health" >/dev/null
 mac --hub-url "$DOCS_HUB_URL" project create production-demo --active
 mac --hub-url "$DOCS_HUB_URL" admin machine register production-host \
   --machine-id machine_production

--- a/docs/presentation/20260902T131314Z-a168e9d0/AUDIT.md
+++ b/docs/presentation/20260902T131314Z-a168e9d0/AUDIT.md
@@ -1,0 +1,57 @@
+# Audit — MAC v1.3.5 release candidate
+
+Audited at commit `a168e9d07ca2ae0222ca68de79983075b22e968b` on
+2026-09-02T13:13:14Z. This audit supports release `v1.3.5`. Generated CLI and
+OpenAPI references are authoritative because CI verifies them against the live
+parser and schema.
+
+## Current-document pass
+
+Every current row in `docs/reference/documentation-inventory.md` was reviewed
+against the candidate tree. The release range is `v1.3.4..a168e9d0`.
+
+| Documentation surface | Decision | Source anchor |
+|---|---|---|
+| Generated CLI reference | changed: AgentBus traffic, roll-call, and news output are documented | `docs/reference/cli.md`; PR #710; PR #713 |
+| Generated OpenAPI reference | changed: AgentBus and fleet-news read surfaces are documented | `docs/reference/openapi.md`; PR #708; PR #713 |
+| Documentation inventory | changed: AgentFabric authoring package is enumerated | `docs/reference/documentation-inventory.md`; PR #694 |
+| AgentFabric authoring package | added: presentation authoring materials are supplemental documentation, not MAC runtime behavior | `docs/presentations/agentfabric-overview/`; PR #694 |
+| Book chapter 17 | changed: the executable learning/directives example has a 120-second budget after its healthy run exceeded 60 seconds | `docs/book/17-learning-evals-scaling.md`; focused chapter-17 receipt |
+| Book chapters 5 and 18 | changed: hub examples wait up to 30 seconds and require a health check before issuing hub commands | `docs/book/05-evidence-review-completion.md`, `docs/book/18-capstone.md`; focused chapter receipts |
+| All other current inventory rows | not changed by this range | source review against `v1.3.4..a168e9d0`; no corresponding documentation diff |
+
+Historical archive rows were reviewed as provenance only and are not current
+operating contracts. `make docs-check` is required again on the release commit.
+
+## Release claims
+
+| Claim | Source |
+|---|---|
+| The tag-triggered release workflow builds a wheel, installs it cleanly, verifies task-executor import, and publishes artifacts | `.github/workflows/release.yml`; PR #707 |
+| Fleet deployment does not fail solely because a gateway readiness probe was slow while the gateway later proved healthy | `deploy/fleet-node-install.sh`, `deploy/deploy-mac-fleet.sh`; PR #709 |
+| Named agents can inspect AgentBus traffic and obtain a roll-call through the CLI and hub dispatch wrapper | `src/mac/cli.py`, `src/mac/dispatch.py`, `src/mac/services.py`; PR #710 |
+| Fleet news is available through read-only API, CLI, and observability surfaces with automation-safe output | `src/mac/news_feed.py`, `src/mac/api.py`, `observe/src/views/News.tsx`; PR #713 |
+| Contract-test terminal guidance allows up to 3,600 seconds for the full suite instead of treating a healthy long run as hung | `skills/mac-agent-terminal-timeout/SKILL.md`; PR #715 |
+| The executable documentation gate permits the healthy learning/directives example to complete within 120 seconds | `docs/book/17-learning-evals-scaling.md`; focused chapter-17 receipt |
+| Hub-backed executable book chapters wait for their local authority before continuing, removing a startup-race failure | `docs/book/05-evidence-review-completion.md`, `docs/book/18-capstone.md`; focused chapter receipts |
+| `make release` requires release-specific documentation and a rebuildable deck before version bump, gated PR, tag, artifact workflow, and optional fleet deployment | `scripts/release.sh`, `Makefile`, `tests/test_release_workflow.py`; PR #716 |
+
+## Current measured surface
+
+| Claim | Evidence |
+|---|---|
+| 433 HTTP routes | generated `docs/reference/openapi.md` at `a168e9d0` |
+| Generated CLI reference has six top-level command groups | generated `docs/reference/cli.md` at `a168e9d0` |
+| 18 executable book chapters | `mkdocs.yml`; `make docs-check` |
+| Eight commits since v1.3.4 | `git rev-list --count v1.3.4..a168e9d0` |
+| No ADR is marked Proposed in this candidate tree | status-line scan of `docs/adr/` at `a168e9d0` |
+
+## Gates and scope
+
+- Candidate commit: `a168e9d07ca2ae0222ca68de79983075b22e968b`.
+- PR #716 CI and Documentation workflows: success, including the expanded sanity scope.
+- Release execution must rerun `make lint`, `make test`, and `make docs-check`
+  on the final version-bump commit.
+- Fleet cutover and image qualification are verified during the optional
+  deployment step; a failed newest generation is retained for fix-forward
+  diagnosis rather than automatically rolled back.

--- a/docs/presentation/20260902T131314Z-a168e9d0/README.md
+++ b/docs/presentation/20260902T131314Z-a168e9d0/README.md
@@ -1,0 +1,26 @@
+# MAC capabilities deck — `a168e9d0`
+
+Point-in-time capabilities deck for the v1.3.5 release candidate, audited at
+commit `a168e9d0` and captured 2026-09-02T13:13:14Z.
+
+## Deck
+
+Slides: [MAC — v1.3.5 release candidate (`a168e9d0`)](https://docs.google.com/presentation/d/16ZYljibDJ1toiyuBpKmxaiqSjsZ7j69bPDIuGB2tDH4/edit?usp=drivesdk)
+
+The deterministic builder and exported Slides deck were verified at six slides.
+
+Six slides, 16:9, describe the operational changes since v1.3.4: artifact
+publication, integration-gate repair, fleet deploy resilience, AgentBus
+visibility, the longer contract-test allowance, and the transactional release
+workflow.
+
+## Rebuild
+
+```console
+$ python3 -m venv /tmp/deckvenv
+$ /tmp/deckvenv/bin/pip install python-pptx
+$ /tmp/deckvenv/bin/python docs/presentation/20260902T131314Z-a168e9d0/build_deck.py
+```
+
+Publish with `scripts/publish-deck-to-slides.py` and `--expect-slides 6`.
+Generated PNGs and PPTX files are ignored and are not committed.

--- a/docs/presentation/20260902T131314Z-a168e9d0/build_deck.py
+++ b/docs/presentation/20260902T131314Z-a168e9d0/build_deck.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Build the six-slide MAC v1.3.5 release-candidate deck."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+HERE = Path(__file__).resolve().parent
+COMMIT = "a168e9d0"
+CAPTURED = "2026-09-02T13:13:14Z"
+OUT = HERE / f"mac-capabilities-{COMMIT}.pptx"
+
+INK = RGBColor(0x1B, 0x25, 0x30)
+SLATE = RGBColor(0x2F, 0x3A, 0x45)
+GREY = RGBColor(0x5A, 0x6B, 0x7A)
+MUTED = RGBColor(0x8A, 0x98, 0xA6)
+WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+BLUE = RGBColor(0x2E, 0x6F, 0x9E)
+AMBER = RGBColor(0xB5, 0x65, 0x1D)
+SAND = RGBColor(0xF2, 0xC4, 0x8A)
+PALE = RGBColor(0xDC, 0xE5, 0xEC)
+FONT = "Helvetica Neue"
+
+prs = Presentation()
+prs.slide_width = Inches(13.333)
+prs.slide_height = Inches(7.5)
+BLANK = prs.slide_layouts[6]
+
+
+def notes(slide, text: str) -> None:
+    slide.notes_slide.notes_text_frame.text = text.strip()
+
+
+def background(slide, color) -> None:
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = color
+
+
+def text_box(slide, x, y, w, h, align=PP_ALIGN.LEFT):
+    box = slide.shapes.add_textbox(x, y, w, h)
+    frame = box.text_frame
+    frame.word_wrap = True
+    frame.paragraphs[0].alignment = align
+    return frame
+
+
+def line(frame, text, size, color, *, bold=False, first=False, after=8):
+    paragraph = frame.paragraphs[0] if first else frame.add_paragraph()
+    paragraph.space_after = Pt(after)
+    run = paragraph.add_run()
+    run.text = text
+    run.font.size = Pt(size)
+    run.font.bold = bold
+    run.font.color.rgb = color
+    run.font.name = FONT
+
+
+def title_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(slide, Inches(0.9), Inches(2.0), Inches(11.5), Inches(2.8))
+    line(frame, "MAC", 54, WHITE, bold=True, first=True, after=8)
+    line(frame, "v1.3.5 release candidate", 32, PALE, after=16)
+    line(frame, "A release procedure that makes the evidence, documentation, and rollout visible.", 18, MUTED)
+    footer = text_box(slide, Inches(0.9), Inches(5.75), Inches(11.5), Inches(0.8))
+    line(footer, f"commit {COMMIT}   ·   captured {CAPTURED}", 16, SAND, bold=True, first=True)
+    notes(slide, "This deck is pinned to the release candidate. AUDIT.md traces each visible claim to the source tree or generated reference.")
+
+
+def change_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(frame, "This release makes long-running change safer to observe and finish", 33, INK, bold=True, first=True)
+    line(frame, "The goal is operational confidence, not a faster-looking dashboard.", 16, GREY)
+    body = text_box(slide, Inches(0.95), Inches(2.05), Inches(11.3), Inches(4.65))
+    for index, (head, detail) in enumerate([
+        ("Artifact publication", "A tag now builds and validates a versioned wheel before publishing the release."),
+        ("Deploy resilience", "A slow but healthy gateway is recorded as degraded rather than turning a node rollout into a false failure."),
+        ("Fleet visibility", "AgentBus traffic, roll-call, and fleet news give operators durable read-side evidence."),
+        ("Healthy test budget", "The contract suite has up to one hour when it is making progress, so verification is not mistaken for a hang."),
+    ]):
+        line(body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2)
+        line(body, detail, 17, SLATE, after=12)
+    notes(slide, "Each point is a shipped change in the audited range, not a planned capability.")
+
+
+def release_flow_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(frame, "A release is now a gated sequence with a clear stop point", 33, INK, bold=True, first=True)
+    line(frame, "The command cannot tag first and explain later.", 16, GREY)
+    body = text_box(slide, Inches(1.0), Inches(2.1), Inches(11.1), Inches(4.5), align=PP_ALIGN.CENTER)
+    steps = ["Audited docs and deck", "Lint, tests, and docs gate", "Release PR", "Tag and artifacts", "Optional fleet rollout"]
+    for idx, step in enumerate(steps):
+        line(body, f"{idx + 1}.  {step}", 23, BLUE if idx < 3 else AMBER, bold=True, first=idx == 0, after=14)
+    notes(slide, "The release target enforces this ordering. Deployment remains optional and follows artifact publication.")
+
+
+def evidence_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(slide, Inches(0.9), Inches(0.7), Inches(11.5), Inches(1.0))
+    line(frame, "The candidate has a verifiable operating surface", 34, WHITE, bold=True, first=True)
+    body = text_box(slide, Inches(0.95), Inches(2.0), Inches(11.2), Inches(4.3))
+    for idx, item in enumerate([
+        "433 HTTP routes in the generated OpenAPI reference",
+        "Six top-level command groups in the generated CLI reference",
+        "18 executable documentation chapters",
+        "Eight commits since v1.3.4",
+        "Expanded sanity scope passed before the release workflow was merged",
+    ]):
+        line(body, item, 22, PALE if idx < 3 else SAND, bold=idx < 3, first=idx == 0, after=12)
+    notes(slide, "Counts are dated observations at this commit. AUDIT.md gives the collection source for each one.")
+
+
+def boundary_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(frame, "Release automation does not erase operational judgement", 33, INK, bold=True, first=True)
+    line(frame, "Automation proves prerequisites; it does not conceal a failed rollout.", 16, GREY)
+    body = text_box(slide, Inches(0.95), Inches(2.1), Inches(11.3), Inches(4.5))
+    line(body, "If the final version bump is not green, the process stops before a tag.", 22, BLUE, bold=True, first=True, after=15)
+    line(body, "If deployment fails, the newest generation is retained with diagnostic evidence and a safety hold for a forward repair.", 22, AMBER, bold=True, after=15)
+    line(body, "The release record, the deck, and the fleet outcome stay separately inspectable.", 22, SLATE, bold=True)
+    notes(slide, "This is a fix-forward policy. A rollback requires explicit break-glass authority.")
+
+
+def closing_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(slide, Inches(0.9), Inches(2.1), Inches(11.5), Inches(2.7), align=PP_ALIGN.CENTER)
+    line(frame, "v1.3.5 is ready to be proven, published, and rolled out", 34, WHITE, bold=True, first=True, after=14)
+    line(frame, "The release target keeps the proof with the release instead of leaving it in a terminal transcript.", 20, PALE)
+    notes(slide, "Close with the practical consequence: a release is now a reproducible, reviewable procedure rather than a sequence remembered by one operator.")
+
+
+for build in (title_slide, change_slide, release_flow_slide, evidence_slide, boundary_slide, closing_slide):
+    build()
+
+prs.save(OUT)
+print(OUT)

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -54,6 +54,7 @@ need to know, the failure message names it when it fires.
 
 | Directory | Commit | Deck | Subject |
 |---|---|---|---|
+| [`20260902T131314Z-a168e9d0`](20260902T131314Z-a168e9d0/README.md) | `a168e9d0` | [Google Slides](https://docs.google.com/presentation/d/16ZYljibDJ1toiyuBpKmxaiqSjsZ7j69bPDIuGB2tDH4/edit?usp=drivesdk) | v1.3.5 release candidate — artifact publication, deploy resilience, fleet visibility, the contract-test allowance, and the transactional release workflow |
 | [`20260831T143751Z-e78a7ba7`](20260831T143751Z-e78a7ba7/README.md) | `e78a7ba7` | [Google Slides](https://docs.google.com/presentation/d/1uPIlC_TYrp3XHd4ARIbrdxNjPiYgAE7pjdi2n_2FUD8/edit) | v1.3.4 — resilient contract gates, supported PostgreSQL CI, host-Python upgrade recovery, and bounded lease-telemetry clock skew |
 | [`20260828T104510Z-d8d491d6`](20260828T104510Z-d8d491d6/README.md) | `d8d491d6` | [Google Slides](https://docs.google.com/presentation/d/1yOOzFqRVwhY6opljcPEzfkzQmdjwylsxi1_hFO_8wJ0/edit) | What the control plane can do today — object model, twelve task states, coordination, fleet, measurement at v1.3.0 |
 | [`20260825T000816Z-e8040fec`](20260825T000816Z-e8040fec/README.md) | `e8040fec` | [Google Slides](https://docs.google.com/presentation/d/1cLzjGERKojHg0w1FOyUnlqlsVu_OZVM5b_kGc7T3fSw/edit) | What the control plane can do today — object model, twelve task states, coordination, fleet, measurement at v1.2.0 |


### PR DESCRIPTION
Adds the v1.3.5 audited release deck and makes executable-book hub readiness and chapter budget explicit. Full make docs-check passes locally.