### PR TITLE
Thread bootstrap.command into the projected-merge publication gate too

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -21489,7 +21489,23 @@ class ControlPlane:
             else:
                 publication_test_runner = getattr(self, "_publication_merge_test_runner", None)
                 if publication_test_runner is None:
-                    publication_test_runner = self._hub_verify_run_contract_test
+                    # The projected-merge gate reuses the hub_verify sandbox
+                    # runner, which also needs bootstrap.command run before
+                    # test.command (see _hub_verify_run_contract_test) -- but
+                    # ContractTestRunner's signature has no bootstrap slot, so
+                    # curry it in here rather than widening that protocol.
+                    run_contract_test = self._hub_verify_run_contract_test
+                    publication_bootstrap_command = _repository_contract_bootstrap_command_for_task(
+                        task
+                    )
+
+                    def publication_test_runner(
+                        repo_dir: str, branch: str, head_sha: str, command: str
+                    ) -> Tuple[int, str]:
+                        return run_contract_test(
+                            repo_dir, branch, head_sha, command, publication_bootstrap_command
+                        )
+
                 contract_gate = validate_projected_merge_contract(
                     str(root),
                     projected_base_sha,

--- a/tests/test_publication_gate_scope.py
+++ b/tests/test_publication_gate_scope.py
@@ -86,6 +86,25 @@ def test_a_short_failure_is_not_mangled():
     assert _failure_excerpt(RuntimeError("boom")) == "boom"
 
 
+def test_the_publication_gate_also_runs_bootstrap_before_its_test_command():
+    """The projected-merge gate reuses _hub_verify_run_contract_test, which
+    needs bootstrap.command run before test.command in a fresh sandbox (see
+    test_hub_verify_evidence_window.py). Confirmed live: mac-fleet-canary's
+    review approved via hub_verify (which got the bootstrap fix), then
+    publication immediately failed with the identical
+    "full repository contract test failed" -- because this second call site
+    curried the runner without threading bootstrap_command through, so the
+    sandbox still had no venv for `.venv/bin/pytest`."""
+    source = inspect.getsource(services.ControlPlane._publish_git_target_attempt)
+
+    assert "_repository_contract_bootstrap_command_for_task" in source, (
+        "the projected-merge gate's runner must supply bootstrap_command to "
+        "_hub_verify_run_contract_test, or every repository whose "
+        "test.command assumes a pre-built toolchain fails publication even "
+        "after review approves it"
+    )
+
+
 def test_the_chosen_gate_command_is_recorded():
     """The scoped and full commands take ~15 and ~45 minutes, and only one fits
     the timeout. A silent fallback to full is indistinguishable from a hang."""


### PR DESCRIPTION
## Summary
- PR #768 fixed `_hub_verify_run_contract_test` to run `bootstrap.command` before `test.command`, but only threaded it through the review-time call site.
- The projected-merge publication gate (`_publish_git_target_attempt` -> `validate_projected_merge_contract`) reuses the same runner via a 4-arg `ContractTestRunner` callback with no bootstrap slot, so it never got the fix.
- Confirmed live on rocky's hub immediately after deploying #768: a `mac-fleet-canary` task's review was approved (hub_verify succeeded), then publication immediately failed with `full repository contract test failed` — the same missing-venv failure, one call site later.
- Curries `bootstrap_command` into the `publication_test_runner` closure at the real (non-test-injected) call site, without widening `merge_queue.ContractTestRunner`'s signature.

## Test plan
- [x] New regression test `test_the_publication_gate_also_runs_bootstrap_before_its_test_command`
- [x] `tests/test_publication_gate_scope.py` (7 passed)
- [x] `tests/test_publication_pull_request.py`, `tests/test_publication_barrier_scope.py` (50 passed)
- [x] `tests/test_control_plane.py -k "publication or projected_merge"` (27 passed)
- [x] `tests/test_worker.py -k publication` (2 passed)