### PR TITLE
Fix opencode auto-rejecting every permission request in non-interactive task runs

### DIFF
--- a/src/mac/coding_agent.py
+++ b/src/mac/coding_agent.py
@@ -919,9 +919,16 @@ def _default_argv(agent: str, binary: str, prompt: str, *, model: str = "") -> L
         # `run` is the non-interactive entry point; the bare `opencode` default
         # subcommand starts a TUI and would hang a task run forever.
         #
-        # No approval-bypass flag is needed or offered: opencode does not
-        # prompt in `run` mode. Confinement is still the executor's OpenShell
-        # gate, exactly as for the others.
+        # `--auto` bypasses opencode's own permission prompts (e.g.
+        # "external_directory"). The comment this replaced claimed opencode
+        # never prompts in `run` mode -- false against current opencode:
+        # confirmed live, every real task execution was silently failing
+        # with every filesystem permission request auto-rejected (nothing
+        # answers an interactive prompt in a non-interactive task run),
+        # blocking agents from reading even their own task worktree.
+        # Confinement is still the executor's OpenShell gate, exactly as for
+        # the others (--dangerously-skip-permissions / --dangerously-bypass-
+        # approvals-and-sandbox above).
         #
         # Model names MUST carry the provider prefix that `opencode models`
         # prints -- "nvidia-inference/switchyard/openai/gpt-5.6-sol", not
@@ -929,7 +936,7 @@ def _default_argv(agent: str, binary: str, prompt: str, *, model: str = "") -> L
         # the CLI and then fails at the server as an opaque
         # "Unexpected server error", which is what a misconfigured node looked
         # like before this was understood.
-        argv = [binary, "run"]
+        argv = [binary, "run", "--auto"]
         if model:
             argv += ["--model", model]
         return [*argv, prompt]

--- a/tests/test_coding_agent_opencode.py
+++ b/tests/test_coding_agent_opencode.py
@@ -97,6 +97,22 @@ def test_argv_uses_run_not_the_bare_default(tmp_path):
     assert argv[-1] == "do the thing"
 
 
+def test_argv_auto_approves_permissions_non_interactively(tmp_path):
+    """opencode's own permission prompts (e.g. "external_directory") are never
+    answered in a non-interactive task run and get auto-rejected, blocking an
+    agent from even its own task worktree -- confirmed live. `--auto` bypasses
+    opencode's own approval gate; OpenShell remains the real confinement, same
+    as claude's --dangerously-skip-permissions and codex's
+    --dangerously-bypass-approvals-and-sandbox."""
+    choice = resolve_coding_agent(
+        env={"MAC_CODING_AGENT": "opencode"},
+        home=_home(tmp_path, auth=True),
+        which=_which({"opencode": "/usr/bin/opencode"}),
+    )
+    argv = coding_agent_argv(choice, "do the thing", env={})
+    assert argv[:3] == ["/usr/bin/opencode", "run", "--auto"]
+
+
 def test_model_pin_is_passed_through(tmp_path):
     choice = resolve_coding_agent(
         env={"MAC_CODING_AGENT": "opencode"},
@@ -105,7 +121,7 @@ def test_model_pin_is_passed_through(tmp_path):
     )
     model = "nvidia-inference/switchyard/openai/gpt-5.3-codex"
     argv = coding_agent_argv(choice, "p", env={"MAC_TASK_MODEL": model})
-    assert argv[2:4] == ["--model", model]
+    assert argv[3:5] == ["--model", model]
 
 
 def test_credential_sync_ships_both_trees(tmp_path):


### PR DESCRIPTION
## Summary
- Critical, fleet-wide finding: every real task execution routed to opencode was failing before doing any work
- Root cause: `opencode run` DOES issue permission prompts (e.g. "external_directory") for filesystem access, contradicting a comment claiming otherwise. Nothing answers these prompts in a non-interactive task run, so they auto-reject -- blocking an agent from even its own task-owned repository worktree
- Confirmed live on two separate fleet nodes (rocky, bullwinkle) via a canary-project stress test: identical failure signature on 3 separate task attempts
- Fix: pass `--auto` (documented by `opencode run --help`: "auto-approve permissions that are not explicitly denied"), matching the same bypass pattern already used for claude (`--dangerously-skip-permissions`) and codex (`--dangerously-bypass-approvals-and-sandbox`)

## Test plan
- [x] `tests/test_coding_agent_opencode.py` (14/14, 1 new test asserting `--auto` is present, 1 existing test's index updated for the new argv position)
- [x] `tests/test_opencode_build_executor.py` + `tests/test_coding_agents_are_provisioned_everywhere.py` (57/57, no other test asserted opencode's exact argv shape)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>