### PR TITLE
Require a real sandbox_id for OpenShell agent_status to report deployed

### DIFF
--- a/src/mac/openshell_service.py
+++ b/src/mac/openshell_service.py
@@ -664,6 +664,16 @@ class OpenShellService:
         )
         deployed = self._status_from_row(row) if row is not None else None
         required = self.agent_requires_openshell(agent_id)
+        # A status row of status="active" alone is not proof of a live sandbox:
+        # confirmed live (rocky/natasha/bullwinkle, 2026-09-03) that
+        # retain-forward recovery can leave a row reporting active with
+        # sandbox_id=null after the sandbox itself never came back up, so
+        # "deployed" must also require a real sandbox identity was recorded.
+        live_sandbox = (
+            deployed is not None
+            and deployed.status == "active"
+            and bool(deployed.sandbox_id)
+        )
         return {
             "schema": "mac.openshell.agent_status.v1",
             "agent_id": agent_id,
@@ -674,9 +684,8 @@ class OpenShellService:
             "deployed_status": deployed.to_dict() if deployed else None,
             "effective": {
                 "assigned": assignment is not None,
-                "deployed": deployed is not None and deployed.status == "active",
-                "fail_closed": required
-                and not (deployed is not None and deployed.status == "active"),
+                "deployed": live_sandbox,
+                "fail_closed": required and not live_sandbox,
             },
         }
 

--- a/tests/test_openshell_management.py
+++ b/tests/test_openshell_management.py
@@ -60,6 +60,26 @@ def test_openshell_policy_crud_versions_assignment_and_status():
     assert detail["assignment"]["id"] == assignment.id
 
 
+def test_active_status_with_no_sandbox_id_is_not_deployed_and_fails_closed():
+    """Live-found on rocky/natasha/bullwinkle (2026-09-03): retain-forward
+    recovery can leave a status row reporting status="active" with
+    sandbox_id=null after the sandbox itself never actually came back up.
+    effective.deployed must require a real recorded sandbox identity, not
+    just the historical status string -- otherwise a required-OpenShell
+    agent with no live sandbox is reported as deployed and not fail-closed."""
+    cp = ControlPlane.in_memory()
+    agent = _agent(cp)
+
+    cp.report_openshell_status(agent.id, status="active", sandbox_id=None)
+
+    detail = cp.get_openshell_status(agent.id)
+    assert detail["deployed_status"]["status"] == "active"
+    assert detail["deployed_status"]["sandbox_id"] is None
+    assert detail["required"] is True
+    assert detail["effective"]["deployed"] is False
+    assert detail["effective"]["fail_closed"] is True
+
+
 def test_action_events_project_command_audit_export_and_memory_summary():
     cp = ControlPlane.in_memory()
     agent = _agent(cp)


### PR DESCRIPTION
## Summary

Part of `task_f2758902a67c4a11af432c169a1b3923`. Live control-plane contradiction confirmed 2026-09-03T15:03Z on natasha and bullwinkle: `mac admin openshell status` reported `effective.deployed=true` and `fail_closed=false` while the persisted deployed row had `sandbox_id=null`, and the agent's own fresh startup probe said its named sandbox was absent.

`agent_status` derived `deployed`/`fail_closed` purely from the historical `status=="active"` string, so a retain-forward recovery that leaves a status row saying "active" for a sandbox that never actually came back up (with `sandbox_id` left null) was reported as healthy and deployed.

## Fix

`effective.deployed` now additionally requires a real recorded `sandbox_id`. An "active" status with no sandbox identity is not deployed and correctly fails closed when OpenShell is required for that agent.

This addresses one specific, concretely-observed defect from the ledger task. The task's broader ask (also invalidating stale `resources.chat_gateway.verified` timestamps against current startup evidence) needs its own staleness-threshold design and is left open — filing as a separate scoped follow-up rather than bundling a half-designed heuristic here.

## Test plan
- [x] `pytest tests/test_openshell_management.py` — 4 passed (including new regression test)
- [x] `pytest tests/test_openshell_fleet_assignment.py tests/test_openshell_bootstrap_contract.py tests/test_openshell_reconcile.py tests/test_openshell_sandbox_lease_reconcile.py tests/test_openshell_sandbox_lifecycle_gc.py tests/test_openshell_sandbox.py` — 190 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)