### PR TITLE
Resolve auto-land's contract gate from the target repo's own contract, not a hardcoded mac-only path

### DIFF
--- a/src/mac/auto_land.py
+++ b/src/mac/auto_land.py
@@ -391,15 +391,27 @@ def _default_subprocess_runner(argv, *, cwd=None):  # pragma: no cover - thin sh
 def run_contract_gate(
     repo_dir: str = ".",
     *,
-    script: str = _CONTRACT_SCRIPT,
+    command: Optional[str] = None,
     runner: Callable[..., Any] = _default_subprocess_runner,
 ) -> ContractResult:
     """Invoke the machine contract gate and translate exit code -> GREEN/RED.
 
+    ``command`` is the target repository's own contract test command (its
+    ``.mac/project.yaml`` ``test.command``, resolved by the caller -- this
+    function has no repository-registry access of its own). It defaults to
+    this repository's own ``scripts/run-contract-tests.sh`` only when the
+    caller has no repository-specific command to offer (e.g. landing this
+    repo itself, or a target with no registered contract).
+
+    Run via ``bash -c`` rather than treated as a script *file*: a real
+    contract's ``test.command`` is an arbitrary shell command (for example
+    ``pytest -q && mypy pkg``), not necessarily a bare path -- ``bash
+    -c`` handles both a bare path and a compound command identically.
     ``scripts/run-contract-tests.sh`` exits 0 only when the tests pass AND the
     coverage-policy floors hold; any nonzero exit is RED.
     """
-    proc = runner(["bash", script], cwd=repo_dir)
+    resolved = (command or _CONTRACT_SCRIPT).strip()
+    proc = runner(["bash", "-c", resolved], cwd=repo_dir)
     rc = int(getattr(proc, "returncode", 1))
     stdout = getattr(proc, "stdout", "") or ""
     stderr = getattr(proc, "stderr", "") or ""
@@ -746,6 +758,30 @@ def notify_human(
     return notification
 
 
+def _resolve_target_test_command(target: str, *, plane: Any) -> Optional[str]:
+    """Best-effort: the target task's own repository contract's test command.
+
+    ``target`` is usually a task id (the normal ``mac review auto-land
+    <task_id>`` shape); it may also be a bare branch/ref, which has no task
+    metadata to consult. Either way this never raises -- a target with no
+    resolvable contract command falls back to this repo's own contract
+    script in :func:`run_contract_gate`, which is the previous behavior.
+    """
+    if plane is None:
+        return None
+    try:
+        task = plane.get_task(target)
+    except Exception:  # noqa: BLE001 - not a task id, or lookup unavailable
+        return None
+    from mac.executor_prompt import _repository_contract_test_command
+
+    try:
+        command = _repository_contract_test_command({"metadata": task.metadata})
+    except Exception:  # noqa: BLE001 - malformed metadata must not block the gate
+        return None
+    return command.strip() or None
+
+
 def build_real_dependencies(
     *,
     plane: Any = None,
@@ -767,7 +803,9 @@ def build_real_dependencies(
     return {
         "author": author,
         "resolve_head_sha": lambda target: _resolve_head_sha(target, repo_dir=repo_dir),
-        "run_contract": lambda target: run_contract_gate(repo_dir),
+        "run_contract": lambda target: run_contract_gate(
+            repo_dir, command=_resolve_target_test_command(target, plane=plane)
+        ),
         "run_review": lambda target: run_adversarial_review(
             target, repo_dir=repo_dir, env=env, author=author
         ),

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -6296,6 +6296,9 @@ def cmd_review_auto_land(args: argparse.Namespace) -> None:
     author = getattr(args, "author", "") or os.environ.get("MAC_AGENT_ID", "")
     if getattr(args, "dry_run", False):
         # Preview only: never runs the contract gate, spawns a reviewer, or lands.
+        # The literal script name below is a fixed label, not necessarily what
+        # will run -- the real gate resolves the target's own repository
+        # contract test command first (see auto_land.run_contract_gate).
         _print(
             {
                 "schema": "mac.auto_land.dry_run.v1",
@@ -6306,7 +6309,8 @@ def cmd_review_auto_land(args: argparse.Namespace) -> None:
                 "author": author,
                 "would_run": ["contract-gate", "adversarial-review"],
                 "gates": [
-                    "contract (scripts/run-contract-tests.sh)",
+                    "contract (the target's own repository-contract test command,"
+                    " falling back to scripts/run-contract-tests.sh)",
                     "adversarial-review (independent agent, default-to-reject)",
                     "independence (reviewer != author)",
                     "head_sha (land only the reviewed revision)",

--- a/tests/test_auto_land.py
+++ b/tests/test_auto_land.py
@@ -219,6 +219,75 @@ def test_run_contract_gate_red_on_nonzero():
     assert result.details["returncode"] == 1
 
 
+def test_run_contract_gate_defaults_to_mac_own_script_via_bash_dash_c():
+    recorded = {}
+
+    def runner(argv, cwd=None):
+        recorded["argv"] = argv
+        recorded["cwd"] = cwd
+        return _Proc(0, "all pass")
+
+    result = run_contract_gate(".", runner=runner)
+    assert result.green is True
+    # "mac"'s own contract script is a bare path; bash -c must still run it
+    # correctly (no regression for the primary repo).
+    assert recorded["argv"] == ["bash", "-c", "scripts/run-contract-tests.sh"]
+
+
+def test_run_contract_gate_runs_a_foreign_repos_compound_test_command():
+    recorded = {}
+
+    def runner(argv, cwd=None):
+        recorded["argv"] = argv
+        return _Proc(0, "1 passed")
+
+    result = run_contract_gate(
+        "/some/other/repo",
+        command=".venv/bin/pytest -q && .venv/bin/mypy toolkit",
+        runner=runner,
+    )
+    assert result.green is True
+    # A compound shell command (&&) must run via `bash -c`, never treated as
+    # a filename -- `bash <that string>` would fail with "No such file".
+    assert recorded["argv"] == [
+        "bash",
+        "-c",
+        ".venv/bin/pytest -q && .venv/bin/mypy toolkit",
+    ]
+
+
+def test_resolve_target_test_command_uses_the_targets_own_repository_contract():
+    from mac.auto_land import _resolve_target_test_command
+
+    class _FakeTask:
+        metadata = {
+            "execution_contract": {
+                "repository_contract": {
+                    "test": {"command": ".venv/bin/pytest -q && .venv/bin/mypy toolkit"}
+                }
+            }
+        }
+
+    class _FakePlane:
+        def get_task(self, target):
+            assert target == "task_abc123"
+            return _FakeTask()
+
+    command = _resolve_target_test_command("task_abc123", plane=_FakePlane())
+    assert command == ".venv/bin/pytest -q && .venv/bin/mypy toolkit"
+
+
+def test_resolve_target_test_command_falls_back_to_none_for_a_non_task_target():
+    from mac.auto_land import _resolve_target_test_command
+
+    class _RaisingPlane:
+        def get_task(self, target):
+            raise LookupError("not a task id")
+
+    assert _resolve_target_test_command("some-branch", plane=_RaisingPlane()) is None
+    assert _resolve_target_test_command("task_x", plane=None) is None
+
+
 class _Choice:
     def __init__(self, available=True, agent="claude"):
         self.available = available


### PR DESCRIPTION
## Summary
- `mac admin review auto-land` was hardcoded to run `scripts/run-contract-tests.sh` for any `--repo-dir`, so it only ever worked for `mac` itself. Confirmed live against a freshly-registered project (`jordanhubbard/mac-fleet-canary`) -- it would invoke a script that doesn't exist there.
- `run_contract_gate()` now resolves the target task's own repository-contract `test.command` (reusing `executor_prompt._repository_contract_test_command`, the same reader normal task execution already uses), falling back to `mac`'s own script only when no contract command resolves.
- Execution now goes through `bash -c`, not `bash <path>` -- a real contract's `test.command` can be a compound shell command (`pytest -q && mypy pkg`), which `bash <string-as-filename>` can't run.

## Test plan
- [x] `tests/test_auto_land.py` (60/60 passing, 4 new tests: bash -c invocation for both the default script and a compound foreign-repo command, contract-command resolution from task metadata, graceful fallback for a non-task target)
- [x] ruff clean
- [x] impact-map current

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>