### PR TITLE
OpenShell gateway bootstrap probe races cold image pull on brand-new nodes (breaks phase-1 restore contract on retry) (task_eb10cdb226fa430bb5100add9d37a1f2)

### DIFF
--- a/deploy/openshell/bootstrap-openshell.sh
+++ b/deploy/openshell/bootstrap-openshell.sh
@@ -120,6 +120,17 @@ openshell_local_gateway(){
   OPENSHELL_GATEWAY_ENDPOINT="$OPENSHELL_LOCAL_GATEWAY_ENDPOINT" "$cli" "$@"
 }
 
+wait_for_local_gateway(){
+  local cli="$1" attempt
+  for ((attempt = 1; attempt <= 120; attempt++)); do
+    if openshell_local_gateway "$cli" status >/dev/null 2>&1; then
+      return 0
+    fi
+    ((attempt == 120)) || sleep 1
+  done
+  return 1
+}
+
 register_and_select_local_gateway(){
   local cli="$1" registrations
   # `gateway add` is not idempotent. Remove the reviewed name when it already
@@ -1788,9 +1799,8 @@ else
   echo "ERROR: OpenShell gateway requires a working systemd user manager or supervisord" >&2
   exit 1
 fi
-sleep 3
-if ! register_and_select_local_gateway "$BIN/openshell" \
-    || ! openshell_local_gateway "$BIN/openshell" status >/dev/null 2>&1; then
+if ! wait_for_local_gateway "$BIN/openshell" \
+    || ! register_and_select_local_gateway "$BIN/openshell"; then
   stop_gateway_fail_closed
   echo "ERROR: OpenShell gateway did not pass its local status probe" >&2
   exit 1

--- a/tests/test_openshell_bootstrap_contract.py
+++ b/tests/test_openshell_bootstrap_contract.py
@@ -256,6 +256,11 @@ def test_openshell_bootstrap_is_docker_engine_only():
     assert "[program:openshell-gateway]" in script
     assert "sudo supervisorctl restart openshell-gateway" in script
     assert "run-gateway.sh" in script
+    assert "wait_for_local_gateway" in script
+    assert "for ((attempt = 1; attempt <= 120; attempt++))" in script
+    assert 'openshell_local_gateway "$cli" status' in script
+    assert "((attempt == 120)) || sleep 1" in script
+    assert "sleep 3" not in script
     assert "unset KUBERNETES_SERVICE_HOST KUBERNETES_SERVICE_PORT KUBERNETES_PORT" in script
     assert "[program:mac-openshell-firewall]" in script
     assert "chain=MAC_OPENSH_GW" in script


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_eb10cdb226fa430bb5100add9d37a1f2`
- head: `6dc6ef4067b34f65bc43d83c39469c3d46d80b97`
- base at push: `7380a984e8583bb859ddf9a68a8393076b9bf44c`
