### PR TITLE
Root-cause rocky failing to self-claim explicitly-targeted tasks (why-unclaimed also times out intermittently) (task_d7499cb18a904b99b2dfd680d6fda87d)

### DIFF
--- a/src/mac/task_lifecycle.py
+++ b/src/mac/task_lifecycle.py
@@ -622,6 +622,8 @@ class DispatchService:
             task_id.id if isinstance(task_id, Task) else str(task_id)
         )
         candidate_agents = list(agents) if agents is not None else self.control_plane.list_agents()
+        if sync_states is None:
+            sync_states = self._sync_barrier_states()
         agent_ids_by_name: Dict[str, List[str]] = {}
         for agent in candidate_agents:
             agent_ids_by_name.setdefault(agent.name, []).append(agent.id)
@@ -706,6 +708,47 @@ class DispatchService:
                 },
             )
         return result
+
+    def _claim_targeted_task_for_agent(
+        self,
+        agent: Any,
+        *,
+        lease_seconds: int,
+    ) -> Optional[JsonDict]:
+        """Claim an explicit agent-id target without rebuilding a global round."""
+
+        rows = self.control_plane.store.query_all(
+            "SELECT * FROM tasks WHERE state = ? "
+            "AND json_extract(metadata, '$.target_agent_id') = ? "
+            "ORDER BY priority DESC, created_at, id LIMIT 100",
+            (TaskState.OPEN.value, agent.id),
+        )
+        if not rows:
+            return None
+        projects = {record.name: record for record in self.control_plane.list_project_records()}
+        agent_snapshot = self._v2_snapshot_agent(
+            agent,
+            self._sync_barrier_states(),
+        )
+        for row in rows:
+            task = self.control_plane._task_from_row(row)
+            task_snapshot = self._v2_snapshot_task(
+                task,
+                projects=projects,
+                agent_ids_by_name={agent.name: [agent.id]},
+            )
+            if not evaluate_pair(task_snapshot, agent_snapshot).allowed:
+                continue
+            try:
+                claimed = self.control_plane.claim_task_v2(
+                    task.id,
+                    agent.id,
+                    lease_seconds=lease_seconds,
+                )
+            except (AuthorizationError, TransitionError, ValidationError):
+                continue
+            return dict(claimed) if isinstance(claimed, Mapping) else claimed
+        return None
 
     def _allocation_v2_inputs(
         self,
@@ -1102,6 +1145,12 @@ class DispatchService:
             assignment = self.control_plane._active_assignment_for_agent(agent)
             if assignment is not None:
                 return assignment
+            targeted = self._claim_targeted_task_for_agent(
+                agent,
+                lease_seconds=lease_seconds,
+            )
+            if targeted is not None:
+                return targeted
 
         if dry_run:
             result, _tasks_by_id, _agents_by_id = self._allocate_v2_round(

--- a/tests/test_dispatch_service_v2.py
+++ b/tests/test_dispatch_service_v2.py
@@ -70,6 +70,30 @@ def test_pull_claim_triggers_global_round_and_ignores_request_filters():
     assert cp._active_assignment_for_agent(second_worker) is not None
 
 
+def test_pull_claims_explicit_target_without_global_allocation_round(monkeypatch):
+    cp = ControlPlane.in_memory()
+    active_project(cp)
+    target = worker(cp, "target")
+    task = cp.create_task(
+        "targeted",
+        project="mac",
+        required_capabilities=["python"],
+        metadata={"target_agent_id": target.id},
+    )
+
+    def global_round_must_not_run(**_kwargs):
+        raise AssertionError("explicit target should use the bounded direct path")
+
+    monkeypatch.setattr(cp.dispatch, "_allocate_v2_round", global_round_must_not_run)
+
+    assignment = cp.claim_next_for_agent(target.id)
+
+    assert assignment is not None
+    assert assignment["task"]["id"] == task.id
+    assert assignment["agent"]["id"] == target.id
+    assert cp.get_task(task.id).state == TaskState.CLAIMED.value
+
+
 def test_idle_pull_is_write_free_and_does_not_claim_reconciliation_leases():
     cp = ControlPlane.in_memory()
     active_project(cp)
@@ -265,3 +289,25 @@ def test_explain_non_open_task_uses_v2_task_rejection():
     assert explanation["task_ready"] is False
     assert explanation["dispatchable"] is False
     assert [reason["code"] for reason in explanation["task_reasons"]] == ["task_not_open"]
+
+
+def test_explain_builds_sync_barrier_state_once_for_all_agents(monkeypatch):
+    cp = ControlPlane.in_memory()
+    active_project(cp)
+    worker(cp, "first")
+    worker(cp, "second")
+    task = cp.create_task("explain", project="mac", required_capabilities=["python"])
+    calls = 0
+    real_non_terminal_tasks = cp._non_terminal_tasks
+
+    def counted_non_terminal_tasks():
+        nonlocal calls
+        calls += 1
+        return real_non_terminal_tasks()
+
+    monkeypatch.setattr(cp, "_non_terminal_tasks", counted_non_terminal_tasks)
+
+    explanation = cp.dispatch.explain_task_dispatch(task.id)
+
+    assert explanation["candidate_count"] == 2
+    assert calls == 1


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_d7499cb18a904b99b2dfd680d6fda87d`
- head: `3028a41dda6fda48490ee569c5d9552270c7b5a6`
- base at push: `1d519b01a427e03a6b73bb5bd64bf5cb706c9de8`
