### PR TITLE
Grant workers a narrow review:advance scope for the post-verdict tick

### DIFF
--- a/src/mac/api.py
+++ b/src/mac/api.py
@@ -2438,11 +2438,23 @@ def _required_scope(method: str, path: str) -> Optional[str]:
         # is doing infra work, not user-facing writes).
         return "deploy"
     if path.startswith("/reviews/default"):
-        # The automated review tick is the closest thing the swarm has
-        # to an auto-merge button. Restrict to admin so an ordinary
-        # `write` token can't flush every reviewable task to
-        # COMPLETED on demand. mac-iez.
-        return "admin"
+        # The automated review tick is the closest thing the swarm has to an
+        # auto-merge button, so it does not fall under the generic `write`
+        # bucket (mac-iez). It is NOT admin-only either: a worker cannot
+        # advance a task's review to COMPLETED by calling this route --
+        # `advance_default_review_workflows` only lands work that already has
+        # a recorded, independently-authored verdict from `/reviews/{id}/decision`
+        # (itself gated by `_assert_review_actor`, so a worker can never
+        # author its own approval). This route just drains the queue for
+        # decisions that already exist. Without a scope a normal fleet worker
+        # holds, every worker's own post-verdict tick call was rejected with
+        # "token lacks required scope: admin", so the queue only drained when
+        # an admin-scoped caller happened to invoke it manually -- REVIEWING
+        # tasks piled up for months. `review:advance` is minted into every
+        # worker credential (WORKER_SCOPES) but is deliberately NOT inherited
+        # by a plain `write` token (TokenPrincipal.has_scope), so a
+        # non-fleet write-scoped caller still cannot flush the queue.
+        return "review:advance"
     if re.match(r"^/tasks/[^/]+/(force-complete|reopen|release|ask|answer)$", path):
         # These recovery/control-plane endpoints bypass normal worker flow or
         # make held work dispatchable. They must never be available to an

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -1021,6 +1021,12 @@ class MacWorker(
         # Rate-limit self-heal rotations: one per window, so a non-key cause of
         # signature rejections can never drive a rotation loop.
         self._last_attestation_heal_at = 0.0
+        # Rate-limit the post-verdict review-tick failure log: a genuine,
+        # ongoing outage (not the routine "token lacks required scope: admin"
+        # rejection this used to hit before every worker credential carried
+        # `review:advance`) should still be visible, but not as a warning per
+        # verdict recorded.
+        self._last_review_advance_failure_logged_at = 0.0
         self.poll_interval_seconds = float(poll_interval_seconds)
         self._inner_loop_wake = threading.Event()
         self._inner_loop = PersistentAgentLoop(
@@ -2767,13 +2773,25 @@ class MacWorker(
                 {},
             )
         except Exception as exc:  # noqa: BLE001 - verdict evidence is already recorded.
-            self._observe_log(
-                "worker.review_workflow.advance_failed",
-                level="warning",
-                subject_type="task",
-                subject_id=task_id,
-                detail={"agent_id": self.agent_id, "error": str(exc)},
-            )
+            # This used to fire on every verdict recorded fleet-wide (any
+            # worker token lacked the scope for /reviews/default/tick,
+            # rejected "token lacks required scope: admin") -- a permanent,
+            # expected failure, not a transient one, so it was pure log spam
+            # rather than a signal anyone could act on. Now that
+            # `review:advance` is minted into every worker credential
+            # (WORKER_SCOPES), a failure here is a real, actionable signal
+            # again -- but still rate-limit it, since a genuine outage would
+            # otherwise still log once per verdict across the whole fleet.
+            now = time.monotonic()
+            if now - self._last_review_advance_failure_logged_at >= 300.0:
+                self._last_review_advance_failure_logged_at = now
+                self._observe_log(
+                    "worker.review_workflow.advance_failed",
+                    level="warning",
+                    subject_type="task",
+                    subject_id=task_id,
+                    detail={"agent_id": self.agent_id, "error": str(exc)},
+                )
 
     def _process_agentbus_control(
         self, *, repository_update_only: bool = False

--- a/src/mac/worker_credentials.py
+++ b/src/mac/worker_credentials.py
@@ -60,7 +60,7 @@ MODE_ENFORCED = "enforced"
 POLICY_MODES = frozenset({MODE_COMPATIBILITY, MODE_ENFORCED})
 
 PACKAGE_CAPABILITY = "work_package_v1"
-WORKER_SCOPES = ("agent", "dispatch", "read", "write")
+WORKER_SCOPES = ("agent", "dispatch", "read", "write", "review:advance")
 ACTIVE_AGENT_STATUSES = frozenset({"idle", "busy", "draining"})
 
 _K8S_NAME = re.compile(r"[^a-z0-9-]+")

--- a/tests/test_api_required_scope.py
+++ b/tests/test_api_required_scope.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from mac.api import _required_scope
+from mac.api import TokenPrincipal, _required_scope
+from mac.worker_credentials import WORKER_SCOPES
 
 
 def test_v1_router_requires_agent_scope_any_method():
@@ -60,3 +61,31 @@ def test_memory_rewrite_routes_are_admin_not_agent():
     # The read-only neighbours keep the surrounding /v1 behaviour.
     assert _required_scope("GET", "/v1/memory/health") == "agent"
     assert _required_scope("GET", "/v1/memory/recall") == "agent"
+
+
+def test_review_tick_requires_review_advance_not_bare_admin():
+    # Regression: this used to be flat "admin", which meant no ordinary fleet
+    # worker credential could ever call it -- every worker's own post-verdict
+    # /reviews/default/tick call was rejected with "token lacks required
+    # scope: admin", so the REVIEWING queue only drained when an admin token
+    # happened to invoke it by hand. `review:advance` is minted into every
+    # worker credential (WORKER_SCOPES) instead.
+    assert _required_scope("POST", "/reviews/default/tick") == "review:advance"
+    assert _required_scope("POST", "/reviews/default/tick?limit=10") == "review:advance"
+
+
+def test_worker_credential_carries_review_advance_scope():
+    assert "review:advance" in WORKER_SCOPES
+
+
+def test_review_advance_scope_semantics():
+    # Admin inherits every scope, including the new one.
+    assert TokenPrincipal(scopes=frozenset({"admin"})).has_scope("review:advance")
+    # A worker-shaped token (WORKER_SCOPES) has it directly.
+    assert TokenPrincipal(scopes=frozenset(WORKER_SCOPES)).has_scope("review:advance")
+    # A plain `write` token does NOT inherit it -- deliberately narrower than
+    # the {"roles", "workflow"} write-inherited scopes, since the review tick
+    # is the closest thing the swarm has to an auto-merge button.
+    assert not TokenPrincipal(scopes=frozenset({"write"})).has_scope("review:advance")
+    # `read` alone obviously doesn't have it either.
+    assert not TokenPrincipal(scopes=frozenset({"read"})).has_scope("review:advance")

--- a/tests/test_worker_credentials.py
+++ b/tests/test_worker_credentials.py
@@ -149,7 +149,7 @@ def test_db_issuance_stores_only_hash_and_projects_exact_agent(tmp_path: Path) -
 
     projected = WorkerCredentialPrincipalProvider(cp.store).tokens()
     assert projected[row["token_hash"]] == {
-        "scopes": ["agent", "dispatch", "read", "write"],
+        "scopes": ["agent", "dispatch", "read", "write", "review:advance"],
         "client_id": issue.record["id"],
         "agent_id": "agent_alpha",
         "principal_kind": "worker",

--- a/tests/test_worker_review_advance_rate_limit.py
+++ b/tests/test_worker_review_advance_rate_limit.py
@@ -1,0 +1,74 @@
+"""_advance_review_workflow_after_verdict must not log-spam on repeat failure.
+
+Before every worker credential carried the `review:advance` scope, this call
+failed on EVERY recorded verdict fleet-wide with the same permanent
+rejection ("token lacks required scope: admin") -- a warning log per verdict,
+forever. Now that the scope gap is closed a failure here is a real signal
+again, but it must still be rate-limited: a genuine outage would otherwise
+still log once per verdict across the whole fleet.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mac import worker
+
+
+class _FailingClient:
+    def __init__(self) -> None:
+        self.posts: list[str] = []
+
+    def post(self, path: str, payload: dict):
+        self.posts.append(path)
+        raise worker.MacApiError("token lacks required scope: admin")
+
+
+def _instance(tmp_path: Path) -> worker.MacWorker:
+    return worker.MacWorker(
+        _FailingClient(),
+        "agent_x",
+        tmp_path / "workspace",
+        lambda _task, _path: worker.WorkerExecution(0, "ok"),
+        self_update_repo=tmp_path,
+    )
+
+
+def test_repeated_failures_within_the_window_log_once(tmp_path, monkeypatch):
+    instance = _instance(tmp_path)
+    logged: list[dict] = []
+    monkeypatch.setattr(
+        instance,
+        "_observe_log",
+        lambda name, **kwargs: logged.append({"name": name, **kwargs}),
+    )
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(worker.time, "monotonic", lambda: clock["t"])
+
+    instance._advance_review_workflow_after_verdict("task_1")
+    clock["t"] += 5.0
+    instance._advance_review_workflow_after_verdict("task_2")
+    clock["t"] += 5.0
+    instance._advance_review_workflow_after_verdict("task_3")
+
+    assert len(instance.client.posts) == 3  # every call still attempted
+    assert len(logged) == 1  # only the first failure was logged
+    assert logged[0]["name"] == "worker.review_workflow.advance_failed"
+
+
+def test_a_failure_outside_the_window_logs_again(tmp_path, monkeypatch):
+    instance = _instance(tmp_path)
+    logged: list[dict] = []
+    monkeypatch.setattr(
+        instance,
+        "_observe_log",
+        lambda name, **kwargs: logged.append({"name": name, **kwargs}),
+    )
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(worker.time, "monotonic", lambda: clock["t"])
+
+    instance._advance_review_workflow_after_verdict("task_1")
+    clock["t"] += 301.0
+    instance._advance_review_workflow_after_verdict("task_2")
+
+    assert len(logged) == 2


### PR DESCRIPTION
## Summary
- `_required_scope` gated the entire `/reviews/default` surface (including the post-verdict advancement tick every worker calls after recording a review verdict) behind `admin` -- so no ordinary fleet worker credential could ever advance its own recorded verdict
- Confirmed live this session: 47 tasks fleet-wide sitting in `reviewing`, some 2+ months old, precisely because of this gap -- the queue only drained when an admin-scoped caller happened to invoke the tick by hand
- Introduces a narrow, additive `review:advance` scope, minted directly into `WORKER_SCOPES` (every fleet worker credential) -- NOT blanket-granted via `write` (deliberately, since the tick is the closest thing the swarm has to an auto-merge button, mac-iez). `admin` continues to inherit it like every other scope.
- The tick itself stays safe to grant broadly: it only lands work that already has an independently-recorded verdict from `/reviews/{id}/decision`, itself gated by `_assert_review_actor` so a worker can never author its own approval -- this route just drains already-decided work.
- Also rate-limits the post-verdict failure log to once per 5 minutes (it used to fire on every verdict recorded fleet-wide -- a permanent, expected rejection, not a transient one, so it was pure log spam; a failure now is a real signal worth keeping, just not once per verdict).

## Test plan
- [x] `tests/test_api_required_scope.py` -- new tests for the route scope and `TokenPrincipal.has_scope` semantics (admin inherits, worker scope has it directly, plain `write` does NOT inherit it)
- [x] `tests/test_worker_review_advance_rate_limit.py` -- new, proves repeated failures within the window log once, a failure outside the window logs again
- [x] Full review-related subset of `test_worker_credentials.py`/`test_control_plane.py` (96 tests) passes, no regressions
- [x] ruff clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>