### PR TITLE
Fix two more sandbox-name-length bugs blocking every coding-agent preflight

### DIFF
--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -959,6 +959,37 @@ def _sandbox_name() -> str:
     return "mac-task-" + uuid.uuid4().hex[:8]
 
 
+_OPENSHELL_SANDBOX_NAME_MAX_LENGTH = 19
+
+
+def _coding_agent_probe_sandbox_name() -> str:
+    """A unique name for the throwaway coding-agent preflight probe sandbox.
+
+    "mac-codingcap-<agent>-<12 hex>" was 29-35 chars depending on agent --
+    every coding-agent preflight failed to even create its probe sandbox
+    with "name exceeds maximum length", surfacing as an opaque
+    "probe_failed"/"route verification failed" for every configured CLI.
+    The agent/route identity already lives in the sandbox's
+    mac.kind=codingcap label, so it isn't needed in the name too.
+    """
+    import uuid
+
+    return "mac-cc-%s" % uuid.uuid4().hex[:10]
+
+
+def _read_only_verifier_sandbox_name() -> str:
+    """A unique name for the read-only-report second verification sandbox.
+
+    "<task-sandbox-name>-verify-<8 hex>" derived from an already-shortened
+    17-char task sandbox name was still 33+ chars. This is a distinct
+    sandbox, so it gets its own compact name rather than deriving from the
+    parent task sandbox's.
+    """
+    import uuid
+
+    return "mac-vf-%s" % uuid.uuid4().hex[:10]
+
+
 def _sandbox_identity_labels() -> List[str]:
     """Durable lease-authority identity labels for the current executor.
 
@@ -3557,9 +3588,7 @@ def _sandbox_run_read_only_repository_verification(
     separately named sandbox, and downloads exactly one bounded result file.
     """
 
-    import uuid
-
-    verifier_name = "%s-verify-%s" % (name[:38], uuid.uuid4().hex[:8])
+    verifier_name = _read_only_verifier_sandbox_name()
     trusted = workspace / _TRUSTED_READ_ONLY_VERIFICATION_FILE
     trusted.unlink(missing_ok=True)
     try:
@@ -5171,9 +5200,7 @@ def _run_coding_agent_preflight_result(choice: Any) -> Dict[str, object]:
     is NOT sufficient. The probe sandbox is always deleted."""
     from . import coding_agent as _ca
 
-    import uuid
-
-    name = "mac-codingcap-%s-%s" % (choice.agent, uuid.uuid4().hex[:12])
+    name = _coding_agent_probe_sandbox_name()
     with tempfile.TemporaryDirectory(prefix="mac-coding-agent-probe-") as tmp:
         private_dir = Path(tmp)
         sandbox_choice = _coding_agent_choice_for_sandbox(choice)

--- a/tests/test_executor_sandbox.py
+++ b/tests/test_executor_sandbox.py
@@ -42,6 +42,36 @@ def test_generated_sandbox_name_fits_openshells_length_limit(monkeypatch) -> Non
     assert name.startswith("mac-task-")
 
 
+def test_coding_agent_preflight_probe_sandbox_name_fits_length_limit() -> None:
+    """A second, separate name-generation site with the same 19-char bug.
+
+    "mac-codingcap-<agent>-<12 hex>" was 29-35 chars depending on agent
+    (e.g. "mac-codingcap-opencode-...") -- every coding-agent preflight
+    failed to even create its probe sandbox with "name exceeds maximum
+    length", surfacing as an opaque "probe_failed"/"route verification
+    failed" for every configured CLI. Live-reproduced on a real fleet node
+    after the primary _sandbox_name() fix was already deployed.
+    """
+    sandbox = importlib.import_module("mac.executor_sandbox")
+
+    name = sandbox._coding_agent_probe_sandbox_name()
+
+    assert len(name) <= 19
+
+
+def test_read_only_verifier_sandbox_name_fits_length_limit() -> None:
+    """A third name-generation site with the same 19-char bug.
+
+    "<task-sandbox-name>-verify-<8 hex>" derived from an already-shortened
+    17-char task sandbox name was still 33+ chars.
+    """
+    sandbox = importlib.import_module("mac.executor_sandbox")
+
+    name = sandbox._read_only_verifier_sandbox_name()
+
+    assert len(name) <= 19
+
+
 def test_loopback_urls_are_rewritten_for_the_sandbox_host() -> None:
     sandbox = importlib.import_module("mac.executor_sandbox")
 


### PR DESCRIPTION
## Summary
- The coding-agent preflight probe used `"mac-codingcap-<agent>-<12 hex>"` (29-35 chars depending on agent) and the read-only-report verifier used `"<task-sandbox-name>-verify-<8 hex>"` (33+ chars even after the task sandbox name itself was already shortened, in a prior commit) — both over openshell's 19-char sandbox name limit. Every coding-agent preflight failed to even create its probe sandbox, surfacing as an opaque `"probe_failed"`/`"route verification failed"` for every configured CLI regardless of credentials — this is the actual reason every coding-agent, including a fully-authenticated opencode, kept failing all night even after the credential-forwarding fixes (#730, #731) landed.
- Extracted both into standalone, testable functions (`_coding_agent_probe_sandbox_name`, `_read_only_verifier_sandbox_name`) matching the existing `_sandbox_name()` pattern, using the same compact `"mac-<tag>-<10 hex>"` (17 chars) scheme.

## Live verification
Ran the real preflight function directly against a real fleet node (natasha), with `mac.env` sourced (so `MAC_OPENSHELL_CREATE_ARGS` correctly pointed at the deployment-pinned runtime image):
```
[executor] coding-agent sandbox preflight (opencode): OK
opencode verified= True failure=
FINAL: opencode True
```
This is the first time any coding-agent preflight has reported `verified=True` on this fleet tonight.

## Test plan
- [x] `pytest tests/test_task_executor.py tests/test_executor_sandbox.py tests/test_gate_timeout_reaches_the_sandbox.py tests/test_openshell_sandbox.py` — 310 tests, including two new regression tests asserting both extracted name functions stay under the 19-char limit.
- [x] Live-verified the real preflight path end to end on natasha before landing this as code.
- [ ] Live canary task through natasha reaching a merged PR (retrying now after this deploys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)