### PR TITLE
Retry open-PR duplicate check on transient failure, preserve the cause

### DIFF
--- a/src/mac/gitops.py
+++ b/src/mac/gitops.py
@@ -1005,11 +1005,29 @@ def _find_existing_task_pr(
 ) -> Optional[PullRequestResult]:
     """Find an open PR for a task across lease-specific branch names."""
     list_url = "%s/repos/%s/%s/pulls?state=open" % (api_base, owner, repo)
-    try:
-        data = _http_get_json(list_url, headers)
-    except Exception:
+    last_exc: Optional[Exception] = None
+    data = None
+    # Concurrent agents publishing to the same small repo can transiently
+    # trip this GET (timeout, rate limiting, momentary forge hiccup) --
+    # confirmed live: one of three agents landing on the same fresh repo
+    # within seconds of each other hit this and silently never opened its
+    # PR, because the failure was fatal on the first try. A few short
+    # retries resolve the transient case without weakening the fail-closed
+    # duplicate-prevention guarantee below.
+    for attempt in range(3):
+        try:
+            data = _http_get_json(list_url, headers)
+            last_exc = None
+            break
+        except Exception as exc:  # noqa: BLE001 - retried below, re-raised with cause if exhausted
+            last_exc = exc
+            if attempt < 2:
+                time.sleep(0.5 * (attempt + 1))
+    if last_exc is not None:
         # Fail closed: an unreadable task index must not mint a possible duplicate.
-        raise RuntimeError("could not verify whether task %s already has an open PR" % task_id)
+        raise RuntimeError(
+            "could not verify whether task %s already has an open PR: %s" % (task_id, last_exc)
+        ) from last_exc
     if not isinstance(data, list):
         raise RuntimeError("forge returned an invalid open-PR index for task %s" % task_id)
     for pr in data:

--- a/tests/test_gitops.py
+++ b/tests/test_gitops.py
@@ -207,6 +207,7 @@ def test_open_pull_request_reuses_task_pr_across_lease_branches(monkeypatch) -> 
 
 def test_open_pull_request_fails_closed_when_task_pr_index_is_unreadable(monkeypatch) -> None:
     monkeypatch.setenv("GH_TOKEN", "ghp_xxx")
+    monkeypatch.setattr("mac.gitops.time.sleep", lambda _seconds: None)
 
     def offline(req: Any, timeout: float = 0) -> _FakeResponse:
         url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
@@ -215,12 +216,51 @@ def test_open_pull_request_fails_closed_when_task_pr_index_is_unreadable(monkeyp
         return _FakeResponse({"default_branch": "main"})
 
     with mock.patch("mac.gitops.urllib.request.urlopen", side_effect=offline):
-        with pytest.raises(RuntimeError, match="could not verify"):
+        with pytest.raises(RuntimeError, match="could not verify") as excinfo:
             open_pull_request(
                 "https://github.com/x/y.git",
                 head="lease-specific",
                 title="work (task_d5b6ebd1146e789c114037cda9fff9d9)",
             )
+    # The underlying transient error is preserved, not swallowed -- a bare
+    # "could not verify" with no cause is undiagnosable when this recurs.
+    assert "offline" in str(excinfo.value)
+    assert excinfo.value.__cause__ is not None
+
+
+def test_open_pull_request_retries_transient_pr_index_failure_then_succeeds(monkeypatch) -> None:
+    # Concurrent agents publishing to the same fresh repo can transiently trip
+    # this GET (rate limiting, a momentary forge hiccup) -- confirmed live: one
+    # of three agents landing on jordanhubbard/mac-fleet-canary within seconds
+    # of the others hit exactly this and never opened its PR because the first
+    # failure was treated as fatal.
+    monkeypatch.setenv("GH_TOKEN", "ghp_xxx")
+    monkeypatch.setattr("mac.gitops.time.sleep", lambda _seconds: None)
+    posts = []
+    attempts = {"list": 0}
+
+    def flaky_then_recovers(req: Any, timeout: float = 0) -> _FakeResponse:
+        url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
+        if req.get_method() == "POST":
+            posts.append(json.loads(req.data.decode("utf-8")))
+            return _FakeResponse({"number": 9, "html_url": "https://github.com/x/y/pull/9"})
+        if "/pulls?state=open" in url:
+            attempts["list"] += 1
+            if attempts["list"] < 3:
+                raise OSError("transient forge hiccup")
+            return _FakeResponse([])
+        return _FakeResponse({"default_branch": "main"})
+
+    with mock.patch("mac.gitops.urllib.request.urlopen", side_effect=flaky_then_recovers):
+        result = open_pull_request(
+            "https://github.com/x/y.git",
+            head="lease-specific",
+            title="work (task_d5b6ebd1146e789c114037cda9fff9d9)",
+        )
+
+    assert result.number == 9
+    assert attempts["list"] == 3
+    assert len(posts) == 1
 
 
 def test_https_remote_for_token_auth_rewrites_ssh_when_token_present(


### PR DESCRIPTION
## Summary
- Root-caused a real bug found live this session: 3 concurrent fleet agents publishing to the same fresh canary repo, one agent's PR-open step silently never fired across all 3 of its tasks
- `_find_existing_task_pr`'s duplicate-check GET failed closed on any exception (correct -- avoids minting a duplicate PR) but also **swallowed the real error**, making a recurrence undiagnosable
- Added a bounded 3-attempt retry with short backoff for this specific transient-prone call, and chained the real exception via `from last_exc`

## Test plan
- [x] `tests/test_gitops.py` (39/39, 1 new test proving retry-then-succeed, 1 existing test extended to assert the real cause is preserved)
- [x] ruff check + format clean
- [x] impact-map current

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>