### PR TITLE
Clarify HGX interactive login recovery

### DIFF
--- a/docs/hgx-elastic-capacity.md
+++ b/docs/hgx-elastic-capacity.md
@@ -17,7 +17,25 @@ command creates capacity. On an HGX-enabled hub, the optional background
 autoscaler invokes the same bounded controller from durable provisioning
 demand; provider work never runs on a dispatcher or HTTP thread.
 
-Enable it only on the authenticated hub that owns HGX provider credentials:
+## HGX authentication
+
+HGX is MAC's external capacity provider, not a token-configured MAC provider.
+There is no HGX API token to mint, paste, or store in a MAC environment file.
+The operating account that will run `hgx` completes the one-time interactive
+browser bounce:
+
+```console
+$ hgx login
+```
+
+After that login succeeds, HGX commands are ready to use in that account; run
+the capacity `status`, `plan`, or explicit `execute` command normally. If an
+HGX session later expires or is revoked, repeat `hgx login` once and retry the
+operation. The adapter recognizes the usual unauthenticated HGX errors and
+reports this recovery without exposing provider stderr.
+
+Enable the optional autoscaler only where its operating context can already
+run the configured `MAC_HGX_BINARY` using that established HGX login session:
 
 ```text
 MAC_HGX_AUTOSCALE_ENABLED=1
@@ -30,9 +48,8 @@ MAC_HGX_AUTOSCALE_SCALE_DOWN_STEP=1
 MAC_HGX_AUTOSCALE_SPARE_MIN_AGE_SECONDS=3600
 ```
 
-The hub process must be able to execute the configured `MAC_HGX_BINARY`
-non-interactively with a valid owner credential. Enabling the service without
-that credential is observable as a provider error and never falls back to
+The autoscaler does not perform an interactive login itself. A missing or
+expired HGX login is observable as a provider error and never falls back to
 unverified capacity.
 
 ## Readiness contract

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -9428,7 +9428,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     hgx = sub.add_parser(
         "hgx",
-        help="operator controls for fungible HGX provider capacity",
+        help=(
+            "operator controls for fungible HGX provider capacity; authenticate "
+            "once with interactive `hgx login` (no API token)"
+        ),
     ).add_subparsers(dest="hgx_command", required=True)
     hgx_capacity = hgx.add_parser(
         "capacity",

--- a/src/mac/hgx_provider.py
+++ b/src/mac/hgx_provider.py
@@ -25,6 +25,10 @@ ad-hoc CLI shelling:
   structure. Results are secret-free dataclasses; any credential-bearing field
   is reduced to an env-var *name* plus a presence flag, mirroring
   :meth:`mac.agent_provider.ProviderDecision.observable`.
+- **HGX login is interactive, not token provisioning.** HGX owns its own
+  browser-backed session.  When it expires, the operator runs ``hgx login``
+  once in the account that runs HGX; MAC neither requests nor stores an HGX
+  API token.
 - **``standard-dind`` is an explicit path.** OpenShell / Docker execution needs
   the ``standard-dind`` flavor; creating one is a first-class, parameterized
   option rather than a magic string callers must remember.
@@ -52,6 +56,7 @@ from mac.fleet_deploy import SshTarget, parse_ssh_target
 __all__ = [
     "HGX_PROVIDER_SCHEMA",
     "STANDARD_DIND_FLAVOR",
+    "HGX_LOGIN_GUIDANCE",
     "HgxError",
     "HgxCommandError",
     "HgxSessionNotFoundError",
@@ -67,6 +72,14 @@ HGX_PROVIDER_SCHEMA = "mac.hgx_provider.v1"
 # The session flavor required when OpenShell/Docker (docker-in-docker)
 # execution is needed. Kept as a named constant so callers never hand-type it.
 STANDARD_DIND_FLAVOR = "standard-dind"
+
+# HGX authenticates through its own browser-backed login session.  Keep this
+# user-facing wording here so commands which surface an expired HGX session
+# give operators the right recovery, rather than suggesting token setup.
+HGX_LOGIN_GUIDANCE = (
+    "HGX uses a one-time interactive `hgx login` browser bounce, not a MAC or "
+    "provider API token. Run `hgx login` once in this operating account, then retry."
+)
 
 # hgx info can print a fallback bootstrap password; it is banned outright.
 _FORBIDDEN_VERB = "info"
@@ -316,11 +329,21 @@ class HgxProvider:
                 argv=argv,
             ) from exc
         if completed.returncode != 0:
+            message = "hgx %s failed (exit %d)" % (verb, completed.returncode)
+            stderr = completed.stderr or ""
+            auth_markers = (
+                "not authenticated",
+                "login token expired",
+                "session revoked",
+                "run: hgx login",
+            )
+            if any(marker in stderr.lower() for marker in auth_markers):
+                message = "%s. %s" % (message, HGX_LOGIN_GUIDANCE)
             raise HgxCommandError(
-                "hgx %s failed (exit %d)" % (verb, completed.returncode),
+                message,
                 argv=argv,
                 returncode=completed.returncode,
-                stderr=completed.stderr or "",
+                stderr=stderr,
             )
         return completed.stdout or ""
 

--- a/tests/test_hgx_provider.py
+++ b/tests/test_hgx_provider.py
@@ -442,6 +442,21 @@ def test_nonzero_exit_raises_command_error(monkeypatch):
     assert excinfo.value.stderr == "boom"
 
 
+def test_expired_hgx_login_explains_the_one_time_browser_bounce(monkeypatch):
+    _install_run(
+        monkeypatch,
+        lambda argv, kw: _FakeCompleted("", "Login token expired. Run: hgx login", returncode=1),
+    )
+
+    with pytest.raises(HgxCommandError) as excinfo:
+        HgxProvider().list()
+
+    message = str(excinfo.value)
+    assert "one-time interactive `hgx login` browser bounce" in message
+    assert "not a MAC or provider API token" in message
+    assert excinfo.value.stderr == "Login token expired. Run: hgx login"
+
+
 def test_missing_binary_raises_command_error(monkeypatch):
     def handler(argv, kw):
         raise FileNotFoundError("no hgx")


### PR DESCRIPTION
Closes task_8d7f1c54.

HGX now explicitly documents and surfaces that authentication is a one-time interactive `hgx login` browser bounce, not MAC/provider API-token provisioning.

Verification:
- `pytest tests/test_hgx_provider.py tests/test_hgx_elastic_capacity.py tests/cli/test_cli_hgx_capacity.py -q` — 82 passed
- Serial contract bulk partition — 624 passed in 17.61s
- The contract wrapper documentation/environment preflights passed. Its protected PostgreSQL-backed phase stalled locally; diagnostic follow-up is held in task_19a36e70.