### PR TITLE
Fix hermes config set to scope model updates to sub-keys, not the whole object

### DIFF
--- a/deploy/hermes/install-hermes-gateway.sh
+++ b/deploy/hermes/install-hermes-gateway.sh
@@ -110,9 +110,15 @@ configure_gateway() {
   hermes="$(hermes_bin)" || die "hermes CLI not found"
   [ "$DRY_RUN" = 1 ] && { log "dry-run: skipping hermes config set calls"; return 0; }
 
-  [ -z "$GATEWAY_MODEL" ]    || "$hermes" config set model "$GATEWAY_MODEL" --force
-  [ -z "$GATEWAY_PROVIDER" ] || "$hermes" config set provider "$GATEWAY_PROVIDER" --force
-  [ -z "$GATEWAY_BASE_URL" ] || "$hermes" config set base_url "$GATEWAY_BASE_URL" --force
+  # Dotted paths ("model.default", not "model") are load-bearing here: Hermes
+  # stores the active model as a nested object (model.default/.provider/
+  # .base_url/.api_key). `config set model ...` replaces that whole object
+  # with a bare scalar, silently discarding base_url/api_key/provider --
+  # confirmed live: it broke a working custom-router setup on the first
+  # idempotent re-run of `prepare` against an already-configured node.
+  [ -z "$GATEWAY_MODEL" ]    || "$hermes" config set model.default "$GATEWAY_MODEL" --force
+  [ -z "$GATEWAY_PROVIDER" ] || "$hermes" config set model.provider "$GATEWAY_PROVIDER" --force
+  [ -z "$GATEWAY_BASE_URL" ] || "$hermes" config set model.base_url "$GATEWAY_BASE_URL" --force
 
   # Home channel: listen to and respond to everything, unprompted. Every
   # other channel the agent is invited into stays mention-only -- that is

--- a/tests/test_hermes_gateway_deploy.py
+++ b/tests/test_hermes_gateway_deploy.py
@@ -137,8 +137,20 @@ def test_configure_gateway_sets_only_provided_fields(tmp_path):
         },
     )
     assert result.returncode == 0, result.stderr
-    assert ["config", "set", "model", "azure/anthropic/claude-sonnet-4-6", "--force"] in calls
-    assert ["config", "set", "provider", "custom", "--force"] in calls
+    assert [
+        "config",
+        "set",
+        "model.default",
+        "azure/anthropic/claude-sonnet-4-6",
+        "--force",
+    ] in calls
+    assert ["config", "set", "model.provider", "custom", "--force"] in calls
+    assert not any(call[:3] == ["config", "set", "model.base_url"] for call in calls)
+    # Regression: a bare "model" (not "model.default") key replaces Hermes's
+    # whole nested model object, silently discarding base_url/api_key/
+    # provider -- confirmed live against a working custom-router setup.
+    assert not any(call[:3] == ["config", "set", "model"] for call in calls)
+    assert not any(call[:3] == ["config", "set", "provider"] for call in calls)
     assert not any(call[:3] == ["config", "set", "base_url"] for call in calls)
 
 


### PR DESCRIPTION
## Summary
- `install-hermes-gateway.sh`'s `configure_gateway()` called `hermes config set model <value> --force`, which replaces Hermes's entire nested `model` object (`default`/`provider`/`base_url`/`api_key`) with a bare scalar
- Applying `prepare` idempotently against rocky (which already had a working custom-router model config pointing at mac's own `/v1` router) silently discarded `base_url`/`api_key`, breaking model routing outright ("No LLM provider configured")
- Switched to dotted-path keys (`model.default`/`model.provider`/`model.base_url`), which `hermes config set` supports and which only touch the named sub-key

## Test plan
- [x] `tests/test_hermes_gateway_deploy.py` (15/15, updated for dotted-path calls + regression assertions that the old bare-key calls never fire)
- [x] Reproduced live on rocky: broke model routing with the old script, confirmed dotted-path form preserves `api_key`/`base_url` while updating `default`
- [x] docs/operator-identity/docs-graph checks clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>