### PR TITLE
Detect a stale reused PR reference by checking its live head branch

### DIFF
--- a/src/mac/gitops.py
+++ b/src/mac/gitops.py
@@ -1652,7 +1652,14 @@ def pull_request_state(
             "error": _scrub_secret(str(exc), token)[:300],
         }
     if not isinstance(pr, dict):
-        return {"known": False, "merged": False, "sha": "", "state": "", "head_sha": ""}
+        return {
+            "known": False,
+            "merged": False,
+            "sha": "",
+            "state": "",
+            "head_sha": "",
+            "head_ref": "",
+        }
     head = pr.get("head") if isinstance(pr.get("head"), dict) else {}
     return {
         "known": True,
@@ -1660,6 +1667,7 @@ def pull_request_state(
         "sha": str(pr.get("merge_commit_sha") or pr.get("merged_commit_id") or "").strip(),
         "state": str(pr.get("state") or ""),
         "head_sha": str((head or {}).get("sha") or "").strip(),
+        "head_ref": str((head or {}).get("ref") or "").strip(),
         "host": host_kind,
     }
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -20683,6 +20683,26 @@ class ControlPlane:
             and (not agent_pr_base or agent_pr_base == canonical_branch)
         )
         if reuse_agent_pr:
+            # The evidence's cached PR reference can be stale: a task-id
+            # marker collision in the reuse lookup (fixed going forward by
+            # requiring a head-branch match, but not retroactively for
+            # evidence recorded before that fix) can leave this number
+            # pointing at a branch other than the one just pushed. A
+            # GitHub PR's head branch is immutable once created, so
+            # reusing a mismatched number is not a retry -- it is a
+            # permanent, silent no-op: the push lands on ``branch``, the
+            # recorded PR keeps whatever branch it always had, and every
+            # future publish attempt "succeeds" at reusing the wrong PR
+            # forever while genuinely conflicting against main. Verify the
+            # live head before trusting the cached reference.
+            observed_pr_head = _gitops.pull_request_state(api_url, agent_pr_number)
+            if (
+                observed_pr_head.get("known")
+                and observed_pr_head.get("head_ref")
+                and observed_pr_head.get("head_ref") != branch
+            ):
+                reuse_agent_pr = False
+        if reuse_agent_pr:
             pr = _gitops.PullRequestResult(
                 host=str(agent_pr.get("forge") or ""),
                 number=agent_pr_number,

--- a/tests/test_publication_pull_request.py
+++ b/tests/test_publication_pull_request.py
@@ -83,6 +83,7 @@ class FakeForge:
         self.checks_pending = False
         self.checks_failed: tuple = ()
         self.checks_known = True
+        self.pr_head_ref = ""
 
     # -- required checks --------------------------------------------------
     def required_check_verdicts(self, repo_url, sha, contexts, **_):
@@ -116,6 +117,7 @@ class FakeForge:
             "sha": self.queue_merged_sha,
             "state": "closed" if self.queue_merged_sha else "open",
             "head_sha": "",
+            "head_ref": self.pr_head_ref,
         }
 
     def land_from_queue(self, sha: str, number: int = 101) -> str:
@@ -545,6 +547,49 @@ def test_hub_reuses_the_pull_request_the_agent_opened(cp, tmp_path, monkeypatch)
     assert proof["squash_merged"] is True
     assert proof["contains_reviewed_head"] is False
     assert proof["pull_request_opened_by"] == "agent"
+
+
+def test_hub_does_not_reuse_a_pr_number_pointing_at_a_different_branch(cp, tmp_path, monkeypatch):
+    """Evidence can carry a PR number whose live head branch is not the one
+    just pushed: a task-id marker collision when the agent's PR-open call
+    reused a stale, unrelated PR (see #770 for how that misidentification
+    happens). A GitHub PR's head branch is immutable, so reusing that
+    number would silently keep pointing at the wrong branch forever while
+    the real work sat on an unreferenced branch. Observed live on
+    mac-fleet-canary: an approved task's publish repeatedly "succeeded" at
+    reusing PR #1 while PR #1's actual head stayed a different task's
+    stale, conflicting branch."""
+    remote, source, main_head, task_head = build_repo(tmp_path)
+    forge = FakeForge(remote, tmp_path / "forge")
+    forge.pr_head_ref = "some/other/task-branch"
+    install_forge(monkeypatch, forge)
+    task, evidence, reviewer = drive_to_approval(
+        cp,
+        source,
+        task_head,
+        pull_request={
+            "opened": True,
+            "forge": "github",
+            "number": 77,
+            "url": "https://github.invalid/acme/widgets/pull/77",
+            "state": "open",
+            "base": "main",
+            "head": "task/feature",
+            "opened_by": "agent",
+        },
+    )
+
+    publication = cp.publish_task(task.id, "git://main", reviewer.id, evidence_id=evidence.id)
+
+    assert publication.status == "published"
+    # The cached PR #77 points at a different branch, so the hub must not
+    # merge it -- it opens its own PR for the branch it actually pushed.
+    assert forge.opened
+    assert forge.merges == [{"number": 101, "method": "squash", "sha": task_head}]
+
+    detail = published_detail(cp, task.id)
+    assert detail["pull_request_number"] == 101
+    assert detail["pull_request_opened_by"] == "hub_fallback"
 
 
 def test_hub_fallback_pull_request_is_recorded_as_a_fallback(cp, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- #770 fixed the identity-collision bug that made `_mac_task_id()` attribute a new PR push to the wrong task, but only for evidence recorded *after* that fix deploys.
- Evidence recorded before it still carries the wrong PR number, and a GitHub PR's head branch is immutable once created, so every future publish attempt kept "successfully" reusing that PR forever — confirmed live: an already-approved `mac-fleet-canary` task retried publication every ~7 minutes for over three hours, each time reporting success at reusing a PR whose actual head was a different task's stale, conflicting branch, while its own resolved commits sat on an unreferenced branch with no open PR at all.
- Before trusting a cached "the agent already opened this PR" reference, ask the forge for that PR's live head branch and compare it to the branch just pushed. A mismatch means the reference is stale — reusing it is a permanent no-op, not a retry — so fall through to the hub's own open-or-find-by-branch path instead, which (via #770) correctly opens a fresh PR for the branch actually being published.
- `pull_request_state()` already fetched a PR's live state for the "did the merge queue land it while we backed off" check; this just also returns its `head_ref` so the new check reuses the same call instead of adding a second forge round trip.

## Test plan
- [x] New regression test `test_hub_does_not_reuse_a_pr_number_pointing_at_a_different_branch` reproduces the exact live scenario
- [x] `tests/test_publication_pull_request.py`, `tests/test_gitops.py`, `tests/test_publication_gate_scope.py`, `tests/test_publication_barrier_scope.py` (92 passed)
- [x] `tests/test_control_plane.py -k "publish or publication or pull_request"` (34 passed)