### PR TITLE
Teach the self-healing sentinel about abandoned deploy holds and stuck draining

### DIFF
--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -1076,7 +1076,9 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_SELF_HEAL_NAP_STALL_SECONDS` | int | consumer-defined | core | Core setting: self heal nap stall seconds. |
 | `MAC_SELF_HEAL_PIN_DIVERGENCE_SECONDS` | int | consumer-defined | core | Core setting: self heal pin divergence seconds. |
 | `MAC_SELF_HEAL_READ_SILENCE_SECONDS` | int | consumer-defined | core | Core setting: self heal read silence seconds. |
+| `MAC_SELF_HEAL_STALE_DEPLOY_HOLD_SECONDS` | int | consumer-defined | core | Core setting: self heal stale deploy hold seconds. |
 | `MAC_SELF_HEAL_STARVATION_SECONDS` | int | consumer-defined | core | Core setting: self heal starvation seconds. |
+| `MAC_SELF_HEAL_STUCK_DRAINING_SECONDS` | int | consumer-defined | core | Core setting: self heal stuck draining seconds. |
 | `MAC_SELF_UPDATE_GIT_TIMEOUT` | int | consumer-defined | core | Core setting: self update git timeout. |
 | `MAC_SELF_UPDATE_REPO` | str | consumer-defined | core | Core setting: self update repo. |
 | `MAC_SELF_UPDATE_SERVICE_TIMEOUT` | int | consumer-defined | core | Core setting: self update service timeout. |

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -12698,9 +12698,31 @@
   },
   {
     "default": null,
+    "description": "Core setting: self heal stale deploy hold seconds.",
+    "family": "core",
+    "name": "MAC_SELF_HEAL_STALE_DEPLOY_HOLD_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/self_healing.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
     "description": "Core setting: self heal starvation seconds.",
     "family": "core",
     "name": "MAC_SELF_HEAL_STARVATION_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/self_healing.py"
+    ],
+    "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Core setting: self heal stuck draining seconds.",
+    "family": "core",
+    "name": "MAC_SELF_HEAL_STUCK_DRAINING_SECONDS",
     "retired": false,
     "sources": [
       "src/mac/self_healing.py"
@@ -14322,6 +14344,7 @@
       "deploy/fleet-node-machine-onboard.py",
       "deploy/fleet-node-phase1-quiesce.sh",
       "src/mac/deploy_env.py",
+      "src/mac/self_healing.py",
       "src/mac/worker.py"
     ],
     "type": "str"

--- a/src/mac/diagnostics.py
+++ b/src/mac/diagnostics.py
@@ -665,3 +665,133 @@ def _lifecycle_stage_dwell(
             },
         )
     ]
+
+
+#: The exact hold-reason prefix deploy/deploy-mac-fleet.sh stamps
+#: (hold_reason="mac admin fleet roll-forward repair retained after
+#: ${deploy_ts}") on an agent it could not cleanly finish deploying. Every
+#: other dispatch_hold reason in the fleet is an intentional, indefinite
+#: operator/interactive hold (e.g. "Interactive Cursor session; executing
+#: only task_X") and must never be matched here -- releasing one of those
+#: would open an isolated interactive session to arbitrary dispatch.
+ROLL_FORWARD_REPAIR_HOLD_PREFIX = "mac admin fleet roll-forward repair retained after "
+
+#: How long a roll-forward-repair hold may persist before it is presumed
+#: abandoned rather than owned by a still-running deploy. Deploys observed in
+#: this fleet complete (or fail back to this hold) within ~15-20 minutes, so
+#: one hour is a conservative multiple, not a tight guess.
+STALE_DISPATCH_HOLD_THRESHOLD_SECONDS = 3600
+
+#: How long an agent may sit in status='draining' before it is presumed stuck
+#: rather than mid-deploy. A deploy's own drain window is bounded by
+#: MAC_PHASE1_TOTAL_TIMEOUT_SECONDS (default 600s / 10 minutes); 30 minutes
+#: gives real deploys generous headroom without leaving a genuinely stuck
+#: agent unreported for hours.
+STUCK_DRAINING_THRESHOLD_SECONDS = 1800
+
+
+@register(
+    "stale-dispatch-hold",
+    "agents held under an abandoned deploy's roll-forward-repair hold",
+)
+def _stale_dispatch_hold(
+    control_plane: Any, threshold_seconds: int = STALE_DISPATCH_HOLD_THRESHOLD_SECONDS
+) -> List[Finding]:
+    from datetime import timedelta
+
+    from mac.models import parse_time, utcnow
+
+    cutoff = (parse_time(utcnow()) - timedelta(seconds=threshold_seconds)).isoformat(
+        timespec="microseconds"
+    )
+    rows = control_plane.store.query_all(
+        "SELECT id, name, dispatch_hold_reason, dispatch_hold_at FROM agents "
+        "WHERE dispatch_hold = 1 AND deleted_at IS NULL "
+        "AND dispatch_hold_reason LIKE ? AND dispatch_hold_at < ? "
+        "ORDER BY dispatch_hold_at",
+        (ROLL_FORWARD_REPAIR_HOLD_PREFIX + "%", cutoff),
+    )
+    if not rows:
+        return [
+            Finding(
+                "stale-dispatch-hold",
+                "ok",
+                "no stale roll-forward-repair holds",
+                {"threshold_seconds": threshold_seconds, "cutoff": cutoff},
+            )
+        ]
+    held = [
+        {
+            "id": row["id"],
+            "name": row["name"],
+            "dispatch_hold_reason": row["dispatch_hold_reason"],
+            "dispatch_hold_at": row["dispatch_hold_at"],
+        }
+        for row in rows
+    ]
+    return [
+        Finding(
+            "stale-dispatch-hold",
+            "warn",
+            "%d agent(s) held under an abandoned roll-forward-repair hold" % len(held),
+            {
+                "threshold_seconds": threshold_seconds,
+                "cutoff": cutoff,
+                "count": len(held),
+                "agents": held,
+            },
+        )
+    ]
+
+
+@register(
+    "stuck-draining",
+    "agents left in status='draining' well past a deploy's own drain window",
+)
+def _stuck_draining(
+    control_plane: Any, threshold_seconds: int = STUCK_DRAINING_THRESHOLD_SECONDS
+) -> List[Finding]:
+    from datetime import timedelta
+
+    from mac.models import parse_time, utcnow
+
+    cutoff = (parse_time(utcnow()) - timedelta(seconds=threshold_seconds)).isoformat(
+        timespec="microseconds"
+    )
+    rows = control_plane.store.query_all(
+        "SELECT id, name, status, health_status, updated_at FROM agents "
+        "WHERE status = 'draining' AND deleted_at IS NULL AND updated_at < ? "
+        "ORDER BY updated_at",
+        (cutoff,),
+    )
+    if not rows:
+        return [
+            Finding(
+                "stuck-draining",
+                "ok",
+                "no agent stuck draining",
+                {"threshold_seconds": threshold_seconds, "cutoff": cutoff},
+            )
+        ]
+    stuck = [
+        {
+            "id": row["id"],
+            "name": row["name"],
+            "health_status": row["health_status"],
+            "updated_at": row["updated_at"],
+        }
+        for row in rows
+    ]
+    return [
+        Finding(
+            "stuck-draining",
+            "warn",
+            "%d agent(s) stuck draining past %d seconds" % (len(stuck), threshold_seconds),
+            {
+                "threshold_seconds": threshold_seconds,
+                "cutoff": cutoff,
+                "count": len(stuck),
+                "agents": stuck,
+            },
+        )
+    ]

--- a/src/mac/self_healing.py
+++ b/src/mac/self_healing.py
@@ -58,6 +58,21 @@ DEFAULT_READ_SILENCE_SECONDS = 24 * 60 * 60.0
 # that left one worker three weeks stale while heartbeating "healthy").
 DEFAULT_PIN_DIVERGENCE_SECONDS = 3 * 60 * 60.0
 DEFAULT_AGENT_SILENCE_SECONDS = 60 * 60.0
+# deploy/deploy-mac-fleet.sh stamps hold_reason="mac admin fleet roll-forward
+# repair retained after ${deploy_ts}" on an agent it could not finish
+# deploying, then leaves that hold for an operator to notice -- there is no
+# companion reconciliation pass. Deploys observed on this fleet complete (or
+# fail back to this hold) within ~15-20 minutes, so one hour is a conservative
+# multiple, not a tight guess.
+DEFAULT_STALE_DEPLOY_HOLD_SECONDS = 60 * 60.0
+# A worker forces status="draining"/health="degraded" on every heartbeat while
+# its deployment barrier file (~/.mac/deploy-start-barrier) still names the
+# generation it was deployed under (worker.py _deployment_barrier_state); the
+# deploy tool's finalize step is supposed to remove that file once the node
+# rejoins the cohort. A deploy's own drain window is bounded by
+# MAC_PHASE1_TOTAL_TIMEOUT_SECONDS (default 600s); 30 minutes gives real
+# deploys generous headroom without leaving a stuck agent unreported for hours.
+DEFAULT_STUCK_DRAINING_SECONDS = 30 * 60.0
 DEFAULT_MAX_ATTEMPTS = 3
 # Per-cycle cap on how many DISTINCT new fix tasks one sentinel run may file.
 # Fingerprint dedup stops re-filing a standing finding, but a single cycle that
@@ -101,6 +116,8 @@ class SelfHealingConfig:
     read_silence_seconds: float = DEFAULT_READ_SILENCE_SECONDS
     pin_divergence_seconds: float = DEFAULT_PIN_DIVERGENCE_SECONDS
     agent_silence_seconds: float = DEFAULT_AGENT_SILENCE_SECONDS
+    stale_deploy_hold_seconds: float = DEFAULT_STALE_DEPLOY_HOLD_SECONDS
+    stuck_draining_seconds: float = DEFAULT_STUCK_DRAINING_SECONDS
     max_attempts: int = DEFAULT_MAX_ATTEMPTS
     max_tasks_per_cycle: int = DEFAULT_MAX_TASKS_PER_CYCLE
     configuration_error: str = ""
@@ -166,6 +183,18 @@ class SelfHealingConfig:
                 DEFAULT_AGENT_SILENCE_SECONDS,
                 10 * 60.0,
                 7 * 24 * 60 * 60.0,
+            ),
+            stale_deploy_hold_seconds=_num(
+                "MAC_SELF_HEAL_STALE_DEPLOY_HOLD_SECONDS",
+                DEFAULT_STALE_DEPLOY_HOLD_SECONDS,
+                5 * 60.0,
+                7 * 24 * 60 * 60.0,
+            ),
+            stuck_draining_seconds=_num(
+                "MAC_SELF_HEAL_STUCK_DRAINING_SECONDS",
+                DEFAULT_STUCK_DRAINING_SECONDS,
+                5 * 60.0,
+                24 * 60 * 60.0,
             ),
             max_attempts=int(_num("MAC_SELF_HEAL_MAX_ATTEMPTS", DEFAULT_MAX_ATTEMPTS, 1, 10)),
             max_tasks_per_cycle=bounded_env_int(
@@ -291,6 +320,8 @@ class SelfHealingSentinel:
                 self._check_daemon_heartbeats,
                 self._check_read_path_silence,
                 self._check_stuck_quarantine,
+                self._check_stale_deploy_hold,
+                self._check_stuck_draining,
                 self._check_fleet_pin_divergence,
                 self._check_agent_unhealthy,
             ):
@@ -549,6 +580,102 @@ class SelfHealingSentinel:
                         ),
                     },
                     # Deliberately unpinned: the held agent cannot claim work.
+                )
+            )
+        return findings
+
+    _ROLL_FORWARD_REPAIR_HOLD_PREFIX = "mac admin fleet roll-forward repair retained after "
+
+    def _check_stale_deploy_hold(self) -> List[Finding]:
+        """A failed deploy leaves an agent held for "roll-forward repair"
+        with no companion process to ever notice or release it -- observed
+        live on 2026-09-01: three agents stayed held for hours across two
+        failed deploy attempts until an operator went looking."""
+        findings: List[Finding] = []
+        now = _utcnow()
+        for agent in self.control_plane.list_agents():
+            if not getattr(agent, "dispatch_hold", False):
+                continue
+            reason = str(getattr(agent, "dispatch_hold_reason", "") or "")
+            if not reason.startswith(self._ROLL_FORWARD_REPAIR_HOLD_PREFIX):
+                continue  # operator/auto-quarantine holds are deliberate; leave them alone
+            held_at = _parse_ts(getattr(agent, "dispatch_hold_at", None))
+            age = None if held_at is None else (now - held_at).total_seconds()
+            if age is not None and age < self.config.stale_deploy_hold_seconds:
+                continue
+            agent_id = str(getattr(agent, "id", "") or "")
+            findings.append(
+                Finding(
+                    fingerprint="stale_deploy_hold:%s" % agent_id,
+                    kind="stale_deploy_hold",
+                    summary=(
+                        "agent %s has been held for roll-forward repair for %s"
+                        % (
+                            agent_id,
+                            "%.0f minutes" % (age / 60.0) if age is not None else "an unknown time",
+                        )
+                    ),
+                    detail={
+                        "agent_id": agent_id,
+                        "hold_reason": reason,
+                        "held_at": getattr(agent, "dispatch_hold_at", None),
+                        "remediation": (
+                            "Confirm the node is actually running the deployed "
+                            "generation and its worker service is healthy (it "
+                            "usually is -- the deploy tool's own finalize step "
+                            "just failed to release the hold). If so, release it "
+                            "with `mac agent resume %s`. If the node is genuinely "
+                            "broken, fix the host first." % agent_id
+                        ),
+                    },
+                    target_agent_id=agent_id,
+                )
+            )
+        return findings
+
+    def _check_stuck_draining(self) -> List[Finding]:
+        """A worker forces status=draining on every heartbeat while its
+        deployment barrier file still names the generation it was deployed
+        under; the deploy tool's finalize step is supposed to remove that
+        file and doesn't always. Observed live on 2026-09-03: an agent sat
+        draining, invisible to dispatch, until an operator noticed."""
+        findings: List[Finding] = []
+        now = _utcnow()
+        for agent in self.control_plane.list_agents():
+            if str(getattr(agent, "status", "") or "") != "draining":
+                continue
+            updated_at = _parse_ts(getattr(agent, "updated_at", None))
+            age = None if updated_at is None else (now - updated_at).total_seconds()
+            if age is not None and age < self.config.stuck_draining_seconds:
+                continue
+            agent_id = str(getattr(agent, "id", "") or "")
+            findings.append(
+                Finding(
+                    fingerprint="stuck_draining:%s" % agent_id,
+                    kind="stuck_draining",
+                    summary=(
+                        "agent %s has been draining for %s"
+                        % (
+                            agent_id,
+                            "%.0f minutes" % (age / 60.0) if age is not None else "an unknown time",
+                        )
+                    ),
+                    detail={
+                        "agent_id": agent_id,
+                        "health_status": str(getattr(agent, "health_status", "") or ""),
+                        "updated_at": getattr(agent, "updated_at", None),
+                        "remediation": (
+                            "SSH to the host and check whether "
+                            "~/.mac/deploy-start-barrier still names the "
+                            "MAC_WORKER_DEPLOY_GENERATION currently in its "
+                            "environment (src/mac/worker.py "
+                            "_deployment_barrier_state()). If so and the node "
+                            "is otherwise healthy on the current generation, "
+                            "remove that file so the next heartbeat drops the "
+                            "drain fence."
+                        ),
+                    },
+                    target_agent_id=agent_id,
                 )
             )
         return findings

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -442,3 +442,66 @@ def test_unsatisfiable_requirements_is_ok_when_every_task_is_runnable():
     findings = diagnostics.run_diagnostics(cp, names=["unsatisfiable-requirements"])
     assert findings[0].severity == "ok"
     assert findings[0].detail["count"] == 0
+
+
+def test_stale_dispatch_hold_check_only_matches_the_roll_forward_repair_reason():
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host", resources={"cpu": 4, "memory_gb": 8})
+    abandoned = cp.register_agent(machine.id, "abandoned-by-deploy", capabilities=[])
+    interactive = cp.register_agent(machine.id, "interactive-session", capabilities=[])
+
+    # A deploy that failed leaves this exact reason string (see
+    # deploy/deploy-mac-fleet.sh's hold_reason=... at "roll-forward repair").
+    cp.set_agent_dispatch_hold(
+        abandoned.id, "mac admin fleet roll-forward repair retained after 20260901T151713Z"
+    )
+    # An intentional, indefinite interactive hold must never be flagged --
+    # releasing one would open an isolated session to arbitrary dispatch.
+    cp.set_agent_dispatch_hold(interactive.id, "Interactive Cursor session; do not dispatch")
+
+    # Both holds are fresh: neither is stale yet.
+    findings = diagnostics.run_diagnostics(cp, names=["stale-dispatch-hold"])
+    assert findings and len(findings) == 1
+    assert findings[0].severity == "ok"
+
+    # Age only the abandoned-deploy hold past the threshold.
+    cp.store.execute(
+        "UPDATE agents SET dispatch_hold_at=? WHERE id=?",
+        ("2000-01-01T00:00:00.000000+00:00", abandoned.id),
+    )
+
+    findings = diagnostics.run_diagnostics(cp, names=["stale-dispatch-hold"])
+    assert findings and len(findings) == 1
+    warn = findings[0]
+    assert warn.severity == "warn"
+    assert warn.detail["count"] == 1
+    flagged_ids = {entry["id"] for entry in warn.detail["agents"]}
+    assert abandoned.id in flagged_ids
+    assert interactive.id not in flagged_ids
+
+
+def test_stuck_draining_check():
+    cp = ControlPlane.in_memory()
+    machine = cp.register_machine("host", resources={"cpu": 4, "memory_gb": 8})
+    agent = cp.register_agent(machine.id, "mid-deploy", capabilities=[])
+
+    findings = diagnostics.run_diagnostics(cp, names=["stuck-draining"])
+    assert findings and len(findings) == 1
+    assert findings[0].severity == "ok"
+
+    # A freshly-drained agent (e.g. genuinely mid-deploy) is not yet stuck.
+    cp.store.execute("UPDATE agents SET status='draining' WHERE id=?", (agent.id,))
+    findings = diagnostics.run_diagnostics(cp, names=["stuck-draining"])
+    assert findings[0].severity == "ok"
+
+    # Aged well past the threshold: a deploy this old is presumed abandoned.
+    cp.store.execute(
+        "UPDATE agents SET status='draining', updated_at=? WHERE id=?",
+        ("2000-01-01T00:00:00.000000+00:00", agent.id),
+    )
+    findings = diagnostics.run_diagnostics(cp, names=["stuck-draining"])
+    assert findings and len(findings) == 1
+    warn = findings[0]
+    assert warn.severity == "warn"
+    assert warn.detail["count"] == 1
+    assert {entry["id"] for entry in warn.detail["agents"]} == {agent.id}

--- a/tests/test_self_healing.py
+++ b/tests/test_self_healing.py
@@ -165,6 +165,59 @@ def test_stuck_quarantine_finding_ignores_operator_holds(cp, monkeypatch):
     assert ("stuck_quarantine:%s" % manual.id) not in fingerprints
 
 
+def test_stale_deploy_hold_finding_ignores_other_hold_reasons(cp, monkeypatch):
+    abandoned = _register_agent(cp, name="abandoned-by-deploy")
+    quarantined = _register_agent(cp, name="zombie")
+    interactive = _register_agent(cp, name="interactive-session")
+    # The exact reason string deploy/deploy-mac-fleet.sh stamps on a hold it
+    # never releases (hold_reason="mac admin fleet roll-forward repair
+    # retained after ${deploy_ts}").
+    cp.set_agent_dispatch_hold(
+        abandoned.id, "mac admin fleet roll-forward repair retained after 20260901T151713Z"
+    )
+    cp.set_agent_dispatch_hold(quarantined.id, "auto_quarantine:consecutive_expiries_no_telemetry")
+    cp.set_agent_dispatch_hold(interactive.id, "Interactive Cursor session; do not dispatch")
+    import mac.self_healing as sh
+    from datetime import timedelta
+
+    real_now = sh._utcnow()
+    monkeypatch.setattr(sh, "_utcnow", lambda: real_now + timedelta(hours=2))
+    report = _sentinel(cp).run_once()
+    fingerprints = [f["fingerprint"] for f in report["findings"]]
+    assert ("stale_deploy_hold:%s" % abandoned.id) in fingerprints
+    assert ("stale_deploy_hold:%s" % quarantined.id) not in fingerprints
+    assert ("stale_deploy_hold:%s" % interactive.id) not in fingerprints
+
+
+def test_stale_deploy_hold_waits_out_the_grace_period(cp):
+    agent = _register_agent(cp, name="mid-deploy")
+    cp.set_agent_dispatch_hold(
+        agent.id, "mac admin fleet roll-forward repair retained after 20260901T151713Z"
+    )
+    # Fresh hold: a deploy could still legitimately own it right now.
+    report = _sentinel(cp).run_once()
+    fingerprints = [f["fingerprint"] for f in report["findings"]]
+    assert ("stale_deploy_hold:%s" % agent.id) not in fingerprints
+
+
+def test_stuck_draining_finding_waits_out_a_real_deploys_drain_window(cp, monkeypatch):
+    agent = _register_agent(cp, name="draining-agent")
+    cp.store.execute("UPDATE agents SET status='draining' WHERE id=?", (agent.id,))
+
+    # Freshly drained: could be a real, in-progress deploy.
+    report = _sentinel(cp).run_once()
+    assert ("stuck_draining:%s" % agent.id) not in [f["fingerprint"] for f in report["findings"]]
+
+    import mac.self_healing as sh
+    from datetime import timedelta
+
+    real_now = sh._utcnow()
+    monkeypatch.setattr(sh, "_utcnow", lambda: real_now + timedelta(hours=1))
+    report = _sentinel(cp).run_once()
+    fingerprints = [f["fingerprint"] for f in report["findings"]]
+    assert ("stuck_draining:%s" % agent.id) in fingerprints
+
+
 # ── act: dedupe ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Two agent-state problems hit live this session had zero supervision:

1. A failed deploy leaves an agent held for "roll-forward repair" with no companion process to ever notice or release it. Three agents (rocky, natasha, bullwinkle) stayed held for hours across two failed deploy attempts on 2026-09-01, found only because an operator went looking with `mac agent list`.
2. A worker's deployment barrier file (`~/.mac/deploy-start-barrier`) sometimes survives the deploy tool's finalize step, forcing `status=draining`/`health=degraded` on every heartbeat indefinitely -- observed on natasha on 2026-09-03, again found by manual inspection.

Neither is covered by the existing `_check_stuck_quarantine` (matches `auto_quarantine` holds only, by explicit design -- "operator holds are deliberate") or `_check_agent_unhealthy` (explicitly skips held agents).

## Change
- `_check_stale_deploy_hold` / `_check_stuck_draining` added to `SelfHealingSentinel`'s observe/plan/act/verify loop (`src/mac/self_healing.py`), following the existing `_check_stuck_quarantine` template exactly: match on the deploy tool's precise hold-reason prefix (`deploy/deploy-mac-fleet.sh`'s `hold_reason="mac admin fleet roll-forward repair retained after ${deploy_ts}"`) -- never an operator/interactive hold, those must stay untouched -- wait out a conservative grace period past what a real deploy takes (1h for holds, 30min for draining vs. deploys observed completing in 15-20min), file a deduped fleet task naming the concrete remediation, and let the sentinel's existing max-attempts/escalation machinery take over.
- Matching read-only `mac admin diagnostics` checks (`stale-dispatch-hold`, `stuck-draining`) for on-demand operator visibility independent of the sentinel's background loop.

`MAC_SELF_HEAL_ENABLED=1` is already set on the live hub, so both new checks start running as part of the existing cycle -- no further configuration needed once this deploys.

## Verification
- New tests: `test_stale_deploy_hold_finding_ignores_other_hold_reasons`, `test_stale_deploy_hold_waits_out_the_grace_period`, `test_stuck_draining_finding_waits_out_a_real_deploys_drain_window` (`tests/test_self_healing.py`); `test_stale_dispatch_hold_check_only_matches_the_roll_forward_repair_reason`, `test_stuck_draining_check` (`tests/test_diagnostics.py`)
- `tests/test_self_healing.py tests/test_diagnostics.py`: 58 passed
- `tests/ -k "self_heal or diagnostics"`: 84 passed
- `ruff check` on all four changed files -- clean