### PR TITLE
Reap merge-queue entries that win a slot but can never open a PR

### DIFF
--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -21332,6 +21332,25 @@ class ControlPlane:
                     ).get("stdout")
                     or ""
                 ).strip()
+                # Same rationale as reconcile_front below, for a different way an
+                # entry can stop moving: it wins its slot, tests clean, and then
+                # every publication attempt fails for a reason retrying cannot
+                # fix (its branch has no commits against main because another
+                # entry already carried the same change home first). It is
+                # never evicted on its own -- claim_slot() only increments
+                # attempts, it does not judge them -- so it sits at the front
+                # forever, burning every publish attempt for entries behind it
+                # too. evict_exhausted() is the reaper for exactly this; it was
+                # defined but never called from anywhere, so it never ran.
+                evicted_stalled = queue.evict_exhausted(queue_repository, canonical_branch)
+                if evicted_stalled:
+                    commands.append(
+                        {
+                            "name": "merge_queue_stalled_reaper",
+                            "attempt": attempt,
+                            "evicted_entry_ids": evicted_stalled,
+                        }
+                    )
                 commands.append(
                     {
                         "name": "merge_queue_front_recovery",

--- a/tests/test_native_merge_queue.py
+++ b/tests/test_native_merge_queue.py
@@ -1200,6 +1200,38 @@ def test_an_entry_marked_tested_with_no_trees_still_cannot_land():
     assert (ok, why) == (False, "entry carries no tested trees")
 
 
+def test_evict_exhausted_clears_a_tested_entry_that_can_never_get_a_pr(queue):
+    """A slot that wins, tests clean, but can never open a PR must not wedge.
+
+    Reproduces a live incident: a task's branch had no commits against main
+    (another entry already landed the same change first), so every
+    publication attempt failed with GitHub 422 "No commits between main and
+    <branch>" and pull_request_number stayed 0 forever. claim_slot() only
+    increments attempts -- it does not judge them -- so the entry sat at the
+    front of the queue burning every publish cycle for the entries behind it,
+    because evict_exhausted() (the reaper built for exactly this) was never
+    called from anywhere in production.
+    """
+
+    front = _claim(queue, "task_no_diff", "A" * 40)
+    assert front.admitted is True
+    queue.record_tested(
+        front.entry.id,
+        owner="hub-a",
+        base_sha="A" * 40,
+        base_tree="tree-a",
+        merge_tree="tree-a",
+    )
+    behind = _admit(queue, "task_alive", "B" * 40)
+
+    evicted = queue.evict_exhausted(REPO, BRANCH)
+    assert evicted == [front.entry.id]
+
+    live = queue.live_entries(REPO, BRANCH)
+    assert [entry.task_id for entry in live] == ["task_alive"]
+    assert live[0].id == behind.id
+
+
 def test_evict_for_task_clears_a_never_attempted_head_of_line_entry(queue):
     """A task cancelled before it ever wins a slot must not wedge the queue.
 

--- a/tests/test_publication_gate_scope.py
+++ b/tests/test_publication_gate_scope.py
@@ -105,6 +105,26 @@ def test_the_publication_gate_also_runs_bootstrap_before_its_test_command():
     )
 
 
+def test_the_publish_attempt_reaps_stalled_merge_queue_entries():
+    """evict_exhausted() must run on the same cadence as reconcile_front().
+
+    An entry that wins a slot, tests clean, and then can never open a pull
+    request (its branch has no commits against main because another entry
+    already landed the same change) is invisible to claim_slot() -- that
+    method only increments attempts, it never judges them. evict_exhausted()
+    is the reaper built for exactly this, but it was defined in
+    native_merge_queue.py and never called from anywhere in services.py, so
+    it never ran and a stalled entry blocked the front of the queue forever.
+    """
+    source = inspect.getsource(services.ControlPlane._publish_git_target_attempt)
+
+    assert "evict_exhausted" in source, (
+        "the publish-attempt loop must call queue.evict_exhausted() before "
+        "claim_slot(), or an entry that wins a slot and then can never open "
+        "a pull request wedges the front of the queue forever"
+    )
+
+
 def test_the_chosen_gate_command_is_recorded():
     """The scoped and full commands take ~15 and ~45 minutes, and only one fits
     the timeout. A silent fallback to full is indistinguishable from a hang."""


### PR DESCRIPTION
## Summary
- A task that wins a merge-queue slot and tests clean can still get permanently stuck: if another entry already landed the same change first, its branch has no commits against main, so every GitHub PR-open attempt fails with 422 "No commits between main and \<branch\>". `claim_slot()` only increments `attempts`, it never judges them, so the entry sits at the front of the queue forever, burning every publish attempt for the entries behind it too.
- `evict_exhausted()`/`stalled_entries()` in `native_merge_queue.py` were built for exactly this case (an entry in a PR-requiring state with `attempts >= 1` and no `pull_request_number`) but were never called from anywhere in production.
- Confirmed live on `mac-fleet-canary`'s hub: a task sat at queue position 178 with attempts climbing (1 → 3) and `pull_request_number` staying 0 for 25+ minutes while every entry behind it starved.
- Wires `queue.evict_exhausted()` into the same publish-attempt cadence as `reconcile_front()`, right before `claim_slot()`.

This is a follow-up to #772 (which fixed the analogous case for a *cancelled* task's entry) — this one covers a *live* task whose entry can never make forward progress for a different reason.

## Test plan
- [x] `pytest tests/test_native_merge_queue.py tests/test_publication_gate_scope.py` — 82/82 passed, including new `test_evict_exhausted_clears_a_tested_entry_that_can_never_get_a_pr` and the wiring-level `test_the_publish_attempt_reaps_stalled_merge_queue_entries`
- [x] `pytest tests/test_control_plane.py tests/test_publication_pull_request.py` — 507/507 passed, no regressions