### PR TITLE
Close diff-coverage gap left by PR #745's targeted-dispatch fix

### DIFF
--- a/tests/test_dispatch_service_v2.py
+++ b/tests/test_dispatch_service_v2.py
@@ -94,6 +94,121 @@ def test_pull_claims_explicit_target_without_global_allocation_round(monkeypatch
     assert cp.get_task(task.id).state == TaskState.CLAIMED.value
 
 
+def test_targeted_task_ineligible_falls_through_to_the_global_round():
+    """A target_agent_id task the agent is not actually eligible for (missing
+    capability) must be skipped by the bounded direct path, not claimed
+    incorrectly and not left stuck blocking the fallback global round."""
+    cp = ControlPlane.in_memory()
+    active_project(cp)
+    target = worker(cp, "target", capabilities=["python"])
+    ineligible_task = cp.create_task(
+        "targeted but ineligible",
+        project="mac",
+        required_capabilities=["rust"],
+        metadata={"target_agent_id": target.id},
+    )
+    fallback_task = cp.create_task(
+        "untargeted fallback",
+        project="mac",
+        required_capabilities=["python"],
+    )
+
+    assignment = cp.claim_next_for_agent(target.id)
+
+    assert assignment is not None
+    assert assignment["task"]["id"] == fallback_task.id
+    assert cp.get_task(ineligible_task.id).state == TaskState.OPEN.value
+
+
+def test_targeted_claim_raising_falls_through_to_a_later_eligible_target(monkeypatch):
+    """claim_task_v2 raising AuthorizationError/TransitionError/ValidationError
+    for one targeted candidate (e.g. a lost claim race) must be swallowed and
+    the loop must continue to the next targeted candidate rather than
+    propagating or silently returning nothing."""
+    from mac.models import ValidationError
+
+    cp = ControlPlane.in_memory()
+    active_project(cp)
+    target = worker(cp, "target")
+    first_task = cp.create_task(
+        "targeted first",
+        project="mac",
+        required_capabilities=["python"],
+        metadata={"target_agent_id": target.id},
+    )
+    second_task = cp.create_task(
+        "targeted second",
+        project="mac",
+        required_capabilities=["python"],
+        metadata={"target_agent_id": target.id},
+    )
+
+    real_claim = cp.claim_task_v2
+
+    def flaky_claim(task_id, agent_id, **kwargs):
+        if task_id == first_task.id:
+            raise ValidationError("synthetic lost-race for test coverage")
+        return real_claim(task_id, agent_id, **kwargs)
+
+    monkeypatch.setattr(cp, "claim_task_v2", flaky_claim)
+
+    assignment = cp.claim_next_for_agent(target.id)
+
+    assert assignment is not None
+    assert assignment["task"]["id"] == second_task.id
+    assert cp.get_task(first_task.id).state == TaskState.OPEN.value
+
+
+def test_no_targeted_tasks_returns_none_and_uses_the_global_round(monkeypatch):
+    """An agent with no target_agent_id-tagged tasks at all must fall straight
+    through the bounded direct path (empty result set) to the ordinary global
+    allocation round, not error or stall."""
+    cp = ControlPlane.in_memory()
+    active_project(cp)
+    target = worker(cp, "target")
+    task = cp.create_task("untargeted", project="mac", required_capabilities=["python"])
+    calls = []
+    real_targeted = cp.dispatch._claim_targeted_task_for_agent
+
+    def counted_targeted(agent, **kwargs):
+        result = real_targeted(agent, **kwargs)
+        calls.append(result)
+        return result
+
+    monkeypatch.setattr(cp.dispatch, "_claim_targeted_task_for_agent", counted_targeted)
+
+    assignment = cp.claim_next_for_agent(target.id)
+
+    assert calls == [None]
+    assert assignment is not None
+    assert assignment["task"]["id"] == task.id
+
+
+def test_explain_reuses_a_caller_supplied_sync_states_without_rebuilding(monkeypatch):
+    """A caller explaining many tasks in one pass (task_flow_report) builds
+    sync_states once and passes it explicitly; explain_task_dispatch must not
+    rebuild it in that case."""
+    cp = ControlPlane.in_memory()
+    active_project(cp)
+    worker(cp, "first")
+    task = cp.create_task("explain", project="mac", required_capabilities=["python"])
+    sync_states = cp.dispatch._sync_barrier_states()
+    calls = 0
+    real_non_terminal_tasks = cp._non_terminal_tasks
+
+    def counted_non_terminal_tasks():
+        nonlocal calls
+        calls += 1
+        return real_non_terminal_tasks()
+
+    monkeypatch.setattr(cp, "_non_terminal_tasks", counted_non_terminal_tasks)
+
+    explanation = cp.dispatch.explain_task_dispatch(task.id, sync_states=sync_states)
+
+    assert explanation["candidate_count"] == 1
+    assert calls == 0
+
+
 def test_idle_pull_is_write_free_and_does_not_claim_reconciliation_leases():
     cp = ControlPlane.in_memory()
     active_project(cp)


### PR DESCRIPTION
## Summary

PR #745 (rocky self-claim fix) merged clean through all PR-time checks, but the \`mainline\` workflow only runs on pushes to \`main\` — not on PRs — and it failed post-merge: diff statement coverage 36.36% (8/22 changed lines), below the 80% safety floor. None of \`_claim_targeted_task_for_agent\`'s non-happy-path branches (no targeted tasks, an ineligible targeted candidate, \`claim_task_v2\` raising a lost-race exception) or \`explain_task_dispatch\`'s caller-supplied-\`sync_states\` branch were exercised by the one test #745 added.

## Fix

Four new tests covering exactly those branches:
- \`test_targeted_task_ineligible_falls_through_to_the_global_round\`
- \`test_targeted_claim_raising_falls_through_to_a_later_eligible_target\`
- \`test_no_targeted_tasks_returns_none_and_uses_the_global_round\`
- \`test_explain_reuses_a_caller_supplied_sync_states_without_rebuilding\`

## Test plan
- [x] \`pytest tests/test_dispatch_service_v2.py tests/test_control_plane.py\` — all pass
- [x] \`coverage run --source=mac.task_lifecycle -m pytest tests/test_dispatch_service_v2.py\` cross-referenced against the exact changed-line set from commit 105c5577 — every line/branch #745 touched is now covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)