### PR TITLE
Forward opencode/pi's static credential files into OpenShell sandboxes

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -2146,6 +2146,40 @@ def _openshell_extra_create_argv(*, require_gpu: bool = False) -> List[str]:
     return filtered
 
 
+# Unlike codex's ~/.codex/auth.json (an OAuth *refresh* token: consuming it
+# inside a disposable sandbox can rotate it and desync the host copy, see
+# _coding_agent_auth_is_safe_for_openshell), these are static API-key files
+# (coding_agent.py's "api_key_file" auth_kind, never "oauth_file"/"oauth").
+# Copying a static key into a throwaway sandbox carries no rotation risk, so
+# -- unlike codex -- there is no env-var-present gate here: the file is the
+# only working credential path for these CLIs on this fleet.
+_SANDBOX_SAFE_CREDENTIAL_FILES: Tuple[Tuple[str, str], ...] = (
+    (".local/share/opencode/auth.json", "opencode"),
+    (".pi/agent/auth.json", "pi"),
+)
+
+
+def _sandbox_credential_upload_argv() -> List[str]:
+    """``--upload`` args copying safe, non-rotating coding-agent credential
+    files from the host's HOME into the sandbox's HOME (_SANDBOX_HOME).
+
+    Only files that actually exist are forwarded, so a host without opencode/pi
+    configured emits nothing extra.
+    """
+    home = Path.home()
+    argv: List[str] = []
+    for relative, _agent in _SANDBOX_SAFE_CREDENTIAL_FILES:
+        source = home / relative
+        try:
+            if not source.is_file():
+                continue
+        except OSError:
+            continue
+        destination = "%s/%s" % (_SANDBOX_HOME, relative)
+        argv += ["--upload", "%s:%s" % (source, destination)]
+    return argv
+
+
 _MANAGED_OPENSHELL_RUNTIME_REF_RE = _re.compile(
     r"ghcr\.io/jordanhubbard/mac-openshell-runtime@sha256:[0-9a-f]{64}"
 )
@@ -2393,6 +2427,7 @@ def _build_sandbox_create_argv(
     argv += _sandbox_label_argv("task", keep=env_bool("MAC_OPENSHELL_KEEP"))
     argv += _openshell_extra_create_argv() if extra_create_argv is None else list(extra_create_argv)
     argv += ["--upload", "%s:%s" % (str(workspace), _SANDBOX_WORKDIR)]
+    argv += _sandbox_credential_upload_argv()
     inner = "\n".join(
         [
             "cd %s" % shlex.quote(sub),
@@ -5030,7 +5065,13 @@ def coding_agent_sandbox_which(name: str) -> Optional[str]:
 
 
 def _build_sandbox_probe_argv(name: str, agent_argv: List[str], private_dir: Path) -> List[str]:
-    """Build a credential-free process argv for the coding-agent probe."""
+    """Build the coding-agent probe's process argv.
+
+    No process-visible secrets: the prompt/command are private uploaded files
+    (see agent_argv's mac.agent_command wrapper), and any credential file this
+    probe needs is copied via _sandbox_credential_upload_argv() -- only the
+    static, non-rotating kinds (coding_agent.py's "api_key_file" auth_kind).
+    """
     if "mac.agent_command" not in agent_argv:
         raise ValueError("sandbox probe must use the private-file command wrapper")
     argv: List[str] = [_openshell_bin(), "sandbox", "create", "--no-auto-providers"]
@@ -5039,6 +5080,7 @@ def _build_sandbox_probe_argv(name: str, agent_argv: List[str], private_dir: Pat
     argv += _openshell_extra_create_argv()
     sandbox_dir = "/sandbox/%s" % private_dir.name
     argv += ["--upload", "%s:/sandbox" % private_dir]
+    argv += _sandbox_credential_upload_argv()
     inner = "\n".join(
         [
             "cd %s" % shlex.quote(sandbox_dir),

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -301,6 +301,50 @@ def test_sandbox_create_maps_repo_worktree_env_inside_upload(tmp_path, monkeypat
     assert "mac_sandbox_toolchain_setup" in argv[-1]
 
 
+def test_sandbox_create_forwards_safe_coding_agent_credential_files(tmp_path, monkeypatch):
+    """opencode/pi's static API-key files must reach the sandbox's HOME.
+
+    Unlike codex's ~/.codex/auth.json (a rotating OAuth refresh token,
+    deliberately excluded -- see _coding_agent_auth_is_safe_for_openshell),
+    opencode's ~/.local/share/opencode/auth.json and pi's
+    ~/.pi/agent/auth.json are static keys with no rotation risk from being
+    copied into a disposable sandbox. Without this forwarding, opencode/pi
+    are present and correctly detected on the host but every in-sandbox
+    preflight fails "route verification failed" because the sandbox process
+    never sees the credential -- reproduced live on a real fleet node.
+    """
+    fake_home = tmp_path / "home"
+    opencode_auth = fake_home / ".local" / "share" / "opencode" / "auth.json"
+    opencode_auth.parent.mkdir(parents=True)
+    opencode_auth.write_text('{"nvidia": {"type": "api", "key": "sk-test"}}', encoding="utf-8")
+    monkeypatch.setattr(te.Path, "home", staticmethod(lambda: fake_home))
+    monkeypatch.setattr(te, "_resolve_openshell_policy", lambda: "/policy.yaml")
+
+    workspace = tmp_path / "task"
+    workspace.mkdir(parents=True)
+    te._write_sandbox_runtime_files(workspace, "/sandbox/task")
+    argv = te._build_sandbox_create_argv(
+        "sb",
+        workspace,
+        "task",
+        [
+            "python",
+            "-m",
+            "mac.agent_command",
+            "--command-file",
+            "/sandbox/task/command.json",
+            "--prompt-file",
+            "/sandbox/task/prompt.txt",
+        ],
+    )
+
+    assert "--upload" in argv
+    uploads = [argv[i + 1] for i, tok in enumerate(argv) if tok == "--upload"]
+    assert "%s:/tmp/.local/share/opencode/auth.json" % opencode_auth in uploads
+    # pi's file doesn't exist in this fixture, so it must not be forwarded.
+    assert not any(".pi/agent/auth.json" in upload for upload in uploads)
+
+
 def test_openshell_create_args_drop_stale_codex_file_auth_when_env_auth_wins(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- Continuation of the deploy-pipeline fix chain (#728, #729). After those landed, a live canary task on natasha reached a genuinely working OpenShell sandbox for the first time (see below), surfacing the next real blocker: coding-agent credentials were never forwarded as files into the sandbox.
- `codex`'s `~/.codex/auth.json` is deliberately excluded from sandbox forwarding (a rotating OAuth refresh token — see `_coding_agent_auth_is_safe_for_openshell`). But `opencode`'s `~/.local/share/opencode/auth.json` and `pi`'s `~/.pi/agent/auth.json` are static API-key files (`coding_agent.py`'s `"api_key_file"` auth_kind, never `"oauth_file"`/`"oauth"`), with no rotation risk from being copied — and on this fleet the file is the *only* working credential path for either CLI. Without forwarding, both are detected as configured on the host but every in-sandbox preflight fails `route verification failed`.
- Adds `_sandbox_credential_upload_argv()`, gated on the file actually existing, wired into both the real task sandbox (`_build_sandbox_create_argv`) and the coding-agent preflight probe (`_build_sandbox_probe_argv`).

## Separately found and fixed live (not in this diff, host-level):
- `~/.mac/bin/openshell-sandbox` on natasha was a dynamically-linked binary built against the host's glibc 2.39, mounted into the Debian-12-based (glibc 2.36) runtime container — every task sandbox crash-looped. Replaced with the correct statically-linked build matching the installed `openshell` CLI version, from `openshell`'s own docker-supervisor cache. This explains why the container image itself was a red herring — the mounted binary was host-installed by mac's own tooling, not baked into the image.
- A stale, personal macOS Codex OAuth file (`/Users/jkh/...` paths) had been synced onto natasha, shadowing the correct env-var-based credential and returning a "refresh token was revoked" error.

## Test plan
- [x] `pytest tests/test_task_executor.py tests/test_executor_sandbox.py tests/test_gate_timeout_reaches_the_sandbox.py tests/test_openshell_sandbox.py` — 308 tests, including a new regression test proving the upload argv is emitted only for files that exist.
- [ ] Live canary task through natasha reaching a merged PR (in progress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)