### PR TITLE
Remove agent-name canary checkpoint comments leaking operator identity from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 Multi-agent coordinator control plane.
 
-<!-- Pipeline-health checkpoint: 2026-09-04 UTC. -->
-<!-- Pipeline-health checkpoint: 2026-09-04 UTC, bullwinkle. -->
-<!-- Pipeline-health checkpoint: 2026-09-04 UTC, rocky. -->
-
 `mac` is a clean-room control plane for fleets of AI agents. It is designed to
 sit underneath a human-facing agent runtime such as OpenClaw under OpenShell, NemoClaw Hermes, or a compatible system.
 


### PR DESCRIPTION
## Summary
`origin/main` is currently red on `test_docs_no_operator_identity.py`: the rocky/natasha/bullwinkle canary PRs (#734-#736) each appended a checkpoint comment to README.md naming the specific fleet agent that produced it, which is exactly what this repo's own "checked-in docs must read as generic for any fleet owner" guard exists to catch. This blocks sanity CI on every subsequent PR.

## Fix
Removed the three checkpoint comment lines entirely — they were disposable diagnostic markers proving the canary pipeline worked, not real documentation content.

## Test plan
- [x] `pytest tests/test_docs_no_operator_identity.py` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)