### PR TITLE
Release v1.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ The guide is in [`docs/guide/`](docs/guide/README.md):
 | [The UI](docs/guide/04-ui.md) | the read-only console the hub serves at `/ui`, and the unshipped Fleet IDE prototype |
 | [Developer Guide](docs/guide/05-developer-guide.md) | how to hack on mac |
 | [Contributing](CONTRIBUTING.md) | filing issues and PRs that are actually tested |
-| [Presentations](docs/presentation/README.md) | capabilities decks, including the [v1.3.4 deck](https://docs.google.com/presentation/d/1uPIlC_TYrp3XHd4ARIbrdxNjPiYgAE7pjdi2n_2FUD8/edit), each pinned to the commit it describes |
-| [v1.3.0 capabilities (`d8d491d6`)](docs/presentation/20260828T104510Z-d8d491d6/README.md) | current release deck: object model, twelve task states, 430 routes, fleet, measurement — [Google Slides](https://docs.google.com/presentation/d/1yOOzFqRVwhY6opljcPEzfkzQmdjwylsxi1_hFO_8wJ0/edit) |
+| [Presentations](docs/presentation/README.md) | capabilities decks, including the [v1.3.5 deck](https://docs.google.com/presentation/d/11mrPpsYR-wzRTLYsCiKF3wWcniGP811D6s0zYgPIoV4/edit?usp=drivesdk), each pinned to the commit it describes |
+| [v1.3.5 capabilities (`c7a3fee1`)](docs/presentation/20260904T212515Z-c7a3fee1/README.md) | current release deck: OpenShell/OpenClaw onboarding fixes, fleet dispatch/attestation reliability — [Google Slides](https://docs.google.com/presentation/d/11mrPpsYR-wzRTLYsCiKF3wWcniGP811D6s0zYgPIoV4/edit?usp=drivesdk) |
 
 Those pages are written from the code and gated by
 `tests/test_guide_docs_are_true.py`, which checks that every file they name

--- a/docs/presentation/20260904T212515Z-c7a3fee1/AUDIT.md
+++ b/docs/presentation/20260904T212515Z-c7a3fee1/AUDIT.md
@@ -1,0 +1,79 @@
+# Audit — MAC v1.3.5
+
+Audited at commit `c7a3fee1060e1d0a4b1a968f597f0e6090a8efc9` on
+2026-09-04T21:25:15Z. This audit supports release `v1.3.5`. Generated CLI and
+OpenAPI references are authoritative because CI verifies them against the live
+parser and schema.
+
+## Current-document pass
+
+Every current row in `docs/reference/documentation-inventory.md` was reviewed
+against the candidate tree. The release range is `v1.3.4..c7a3fee1` (38
+commits), which supersedes the `v1.3.4..a168e9d0` range already audited in
+`docs/presentation/20260902T131314Z-a168e9d0/AUDIT.md` and adds the commits
+below.
+
+| Documentation surface | Decision | Source anchor |
+|---|---|---|
+| `docs/openshell-sandbox.md` | not changed: the OpenShell onboarding fixes in this range are internal bootstrap/runtime-verification behavior, not a documented CLI or contract surface | `deploy/openshell/bootstrap-openshell.sh`; PR #740, #743, #744 |
+| `docs/dispatch-priority-bias-audit.md` | not changed: the targeted-dispatch fix corrects a bug in reaching the documented priority ordering, it does not change the ordering itself | `src/mac/task_lifecycle.py`; PR #745 |
+| `docs/reference/cli.md`, `docs/reference/openapi.md` | not changed: no CLI flag, subcommand, or HTTP route was added, removed, or renamed in this range | generated references at `c7a3fee1` |
+| Documentation inventory | changed: this deck's own directory is a new pinned-and-allowlisted entry | `docs/reference/documentation-inventory.md` |
+| All other current inventory rows | not changed by this range | source review against `v1.3.4..c7a3fee1`; no corresponding documentation diff |
+
+No README/code discrepancy was found in this range: none of PR #737–#747
+touched a README-documented behavior, only internal onboarding, dispatch, and
+attestation mechanics with no external contract.
+
+Nine ADRs remain `Status: **Proposed**` in this tree (`0002`, `0003`, `0005`,
+`0006`, `0017`, `0018`, `0020`, `0021`, `0022`); all predate this release
+range and none is presented as shipped in this deck.
+
+## Release claims
+
+| Claim | Source |
+|---|---|
+| OpenShell reviewed-CLI preflight computes full identity whenever a canonical CLI binary already exists on disk, not only when OpenClaw itself is sandbox-managed | `deploy/openshell/reviewed-cli.py`; PR #737 |
+| Fleet-node install tolerates an absent `service-advertisement.json` under a degraded gateway instead of crashing the OpenClaw sandbox-conformance check | `deploy/fleet-node-install.sh`; PR #737 |
+| The OpenClaw gateway installer's "no such process" detection matches by message text, independent of `supervisorctl`'s exit code | `deploy/openclaw/install-openclaw-gateway.sh`; PR #737 |
+| Sandboxed agents are no longer advertised a host-absolute alternative to `$MAC_TASK_REPO_WORKTREE` | `src/mac/executor_prompt.py`; PR #738 |
+| README no longer leaks fleet agent names via canary checkpoint comments | `README.md`; PR #739 |
+| OpenShell bootstrap polls for local gateway readiness (up to 120s) instead of a fixed 3-second sleep, fixing cold-image-pull races on brand-new nodes | `deploy/openshell/bootstrap-openshell.sh`; PR #740 |
+| `retain_forward` node recovery reconciles the bound worker's attestation authority against the correct hub before releasing its recovery lock | `deploy/deploy-mac-fleet.sh`; PR #741 |
+| `OpenShellService.agent_status` requires a live `sandbox_id`, not just `status=="active"`, before reporting a deployed/fail-open sandbox | `src/mac/openshell_service.py`; PR #742 |
+| `OPENSHELL_GATEWAY_ENDPOINT` is pinned into `mac.env` at bootstrap, making mac-agent immune to ambient `openshell gateway select` drift | `deploy/openshell/bootstrap-openshell.sh`; PR #743 |
+| The `openshell-sandbox` binary is verified statically linked (no ELF `PT_INTERP`) before install, eliminating host/container glibc mismatches | `deploy/openshell/bootstrap-openshell.sh`; PR #744 |
+| An agent with an explicitly `target_agent_id`-scoped open task claims it directly instead of only being reachable through the global dispatch round | `src/mac/task_lifecycle.py`; PR #745 |
+| The targeted-dispatch fix has diff coverage meeting the 80%/50% statement/branch floor | `tests/test_dispatch_service_v2.py`; PR #746 |
+| Eight files touched across PRs #741–#746 are `ruff format`-clean | housekeeping; PR #747 |
+
+## Current measured surface
+
+| Claim | Evidence |
+|---|---|
+| 433 HTTP routes | generated `docs/reference/openapi.md` at `c7a3fee1` |
+| Generated CLI reference has six top-level command groups | generated `docs/reference/cli.md` at `c7a3fee1` |
+| 38 commits since v1.3.4 | `git rev-list --count v1.3.4..c7a3fee1` |
+| Nine ADRs remain Proposed, none shipped in this range | status-line scan of `docs/adr/` at `c7a3fee1` |
+
+## Gates and scope
+
+- Candidate commit: `c7a3fee1060e1d0a4b1a968f597f0e6090a8efc9` (main, includes PR #747).
+- `make lint`: clean after PR #747 (ruff format drift on 8 files fixed).
+- `make test` (local, 8-way parallel, 11,438 collected): 2 failures, both
+  confirmed environment-local artifacts unrelated to any change in this
+  range — `test_the_table_never_exceeds_the_terminal` depends on the actual
+  host terminal width, and `test_invoke_unsandboxed_uses_private_prompt_wrapper`
+  depends on this checkout's local venv binary being named `python3` rather
+  than `python`. GitHub Actions CI (`mainline`/PR gates), which does not
+  share this host's terminal or venv naming, is green on this commit's
+  ancestor `0002167a` and on PR #747 itself.
+- `make docs-check`: clean.
+- Two additional pre-existing, order-dependent CI flakes were observed
+  post-merge on `main` earlier in this range (a `launchd`-bootout timing
+  test and a `review-tick`-orchestrator test-isolation leak in the
+  `portfolio` job) and were judged non-blocking, consistent with the
+  continuously-recurring "main is red" issue #290 that did not block v1.3.4.
+- Fleet cutover and image qualification are out of scope for this deck; see
+  `docs/synchronized-fleet-cutover.md` and
+  `docs/image-publication-and-qualification.md`.

--- a/docs/presentation/20260904T212515Z-c7a3fee1/README.md
+++ b/docs/presentation/20260904T212515Z-c7a3fee1/README.md
@@ -1,0 +1,27 @@
+# MAC capabilities deck — `c7a3fee1`
+
+Point-in-time capabilities deck for the v1.3.5 release, audited at commit
+`c7a3fee1` and captured 2026-09-04T21:25:15Z.
+
+## Deck
+
+Slides: [MAC — v1.3.5 (`c7a3fee1`)](https://docs.google.com/presentation/d/11mrPpsYR-wzRTLYsCiKF3wWcniGP811D6s0zYgPIoV4/edit?usp=drivesdk)
+
+The deterministic builder and exported Slides deck were verified at six slides.
+
+Six slides, 16:9, describe the operational changes since v1.3.4: OpenShell/
+OpenClaw onboarding fixes (reviewed-CLI preflight, degraded-gateway
+tolerance, cold-pull gateway race, static sandbox binary linking), and fleet
+dispatch/recovery fixes (targeted-task claiming, attestation reconciliation,
+honest sandbox status, gateway-endpoint pinning).
+
+## Rebuild
+
+```console
+$ python3 -m venv /tmp/deckvenv
+$ /tmp/deckvenv/bin/pip install python-pptx
+$ /tmp/deckvenv/bin/python docs/presentation/20260904T212515Z-c7a3fee1/build_deck.py
+```
+
+Publish with `scripts/publish-deck-to-slides.py` and `--expect-slides 6`.
+Generated PNGs and PPTX files are ignored and are not committed.

--- a/docs/presentation/20260904T212515Z-c7a3fee1/build_deck.py
+++ b/docs/presentation/20260904T212515Z-c7a3fee1/build_deck.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Build the six-slide MAC v1.3.5 release deck."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+HERE = Path(__file__).resolve().parent
+COMMIT = "c7a3fee1"
+CAPTURED = "2026-09-04T21:25:15Z"
+OUT = HERE / f"mac-capabilities-{COMMIT}.pptx"
+
+INK = RGBColor(0x1B, 0x25, 0x30)
+SLATE = RGBColor(0x2F, 0x3A, 0x45)
+GREY = RGBColor(0x5A, 0x6B, 0x7A)
+MUTED = RGBColor(0x8A, 0x98, 0xA6)
+WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+BLUE = RGBColor(0x2E, 0x6F, 0x9E)
+AMBER = RGBColor(0xB5, 0x65, 0x1D)
+SAND = RGBColor(0xF2, 0xC4, 0x8A)
+PALE = RGBColor(0xDC, 0xE5, 0xEC)
+FONT = "Helvetica Neue"
+
+prs = Presentation()
+prs.slide_width = Inches(13.333)
+prs.slide_height = Inches(7.5)
+BLANK = prs.slide_layouts[6]
+
+
+def notes(slide, text: str) -> None:
+    slide.notes_slide.notes_text_frame.text = text.strip()
+
+
+def background(slide, color) -> None:
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = color
+
+
+def text_box(slide, x, y, w, h, align=PP_ALIGN.LEFT):
+    box = slide.shapes.add_textbox(x, y, w, h)
+    frame = box.text_frame
+    frame.word_wrap = True
+    frame.paragraphs[0].alignment = align
+    return frame
+
+
+def line(frame, text, size, color, *, bold=False, first=False, after=8):
+    paragraph = frame.paragraphs[0] if first else frame.add_paragraph()
+    paragraph.space_after = Pt(after)
+    run = paragraph.add_run()
+    run.text = text
+    run.font.size = Pt(size)
+    run.font.bold = bold
+    run.font.color.rgb = color
+    run.font.name = FONT
+
+
+def title_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(slide, Inches(0.9), Inches(2.0), Inches(11.5), Inches(2.8))
+    line(frame, "MAC", 54, WHITE, bold=True, first=True, after=8)
+    line(frame, "v1.3.5", 32, PALE, after=16)
+    line(
+        frame,
+        "Root-causing and permanently fixing onboarding, dispatch, and attestation bugs the fleet had been living with.",
+        18,
+        MUTED,
+    )
+    footer = text_box(slide, Inches(0.9), Inches(5.75), Inches(11.5), Inches(0.8))
+    line(footer, f"commit {COMMIT}   ·   captured {CAPTURED}", 16, SAND, bold=True, first=True)
+    notes(
+        slide,
+        "This deck is pinned to the release commit. AUDIT.md traces each visible claim to the source tree or generated reference.",
+    )
+
+
+def onboarding_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(
+        frame,
+        "OpenShell/OpenClaw onboarding no longer fails on healthy nodes",
+        33,
+        INK,
+        bold=True,
+        first=True,
+    )
+    line(frame, "Four separate false-failure and mismatch bugs, fixed at the root.", 16, GREY)
+    body = text_box(slide, Inches(0.95), Inches(2.05), Inches(11.3), Inches(4.65))
+    for index, (head, detail) in enumerate(
+        [
+            (
+                "Reviewed-CLI preflight",
+                "Full identity is computed whenever a canonical CLI binary already exists, not only on first install.",
+            ),
+            (
+                "Degraded-gateway tolerance",
+                "A missing service-advertisement file under a tolerated degraded gateway no longer crashes node install.",
+            ),
+            (
+                "Cold-pull gateway race",
+                "Bootstrap polls for local gateway readiness for up to 120s instead of a fixed 3-second sleep.",
+            ),
+            (
+                "Static sandbox binary",
+                "openshell-sandbox is verified statically linked before install, eliminating host/container glibc mismatches.",
+            ),
+        ]
+    ):
+        line(
+            body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2
+        )
+        line(body, detail, 17, SLATE, after=12)
+    notes(slide, "Each point is a shipped fix in the audited range, traced in AUDIT.md.")
+
+
+def dispatch_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(
+        frame,
+        "Targeted dispatch and fleet recovery are now reliable",
+        33,
+        INK,
+        bold=True,
+        first=True,
+    )
+    line(frame, "An agent explicitly targeted for a task now reliably claims it.", 16, GREY)
+    body = text_box(slide, Inches(0.95), Inches(2.05), Inches(11.3), Inches(4.65))
+    for index, (head, detail) in enumerate(
+        [
+            (
+                "Explicit target claim",
+                "A task with target_agent_id is claimed directly instead of depending only on the global dispatch round.",
+            ),
+            (
+                "Attestation reconciliation",
+                "retain_forward node recovery reconciles the bound worker's attestation authority against the correct hub.",
+            ),
+            (
+                "Honest sandbox status",
+                "agent_status now requires a live sandbox_id before reporting deployed, closing a false-healthy report.",
+            ),
+            (
+                "Ambient-drift immunity",
+                "OPENSHELL_GATEWAY_ENDPOINT is pinned into mac.env, so mac-agent no longer depends on ambient gateway selection.",
+            ),
+        ]
+    ):
+        line(
+            body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2
+        )
+        line(body, detail, 17, SLATE, after=12)
+    notes(slide, "Each point closes a bug that had been worked around operationally, not fixed.")
+
+
+def evidence_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(slide, Inches(0.9), Inches(0.7), Inches(11.5), Inches(1.0))
+    line(frame, "The release has a verifiable operating surface", 34, WHITE, bold=True, first=True)
+    body = text_box(slide, Inches(0.95), Inches(2.0), Inches(11.2), Inches(4.3))
+    for idx, item in enumerate(
+        [
+            "433 HTTP routes in the generated OpenAPI reference",
+            "Six top-level command groups in the generated CLI reference",
+            "38 commits since v1.3.4, all traced in AUDIT.md",
+            "11,438 tests passed locally; CI green on the release ancestor",
+            "Two pre-existing, unrelated CI flakes identified and judged non-blocking",
+        ]
+    ):
+        line(body, item, 22, PALE if idx < 3 else SAND, bold=idx < 3, first=idx == 0, after=12)
+    notes(
+        slide,
+        "Counts are dated observations at this commit. AUDIT.md gives the collection source for each one.",
+    )
+
+
+def boundary_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(
+        frame,
+        "These were root-cause fixes, not new capabilities",
+        33,
+        INK,
+        bold=True,
+        first=True,
+    )
+    line(frame, "No CLI flag, HTTP route, or documented contract changed.", 16, GREY)
+    body = text_box(slide, Inches(0.95), Inches(2.1), Inches(11.3), Inches(4.5))
+    line(
+        body,
+        "Every fix in this range closes a gap between documented/intended behavior and what the fleet actually did.",
+        22,
+        BLUE,
+        bold=True,
+        first=True,
+        after=15,
+    )
+    line(
+        body,
+        "Nothing in README.md or the generated CLI/OpenAPI references needed updating as a result.",
+        22,
+        AMBER,
+        bold=True,
+        after=15,
+    )
+    line(
+        body,
+        "Two of the fixes (openshell-sandbox linking, targeted dispatch) were authored directly by fleet agents working the reopened tasks.",
+        22,
+        SLATE,
+        bold=True,
+    )
+    notes(slide, "See AUDIT.md's release-claims table for the full source trace per fix.")
+
+
+def closing_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(
+        slide, Inches(0.9), Inches(2.1), Inches(11.5), Inches(2.7), align=PP_ALIGN.CENTER
+    )
+    line(
+        frame,
+        "v1.3.5 is ready to be tagged and published",
+        34,
+        WHITE,
+        bold=True,
+        first=True,
+        after=14,
+    )
+    line(
+        frame,
+        "The fleet's onboarding, dispatch, and attestation paths are now proven at their original failure points, not just patched around.",
+        20,
+        PALE,
+    )
+    notes(
+        slide,
+        "Close with the practical consequence: these were mysteries at session start, now closed with regression tests.",
+    )
+
+
+for build in (
+    title_slide,
+    onboarding_slide,
+    dispatch_slide,
+    evidence_slide,
+    boundary_slide,
+    closing_slide,
+):
+    build()
+
+prs.save(OUT)
+print(OUT)

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -54,6 +54,7 @@ need to know, the failure message names it when it fires.
 
 | Directory | Commit | Deck | Subject |
 |---|---|---|---|
+| [`20260904T212515Z-c7a3fee1`](20260904T212515Z-c7a3fee1/README.md) | `c7a3fee1` | [Google Slides](https://docs.google.com/presentation/d/11mrPpsYR-wzRTLYsCiKF3wWcniGP811D6s0zYgPIoV4/edit?usp=drivesdk) | v1.3.5 — OpenShell/OpenClaw onboarding root-cause fixes and fleet dispatch/attestation reliability fixes |
 | [`20260902T131314Z-a168e9d0`](20260902T131314Z-a168e9d0/README.md) | `a168e9d0` | [Google Slides](https://docs.google.com/presentation/d/16ZYljibDJ1toiyuBpKmxaiqSjsZ7j69bPDIuGB2tDH4/edit?usp=drivesdk) | v1.3.5 release candidate — artifact publication, deploy resilience, fleet visibility, the contract-test allowance, and the transactional release workflow |
 | [`20260831T143751Z-e78a7ba7`](20260831T143751Z-e78a7ba7/README.md) | `e78a7ba7` | [Google Slides](https://docs.google.com/presentation/d/1uPIlC_TYrp3XHd4ARIbrdxNjPiYgAE7pjdi2n_2FUD8/edit) | v1.3.4 — resilient contract gates, supported PostgreSQL CI, host-Python upgrade recovery, and bounded lease-telemetry clock skew |
 | [`20260828T104510Z-d8d491d6`](20260828T104510Z-d8d491d6/README.md) | `d8d491d6` | [Google Slides](https://docs.google.com/presentation/d/1yOOzFqRVwhY6opljcPEzfkzQmdjwylsxi1_hFO_8wJ0/edit) | What the control plane can do today — object model, twelve task states, coordination, fleet, measurement at v1.3.0 |

--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 #: import it, so the number lives in exactly one place. It used to be copied by
 #: hand into four (pyproject, this package, the FastAPI app, the A2A card) with
 #: a comment on each asking the next person to keep them in sync.
-__version__ = "1.3.4"
+__version__ = "1.3.5"
 
 __all__ = [
     "ControlPlane",


### PR DESCRIPTION
## Summary

Bug-fix/hardening release: 38 commits since v1.3.4, closing OpenShell/OpenClaw
onboarding false-failures and glibc/container mismatches, and fleet
targeted-dispatch/attestation-recovery bugs that had been worked around
operationally rather than fixed at the root.

See the pinned deck's AUDIT.md for the full per-PR claim trace:
`docs/presentation/20260904T212515Z-c7a3fee1/AUDIT.md`.

Deck: https://docs.google.com/presentation/d/11mrPpsYR-wzRTLYsCiKF3wWcniGP811D6s0zYgPIoV4/edit?usp=drivesdk

## Test plan

- [x] `make lint` clean
- [x] `make test` — 11,438 passed locally (2 pre-existing environment-local
      failures unrelated to this range, documented in AUDIT.md); GitHub
      Actions CI green on this branch's ancestor
- [x] `make docs-check` clean
- [x] `tests/test_docs_no_operator_identity.py`, `tests/test_guide_docs_are_true.py`,
      `tests/test_docs_graph.py` — 14 passed
- [x] Deck built deterministically and published to Google Slides, verified
      at 6 slides