### PR TITLE
Skip decommissioned agents in stale sweep

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -17965,7 +17965,7 @@ class ControlPlane:
         rows = self.store.query_all(
             """
             SELECT * FROM agents
-            WHERE status != ? AND last_seen_at <= ?
+            WHERE status != ? AND deleted_at IS NULL AND last_seen_at <= ?
             ORDER BY last_seen_at, id
             """,
             (AgentStatus.OFFLINE.value, cutoff),

--- a/tests/test_agent_liveness.py
+++ b/tests/test_agent_liveness.py
@@ -69,6 +69,20 @@ def test_marking_an_agent_offline_does_not_refresh_its_last_seen(cp) -> None:
     )
 
 
+def test_stale_sweep_skips_tombstoned_agents(cp) -> None:
+    """A decommissioned row must not make the hub liveness tick fail."""
+    tombstoned = _agent(cp, "decommissioned")
+    live = _agent(cp, "stale-live")
+    cp.delete_agent(tombstoned.id, actor="test")
+    _age_last_seen(cp, tombstoned.id, 3600)
+    _age_last_seen(cp, live.id, 3600)
+
+    marked = cp.mark_stale_agents_offline(60)
+
+    assert [agent.id for agent in marked] == [live.id]
+    assert cp.get_agent(tombstoned.id).deleted_at
+
+
 def test_a_real_heartbeat_still_refreshes_last_seen(cp) -> None:
     """The fix must not break the thing heartbeats are for."""
     agent = _agent(cp, "live")


### PR DESCRIPTION
Fixes the retained Rocky deployment blocker: the hub tick selected tombstoned agent rows, then heartbeat validation rejected them. The stale-agent query now excludes `deleted_at IS NOT NULL` rows and includes a regression test.

Validation:
- `pytest tests/test_agent_liveness.py::test_stale_sweep_skips_tombstoned_agents -q` (1 passed)
- `ruff check src/mac/services.py tests/test_agent_liveness.py`
- `ruff format --check src/mac/services.py tests/test_agent_liveness.py`
- `scripts/run-contract-tests.sh` preflight: 624 passed; broad PostgreSQL phase stopped after 33 passes / 5:36 because serial execution projects to impractical duration.