### PR TITLE
Evict a cancelled task's merge-queue entry so it cannot wedge the queue forever

### DIFF
--- a/src/mac/native_merge_queue.py
+++ b/src/mac/native_merge_queue.py
@@ -1161,6 +1161,29 @@ class NativeMergeQueue:
     #: the PR, so a queued entry with no number is normal and momentary.
     PR_REQUIRING_STATES = (STATE_TESTING, STATE_TESTED)
 
+    def evict_for_task(self, task_id: str, *, reason: str) -> Optional[JsonDict]:
+        """Evict this task's live queue entry, wherever it is, if it has one.
+
+        Covers the case ``stalled_entries``/``evict_exhausted`` cannot: a task
+        that is cancelled (superseded, admin-closed, ...) before it ever wins a
+        slot leaves an entry with ``attempts == 0``, which neither of those
+        checks touches. Nothing else will ever retry ``claim_slot`` for a
+        cancelled task, so that entry -- often the head of the line -- sits
+        forever, blocking every entry behind it. The caller (task cancellation)
+        knows only the task id, not the entry's repository/branch, so this
+        looks the entry up directly rather than requiring both.
+        """
+
+        row = self._store.query_one(
+            "SELECT * FROM merge_queue_entries WHERE task_id = ? AND state IN (?, ?, ?) "
+            "ORDER BY position DESC LIMIT 1",
+            (task_id, *LIVE_STATES),
+        )
+        if row is None:
+            return None
+        entry = self._from_row(row)
+        return self.evict(entry.id, reason=reason)
+
     def stalled_entries(self, repository: str, branch: str) -> List[QueueEntry]:
         """Live entries that cannot progress, however long they are left.
 

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -11029,7 +11029,7 @@ class ControlPlane:
             TaskState.CANCELLED.value,
         }:
             raise ValidationError("operator close only supports completed or cancelled")
-        return self._transition_task_impl(
+        result = self._transition_task_impl(
             task_id,
             target,
             actor,
@@ -11039,6 +11039,9 @@ class ControlPlane:
             drain_outbox=drain_outbox,
             conn=None,
         )
+        if target == TaskState.CANCELLED.value:
+            self._evict_merge_queue_entry_for_cancelled_task(task_id)
+        return result
 
     def transition_task(
         self,
@@ -11050,7 +11053,7 @@ class ControlPlane:
         lease_id: Optional[str] = None,
         drain_outbox: bool = True,
     ) -> Task:
-        return self._transition_task_impl(
+        result = self._transition_task_impl(
             task_id,
             target_state,
             actor,
@@ -11060,6 +11063,32 @@ class ControlPlane:
             drain_outbox=drain_outbox,
             conn=None,
         )
+        if _state_value(target_state) == TaskState.CANCELLED.value:
+            self._evict_merge_queue_entry_for_cancelled_task(task_id)
+        return result
+
+    def _evict_merge_queue_entry_for_cancelled_task(self, task_id: str) -> None:
+        """Clear this task's live merge-queue entry, if it has one.
+
+        A cancelled task will never call ``claim_slot`` again, so an entry it
+        already holds -- often still at ``attempts == 0`` because it was
+        cancelled before winning a slot -- would otherwise sit in the queue
+        forever with no reaper able to touch it (``stalled_entries`` requires
+        ``attempts >= 1``). Left alone, that is a permanent head-of-line block
+        for every entry behind it. Best-effort: a queue lookup failure must
+        never block the cancellation itself.
+        """
+
+        try:
+            self._native_merge_queue().evict_for_task(
+                task_id, reason="owning task was cancelled"
+            )
+        except Exception:  # noqa: BLE001 - cancellation must still succeed.
+            logging.getLogger("mac.merge_queue").warning(
+                "failed to evict merge queue entry for cancelled task %s",
+                task_id,
+                exc_info=True,
+            )
 
     def request_task_input(
         self,

--- a/tests/test_native_merge_queue.py
+++ b/tests/test_native_merge_queue.py
@@ -1200,6 +1200,62 @@ def test_an_entry_marked_tested_with_no_trees_still_cannot_land():
     assert (ok, why) == (False, "entry carries no tested trees")
 
 
+def test_evict_for_task_clears_a_never_attempted_head_of_line_entry(queue):
+    """A task cancelled before it ever wins a slot must not wedge the queue.
+
+    ``stalled_entries``/``evict_exhausted`` both require ``attempts >= 1``, so
+    an entry admitted but never claimed (attempts == 0) is invisible to them.
+    Its owning task, once cancelled, never calls ``claim_slot`` again, so
+    nothing else will ever move it out of the way of the entries behind it.
+    """
+
+    front = _admit(queue, "task_dead", "A" * 40)
+    behind = _admit(queue, "task_alive", "B" * 40)
+    assert front.attempts == 0
+    assert front.state == STATE_QUEUED
+
+    result = queue.evict_for_task("task_dead", reason="owning task was cancelled")
+    assert result is not None
+    assert result["changed"] is True
+
+    live = queue.live_entries(REPO, BRANCH)
+    assert [entry.task_id for entry in live] == ["task_alive"]
+    assert live[0].id == behind.id
+
+    plan = _claim(queue, "task_alive", "B" * 40)
+    assert plan.admitted is True
+
+
+def test_evict_for_task_is_a_noop_when_the_task_has_no_live_entry(queue):
+    assert queue.evict_for_task("task_never_queued", reason="owning task was cancelled") is None
+
+
+def test_cancelling_a_task_evicts_its_never_attempted_merge_queue_entry(cp):
+    """Wiring test: ControlPlane.close_task(..., CANCELLED) must reach the queue.
+
+    Reproduces the live incident directly: a conflict-integration task admits
+    an entry to the front of the queue, is superseded and cancelled before it
+    ever wins a slot (attempts stays 0), and -- without this hook -- that dead
+    entry blocks every entry behind it forever.
+    """
+
+    front = cp.create_task("front task", project="widgets")
+    behind = cp.create_task("behind task", project="widgets")
+    queue = cp._native_merge_queue()
+    queue.admit(repository=REPO, branch=BRANCH, task_id=front.id, head_sha="A" * 40)
+    queue.admit(repository=REPO, branch=BRANCH, task_id=behind.id, head_sha="B" * 40)
+
+    cp.close_task(
+        front.id,
+        TaskState.CANCELLED.value,
+        "test-actor",
+        {"reason": "superseded in test"},
+    )
+
+    live = queue.live_entries(REPO, BRANCH)
+    assert [entry.task_id for entry in live] == [behind.id]
+
+
 def test_two_workers_cannot_hold_the_same_slot(queue):
     """The exclusivity guarantee: a CAS loser is told to wait, not let through."""
 


### PR DESCRIPTION
## Summary
- An entry admitted to the native merge queue but cancelled before it ever wins a `claim_slot()` lease stays at `attempts == 0` forever. Neither `stalled_entries()` nor `evict_exhausted()` can reap it (both require `attempts >= 1`), and a cancelled task never calls `claim_slot()` again, so the entry — often the head of the line — permanently blocks every entry behind it.
- Also found `evict_exhausted()`/`stalled_entries()` are dead code: zero production callers anywhere in `src/mac`, so even entries that legitimately exhaust their attempt cap were never being reaped either.
- Adds `NativeMergeQueue.evict_for_task()` (looks up a live entry by `task_id` alone, since the cancellation caller has only the task id) and wires it into `ControlPlane.close_task()`/`transition_task()` on the `CANCELLED` transition, best-effort so a queue lookup failure never blocks the cancellation itself.

Observed live on rocky's hub (mac-fleet-canary project): a conflict-integration task's queue entry sat wedged at the front of the queue for 45+ minutes after being superseded/cancelled, with 7 sibling tasks queued behind it making zero progress.

## Test plan
- [x] `pytest tests/test_native_merge_queue.py` — 73/73 passed, including new `test_evict_for_task_clears_a_never_attempted_head_of_line_entry`, `test_evict_for_task_is_a_noop_when_the_task_has_no_live_entry`, and the wiring-level `test_cancelling_a_task_evicts_its_never_attempted_merge_queue_entry`
- [x] `pytest tests/test_control_plane.py tests/test_dependency_cancelled_with_disposition_satisfies_join.py tests/test_repository_ref_lifecycle.py` — 480/480 passed, no regressions