### PR TITLE
Fleet deploy phase-1 quiescence intermittently times out on a different host each run (task_5597230096454295991cb10a4c2a4e5f)

### DIFF
--- a/deploy/fleet-node-phase1-quiesce.sh
+++ b/deploy/fleet-node-phase1-quiesce.sh
@@ -1135,6 +1135,28 @@ def run_bounded(
     remaining = deadline - time.monotonic()
     if remaining <= 0:
         raise QuiescenceFailure("phase-1 supervisor deadline expired")
+    started = time.monotonic()
+    # Manager argv contains only reviewed service identities. Including the
+    # operation and target makes a timeout actionable without exposing manager
+    # output or the ambient deployment environment.
+    operation = next(
+        (
+            value
+            for value in argv
+            if value
+            in {
+                "show",
+                "is-enabled",
+                "stop",
+                "start",
+                "print",
+                "bootout",
+                "status",
+            }
+        ),
+        "unknown",
+    )
+    target = argv[-1] if argv else "unknown"
     try:
         with tempfile.TemporaryFile(mode="w+b") as stdout_file, tempfile.TemporaryFile(
             mode="w+b"
@@ -1153,7 +1175,12 @@ def run_bounded(
                 # Every manager command owns a fresh process group so a timeout
                 # cannot strand sudo helpers or manager descendants.
                 _terminate_process_group(process)
-                raise QuiescenceFailure("phase-1 supervisor command timed out")
+                elapsed = time.monotonic() - started
+                raise QuiescenceFailure(
+                    "phase-1 supervisor command timed out: "
+                    "operation=%s target=%s elapsed_seconds=%.1f limit_seconds=%.1f"
+                    % (operation, target, elapsed, min(command_timeout, remaining))
+                )
             stdout_size = os.fstat(stdout_file.fileno()).st_size
             stderr_size = os.fstat(stderr_file.fileno()).st_size
             if (
@@ -3012,7 +3039,20 @@ except Exception as exc:
 PY
 }
 
-run_supervisor_phase1_operation
+supervisor_rc=0
+run_supervisor_phase1_operation || supervisor_rc=$?
+if [ "$supervisor_rc" -ne 0 ]; then
+  if [ "$ACTION" = quiesce ]; then
+    if MAC_PHASE1_SUPERVISOR_COMPENSATE=1 run_supervisor_phase1_operation; then
+      printf '%s\n' \
+        "phase-1 supervisor operation failed; supervisor restored to its pre-attempt state" >&2
+    else
+      printf '%s\n' \
+        "phase-1 supervisor operation failed AND supervisor compensation failed; worker service may be stopped" >&2
+    fi
+  fi
+  exit "$supervisor_rc"
+fi
 
 if [ "$ACTION" = resume_media ]; then
   printf 'phase-1 media resume complete: agent=%s generation=%s proof=%s\n' \

--- a/tests/test_fleet_node_phase1_quiesce.py
+++ b/tests/test_fleet_node_phase1_quiesce.py
@@ -434,6 +434,10 @@ case "$command" in
     ;;
   stop)
     unit=${1:?}
+    if [ "${FAKE_SYSTEMD_MODE:-normal}" = timeout-after-agent-stop ] \
+        && [ "$unit" = mac-hermes-gateway.service ]; then
+      sleep 30
+    fi
     : > "$FAKE_SYSTEMD_STATE/$unit"
     printf 'systemd:%s\\n' "$unit" >> "$FAKE_PHASE1_EVENTS"
     ;;
@@ -1015,6 +1019,10 @@ def test_supervisor_subprocess_timeout_is_bounded(tmp_path: Path) -> None:
 
     assert result.returncode != 0
     assert "command timed out" in result.stderr
+    assert "operation=show" in result.stderr
+    assert "target=mac-agent.service" in result.stderr
+    assert "elapsed_seconds=" in result.stderr
+    assert "limit_seconds=0.5" in result.stderr
     assert "daemon" not in Path(env["FAKE_PHASE1_EVENTS"]).read_text(encoding="utf-8")
     child_pid = int(Path(env["FAKE_TIMEOUT_CHILD_PID_FILE"]).read_text(encoding="utf-8"))
     child_deadline = time.monotonic() + 15
@@ -1026,6 +1034,31 @@ def test_supervisor_subprocess_timeout_is_bounded(tmp_path: Path) -> None:
         time.sleep(0.01)
     else:
         pytest.fail("timed-out supervisor command left a child process running")
+
+
+def test_supervisor_failure_restores_services_stopped_before_later_timeout(
+    tmp_path: Path,
+) -> None:
+    env = _base_case(tmp_path, "systemd")
+    state = tmp_path / "systemd-state"
+    state.mkdir()
+    env.update(
+        {
+            "FAKE_SYSTEMD_STATE": str(state),
+            "FAKE_SYSTEMD_MODE": "timeout-after-agent-stop",
+            "MAC_PHASE1_COMMAND_TIMEOUT_SECONDS": "0.5",
+            "MAC_PHASE1_TOTAL_TIMEOUT_SECONDS": "8",
+        }
+    )
+    _install_systemctl(tmp_path / "bin")
+
+    result = _run(env)
+
+    assert result.returncode != 0
+    assert "operation=stop" in result.stderr
+    assert "target=mac-hermes-gateway.service" in result.stderr
+    assert "supervisor restored to its pre-attempt state" in result.stderr
+    assert not (state / "mac-agent.service").exists()
 
 
 def test_supervisor_output_is_kernel_capped_while_command_runs(tmp_path: Path) -> None:


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_5597230096454295991cb10a4c2a4e5f`
- head: `b96b1bb00df16a997d3a788fc955fc7c6d3fcf5f`
- base at push: `474408245fe2cc33fd22c6f9420fd78fcd87d4ef`
