### PR TITLE
Forward opencode's model config into the OpenShell sandbox too

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -2153,8 +2153,15 @@ def _openshell_extra_create_argv(*, require_gpu: bool = False) -> List[str]:
 # Copying a static key into a throwaway sandbox carries no rotation risk, so
 # -- unlike codex -- there is no env-var-present gate here: the file is the
 # only working credential path for these CLIs on this fleet.
+#
+# opencode.json is not a credential (opencode's auth.json already carries the
+# key) but its absence is just as fatal: without it opencode falls back to
+# its own built-in default model, observed live to be one the configured
+# provider has since retired ("has reached its end of life"), rather than
+# the model this fleet actually provisions in the host config.
 _SANDBOX_SAFE_CREDENTIAL_FILES: Tuple[Tuple[str, str], ...] = (
     (".local/share/opencode/auth.json", "opencode"),
+    (".config/opencode/opencode.json", "opencode"),
     (".pi/agent/auth.json", "pi"),
 )
 

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -317,6 +317,9 @@ def test_sandbox_create_forwards_safe_coding_agent_credential_files(tmp_path, mo
     opencode_auth = fake_home / ".local" / "share" / "opencode" / "auth.json"
     opencode_auth.parent.mkdir(parents=True)
     opencode_auth.write_text('{"nvidia": {"type": "api", "key": "sk-test"}}', encoding="utf-8")
+    opencode_config = fake_home / ".config" / "opencode" / "opencode.json"
+    opencode_config.parent.mkdir(parents=True)
+    opencode_config.write_text('{"model": "nvidia-inference/switchyard/openai/gpt-5.6-sol"}', encoding="utf-8")
     monkeypatch.setattr(te.Path, "home", staticmethod(lambda: fake_home))
     monkeypatch.setattr(te, "_resolve_openshell_policy", lambda: "/policy.yaml")
 
@@ -341,6 +344,7 @@ def test_sandbox_create_forwards_safe_coding_agent_credential_files(tmp_path, mo
     assert "--upload" in argv
     uploads = [argv[i + 1] for i, tok in enumerate(argv) if tok == "--upload"]
     assert "%s:/tmp/.local/share/opencode/auth.json" % opencode_auth in uploads
+    assert "%s:/tmp/.config/opencode/opencode.json" % opencode_config in uploads
     # pi's file doesn't exist in this fixture, so it must not be forwarded.
     assert not any(".pi/agent/auth.json" in upload for upload in uploads)
 


### PR DESCRIPTION
## Summary
- Follow-up to #730. Forwarding only `auth.json` got opencode authenticating inside the sandbox, but without `opencode.json` (the model/provider config — not a credential, the key already lives in `auth.json`) opencode falls back to its own built-in default model.
- Live-reproduced on natasha: the sandbox picked `z-ai/glm-5.2` and failed with `Gone: the model 'z-ai/glm-5.2' has reached its end of life on 2026-08-21T09:00:00Z`, while the host config declares the fleet's actual provisioned model (`nvidia-inference/switchyard/openai/gpt-5.6-sol`), which works fine.
- Forwarding `opencode.json` alongside `auth.json` fixes it — confirmed live in the same sandbox/task: `opencode run "say hi"` now selects `switchyard/openai/gpt-5.6-sol` and returns `hi`.

## Test plan
- [x] `pytest tests/test_task_executor.py tests/test_executor_sandbox.py` — 213 tests, including an updated regression test asserting both files are forwarded.
- [x] Live-verified directly in a real fleet sandbox on natasha (manual `docker cp` + `opencode run`) before landing this as code.
- [ ] Live canary task through natasha reaching a merged PR (retrying now after this deploys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)