### PR TITLE
Eliminate fleet task stranding defects

### DIFF
--- a/src/mac/allocator.py
+++ b/src/mac/allocator.py
@@ -142,7 +142,12 @@ class AllocationTask:
     # it wants evidence about which kinds are genuinely executor-free rather
     # than a guess.
     requires_execution: bool = True
+    # Operator/safety exclusions are hard. Retry exclusions are a placement
+    # preference that is relaxed only when every otherwise-valid pair is
+    # excluded; keeping them separate is what lets the claim transaction
+    # repeat the allocator's exact decision.
     excluded_agent_ids: FrozenSet[str] = field(default_factory=frozenset)
+    retry_excluded_agent_ids: FrozenSet[str] = field(default_factory=frozenset)
     required_capabilities: FrozenSet[str] = field(default_factory=frozenset)
     required_resources: Mapping[str, Any] = field(default_factory=dict)
     required_hardware: Mapping[str, Any] = field(default_factory=dict)
@@ -389,6 +394,7 @@ class AssignmentProposal:
     agent_id: str
     task_rank: int
     agent_rank: int
+    retry_exclusion_relaxed: bool = False
 
     def to_dict(self) -> JsonDict:
         return {
@@ -397,6 +403,7 @@ class AssignmentProposal:
             "agent_id": self.agent_id,
             "task_rank": self.task_rank,
             "agent_rank": self.agent_rank,
+            "retry_exclusion_relaxed": self.retry_exclusion_relaxed,
         }
 
 
@@ -943,7 +950,7 @@ def evaluate_pair(
         # requirements -- pointing the operator at agent capabilities when the
         # actual bar was an exclusion. Codes are matched on their stem
         # (rejection_kind), so suffixing is backwards compatible.
-        if agent.id in task.excluded_agent_ids:
+        if agent.id in task.excluded_agent_ids or agent.id in task.retry_excluded_agent_ids:
             reasons.append("%s:excluded" % AGENT_TARGET_MISMATCH)
         if task.target_agent_id is not None and task.target_agent_id != agent.id:
             reasons.append("%s:pinned" % AGENT_TARGET_MISMATCH)
@@ -998,6 +1005,29 @@ def evaluate_pair(
         agent_id=agent.id,
         agent_rejections=tuple(reasons),
     )
+
+
+def relax_retry_exclusions(
+    task: AllocationTask,
+    agents: Iterable[AllocationAgent],
+) -> Tuple[AllocationTask, Tuple[str, ...]]:
+    """Drop retry-only exclusions when they are the sole placement barrier.
+
+    Explicit operator/safety exclusions remain hard. The returned agent ids
+    make the relaxation an explicit part of the proposal handed to the
+    transactional claim boundary instead of an allocator-local fiction.
+    """
+
+    agent_list = list(agents)
+    if not task.retry_excluded_agent_ids:
+        return task, ()
+    if any(evaluate_pair(task, agent).allowed for agent in agent_list):
+        return task, ()
+    unbarred = replace(task, retry_excluded_agent_ids=frozenset())
+    recovered = tuple(
+        sorted(agent.id for agent in agent_list if evaluate_pair(unbarred, agent).allowed)
+    )
+    return (unbarred, recovered) if recovered else (task, ())
 
 
 class AuthoritativeAllocator:
@@ -1110,12 +1140,9 @@ class AuthoritativeAllocator:
         # which is how the first attempt at this fix silently changed nothing.
         relaxed_exclusions: Dict[str, tuple[str, ...]] = {}
         for index, task in enumerate(task_list):
-            if not task_evaluations[task.id].allowed or not task.excluded_agent_ids:
+            if not task_evaluations[task.id].allowed or not task.retry_excluded_agent_ids:
                 continue
-            if any(base_pairs[(task.id, agent.id)].allowed for agent in agent_list):
-                continue
-            unbarred = replace(task, excluded_agent_ids=frozenset())
-            recovered = [agent.id for agent in agent_list if evaluate_pair(unbarred, agent).allowed]
+            unbarred, recovered = relax_retry_exclusions(task, agent_list)
             if not recovered:
                 continue
             task_list[index] = unbarred
@@ -1239,6 +1266,7 @@ class AuthoritativeAllocator:
                     agent_id=agent.id,
                     task_rank=task_rank,
                     agent_rank=agent_rank,
+                    retry_exclusion_relaxed=task.id in relaxed_exclusions,
                 )
                 try:
                     committed = claim_pair(proposal)

--- a/src/mac/judgement.py
+++ b/src/mac/judgement.py
@@ -53,6 +53,8 @@ _IN_FLIGHT_STATES = frozenset({"claimed", "running", "needs_review", "reviewing"
 _ORPHAN_PR_STATES = frozenset({"completed", "cancelled"})
 _UNLANDED_PR_STATES = frozenset({"failed", "blocked", "reviewing", "needs_review", "waiting"})
 _TASK_ID_RE = re.compile(r"task_[0-9a-f]{8,}")
+_FULL_TASK_ID_RE = re.compile(r"task_[0-9a-f]{32}$")
+_GIT_SHA_RE = re.compile(r"[0-9a-fA-F]{40}$")
 _NONTERMINAL_STATES = frozenset(
     {
         "open",
@@ -82,6 +84,18 @@ def _parse_ts(value: Any) -> Optional[datetime]:
         return datetime.fromisoformat(raw.replace("Z", "+00:00"))
     except ValueError:
         return None
+
+
+def _merged_pr_task_ids(pr: Mapping[str, Any]) -> set[str]:
+    """Return only task ids the merged PR identifies as its own work."""
+
+    ids = _task_ids_from_text(
+        " ".join([str(pr.get("title") or ""), str(pr.get("headRefName") or "")])
+    )
+    for line in str(pr.get("body") or "").splitlines():
+        if re.match(r"^\s*task(?:\s+id)?\s*:", line, flags=re.IGNORECASE):
+            ids |= _task_ids_from_text(line)
+    return ids
 
 
 @dataclass(frozen=True)
@@ -593,8 +607,6 @@ class JudgementProcess:
             return []
         open_prs = [pr for pr in (listing.get("open") or []) if isinstance(pr, Mapping)]
         merged_prs = [pr for pr in (listing.get("merged") or []) if isinstance(pr, Mapping)]
-        if not open_prs:
-            return []
         merged_task_ids = set()
         for pr in merged_prs:
             merged_task_ids |= _task_ids_from_text(
@@ -607,6 +619,45 @@ class JudgementProcess:
                 )
             )
         findings: List[Finding] = []
+        for pr in merged_prs:
+            ids = _merged_pr_task_ids(pr)
+            for raw_id in ids:
+                # Automatic completion is materially stronger than the
+                # operator-facing prefix resolver. Require the PR to carry the
+                # full durable id so incidental short references cannot close
+                # unrelated work.
+                if not _FULL_TASK_ID_RE.fullmatch(raw_id):
+                    continue
+                task = self._resolve_task(raw_id)
+                task_id = str(getattr(task, "id", "") or "")
+                state = str(getattr(task, "state", "") or "").lower()
+                if task_id != raw_id or state == "completed":
+                    continue
+                merge_commit = pr.get("mergeCommit")
+                merge_sha = (
+                    str(merge_commit.get("oid") or "")
+                    if isinstance(merge_commit, Mapping)
+                    else str(merge_commit or "")
+                )
+                findings.append(
+                    Finding(
+                        kind="merged_task_not_reconciled",
+                        task_id=task_id,
+                        summary=("PR #%d merged but %s is still %s" % (
+                            int(pr.get("number") or 0), task_id, state or "unknown"
+                        )),
+                        detail={
+                            "pr_number": int(pr.get("number") or 0),
+                            "url": str(pr.get("url") or ""),
+                            "task_state": state,
+                            "base_ref_name": str(pr.get("baseRefName") or "main"),
+                            "head_sha": str(pr.get("headRefOid") or ""),
+                            "merge_sha": merge_sha,
+                            "merged_at": str(pr.get("mergedAt") or ""),
+                        },
+                        recommended_action="reconcile_merged_task",
+                    )
+                )
         by_task: Dict[str, List[Mapping[str, Any]]] = {}
         for pr in open_prs:
             ids = _task_ids_from_text(
@@ -710,9 +761,22 @@ class JudgementProcess:
     ) -> List[Dict[str, Any]]:
         actions: List[Dict[str, Any]] = []
         budget = self.config.max_actions_per_cycle
+        interventions_used = 0
         fleet_stopped = False
+
+        def append_result(result: Dict[str, Any]) -> None:
+            nonlocal interventions_used
+            actions.append(result)
+            if result.get("action") not in {
+                "skipped",
+                "already_stopped",
+                "already_held",
+                "already_completed",
+            }:
+                interventions_used += 1
+
         for finding in findings:
-            if len(actions) >= budget:
+            if interventions_used >= budget:
                 actions.append(
                     {
                         "action": "skipped",
@@ -724,29 +788,121 @@ class JudgementProcess:
                 continue
             recommended = finding.recommended_action
             if recommended == "close_pr":
-                actions.append(self._close_pull_request(actor=actor, finding=finding))
+                append_result(self._close_pull_request(actor=actor, finding=finding))
+                continue
+            if recommended == "reconcile_merged_task":
+                append_result(self._reconcile_merged_task(actor=actor, finding=finding))
                 continue
             if recommended == "fleet_stop":
                 if fleet_stopped:
                     continue
-                actions.append(self._fleet_stop(actor=actor, run_id=run_id, finding=finding))
+                append_result(self._fleet_stop(actor=actor, run_id=run_id, finding=finding))
                 fleet_stopped = True
                 continue
             if recommended == "hold_agent" and finding.agent_id:
-                actions.append(self._hold_agent(finding.agent_id, actor=actor, finding=finding))
+                append_result(self._hold_agent(finding.agent_id, actor=actor, finding=finding))
                 continue
-            if finding.task_id:
-                actions.append(self._stop_task(finding.task_id, actor=actor, finding=finding))
+            if recommended == "stop_task" and finding.task_id:
+                append_result(self._stop_task(finding.task_id, actor=actor, finding=finding))
                 if (
                     finding.kind == "semantic_reviewer_still_assigned"
                     and not fleet_stopped
                     and self._semantic_assignment_count(findings) >= 3
                 ):
-                    actions.append(self._fleet_stop(actor=actor, run_id=run_id, finding=finding))
-                    actions.append(self._redeploy(actor=actor, run_id=run_id, finding=finding))
-                    actions.append(self._fleet_start(actor=actor, run_id=run_id, finding=finding))
+                    append_result(self._fleet_stop(actor=actor, run_id=run_id, finding=finding))
+                    append_result(self._redeploy(actor=actor, run_id=run_id, finding=finding))
+                    append_result(self._fleet_start(actor=actor, run_id=run_id, finding=finding))
                     fleet_stopped = True
+                continue
+            actions.append(
+                {
+                    "action": "skipped",
+                    "reason": "no_recommended_action",
+                    "finding_kind": finding.kind,
+                    "task_id": finding.task_id,
+                }
+            )
         return actions
+
+    def _reconcile_merged_task(self, *, actor: str, finding: Finding) -> Dict[str, Any]:
+        detail = finding.detail or {}
+        task_id = str(finding.task_id or "")
+        try:
+            task = self.control_plane.get_task(task_id)
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "action": "skipped",
+                "reason": "task_missing",
+                "task_id": task_id,
+                "finding_kind": finding.kind,
+                "error": str(exc)[:200],
+            }
+        if str(getattr(task, "state", "") or "") == "completed":
+            return {
+                "action": "already_completed",
+                "task_id": task_id,
+                "finding_kind": finding.kind,
+            }
+        head_sha = str(detail.get("head_sha") or "")
+        merge_sha = str(detail.get("merge_sha") or "")
+        if not (_GIT_SHA_RE.fullmatch(head_sha) and _GIT_SHA_RE.fullmatch(merge_sha)):
+            return {
+                "action": "skipped",
+                "reason": "merged_pr_sha_missing",
+                "task_id": task_id,
+                "finding_kind": finding.kind,
+            }
+        branch = str(detail.get("base_ref_name") or "main").strip()
+        number = int(detail.get("pr_number") or 0)
+        verification = {
+            "schema": "mac.worker_evidence.v1",
+            "status": "complete",
+            "evidence_type": "repo_change",
+            "repo": {"head_sha": head_sha, "pushed": True},
+            "canonical_integration": {
+                "schema": "mac.canonical_integration.v1",
+                "status": "pass",
+                "canonical_ref": "refs/heads/%s" % branch,
+                "canonical_tip_sha": merge_sha,
+                "reviewed_head_sha": head_sha,
+                "contains_reviewed_head": head_sha == merge_sha,
+                "remote_verified": True,
+                "publication_mode": "forge_reconciliation",
+                "forge_merged": True,
+                "pull_request_url": str(detail.get("url") or ""),
+                "pull_request_number": number,
+            },
+        }
+        try:
+            self.control_plane.add_evidence(
+                task_id,
+                "test",
+                "ledger://merged-pull-request/%d/%s" % (number, merge_sha),
+                "Forge reports PR #%d merged at %s" % (number, merge_sha),
+                actor,
+                metadata={"verification": verification},
+                _trusted_internal=True,
+            )
+            completed = self.control_plane.force_complete_task(
+                task_id,
+                actor,
+                reason="reconciled from merged PR #%d" % number,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return {
+                "action": "error",
+                "task_id": task_id,
+                "finding_kind": finding.kind,
+                "error": str(exc)[:200],
+            }
+        return {
+            "action": "task_reconciled",
+            "task_id": task_id,
+            "finding_kind": finding.kind,
+            "state": getattr(completed, "state", "completed"),
+            "pr_number": number,
+            "merge_sha": merge_sha,
+        }
 
     def _close_pull_request(self, *, actor: str, finding: Finding) -> Dict[str, Any]:
         number = int((finding.detail or {}).get("pr_number") or 0)
@@ -794,10 +950,19 @@ class JudgementProcess:
         reason = "%s%s" % (HOLD_REASON_PREFIX, finding.kind)
         try:
             task = self.control_plane.get_task(task_id)
-            if str(getattr(task, "state", "") or "") == "stopped":
+            state = str(getattr(task, "state", "") or "")
+            if state == "stopped":
                 return {
                     "action": "already_stopped",
                     "task_id": task_id,
+                    "finding_kind": finding.kind,
+                }
+            if state not in _NONTERMINAL_STATES:
+                return {
+                    "action": "skipped",
+                    "reason": "terminal_task",
+                    "task_id": task_id,
+                    "task_state": state,
                     "finding_kind": finding.kind,
                 }
             self.control_plane.stop_task(task_id, actor=actor, reason=reason)
@@ -827,6 +992,13 @@ class JudgementProcess:
                 return {
                     "action": "skipped",
                     "reason": "virtual_agent",
+                    "agent_id": agent_id,
+                    "finding_kind": finding.kind,
+                }
+            agent = self.control_plane.get_agent(agent_id)
+            if bool(getattr(agent, "dispatch_hold", False)):
+                return {
+                    "action": "already_held",
                     "agent_id": agent_id,
                     "finding_kind": finding.kind,
                 }
@@ -1123,7 +1295,7 @@ def _default_pr_lister(repo_root: str) -> Dict[str, Any]:
                 "--limit",
                 str(limit),
                 "--json",
-                "number,title,body,headRefName,url,mergeable",
+                "number,title,body,headRefName,baseRefName,headRefOid,mergeCommit,mergedAt,url,mergeable",
             ],
             cwd=repo_root,
             check=False,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -11793,13 +11793,28 @@ class ControlPlane:
                 and reviewed_sha == head_sha
                 and integration.get("squash_merged") is True
             )
+            # The hourly forge reconciler observes GitHub's merged PR record
+            # directly. That proves the reviewed head's content landed even
+            # when the checkout no longer has enough graph history to
+            # distinguish merge, squash, and rebase strategies.
+            proof_forge_merged = (
+                _GIT_SHA_RE.match(reviewed_sha)
+                and reviewed_sha == head_sha
+                and integration.get("forge_merged") is True
+                and int(integration.get("pull_request_number") or 0) > 0
+            )
             if (
                 str(integration.get("status") or "").strip().lower() in {"pass", "passed"}
                 and integration.get("remote_verified") is True
                 and str(integration.get("canonical_ref") or "").strip() == canonical_ref
                 and _GIT_SHA_RE.match(head_sha)
                 and _GIT_SHA_RE.match(proof_sha)
-                and (head_sha == proof_sha or proof_carries_reviewed_head or proof_squash_merged)
+                and (
+                    head_sha == proof_sha
+                    or proof_carries_reviewed_head
+                    or proof_squash_merged
+                    or proof_forge_merged
+                )
             ):
                 return
         raise ValidationError(
@@ -11813,6 +11828,8 @@ class ControlPlane:
         task_id: str,
         agent_id: str,
         lease_seconds: int = 900,
+        *,
+        allow_retry_exclusion_reuse: bool = False,
     ) -> JsonDict:
         """Atomically commit an allocator-v2 task/agent proposal.
 
@@ -11830,6 +11847,7 @@ class ControlPlane:
             sync_beads=False,
             assignment_allocator="authoritative-hub",
             authoritative_allocator_v2=True,
+            allow_retry_exclusion_reuse=allow_retry_exclusion_reuse,
         )
         agent = self.get_agent(agent_id)
         return {
@@ -11848,6 +11866,7 @@ class ControlPlane:
         allow_cooperative_reuse: bool = False,
         assignment_allocator: str = "control-plane",
         authoritative_allocator_v2: bool = False,
+        allow_retry_exclusion_reuse: bool = False,
     ) -> Tuple[Task, Lease]:
         lease_seconds = self._validated_task_lease_seconds(lease_seconds)
         task = self.get_task(task_id)
@@ -12114,6 +12133,7 @@ class ControlPlane:
                     project_paused=project_paused,
                     break_glass=break_glass,
                     role_reason=role_reason,
+                    allow_retry_exclusion_reuse=allow_retry_exclusion_reuse,
                 )
             else:
                 ineligible_reason = self._claim_snapshot_ineligibility_reason(
@@ -26259,6 +26279,7 @@ class ControlPlane:
         project_paused: bool,
         break_glass: Optional[BreakGlassAuthorization],
         role_reason: Optional[str],
+        allow_retry_exclusion_reuse: bool = False,
     ) -> Optional[str]:
         """Re-check only allocator-v2 hard constraints under transaction locks.
 
@@ -26299,11 +26320,15 @@ class ControlPlane:
             return None
 
         metadata = ensure_json_object(task.metadata)
-        excluded: set[str] = set()
-        for key in ("excluded_agent_ids", "retry_excluded_agent_ids"):
-            values = metadata.get(key)
-            if isinstance(values, list):
-                excluded.update(str(value) for value in values if str(value))
+        excluded = (
+            {str(value) for value in metadata.get("excluded_agent_ids", []) if str(value)}
+            if isinstance(metadata.get("excluded_agent_ids"), list)
+            else set()
+        )
+        if not allow_retry_exclusion_reuse:
+            retry_excluded = metadata.get("retry_excluded_agent_ids")
+            if isinstance(retry_excluded, list):
+                excluded.update(str(value) for value in retry_excluded if str(value))
         if agent.id in excluded:
             return "explicit_agent_excluded"
         target_agent_id = str(metadata.get("target_agent_id") or "").strip()

--- a/src/mac/task_flow_analytics.py
+++ b/src/mac/task_flow_analytics.py
@@ -1426,6 +1426,8 @@ class TaskFlowAnalyticsService:
     def _stranding_reason(
         stage: str,
         dispatch: Optional[Mapping[str, Any]],
+        *,
+        dispatch_diagnostic: str = "available",
     ) -> str:
         if stage == TaskFlowStage.READY_QUEUE.value:
             if dispatch is not None:
@@ -1436,6 +1438,8 @@ class TaskFlowAnalyticsService:
                         return str(first["code"])
                 if dispatch.get("dispatchable"):
                     return "dispatcher_backlog"
+            if dispatch_diagnostic != "available":
+                return "dispatch_diagnostic_%s" % dispatch_diagnostic
             return "ready_unclaimed"
         return {
             TaskFlowStage.INTAKE.value: "dependency_or_intake_wait",
@@ -1609,7 +1613,8 @@ class TaskFlowAnalyticsService:
         active_rows = [
             _row_dict(row)
             for row in self.store.query_all(
-                "SELECT s.*, t.title, t.state, t.owner_agent_id, t.updated_at AS task_updated_at "
+                "SELECT s.*, t.title, t.state, t.metadata AS task_metadata, "
+                "t.owner_agent_id, t.updated_at AS task_updated_at "
                 "FROM task_flow_spans s JOIN tasks t ON t.id = s.task_id "
                 "WHERE %s ORDER BY s.started_at, s.task_id LIMIT 500"
                 % " AND ".join(active_clauses),
@@ -1622,10 +1627,23 @@ class TaskFlowAnalyticsService:
         dispatch_explanation_count = 0
         dispatch_explanation_limit = 50
         for row in active_rows:
+            # A deliberate operator/task hold is not stranded work. Old spans
+            # can remain open while a task is parked, so filtering only SQL
+            # terminal states mislabeled held rows as ready-unclaimed once the
+            # bounded explanation budget was exhausted.
+            if str(row["state"]) == TaskState.STOPPED.value:
+                continue
+            task_metadata = json_loads(row.get("task_metadata"), {})
+            if (
+                row["stage"] == TaskFlowStage.READY_QUEUE.value
+                and ensure_json_object(task_metadata).get("no_dispatch") is True
+            ):
+                continue
             age = _seconds(str(row["started_at"]), now)
             if age < float(warning_seconds):
                 continue
             dispatch: Optional[Mapping[str, Any]] = None
+            dispatch_diagnostic = "available"
             if (
                 dispatch_explainer is not None
                 and row["stage"] == TaskFlowStage.READY_QUEUE.value
@@ -1635,9 +1653,18 @@ class TaskFlowAnalyticsService:
                     dispatch = dispatch_explainer(str(row["task_id"]))
                     dispatch_explanation_count += 1
                 except Exception:
-                    dispatch = None
+                    dispatch_diagnostic = "failed"
+            elif (
+                dispatch_explainer is not None
+                and row["stage"] == TaskFlowStage.READY_QUEUE.value
+            ):
+                dispatch_diagnostic = "deferred"
             severity = "critical" if age >= float(critical_seconds) else "warning"
-            reason = self._stranding_reason(str(row["stage"]), dispatch)
+            reason = self._stranding_reason(
+                str(row["stage"]),
+                dispatch,
+                dispatch_diagnostic=dispatch_diagnostic,
+            )
             fingerprint = hashlib.sha256(
                 (
                     "%s\x00%s\x00%s\x00%s"

--- a/src/mac/task_lifecycle.py
+++ b/src/mac/task_lifecycle.py
@@ -25,6 +25,7 @@ from mac.allocator import (
     evaluate_pair,
     evaluate_task,
     normalize_execution_mode,
+    relax_retry_exclusions,
 )
 from mac.executor_scope import compute_scope_estimate_from_lessons
 from mac.models import (
@@ -356,11 +357,8 @@ class DispatchService:
             )
         if break_glass is not None:
             target_agent_id = break_glass.agent_id
-        excluded_agent_ids: set[str] = set()
-        for key in ("excluded_agent_ids", "retry_excluded_agent_ids"):
-            values = metadata.get(key)
-            if isinstance(values, list):
-                excluded_agent_ids.update(str(value) for value in values if str(value))
+        explicit_excluded = metadata.get("excluded_agent_ids")
+        retry_excluded = metadata.get("retry_excluded_agent_ids")
         return AllocationTask(
             id=task.id,
             priority=task.priority,
@@ -390,7 +388,16 @@ class DispatchService:
                     | self.control_plane._prior_attempt_agent_ids(task)
                 )
             ),
-            excluded_agent_ids=frozenset(excluded_agent_ids),
+            excluded_agent_ids=frozenset(
+                str(value) for value in explicit_excluded or () if str(value)
+            )
+            if isinstance(explicit_excluded, list)
+            else frozenset(),
+            retry_excluded_agent_ids=frozenset(
+                str(value) for value in retry_excluded or () if str(value)
+            )
+            if isinstance(retry_excluded, list)
+            else frozenset(),
             required_capabilities=frozenset(task.required_capabilities or []),
             required_resources=required_resources,
             required_hardware=required_hardware,
@@ -638,9 +645,12 @@ class DispatchService:
         candidates = []
         agent_snapshots = []
         for agent in candidate_agents:
-            agent_snapshot = self._v2_snapshot_agent(agent, sync_states)
-            agent_snapshots.append(agent_snapshot)
-            pair = evaluate_pair(task_snapshot, agent_snapshot)
+            agent_snapshots.append(self._v2_snapshot_agent(agent, sync_states))
+        effective_snapshot, relaxed_agent_ids = relax_retry_exclusions(
+            task_snapshot, agent_snapshots
+        )
+        for agent, agent_snapshot in zip(candidate_agents, agent_snapshots):
+            pair = evaluate_pair(effective_snapshot, agent_snapshot)
             candidates.append(
                 {
                     "agent_id": agent.id,
@@ -658,7 +668,9 @@ class DispatchService:
             )
         )
         eligible_count = sum(1 for item in candidates if item["eligible"])
-        requirement_eligibility = classify_requirement_eligibility(task_snapshot, agent_snapshots)
+        requirement_eligibility = classify_requirement_eligibility(
+            effective_snapshot, agent_snapshots
+        )
         task_reasons = [self._v2_dispatch_reason(code) for code in task_evaluation.task_rejections]
         if task_reasons:
             unclaimed = list(task_reasons)
@@ -680,6 +692,8 @@ class DispatchService:
             "task_ready": task_evaluation.allowed,
             "dispatchable": bool(eligible_count),
             "eligible_agent_count": eligible_count,
+            "retry_exclusion_relaxed": bool(relaxed_agent_ids),
+            "retry_exclusion_relaxed_agent_ids": list(relaxed_agent_ids),
             "candidate_count": len(candidates),
             "candidate_limit": limit_value,
             "candidate_truncated": len(candidates) > limit_value,
@@ -737,6 +751,9 @@ class DispatchService:
                 projects=projects,
                 agent_ids_by_name={agent.name: [agent.id]},
             )
+            task_snapshot, relaxed_agent_ids = relax_retry_exclusions(
+                task_snapshot, [agent_snapshot]
+            )
             if not evaluate_pair(task_snapshot, agent_snapshot).allowed:
                 continue
             try:
@@ -744,6 +761,7 @@ class DispatchService:
                     task.id,
                     agent.id,
                     lease_seconds=lease_seconds,
+                    allow_retry_exclusion_reuse=agent.id in relaxed_agent_ids,
                 )
             except (AuthorizationError, TransitionError, ValidationError):
                 continue
@@ -876,6 +894,7 @@ class DispatchService:
                     proposal.task_id,
                     proposal.agent_id,
                     lease_seconds=lease_seconds,
+                    allow_retry_exclusion_reuse=proposal.retry_exclusion_relaxed,
                 )
             except TransitionError as exc:
                 return ClaimCommit.rejected("%s:%s" % (exc.__class__.__name__, str(exc)))

--- a/tests/test_dispatch_service_v2.py
+++ b/tests/test_dispatch_service_v2.py
@@ -94,6 +94,39 @@ def test_pull_claims_explicit_target_without_global_allocation_round(monkeypatch
     assert cp.get_task(task.id).state == TaskState.CLAIMED.value
 
 
+def test_retry_exclusion_relaxation_reaches_the_transactional_claim_boundary():
+    """Regression: allocator selection and the locked claim must agree.
+
+    The former fake-claim coverage passed while the live dispatcher selected
+    the pinned worker and then rejected it from persisted metadata forever.
+    """
+
+    cp = ControlPlane.in_memory()
+    active_project(cp)
+    target = worker(cp, "target")
+    task = cp.create_task(
+        "targeted retry",
+        project="mac",
+        required_capabilities=["python"],
+        metadata={
+            "target_agent_id": target.id,
+            "retry_excluded_agent_ids": [target.id],
+        },
+    )
+
+    explanation = cp.dispatch.explain_task_dispatch(task.id)
+    assignment = cp.dispatch_once()
+
+    assert explanation["task_ready"] is True
+    assert explanation["dispatchable"] is True
+    assert explanation["retry_exclusion_relaxed"] is True
+    assert explanation["retry_exclusion_relaxed_agent_ids"] == [target.id]
+    assert assignment is not None
+    assert assignment["task"]["id"] == task.id
+    assert assignment["agent"]["id"] == target.id
+    assert cp.get_task(task.id).state == TaskState.CLAIMED.value
+
+
 def test_targeted_task_ineligible_falls_through_to_the_global_round():
     """A target_agent_id task the agent is not actually eligible for (missing
     capability) must be skipped by the bounded direct path, not claimed

--- a/tests/test_judgement.py
+++ b/tests/test_judgement.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from mac.judgement import (
+    Finding,
     HOLD_REASON_PREFIX,
     JUDGEMENT_SCHEMA,
     JudgementConfig,
@@ -229,6 +230,92 @@ def test_cycle_budget_caps_interventions(cp):
     skipped = [action for action in report["actions"] if action.get("reason") == "cycle_budget"]
     assert len(stopped) == 1
     assert skipped
+
+
+def test_terminal_and_already_stopped_findings_do_not_consume_action_budget(cp):
+    failed = cp.create_task("failed historical row", project="mac")
+    stopped = cp.create_task("already parked", project="mac")
+    live = cp.create_task("live intervention", project="mac")
+    with cp.store.transaction() as conn:
+        conn.execute("UPDATE tasks SET state = ? WHERE id = ?", ("failed", failed.id))
+    cp.stop_task(stopped.id, actor="test", reason="fixture")
+    findings = [
+        Finding(
+            kind="old_failure",
+            task_id=failed.id,
+            summary="terminal",
+            recommended_action="stop_task",
+        ),
+        Finding(
+            kind="already_parked",
+            task_id=stopped.id,
+            summary="stopped",
+            recommended_action="stop_task",
+        ),
+        Finding(
+            kind="live_problem",
+            task_id=live.id,
+            summary="actionable",
+            recommended_action="stop_task",
+        ),
+    ]
+
+    actions = _process(cp, max_actions_per_cycle=1)._act_on_findings(
+        findings, actor="test", run_id="budget"
+    )
+
+    assert [action["action"] for action in actions] == [
+        "skipped",
+        "already_stopped",
+        "task_stopped",
+    ]
+    assert cp.get_task(live.id).state == TaskState.STOPPED.value
+
+
+def test_merged_pull_request_reconciles_the_named_repository_task(cp):
+    head_sha = "a" * 40
+    merge_sha = "b" * 40
+    task = cp.create_task(
+        "merged out of band",
+        project="mac",
+        metadata={
+            "execution_contract": {
+                "type": "repository",
+                "repository_contract": {"canonical_branch": "main"},
+            }
+        },
+    )
+
+    def lister(_root):
+        return {
+            "open": [],
+            "merged": [
+                {
+                    "number": 776,
+                    "title": "land repair (%s)" % task.id,
+                    "body": "",
+                    "headRefName": "codex/repair",
+                    "baseRefName": "main",
+                    "headRefOid": head_sha,
+                    "mergeCommit": {"oid": merge_sha},
+                    "mergedAt": "2026-09-07T23:03:55Z",
+                    "url": "https://example.test/776",
+                    "mergeable": "UNKNOWN",
+                }
+            ],
+        }
+
+    report = _process(cp, pr_lister=lister).run_once()
+
+    assert cp.get_task(task.id).state == TaskState.COMPLETED.value
+    assert any(action["action"] == "task_reconciled" for action in report["actions"])
+    proofs = [
+        evidence.metadata["verification"]["canonical_integration"]
+        for evidence in cp.list_evidence(task.id)
+        if evidence.metadata.get("verification", {}).get("canonical_integration")
+    ]
+    assert proofs[-1]["canonical_tip_sha"] == merge_sha
+    assert proofs[-1]["reviewed_head_sha"] == head_sha
 
 
 def test_orphaned_pull_request_is_closed(cp):

--- a/tests/test_retry_exclusion_ratchet.py
+++ b/tests/test_retry_exclusion_ratchet.py
@@ -31,6 +31,8 @@ requirement, which sent the operator to add capabilities that were already there
 
 from __future__ import annotations
 
+from dataclasses import replace
+
 import pytest
 
 from mac.allocator import (
@@ -51,7 +53,7 @@ def _task(excluded=(), target=None, capabilities=CAPABLE):
         priority=1,
         created_at="2026-08-02T03:00:25Z",
         required_capabilities=frozenset(capabilities),
-        excluded_agent_ids=frozenset(excluded),
+        retry_excluded_agent_ids=frozenset(excluded),
         target_agent_id=target,
     )
 
@@ -103,6 +105,15 @@ def test_the_exclusion_is_honoured_when_an_alternative_exists():
     placed = _dispatch(_task(excluded={"agent_worker5"}), _fleet(extra_capable=True))
 
     assert placed == ["agent_worker9"]
+
+
+def test_an_explicit_safety_exclusion_is_never_relaxed():
+    task = replace(
+        _task(),
+        excluded_agent_ids=frozenset({"agent_worker5"}),
+    )
+
+    assert _dispatch(task, _fleet()) == []
 
 
 def test_an_unexcluded_task_is_unaffected():

--- a/tests/test_task_flow_analytics.py
+++ b/tests/test_task_flow_analytics.py
@@ -15,6 +15,7 @@ from mac.api import create_app
 from mac.cli import build_parser
 from mac.models import TaskFlowStage, TaskState, parse_time, utcnow
 from mac.services import ControlPlane
+from mac.task_flow_analytics import TaskFlowAnalyticsService
 
 
 def _running_task(cp: ControlPlane, *, project: str = "flow"):
@@ -129,6 +130,39 @@ def test_report_opens_and_resolves_stranding_episode():
         (episode["id"],),
     )
     assert resolved["resolved_at"] == when
+
+
+def test_report_does_not_call_deliberately_held_work_stranded():
+    cp = ControlPlane.in_memory()
+    task = cp.create_task(
+        "staged for later",
+        project="flow",
+        metadata={"no_dispatch": True},
+    )
+    future = (parse_time(utcnow()) + timedelta(minutes=11)).isoformat(timespec="microseconds")
+
+    report = cp.task_flow.report(
+        warning_seconds=300,
+        critical_seconds=600,
+        refresh_limit=0,
+        dispatch_explainer=lambda _task_id: (_ for _ in ()).throw(
+            AssertionError("held tasks must not consume dispatch diagnostics")
+        ),
+        observed_at=future,
+    )
+
+    assert task.id not in {episode["task_id"] for episode in report["stranding"]["episodes"]}
+
+
+def test_deferred_dispatch_diagnostics_are_not_reported_as_ready_unclaimed():
+    assert (
+        TaskFlowAnalyticsService._stranding_reason(
+            TaskFlowStage.READY_QUEUE.value,
+            None,
+            dispatch_diagnostic="deferred",
+        )
+        == "dispatch_diagnostic_deferred"
+    )
 
 
 def test_contention_uses_digest_and_is_included_in_snapshot():


### PR DESCRIPTION
## Summary

- distinguish retry-derived exclusions from explicit safety exclusions and carry the allocator's last-resort decision through the real claim transaction
- stop judgement no-ops/errors from exhausting the intervention budget, and honor each finding's recommended action
- reconcile merged forge PRs whose canonical task IDs remain open by recording validated integration proof
- exclude held/stopped work from stranding and report diagnostic deferral/failure honestly instead of false `ready_unclaimed`

## Live defects addressed

- `task_ba4321315bb1487a9a19e01a60721ac5`: Rocky was simultaneously targeted and retry-excluded; explain-time relaxation was lost when the transaction reread persistent metadata
- `task_406dcbb7099b4e5793be98aed86ff21b`: PR #776 merged but the ledger task remained open/held
- judgement cycles spent their whole budget on terminal/no-op findings
- throughput classified held and diagnostically deferred tasks as stranded-ready

The obsolete stopped-HGX canary task was cancelled separately. This change does not restore or start the HGX session.

## Verification

- `scripts/run-contract-tests.sh`: 11,327 parallel tests passed, 200 protected serial tests passed, 7 skipped, 1 expected xfail
- coverage: 88.43% statements, 78.54% branches
- focused regression/boundary run: 152 passed
- `git diff --check`

Task: task_0837312cf2335405cad948a2a50c810d
