### PR TITLE
Deliver the full cron-job body through --message, not --presentation

### DIFF
--- a/deploy/openclaw/run-script-cron-job.py
+++ b/deploy/openclaw/run-script-cron-job.py
@@ -587,7 +587,15 @@ def message_args(
 ) -> list:
     """Build the ``openclaw-message`` argv (kept pure so it is testable).
 
-    The body travels as JSON in ``--presentation``, never as ``--message``.
+    The full body travels in ``--message``, escaped, never in
+    ``--presentation``. A prior version of this function put the body only in
+    ``--presentation``'s JSON ``text`` field on the assumption that field was
+    the Slack message content. It is not: openclaw's ``send`` action builds
+    the delivered payload as ``{text: message, ...presentation}`` -- the
+    ``--message`` value becomes the Slack text, and ``presentation`` is
+    additive structure (blocks/context/dividers/buttons), not a text
+    replacement. Every job delivered this way posted only its short header
+    with the real content silently dropped.
 
     ``openclaw-message`` is a five-line wrapper that execs
     ``openshell sandbox exec ... -- openclaw message "$@"``, and OpenShell's exec
@@ -601,9 +609,11 @@ def message_args(
     job output is prose and is therefore always multi-line: on the hub, three
     jobs ran hourly and failed 220 times each on exactly this.
 
-    ``json.dumps`` escapes the newlines, so the token crossing the boundary has
-    none while the body survives intact. ``--message`` keeps a single-line
-    summary because the CLI requires it.
+    openclaw's own send path unescapes a literal ``\\n`` two-character
+    sequence back into a real newline before building the payload text
+    (``message.replaceAll("\\n", "\n")``), so encoding real newlines that way
+    survives the sandbox boundary (no literal newline byte in argv) while
+    still rendering as a multi-line Slack message.
     """
     return [
         message_bin,
@@ -615,26 +625,23 @@ def message_args(
         "--target",
         "channel:%s" % channel_id,
         "--message",
-        summary_line(text),
-        "--presentation",
-        json.dumps({"text": text}),
+        encode_message_body(text),
     ]
 
 
-def summary_line(text: str, *, limit: int = 200) -> str:
-    """A single-line stand-in for a multi-line body.
+def encode_message_body(text: str) -> str:
+    """Escape real newlines as literal ``\\n`` so a multi-line body survives
+    OpenShell's argv boundary and openclaw's own unescape step restores it.
+
+    Both CRLF and bare CR are normalized to LF first: OpenShell's argv
+    boundary refuses a literal carriage return exactly as it refuses a
+    literal newline, and openclaw's unescape step only restores ``\\n``.
 
     Never empty: the CLI rejects a missing message, and a job whose output was
     whitespace would otherwise fail for a second, unrelated reason.
     """
-    first = ""
-    for line in str(text or "").splitlines():
-        if line.strip():
-            first = line.strip()
-            break
-    if not first:
-        return "(no summary)"
-    return first[:limit]
+    normalized = str(text or "").replace("\r\n", "\n").replace("\r", "\n").strip()
+    return normalized.replace("\n", "\\n") or "(no content)"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_dream_cycle_runner.py
+++ b/tests/test_dream_cycle_runner.py
@@ -247,21 +247,32 @@ def test_no_argument_ever_carries_a_newline_across_the_sandbox_boundary() -> Non
 
 
 def test_the_multi_line_body_survives_the_escaping() -> None:
-    """Escaping that loses the body would trade a loud failure for a quiet one."""
-    import json as _json
+    """Escaping that loses the body would trade a loud failure for a quiet one.
 
+    The body travels in ``--message`` itself, encoded, and openclaw's own
+    ``send`` action unescapes it back into the delivered Slack text -- the
+    prior design put the body only in ``--presentation``, which openclaw
+    treats as additive structure, not the message text, so every job
+    delivered that way posted an empty-looking broadcast (header only).
+    """
     body = "first line\nsecond line\nthird line"
     args = runner.message_args("/bin/openclaw-message", "slack", "C0123ABC", body, account="a")
-    presentation = args[args.index("--presentation") + 1]
+    message = args[args.index("--message") + 1]
 
-    assert _json.loads(presentation)["text"] == body
+    assert message == "first line\\nsecond line\\nthird line"
+    assert "--presentation" not in args
 
 
-def test_the_summary_line_is_never_empty() -> None:
+def test_encode_message_body_is_never_empty() -> None:
     """The CLI rejects a missing message, so whitespace-only output must not
     fail for a second, unrelated reason."""
-    assert runner.summary_line("   \n\n  ") == "(no summary)"
-    assert runner.summary_line("\n\nreal first line\nsecond") == "real first line"
+    assert runner.encode_message_body("   \n\n  ") == "(no content)"
+    assert runner.encode_message_body("first line\nsecond line") == "first line\\nsecond line"
+
+
+def test_encode_message_body_normalizes_bare_and_windows_line_endings() -> None:
+    """A bare CR trips OpenShell's argv boundary exactly like a bare LF does."""
+    assert runner.encode_message_body("a\r\nb\rc") == "a\\nb\\nc"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- Rocky's Slack-delivered cron jobs (kslug-nightly-news, dream-cycle, dream-synthesis) posted only their short header line, with the real broadcast body silently dropped.
- Root cause: openclaw's `send` action builds the delivered payload as `{text: message, ...presentation}` — `--message` becomes the Slack text, and `--presentation` is additive structure (blocks/context/dividers/buttons), not a text replacement. `message_args()` put the full body only in `--presentation`'s JSON `text` field on the (incorrect) assumption that field carried the message content.
- Fix: encode the full body into `--message` itself, escaping real newlines as literal `\n` two-character sequences. openclaw's own send path unescapes that sequence back into a real newline before building the payload text, so the body survives OpenShell's argv-newline boundary (which rejects any argv token containing a literal newline/carriage-return byte) while still rendering as a multi-line Slack message.
- Verified directly against rocky's live gateway: sent a real (non-dry-run) multi-line message via `openclaw message send`, then read it back via `openclaw message read` and confirmed the full multi-line text was delivered, not just the header.

## Test plan
- [x] `tests/test_dream_cycle_runner.py` (35/35 passing) — updated `message_args`/escaping tests for the new design, added `encode_message_body` coverage including CRLF/bare-CR normalization
- [x] `tests/test_openclaw_gateway_deploy.py tests/test_script_job_home.py` (144/144 passing)
- [x] `ruff check` clean
- [x] Live verification on rocky: real Slack send + read-back confirms full multi-line content renders (message id `1788592827.290649`, channel `C0AH1QJCT7F`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)