### PR TITLE
Harden CLI-session hooks against version skew (task_406dcbb7099b4e5793be98aed86ff21b)

### DIFF
--- a/docs/adr/0032-cli-session-hooks-not-tmux.md
+++ b/docs/adr/0032-cli-session-hooks-not-tmux.md
@@ -1,6 +1,6 @@
 # ADR 0032: CLI sessions use each harness's hooks, not tmux, for recording and AgentBus injection
 
-- Status: Proposed
+- Status: Partially implemented (2026-09-07: auto-trigger + Claude Code inject job)
 - Date: 2026-08-24
 - Decision owner: MAC fleet owner
 - Related: [ADR 0023](0023-one-skill-source-many-harness-plugins.md) — one
@@ -201,3 +201,49 @@ the bus is the announcement. Same posture as ADR 0026 §2 for emission.
 - Replacing OpenShell isolation, leases, or the merge queue.
 - Recording raw transcripts into Qdrant. ADR 0030 still wants an
   extract, not a pane dump.
+
+## Update 2026-09-07: the install step is now automatic
+
+The original decision assumed an operator runs `mac admin plugin
+install` by hand to wire a harness's hook config. That is a gap of its
+own: a session that never runs the installer is deaf, silently, with
+no error to notice — the exact failure shape this ADR exists to fix,
+one layer up.
+
+`src/mac/cli_session.py` removes the manual step. `mac`'s `main()`
+now calls `cli_session.auto_join()` on every invocation; it is a
+total no-op unless a known coding-CLI harness is detected in the
+environment (`CLAUDECODE=1` for Claude Code — the only signal
+verified against a live session so far), in which case it:
+
+1. Idempotently registers a durable `(machine, agent)` identity
+   scoped to `(hostname, os-user)`, owned by the caller's `Human`
+   principal when one resolves, `visibility="private"` otherwise
+   `"shared"`. Both `register_machine`/`register_agent` are
+   `INSERT ... ON CONFLICT DO UPDATE` upserts, so repeated calls are
+   free; a local cache under `~/.mac/cli-session/` additionally
+   skips the network round trip within `DEFAULT_CACHE_TTL_SECONDS`.
+2. Idempotently merges a fail-open adapter for `mac admin cli-session
+   hook` into the harness's own hook config (`~/.claude/settings.json`
+   `hooks.SessionStart` / `hooks.UserPromptSubmit` for Claude Code) —
+   merges alongside whatever hooks already exist, never replaces the
+   array. The adapter emits valid empty hook JSON if the installed
+   `mac` binary is temporarily older than the config.
+
+`mac admin cli-session hook` is the adapter program this ADR
+describes: a non-blocking `drain_agentbus_inbox` call rendered as the
+harness's hook-output JSON shape (`hookSpecificOutput.additionalContext`
+for Claude Code), empty inbox → empty context, any failure → empty
+context, never a blocked prompt or a non-zero exit.
+
+**Shipped**: the auto-trigger mechanism, generically; the Claude Code
+inject job, fully verified from inside a live Claude Code session.
+
+**Deferred, tracked as a follow-up task**:
+- Codex, Cursor, and OpenCode adapters. Their harness-detection env
+  vars and hook config shapes are named in this ADR's table but were
+  not verified against a live session of each, and guessing wrong
+  would silently install into the wrong config file — worse than not
+  installing at all.
+- The **record** job (`PreToolUse`/`PostToolUse`/`Stop`/`SessionEnd`
+  → `mac.cli_session.turn.v1`). Only inject shipped in this pass.

--- a/docs/env-config-reference.md
+++ b/docs/env-config-reference.md
@@ -559,6 +559,7 @@ Defaults shown as `consumer-defined` are intentionally owned by the calling subs
 | `MAC_HUB_VERIFY_RUNNER` | str | consumer-defined | hub | Hub setting: hub verify runner. |
 | `MAC_HUB_VERIFY_TIMEOUT` | int | consumer-defined | hub | Hub setting: hub verify timeout. |
 | `MAC_HUMAN` | str | consumer-defined | core | Core setting: human. |
+| `MAC_HUMAN_USERNAME` | str | consumer-defined | core | Core setting: human username. |
 | `MAC_IDE_HANDOFF_FILE` | str | consumer-defined | core | Core setting: ide handoff file. |
 | `MAC_IDE_PROXY_TOKEN` | str | consumer-defined | core | Core setting: ide proxy token. |
 | `MAC_IMAGE_BUILDER` | str | consumer-defined | core | Core setting: image builder. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,7 +55,7 @@ The objects mac models. Start here:
 Everything else:
   admin  fleet, runtime and control-plane administration
 
-54 administrative commands live under `mac admin` (`mac admin help` lists them).
+55 administrative commands live under `mac admin` (`mac admin help` lists them).
 They moved: `mac fleet ...` is now `mac admin fleet ...`, and the old spelling says so.
 
 Run `mac help --all` to see every command in one list.
@@ -251,6 +251,7 @@ Fleet and machines:
   openshell      sandboxed execution environments for agents
   mcp            serve the ledger to coding agents as Model Context Protocol tools
   plugin         install mac skills and MCP into Claude, Codex, Cursor, OpenCode
+  cli-session    auto-join this CLI session to the AgentBus (ADR 0032 auto-trigger)
   sandbox-image  the sandbox IMAGE: its bill of materials and its rollout
   runtime        runtime images and environment definitions
   rollout        staged rollout of a runtime or configuration

--- a/src/mac/cli.py
+++ b/src/mac/cli.py
@@ -795,6 +795,26 @@ def _plane(args: argparse.Namespace) -> Any:
     return resolve_dispatch(args)
 
 
+def _maybe_auto_join_cli_session(args: argparse.Namespace) -> None:
+    """Best-effort ADR 0032 auto-trigger: never affects the command's outcome.
+
+    Skips its own subcommands (``mac admin cli-session ...``) to avoid a
+    redundant registration call ahead of the explicit one, and is a total
+    no-op when no known coding-CLI harness is detected in the environment --
+    the overwhelmingly common case for scripted/CI/plain-terminal usage.
+    """
+    if getattr(args, "cli_session_command", None) is not None:
+        return
+    try:
+        from mac import cli_session
+
+        if cli_session.detect_live_harness() is None:
+            return
+        cli_session.auto_join(_plane(args))
+    except Exception:  # noqa: BLE001 - ambient side effect, never fatal
+        pass
+
+
 def cmd_mcp_serve(args: argparse.Namespace) -> None:
     """Serve the mac ledger to a coding agent as MCP tools, over stdio.
 
@@ -810,6 +830,37 @@ def cmd_mcp_serve(args: argparse.Namespace) -> None:
     from mac.mcp_server import serve
 
     raise SystemExit(serve(_plane(args)))
+
+
+def cmd_cli_session_ensure_registered(args: argparse.Namespace) -> None:
+    """Idempotently register this host+user as a live AgentBus identity.
+
+    ``main()`` calls this automatically when a known coding-CLI harness is
+    detected (ADR 0032's auto-trigger addendum); this verb exists so an
+    operator can also run it by hand, or a script can pre-warm the cache.
+    """
+    from mac import cli_session
+
+    identity = cli_session.ensure_registered_cached(
+        _plane(args),
+        harness=args.harness or cli_session.detect_live_harness() or "unknown",
+    )
+    cli_session.install_hook_config(args.harness or cli_session.detect_live_harness() or "")
+    _print(identity)
+
+
+def cmd_cli_session_hook(args: argparse.Namespace) -> None:
+    """The program a harness's hook config invokes at a turn boundary.
+
+    Drains this session's AgentBus inbox without blocking and prints the
+    harness's own hook-output JSON shape. Never raises and never exits
+    non-zero for a drain failure -- an empty/failed drain must look like a
+    normal turn to the harness, not a broken hook (ADR 0032 §5).
+    """
+    from mac import cli_session
+
+    output = cli_session.run_hook(_plane(args), harness=args.harness, event=args.event)
+    _print(output)
 
 
 def cmd_plugin_install(args: argparse.Namespace) -> None:
@@ -9526,6 +9577,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="override the user home used to find harness config directories",
     )
     _set(cmd_plugin_uninstall, plugin_uninstall)
+    cli_session = sub.add_parser(
+        "cli-session",
+        help="auto-join this CLI session to the AgentBus (ADR 0032 auto-trigger)",
+    ).add_subparsers(dest="cli_session_command", required=True)
+    cli_session_ensure = cli_session.add_parser(
+        "ensure-registered",
+        help="idempotently register this host+user as a live AgentBus identity",
+    )
+    cli_session_ensure.add_argument(
+        "--harness",
+        help="coding CLI harness (default: auto-detect from the environment)",
+    )
+    _set(cmd_cli_session_ensure_registered, cli_session_ensure)
+    cli_session_hook = cli_session.add_parser(
+        "hook",
+        help="drain this session's AgentBus inbox; invoked by a harness's own hook config",
+    )
+    cli_session_hook.add_argument("--harness", default="claude")
+    cli_session_hook.add_argument(
+        "--event",
+        choices=("SessionStart", "UserPromptSubmit"),
+        default="UserPromptSubmit",
+    )
+    _set(cmd_cli_session_hook, cli_session_hook)
     openshell = sub.add_parser(
         "openshell", help="OpenShell sandbox guardrail commands"
     ).add_subparsers(dest="openshell_command", required=True)
@@ -12530,6 +12605,7 @@ def main(argv: Optional[Iterable[str]] = None) -> int:
         return 0
     _redirect_moved_command(raw)
     args = parser.parse_args(raw)
+    _maybe_auto_join_cli_session(args)
     try:
         args.func(args)
     except MACError as exc:

--- a/src/mac/cli_session.py
+++ b/src/mac/cli_session.py
@@ -1,0 +1,383 @@
+"""Ambient CLI session auto-join to the AgentBus (ADR 0032, auto-trigger addendum).
+
+ADR 0032 designed the *delivery* mechanism -- a per-harness hook adapter that
+non-blocking-drains an agent's AgentBus inbox and returns the messages as
+additional context at a turn boundary -- but assumed a human operator runs
+``mac admin plugin install`` once, by hand, to wire the hook config in. That
+manual step is a gap: a coding CLI session that has ``mac`` on ``$PATH`` and
+never runs the installer is deaf to the bus forever, silently, with no error
+to notice.
+
+This module removes that manual step. The first time ``mac`` is invoked from
+*inside* a detected coding-CLI harness (Claude Code today; see
+``_HARNESS_ENV_SIGNATURES``), it self-registers a durable, host+user-scoped
+agent identity and installs the harness's hook config -- both idempotent, so
+every subsequent invocation is a cheap cache hit, not a repeated write.
+
+Two deliberate scope cuts against the ADR's full design, both because this is
+new code that has to be trustworthy before it is widened:
+
+* Only the **inject** job (drain inbox -> additionalContext) ships here. The
+  **record** job (turn/tool events -> ``mac.cli_session.turn.v1``) is not
+  implemented; see the follow-up task filed alongside this change.
+* Only Claude Code's harness-detection signal is verified against a live
+  session (``CLAUDECODE=1``, confirmed 2026-09-07 from inside one). Codex,
+  Cursor, and OpenCode are real harnesses ADR 0032 names, but guessing their
+  env-var signal wrong would silently install into the wrong config file, so
+  they are left for a follow-up that can verify each one live.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional
+
+from mac import mac_paths
+from mac.models import MACError, NotFoundError
+
+logger = logging.getLogger("mac.cli_session")
+
+#: Env-var signatures that reveal ``mac`` is running INSIDE a known coding
+#: harness's own process tree, as opposed to a plain terminal. Add an entry
+#: only once verified from inside a live session of that harness.
+_HARNESS_ENV_SIGNATURES: Dict[str, str] = {
+    "claude": "CLAUDECODE",
+}
+
+#: How long a successful registration is trusted before the next invocation
+#: re-verifies with the hub. Idempotent on the hub side either way; this only
+#: bounds how often an ordinary command pays the network round trip.
+DEFAULT_CACHE_TTL_SECONDS = 6 * 3600
+
+_LEGACY_HOOK_COMMAND = "mac admin cli-session hook"
+
+
+def detect_live_harness(environ: Optional[Mapping[str, str]] = None) -> Optional[str]:
+    """Which known coding-CLI harness this process is running inside, if any."""
+    env = environ if environ is not None else os.environ
+    for harness, var in _HARNESS_ENV_SIGNATURES.items():
+        if str(env.get(var) or "").strip():
+            return harness
+    return None
+
+
+def session_identity(hostname: str, user: str) -> Dict[str, str]:
+    """A stable (machine_id, agent_id, name) for this (host, os-user) pair.
+
+    Deterministic and content-free by design: re-deriving it never requires
+    reading back what was registered last time, so a cold cache is not a
+    different identity, it is the same identity computed again.
+    """
+    host_digest = hashlib.sha256(hostname.encode("utf-8")).hexdigest()[:16]
+    pair_digest = hashlib.sha256(("%s:%s" % (hostname, user)).encode("utf-8")).hexdigest()[:16]
+    return {
+        "machine_id": "machine_cli_%s" % host_digest,
+        "agent_id": "agent_cli_%s" % pair_digest,
+        "name": "cli-session-%s@%s" % (user, hostname),
+    }
+
+
+def _cache_path(agent_id: str) -> Path:
+    return mac_paths.mac_home() / "cli-session" / ("%s.json" % agent_id)
+
+
+def _cached_registration(agent_id: str, ttl_seconds: int) -> Optional[Dict[str, Any]]:
+    path = _cache_path(agent_id)
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    if (time.time() - stat.st_mtime) > ttl_seconds:
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_cache(agent_id: str, record: Dict[str, Any]) -> None:
+    path = _cache_path(agent_id)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record, sort_keys=True), encoding="utf-8")
+    except OSError:
+        # Losing the cache costs one extra network round trip next time, not
+        # correctness -- registration itself is idempotent.
+        pass
+
+
+def _resolve_owner_human_id(plane: Any, user: str) -> Optional[str]:
+    """Best-effort: bind the agent to a registered Human if one matches.
+
+    Not required -- ``register_agent`` accepts no owner and falls back to
+    shared visibility -- but a private, owned identity is the better default
+    when the caller's own username happens to already be a registered
+    principal (e.g. a fleet operator's laptop).
+    """
+    for candidate in (user, os.environ.get("MAC_HUMAN_USERNAME") or ""):
+        candidate = str(candidate or "").strip()
+        if not candidate:
+            continue
+        try:
+            return plane.get_human_by_username(candidate).id
+        except NotFoundError:
+            continue
+        except MACError:
+            continue
+    return None
+
+
+def ensure_registered(
+    plane: Any,
+    *,
+    harness: str,
+    hostname: Optional[str] = None,
+    user: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Idempotently register this (host, user) as a live AgentBus identity.
+
+    Safe to call on every invocation: ``register_machine``/``register_agent``
+    are both ``INSERT ... ON CONFLICT DO UPDATE`` upserts on the hub, so a
+    repeat call refreshes ``last_seen_at`` rather than creating a duplicate
+    or erroring. Callers that want to avoid the network round trip on every
+    command should check :func:`ensure_registered_cached` instead.
+    """
+    hostname = hostname or socket.gethostname()
+    user = user or os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+    identity = session_identity(hostname, user)
+    plane.register_machine(
+        hostname=hostname,
+        machine_id=identity["machine_id"],
+        labels={"kind": "cli-session-host"},
+    )
+    owner_human_id = _resolve_owner_human_id(plane, user)
+    plane.register_agent(
+        machine_id=identity["machine_id"],
+        name=identity["name"],
+        agent_id=identity["agent_id"],
+        capabilities=["cli_session", "harness:%s" % harness],
+        owner_human_id=owner_human_id,
+        actor="cli-session-autojoin",
+    )
+    return identity
+
+
+def ensure_registered_cached(
+    plane: Any,
+    *,
+    harness: str,
+    hostname: Optional[str] = None,
+    user: Optional[str] = None,
+    ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS,
+) -> Dict[str, Any]:
+    """:func:`ensure_registered`, but skip the network round trip on a warm cache."""
+    hostname = hostname or socket.gethostname()
+    user = user or os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+    identity = session_identity(hostname, user)
+    cached = _cached_registration(identity["agent_id"], ttl_seconds)
+    if cached is not None:
+        return cached
+    identity = ensure_registered(plane, harness=harness, hostname=hostname, user=user)
+    _write_cache(identity["agent_id"], identity)
+    return identity
+
+
+def auto_join(
+    plane: Any,
+    *,
+    environ: Optional[Mapping[str, str]] = None,
+    ttl_seconds: int = DEFAULT_CACHE_TTL_SECONDS,
+) -> Optional[Dict[str, Any]]:
+    """The single entry point the CLI's main() calls on every invocation.
+
+    Returns the identity dict on success, ``None`` on anything else (no
+    harness detected, no hub reachable, registration failed). Never raises:
+    a session that cannot join the bus must still run the command it was
+    actually asked to run (ADR 0032 §5, "failure must not take down the
+    session").
+    """
+    harness = detect_live_harness(environ)
+    if harness is None:
+        return None
+    try:
+        identity = ensure_registered_cached(plane, harness=harness, ttl_seconds=ttl_seconds)
+        # Source-tree tests and one-off PYTHONPATH invocations must not publish
+        # a hook that the persistent CLI cannot execute on the next turn.
+        if _hook_command_available():
+            install_hook_config(harness)
+        return identity
+    except Exception:  # noqa: BLE001 - ambient best-effort, never fatal
+        logger.debug("cli-session auto-join failed", exc_info=True)
+        return None
+
+
+# -- hook config installation -----------------------------------------------
+
+
+def _claude_settings_path(user_home: Optional[Path] = None) -> Path:
+    home = user_home or Path.home()
+    return home / ".claude" / "settings.json"
+
+
+def _hook_command(event: str = "UserPromptSubmit") -> str:
+    """Shell adapter written into Claude settings.
+
+    The fallback is deliberately valid for every Claude hook event. A missing,
+    older, or temporarily broken ``mac`` executable must make the session deaf
+    for one turn, never reject the user's prompt.
+    """
+    return (
+        "mac admin cli-session hook --event %s 2>/dev/null || "
+        "printf '%s\\n' '{\"continue\":true}'" % (event, "%s")
+    )
+
+
+def _hook_command_available(environ: Optional[Mapping[str, str]] = None) -> bool:
+    """Whether the persistent ``mac`` on PATH implements the hook command.
+
+    Drop PYTHONPATH before probing. Otherwise a test running unreleased source
+    can make an older installed entry point appear to support the new parser,
+    which is exactly how the global Claude configuration escaped prematurely.
+    """
+    env = dict(environ if environ is not None else os.environ)
+    env.pop("PYTHONPATH", None)
+    executable = shutil.which("mac", path=env.get("PATH"))
+    if not executable:
+        return False
+    try:
+        result = subprocess.run(
+            [executable, "admin", "cli-session", "hook", "--help"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def _merge_claude_hooks(path: Path) -> bool:
+    """Idempotently add mac's inject hook to Claude Code's settings.json.
+
+    Merges alongside whatever hooks already exist for the same events --
+    never replaces the array, never drops an entry that is not ours. Returns
+    True iff the file was written (a real change happened).
+    """
+    document: Dict[str, Any] = {}
+    if path.is_file():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            loaded = {}
+        if isinstance(loaded, dict):
+            document = loaded
+    hooks = document.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        hooks = {}
+        document["hooks"] = hooks
+    changed = False
+    for event in ("SessionStart", "UserPromptSubmit"):
+        command = _hook_command(event)
+        entries = hooks.setdefault(event, [])
+        if not isinstance(entries, list):
+            entries = []
+            hooks[event] = entries
+        already_present = False
+        for entry in entries:
+            if not isinstance(entry, dict) or not isinstance(entry.get("hooks"), list):
+                continue
+            for hook in entry["hooks"]:
+                if not isinstance(hook, dict):
+                    continue
+                configured = hook.get("command")
+                if configured == command:
+                    already_present = True
+                elif configured == _LEGACY_HOOK_COMMAND:
+                    hook["command"] = command
+                    already_present = True
+                    changed = True
+        if already_present:
+            continue
+        entries.append({"hooks": [{"type": "command", "command": command}]})
+        changed = True
+    if not changed:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return True
+
+
+def install_hook_config(harness: str, *, user_home: Optional[Path] = None) -> bool:
+    """Wire ``harness``'s own hook config to point at ``mac admin cli-session hook``.
+
+    Only Claude Code is implemented. Other harnesses return False (no-op)
+    until their adapter is verified live -- see the module docstring.
+    """
+    if harness == "claude":
+        return _merge_claude_hooks(_claude_settings_path(user_home))
+    return False
+
+
+# -- the hook program itself -------------------------------------------------
+
+
+def render_claude_hook_output(
+    messages: List[Dict[str, Any]], *, event: str = "UserPromptSubmit"
+) -> Dict[str, Any]:
+    """Shape drained AgentBus messages as Claude Code's hook output contract.
+
+    Empty inbox -> empty additionalContext, not an error and not an absent
+    key: ADR 0032 §1 requires an empty inbox to still produce a valid empty
+    hook payload, so a session with nothing waiting sees a normal turn.
+    """
+    if not messages:
+        return {"hookSpecificOutput": {"hookEventName": event, "additionalContext": ""}}
+    lines = ["You have %d pending message(s) from the MAC fleet AgentBus:" % len(messages)]
+    for entry in messages:
+        sender = str(entry.get("sender_agent_id") or "unknown")
+        payload = entry.get("payload")
+        text = payload if isinstance(payload, str) else json.dumps(payload)
+        lines.append("- from %s: %s" % (sender, text))
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": event,
+            "additionalContext": "\n".join(lines),
+        }
+    }
+
+
+def run_hook(
+    plane: Any,
+    *,
+    harness: str = "claude",
+    event: str = "UserPromptSubmit",
+    environ: Optional[Mapping[str, str]] = None,
+) -> Dict[str, Any]:
+    """Non-blocking drain + render, for the harness's hook adapter to print.
+
+    Never raises: a hook that cannot reach the hub must record and inject
+    nothing for that turn without blocking the user's prompt (ADR 0032 §5).
+    """
+    try:
+        hostname = socket.gethostname()
+        user = os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+        identity = session_identity(hostname, user)
+        result = plane.drain_agentbus_inbox(identity["agent_id"])
+        messages = list(result.get("messages") or [])
+    except Exception:  # noqa: BLE001 - a deaf turn beats a blocked one
+        logger.debug("cli-session hook drain failed", exc_info=True)
+        messages = []
+    if harness == "claude":
+        return render_claude_hook_output(messages, event=event)
+    return {}

--- a/src/mac/cli_surface.py
+++ b/src/mac/cli_surface.py
@@ -197,6 +197,7 @@ COMMAND_GROUPS: Tuple[Tuple[str, Tuple[Tuple[str, str], ...]], ...] = (
             ("openshell", "sandboxed execution environments for agents"),
             ("mcp", "serve the ledger to coding agents as Model Context Protocol tools"),
             ("plugin", "install mac skills and MCP into Claude, Codex, Cursor, OpenCode"),
+            ("cli-session", "auto-join this CLI session to the AgentBus (ADR 0032 auto-trigger)"),
             ("sandbox-image", "the sandbox IMAGE: its bill of materials and its rollout"),
             ("runtime", "runtime images and environment definitions"),
             ("rollout", "staged rollout of a runtime or configuration"),

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -6650,6 +6650,17 @@
   },
   {
     "default": null,
+    "description": "Core setting: human username.",
+    "family": "core",
+    "name": "MAC_HUMAN_USERNAME",
+    "retired": false,
+    "sources": [
+      "src/mac/cli_session.py"
+    ],
+    "type": "str"
+  },
+  {
+    "default": null,
     "description": "Core setting: ide handoff file.",
     "family": "core",
     "name": "MAC_IDE_HANDOFF_FILE",

--- a/tests/cli/test_cli_session.py
+++ b/tests/cli/test_cli_session.py
@@ -1,0 +1,69 @@
+"""`mac admin cli-session` at the CLI layer (ADR 0032)."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+
+from mac import cli_session
+from mac.cli import main
+from mac.test_support import dsn_for
+
+
+def _run(tmp_path, *args):
+    out = io.StringIO()
+    err = io.StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    sys.stdout, sys.stderr = out, err
+    try:
+        rc = main(["--db", dsn_for(tmp_path), "--json", *args])
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+    raw = out.getvalue().strip()
+    return rc, (json.loads(raw) if raw else None), err.getvalue()
+
+
+def test_cli_session_ensure_registered_uses_isolated_hook_config(tmp_path, monkeypatch):
+    settings = tmp_path / "user" / ".claude" / "settings.json"
+    monkeypatch.setattr(cli_session, "_claude_settings_path", lambda user_home=None: settings)
+    monkeypatch.setattr(
+        cli_session,
+        "_cache_path",
+        lambda agent_id: tmp_path / "cache" / (agent_id + ".json"),
+    )
+
+    rc, identity, err = _run(
+        tmp_path,
+        "admin",
+        "cli-session",
+        "ensure-registered",
+        "--harness",
+        "claude",
+    )
+
+    assert rc in (None, 0), err
+    assert identity["agent_id"].startswith("agent_cli_")
+    document = json.loads(settings.read_text(encoding="utf-8"))
+    assert document["hooks"]["UserPromptSubmit"][0]["hooks"][0][
+        "command"
+    ] == cli_session._hook_command("UserPromptSubmit")
+
+
+def test_cli_session_hook_renders_the_selected_event(tmp_path):
+    rc, output, err = _run(
+        tmp_path,
+        "admin",
+        "cli-session",
+        "hook",
+        "--event",
+        "SessionStart",
+    )
+
+    assert rc in (None, 0), err
+    assert output == {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": "",
+        }
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,18 @@ def _no_ticket_mirror(monkeypatch):
     monkeypatch.setenv("MAC_NO_TICKET_MIRROR", "1")
 
 
+@pytest.fixture(autouse=True)
+def _no_live_coding_harness(monkeypatch):
+    """Tests never inherit a developer's live coding-harness identity.
+
+    CLI tests call ``main()`` in-process. Inheriting ``CLAUDECODE=1`` made an
+    unreleased auto-join implementation write to the developer's real
+    ``~/.claude/settings.json`` during pytest. Tests that exercise harness
+    detection pass an explicit environment or opt in with ``monkeypatch``.
+    """
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+
+
 # ----------------------------------------------------------------------
 # Live-Postgres fixtures (K8s Phase 3.6).
 #

--- a/tests/test_cli_session.py
+++ b/tests/test_cli_session.py
@@ -1,0 +1,275 @@
+"""CLI session auto-join to the AgentBus (ADR 0032 auto-trigger addendum).
+
+The claim under test: a `mac` invocation from inside a detected coding-CLI
+harness registers a durable identity and wires that harness's hook config,
+with no separate `mac admin plugin install` step -- and does all of that
+without ever blocking or failing the command the user actually ran.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from mac import cli_session
+from mac.services import ControlPlane
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cli_session_state(tmp_path, monkeypatch):
+    """Every test in this file runs against scratch cache and config paths.
+
+    ``ensure_registered_cached``/``auto_join`` persist a small marker under
+    ``~/.mac/cli-session/`` on the real machine by default. Without this
+    fixture, test state survives into the next test and can escape onto the
+    developer's or CI runner's real home directory.
+    """
+    monkeypatch.setattr(
+        cli_session, "_cache_path", lambda agent_id: tmp_path / (agent_id + ".json")
+    )
+    monkeypatch.setattr(
+        cli_session,
+        "_claude_settings_path",
+        lambda user_home=None: (user_home or tmp_path) / ".claude" / "settings.json",
+    )
+
+
+@pytest.fixture()
+def cp():
+    return ControlPlane.in_memory()
+
+
+def test_detect_live_harness_recognizes_claude_code():
+    assert cli_session.detect_live_harness({"CLAUDECODE": "1"}) == "claude"
+
+
+def test_detect_live_harness_is_none_for_a_plain_terminal():
+    assert cli_session.detect_live_harness({"PATH": "/usr/bin", "TERM": "xterm"}) is None
+
+
+def test_session_identity_is_deterministic_and_host_user_scoped():
+    a = cli_session.session_identity("laptop.local", "jordanh")
+    b = cli_session.session_identity("laptop.local", "jordanh")
+    other_user = cli_session.session_identity("laptop.local", "someoneelse")
+    other_host = cli_session.session_identity("other.local", "jordanh")
+
+    assert a == b
+    assert a["agent_id"] != other_user["agent_id"]
+    assert a["agent_id"] != other_host["agent_id"]
+    # The machine identity is host-scoped only, so two users on the same
+    # laptop share one machine row rather than each registering a duplicate.
+    assert (
+        a["machine_id"] == cli_session.session_identity("laptop.local", "someoneelse")["machine_id"]
+    )
+
+
+def test_ensure_registered_creates_a_live_agentbus_participant(cp):
+    identity = cli_session.ensure_registered(
+        cp, harness="claude", hostname="laptop.local", user="jordanh"
+    )
+
+    agent = cp.get_agent(identity["agent_id"])
+    assert agent.id == identity["agent_id"]
+    assert "cli_session" in agent.capabilities
+    assert "harness:claude" in agent.capabilities
+
+    # And it is a genuinely live bus participant: sending it a message and
+    # draining its inbox works without a NotFoundError, which is exactly the
+    # failure mode an unregistered ad-hoc agent_id hits today.
+    cp.register_machine(hostname="sender.local", machine_id="machine_sender")
+    cp.register_agent(machine_id="machine_sender", name="sender", agent_id="agent_sender")
+    stream = cp.open_agentbus_stream(
+        sender_agent_id="agent_sender", recipient_agent_id=identity["agent_id"]
+    )
+    cp.append_agentbus_chunk(stream.id, "agent_sender", payload={"text": "hello"})
+    drained = cp.drain_agentbus_inbox(identity["agent_id"])
+    assert drained["count"] == 1
+
+
+def test_ensure_registered_is_idempotent(cp):
+    first = cli_session.ensure_registered(cp, harness="claude", hostname="h", user="u")
+    second = cli_session.ensure_registered(cp, harness="claude", hostname="h", user="u")
+
+    assert first["agent_id"] == second["agent_id"]
+    agents = cp.list_agents() if hasattr(cp, "list_agents") else None
+    if agents is not None:
+        matching = [a for a in agents if a.id == first["agent_id"]]
+        assert len(matching) == 1
+
+
+def test_ensure_registered_cached_skips_the_second_call_within_ttl(cp, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        cli_session, "_cache_path", lambda agent_id: tmp_path / (agent_id + ".json")
+    )
+    calls = []
+    real = cli_session.ensure_registered
+
+    def counting(*args, **kwargs):
+        calls.append(1)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(cli_session, "ensure_registered", counting)
+
+    cli_session.ensure_registered_cached(
+        cp, harness="claude", hostname="h", user="u", ttl_seconds=3600
+    )
+    cli_session.ensure_registered_cached(
+        cp, harness="claude", hostname="h", user="u", ttl_seconds=3600
+    )
+
+    assert len(calls) == 1
+
+
+def test_auto_join_is_a_silent_noop_with_no_detected_harness(cp):
+    assert cli_session.auto_join(cp, environ={"TERM": "xterm"}) is None
+
+
+def test_auto_join_never_raises_when_the_plane_is_broken():
+    class BrokenPlane:
+        def register_machine(self, *a, **k):
+            raise RuntimeError("hub unreachable")
+
+    # Must not raise -- ADR 0032 sec 5: failure must not take down the session.
+    assert cli_session.auto_join(BrokenPlane(), environ={"CLAUDECODE": "1"}) is None
+
+
+def test_merge_claude_hooks_is_idempotent_and_preserves_existing_hooks(tmp_path):
+    document_path = tmp_path / "settings.json"
+    document_path.write_text(
+        json.dumps(
+            {"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "echo hi"}]}]}}
+        ),
+        encoding="utf-8",
+    )
+
+    first_write = cli_session._merge_claude_hooks(document_path)
+    assert first_write is True
+    second_write = cli_session._merge_claude_hooks(document_path)
+    assert second_write is False
+
+    document = json.loads(document_path.read_text(encoding="utf-8"))
+    session_start = document["hooks"]["SessionStart"]
+    # The pre-existing hook survives untouched.
+    assert any(
+        h.get("command") == "echo hi" for entry in session_start for h in entry.get("hooks", [])
+    )
+    # And mac's own fail-open hook was added alongside it, not in place of it.
+    command = next(
+        h["command"]
+        for entry in session_start
+        for h in entry.get("hooks", [])
+        if "cli-session hook" in h.get("command", "")
+    )
+    assert command == cli_session._hook_command("SessionStart")
+    assert "||" in command
+    assert len(session_start) == 2
+
+
+def test_merge_claude_hooks_upgrades_the_blocking_legacy_command(tmp_path):
+    document_path = tmp_path / "settings.json"
+    document_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "UserPromptSubmit": [
+                        {"hooks": [{"type": "command", "command": "mac admin cli-session hook"}]}
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert cli_session._merge_claude_hooks(document_path) is True
+    document = json.loads(document_path.read_text(encoding="utf-8"))
+    configured = document["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+    assert configured == cli_session._hook_command("UserPromptSubmit")
+
+
+def test_generated_hook_fails_open_when_mac_command_is_missing(tmp_path):
+    result = subprocess.run(
+        cli_session._hook_command("UserPromptSubmit"),
+        shell=True,
+        capture_output=True,
+        text=True,
+        env={"PATH": str(tmp_path)},
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {"continue": True}
+
+
+def test_hook_command_availability_ignores_unreleased_pythonpath(monkeypatch):
+    observed = {}
+
+    def fake_run(argv, **kwargs):
+        observed["argv"] = argv
+        observed["env"] = kwargs["env"]
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cli_session.shutil, "which", lambda command, path=None: "/bin/mac")
+    monkeypatch.setattr(cli_session.subprocess, "run", fake_run)
+
+    assert cli_session._hook_command_available(
+        {"PATH": "/bin", "PYTHONPATH": "/tmp/unreleased/src"}
+    )
+    assert observed["argv"] == ["/bin/mac", "admin", "cli-session", "hook", "--help"]
+    assert "PYTHONPATH" not in observed["env"]
+
+
+def test_auto_join_does_not_publish_hook_before_command_is_installed(cp, tmp_path, monkeypatch):
+    monkeypatch.setattr(cli_session, "_hook_command_available", lambda environ=None: False)
+
+    identity = cli_session.auto_join(
+        cp,
+        environ={"CLAUDECODE": "1", "USER": "test-user"},
+    )
+
+    assert identity is not None
+    assert not (tmp_path / ".claude" / "settings.json").exists()
+
+
+def test_install_hook_config_writes_under_the_given_user_home(tmp_path):
+    changed = cli_session.install_hook_config("claude", user_home=tmp_path)
+    assert changed is True
+    written = tmp_path / ".claude" / "settings.json"
+    assert written.is_file()
+    document = json.loads(written.read_text(encoding="utf-8"))
+    assert "SessionStart" in document["hooks"]
+
+
+def test_install_hook_config_is_a_noop_for_an_unimplemented_harness(tmp_path):
+    assert cli_session.install_hook_config("cursor", user_home=tmp_path) is False
+    assert not (tmp_path / ".cursor").exists()
+
+
+def test_render_claude_hook_output_empty_inbox_is_valid_not_an_error():
+    output = cli_session.render_claude_hook_output([])
+    assert output["hookSpecificOutput"]["additionalContext"] == ""
+
+
+def test_render_claude_hook_output_names_the_actual_event():
+    output = cli_session.render_claude_hook_output([], event="SessionStart")
+    assert output["hookSpecificOutput"]["hookEventName"] == "SessionStart"
+
+
+def test_render_claude_hook_output_lists_pending_messages():
+    output = cli_session.render_claude_hook_output(
+        [{"sender_agent_id": "agent_rocky", "payload": {"text": "check the queue"}}]
+    )
+    context = output["hookSpecificOutput"]["additionalContext"]
+    assert "agent_rocky" in context
+    assert "check the queue" in context
+
+
+def test_run_hook_drains_and_renders_without_raising_on_a_broken_plane():
+    class BrokenPlane:
+        def drain_agentbus_inbox(self, *a, **k):
+            raise RuntimeError("hub unreachable")
+
+    output = cli_session.run_hook(BrokenPlane(), harness="claude")
+    assert output["hookSpecificOutput"]["additionalContext"] == ""


### PR DESCRIPTION
## Summary

- restore Claude Code after an unreleased in-process test leaked a blocking global hook
- add fail-open, event-aware CLI-session hooks and refuse to publish them until the persistent mac executable supports the command
- isolate live harness state and user config in tests

## Verification

- scripts/run-contract-tests.sh: 11,320 parallel tests passed; 199 serial tests passed; 4 skipped; 1 xfailed; coverage policy passed
- post-rebase focused/upstream verification: 63 passed
- scoped Ruff format: passed
- repository-wide make lint: static checks passed; format check reports three pre-existing files outside this patch

Task: task_406dcbb7099b4e5793be98aed86ff21b
