### PR TITLE
Pin OPENSHELL_GATEWAY_ENDPOINT into mac.env so mac-agent is immune to ambient gateway drift

### DIFF
--- a/deploy/openshell/bootstrap-openshell.sh
+++ b/deploy/openshell/bootstrap-openshell.sh
@@ -1832,7 +1832,7 @@ else
   log "codex file auth upload: disabled (rotating OAuth state is not durable in throwaway sandboxes)"
 fi
 cp -a "$ENVF" "$ENVF.bak-openshell-$(date +%Y%m%dT%H%M%S 2>/dev/null || echo bootstrap)"
-sed -i '/^# OpenShell sandbox enforcement/d;/^MAC_OPENSHELL_SANDBOX=/d;/^MAC_OPENSHELL_GC=/d;/^MAC_OPENSHELL_STALE_AFTER_SECONDS=/d;/^MAC_HERMES_PYTHON=/d;/^MAC_OPENSHELL_POLICY=/d;/^MAC_OPENSHELL_BIN=/d;/^MAC_OPENSHELL_CREATE_ARGS=/d;/^MAC_OPENSHELL_GPU_AVAILABLE=/d;/^MAC_ALLOW_UNSANDBOXED_YOLO=/d;/^MAC_OPENSHELL_REPO_REQUIRES_CODING_AGENT=/d' "$ENVF"
+sed -i '/^# OpenShell sandbox enforcement/d;/^MAC_OPENSHELL_SANDBOX=/d;/^MAC_OPENSHELL_GC=/d;/^MAC_OPENSHELL_STALE_AFTER_SECONDS=/d;/^MAC_HERMES_PYTHON=/d;/^MAC_OPENSHELL_POLICY=/d;/^MAC_OPENSHELL_BIN=/d;/^MAC_OPENSHELL_CREATE_ARGS=/d;/^MAC_OPENSHELL_GPU_AVAILABLE=/d;/^MAC_ALLOW_UNSANDBOXED_YOLO=/d;/^MAC_OPENSHELL_REPO_REQUIRES_CODING_AGENT=/d;/^OPENSHELL_GATEWAY_ENDPOINT=/d' "$ENVF"
 sandbox_image_ref="${OSH_RUNTIME_IMAGE_REF:-$OSH_IMAGE_TAG}"
 {
   echo ""
@@ -1845,6 +1845,17 @@ sandbox_image_ref="${OSH_RUNTIME_IMAGE_REF:-$OSH_IMAGE_TAG}"
   echo "MAC_OPENSHELL_CREATE_ARGS=\"--from $sandbox_image_ref$codex_uploads\""
   echo "MAC_OPENSHELL_GPU_AVAILABLE=$gpu_runtime_available"
   echo "MAC_OPENSHELL_REPO_REQUIRES_CODING_AGENT=1"
+  # Pin the gateway every mac-agent subprocess talks to, matching what this
+  # script already uses for its own openshell_local_gateway() calls (line
+  # ~120). Without this, mac-agent's executor inherits whatever gateway the
+  # openshell CLI's own persisted "active gateway" selection happens to be --
+  # local, unrelated state any other process (e.g. a NemoClaw pilot) can
+  # silently repoint. Live-found on natasha (2026-09-04): the active gateway
+  # drifted to a NemoClaw pilot endpoint, so every coding-agent sandbox
+  # preflight probe uniformly failed (all 5 configured agents) with no
+  # per-agent credential explanation, because they were all quietly hitting
+  # the wrong gateway.
+  echo "OPENSHELL_GATEWAY_ENDPOINT=$OPENSHELL_LOCAL_GATEWAY_ENDPOINT"
   [ "$DO_FAILCLOSED" = 1 ] && echo "MAC_ALLOW_UNSANDBOXED_YOLO=0"
 } >> "$ENVF"
 # sanity: mac.env must still source cleanly (quoting)

--- a/tests/test_openshell_bootstrap_contract.py
+++ b/tests/test_openshell_bootstrap_contract.py
@@ -284,6 +284,31 @@ def test_openshell_bootstrap_is_docker_engine_only():
     assert all("--env" not in line and " -- " not in line for line in create_arg_lines)
 
 
+def test_bootstrap_pins_the_managed_gateway_endpoint_into_mac_env():
+    """Live-found on natasha (2026-09-04): the openshell CLI's own persisted
+    "active gateway" selection is local, unrelated state that any other
+    process (a NemoClaw pilot, in this case) can silently repoint. Because
+    mac-agent's executor never explicitly set OPENSHELL_GATEWAY_ENDPOINT, it
+    inherited whatever gateway happened to be selected, and every
+    coding-agent sandbox preflight probe (all 5 configured agents) failed
+    uniformly with no per-agent credential explanation -- they were all
+    quietly hitting the wrong gateway. bootstrap-openshell.sh must pin this
+    into mac.env exactly like it already pins its own
+    openshell_local_gateway() calls to OPENSHELL_LOCAL_GATEWAY_ENDPOINT, so
+    mac-agent's process (which sources mac.env) is immune to that drift."""
+    script = (ROOT / "deploy" / "openshell" / "bootstrap-openshell.sh").read_text(
+        encoding="utf-8"
+    )
+    assert 'OPENSHELL_LOCAL_GATEWAY_ENDPOINT="http://127.0.0.1:17670"' in script
+    recipe = script.split('# --- 11. env recipe in mac.env', 1)[1].split(
+        "# sanity: mac.env must still source cleanly", 1
+    )[0]
+    assert 'echo "OPENSHELL_GATEWAY_ENDPOINT=$OPENSHELL_LOCAL_GATEWAY_ENDPOINT"' in recipe
+    # The stale-key cleanup sed must also strip a prior run's value so
+    # rerunning bootstrap can never leave two conflicting definitions.
+    assert "/^OPENSHELL_GATEWAY_ENDPOINT=/d" in script
+
+
 def test_linux_bootstrap_installs_and_verifies_docker_buildx():
     script = (ROOT / "deploy" / "openshell" / "bootstrap-openshell.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Live-found on natasha (2026-09-04): `mac admin fleet creds-status` showed `ROUTE UNAVAILABLE (probe_failed)` uniformly for all 5 configured coding agents (claude, codex, cursor, opencode, pi), while bullwinkle had several working.

`openshell gateway list` on natasha showed two registered gateways — the mac-managed `openshell` (`http://127.0.0.1:17670`, plaintext, version 0.0.72, the fleet pin) and a `nemoclaw` pilot gateway (`https://127.0.0.1:8080`, mTLS) — with `nemoclaw` marked as the CLI's active/default gateway.

mac-agent's executor never explicitly sets `OPENSHELL_GATEWAY_ENDPOINT` when it invokes the `openshell` CLI; every subprocess call simply inherits mac-agent's own process environment. Since `mac.env` never carried this variable, every one of those calls silently followed the `openshell` CLI's own persisted "active gateway" selection — local, unrelated state that any other process (here, a NemoClaw pilot) can repoint without mac-agent's knowledge. Once the active gateway drifted, mac-agent kept quietly talking to the wrong gateway, and every coding-agent probe failed uniformly with no per-agent credential explanation.

## Fix

`bootstrap-openshell.sh` already pins `OPENSHELL_GATEWAY_ENDPOINT` to `OPENSHELL_LOCAL_GATEWAY_ENDPOINT` for its own internal `openshell_local_gateway()` calls, but never wrote that pin into the node's persisted `mac.env` for mac-agent's own runtime process to inherit. `deploy_env.py` already lists `OPENSHELL_GATEWAY_ENDPOINT` as a managed runtime key; it was simply never emitted. Add it to the same env-recipe block that already writes the other managed keys.

Operationally recovered natasha immediately via `openshell gateway select openshell`; this change makes the fix durable across redeploys and immune to future ambient-gateway drift from any source.

## Test plan
- [x] `bash -n deploy/openshell/bootstrap-openshell.sh` — syntax OK
- [x] `pytest tests/test_openshell_bootstrap_contract.py` — 27 passed (including new regression test)
- [x] `pytest tests/test_deploy_env_edges.py tests/test_openshell_sandbox.py` — 113 passed
- [x] Live verified on natasha: `mac admin fleet creds-status` now shows `opencode`/`codex` verified (matching bullwinkle's pattern) after the operational gateway-select fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)