### PR TITLE
Apply ruff format to files touched by recent PRs

### DIFF
--- a/docs/presentation/20260902T131314Z-a168e9d0/build_deck.py
+++ b/docs/presentation/20260902T131314Z-a168e9d0/build_deck.py
@@ -67,25 +67,56 @@ def title_slide() -> None:
     frame = text_box(slide, Inches(0.9), Inches(2.0), Inches(11.5), Inches(2.8))
     line(frame, "MAC", 54, WHITE, bold=True, first=True, after=8)
     line(frame, "v1.3.5 release candidate", 32, PALE, after=16)
-    line(frame, "A release procedure that makes the evidence, documentation, and rollout visible.", 18, MUTED)
+    line(
+        frame,
+        "A release procedure that makes the evidence, documentation, and rollout visible.",
+        18,
+        MUTED,
+    )
     footer = text_box(slide, Inches(0.9), Inches(5.75), Inches(11.5), Inches(0.8))
     line(footer, f"commit {COMMIT}   ·   captured {CAPTURED}", 16, SAND, bold=True, first=True)
-    notes(slide, "This deck is pinned to the release candidate. AUDIT.md traces each visible claim to the source tree or generated reference.")
+    notes(
+        slide,
+        "This deck is pinned to the release candidate. AUDIT.md traces each visible claim to the source tree or generated reference.",
+    )
 
 
 def change_slide() -> None:
     slide = prs.slides.add_slide(BLANK)
     frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
-    line(frame, "This release makes long-running change safer to observe and finish", 33, INK, bold=True, first=True)
+    line(
+        frame,
+        "This release makes long-running change safer to observe and finish",
+        33,
+        INK,
+        bold=True,
+        first=True,
+    )
     line(frame, "The goal is operational confidence, not a faster-looking dashboard.", 16, GREY)
     body = text_box(slide, Inches(0.95), Inches(2.05), Inches(11.3), Inches(4.65))
-    for index, (head, detail) in enumerate([
-        ("Artifact publication", "A tag now builds and validates a versioned wheel before publishing the release."),
-        ("Deploy resilience", "A slow but healthy gateway is recorded as degraded rather than turning a node rollout into a false failure."),
-        ("Fleet visibility", "AgentBus traffic, roll-call, and fleet news give operators durable read-side evidence."),
-        ("Healthy test budget", "The contract suite has up to one hour when it is making progress, so verification is not mistaken for a hang."),
-    ]):
-        line(body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2)
+    for index, (head, detail) in enumerate(
+        [
+            (
+                "Artifact publication",
+                "A tag now builds and validates a versioned wheel before publishing the release.",
+            ),
+            (
+                "Deploy resilience",
+                "A slow but healthy gateway is recorded as degraded rather than turning a node rollout into a false failure.",
+            ),
+            (
+                "Fleet visibility",
+                "AgentBus traffic, roll-call, and fleet news give operators durable read-side evidence.",
+            ),
+            (
+                "Healthy test budget",
+                "The contract suite has up to one hour when it is making progress, so verification is not mistaken for a hang.",
+            ),
+        ]
+    ):
+        line(
+            body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2
+        )
         line(body, detail, 17, SLATE, after=12)
     notes(slide, "Each point is a shipped change in the audited range, not a planned capability.")
 
@@ -93,54 +124,142 @@ def change_slide() -> None:
 def release_flow_slide() -> None:
     slide = prs.slides.add_slide(BLANK)
     frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
-    line(frame, "A release is now a gated sequence with a clear stop point", 33, INK, bold=True, first=True)
+    line(
+        frame,
+        "A release is now a gated sequence with a clear stop point",
+        33,
+        INK,
+        bold=True,
+        first=True,
+    )
     line(frame, "The command cannot tag first and explain later.", 16, GREY)
-    body = text_box(slide, Inches(1.0), Inches(2.1), Inches(11.1), Inches(4.5), align=PP_ALIGN.CENTER)
-    steps = ["Audited docs and deck", "Lint, tests, and docs gate", "Release PR", "Tag and artifacts", "Optional fleet rollout"]
+    body = text_box(
+        slide, Inches(1.0), Inches(2.1), Inches(11.1), Inches(4.5), align=PP_ALIGN.CENTER
+    )
+    steps = [
+        "Audited docs and deck",
+        "Lint, tests, and docs gate",
+        "Release PR",
+        "Tag and artifacts",
+        "Optional fleet rollout",
+    ]
     for idx, step in enumerate(steps):
-        line(body, f"{idx + 1}.  {step}", 23, BLUE if idx < 3 else AMBER, bold=True, first=idx == 0, after=14)
-    notes(slide, "The release target enforces this ordering. Deployment remains optional and follows artifact publication.")
+        line(
+            body,
+            f"{idx + 1}.  {step}",
+            23,
+            BLUE if idx < 3 else AMBER,
+            bold=True,
+            first=idx == 0,
+            after=14,
+        )
+    notes(
+        slide,
+        "The release target enforces this ordering. Deployment remains optional and follows artifact publication.",
+    )
 
 
 def evidence_slide() -> None:
     slide = prs.slides.add_slide(BLANK)
     background(slide, SLATE)
     frame = text_box(slide, Inches(0.9), Inches(0.7), Inches(11.5), Inches(1.0))
-    line(frame, "The candidate has a verifiable operating surface", 34, WHITE, bold=True, first=True)
+    line(
+        frame, "The candidate has a verifiable operating surface", 34, WHITE, bold=True, first=True
+    )
     body = text_box(slide, Inches(0.95), Inches(2.0), Inches(11.2), Inches(4.3))
-    for idx, item in enumerate([
-        "433 HTTP routes in the generated OpenAPI reference",
-        "Six top-level command groups in the generated CLI reference",
-        "18 executable documentation chapters",
-        "Eight commits since v1.3.4",
-        "Expanded sanity scope passed before the release workflow was merged",
-    ]):
+    for idx, item in enumerate(
+        [
+            "433 HTTP routes in the generated OpenAPI reference",
+            "Six top-level command groups in the generated CLI reference",
+            "18 executable documentation chapters",
+            "Eight commits since v1.3.4",
+            "Expanded sanity scope passed before the release workflow was merged",
+        ]
+    ):
         line(body, item, 22, PALE if idx < 3 else SAND, bold=idx < 3, first=idx == 0, after=12)
-    notes(slide, "Counts are dated observations at this commit. AUDIT.md gives the collection source for each one.")
+    notes(
+        slide,
+        "Counts are dated observations at this commit. AUDIT.md gives the collection source for each one.",
+    )
 
 
 def boundary_slide() -> None:
     slide = prs.slides.add_slide(BLANK)
     frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
-    line(frame, "Release automation does not erase operational judgement", 33, INK, bold=True, first=True)
+    line(
+        frame,
+        "Release automation does not erase operational judgement",
+        33,
+        INK,
+        bold=True,
+        first=True,
+    )
     line(frame, "Automation proves prerequisites; it does not conceal a failed rollout.", 16, GREY)
     body = text_box(slide, Inches(0.95), Inches(2.1), Inches(11.3), Inches(4.5))
-    line(body, "If the final version bump is not green, the process stops before a tag.", 22, BLUE, bold=True, first=True, after=15)
-    line(body, "If deployment fails, the newest generation is retained with diagnostic evidence and a safety hold for a forward repair.", 22, AMBER, bold=True, after=15)
-    line(body, "The release record, the deck, and the fleet outcome stay separately inspectable.", 22, SLATE, bold=True)
-    notes(slide, "This is a fix-forward policy. A rollback requires explicit break-glass authority.")
+    line(
+        body,
+        "If the final version bump is not green, the process stops before a tag.",
+        22,
+        BLUE,
+        bold=True,
+        first=True,
+        after=15,
+    )
+    line(
+        body,
+        "If deployment fails, the newest generation is retained with diagnostic evidence and a safety hold for a forward repair.",
+        22,
+        AMBER,
+        bold=True,
+        after=15,
+    )
+    line(
+        body,
+        "The release record, the deck, and the fleet outcome stay separately inspectable.",
+        22,
+        SLATE,
+        bold=True,
+    )
+    notes(
+        slide, "This is a fix-forward policy. A rollback requires explicit break-glass authority."
+    )
 
 
 def closing_slide() -> None:
     slide = prs.slides.add_slide(BLANK)
     background(slide, SLATE)
-    frame = text_box(slide, Inches(0.9), Inches(2.1), Inches(11.5), Inches(2.7), align=PP_ALIGN.CENTER)
-    line(frame, "v1.3.5 is ready to be proven, published, and rolled out", 34, WHITE, bold=True, first=True, after=14)
-    line(frame, "The release target keeps the proof with the release instead of leaving it in a terminal transcript.", 20, PALE)
-    notes(slide, "Close with the practical consequence: a release is now a reproducible, reviewable procedure rather than a sequence remembered by one operator.")
+    frame = text_box(
+        slide, Inches(0.9), Inches(2.1), Inches(11.5), Inches(2.7), align=PP_ALIGN.CENTER
+    )
+    line(
+        frame,
+        "v1.3.5 is ready to be proven, published, and rolled out",
+        34,
+        WHITE,
+        bold=True,
+        first=True,
+        after=14,
+    )
+    line(
+        frame,
+        "The release target keeps the proof with the release instead of leaving it in a terminal transcript.",
+        20,
+        PALE,
+    )
+    notes(
+        slide,
+        "Close with the practical consequence: a release is now a reproducible, reviewable procedure rather than a sequence remembered by one operator.",
+    )
 
 
-for build in (title_slide, change_slide, release_flow_slide, evidence_slide, boundary_slide, closing_slide):
+for build in (
+    title_slide,
+    change_slide,
+    release_flow_slide,
+    evidence_slide,
+    boundary_slide,
+    closing_slide,
+):
     build()
 
 prs.save(OUT)

--- a/src/mac/executor_prompt.py
+++ b/src/mac/executor_prompt.py
@@ -864,9 +864,7 @@ def _coordination_section(task: Dict[str, Any]) -> str:
     )
 
 
-def build_task_prompt(
-    task: Dict[str, Any], lessons: Optional[List[str]] = None
-) -> str:
+def build_task_prompt(task: Dict[str, Any], lessons: Optional[List[str]] = None) -> str:
     """Build the full executor prompt text for the given task."""
     metadata = task.get("metadata") if isinstance(task, dict) else {}
     evidence_contract = (

--- a/src/mac/openshell_service.py
+++ b/src/mac/openshell_service.py
@@ -670,9 +670,7 @@ class OpenShellService:
         # sandbox_id=null after the sandbox itself never came back up, so
         # "deployed" must also require a real sandbox identity was recorded.
         live_sandbox = (
-            deployed is not None
-            and deployed.status == "active"
-            and bool(deployed.sandbox_id)
+            deployed is not None and deployed.status == "active" and bool(deployed.sandbox_id)
         )
         return {
             "schema": "mac.openshell.agent_status.v1",

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -2784,7 +2784,7 @@ def test_gateway_log_classifier_failure_is_non_fatal_by_default_for_openclaw():
         'if [ "${MAC_CHAT_GATEWAY_IMPL:-openclaw}" = "openclaw" ]; then\n'
         "  # classify_gateway_logs exits nonzero",
         1,
-    )[1].split("log \"verifying hub health", 1)[0]
+    )[1].split('log "verifying hub health', 1)[0]
 
     assert "if ! classify_gateway_logs " in call_site
     assert "handle_failed_openclaw_successor " in call_site
@@ -2792,9 +2792,9 @@ def test_gateway_log_classifier_failure_is_non_fatal_by_default_for_openclaw():
     assert "note_gateway_degraded " in call_site
     # The old form let classify_gateway_logs's own SystemExit(1) propagate
     # unguarded straight into the script's error trap.
-    assert re.search(
-        r'^\s*classify_gateway_logs "\$gateway_log"\s*$', call_site, re.MULTILINE
-    ) is None
+    assert (
+        re.search(r'^\s*classify_gateway_logs "\$gateway_log"\s*$', call_site, re.MULTILINE) is None
+    )
 
 
 def test_fleet_deploy_treats_unconfigured_discord_startup_as_benign():

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -4610,7 +4610,10 @@ def test_retain_forward_recovery_reconciles_attestation_authority_after_release(
     recovery = deploy.split("recover_cohort_node() {", 1)[1].split(
         "\n}\n\nrecover_active_cohort_transaction", 1
     )[0]
-    assert 'local epoch_id="$1" owner_nonce="$2" fleet_name="$3" candidate_b64="$4" hub_agent="$5"' in recovery
+    assert (
+        'local epoch_id="$1" owner_nonce="$2" fleet_name="$3" candidate_b64="$4" hub_agent="$5"'
+        in recovery
+    )
 
     retain_forward_case = recovery.split("retain_forward)", 1)[1].split("\n      ;;\n  esac", 1)[0]
     assert "retain_remote_generation_for_forward_repair" in retain_forward_case
@@ -4626,7 +4629,14 @@ def test_retain_forward_recovery_reconciles_attestation_authority_after_release(
         'release_remote_deployment_lock "$agent" "$reconcile_deployment_id"', reconcile_call
     )
     aborted_node = recovery.index("cohort_journal_mutate aborted-node", reconcile_release)
-    assert release_lock < reconcile_guard < reconcile_acquire < reconcile_call < reconcile_release < aborted_node
+    assert (
+        release_lock
+        < reconcile_guard
+        < reconcile_acquire
+        < reconcile_call
+        < reconcile_release
+        < aborted_node
+    )
 
     for call_site in (
         'recover_cohort_node \\\n      "$epoch_id" "$owner_nonce" "$fleet_name" "$candidate_b64" "$hub_agent"',

--- a/tests/test_fleet_node_daemon_quiescence.py
+++ b/tests/test_fleet_node_daemon_quiescence.py
@@ -1070,10 +1070,7 @@ def test_stop_wrapper_timeout_reports_actionable_timeout_evidence(tmp_path: Path
     assert "elapsed=" in run.result.stderr
     assert "effective_timeout=1.000s" in run.result.stderr
     assert "requested_timeout=1.000s" in run.result.stderr
-    assert (
-        "limiting_bound=MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS"
-        in run.result.stderr
-    )
+    assert "limiting_bound=MAC_DEPLOY_DAEMON_COMMAND_TIMEOUT_SECONDS" in run.result.stderr
     _assert_no_secret(run)
 
 

--- a/tests/test_openshell_bootstrap_contract.py
+++ b/tests/test_openshell_bootstrap_contract.py
@@ -301,11 +301,9 @@ def test_bootstrap_pins_the_managed_gateway_endpoint_into_mac_env():
     into mac.env exactly like it already pins its own
     openshell_local_gateway() calls to OPENSHELL_LOCAL_GATEWAY_ENDPOINT, so
     mac-agent's process (which sources mac.env) is immune to that drift."""
-    script = (ROOT / "deploy" / "openshell" / "bootstrap-openshell.sh").read_text(
-        encoding="utf-8"
-    )
+    script = (ROOT / "deploy" / "openshell" / "bootstrap-openshell.sh").read_text(encoding="utf-8")
     assert 'OPENSHELL_LOCAL_GATEWAY_ENDPOINT="http://127.0.0.1:17670"' in script
-    recipe = script.split('# --- 11. env recipe in mac.env', 1)[1].split(
+    recipe = script.split("# --- 11. env recipe in mac.env", 1)[1].split(
         "# sanity: mac.env must still source cleanly", 1
     )[0]
     assert 'echo "OPENSHELL_GATEWAY_ENDPOINT=$OPENSHELL_LOCAL_GATEWAY_ENDPOINT"' in recipe

--- a/tests/test_task_executor.py
+++ b/tests/test_task_executor.py
@@ -318,7 +318,9 @@ def test_sandbox_create_forwards_safe_coding_agent_credential_files(tmp_path, mo
     opencode_auth.write_text('{"nvidia": {"type": "api", "key": "sk-test"}}', encoding="utf-8")
     opencode_config = fake_home / ".config" / "opencode" / "opencode.json"
     opencode_config.parent.mkdir(parents=True)
-    opencode_config.write_text('{"model": "nvidia-inference/switchyard/openai/gpt-5.6-sol"}', encoding="utf-8")
+    opencode_config.write_text(
+        '{"model": "nvidia-inference/switchyard/openai/gpt-5.6-sol"}', encoding="utf-8"
+    )
     monkeypatch.setattr(te.Path, "home", staticmethod(lambda: fake_home))
     monkeypatch.setattr(te, "_resolve_openshell_policy", lambda: "/policy.yaml")
 


### PR DESCRIPTION
Housekeeping: `make lint` failed on main because 8 files (touched across PRs #741-746) had drifted from ruff's formatting. No behavior change.