### PR TITLE
Fix three task-lifecycle bugs blocking fleet autonomy under concurrency

### DIFF
--- a/src/mac/api_client.py
+++ b/src/mac/api_client.py
@@ -32,7 +32,21 @@ def _default_timeout_seconds() -> float:
 
 
 class MacApiError(RuntimeError):
-    """Raised when a MAC API operation cannot be completed."""
+    """Raised when a MAC API operation cannot be completed.
+
+    ``status_code``/``detail`` are populated for an HTTP error response
+    (None for a transport-level failure like a timeout or DNS error) so a
+    caller can distinguish a transient, retryable condition -- a fenced-write
+    conflict ("task state changed during fenced write; retry") reported as a
+    normal HTTP 400 -- from a genuine, permanent rejection, without having to
+    string-match the formatted message. The message format itself is
+    unchanged for existing ``str(exc)`` callers.
+    """
+
+    def __init__(self, message: str, *, status_code: Optional[int] = None, detail: str = ""):
+        super().__init__(message)
+        self.status_code = status_code
+        self.detail = detail
 
 
 class MacApiClient:
@@ -95,7 +109,11 @@ class MacApiClient:
                 raw = response.read().decode("utf-8")
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8")
-            raise MacApiError("mac API %s %s failed: %s" % (method, path, detail)) from exc
+            raise MacApiError(
+                "mac API %s %s failed: %s" % (method, path, detail),
+                status_code=exc.code,
+                detail=detail,
+            ) from exc
         except urllib.error.URLError as exc:
             raise MacApiError("mac API %s %s failed: %s" % (method, path, exc.reason)) from exc
         except OSError as exc:

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -188,6 +188,7 @@ from mac.models import (
     WorkflowDraft,
 )
 from mac.repository_hygiene import (
+    AUTO_CLEANUP_DISPOSITIONS,
     repository_ref_lifecycle_for_transition,
 )
 from mac.env_config import resolve_hub_agent
@@ -24367,6 +24368,26 @@ class ControlPlane:
     def _dependency_state_satisfies_join(state: str, metadata: Any, join: str) -> bool:
         if state == TaskState.COMPLETED.value:
             return True
+        if state == TaskState.CANCELLED.value:
+            # A cancellation whose disposition asserts the underlying goal was
+            # met elsewhere (the same AUTO_CLEANUP_DISPOSITIONS set governing
+            # repository-ref cleanup: duplicate/superseded/not_applicable)
+            # satisfies even the strict "all_success" join -- it is not a
+            # failure to route around, it IS the resolution. Confirmed live:
+            # an onboarding task was closed --cancelled --disposition
+            # not_applicable after its repository contract was registered
+            # through a different, equally valid path; its 10 dependents had
+            # no join-policy opt-in (the default is "all_success") and stayed
+            # permanently blocked/waiting until dependencies were cleared by
+            # hand. A genuine "this isn't happening" cancellation
+            # (disposition=preserve, or none) still only satisfies
+            # "all_settled" below, unchanged.
+            lifecycle = ensure_json_object(
+                ensure_json_object(metadata).get("repository_ref_lifecycle")
+            )
+            disposition = str(lifecycle.get("disposition") or "").strip().lower()
+            if disposition in AUTO_CLEANUP_DISPOSITIONS:
+                return True
         if join != "all_settled":
             return False
         if state in {

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -223,6 +223,50 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+#: Bounded retry for a fenced-write conflict on a state-mutating API call
+#: (currently just POST .../start). A fenced write means the server detected
+#: a CONCURRENT, valid write racing this one and refused rather than
+#: corrupting state -- by construction transient, since the conflicting
+#: writer's own operation is already completing. Confirmed live: an unrelated
+#: concurrent operator call (mac task update --dependencies) racing an
+#: agent's claim+start on the same task produced exactly this 400, and the
+#: worker treated it as a fatal "worker_exception", transitioning the task
+#: straight to permanently blocked instead of retrying what the server's own
+#: error message says is retryable ("task state changed during fenced
+#: write; retry"). 3 attempts with a short, fixed backoff resolves this in
+#: virtually all real cases without masking a genuinely stuck/looping
+#: conflict behind indefinite retries.
+FENCED_WRITE_RETRY_ATTEMPTS = 3
+FENCED_WRITE_RETRY_DELAY_SECONDS = 0.5
+
+
+def _is_fenced_write_conflict(exc: "MacApiError") -> bool:
+    if exc.status_code != 400:
+        return False
+    return "fenced write" in (exc.detail or str(exc)).lower()
+
+
+def _post_with_fenced_write_retry(
+    client: "MacApiClient",
+    path: str,
+    payload: JsonDict,
+    *,
+    attempts: int = FENCED_WRITE_RETRY_ATTEMPTS,
+    delay_seconds: float = FENCED_WRITE_RETRY_DELAY_SECONDS,
+    sleep: Callable[[float], None] = time.sleep,
+) -> Any:
+    last_exc: Optional[MacApiError] = None
+    for attempt in range(1, max(1, attempts) + 1):
+        try:
+            return client.post(path, payload)
+        except MacApiError as exc:
+            if not _is_fenced_write_conflict(exc) or attempt == attempts:
+                raise
+            last_exc = exc
+            sleep(delay_seconds)
+    raise last_exc  # pragma: no cover - unreachable, loop always returns or raises
+
+
 #: How long after the first SIGTERM/SIGINT the worker keeps letting the current
 #: task run before it actively abandons the assignment (releases the lease and
 #: goes offline). Tuned to the unit that runs it: ``mac-agent-service`` sets
@@ -1596,7 +1640,8 @@ class MacWorker(
             detail={"lease_id": lease_id, "agent_id": self.agent_id},
         )
         try:
-            self.client.post(
+            _post_with_fenced_write_retry(
+                self.client,
                 "/tasks/%s/start?%s"
                 % (
                     quote(task_id, safe=""),
@@ -5042,17 +5087,33 @@ class MacWorker(
         ):
             problems.append("verification.signed_by and verification.signature are required")
         if evidence_type:
-            if (
-                evidence_type == "investigation"
-                and declared_non_repository_outcome_evidence_type(
-                    ensure_json_object(task_payload.get("metadata"))
-                )
-                != "investigation"
-            ):
+            declared_outcome = declared_non_repository_outcome_evidence_type(
+                ensure_json_object(task_payload.get("metadata"))
+            )
+            if evidence_type == "investigation" and declared_outcome != "investigation":
                 problems.append(
                     "investigation evidence requires an operator-authored "
                     "investigation execution contract"
                 )
+            elif declared_outcome and evidence_type != declared_outcome:
+                # The reverse mismatch: the task's own execution contract
+                # declares a non-repository outcome (e.g. an onboarding
+                # contract-authoring task, evidence_type=investigation,
+                # repository_required=False -- see
+                # ControlPlane._normalize_task_execution_contract), but the
+                # agent's own evidence manifest claims a repo-coupled type
+                # (commonly "repo_change", the executor's generic default
+                # whenever it made a git commit). Trusting the agent's claim
+                # here demanded pushed=true/pr_url from a task whose own
+                # instructions explicitly say "do NOT push or open a pull
+                # request" -- confirmed live: an agent that followed those
+                # instructions correctly was blocked by its own tooling's
+                # wrong evidence_type default. The task's declared contract
+                # is the operator's authoritative intent; the agent cannot
+                # unilaterally impose a stricter requirement than what was
+                # asked. Coerce rather than reject: the agent already did
+                # the work correctly, so use the correct decoder for it.
+                evidence_type = declared_outcome
             problems.extend(
                 _worker_verification_contract_problems(
                     manifest,

--- a/tests/test_dependency_cancelled_with_disposition_satisfies_join.py
+++ b/tests/test_dependency_cancelled_with_disposition_satisfies_join.py
@@ -1,0 +1,130 @@
+"""A cancelled dependency whose disposition asserts its goal was met
+elsewhere satisfies even the strict default "all_success" join, not just
+"all_settled".
+
+Confirmed live: a repository-onboarding task was closed
+`--cancelled --disposition not_applicable` after its actual goal (a
+registered repository contract) was achieved through a different, equally
+valid path (a direct `mac admin bridge repository register` call). Its 10
+dependents had no join-policy opt-in -- the default is "all_success" -- and
+stayed permanently blocked/waiting, requiring dependencies to be cleared by
+hand on every one of them.
+
+Note: "duplicate"/"superseded" dispositions already redirect the dependency
+edge to their replacement_task_id (see _canonical_task_dependency_ids /
+whatever rewires the edge on close) -- the join then correctly waits on the
+replacement instead of releasing blindly, which is MORE correct than a bare
+release and is exercised separately below. Only "not_applicable" (no
+replacement -- "this need doesn't exist anymore, full stop") hits the new
+_dependency_state_satisfies_join branch directly and releases immediately.
+
+A genuine "this isn't happening" cancellation (no disposition, or
+disposition=preserve/failed_attempt) must still NOT satisfy "all_success" --
+that half is already covered by test_all_success_is_unaffected in
+test_dependency_settled_without_output.py and is re-asserted here too, so the
+two behaviors stay visibly paired.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.models import TaskState
+from mac.services import ControlPlane
+
+
+@pytest.fixture()
+def cp():
+    plane = ControlPlane.in_memory()
+    plane.create_project("mac", dispatch_paused=False)
+    return plane
+
+
+def _force_complete(cp, task_id: str) -> None:
+    cp.store.execute(
+        "UPDATE tasks SET state = ? WHERE id = ?", (TaskState.COMPLETED.value, task_id)
+    )
+
+
+def test_cancelled_not_applicable_satisfies_all_success_immediately(cp):
+    child = cp.create_task("author a project contract", project="mac")
+    parent = cp.create_task(
+        "ordinary downstream work",
+        project="mac",
+        dependencies=[child.id],
+    )
+
+    cp.close_task(
+        child.id,
+        "cancelled",
+        "operator",
+        detail={
+            "disposition": "not_applicable",
+            "reason": "goal achieved through a different path",
+        },
+    )
+
+    assert cp._dependencies_satisfied(cp.get_task(parent.id)) is True
+
+
+@pytest.mark.parametrize("disposition", ["superseded", "duplicate"])
+def test_cancelled_with_replacement_redirects_the_join_not_releases_it(cp, disposition):
+    """The join must not release blindly when there IS a replacement --
+    it should wait on the replacement's own completion instead."""
+    child = cp.create_task("author a project contract", project="mac")
+    parent = cp.create_task(
+        "ordinary downstream work",
+        project="mac",
+        dependencies=[child.id],
+    )
+    replacement = cp.create_task("the equally valid other path", project="mac")
+
+    cp.close_task(
+        child.id,
+        "cancelled",
+        "operator",
+        detail={
+            "disposition": disposition,
+            "reason": "goal achieved through a different path",
+            "replacement_task_id": replacement.id,
+        },
+    )
+
+    # Redirected, not yet satisfied: the replacement hasn't completed.
+    assert cp._canonical_task_dependency_ids(parent.id) == [replacement.id]
+    assert cp._dependencies_satisfied(cp.get_task(parent.id)) is False
+
+    _force_complete(cp, replacement.id)
+
+    assert cp._dependencies_satisfied(cp.get_task(parent.id)) is True
+
+
+def test_cancelled_with_no_disposition_still_blocks_all_success(cp):
+    child = cp.create_task("do the thing", project="mac")
+    parent = cp.create_task(
+        "ordinary downstream work",
+        project="mac",
+        dependencies=[child.id],
+    )
+
+    cp.close_task(child.id, "cancelled", "operator", detail={"reason": "abandoned"})
+
+    assert cp._dependencies_satisfied(cp.get_task(parent.id)) is False
+
+
+def test_cancelled_failed_attempt_still_blocks_all_success(cp):
+    child = cp.create_task("do the thing", project="mac")
+    parent = cp.create_task(
+        "ordinary downstream work",
+        project="mac",
+        dependencies=[child.id],
+    )
+
+    cp.close_task(
+        child.id,
+        "cancelled",
+        "operator",
+        detail={"disposition": "failed_attempt", "reason": "retries exhausted"},
+    )
+
+    assert cp._dependencies_satisfied(cp.get_task(parent.id)) is False

--- a/tests/test_worker_fenced_write_retry.py
+++ b/tests/test_worker_fenced_write_retry.py
@@ -1,0 +1,93 @@
+"""A fenced-write conflict on POST .../start is transient by construction
+(the server detected a concurrent, valid write racing this one and refused
+rather than corrupt state) -- the worker must retry it a bounded number of
+times instead of treating it as a fatal worker_exception.
+
+Confirmed live: an unrelated concurrent operator call (`mac task update
+--dependencies`) racing an agent's claim+start on the same task produced
+`mac API POST /tasks/<id>/start?... failed:
+{"detail":"task state changed during fenced write; retry"}` -- HTTP 400 --
+and the worker transitioned the task straight to permanently `blocked`
+rather than retrying what the server's own error message says is
+retryable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mac.api_client import MacApiError
+from mac.worker import (
+    FENCED_WRITE_RETRY_ATTEMPTS,
+    _is_fenced_write_conflict,
+    _post_with_fenced_write_retry,
+)
+
+
+def _fenced_write_error() -> MacApiError:
+    detail = '{"detail":"task state changed during fenced write; retry"}'
+    return MacApiError(
+        "mac API POST /tasks/task_x/start?... failed: %s" % detail,
+        status_code=400,
+        detail=detail,
+    )
+
+
+def _ordinary_400() -> MacApiError:
+    detail = '{"detail":"lease_id does not match the active lease"}'
+    return MacApiError(
+        "mac API POST /tasks/task_x/start?... failed: %s" % detail,
+        status_code=400,
+        detail=detail,
+    )
+
+
+def test_is_fenced_write_conflict_matches_only_the_specific_400():
+    assert _is_fenced_write_conflict(_fenced_write_error()) is True
+    assert _is_fenced_write_conflict(_ordinary_400()) is False
+
+
+def test_retries_and_succeeds_on_a_transient_fenced_write_conflict():
+    calls = {"count": 0}
+
+    class _Client:
+        def post(self, path, payload):
+            calls["count"] += 1
+            if calls["count"] < 2:
+                raise _fenced_write_error()
+            return {"ok": True, "path": path}
+
+    result = _post_with_fenced_write_retry(
+        _Client(), "/tasks/task_x/start", {}, sleep=lambda _seconds: None
+    )
+
+    assert result == {"ok": True, "path": "/tasks/task_x/start"}
+    assert calls["count"] == 2
+
+
+def test_gives_up_after_the_bounded_attempt_count():
+    calls = {"count": 0}
+
+    class _Client:
+        def post(self, path, payload):
+            calls["count"] += 1
+            raise _fenced_write_error()
+
+    with pytest.raises(MacApiError):
+        _post_with_fenced_write_retry(_Client(), "/tasks/task_x/start", {}, sleep=lambda _s: None)
+
+    assert calls["count"] == FENCED_WRITE_RETRY_ATTEMPTS
+
+
+def test_an_ordinary_400_is_not_retried():
+    calls = {"count": 0}
+
+    class _Client:
+        def post(self, path, payload):
+            calls["count"] += 1
+            raise _ordinary_400()
+
+    with pytest.raises(MacApiError):
+        _post_with_fenced_write_retry(_Client(), "/tasks/task_x/start", {}, sleep=lambda _s: None)
+
+    assert calls["count"] == 1

--- a/tests/test_worker_investigation_evidence_type_mismatch.py
+++ b/tests/test_worker_investigation_evidence_type_mismatch.py
@@ -1,0 +1,110 @@
+"""Regression: a task whose own execution contract declares a non-repository
+outcome (evidence_type=investigation, repository_required=False -- e.g. the
+`mac project register` onboarding task, whose own instructions say "do NOT
+push or open a pull request") must not be blocked by demanding
+pushed=true/pr_url just because the agent's own evidence manifest defaulted
+to evidence_type="repo_change" (the executor's generic default whenever it
+made a git commit). Confirmed live: an agent (bullwinkle) did the onboarding
+work correctly -- authored .mac/project.yaml, committed it locally exactly as
+instructed -- and was blocked with "repo evidence requires pushed=true with
+remote_ref, or pr_url" anyway, because the worker trusted the agent's
+(wrong) manifest evidence_type over the task's own declared contract.
+
+The task's declared execution_contract is the operator's authoritative
+intent; the worker must coerce a mismatched agent-claimed evidence_type back
+to the task's declared non-repository outcome rather than reject the work.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from mac import worker
+from mac.worker import MacWorker
+
+
+def _write_task(task_dir: Path, task_id: str, *, metadata: Dict[str, Any]) -> None:
+    (task_dir / "task.json").write_text(
+        json.dumps(
+            {"task": {"id": task_id, "title": "author project contract", "metadata": metadata}}
+        ),
+        encoding="utf-8",
+    )
+
+
+def _investigation_task_metadata() -> Dict[str, Any]:
+    # Mirrors ControlPlane._register_repository_onboarding_task's metadata
+    # shape: a top-level evidence_type hint plus the normalized
+    # execution_contract it drives (mac.task_execution_contract.v1,
+    # reason=explicit_non_repository_outcome, repository_required=False).
+    return {
+        "evidence_type": "investigation",
+        "execution_contract": {
+            "schema": "mac.task_execution_contract.v1",
+            "type": "operator_directive",
+            "evidence_type": "investigation",
+            "quality": "weak",
+            "reason": "explicit_non_repository_outcome",
+            "repository_required": False,
+            "repository_context": {"workflow_role": "work"},
+            "required_capabilities": [],
+        },
+    }
+
+
+def _manifest(evidence_type: str, *, pushed: bool = False) -> Dict[str, Any]:
+    repo: Dict[str, Any] = {"head_sha": "a" * 40, "dirty": False, "pushed": pushed}
+    return {
+        "schema": worker.VERIFICATION_SCHEMA,
+        "status": "complete",
+        "evidence_type": evidence_type,
+        "signed_by": "agent-test",
+        "signature": "sig",
+        "repo": repo,
+        "summary": "authored .mac/project.yaml and committed it locally",
+    }
+
+
+def _make_worker() -> MacWorker:
+    return MacWorker.__new__(MacWorker)  # type: ignore[call-arg]
+
+
+def test_agent_mislabeled_repo_change_is_coerced_to_declared_investigation(tmp_path: Path):
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    _write_task(task_dir, "task_onboard", metadata=_investigation_task_metadata())
+
+    # The agent did the work correctly (committed locally, did not push, per
+    # its instructions) but its own tooling defaulted evidence_type to
+    # "repo_change" rather than the task-declared "investigation".
+    manifest = _manifest("repo_change", pushed=False)
+    evidence = {"metadata": {"verification": manifest}}
+
+    w = _make_worker()
+    problems = w._execution_submission_problems(task_dir, evidence)
+
+    assert problems == [], (
+        "a task-declared non-repository outcome must not be rejected for "
+        "missing push evidence just because the agent's manifest claimed "
+        "repo_change: %r" % (problems,)
+    )
+
+
+def test_agent_falsely_claiming_investigation_is_still_rejected(tmp_path: Path):
+    # The reverse direction (already covered, kept here as a paired
+    # sanity check so the two behaviors are visibly symmetric in one file):
+    # an agent cannot unilaterally claim evidence_type=investigation on an
+    # ordinary repo_change task to dodge push requirements.
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    _write_task(task_dir, "task_ordinary", metadata={})
+
+    manifest = _manifest("investigation", pushed=False)
+    evidence = {"metadata": {"verification": manifest}}
+
+    w = _make_worker()
+    problems = w._execution_submission_problems(task_dir, evidence)
+
+    assert any("operator-authored" in problem for problem in problems)


### PR DESCRIPTION
## Summary
Three real, live-confirmed defects undermining "take any task all the way to fruition when multiple agents/operations race on the same repo, branch, or dependency graph":

1. **`worker.py`**: a task whose own `execution_contract` declares a non-repository outcome (`evidence_type=investigation`, `repository_required=False` — e.g. the `mac project register` onboarding task, whose own instructions say "do NOT push") was rejected demanding `pushed=true`/`pr_url` whenever the agent's own evidence manifest defaulted `evidence_type` to `"repo_change"`. Fixed by coercing a mismatched agent-claimed `evidence_type` back to the task's declared contract.
2. **`services.py`**: a cancelled dependency with a disposition asserting its goal was met elsewhere (`not_applicable`, no replacement task) left dependents permanently blocked under the default `all_success` join. Fixed `_dependency_state_satisfies_join` to treat this case as satisfying even the strict join. (`superseded`/`duplicate` were already correctly handled via edge redirection — verified, not touched.)
3. **`worker.py`/`api_client.py`**: a fenced-write conflict on `POST .../start` (server says "retry" in its own error) was treated as fatal, permanently blocking the task. Added a bounded 3-attempt retry specific to this condition; `MacApiError` now carries `status_code`/`detail` so this doesn't require string-matching.

## Test plan
- [x] 11 new regression tests across 3 new test files, all passing
- [x] 477 existing worker/api_client tests pass, no regressions
- [x] ruff check + format clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>