### PR TITLE
Release v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ The guide is in [`docs/guide/`](docs/guide/README.md):
 | [The UI](docs/guide/04-ui.md) | the read-only console the hub serves at `/ui`, and the unshipped Fleet IDE prototype |
 | [Developer Guide](docs/guide/05-developer-guide.md) | how to hack on mac |
 | [Contributing](CONTRIBUTING.md) | filing issues and PRs that are actually tested |
-| [Presentations](docs/presentation/README.md) | capabilities decks, including the [v1.3.5 deck](https://docs.google.com/presentation/d/11mrPpsYR-wzRTLYsCiKF3wWcniGP811D6s0zYgPIoV4/edit?usp=drivesdk), each pinned to the commit it describes |
-| [v1.3.5 capabilities (`c7a3fee1`)](docs/presentation/20260904T212515Z-c7a3fee1/README.md) | current release deck: OpenShell/OpenClaw onboarding fixes, fleet dispatch/attestation reliability — [Google Slides](https://docs.google.com/presentation/d/11mrPpsYR-wzRTLYsCiKF3wWcniGP811D6s0zYgPIoV4/edit?usp=drivesdk) |
+| [Presentations](docs/presentation/README.md) | capabilities decks, including the [v1.4.0 deck](https://docs.google.com/presentation/d/1VX5AkOBjjz4X2DsUynYazO4ok9KuFXz7CjQN785HVkY/edit?usp=drivesdk), each pinned to the commit it describes |
+| [v1.4.0 capabilities (`a787bff1`)](docs/presentation/20260906T051311Z-a787bff1/README.md) | current release deck: OpenClaw chat-gateway hardening, its filesystem root cause, and the cutover back to Hermes — [Google Slides](https://docs.google.com/presentation/d/1VX5AkOBjjz4X2DsUynYazO4ok9KuFXz7CjQN785HVkY/edit?usp=drivesdk) |
 
 Those pages are written from the code and gated by
 `tests/test_guide_docs_are_true.py`, which checks that every file they name

--- a/docs/presentation/20260906T051311Z-a787bff1/AUDIT.md
+++ b/docs/presentation/20260906T051311Z-a787bff1/AUDIT.md
@@ -1,0 +1,58 @@
+# Audit — MAC v1.4.0
+
+Audited at commit `a787bff1` on 2026-09-06T05:13:11Z. This audit supports
+release `v1.4.0`. Generated CLI and OpenAPI references are authoritative
+because CI verifies them against the live parser and schema.
+
+## Current-document pass
+
+Every current row in `docs/reference/documentation-inventory.md` was reviewed
+against the candidate tree. The release range is `v1.3.5..a787bff1` (9
+commits: PR #749–#756, plus a lint-format housekeeping commit).
+
+| Documentation surface | Decision | Source anchor |
+|---|---|---|
+| `docs/hermes-vendor-fate.md` | changed and current: already carries a `## Update (2026-09-05)` section describing the OpenClaw→Hermes chat-gateway cutover, the filesystem root cause, and the shell-installer (not vendored, not pip) distribution model | `docs/hermes-vendor-fate.md`; PR #752, #753 |
+| `docs/openclaw-identities.md` | **stale, discrepancy recorded, not fixed in this pass**: this doc describes "OpenClaw is the only provider delivery path" and details OpenClaw-specific mechanics (pinned binary inside the OpenShell sandbox). That is no longer true for any of the three fleet nodes, all now on Hermes. Rewriting this doc's OpenClaw-specific mechanics for Hermes is real scope beyond this release's code changes — filed as follow-up rather than rushed here | `docs/openclaw-identities.md` lines 1, 12, 29–31, 70; contradicted by `deploy/hermes/install-hermes-gateway.sh`, PR #752 |
+| `docs/openshell-sandbox.md` | not changed: describes Hermes running *inside* OpenShell for autonomous **task execution** (`_hermes_argv` in `src/mac/task_executor.py`) — a different Hermes usage than the chat-gateway daemon this release cuts over. Not affected by PR #749–#756 | `src/mac/task_executor.py`; unchanged in this range |
+| `docs/hermes-retirement-premises.md` | not changed: a dated (2026-08-04) historical findings record of the original retirement's premises. Still accurate as history; `docs/hermes-vendor-fate.md`'s update supersedes its conclusion, not its record | unchanged in this range |
+| `docs/hermes-boundary.md`, `docs/hermes-integration.md` | not changed: already implementation-agnostic ("Hermes, OpenClaw, or an equivalent runtime") or scoped to the unrelated `mac-hermes` task-adapter CLI, not the chat gateway | unchanged in this range |
+| `docs/reference/cli.md`, `docs/reference/openapi.md` | not changed: no CLI flag, subcommand, or HTTP route was added, removed, or renamed in this range | generated references at `a787bff1` |
+| Documentation inventory | changed: this deck's own directory is a new pinned-and-allowlisted entry | `docs/reference/documentation-inventory.md` |
+| All other current inventory rows | not changed by this range | source review against `v1.3.5..a787bff1` |
+
+## Release claims
+
+| Claim | Source |
+|---|---|
+| OpenClaw's colliding hourly cron jobs (`dream-cycle`, `dream-synthesis`, both `0 * * * *`) are staggered apart | `deploy/openclaw/install-openclaw-gateway.sh`; PR #749 |
+| A host-side `flock` mutex serializes every sandboxed OpenClaw CLI invocation | `deploy/openclaw/run-script-cron-job.py`; PR #750 |
+| OpenClaw message delivery encodes the full body through `--message` (escaped newlines), not the silently-ignored `--presentation` field | `deploy/openclaw/run-script-cron-job.py`; PR #751 |
+| **Root cause identified**: OpenClaw's OpenShell sandbox state mount runs on Docker Desktop's overlayfs (VirtioFS-backed macOS VM), where POSIX advisory locking is broken enough that a fresh, empty SQLite WAL database hangs indefinitely under trivial write load — proven directly, not fixable in this repository | live reproduction, documented in `docs/hermes-vendor-fate.md`; upstream issue `github.com/openclaw/openclaw/issues/139214` |
+| The fleet's chat gateway is Hermes again, not OpenClaw, on all three nodes | `docs/hermes-vendor-fate.md`; PR #752 |
+| Hermes is depended on via upstream's official shell installer, never vendored and never pip-installed (upstream's own `setup.py` refuses to build a wheel or sdist) | `deploy/hermes/install-hermes-gateway.sh`; PR #752, #753 |
+| Repo-owned Hermes lifecycle automation exists: `prepare`/`verify`/`finalize`/`withdraw`, matching `install-openclaw-gateway.sh`'s pattern | `deploy/hermes/install-hermes-gateway.sh`; PR #753 |
+| NemoClaw (a locally-built pilot, not a third-party product) shares the same sandbox-filesystem risk class; tracked, not currently deployed on any macOS host | ledger `task_cc97f8c769aa4175b95e92d57287a128`; PR #754 |
+| `hermes` is a first-class `MAC_CHAT_GATEWAY_IMPL` value in `deploy/fleet-node-install.sh`'s dispatch and `deploy-mac-fleet.sh`'s transactional orchestration | `deploy/fleet-node-install.sh`; PR #755 |
+| `hermes config set` writes go to the correct dotted sub-key (`model.default`/`.provider`/`.base_url`), not the whole nested `model` object — a real regression was caught live in production (an idempotent `prepare` re-run silently discarded a working custom-router `base_url`/`api_key`) and fixed | `deploy/hermes/install-hermes-gateway.sh`; PR #756 |
+| `deploy/hermes/install-hermes-gateway.sh prepare` sets `SLACK_ALLOWED_USERS=*` in `~/.hermes/.env` — a second real bug caught live: Hermes defaults every platform to `dm_policy`/`group_policy=pairing` and silently rejects any sender not on an explicit allowlist, with no startup failure, only a log line. None of the three cutover nodes had this set, meaning all three were silently rejecting every Slack message, including @mentions in the home channel. `verify` now fails closed if it is unset | `deploy/hermes/install-hermes-gateway.sh`, `tests/test_hermes_gateway_deploy.py`; confirmed applied on all three fleet nodes |
+
+## Current measured surface
+
+| Claim | Evidence |
+|---|---|
+| 9 commits since v1.3.5 | `git rev-list --count v1.3.5..a787bff1` |
+| One local-only test failure (`tests/cli/test_task_table_column_widths.py::test_the_table_never_exceeds_the_terminal`), terminal-width dependent, does not reproduce in GitHub CI | local `make test` run at `a787bff1`; consistent with the same test's status noted during this session's fleet cutover work |
+| `make lint`, `make docs-check` clean at `a787bff1` | local run at `a787bff1` (one formatting fix applied and committed pre-audit: `a787bff1` itself) |
+
+## Gates and scope
+
+This release's actual code changes are entirely in `deploy/openclaw/` and
+`deploy/hermes/` (chat-gateway reliability and the OpenClaw→Hermes cutover) —
+no HTTP route, CLI surface, or public Python API changed. The fleet-operational
+outcome (all three nodes live on Hermes, verified healthy, `#rockyandfriends`
+free-response channel policy applied identically) was executed by hand this
+session and is not itself a code change; it is recorded here as ground truth
+for the claims table above, cross-referenced against the actual merged PRs
+that make it durable (PR #753, #755 codify what was, until they landed, a
+manual and non-reproducible SSH procedure).

--- a/docs/presentation/20260906T051311Z-a787bff1/README.md
+++ b/docs/presentation/20260906T051311Z-a787bff1/README.md
@@ -1,0 +1,31 @@
+# MAC capabilities deck — `a787bff1`
+
+Point-in-time capabilities deck for the v1.4.0 release, audited at commit
+`a787bff1` and captured 2026-09-06T05:13:11Z.
+
+## Deck
+
+Slides: [MAC — v1.4.0 (`a787bff1`)](https://docs.google.com/presentation/d/1VX5AkOBjjz4X2DsUynYazO4ok9KuFXz7CjQN785HVkY/edit?usp=drivesdk)
+
+The deterministic builder and exported Slides deck were verified at six slides.
+
+Six slides, 16:9, describe the fleet's chat-gateway reliability work since
+v1.3.5: three OpenClaw hardening fixes (cron schedule collision, a host-side
+flock mutex, message-body encoding), the filesystem-level root cause that
+made those insufficient (broken POSIX locking on a Docker Desktop overlayfs
+mount, reported upstream), the cutover of all three fleet nodes' chat gateway
+from OpenClaw back to Hermes (shell-installed, not vendored, not pip-installed),
+and a real regression caught live in production during that cutover (a
+config-writer that silently discarded a working model provider configuration,
+fixed with dotted-path keys).
+
+## Rebuild
+
+```console
+$ python3 -m venv /tmp/deckvenv
+$ /tmp/deckvenv/bin/pip install python-pptx
+$ /tmp/deckvenv/bin/python docs/presentation/20260906T051311Z-a787bff1/build_deck.py
+```
+
+Publish with `scripts/publish-deck-to-slides.py` and `--expect-slides 6`.
+Generated PNGs and PPTX files are ignored and are not committed.

--- a/docs/presentation/20260906T051311Z-a787bff1/build_deck.py
+++ b/docs/presentation/20260906T051311Z-a787bff1/build_deck.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Build the six-slide MAC v1.4.0 release deck."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+HERE = Path(__file__).resolve().parent
+COMMIT = "a787bff1"
+CAPTURED = "2026-09-06T05:13:11Z"
+OUT = HERE / f"mac-capabilities-{COMMIT}.pptx"
+
+INK = RGBColor(0x1B, 0x25, 0x30)
+SLATE = RGBColor(0x2F, 0x3A, 0x45)
+GREY = RGBColor(0x5A, 0x6B, 0x7A)
+MUTED = RGBColor(0x8A, 0x98, 0xA6)
+WHITE = RGBColor(0xFF, 0xFF, 0xFF)
+BLUE = RGBColor(0x2E, 0x6F, 0x9E)
+AMBER = RGBColor(0xB5, 0x65, 0x1D)
+SAND = RGBColor(0xF2, 0xC4, 0x8A)
+PALE = RGBColor(0xDC, 0xE5, 0xEC)
+FONT = "Helvetica Neue"
+
+prs = Presentation()
+prs.slide_width = Inches(13.333)
+prs.slide_height = Inches(7.5)
+BLANK = prs.slide_layouts[6]
+
+
+def notes(slide, text: str) -> None:
+    slide.notes_slide.notes_text_frame.text = text.strip()
+
+
+def background(slide, color) -> None:
+    fill = slide.background.fill
+    fill.solid()
+    fill.fore_color.rgb = color
+
+
+def text_box(slide, x, y, w, h, align=PP_ALIGN.LEFT):
+    box = slide.shapes.add_textbox(x, y, w, h)
+    frame = box.text_frame
+    frame.word_wrap = True
+    frame.paragraphs[0].alignment = align
+    return frame
+
+
+def line(frame, text, size, color, *, bold=False, first=False, after=8):
+    paragraph = frame.paragraphs[0] if first else frame.add_paragraph()
+    paragraph.space_after = Pt(after)
+    run = paragraph.add_run()
+    run.text = text
+    run.font.size = Pt(size)
+    run.font.bold = bold
+    run.font.color.rgb = color
+    run.font.name = FONT
+
+
+def title_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(slide, Inches(0.9), Inches(2.0), Inches(11.5), Inches(2.8))
+    line(frame, "MAC", 54, WHITE, bold=True, first=True, after=8)
+    line(frame, "v1.4.0", 32, PALE, after=16)
+    line(
+        frame,
+        "The fleet's chat gateway is Hermes again: OpenClaw's onboarding was hardened, then its unfixable"
+        " root cause forced a cutover.",
+        18,
+        MUTED,
+    )
+    footer = text_box(slide, Inches(0.9), Inches(5.75), Inches(11.5), Inches(0.8))
+    line(footer, f"commit {COMMIT}   ·   captured {CAPTURED}", 16, SAND, bold=True, first=True)
+    notes(
+        slide,
+        "This deck is pinned to the release commit. AUDIT.md traces each visible claim to the source tree or generated reference.",
+    )
+
+
+def hardening_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(
+        frame,
+        "OpenClaw was given an honest try first",
+        33,
+        INK,
+        bold=True,
+        first=True,
+    )
+    line(frame, "Three real reliability bugs, fixed before the root cause was found.", 16, GREY)
+    body = text_box(slide, Inches(0.95), Inches(2.05), Inches(11.3), Inches(4.65))
+    for index, (head, detail) in enumerate(
+        [
+            (
+                "Cron schedule collision",
+                "Two hourly jobs sharing an identical schedule raced to open the same SQLite state file every hour.",
+            ),
+            (
+                "Host-side flock mutex",
+                "Every sandboxed OpenClaw CLI invocation now serializes through a single host-owned lock file.",
+            ),
+            (
+                "Message-body encoding",
+                "Delivery silently dropped the message body via an ignored --presentation field; fixed to encode through --message.",
+            ),
+        ]
+    ):
+        line(
+            body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2
+        )
+        line(body, detail, 17, SLATE, after=12)
+    notes(slide, "Each point is a shipped fix, traced in AUDIT.md. None of them fixed the underlying problem.")
+
+
+def root_cause_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(slide, Inches(0.9), Inches(0.6), Inches(11.5), Inches(1.3))
+    line(frame, "The root cause was outside this repository", 33, WHITE, bold=True, first=True)
+    body = text_box(slide, Inches(0.95), Inches(2.0), Inches(11.3), Inches(4.5))
+    line(
+        body,
+        "OpenClaw's sandboxed state database sat on Docker Desktop's overlayfs.",
+        22,
+        PALE,
+        bold=True,
+        first=True,
+        after=14,
+    )
+    line(
+        body,
+        "POSIX advisory locking is broken enough there that a fresh, empty SQLite WAL database hung"
+        " indefinitely under a trivial write load — proven directly, not inferred.",
+        19,
+        MUTED,
+        after=20,
+    )
+    line(
+        body,
+        "A high-severity bug report was filed upstream with the reproduction.",
+        20,
+        SAND,
+        bold=True,
+    )
+    notes(
+        slide,
+        "This is the pivot slide: three prior fixes closed real bugs but couldn't touch a filesystem-level"
+        " locking failure. See AUDIT.md for the upstream issue link.",
+    )
+
+
+def cutover_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(frame, "The fleet's chat gateway is Hermes again", 33, INK, bold=True, first=True)
+    line(frame, "Not vendored, not pip-installed — upstream's own distribution model.", 16, GREY)
+    body = text_box(slide, Inches(0.95), Inches(2.05), Inches(11.3), Inches(4.65))
+    for index, (head, detail) in enumerate(
+        [
+            (
+                "Shell-installed, not vendored",
+                "Upstream's official installer, run per node. The 444k-line vendored snapshot removed last month stays removed.",
+            ),
+            (
+                "State migrated, not lost",
+                "hermes claw migrate pulled each node's accumulated OpenClaw identity, memory, and skills across during cutover.",
+            ),
+            (
+                "Repo-owned lifecycle, not manual",
+                "deploy/hermes/install-hermes-gateway.sh (prepare/verify/finalize/withdraw) is now a first-class fleet-deploy option.",
+            ),
+        ]
+    ):
+        line(
+            body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2
+        )
+        line(body, detail, 17, SLATE, after=12)
+    notes(slide, "Each point closes a gap between the manual cutover and durable, reproducible automation.")
+
+
+def caught_live_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    frame = text_box(slide, Inches(0.85), Inches(0.45), Inches(11.6), Inches(1.35))
+    line(frame, "A regression was caught live, not in CI", 33, INK, bold=True, first=True)
+    line(frame, "Applying the new automation idempotently broke a working node.", 16, GREY)
+    body = text_box(slide, Inches(0.95), Inches(2.1), Inches(11.3), Inches(4.5))
+    line(
+        body,
+        "hermes config set model <value> silently replaces the entire nested model configuration"
+        " object, discarding a working base_url and api_key.",
+        22,
+        AMBER,
+        bold=True,
+        first=True,
+        after=16,
+    )
+    line(
+        body,
+        "Re-running the installer against an already-configured node broke model routing outright."
+        " Caught by a live verification call before it reached a second node.",
+        19,
+        SLATE,
+        after=16,
+    )
+    line(
+        body,
+        "Fixed with dotted-path keys (model.default / model.provider / model.base_url), which only"
+        " touch the named sub-key.",
+        20,
+        BLUE,
+        bold=True,
+    )
+    notes(slide, "This is the kind of bug a test suite doesn't catch: it only reproduces against real, prior state.")
+
+
+def closing_slide() -> None:
+    slide = prs.slides.add_slide(BLANK)
+    background(slide, SLATE)
+    frame = text_box(
+        slide, Inches(0.9), Inches(2.1), Inches(11.5), Inches(2.7), align=PP_ALIGN.CENTER
+    )
+    line(
+        frame,
+        "v1.4.0 is ready to be tagged and published",
+        34,
+        WHITE,
+        bold=True,
+        first=True,
+        after=14,
+    )
+    line(
+        frame,
+        "All three fleet nodes are live on Hermes, verified healthy, and durably managed —"
+        " not a workaround, a real architectural correction.",
+        20,
+        PALE,
+    )
+    notes(
+        slide,
+        "Close with the practical consequence: chat-gateway reliability was a live production incident,"
+        " now closed with root cause, fix, and durable automation.",
+    )
+
+
+for build in (
+    title_slide,
+    hardening_slide,
+    root_cause_slide,
+    cutover_slide,
+    caught_live_slide,
+    closing_slide,
+):
+    build()
+
+prs.save(OUT)
+print(OUT)

--- a/docs/presentation/README.md
+++ b/docs/presentation/README.md
@@ -54,6 +54,7 @@ need to know, the failure message names it when it fires.
 
 | Directory | Commit | Deck | Subject |
 |---|---|---|---|
+| [`20260906T051311Z-a787bff1`](20260906T051311Z-a787bff1/README.md) | `a787bff1` | [Google Slides](https://docs.google.com/presentation/d/1VX5AkOBjjz4X2DsUynYazO4ok9KuFXz7CjQN785HVkY/edit?usp=drivesdk) | v1.4.0 — OpenClaw chat-gateway reliability hardening, the filesystem root cause that forced a cutover, and the fleet's chat gateway moving back to Hermes |
 | [`20260904T212515Z-c7a3fee1`](20260904T212515Z-c7a3fee1/README.md) | `c7a3fee1` | [Google Slides](https://docs.google.com/presentation/d/11mrPpsYR-wzRTLYsCiKF3wWcniGP811D6s0zYgPIoV4/edit?usp=drivesdk) | v1.3.5 — OpenShell/OpenClaw onboarding root-cause fixes and fleet dispatch/attestation reliability fixes |
 | [`20260902T131314Z-a168e9d0`](20260902T131314Z-a168e9d0/README.md) | `a168e9d0` | [Google Slides](https://docs.google.com/presentation/d/16ZYljibDJ1toiyuBpKmxaiqSjsZ7j69bPDIuGB2tDH4/edit?usp=drivesdk) | v1.3.5 release candidate — artifact publication, deploy resilience, fleet visibility, the contract-test allowance, and the transactional release workflow |
 | [`20260831T143751Z-e78a7ba7`](20260831T143751Z-e78a7ba7/README.md) | `e78a7ba7` | [Google Slides](https://docs.google.com/presentation/d/1uPIlC_TYrp3XHd4ARIbrdxNjPiYgAE7pjdi2n_2FUD8/edit) | v1.3.4 — resilient contract gates, supported PostgreSQL CI, host-Python upgrade recovery, and bounded lease-telemetry clock skew |

--- a/src/mac/__init__.py
+++ b/src/mac/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 #: import it, so the number lives in exactly one place. It used to be copied by
 #: hand into four (pyproject, this package, the FastAPI app, the A2A card) with
 #: a comment on each asking the next person to keep them in sync.
-__version__ = "1.3.5"
+__version__ = "1.4.0"
 
 __all__ = [
     "ControlPlane",

--- a/tests/test_openclaw_gateway_deploy.py
+++ b/tests/test_openclaw_gateway_deploy.py
@@ -695,7 +695,7 @@ def _extract_finalize_cron_plan_script() -> str:
     (curiosity-job upsert + same-schedule staggering) out of the installer so it
     can be executed directly against synthetic job data."""
     installer = INSTALLER.read_text(encoding="utf-8")
-    marker = 'python3 - "$MANAGED_DIR/cron-plan.json" <<\'PY\'\n'
+    marker = "python3 - \"$MANAGED_DIR/cron-plan.json\" <<'PY'\n"
     start = installer.index(marker) + len(marker)
     end = installer.index("\nPY", start)
     return installer[start:end]
@@ -720,13 +720,19 @@ def test_finalize_cron_plan_staggers_jobs_sharing_an_identical_schedule(tmp_path
                 "jobs": [
                     {"legacy_id": "adf20933eff0", "name": "dream-cycle", "cron": "0 * * * *"},
                     {"legacy_id": "2d437df2441e", "name": "dream-synthesis", "cron": "0 * * * *"},
-                    {"legacy_id": "61c34b2f9752", "name": "kslug-nightly-news", "cron": "0 6 * * *"},
+                    {
+                        "legacy_id": "61c34b2f9752",
+                        "name": "kslug-nightly-news",
+                        "cron": "0 6 * * *",
+                    },
                 ],
             }
         ),
         encoding="utf-8",
     )
-    subprocess.run(["python3", "-c", script, str(plan_path)], check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["python3", "-c", script, str(plan_path)], check=True, capture_output=True, text=True
+    )
 
     plan = json.loads(plan_path.read_text(encoding="utf-8"))
     by_name = {job["name"]: job["cron"] for job in plan["jobs"]}


### PR DESCRIPTION
## Summary

Chat-gateway reliability release: OpenClaw was given an honest hardening pass
(PR #749–#751), but its true root cause — Docker Desktop's overlayfs breaking
POSIX advisory locking under OpenShell sandbox state — is outside this repo's
control. The fleet's chat gateway moved back to Hermes (PR #752), with real,
repo-owned lifecycle automation restored (PR #753, #755) instead of a manual
per-node procedure. A live regression discovered during rollout (`hermes
config set model` silently discarding a working provider config) is fixed
(PR #756), plus a second live-caught bug (`SLACK_ALLOWED_USERS` unset,
silently rejecting all Slack senders) fixed alongside.

- Bump `__version__` to 1.4.0
- Capabilities deck pinned to `a787bff1`, audited, published to Google Slides
- All docs gates green: operator-identity, docs-graph, guide-docs-are-true

## Test plan
- [x] `make lint` clean
- [x] `make test` (11,438+ passed; one known local-only, terminal-width-dependent flake, does not reproduce in CI)
- [x] `make docs-check` clean
- [x] `test_docs_no_operator_identity.py`, `test_guide_docs_are_true.py`, `test_docs_graph.py` — 14/14 pass
- [x] `scripts/check-docs-graph.py` — 217 docs reachable, no orphans

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>