### PR TITLE
Recognize current task-execution attestation for dispatch, not stale chat-gateway snapshot

### DIFF
--- a/src/mac/allocator.py
+++ b/src/mac/allocator.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, FrozenSet, Iterable, Mapping, Optional, 
 from uuid import uuid4
 
 from mac.agent_health import advisory_health_dispatch_ready
+from mac.models import REPORT_REPOSITORY_EXECUTOR_POSTURES
 from mac.roles_service import machine_hardware_satisfies
 
 
@@ -283,14 +284,47 @@ class AllocationAgent:
         # requirement; making silence disqualifying would strand every worker
         # mid-upgrade. The unsatisfiable-requirements diagnostic reports the
         # silent ones separately.
+        # ``openclaw_runtime.confinement`` describes the OpenClaw chat
+        # gateway's own OpenShell container -- a claim about that process,
+        # never about this agent's TASK-execution sandbox. It happened to be
+        # a usable proxy while every fleet node ran OpenClaw, and happens to
+        # keep working today only where a pre-cutover value is still sitting
+        # unrefreshed in the DB (confirmed live: natasha/bullwinkle still
+        # carry a 2026-09-04 OpenClaw-era snapshot after their chat gateway
+        # moved to Hermes). The moment that stale value is cleared by a
+        # normal re-registration -- which is exactly what happened to rocky
+        # this session -- a fully healthy host-install worker reads as
+        # "no execution boundary" and dispatch starves it, even though its
+        # own executor already reported a verified attestation for the
+        # thing this check actually cares about.
+        #
+        # ``report_repository_executor_attestation`` (worker.py's
+        # ``read_only_report_repository_executor_attestation``) is that
+        # thing: a fresh, per-registration, schema-versioned claim about
+        # THIS agent's task-execution boundary, covering both the Linux
+        # OpenShell/Landlock posture and the macOS host-install posture ADR
+        # 0015 establishes as the legitimate, by-design confinement for a
+        # darwin node (no container is possible there, so "macos_host" is
+        # not an absence of a boundary -- it is the boundary).
         runtime = resources.get("openclaw_runtime")
         confinement = runtime.get("confinement") if isinstance(runtime, Mapping) else None
-        proven = bool(
+        proven_legacy = bool(
             isinstance(confinement, Mapping)
             and str(confinement.get("provider") or "").strip()
             and isinstance(runtime, Mapping)
             and runtime.get("verified") is True
         )
+        attestation = resources.get("report_repository_executor_attestation")
+        proven_attestation = bool(
+            isinstance(attestation, Mapping)
+            and attestation.get("verified") is True
+            and (
+                str(attestation.get("platform") or ""),
+                str(attestation.get("isolation_posture") or ""),
+            )
+            in REPORT_REPOSITORY_EXECUTOR_POSTURES
+        )
+        proven = proven_legacy or proven_attestation
         contradicted = resources.get("openshell_required") is False
         execution_boundary_verified = proven or not contradicted
         return cls(

--- a/tests/test_allocator.py
+++ b/tests/test_allocator.py
@@ -91,3 +91,68 @@ def test_execution_boundary_reads_three_states_not_two():
     assert agent(proven_but_flagged).execution_boundary_verified is True
     assert agent({}).execution_boundary_verified is True
     assert agent({"openshell_required": True}).execution_boundary_verified is True
+
+
+def test_a_macos_host_install_attestation_proves_the_boundary_without_openclaw_runtime():
+    """``openclaw_runtime.confinement`` describes the chat gateway's own
+    sandbox, not this agent's task-execution boundary -- it was only ever a
+    usable proxy while every node ran OpenClaw as that gateway. Confirmed
+    live 2026-09-06: rocky's chat gateway moved to Hermes, a normal
+    re-registration cleared its now-stale ``openclaw_runtime`` value, and a
+    fully healthy macOS host-install worker (ADR 0015: no container is
+    possible on darwin, so ``macos_host`` posture *is* the boundary) read as
+    having no execution boundary at all -- even though its own executor had
+    already reported a verified attestation for exactly this.
+    """
+
+    def agent(resources):
+        return AllocationAgent.from_hub_record(
+            {
+                "id": "a",
+                "capabilities": ["python"],
+                "health_status": "healthy",
+                "resources": resources,
+            },
+            online=True,
+            capacity=1,
+            active_leases=0,
+            machine_trusted=True,
+        )
+
+    macos_host_no_container = {
+        "openshell_required": False,
+        "report_repository_executor_attestation": {
+            "platform": "darwin",
+            "isolation_posture": "macos_host",
+            "verified": True,
+        },
+    }
+    linux_landlock = {
+        "openshell_required": False,
+        "report_repository_executor_attestation": {
+            "platform": "linux",
+            "isolation_posture": "landlock_enforced",
+            "verified": True,
+        },
+    }
+    unverified_attestation = {
+        "openshell_required": False,
+        "report_repository_executor_attestation": {
+            "platform": "darwin",
+            "isolation_posture": "macos_host",
+            "verified": False,
+        },
+    }
+    unrecognized_posture = {
+        "openshell_required": False,
+        "report_repository_executor_attestation": {
+            "platform": "darwin",
+            "isolation_posture": "some_future_posture",
+            "verified": True,
+        },
+    }
+
+    assert agent(macos_host_no_container).execution_boundary_verified is True
+    assert agent(linux_landlock).execution_boundary_verified is True
+    assert agent(unverified_attestation).execution_boundary_verified is False
+    assert agent(unrecognized_posture).execution_boundary_verified is False


### PR DESCRIPTION
## Summary
- `allocator.py`'s execution-boundary proof read `resources[\"openclaw_runtime\"].confinement` -- a claim about the OpenClaw chat gateway's own OpenShell container, never about the agent's task-execution sandbox
- Confirmed live: after this session's Hermes chat-gateway cutover, rocky's `openclaw_runtime` was correctly cleared by a normal re-registration; natasha/bullwinkle still carry an unrefreshed pre-cutover snapshot, which is why they still coincidentally pass this check
- rocky then read as having no execution boundary at all (`agent_no_execution_boundary`, rejecting it from every dispatch candidacy) even though its own executor had already reported a verified attestation (`report_repository_executor_attestation`) proving exactly this -- a `macos_host` posture, which ADR 0015 establishes as the legitimate, by-design confinement for a darwin host-install node

## Changes
- Recognize `(platform, isolation_posture)` from the current, per-registration `report_repository_executor_attestation` against `REPORT_REPOSITORY_EXECUTOR_POSTURES` as proof, alongside (not instead of) the legacy `openclaw_runtime` check

## Test plan
- [x] `tests/test_allocator.py` (4/4, 1 new test covering macos_host/landlock proof, unverified attestation, and an unrecognized posture)
- [x] `tests/test_requirement_eligibility.py`, `tests/test_dispatch_service_v2.py` (34/34 total, no regressions)
- [x] ruff clean, impact-map current
- [x] Verified live against rocky's and natasha's actual current resource records

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>