### PR TITLE
Forward MAC_DEPLOY_DAEMON_*_TIMEOUT_SECONDS to phase-1 quiesce, not just phase-2

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -8075,10 +8075,31 @@ quiesce_remote_agent_for_cohort() {
   ssh_target="${ssh_parts[$last_index]}"
   ssh_args=("${ssh_parts[@]:0:$last_index}")
   fence_exec="$(remote_deployment_fenced_exec "$deployment_id" 0 bash -s)"
+  # Daemon stop wrappers (especially a managed OpenClaw sandbox checkpoint) can
+  # exceed the node default quiescence bound the same way they can at phase 2
+  # (see deploy_host's identical forward a few hundred lines below) -- an
+  # operator override is worthless if it only reaches phase 2, since phase 1
+  # (this quiesce step) is where the daemon is actually stopped and where
+  # "managed OpenClaw stop wrapper timed out" is actually raised. Forward only
+  # when set so an empty assignment cannot fail-close bounded_number() on the
+  # node.
+  local daemon_timeout_env="" _timeout_var
+  for _timeout_var in \
+    MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS \
+    MAC_DEPLOY_DAEMON_PRESERVATION_TIMEOUT_SECONDS \
+    MAC_DEPLOY_DAEMON_QUIESCENCE_TIMEOUT_SECONDS \
+    MAC_DEPLOY_DAEMON_LEASE_DRAIN_TIMEOUT_SECONDS \
+    MAC_DEPLOY_DAEMON_QUIESCENCE_POLL_SECONDS \
+    MAC_DEPLOY_DAEMON_TOTAL_TIMEOUT_SECONDS
+  do
+    if [ -n "${!_timeout_var:-}" ]; then
+      daemon_timeout_env="${daemon_timeout_env}${_timeout_var}=$(shell_quote "${!_timeout_var}") "
+    fi
+  done
   if ! ssh -o BatchMode=yes -o ConnectTimeout=10 \
     -o ServerAliveInterval=30 -o ServerAliveCountMax=6 \
     "${ssh_args[@]}" "$ssh_target" \
-    "MAC_PHASE1_AGENT=$(shell_quote "$agent") MAC_PHASE1_FLEET=$(shell_quote "$fleet_name") MAC_PHASE1_OS=$(shell_quote "$os_kind") MAC_PHASE1_REV=$(shell_quote "$GIT_REV") MAC_PHASE1_GENERATION=$(shell_quote "$deployment_id") MAC_PHASE1_SUPERVISOR=$(shell_quote "$supervisor") MAC_PHASE1_HELPER=$(shell_quote "$remote_helper") MAC_PHASE1_FUNCTIONS=$(shell_quote "$remote_functions") MAC_PHASE1_RESTORE_SHA256=$(shell_quote "$restore_contract_sha256") MAC_PHASE1_OSH_VERSION=$(shell_quote "$OPENSHELL_REVIEWED_CLI_VERSION") MAC_PHASE1_OSH_ASSET_SHA=$(shell_quote "$openshell_asset_sha") MAC_PHASE1_OSH_CLI_SHA=$(shell_quote "$openshell_cli_sha") MAC_PHASE1_OSH_RECEIPT_SHA=$(shell_quote "$openshell_receipt_sha") $fence_exec" <<'REMOTE_PHASE1'
+    "${daemon_timeout_env}MAC_PHASE1_AGENT=$(shell_quote "$agent") MAC_PHASE1_FLEET=$(shell_quote "$fleet_name") MAC_PHASE1_OS=$(shell_quote "$os_kind") MAC_PHASE1_REV=$(shell_quote "$GIT_REV") MAC_PHASE1_GENERATION=$(shell_quote "$deployment_id") MAC_PHASE1_SUPERVISOR=$(shell_quote "$supervisor") MAC_PHASE1_HELPER=$(shell_quote "$remote_helper") MAC_PHASE1_FUNCTIONS=$(shell_quote "$remote_functions") MAC_PHASE1_RESTORE_SHA256=$(shell_quote "$restore_contract_sha256") MAC_PHASE1_OSH_VERSION=$(shell_quote "$OPENSHELL_REVIEWED_CLI_VERSION") MAC_PHASE1_OSH_ASSET_SHA=$(shell_quote "$openshell_asset_sha") MAC_PHASE1_OSH_CLI_SHA=$(shell_quote "$openshell_cli_sha") MAC_PHASE1_OSH_RECEIPT_SHA=$(shell_quote "$openshell_receipt_sha") $fence_exec" <<'REMOTE_PHASE1'
 set -euo pipefail
 helper="${MAC_PHASE1_HELPER:?}"
 functions="${MAC_PHASE1_FUNCTIONS:?}"

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -4758,6 +4758,61 @@ printf '%s\n' "$result"
     ]
 
 
+def test_phase1_quiesce_forwards_daemon_timeout_overrides_to_the_node(tmp_path, monkeypatch):
+    # Regression: an operator-set MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS
+    # override reached deploy_host's phase-2 SSH command (see
+    # test_daemon_and_openclaw_timeouts_are_forwarded_only_when_set) but NOT
+    # this phase-1 quiesce SSH command -- the one that actually stops the
+    # daemon and raises "managed OpenClaw stop wrapper timed out" when the
+    # node's 20s default is too tight. An override that never reaches the
+    # step it exists for is worthless; observed live on 2026-09-03: setting
+    # the override made no difference across repeated deploy attempts,
+    # every one failing at this exact quiesce step with the node's
+    # unmodified 20s default.
+    deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    quiesce = (
+        "quiesce_remote_agent_for_cohort() {"
+        + deploy.split("quiesce_remote_agent_for_cohort() {", 1)[1].split(
+            "\n}\n\nprepare_remote_mac_agent_deployment", 1
+        )[0]
+        + "\n}"
+    )
+    ssh_command_file = tmp_path / "ssh-command"
+    snippet = f"""set -u
+TMPDIR_LOCAL={shlex.quote(str(tmp_path))}
+DEPLOY_CONTROLLER_NONCE=controller
+PHASE1_QUIESCE_HELPER=/fixture/helper
+PHASE1_DAEMON_FUNCTIONS=/fixture/functions
+OPENSHELL_REVIEWED_CLI_VERSION=fixture-version
+GIT_REV=fixture-revision
+MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS=300
+MAC_DEPLOY_DAEMON_QUIESCENCE_TIMEOUT_SECONDS=600
+stable_worker_agent_id() {{ printf '%s\n' agent_fixture; }}
+phase1_restore_contract_digest_for_agent() {{ printf '%s\n' restore-sha; }}
+reviewed_openshell_cli_status_value() {{ printf '%s\n' "$2-sha"; }}
+fenced_remote_upload() {{ return 0; }}
+ssh_target_args() {{ printf '%s\\0' fixture-target; }}
+remote_deployment_fenced_exec() {{ printf '%s\n' fixture-fence; }}
+shell_quote() {{ printf '%q' "$1"; }}
+ssh() {{ printf '%s\n' "${{@: -1}}" > {shlex.quote(str(ssh_command_file))}; return 23; }}
+{quiesce}
+set +e
+quiesce_remote_agent_for_cohort fixture exact-generation systemd mac linux
+true
+"""
+    result = subprocess.run(["bash", "-c", snippet], text=True, capture_output=True, check=False)
+    assert result.returncode == 0, result.stderr
+    command = ssh_command_file.read_text(encoding="utf-8")
+    assert "MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS=300" in command
+    assert "MAC_DEPLOY_DAEMON_QUIESCENCE_TIMEOUT_SECONDS=600" in command
+    # Unset overrides must not appear as empty assignments (would fail-close
+    # bounded_number() on the node).
+    assert "MAC_DEPLOY_DAEMON_PRESERVATION_TIMEOUT_SECONDS=" not in command
+    assert "MAC_DEPLOY_DAEMON_LEASE_DRAIN_TIMEOUT_SECONDS=" not in command
+    assert "MAC_DEPLOY_DAEMON_QUIESCENCE_POLL_SECONDS=" not in command
+    assert "MAC_DEPLOY_DAEMON_TOTAL_TIMEOUT_SECONDS=" not in command
+
+
 def test_recovery_aborts_unmutated_pre_route_without_route_attestation(tmp_path):
     # The journal classifier can report direction=abort_unmutated for a
     # transaction that never bound a route identity or mutated the hub/nodes


### PR DESCRIPTION
## Summary
An operator-set `MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS` override reached `deploy_host`'s phase-2 SSH command (the fix in #721) but never reached `quiesce_remote_agent_for_cohort`'s phase-1 SSH command -- the one that actually stops the daemon and raises `"managed OpenClaw stop wrapper timed out; effective_timeout=20.000s ... limiting_bound=MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS"` when the node's 20s default is too tight. Phase 1's SSH command only ever set a fixed `MAC_PHASE1_*` env list; the `DAEMON_*_TIMEOUT` vars were simply never in it.

## Root cause, live-confirmed
Repeatedly ran the real fleet deploy tonight (2026-09-03) with `MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS=300` explicitly exported, and it made no difference across multiple attempts -- every one failed at the exact same quiesce step with the node's unmodified 20s bound. Traced it to `quiesce_remote_agent_for_cohort` (deploy/deploy-mac-fleet.sh) never forwarding these vars into its SSH command, unlike the sibling `deploy_host` function a few hundred lines below, which already does (per #721 and `test_daemon_and_openclaw_timeouts_are_forwarded_only_when_set`). Every `DAEMON_*_TIMEOUT` sibling (`PRESERVATION`/`QUIESCENCE`/`LEASE_DRAIN`/`QUIESCENCE_POLL`/`TOTAL`) had the identical gap.

This is very plausibly the actual root cause behind the long-standing, already-tracked `task_5597230096454295991cb10a4c2a4e5f` ("phase-1 quiescence intermittently times out on a different host each run") -- an operator override for exactly this situation existed and was documented, but silently never worked.

## Change
Forward the same set `deploy_host` already forwards into `quiesce_remote_agent_for_cohort`'s SSH command, using the identical "only when the operator set a value" guard (an empty assignment would fail-close `bounded_number()` on the node).

## Verification
- New test: `test_phase1_quiesce_forwards_daemon_timeout_overrides_to_the_node` -- executes the real bash function with a stubbed `ssh` that captures the actual constructed command string, and asserts the override values appear in it (and unset ones don't, as empty assignments)
- `tests/test_deploy_fleet_drain.py tests/test_deploy_agent_configs.py tests/test_fleet_node_daemon_quiescence.py tests/test_setup_entrypoint.py`: 364 passed
- `ruff check` -- clean