### PR TITLE
Do not drain hub verifier as task work

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -7469,7 +7469,10 @@ def classify_live_task_sandbox(sandbox):
         return record
     if owner != "mac":
         return record
-    if kind not in managed_task_sandbox_kinds:
+    # Only executor task sandboxes carry a durable task lease. Verification
+    # and probe sandboxes can be owned by long-lived hub processes and must
+    # not be mistaken for worker work that can drain during a fleet rollout.
+    if kind != "task":
         return record
     if not pid_raw:
         return record

--- a/tests/test_fleet_node_daemon_quiescence.py
+++ b/tests/test_fleet_node_daemon_quiescence.py
@@ -1353,6 +1353,24 @@ def test_live_lease_owned_sandbox_is_never_interrupted_during_drain(
     _assert_no_secret(run)
 
 
+def test_live_hubverify_sandbox_does_not_block_task_lease_drain(tmp_path: Path) -> None:
+    """A hub-owned verifier is not a worker task lease and remains untouched."""
+    hubverify = _managed_task_sandbox(
+        "mac-hubverify-live-fixture", kind="hubverify", pid=os.getpid()
+    )
+    run = _run_quiescence(
+        tmp_path,
+        sandbox_source="none",
+        sandbox_present=False,
+        extra_env={"FAKE_STALE_SANDBOXES": json.dumps([hubverify])},
+    )
+
+    receipt = _assert_success_marker(run)
+    assert receipt["openshell_task_sandboxes"]["final_state"] == "quiescent"
+    assert not any("sandbox delete mac-hubverify-live-fixture" in line for line in _call_lines(run))
+    _assert_no_secret(run)
+
+
 def test_multiple_stale_task_sandboxes_are_reaped_in_one_gate_pass(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Fixes the successor rollout quiescence blocker: a live `hubverify` sandbox owned by the hub PID was misclassified as a lease-owned task sandbox. Only `mac.kind=task` can represent active worker work for lease draining; other managed kinds remain eligible for dead-PID reconciliation.

Validation:
- `pytest tests/test_fleet_node_daemon_quiescence.py::test_live_hubverify_sandbox_does_not_block_task_lease_drain tests/test_fleet_node_daemon_quiescence.py::test_live_lease_owned_sandbox_is_never_interrupted_during_drain -q` (2 passed)
- `ruff check` and `ruff format --check` on the test file.