### PR TITLE
Fix mac-agent crash-looping forever after a standalone Hermes cutover

### DIFF
--- a/deploy/hermes/install-hermes-gateway.sh
+++ b/deploy/hermes/install-hermes-gateway.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 HERMES_INSTALL_URL="${MAC_HERMES_INSTALL_URL:-https://hermes-agent.nousresearch.com/install.sh}"
 FLEET_NAME="${MAC_HERMES_FLEET_NAME:-${MAC_FLEET_NAME:-mac}}"
+MAC_HOME="${MAC_HOME:-$HOME/.mac}"
 HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
 # Migration source: the chat gateway Hermes is taking channel ownership from.
 # "openclaw" is the only interface `mac admin human-interface port` and
@@ -210,6 +211,11 @@ verify_gateway() {
            "every platform to dm_policy/group_policy=pairing and silently rejects" \
            "every sender (including @mentions) with no startup failure; run" \
            "ensure_user_allowlist (prepare) first"
+  grep -q '^MAC_CHAT_GATEWAY_IMPL=hermes$' "$MAC_HOME/mac.env" 2>/dev/null \
+    || die "MAC_CHAT_GATEWAY_IMPL is not 'hermes' in $MAC_HOME/mac.env -- mac-agent's" \
+           "own startup self-test derives its OpenClaw-required branch from this" \
+           "variable and will crash-loop forever demanding an OpenClaw advertisement" \
+           "that no longer exists; run ensure_chat_gateway_impl_env (prepare) first"
   status="$("$hermes" gateway status --deep 2>&1)" || die "hermes gateway status failed:
 $status"
   printf '%s\n' "$status"
@@ -233,12 +239,34 @@ $status" ;;
   esac
 }
 
+ensure_chat_gateway_impl_env() {
+  # mac-agent's own startup self-test derives its OpenClaw-required-or-not
+  # branch from MAC_CHAT_GATEWAY_IMPL in ~/.mac/mac.env (see
+  # deploy/fleet-node-install.sh's embedded self-test:
+  # `openclaw_required = MAC_CHAT_GATEWAY_IMPL == "openclaw"`) -- but only
+  # fleet-node-install.sh's own full deploy path ever wrote that variable.
+  # A cutover run through this standalone installer (as every node's Hermes
+  # cutover was, this session) never touched it, so mac.env kept claiming
+  # "openclaw" after the gateway was gone. Confirmed live: mac-agent then
+  # crash-loops forever at startup, since the self-test hard-requires an
+  # OpenClaw advertisement that no longer exists -- and the agent is
+  # `agent_offline`/`agent_unhealthy` for as long as it never starts.
+  local env_file="$MAC_HOME/mac.env"
+  mkdir -p "$MAC_HOME"
+  touch "$env_file"
+  if grep -q '^MAC_CHAT_GATEWAY_IMPL=' "$env_file" 2>/dev/null; then
+    sed -i.bak '/^MAC_CHAT_GATEWAY_IMPL=/d' "$env_file" && rm -f "$env_file.bak"
+  fi
+  printf 'MAC_CHAT_GATEWAY_IMPL=hermes\n' >> "$env_file"
+}
+
 prepare() {
   install_hermes
   port_credentials
   migrate_claw_state
   ensure_user_allowlist
   ensure_home_channel_env
+  ensure_chat_gateway_impl_env
   configure_gateway
   install_service
 }

--- a/scripts/resolve-impacted-tests.py
+++ b/scripts/resolve-impacted-tests.py
@@ -103,6 +103,7 @@ PATH_TEST_CONTRACTS: dict[str, tuple[str, ...]] = {
         "tests/test_generated_artifact_guards_always_run.py",
         "tests/test_github_review_key_install.py",
         "tests/test_git_toolchain_floor.py",
+        "tests/test_hermes_gateway_deploy.py",
         "tests/test_hermes_prompt_bridge_inert.py",
         "tests/test_hub_does_not_log_on_the_event_loop.py",
         "tests/test_hub_upgrade_supervisor.py",

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -928,6 +928,7 @@
     "retired": false,
     "sources": [
       "deploy/fleet-node-install.sh",
+      "deploy/hermes/install-hermes-gateway.sh",
       "src/mac/deploy_env.py",
       "src/mac/worker.py"
     ],

--- a/tests/test_hermes_gateway_deploy.py
+++ b/tests/test_hermes_gateway_deploy.py
@@ -84,6 +84,10 @@ def _run(
     # ensure_user_allowlist) already ran.
     if not (extra_env or {}).get("_OMIT_ALLOWLIST_ENV"):
         (hermes_home / ".env").write_text("SLACK_ALLOWED_USERS=*\n", encoding="utf-8")
+    mac_home = home / ".mac"
+    mac_home.mkdir(parents=True, exist_ok=True)
+    if not (extra_env or {}).get("_OMIT_GATEWAY_IMPL_ENV"):
+        (mac_home / "mac.env").write_text("MAC_CHAT_GATEWAY_IMPL=hermes\n", encoding="utf-8")
     env = {
         "PATH": f"{bin_dir}:/usr/bin:/bin",
         "HOME": str(home),
@@ -93,8 +97,9 @@ def _run(
         "FAKE_HERMES_SCENARIO": scenario,
         "FAKE_MAC_CALLS": str(mac_calls_path),
     }
+    _test_only_flags = {"_OMIT_ALLOWLIST_ENV", "_OMIT_GATEWAY_IMPL_ENV"}
     if extra_env:
-        env.update({k: v for k, v in extra_env.items() if k != "_OMIT_ALLOWLIST_ENV"})
+        env.update({k: v for k, v in extra_env.items() if k not in _test_only_flags})
     result = subprocess.run(
         ["bash", str(INSTALLER), subcommand],
         capture_output=True,
@@ -159,6 +164,44 @@ def test_prepare_does_not_duplicate_an_existing_allowlist_line(tmp_path):
     assert result.returncode == 0, result.stderr
     lines = [line for line in env_file.read_text(encoding="utf-8").splitlines() if line]
     assert lines == ["SLACK_ALLOWED_USERS=U0123"]
+
+
+def test_verify_fails_closed_when_gateway_impl_env_is_missing_or_wrong(tmp_path):
+    # Regression: mac-agent's own startup self-test derives its
+    # OpenClaw-required branch from MAC_CHAT_GATEWAY_IMPL in ~/.mac/mac.env.
+    # A Hermes cutover run through this installer (rather than the full
+    # fleet-node-install.sh deploy path) never touched that variable, so it
+    # kept claiming "openclaw" after the gateway was gone -- mac-agent then
+    # crash-loops forever demanding an OpenClaw advertisement that no longer
+    # exists, and the agent is offline/unhealthy for as long as it never
+    # starts. Confirmed live on all three fleet nodes.
+    result, _calls = _run(
+        tmp_path, "verify", scenario="healthy", extra_env={"_OMIT_GATEWAY_IMPL_ENV": "1"}
+    )
+    assert result.returncode != 0
+    assert "mac_chat_gateway_impl" in result.stderr.lower()
+
+
+def test_prepare_writes_the_chat_gateway_impl_env_var(tmp_path):
+    home = tmp_path / "home"
+    mac_home = home / ".mac"
+    mac_home.mkdir(parents=True, exist_ok=True)
+    env_file = mac_home / "mac.env"
+    result, _calls = _run(tmp_path, "prepare", extra_env={"_OMIT_GATEWAY_IMPL_ENV": "1"})
+    assert result.returncode == 0, result.stderr
+    assert env_file.read_text(encoding="utf-8").strip() == "MAC_CHAT_GATEWAY_IMPL=hermes"
+
+
+def test_prepare_corrects_a_stale_openclaw_gateway_impl_value(tmp_path):
+    home = tmp_path / "home"
+    mac_home = home / ".mac"
+    mac_home.mkdir(parents=True, exist_ok=True)
+    env_file = mac_home / "mac.env"
+    env_file.write_text("MAC_CHAT_GATEWAY_IMPL=openclaw\n", encoding="utf-8")
+    result, _calls = _run(tmp_path, "prepare", extra_env={"_OMIT_GATEWAY_IMPL_ENV": "1"})
+    assert result.returncode == 0, result.stderr
+    lines = [line for line in env_file.read_text(encoding="utf-8").splitlines() if line]
+    assert lines == ["MAC_CHAT_GATEWAY_IMPL=hermes"]
 
 
 def test_withdraw_stops_the_gateway_without_uninstalling(tmp_path):


### PR DESCRIPTION
## Summary
- Root cause: `mac-agent`'s own startup self-test derives its OpenClaw-required branch from `MAC_CHAT_GATEWAY_IMPL` in `~/.mac/mac.env` (`deploy/fleet-node-install.sh`), but only the full `fleet-node-install.sh` deploy path ever wrote that variable -- `deploy/hermes/install-hermes-gateway.sh` never did
- Every fleet node's Hermes cutover this session ran through the standalone installer, so `mac.env` kept claiming `openclaw` after the gateway was withdrawn
- Confirmed live: rocky's `mac-agent` crash-looped forever at startup demanding an OpenClaw advertisement that no longer existed -- `agent_offline`/`agent_unhealthy` in dispatch evaluation, unable to claim any task at all. Fixed by hand on all three fleet nodes (rocky, natasha, bullwinkle -- all had the identical stale value)
- This PR closes it durably: `ensure_chat_gateway_impl_env()` sets `MAC_CHAT_GATEWAY_IMPL=hermes` in `~/.mac/mac.env` during `prepare`, and `verify_gateway()` fails closed if it's missing or wrong

## Test plan
- [x] `tests/test_hermes_gateway_deploy.py` -- 24/24 pass (3 new tests: writes on prepare, corrects a stale `openclaw` value, fails closed when missing)
- [x] Reproduced and fixed live on rocky (full crash-loop to stable, self-test passing)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>