### PR TITLE
Run bootstrap.command before test.command in hub_verify sandboxes

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -448,6 +448,23 @@ def _repository_contract_test_command_for_task(task: "Task") -> str:
     return ""
 
 
+def _repository_contract_bootstrap_command_for_task(task: "Task") -> str:
+    """The repository contract's bootstrap command for a task, or "" if none
+    is declared. Mirrors ``_repository_contract_test_command_for_task``."""
+    metadata = ensure_json_object(task.metadata)
+    for path in (
+        ("execution_contract", "bootstrap"),
+        ("execution_contract", "repository_contract", "bootstrap"),
+        ("origin", "repository_contract", "bootstrap"),
+        ("repository_contract", "bootstrap"),
+    ):
+        node = _nested_json_object(metadata, *path)
+        command = str(node.get("command") or "").strip()
+        if command:
+            return command
+    return ""
+
+
 def _repository_contracts_from_metadata(metadata: JsonDict) -> List[JsonDict]:
     contracts: List[JsonDict] = []
     seen: set[str] = set()
@@ -27251,7 +27268,12 @@ class ControlPlane:
         }
 
     def _hub_verify_run_contract_test(
-        self, remote_url: str, branch: str, head_sha: str, test_command: str
+        self,
+        remote_url: str,
+        branch: str,
+        head_sha: str,
+        test_command: str,
+        bootstrap_command: str = "",
     ) -> Tuple[int, str]:
         """Clone the pushed branch and run the contract test in an isolated
         OpenShell sandbox on the hub. Returns (returncode, tail_of_output).
@@ -27418,10 +27440,11 @@ class ControlPlane:
                 "/bin/bash",
                 "-c",
                 "export PATH=%s; hash -r 2>/dev/null || true; "
-                "cd /sandbox && tar xzf repo.tgz && %scd /sandbox/repo && %s"
+                "cd /sandbox && tar xzf repo.tgz && %scd /sandbox/repo && %s%s"
                 % (
                     SANDBOX_BASE_PATH,
                     _HUB_VERIFY_GIT_PREFLIGHT,
+                    ("%s && " % bootstrap_command) if bootstrap_command else "",
                     test_command or "scripts/run-contract-tests.sh",
                 ),
             ]
@@ -27736,9 +27759,14 @@ class ControlPlane:
         # suite for broad or uncertain changes. This keeps the independent hub
         # environment without unconditionally duplicating mainline coverage.
         test_command = self._hub_review_test_command(task, info)
+        bootstrap_command = _repository_contract_bootstrap_command_for_task(task)
         try:
             returncode, output = self._hub_verify_run_contract_test(
-                info["remote_url"], info["branch"], info["head_sha"], test_command
+                info["remote_url"],
+                info["branch"],
+                info["head_sha"],
+                test_command,
+                bootstrap_command,
             )
         except Exception as exc:  # noqa: BLE001 - a verify crash must not wedge the workflow
             self._record_default_review_observation(

--- a/tests/test_hub_verify_evidence_window.py
+++ b/tests/test_hub_verify_evidence_window.py
@@ -152,6 +152,52 @@ def test_a_genuinely_dead_harness_is_still_unavailable(monkeypatch):
     assert hub_verification_unavailable_reason(output) == "ssh exited with status"
 
 
+def test_hub_verify_runs_bootstrap_before_test_command(monkeypatch):
+    """A repository whose test.command assumes a pre-built toolchain (e.g.
+    ``.venv/bin/pytest``) is unrunnable in a fresh sandbox unless
+    bootstrap.command has already created that toolchain. Observed live on
+    the mac-fleet-canary repository: every hub_verify attempt failed with
+    ``.venv/bin/pytest: No such file or directory`` (exit 127) because the
+    sandbox never ran bootstrap.command -- permanently stranding every task
+    that used a venv-relative test command."""
+    captured_argv = {}
+
+    def run(argv, **kwargs):
+        done = lambda rc, out="", err="": subprocess.CompletedProcess(argv, rc, out, err)
+        if argv[0] == "git" and "rev-parse" in argv:
+            return done(0, HEAD_SHA + "\n")
+        if argv[0] in ("git", "tar", "bash"):
+            return done(0)
+        if "delete" in argv:
+            return done(0)
+        captured_argv["argv"] = argv
+        return done(0, "all passed")
+
+    monkeypatch.setattr(services.subprocess, "run", run)
+    monkeypatch.setattr(gitops, "askpass_remote_auth", lambda url: (url, {}), raising=False)
+    monkeypatch.setenv(
+        "MAC_HUB_VERIFY_IMAGE",
+        "ghcr.io/jordanhubbard/mac-openshell-runtime@sha256:" + "a" * 64,
+    )
+    plane = types.SimpleNamespace()
+    ControlPlane._hub_verify_run_contract_test(
+        plane,
+        "https://example.invalid/r.git",
+        "b",
+        HEAD_SHA,
+        ".venv/bin/pytest -q",
+        'python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"',
+    )
+
+    shell_command = captured_argv["argv"][-1]
+    bootstrap_index = shell_command.index("python3 -m venv .venv")
+    test_index = shell_command.index(".venv/bin/pytest -q")
+    assert bootstrap_index < test_index, (
+        "bootstrap.command must run before test.command so the sandbox's "
+        "toolchain exists when the test runs"
+    )
+
+
 def test_hub_verify_refuses_the_obsolete_local_hermes_image(monkeypatch):
     monkeypatch.setenv("MAC_HUB_VERIFY_IMAGE", "localhost/mac-hermes:net")
 


### PR DESCRIPTION
## Summary
- Every `hub_verify` attempt on a repository whose `test.command` assumes a pre-built toolchain (e.g. `.venv/bin/pytest`) was permanently failing with `No such file or directory` (exit 127): the sandbox is fresh per invocation, and `_hub_verify_run_contract_test` never ran `bootstrap.command` before the test command — only the git preflight.
- Confirmed live on rocky's hub: all 9 `mac-fleet-canary` tasks were permanently stuck in `reviewing`, each with an identical `ssh exited with status` (exit 127, `.venv/bin/pytest: No such file or directory`) `hub_verify_unavailable` observation recorded by the publication-worker sweep every ~6-7 minutes since the tasks were submitted for review.
- Threads the repository contract's `bootstrap.command` through `_hub_verify_run_contract_test` and prepends it to the in-sandbox shell command when declared, mirroring how the executor sandbox (`executor_sandbox.py`) already runs bootstrap before its own test invocation.

## Test plan
- [x] New regression test `test_hub_verify_runs_bootstrap_before_test_command` asserts bootstrap.command appears before test.command in the generated sandbox shell command
- [x] `tests/test_hub_verify_evidence_window.py` (7 passed)
- [x] `tests/test_publication_gate_scope.py`, `tests/test_publication_barrier_scope.py` (9 passed)
- [x] `tests/test_control_plane.py -k hub_verify` (18 passed)