### PR TITLE
Preserve deploy command timeout overrides

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,12 @@ def run_setup_fleet(args: Sequence[str]) -> int:
 
 
 def deploy_env(env_file: Path | None = None) -> Dict[str, str]:
-    env = dict(os.environ)
-    env.update(parse_env_file((env_file or DEFAULT_ENV_FILE).expanduser()))
+    # The file supplies durable operator defaults; an explicit invocation
+    # override must reach deploy/deploy-mac-fleet.sh unchanged.  In particular,
+    # bounded recovery knobs are deliberately set on one deploy command and
+    # must not be silently reset by a stale value in ~/.mac/.env.
+    env = parse_env_file((env_file or DEFAULT_ENV_FILE).expanduser())
+    env.update(os.environ)
     env["PYTHON"] = sys.executable
     return env
 

--- a/tests/test_setup_entrypoint.py
+++ b/tests/test_setup_entrypoint.py
@@ -71,13 +71,18 @@ def test_setup_py_builds_deploy_args_from_plan():
     ]
 
 
-def test_setup_py_deploy_env_loads_generated_env_file(tmp_path):
+def test_setup_py_deploy_env_loads_generated_env_file(tmp_path, monkeypatch):
     setup = _load_setup_module()
     env_file = tmp_path / ".env"
-    env_file.write_text("MAC_API_TOKEN=from-file\n", encoding="utf-8")
+    env_file.write_text(
+        "MAC_API_TOKEN=from-file\nMAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS=20\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS", "300")
 
     values = setup.deploy_env(env_file)
 
     assert values["MAC_API_TOKEN"] == "from-file"
+    assert values["MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS"] == "300"
     assert values["PYTHON"] == sys.executable
     assert values.get("PATH") == os.environ.get("PATH")


### PR DESCRIPTION
## Summary
- preserve an explicit deployment command timeout over the local default env file
- prove the behavior in the setup entrypoint test

## Verification
- `pytest tests/test_setup_entrypoint.py tests/test_deploy_fleet_drain.py tests/test_fleet_node_daemon_quiescence.py -q` (221 passed)
- `ruff check setup.py tests/test_setup_entrypoint.py`
- `scripts/run-contract-tests.sh` preflight (624 passed); extended full suite reached 2,891 passing tests before the bounded operator stop, with no failures

This fixes the Rocky OpenClaw repair path: an explicit `MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS=300` must reach the node instead of being overwritten by `~/.mac/.env`.