### PR TITLE
Stop advertising a host-absolute repo path to sandboxed agents

### DIFF
--- a/src/mac/executor_prompt.py
+++ b/src/mac/executor_prompt.py
@@ -516,7 +516,18 @@ def repository_contract_section(task: Dict[str, Any]) -> str:
     lines.extend(
         [
             "For normal repository tasks, MAC prepares a task-owned git worktree before the executor starts.",
-            "Use $MAC_TASK_REPO_WORKTREE, or metadata.runtime.repository_worktree in task.json, as the only writable checkout.",
+            # Deliberately NOT offering task.json's runtime.repository_worktree
+            # metadata field here as an alternative: that field is a
+            # host-absolute path for the worker's own host-side orchestration
+            # (see worker.py/worker_repo_prep.py), not a path that exists
+            # inside the sandbox. Advertising it here previously sent an agent
+            # straight at it -- auto-rejected as "external_directory" by the
+            # sandbox's own permission model, the same failure mode
+            # $MAC_TASK_FILE's deferral fixed for task.json itself.
+            # $MAC_TASK_REPO_WORKTREE is exported correctly for both the
+            # sandboxed and non-sandboxed execution paths, so it is the only
+            # reference that belongs in agent-facing text.
+            "Use $MAC_TASK_REPO_WORKTREE as the only writable checkout.",
             "Treat origin.repository_path / $MAC_TASK_REPO_SOURCE as read-only registered source state; do not edit it for feature or bug work.",
             "The registered source checkout remains clean; make and test all changes in the task worktree.",
             "Agent ownership ends with tested task-worktree changes and preliminary evidence. The deterministic host finalizer exclusively owns fetching canonical state, rebasing, committing tracked modifications, pushing, and publication; host-finalized evidence supplies the pushed ref.",

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -3188,7 +3188,14 @@ def test_executor_prompt_includes_repository_runtime_contract():
 
     assert "def repository_contract_section(task: Dict[str, Any]) -> str:" in script
     assert "Repository runtime contract:" in script
-    assert "metadata.runtime.repository_worktree" in script
+    assert "Use $MAC_TASK_REPO_WORKTREE as the only writable checkout." in script
+    # NOT advertised as an alternative: metadata.runtime.repository_worktree is a
+    # host-absolute path for the worker's own host-side orchestration, not one
+    # that exists inside the sandbox. An agent that read it and tried to access
+    # it directly was auto-rejected as "external_directory" -- the same failure
+    # mode $MAC_TASK_FILE's deferral fixed for task.json (see
+    # repository_contract_section's neighboring comment).
+    assert "metadata.runtime.repository_worktree" not in script
     assert "origin.repository_path / $MAC_TASK_REPO_SOURCE as read-only" in script
     assert "Agent ownership ends with tested task-worktree changes" in script
     assert "deterministic host finalizer exclusively owns fetching" in script


### PR DESCRIPTION
## Summary

Three fleet tasks this session (`task_33bd332422064517be38e1f9d0fb056f`, `task_d7499cb18a904b99b2dfd680d6fda87d`, `task_eb10cdb226fa430bb5100add9d37a1f2`) all failed identically: a sandboxed coding agent (opencode) read `repository-worktree.json` / `task.json`'s `metadata.runtime.repository_worktree` field, got the host-absolute repo-lease checkout path, and tried to access it directly — auto-rejected as `external_directory` by the sandbox's own permission model.

This is the same bug class already fixed in #733 for `task.json`'s own file path (which now defers to `$MAC_TASK_FILE`): `executor_prompt.py`'s `repository_contract_section()` correctly told agents to use `$MAC_TASK_REPO_WORKTREE`, but also advertised `metadata.runtime.repository_worktree in task.json` as an equally valid alternative — and that field is host-absolute, written for the worker's own host-side orchestration, not something that exists inside the sandbox.

## Fix
Removed the unsafe alternative from the agent-facing instruction. `$MAC_TASK_REPO_WORKTREE` is exported correctly for both the sandboxed and non-sandboxed execution paths, so it's the only reference that belongs in agent-facing text.

## Test plan
- [x] `pytest tests/test_deploy_agent_configs.py tests/test_agent_coordination_prompt.py tests/test_executor_scope.py tests/test_task_executor.py` — 359 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)