### PR TITLE
Wire attestation reconciliation into retain_forward recovery, fixing node/hub key divergence

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -14077,7 +14077,7 @@ PY
 }
 
 recover_cohort_node() {
-  local epoch_id="$1" owner_nonce="$2" fleet_name="$3" candidate_b64="$4"
+  local epoch_id="$1" owner_nonce="$2" fleet_name="$3" candidate_b64="$4" hub_agent="$5"
   local values agent stable_id runtime_generation deployment_id deploy_ts source_commit
   local os_kind supervisor requested_action restore_contract_sha256 probe action evidence
   local phase2_evidence phase1_evidence
@@ -14207,6 +14207,40 @@ PY
   if ! release_remote_deployment_lock "$agent" "$deployment_id"; then
     return 1
   fi
+  if [ "$action" = retain_forward ]; then
+    # retain_forward preserves node state as-is, including any attestation
+    # candidate key that install_and_prove_attestation_candidate already
+    # installed before the hub epoch aborted. Hub abort discards the pending
+    # candidate row, so the node's installed key and the hub's registered
+    # authoritative key can now diverge -- the node keeps signing with a key
+    # the hub no longer recognizes (or vice versa). Reconcile now: probe the
+    # node, verify against the hub's currently registered key, and only
+    # rotate if that verification fails. No split authority may survive
+    # this recovery step.
+    #
+    # reconcile_bound_worker_attestation_key asserts (does not acquire) a
+    # lock under its own freshly computed deployment_id_for_agent -- the
+    # aborted generation's lock above was already released, so acquire a new
+    # one under that exact id for this standalone reconciliation, distinct
+    # from both the aborted generation and any later fresh deployment.
+    [ -n "$hub_agent" ] || {
+      echo "ERROR: ${agent}: retain_forward recovery lacks the hub agent needed to reconcile attestation authority" >&2
+      return 1
+    }
+    local reconcile_deployment_id
+    reconcile_deployment_id="$(deployment_id_for_agent "$agent")"
+    if ! acquire_remote_deployment_lock "$agent" "$reconcile_deployment_id" 0; then
+      return 1
+    fi
+    if ! reconcile_bound_worker_attestation_key \
+      "$agent" "$hub_agent" "$supervisor" "$fleet_name"; then
+      release_remote_deployment_lock "$agent" "$reconcile_deployment_id" >/dev/null 2>&1 || true
+      return 1
+    fi
+    if ! release_remote_deployment_lock "$agent" "$reconcile_deployment_id"; then
+      return 1
+    fi
+  fi
   if ! cohort_journal_mutate aborted-node "$epoch_id" \
     "$COHORT_JOURNAL_REVISION" "aborted-${stable_id}" "$owner_nonce" \
     --agent-name "$agent" --stable-id "$stable_id" \
@@ -14313,7 +14347,7 @@ PY
   while IFS= read -r candidate_b64; do
     [ -n "$candidate_b64" ] || continue
     recover_cohort_node \
-      "$epoch_id" "$owner_nonce" "$fleet_name" "$candidate_b64"
+      "$epoch_id" "$owner_nonce" "$fleet_name" "$candidate_b64" "$hub_agent"
   done < <(printf '%s' "$status" | "$PYTHON_BIN" -c '
 import base64,json,sys
 status=json.load(sys.stdin)
@@ -14863,7 +14897,7 @@ PY
     while IFS= read -r candidate_b64; do
       [ -n "$candidate_b64" ] || continue
       if ! recover_cohort_node \
-        "$epoch_id" "$owner_nonce" "$fleet_name" "$candidate_b64"; then
+        "$epoch_id" "$owner_nonce" "$fleet_name" "$candidate_b64" "$hub_agent"; then
         return 1
       fi
     done < "$candidates_file"

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -4595,6 +4595,46 @@ def test_typed_prepare_and_composite_rollback_are_journal_ordered():
     assert phase2 < phase1 < composite < aborted
 
 
+def test_retain_forward_recovery_reconciles_attestation_authority_after_release():
+    """retain_forward preserves node state as-is, including any attestation
+    candidate key install_and_prove_attestation_candidate already installed
+    before the hub epoch aborted -- hub abort discards the pending candidate
+    row, so the node's installed key and the hub's registered key can
+    diverge. reconcile_bound_worker_attestation_key exists precisely to fix
+    this (probe, verify against the hub, rotate only if needed) but had no
+    call site. It must run only for retain_forward, only after that
+    recovery's own generation lock is released (reconcile asserts its own
+    freshly computed deployment_id_for_agent lock, which it acquires here
+    under a distinct id), and before the aborted-node journal mutation."""
+    deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    recovery = deploy.split("recover_cohort_node() {", 1)[1].split(
+        "\n}\n\nrecover_active_cohort_transaction", 1
+    )[0]
+    assert 'local epoch_id="$1" owner_nonce="$2" fleet_name="$3" candidate_b64="$4" hub_agent="$5"' in recovery
+
+    retain_forward_case = recovery.split("retain_forward)", 1)[1].split("\n      ;;\n  esac", 1)[0]
+    assert "retain_remote_generation_for_forward_repair" in retain_forward_case
+    assert "reconcile_bound_worker_attestation_key" not in retain_forward_case
+
+    release_lock = recovery.index('release_remote_deployment_lock "$agent" "$deployment_id"')
+    reconcile_guard = recovery.index('if [ "$action" = retain_forward ]; then', release_lock)
+    reconcile_acquire = recovery.index(
+        'acquire_remote_deployment_lock "$agent" "$reconcile_deployment_id" 0', reconcile_guard
+    )
+    reconcile_call = recovery.index("reconcile_bound_worker_attestation_key", reconcile_acquire)
+    reconcile_release = recovery.index(
+        'release_remote_deployment_lock "$agent" "$reconcile_deployment_id"', reconcile_call
+    )
+    aborted_node = recovery.index("cohort_journal_mutate aborted-node", reconcile_release)
+    assert release_lock < reconcile_guard < reconcile_acquire < reconcile_call < reconcile_release < aborted_node
+
+    for call_site in (
+        'recover_cohort_node \\\n      "$epoch_id" "$owner_nonce" "$fleet_name" "$candidate_b64" "$hub_agent"',
+        'recover_cohort_node \\\n        "$epoch_id" "$owner_nonce" "$fleet_name" "$candidate_b64" "$hub_agent"',
+    ):
+        assert call_site in deploy
+
+
 def test_phase1_recovery_replays_retained_helper_and_reviewed_cli_identity(tmp_path):
     deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
     restore_function = (


### PR DESCRIPTION
## Summary

Fixes ledger task `task_99d9fccdb580449a81095b55a17442de`, proven live on 2026-09-03: Rocky's operator-result canary evidence was rejected twice because `verification.signature` did not verify against the registered attestation key. Root cause traced to a deterministic node/hub attestation-authority split:

- `install_and_prove_attestation_candidate` installs a fresh attestation key on the node *before* the hub epoch that would register it as authoritative fully commits.
- If that hub epoch then aborts, the pending candidate row is discarded hub-side, but `retain_forward` recovery deliberately preserves node state as-is (by design, for live diagnosis) — including the now-orphaned installed key.
- The node keeps signing with a key the hub no longer recognizes as authoritative. The fingerprint of Rocky's process key matched exactly the candidate fingerprint from an aborted epoch, confirming this live.

`reconcile_bound_worker_attestation_key` already existed, fully implemented (probe → verify against the hub's current registered key → rotate only if that fails → reinstall → restart → re-prove, no raw key ever printed or placed in argv/env), but had no call site.

## Fix

- Thread `hub_agent` into `recover_cohort_node`.
- After `retain_forward`'s own generation lock is released, acquire a fresh `deployment_id`-scoped lock and call `reconcile_bound_worker_attestation_key` before the `aborted-node` journal mutation.
- This runs for every `retain_forward` recovery, self-healing whichever direction the divergence went.

## Test plan
- [x] `bash -n deploy/deploy-mac-fleet.sh` — syntax OK
- [x] `pytest tests/test_deploy_fleet_drain.py` — 130 passed, including a new structural regression test proving the call ordering (lock release → retain_forward guard → fresh lock acquire → reconcile call → fresh lock release → aborted-node mutation) and that both `recover_cohort_node` call sites thread `hub_agent` through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)