### PR TITLE
Stop dropping review advancement on a concurrent-submission race

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -22944,13 +22944,25 @@ class ControlPlane:
                 # and fall through to publication.
                 pass
             elif self._verdict_value(verdict_evidence) == "rejected":
-                review = self.submit_review(
-                    review.id,
-                    ReviewStatus.REJECTED.value,
-                    review.reviewer_agent_id,
-                    reason="reviewer rejected via signed verdict evidence",
-                    evidence_id=verdict_evidence.id,
-                )
+                try:
+                    review = self.submit_review(
+                        review.id,
+                        ReviewStatus.REJECTED.value,
+                        review.reviewer_agent_id,
+                        reason="reviewer rejected via signed verdict evidence",
+                        evidence_id=verdict_evidence.id,
+                    )
+                except ValidationError:
+                    # A concurrent advancer (the event-driven consumer and the
+                    # periodic sweep both call this function) may have already
+                    # submitted the same verdict between our stale read and
+                    # this write. If the review already landed in the state we
+                    # were about to write, this is a duplicate, not a failure
+                    # -- fall through with the winner's row instead of
+                    # dropping the advancement on the floor.
+                    review = self.reviews.get_review(review.id)
+                    if review.status != ReviewStatus.REJECTED.value:
+                        raise
                 self._record_default_review_observation(
                     task_id,
                     "workflow.default_review.rejected",
@@ -22974,13 +22986,20 @@ class ControlPlane:
                     evidence_id=verdict_evidence.id,
                 )
             else:
-                review = self.submit_review(
-                    review.id,
-                    ReviewStatus.APPROVED.value,
-                    review.reviewer_agent_id,
-                    reason="reviewer approved via signed verdict evidence",
-                    evidence_id=verdict_evidence.id,
-                )
+                try:
+                    review = self.submit_review(
+                        review.id,
+                        ReviewStatus.APPROVED.value,
+                        review.reviewer_agent_id,
+                        reason="reviewer approved via signed verdict evidence",
+                        evidence_id=verdict_evidence.id,
+                    )
+                except ValidationError:
+                    # See the rejected branch above: a concurrent advancer may
+                    # have already submitted this same approval.
+                    review = self.reviews.get_review(review.id)
+                    if review.status != ReviewStatus.APPROVED.value:
+                        raise
                 self._record_default_review_observation(
                     task_id,
                     "workflow.default_review.approved",


### PR DESCRIPTION
## Summary
- `advance_default_review_workflow` is invoked from both the event-driven review-advance consumer and the periodic sweep. When both race to submit the same verdict for a task, `submit_review`'s fenced `UPDATE ... WHERE status = 'pending'` matches zero rows for the loser and raises `ValidationError("review state changed during submission; retry")`.
- Both call sites only caught this as a generic `Exception`, logged it (`event-driven review advance failed for %s` / a sweep-error observation), and moved on — silently dropping the advancement and stranding the task in `reviewing` forever, even though the review was correctly decided by the winning racer.
- Found live on rocky's hub after redeploying PR #764/#765: multiple canary tasks sat in `reviewing` with `pending` reviews indefinitely, and `mac-service.log` showed this exact `ValidationError` firing repeatedly for real tasks.
- Fix: on that specific `ValidationError`, reload the review; if a concurrent racer already landed the same terminal status we were about to write, treat it as a duplicate and continue with the winner's row instead of failing the whole advancement.

## Test plan
- [x] `uv run --extra dev pytest tests/test_review_protocol_rejection.py tests/test_review_tick_stall_diagnosis.py` — 33 passed
- [x] `uv run --extra dev pytest tests/test_control_plane.py -k review` — 96 passed