### PR TITLE
Restore repo-owned Hermes gateway lifecycle automation

### DIFF
--- a/deploy/hermes/install-hermes-gateway.sh
+++ b/deploy/hermes/install-hermes-gateway.sh
@@ -17,7 +17,7 @@ HERMES_INSTALL_URL="${MAC_HERMES_INSTALL_URL:-https://hermes-agent.nousresearch.
 FLEET_NAME="${MAC_HERMES_FLEET_NAME:-${MAC_FLEET_NAME:-mac}}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # Migration source: the chat gateway Hermes is taking channel ownership from.
-# "openclaw" is the only interface `mac human-interface port` and
+# "openclaw" is the only interface `mac admin human-interface port` and
 # `hermes claw migrate` currently know how to read from.
 FROM_INTERFACE="${MAC_HERMES_FROM_INTERFACE:-openclaw}"
 OPENCLAW_HOME="${MAC_HERMES_OPENCLAW_SOURCE:-$HOME/.openclaw}"
@@ -56,8 +56,8 @@ install_hermes() {
 port_credentials() {
   command -v mac >/dev/null 2>&1 || { log "no 'mac' CLI on PATH; skipping credential port"; return 0; }
   log "porting identity/memory/messaging credentials from $FROM_INTERFACE to hermes"
-  [ "$DRY_RUN" = 1 ] && { mac human-interface port --from "$FROM_INTERFACE" --to hermes || true; return 0; }
-  mac human-interface port --from "$FROM_INTERFACE" --to hermes --apply \
+  [ "$DRY_RUN" = 1 ] && { mac admin human-interface port --from "$FROM_INTERFACE" --to hermes || true; return 0; }
+  mac admin human-interface port --from "$FROM_INTERFACE" --to hermes --apply \
     || log "WARNING: credential port reported a problem; continuing (Hermes may already have credentials)"
 }
 

--- a/deploy/hermes/install-hermes-gateway.sh
+++ b/deploy/hermes/install-hermes-gateway.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Prepare, verify, or withdraw MAC's Hermes chat gateway.
+#
+# Hermes is not vendored in this repo (see docs/hermes-vendor-fate.md for why
+# that was tried once and abandoned) and does not support a normal `pip
+# install` -- its own setup.py refuses to build a wheel or sdist ("Hermes is
+# distributed via the shell installer, Docker image, or Nix"). This script
+# drives upstream's own shell installer and its own CLI (`hermes config set`,
+# `hermes gateway install`, `hermes claw migrate`) rather than reimplementing
+# any of that logic in-tree. It is the host-level sibling of
+# deploy/openclaw/install-openclaw-gateway.sh -- same prepare/verify/finalize/
+# withdraw shape, same MAC_HOME conventions -- but Hermes runs as a bare host
+# process (no OpenShell sandbox), so there is no container lifecycle here.
+set -euo pipefail
+
+HERMES_INSTALL_URL="${MAC_HERMES_INSTALL_URL:-https://hermes-agent.nousresearch.com/install.sh}"
+FLEET_NAME="${MAC_HERMES_FLEET_NAME:-${MAC_FLEET_NAME:-mac}}"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+# Migration source: the chat gateway Hermes is taking channel ownership from.
+# "openclaw" is the only interface `mac human-interface port` and
+# `hermes claw migrate` currently know how to read from.
+FROM_INTERFACE="${MAC_HERMES_FROM_INTERFACE:-openclaw}"
+OPENCLAW_HOME="${MAC_HERMES_OPENCLAW_SOURCE:-$HOME/.openclaw}"
+DRY_RUN="${MAC_HERMES_DRY_RUN:-0}"
+
+# Fleet-config-supplied gateway policy (docs/fleet-registry-schema.md's
+# `hermes:` block: slack_home_channel_name, gateway_model, gateway_provider,
+# gateway_base_url). Any of these may be empty -- an empty value means "leave
+# whatever Hermes already has configured alone".
+SLACK_HOME_CHANNEL_NAME="${MAC_HERMES_SLACK_HOME_CHANNEL_NAME:-}"
+GATEWAY_MODEL="${MAC_HERMES_GATEWAY_MODEL:-}"
+GATEWAY_PROVIDER="${MAC_HERMES_GATEWAY_PROVIDER:-}"
+GATEWAY_BASE_URL="${MAC_HERMES_GATEWAY_BASE_URL:-}"
+
+log() { printf '[install-hermes-gateway] %s\n' "$*"; }
+die() { log "ERROR: $*" >&2; exit 1; }
+
+hermes_bin() {
+  command -v hermes 2>/dev/null && return 0
+  [ -x "$HOME/.local/bin/hermes" ] && { printf '%s\n' "$HOME/.local/bin/hermes"; return 0; }
+  return 1
+}
+
+install_hermes() {
+  if hermes_bin >/dev/null 2>&1; then
+    log "hermes CLI already installed ($(hermes_bin))"
+    return 0
+  fi
+  log "installing Hermes via upstream's shell installer ($HERMES_INSTALL_URL)"
+  [ "$DRY_RUN" = 1 ] && { log "dry-run: skipping installer"; return 0; }
+  curl -fsSL "$HERMES_INSTALL_URL" | bash \
+    || die "Hermes shell installer failed"
+  hermes_bin >/dev/null 2>&1 || die "hermes CLI not found on PATH or in ~/.local/bin after install"
+}
+
+port_credentials() {
+  command -v mac >/dev/null 2>&1 || { log "no 'mac' CLI on PATH; skipping credential port"; return 0; }
+  log "porting identity/memory/messaging credentials from $FROM_INTERFACE to hermes"
+  [ "$DRY_RUN" = 1 ] && { mac human-interface port --from "$FROM_INTERFACE" --to hermes || true; return 0; }
+  mac human-interface port --from "$FROM_INTERFACE" --to hermes --apply \
+    || log "WARNING: credential port reported a problem; continuing (Hermes may already have credentials)"
+}
+
+migrate_claw_state() {
+  [ -d "$OPENCLAW_HOME" ] || { log "no OpenClaw home at $OPENCLAW_HOME; skipping claw migrate"; return 0; }
+  local hermes
+  hermes="$(hermes_bin)" || die "hermes CLI not found"
+  log "migrating OpenClaw identity/memory/skills into Hermes ($OPENCLAW_HOME -> $HERMES_HOME)"
+  [ "$DRY_RUN" = 1 ] && { "$hermes" claw migrate --source "$OPENCLAW_HOME" --dry-run || true; return 0; }
+  "$hermes" claw migrate --source "$OPENCLAW_HOME" --preset full --overwrite --yes \
+    || log "WARNING: claw migrate reported a problem; continuing with whatever Hermes already has"
+}
+
+# Resolve a Slack channel *name* (e.g. "rockyandfriends") to the channel ID
+# Hermes's own config wants for slack.free_response_channels. Hermes caches a
+# channel directory once the gateway has connected at least once; before that
+# there is nothing to resolve against, and this deliberately does not fail --
+# a later run (after the gateway has connected) will pick it up.
+resolve_home_channel_id() {
+  local name="$1" hermes
+  hermes="$(hermes_bin)" || return 1
+  local directory
+  directory="$(find "$HERMES_HOME" -iname '*channel_directory*.json' 2>/dev/null | head -1)"
+  [ -n "$directory" ] || return 1
+  python3 - "$directory" "$name" <<'PY'
+import json
+import sys
+
+path, wanted = sys.argv[1], sys.argv[2].lstrip("#").lower()
+try:
+    data = json.load(open(path, encoding="utf-8"))
+except (OSError, ValueError):
+    raise SystemExit(1)
+channels = data if isinstance(data, list) else data.get("channels", [])
+for entry in channels:
+    if not isinstance(entry, dict):
+        continue
+    name = str(entry.get("name") or "").lstrip("#").lower()
+    if name == wanted:
+        channel_id = entry.get("id") or entry.get("channel_id")
+        if channel_id:
+            print(channel_id)
+            raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+configure_gateway() {
+  local hermes
+  hermes="$(hermes_bin)" || die "hermes CLI not found"
+  [ "$DRY_RUN" = 1 ] && { log "dry-run: skipping hermes config set calls"; return 0; }
+
+  [ -z "$GATEWAY_MODEL" ]    || "$hermes" config set model "$GATEWAY_MODEL" --force
+  [ -z "$GATEWAY_PROVIDER" ] || "$hermes" config set provider "$GATEWAY_PROVIDER" --force
+  [ -z "$GATEWAY_BASE_URL" ] || "$hermes" config set base_url "$GATEWAY_BASE_URL" --force
+
+  # Home channel: listen to and respond to everything, unprompted. Every
+  # other channel the agent is invited into stays mention-only -- that is
+  # slack.require_mention's default (true) and is left untouched here.
+  "$hermes" config set slack.require_mention true --force
+  if [ -n "$SLACK_HOME_CHANNEL_NAME" ]; then
+    local channel_id
+    if channel_id="$(resolve_home_channel_id "$SLACK_HOME_CHANNEL_NAME")"; then
+      log "setting free_response_channels for home channel $SLACK_HOME_CHANNEL_NAME ($channel_id)"
+      "$hermes" config set slack.free_response_channels "$channel_id" --force
+    else
+      log "WARNING: could not resolve #$SLACK_HOME_CHANNEL_NAME to a channel id yet" \
+          "(gateway may not have connected to Slack before); re-run prepare after it has"
+    fi
+  fi
+}
+
+install_service() {
+  local hermes
+  hermes="$(hermes_bin)" || die "hermes CLI not found"
+  [ "$DRY_RUN" = 1 ] && { log "dry-run: skipping hermes gateway install"; return 0; }
+  log "installing Hermes gateway as a supervised background service"
+  # No --system: both systemd and launchd targets here are user-level
+  # services (linger is what keeps a systemd --user unit alive across
+  # logout on Linux nodes without root). --force makes this idempotent
+  # against a prior manual install.
+  "$hermes" gateway install --force --start-now --start-on-login \
+    || die "hermes gateway install failed"
+}
+
+verify_gateway() {
+  local hermes status
+  hermes="$(hermes_bin)" || die "hermes CLI not found"
+  status="$("$hermes" gateway status --deep 2>&1)" || die "hermes gateway status failed:
+$status"
+  printf '%s\n' "$status"
+  # Order matters: "not supervised"/"unsupervised" both contain the substring
+  # "supervised", so the negative checks must run first or a detached-process
+  # gateway would pass the naive positive match below.
+  case "$status" in
+    *[Nn]ot\ supervised*|*[Uu]nsupervised*|*detached\ process*)
+      die "Hermes gateway is not supervised (would not survive a crash/reboot):
+$status" ;;
+  esac
+  case "$status" in
+    *[Uu]nhealthy*|*[Nn]ot\ running*|*[Ss]topped*)
+      die "Hermes gateway is not healthy:
+$status" ;;
+  esac
+  case "$status" in
+    *[Ss]upervised*) ;;
+    *) die "Hermes gateway does not report itself as supervised:
+$status" ;;
+  esac
+}
+
+prepare() {
+  install_hermes
+  port_credentials
+  migrate_claw_state
+  configure_gateway
+  install_service
+}
+
+verify() { verify_gateway; }
+
+finalize() {
+  verify_gateway
+  log "Hermes gateway prepared and verified for fleet '$FLEET_NAME'"
+}
+
+withdraw() {
+  local hermes
+  hermes="$(hermes_bin)" || { log "hermes CLI not installed; nothing to withdraw"; return 0; }
+  log "stopping Hermes gateway (config and credentials are left in place)"
+  "$hermes" gateway stop || log "WARNING: hermes gateway stop reported a problem"
+}
+
+case "${1:-prepare}" in
+  prepare)  prepare ;;
+  verify)   verify ;;
+  finalize) finalize ;;
+  withdraw) withdraw ;;
+  *) die "usage: $0 [prepare|verify|finalize|withdraw]" ;;
+esac

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -472,7 +472,10 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HERMES_ALLOW_APPROVAL_PROMPTS` | bool | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes allow approval prompts. |
 | `MAC_HERMES_APPLY_GATEWAY_RUNTIME_SHIM` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes apply gateway runtime shim. |
 | `MAC_HERMES_APPLY_SLACK_ACCOUNT_SHIM` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes apply slack account shim. |
+| `MAC_HERMES_DRY_RUN` | bool | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes dry run. |
 | `MAC_HERMES_EXISTING_PORT` | int | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes existing port. |
+| `MAC_HERMES_FLEET_NAME` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes fleet name. |
+| `MAC_HERMES_FROM_INTERFACE` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes from interface. |
 | `MAC_HERMES_GATEWAY_API_KEY` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes gateway api key. |
 | `MAC_HERMES_GATEWAY_BASE_URL` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes gateway base url. |
 | `MAC_HERMES_GATEWAY_MODEL` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes gateway model. |
@@ -480,9 +483,11 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HERMES_GATEWAY_REQUEST_TIMEOUT_SECONDS` | int | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes gateway request timeout seconds. |
 | `MAC_HERMES_GATEWAY_STALE_TIMEOUT_SECONDS` | int | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes gateway stale timeout seconds. |
 | `MAC_HERMES_HOME` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes home. |
+| `MAC_HERMES_INSTALL_URL` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes install url. |
 | `MAC_HERMES_INSTANCE_ID` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes instance id. |
 | `MAC_HERMES_LOG_SUMMARY` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes log summary. |
 | `MAC_HERMES_MESSAGE_BIN` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes message bin. |
+| `MAC_HERMES_OPENCLAW_SOURCE` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes openclaw source. |
 | `MAC_HERMES_PERSONA_ID` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes persona id. |
 | `MAC_HERMES_PYTHON` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes python. |
 | `MAC_HERMES_RUNTIME_CONTEXT_FILE` | str | consumer-defined | hermes-runtime | Hermes Runtime setting: hermes runtime context file. |

--- a/docs/hermes-vendor-fate.md
+++ b/docs/hermes-vendor-fate.md
@@ -84,3 +84,40 @@ the hub's accumulated OpenClaw state into Hermes during the cutover).
 (`mac-cron-script-runner`) now drives its agent turn and delivery through
 this CLI instead of the OpenClaw sandbox wrappers; see that file's
 `_default_hermes_bin()` / `default_agent_runner()` / `message_args()`.
+
+## Update (2026-09-05): repo-owned lifecycle automation restored
+
+The cutover above was driven by hand over SSH, once per node -- real, but not
+durable: a fresh node bootstrap, a redeploy, or a wiped `~/.hermes` would not
+reproduce it, and every step would need to be re-derived from memory. That gap
+is now closed by `deploy/hermes/install-hermes-gateway.sh`, the host-level
+sibling of `deploy/openclaw/install-openclaw-gateway.sh` (same
+`prepare`/`verify`/`finalize`/`withdraw` shape; no container lifecycle, since
+Hermes runs as a bare host process rather than an OpenShell sandbox). It
+codifies the same steps done by hand: run upstream's shell installer if
+`hermes` isn't already on `PATH`, port identity/memory/messaging credentials
+from OpenClaw (`mac human-interface port --from openclaw --to hermes --apply`),
+pull any existing OpenClaw workspace across (`hermes claw migrate`), set the
+channel-behavior policy from fleet config (`slack.require_mention` /
+`slack.free_response_channels`, resolved from the `hermes.slack_home_channel_name`
+fleet-config field to a channel id via Hermes's own cached channel directory),
+and install the gateway as a properly supervised background service
+(`hermes gateway install`).
+
+This does not touch the deleted vendored-in-process model from the update
+above -- `install-hermes-gateway.sh` only shells out to the externally
+installed `hermes` CLI, the same as `run-script-cron-job.py` already does.
+
+**Known gap, not yet closed**: `deploy/fleet-node-install.sh`'s
+`MAC_CHAT_GATEWAY_IMPL` dispatch (the ~14k-line per-node installer
+`deploy-mac-fleet.sh` drives over SSH) still only wires up `openclaw`,
+`nemoclaw`, and `none` as first-class values in its systemd/launchd/supervisord
+branches; it does not yet call `install-hermes-gateway.sh`. Wiring `hermes` in
+there as a first-class value, matching the transactional
+prepare/verify/finalize/withdraw/rollback cutover `deploy-mac-fleet.sh` already
+orchestrates for OpenClaw, is real follow-up work, not done here -- it touches
+a large, live, critical file and deserved its own focused pass rather than a
+rushed edit alongside everything else in this update. Until that lands, a new
+node's Hermes gateway is set up the same way the three cutover nodes were:
+`deploy/hermes/install-hermes-gateway.sh prepare` run directly against the
+node, with `MAC_HERMES_*` env vars populated from its `fleets.yaml` entry.

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -5322,6 +5322,7 @@
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/hermes/install-hermes-gateway.sh",
       "deploy/openclaw/install-openclaw-gateway.sh",
       "src/mac/api.py",
       "src/mac/deploy_env.py",
@@ -5558,6 +5559,17 @@
   },
   {
     "default": null,
+    "description": "Hermes Runtime setting: hermes dry run.",
+    "family": "hermes-runtime",
+    "name": "MAC_HERMES_DRY_RUN",
+    "retired": false,
+    "sources": [
+      "deploy/hermes/install-hermes-gateway.sh"
+    ],
+    "type": "bool"
+  },
+  {
+    "default": null,
     "description": "Hermes Runtime setting: hermes existing port.",
     "family": "hermes-runtime",
     "name": "MAC_HERMES_EXISTING_PORT",
@@ -5566,6 +5578,28 @@
       "deploy/nemoclaw/install-nemoclaw-pilot.sh"
     ],
     "type": "int"
+  },
+  {
+    "default": null,
+    "description": "Hermes Runtime setting: hermes fleet name.",
+    "family": "hermes-runtime",
+    "name": "MAC_HERMES_FLEET_NAME",
+    "retired": false,
+    "sources": [
+      "deploy/hermes/install-hermes-gateway.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Hermes Runtime setting: hermes from interface.",
+    "family": "hermes-runtime",
+    "name": "MAC_HERMES_FROM_INTERFACE",
+    "retired": false,
+    "sources": [
+      "deploy/hermes/install-hermes-gateway.sh"
+    ],
+    "type": "str"
   },
   {
     "default": null,
@@ -5594,6 +5628,7 @@
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/hermes/install-hermes-gateway.sh",
       "deploy/nemoclaw/docker-compose.yaml",
       "deploy/openclaw/install-openclaw-gateway.sh",
       "src/mac/agent_provider.py",
@@ -5612,6 +5647,7 @@
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/hermes/install-hermes-gateway.sh",
       "deploy/nemoclaw/docker-compose.yaml",
       "deploy/openclaw/install-openclaw-gateway.sh",
       "src/mac/agent_provider.py",
@@ -5631,6 +5667,7 @@
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/hermes/install-hermes-gateway.sh",
       "deploy/nemoclaw/docker-compose.yaml",
       "src/mac/agent_provider.py",
       "src/mac/deploy_env.py",
@@ -5675,6 +5712,17 @@
   },
   {
     "default": null,
+    "description": "Hermes Runtime setting: hermes install url.",
+    "family": "hermes-runtime",
+    "name": "MAC_HERMES_INSTALL_URL",
+    "retired": false,
+    "sources": [
+      "deploy/hermes/install-hermes-gateway.sh"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Hermes Runtime setting: hermes instance id.",
     "family": "hermes-runtime",
     "name": "MAC_HERMES_INSTANCE_ID",
@@ -5710,6 +5758,17 @@
     "sources": [
       "deploy/openclaw/install-openclaw-gateway.sh",
       "deploy/openclaw/run-script-cron-job.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
+    "description": "Hermes Runtime setting: hermes openclaw source.",
+    "family": "hermes-runtime",
+    "name": "MAC_HERMES_OPENCLAW_SOURCE",
+    "retired": false,
+    "sources": [
+      "deploy/hermes/install-hermes-gateway.sh"
     ],
     "type": "str"
   },
@@ -5830,6 +5889,7 @@
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/hermes/install-hermes-gateway.sh",
       "deploy/openclaw/install-openclaw-gateway.sh",
       "deploy/sync-hermes-home-channels.py",
       "src/mac/deploy_env.py",
@@ -6139,6 +6199,7 @@
       "deploy/fleet-node-install.sh",
       "deploy/fleet-node-phase1-quiesce.sh",
       "deploy/fleet-node-substrate-adopt.py",
+      "deploy/hermes/install-hermes-gateway.sh",
       "deploy/install-firecrawl-gateway.sh",
       "deploy/install-headscale.sh",
       "deploy/install-postgres-service.sh",

--- a/tests/test_hermes_gateway_deploy.py
+++ b/tests/test_hermes_gateway_deploy.py
@@ -199,6 +199,7 @@ def test_prepare_ports_credentials_via_mac_human_interface(tmp_path):
         json.loads(line) for line in mac_calls_path.read_text(encoding="utf-8").splitlines() if line
     ]
     assert [
+        "admin",
         "human-interface",
         "port",
         "--from",

--- a/tests/test_hermes_gateway_deploy.py
+++ b/tests/test_hermes_gateway_deploy.py
@@ -1,0 +1,255 @@
+"""Contract tests for MAC's host-level Hermes chat gateway installer."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.process_e2e
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "deploy" / "hermes" / "install-hermes-gateway.sh"
+
+FAKE_HERMES = """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+with Path(os.environ["FAKE_HERMES_CALLS"]).open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(args) + "\\n")
+
+scenario = os.environ.get("FAKE_HERMES_SCENARIO", "healthy")
+
+if args[:2] == ["gateway", "status"]:
+    if scenario == "unsupervised":
+        print("Gateway is running as a detached process (not supervised).")
+    elif scenario == "unhealthy":
+        print("Gateway is supervised by launchd, but reports Unhealthy.")
+    else:
+        print("Gateway is supervised by launchd and Running.")
+    raise SystemExit(0)
+
+raise SystemExit(0)
+"""
+
+FAKE_MAC = """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+args = sys.argv[1:]
+with Path(os.environ["FAKE_MAC_CALLS"]).open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(args) + "\\n")
+raise SystemExit(0)
+"""
+
+
+def _prepare_bin(tmp_path: Path, calls_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    fake_hermes = bin_dir / "hermes"
+    fake_hermes.write_text(FAKE_HERMES, encoding="utf-8")
+    fake_hermes.chmod(0o755)
+    fake_mac = bin_dir / "mac"
+    fake_mac.write_text(FAKE_MAC, encoding="utf-8")
+    fake_mac.chmod(0o755)
+    return bin_dir
+
+
+def _run(
+    tmp_path: Path,
+    subcommand: str,
+    *,
+    scenario: str = "healthy",
+    extra_env: dict | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list]:
+    calls_path = tmp_path / "hermes-calls.jsonl"
+    calls_path.write_text("", encoding="utf-8")
+    mac_calls_path = tmp_path / "mac-calls.jsonl"
+    mac_calls_path.write_text("", encoding="utf-8")
+    bin_dir = _prepare_bin(tmp_path, calls_path)
+    home = tmp_path / "home"
+    (home / ".local" / "bin").mkdir(parents=True, exist_ok=True)
+    env = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "HOME": str(home),
+        "HERMES_HOME": str(home / ".hermes"),
+        "MAC_HERMES_OPENCLAW_SOURCE": str(home / "no-openclaw-here"),
+        "FAKE_HERMES_CALLS": str(calls_path),
+        "FAKE_HERMES_SCENARIO": scenario,
+        "FAKE_MAC_CALLS": str(mac_calls_path),
+    }
+    if extra_env:
+        env.update(extra_env)
+    result = subprocess.run(
+        ["bash", str(INSTALLER), subcommand],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+    calls = [
+        json.loads(line) for line in calls_path.read_text(encoding="utf-8").splitlines() if line
+    ]
+    return result, calls
+
+
+def test_verify_passes_when_gateway_is_supervised(tmp_path):
+    result, calls = _run(tmp_path, "verify", scenario="healthy")
+    assert result.returncode == 0, result.stderr
+    assert ["gateway", "status", "--deep"] in calls
+
+
+def test_verify_fails_when_gateway_is_unsupervised(tmp_path):
+    result, _calls = _run(tmp_path, "verify", scenario="unsupervised")
+    assert result.returncode != 0
+    assert "supervised" in result.stderr.lower()
+
+
+def test_verify_fails_when_gateway_is_unhealthy(tmp_path):
+    result, _calls = _run(tmp_path, "verify", scenario="unhealthy")
+    assert result.returncode != 0
+    assert "not healthy" in result.stderr.lower()
+
+
+def test_withdraw_stops_the_gateway_without_uninstalling(tmp_path):
+    result, calls = _run(tmp_path, "withdraw")
+    assert result.returncode == 0, result.stderr
+    assert ["gateway", "stop"] in calls
+    assert not any(call[:2] == ["gateway", "uninstall"] for call in calls)
+
+
+def test_configure_gateway_sets_only_provided_fields(tmp_path):
+    result, calls = _run(
+        tmp_path,
+        "prepare",
+        extra_env={
+            "MAC_HERMES_GATEWAY_MODEL": "azure/anthropic/claude-sonnet-4-6",
+            "MAC_HERMES_GATEWAY_PROVIDER": "custom",
+            "MAC_HERMES_GATEWAY_BASE_URL": "",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert ["config", "set", "model", "azure/anthropic/claude-sonnet-4-6", "--force"] in calls
+    assert ["config", "set", "provider", "custom", "--force"] in calls
+    assert not any(call[:3] == ["config", "set", "base_url"] for call in calls)
+
+
+def test_configure_gateway_always_requires_mention_by_default(tmp_path):
+    _result, calls = _run(tmp_path, "prepare")
+    assert ["config", "set", "slack.require_mention", "true", "--force"] in calls
+
+
+def test_free_response_channel_is_set_when_directory_resolves_the_name(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    hermes_home = home / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    directory = hermes_home / "channel_directory.json"
+    directory.write_text(
+        json.dumps({"channels": [{"name": "rockyandfriends", "id": "C0AMSBEU7CJ"}]}),
+        encoding="utf-8",
+    )
+    result, calls = _run(
+        tmp_path,
+        "prepare",
+        extra_env={"MAC_HERMES_SLACK_HOME_CHANNEL_NAME": "rockyandfriends"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert [
+        "config",
+        "set",
+        "slack.free_response_channels",
+        "C0AMSBEU7CJ",
+        "--force",
+    ] in calls
+
+
+def test_free_response_channel_is_skipped_gracefully_when_unresolvable(tmp_path):
+    result, calls = _run(
+        tmp_path,
+        "prepare",
+        extra_env={"MAC_HERMES_SLACK_HOME_CHANNEL_NAME": "somechannel"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert not any(call[:3] == ["config", "set", "slack.free_response_channels"] for call in calls)
+
+
+def test_prepare_skips_install_when_hermes_already_on_path(tmp_path):
+    result, calls = _run(tmp_path, "prepare")
+    assert result.returncode == 0, result.stderr
+    # No shell-installer invocation is observable through the fake hermes
+    # binary's own call log (it's already "installed"); prepare should reach
+    # gateway install regardless.
+    assert ["gateway", "install", "--force", "--start-now", "--start-on-login"] in calls
+
+
+def test_prepare_ports_credentials_via_mac_human_interface(tmp_path):
+    result, calls = _run(tmp_path, "prepare")
+    assert result.returncode == 0, result.stderr
+    mac_calls_path = tmp_path / "mac-calls.jsonl"
+    mac_calls = [
+        json.loads(line) for line in mac_calls_path.read_text(encoding="utf-8").splitlines() if line
+    ]
+    assert [
+        "human-interface",
+        "port",
+        "--from",
+        "openclaw",
+        "--to",
+        "hermes",
+        "--apply",
+    ] in mac_calls
+
+
+def test_prepare_migrates_claw_state_when_openclaw_home_present(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    openclaw_home = home / ".openclaw"
+    openclaw_home.mkdir(parents=True, exist_ok=True)
+    result, calls = _run(
+        tmp_path,
+        "prepare",
+        extra_env={"MAC_HERMES_OPENCLAW_SOURCE": str(openclaw_home)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert [
+        "claw",
+        "migrate",
+        "--source",
+        str(openclaw_home),
+        "--preset",
+        "full",
+        "--overwrite",
+        "--yes",
+    ] in calls
+
+
+def test_prepare_skips_claw_migrate_when_no_openclaw_home(tmp_path):
+    result, calls = _run(tmp_path, "prepare")
+    assert result.returncode == 0, result.stderr
+    assert not any(call[:2] == ["claw", "migrate"] for call in calls)
+
+
+def test_finalize_runs_verify(tmp_path):
+    result, calls = _run(tmp_path, "finalize", scenario="healthy")
+    assert result.returncode == 0, result.stderr
+    assert ["gateway", "status", "--deep"] in calls
+
+
+def test_finalize_fails_when_gateway_unhealthy(tmp_path):
+    result, _calls = _run(tmp_path, "finalize", scenario="unhealthy")
+    assert result.returncode != 0
+
+
+def test_unknown_subcommand_fails_closed(tmp_path):
+    result, _calls = _run(tmp_path, "bogus")
+    assert result.returncode != 0
+    assert "usage" in result.stderr.lower()

--- a/tests/test_hermes_vendor_fate.py
+++ b/tests/test_hermes_vendor_fate.py
@@ -30,7 +30,18 @@ def test_vendored_hermes_tree_is_gone() -> None:
     assert not (SRC_MAC / "_hermes").exists()
     assert not (SRC_MAC / "hermes_vendor.py").exists()
     assert not (SRC_MAC / "hermes_gateway.py").exists()
-    assert not (ROOT / "deploy" / "hermes").exists()
+    # deploy/hermes/ itself came back (2026-09-05) to hold
+    # install-hermes-gateway.sh, the host-level lifecycle script that shells
+    # out to an externally-installed `hermes` CLI -- see
+    # docs/hermes-vendor-fate.md. What must stay gone is the vendoring
+    # machinery it used to hold: the pinned snapshot, its local patch set, and
+    # the plugin/tool overlay applied on top of it.
+    deploy_hermes = ROOT / "deploy" / "hermes"
+    assert not (deploy_hermes / "SNAPSHOT.md").exists()
+    assert not (deploy_hermes / "HERMES_TREE_SHA256").exists()
+    assert not (deploy_hermes / "LOCAL_PATCHES.md").exists()
+    assert not (deploy_hermes / "overlay").exists()
+    assert not list(deploy_hermes.glob("*.patch"))
 
 
 def test_a_no_live_hermes_cli_imports_in_mac_sources() -> None:


### PR DESCRIPTION
## Summary
- Adds `deploy/hermes/install-hermes-gateway.sh`, the host-level sibling of `deploy/openclaw/install-openclaw-gateway.sh` (same prepare/verify/finalize/withdraw shape), codifying the Hermes cutover steps from PR #752 that were previously only done by hand over SSH: shell-install, credential porting (`mac human-interface port`), `hermes claw migrate`, channel-behavior policy (`slack.require_mention` / `slack.free_response_channels`, resolved from the `hermes.slack_home_channel_name` fleet-config field), and supervised service install.
- Config field names and service-naming conventions are recovered from the pre-vendoring-removal `deploy/fleet-node-install.sh` (git history at `3ebde2dd~1`), adapted from its old in-process-import model to shell out to the externally installed `hermes` CLI instead.
- Adds `tests/test_hermes_gateway_deploy.py` (15 tests, fake `hermes`/`mac` binaries recording invocations) — caught and fixed a real bug in `verify_gateway`'s status-string matching (`"not supervised"` was matching the positive `*supervised*` glob).
- Updates `docs/hermes-vendor-fate.md` with an honest status: what's automated now, and what's explicitly *not* done (wiring `hermes` as a first-class `MAC_CHAT_GATEWAY_IMPL` value into `fleet-node-install.sh`'s much larger systemd/launchd/supervisord dispatch — flagged as real follow-up work, not attempted here to avoid a rushed edit to a large, live, critical file).

## Test plan
- [x] `tests/test_hermes_gateway_deploy.py` — 15/15 pass
- [x] `tests/test_docs_no_operator_identity.py`, `tests/test_guide_docs_are_true.py` — pass (staged before running)
- [x] `python scripts/check-docs-graph.py` — passes, no orphans
- [x] `python scripts/generate-env-config-registry.py` — regenerated for the new `MAC_HERMES_*` vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)