### PR TITLE
Stagger OpenClaw cron jobs that share an identical schedule

### DIFF
--- a/deploy/openclaw/install-openclaw-gateway.sh
+++ b/deploy/openclaw/install-openclaw-gateway.sh
@@ -1747,6 +1747,31 @@ for index, job in enumerate(jobs):
         break
 else:
     jobs.append(managed)
+# task_2e7e9e31: jobs sharing an identical cron expression fire the local
+# openclaw CLI at the same instant, and concurrent invocations race to open
+# the same host-persisted plugin-state SQLite database -- observed as
+# intermittent "database disk image is malformed" corruption on rocky
+# (dream-cycle and dream-synthesis were both migrated from Hermes with the
+# unstaggered "0 * * * *" expression). Stagger same-schedule jobs a few
+# minutes apart so they never fire simultaneously; only simple fixed-minute
+# schedules are adjusted, and the first job in each group keeps its original
+# minute so existing external expectations (e.g. dashboards) are undisturbed.
+by_cron = {}
+for index, job in enumerate(jobs):
+    cron = str(job.get("cron") or "").strip()
+    if cron:
+        by_cron.setdefault(cron, []).append(index)
+for cron, indices in by_cron.items():
+    if len(indices) < 2:
+        continue
+    fields = cron.split()
+    if len(fields) != 5 or not fields[0].isdigit():
+        continue
+    base_minute = int(fields[0])
+    for offset, index in enumerate(indices[1:], start=1):
+        staggered = list(fields)
+        staggered[0] = str((base_minute + offset * 5) % 60)
+        jobs[index]["cron"] = " ".join(staggered)
 with open(path, "w", encoding="utf-8") as handle:
     json.dump(plan, handle, indent=2, sort_keys=True)
     handle.write("\n")

--- a/tests/test_openclaw_gateway_deploy.py
+++ b/tests/test_openclaw_gateway_deploy.py
@@ -690,6 +690,54 @@ def test_installer_preserves_public_identity_and_migrated_script_jobs() -> None:
     assert 'not str(job.get("legacy_script") or "").strip()' in installer
 
 
+def _extract_finalize_cron_plan_script() -> str:
+    """Pull the embedded python heredoc that finalizes MANAGED_DIR/cron-plan.json
+    (curiosity-job upsert + same-schedule staggering) out of the installer so it
+    can be executed directly against synthetic job data."""
+    installer = INSTALLER.read_text(encoding="utf-8")
+    marker = 'python3 - "$MANAGED_DIR/cron-plan.json" <<\'PY\'\n'
+    start = installer.index(marker) + len(marker)
+    end = installer.index("\nPY", start)
+    return installer[start:end]
+
+
+def test_finalize_cron_plan_staggers_jobs_sharing_an_identical_schedule(tmp_path: Path) -> None:
+    """task_2e7e9e31: dream-cycle and dream-synthesis were both migrated from
+    Hermes with the identical unstaggered cron expression "0 * * * *", so both
+    fire the local openclaw CLI at the same instant every hour. Concurrent
+    invocations race to open the same host-persisted plugin-state SQLite
+    database, observed on rocky as intermittent "database disk image is
+    malformed" corruption. Jobs sharing a schedule must be staggered a few
+    minutes apart when the plan is finalized."""
+    script = _extract_finalize_cron_plan_script()
+    assert "by_cron" in script, "finalize step must group jobs by cron expression"
+
+    plan_path = tmp_path / "cron-plan.json"
+    plan_path.write_text(
+        json.dumps(
+            {
+                "schema": "mac.openclaw_cron_migration.v1",
+                "jobs": [
+                    {"legacy_id": "adf20933eff0", "name": "dream-cycle", "cron": "0 * * * *"},
+                    {"legacy_id": "2d437df2441e", "name": "dream-synthesis", "cron": "0 * * * *"},
+                    {"legacy_id": "61c34b2f9752", "name": "kslug-nightly-news", "cron": "0 6 * * *"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(["python3", "-c", script, str(plan_path)], check=True, capture_output=True, text=True)
+
+    plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    by_name = {job["name"]: job["cron"] for job in plan["jobs"]}
+    # First job in the colliding group keeps its original minute...
+    assert by_name["dream-cycle"] == "0 * * * *"
+    # ...the second is staggered away from it, so they no longer fire together.
+    assert by_name["dream-synthesis"] == "5 * * * *"
+    # A schedule with no collision is left untouched.
+    assert by_name["kslug-nightly-news"] == "0 6 * * *"
+
+
 def test_apply_cron_plan_receipt_counts_only_successful_cli_mutations(tmp_path: Path) -> None:
     result, evidence = _run_apply_cron_plan(tmp_path, "success")
 


### PR DESCRIPTION
## Summary
- Root-causes "why is rocky not running his cron jobs" (task_2e7e9e31fda34902a288324792b4baeb): it's not DNS. `dream-cycle` and `dream-synthesis` were both migrated from Hermes with the identical unstaggered cron expression `0 * * * *`, so both fire the local `openclaw` CLI at the same instant every hour, racing to open the same host-persisted plugin-state SQLite database — observed as intermittent `database disk image is malformed` corruption that silently failed delivery until a later scheduled retry succeeded.
- The cron-plan finalize step in `install-openclaw-gateway.sh` (already re-run on every install/deploy) now groups jobs by cron expression and staggers same-schedule jobs a few minutes apart, leaving the first job in each group on its original minute.

## Test plan
- [x] New regression test `test_finalize_cron_plan_staggers_jobs_sharing_an_identical_schedule` extracts and executes the finalize snippet against synthetic dream-cycle/dream-synthesis/kslug-nightly-news data, asserting the collision is staggered and the non-colliding schedule is untouched.
- [x] `tests/test_openclaw_gateway_deploy.py` full file: 106 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
