### PR TITLE
Fix Hermes fleet nodes never having a Slack home channel set

### DIFF
--- a/deploy/hermes/install-hermes-gateway.sh
+++ b/deploy/hermes/install-hermes-gateway.sh
@@ -120,6 +120,44 @@ ensure_user_allowlist() {
     || printf 'SLACK_ALLOWED_USERS=*\n' >> "$env_file"
 }
 
+# Set Hermes's own home channel (where it delivers cron-job results and
+# cross-platform messages) from fleet config, not the interactive `/hermes
+# sethome` Slack command -- confirmed live: every fleet node greeted its
+# first message with "No home channel is set for Slack... Type /hermes
+# sethome", because nothing had ever set one. `SLACK_HOME_CHANNEL` (+
+# `_NAME`) in ~/.hermes/.env is what Hermes's own config loader
+# (gateway/config_env.py::_slack_home) reads at every startup -- the same
+# load path already used for SLACK_ALLOWED_USERS, and distinct from
+# slack.free_response_channels/slack.require_mention (configure_gateway,
+# below), which govern response behavior, not delivery routing.
+#
+# Resolving the channel name to an ID needs channel_directory.json, which
+# Hermes only writes after its first successful Slack connection -- same
+# ordering constraint resolve_home_channel_id already has for
+# free_response_channels. A node that has never connected simply gets this
+# on its next prepare, after the gateway installed by this same run has
+# connected once.
+ensure_home_channel_env() {
+  [ -n "$SLACK_HOME_CHANNEL_NAME" ] || return 0
+  local env_file="$HERMES_HOME/.env" channel_id
+  mkdir -p "$HERMES_HOME"
+  touch "$env_file"
+  if channel_id="$(resolve_home_channel_id "$SLACK_HOME_CHANNEL_NAME")"; then
+    log "setting Hermes home channel to $SLACK_HOME_CHANNEL_NAME ($channel_id)"
+    grep -v '^SLACK_HOME_CHANNEL=\|^SLACK_HOME_CHANNEL_NAME=' "$env_file" > "$env_file.tmp" 2>/dev/null \
+      || : > "$env_file.tmp"
+    {
+      cat "$env_file.tmp"
+      printf 'SLACK_HOME_CHANNEL=%s\n' "$channel_id"
+      printf 'SLACK_HOME_CHANNEL_NAME=%s\n' "$SLACK_HOME_CHANNEL_NAME"
+    } > "$env_file"
+    rm -f "$env_file.tmp"
+  else
+    log "WARNING: could not resolve #$SLACK_HOME_CHANNEL_NAME to a channel id yet" \
+        "(gateway may not have connected to Slack before); re-run prepare after it has"
+  fi
+}
+
 configure_gateway() {
   local hermes
   hermes="$(hermes_bin)" || die "hermes CLI not found"
@@ -200,6 +238,7 @@ prepare() {
   port_credentials
   migrate_claw_state
   ensure_user_allowlist
+  ensure_home_channel_env
   configure_gateway
   install_service
 }

--- a/tests/test_hermes_gateway_deploy.py
+++ b/tests/test_hermes_gateway_deploy.py
@@ -236,6 +236,74 @@ def test_free_response_channel_is_skipped_gracefully_when_unresolvable(tmp_path)
     assert not any(call[:3] == ["config", "set", "slack.free_response_channels"] for call in calls)
 
 
+def test_home_channel_env_is_set_when_directory_resolves_the_name(tmp_path):
+    # Regression: every fleet node greeted its first Slack message with
+    # "No home channel is set for Slack... Type /hermes sethome" because
+    # nothing had ever written SLACK_HOME_CHANNEL -- the env var Hermes's
+    # own config loader reads at every startup (distinct from
+    # slack.free_response_channels, which only governs response behavior).
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    hermes_home = home / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    directory = hermes_home / "channel_directory.json"
+    directory.write_text(
+        json.dumps({"channels": [{"name": "rockyandfriends", "id": "C0AMSBEU7CJ"}]}),
+        encoding="utf-8",
+    )
+    result, _calls = _run(
+        tmp_path,
+        "prepare",
+        extra_env={"MAC_HERMES_SLACK_HOME_CHANNEL_NAME": "rockyandfriends"},
+    )
+    assert result.returncode == 0, result.stderr
+    env_lines = (hermes_home / ".env").read_text(encoding="utf-8").splitlines()
+    assert "SLACK_HOME_CHANNEL=C0AMSBEU7CJ" in env_lines
+    assert "SLACK_HOME_CHANNEL_NAME=rockyandfriends" in env_lines
+
+
+def test_home_channel_env_is_skipped_gracefully_when_unresolvable(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    hermes_home = home / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    result, _calls = _run(
+        tmp_path,
+        "prepare",
+        extra_env={"MAC_HERMES_SLACK_HOME_CHANNEL_NAME": "somechannel"},
+    )
+    assert result.returncode == 0, result.stderr
+    env_text = (hermes_home / ".env").read_text(encoding="utf-8")
+    assert "SLACK_HOME_CHANNEL=" not in env_text
+
+
+def test_home_channel_env_rerun_replaces_rather_than_duplicates(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    hermes_home = home / ".hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "channel_directory.json").write_text(
+        json.dumps({"channels": [{"name": "rockyandfriends", "id": "C0AMSBEU7CJ"}]}),
+        encoding="utf-8",
+    )
+    (hermes_home / ".env").write_text(
+        "SLACK_ALLOWED_USERS=*\n"
+        "SLACK_HOME_CHANNEL=CSTALE00000\n"
+        "SLACK_HOME_CHANNEL_NAME=stalechannel\n",
+        encoding="utf-8",
+    )
+    result, _calls = _run(
+        tmp_path,
+        "prepare",
+        extra_env={"MAC_HERMES_SLACK_HOME_CHANNEL_NAME": "rockyandfriends"},
+    )
+    assert result.returncode == 0, result.stderr
+    env_lines = (hermes_home / ".env").read_text(encoding="utf-8").splitlines()
+    assert env_lines.count("SLACK_HOME_CHANNEL=C0AMSBEU7CJ") == 1
+    assert "SLACK_HOME_CHANNEL=CSTALE00000" not in env_lines
+    assert "SLACK_HOME_CHANNEL_NAME=stalechannel" not in env_lines
+
+
 def test_prepare_skips_install_when_hermes_already_on_path(tmp_path):
     result, calls = _run(tmp_path, "prepare")
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Live incident: every fleet node greeted its first Slack message with "No home channel is set for Slack... Type /hermes sethome to make this chat your home channel" -- there is no one to run an interactive Slack command for an unattended fleet agent
- Root cause: Hermes's home channel (where it delivers cron-job results and cross-platform messages) is a distinct concept from `slack.free_response_channels`/`slack.require_mention` (already correctly set by `configure_gateway`, which govern response behavior). Nothing had ever set the home channel itself.
- `SLACK_HOME_CHANNEL` (+ `SLACK_HOME_CHANNEL_NAME`) in `~/.hermes/.env` is what Hermes's own config loader reads at every startup -- same load path already proven for `SLACK_ALLOWED_USERS` (#757)
- `ensure_home_channel_env()` resolves the fleet-configured channel name via the existing `resolve_home_channel_id()` helper and writes both keys, replacing rather than duplicating on a re-run
- Fixed live on all three fleet nodes (rocky, natasha, bullwinkle) ahead of this PR, each verified directly via Hermes's own `gateway.config.load_gateway_config()` returning the correct `HomeChannel` for `Platform.SLACK`

Note: `deploy/sync-hermes-home-channels.py` takes a different, MAC-side approach (`slack_home_channels.json` consumed by `worker.py`'s own Slack-delivery code) written for the OpenClaw era -- its own consumer comments "hermes is no longer an accepted persona runtime". Not reused; that's now stale in the other direction and is separate cleanup, out of scope here.

## Test plan
- [x] `tests/test_hermes_gateway_deploy.py` (21/21, 3 new: set-on-resolve, skip-gracefully-when-unresolvable, replace-not-duplicate-on-rerun)
- [x] docs/operator-identity/docs-graph checks clean
- [x] Verified live on all three fleet nodes via Hermes's own config loader

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>