### PR TITLE
Fix PR-reuse identity collision that permanently strands conflict-integration branches

### DIFF
--- a/src/mac/gitops.py
+++ b/src/mac/gitops.py
@@ -986,10 +986,31 @@ def open_pull_request(
 
 
 _MAC_TASK_MARKER_RE = re.compile(r"\btask_[0-9a-f]{8,32}\b")
+_MAC_TASK_BODY_MARKER_RE = re.compile(r"- task: `(task_[0-9a-f]{8,32})`")
 
 
 def _mac_task_id(title: str, body: str) -> str:
-    """Stable task identity embedded in every MAC-authored pull request."""
+    """Stable task identity embedded in every MAC-authored pull request.
+
+    Every PR body mac opens carries an unambiguous ``- task: `<id>` ``
+    marker (see ``agent_pull_request`` / the hub's own publish body) naming
+    the task that actually owns this PR, so that marker is checked first.
+    Falling back to the first task-id-shaped token anywhere in title+body
+    misidentifies a conflict-integration task's PR: its title deliberately
+    names the ORIGINAL task it is repairing (see
+    ``_handoff_conflict_to_integration``) before its own id, e.g. "Integrate
+    conflicting approved task task_A onto current main (task_B)" -- a bare
+    first-match search returns task_A, so the reuse lookup below finds and
+    silently "reuses" task_A's already-open, unrelated PR. That PR's head
+    branch is immutable once created, so the reuse is a no-op: the real fix
+    lands on an orphaned branch with no open PR, while the stale PR stays
+    permanently CONFLICTING. Observed live on mac-fleet-canary: every
+    retry for hours kept "successfully" reusing PR #1 (task_A's PR) for
+    task_B's resolved commits.
+    """
+    body_match = _MAC_TASK_BODY_MARKER_RE.search(body or "")
+    if body_match:
+        return body_match.group(1)
     match = _MAC_TASK_MARKER_RE.search("%s\n%s" % (title, body))
     return match.group(0) if match else ""
 

--- a/tests/test_gitops.py
+++ b/tests/test_gitops.py
@@ -205,6 +205,54 @@ def test_open_pull_request_reuses_task_pr_across_lease_branches(monkeypatch) -> 
     assert posts == []
 
 
+def test_open_pull_request_does_not_reuse_an_unrelated_tasks_pr(monkeypatch) -> None:
+    """A conflict-integration task's title deliberately names the ORIGINAL
+    task it repairs (see _handoff_conflict_to_integration), e.g. "Integrate
+    conflicting approved task task_A onto current main (task_B)". Reusing
+    task_A's already-open PR for task_B's push is wrong: that PR's head
+    branch is immutable, so it silently stays bound to task_A's stale
+    branch forever while task_B's resolved commits land on an orphaned,
+    PR-less branch. Observed live on mac-fleet-canary."""
+    monkeypatch.setenv("GH_TOKEN", "ghp_xxx")
+    posts = []
+    task_a = "task_3ac578f2ec0a4ea98371edf41e29b8d4"
+    task_b = "task_00b35c19f421d211cdf8076763046914"
+
+    def fake_urlopen(req: Any, timeout: float = 0) -> _FakeResponse:
+        url = req.full_url if hasattr(req, "full_url") else req.get_full_url()
+        if req.get_method() == "POST":
+            posts.append(json.loads(req.data.decode("utf-8")))
+            return _FakeResponse({"number": 2, "html_url": "https://github.com/x/y/pull/2"})
+        if "/pulls?state=open" in url:
+            return _FakeResponse(
+                [
+                    {
+                        "number": 1,
+                        "html_url": "https://github.com/x/y/pull/1",
+                        "state": "open",
+                        "title": "canary: implement toolkit/union_find.py (%s)" % task_a,
+                        "body": "- task: `%s`" % task_a,
+                        "head": {"ref": "mac/agent_rocky/%s-lease_old" % task_a},
+                        "base": {"ref": "main"},
+                    }
+                ]
+            )
+        return _FakeResponse({"default_branch": "main"})
+
+    with mock.patch("mac.gitops.urllib.request.urlopen", side_effect=fake_urlopen):
+        result = open_pull_request(
+            "https://github.com/x/y.git",
+            head="mac/agent_rocky/%s-lease_new" % task_b,
+            title="Integrate conflicting approved task %s onto current main (%s)" % (task_a, task_b),
+            body="- task: `%s`\n- head: `deadbeef`\n- base at push: `cafef00d`\n" % task_b,
+        )
+
+    assert result.number == 2
+    assert result.reused is False
+    assert len(posts) == 1
+    assert posts[0]["head"] == "mac/agent_rocky/%s-lease_new" % task_b
+
+
 def test_open_pull_request_fails_closed_when_task_pr_index_is_unreadable(monkeypatch) -> None:
     monkeypatch.setenv("GH_TOKEN", "ghp_xxx")
     monkeypatch.setattr("mac.gitops.time.sleep", lambda _seconds: None)


### PR DESCRIPTION
## Summary
- `_mac_task_id()` returned the FIRST `task_<hex>`-shaped token found anywhere in `title+body`. A conflict-integration task's title deliberately names the *original* task it repairs before its own id — e.g. `"Integrate conflicting approved task task_A onto current main (task_B)"` — so the first-match scan returned `task_A` instead of the PR's actual owner, `task_B`.
- That misidentification fed `_find_existing_task_pr()`, which then "reused" `task_A`'s already-open, unrelated PR for `task_B`'s push. A GitHub PR's head branch is immutable after creation, so the "reuse" silently left that PR bound to `task_A`'s stale, conflicting branch forever, while `task_B`'s resolved commits landed on an orphaned branch with no open PR at all.
- Confirmed live on `mac-fleet-canary`: a conflict-integration task's publish retried every ~7 minutes for 40+ minutes, each time reporting success (`"reused"` PR #1), while PR #1 stayed permanently `CONFLICTING` because it was never the right PR to update — this was the actual cause behind all 8 remaining canary tasks appearing stuck after the hub_verify bootstrap fixes (#768, #769) landed.
- Every PR mac opens already carries an unambiguous `` - task: `<id>` `` body marker naming its true owner (`agent_pull_request`, and the hub's own publish fallback). Prefer that marker in `_mac_task_id()` before falling back to the old first-match scan, so cross-task id mentions in descriptive title text can no longer collide with it.

## Test plan
- [x] New regression test `test_open_pull_request_does_not_reuse_an_unrelated_tasks_pr` reproduces the exact collision and asserts a fresh PR is opened for the actual owning task
- [x] `tests/test_gitops.py` (40 passed, including the existing `reuses_task_pr_across_lease_branches` test — same-task reuse across retries still works)
- [x] `tests/test_publication_pull_request.py`, `tests/test_repository_hygiene.py`, `tests/test_repository_ref_reconciler.py` (114 passed)