### PR TITLE
Close physical fleet recovery gaps (task_0255c029420430efa11c2ca6b34e5188)

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -4986,6 +4986,7 @@ verified_contract_call \
   --supervisor "\$rollback_supervisor" \
   --control-plane-mode "\$rollback_control_mode" \
   --control-plane-port "\$MAC_PORT" \
+  --control-plane-host 127.0.0.1 \
   --receipt "\$ROLLBACK_LOG_DIR/rollback-\$ROLLBACK_TS-quiesce.json" \
   "\${rollback_args[@]}"
 
@@ -6613,6 +6614,9 @@ stop_existing_services_for_deploy() {
   if control_plane_enabled; then
     control_mode=active
   fi
+  while IFS= read -r host; do
+    [ -z "$host" ] || args+=(--control-plane-host "$host")
+  done < <(printf '%s' "${MAC_BIND_HOST:-127.0.0.1}" | tr ',' '\n')
   case "$SUPERVISOR_KIND" in
     systemd)
       args=(

--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -7673,6 +7673,129 @@ def delete_managed_task_sandbox(name):
         raise QuiescenceFailure("OpenShell task sandbox deletion failed")
 
 
+def legacy_task_container_candidates(runtimes, openshell_sandboxes):
+    """Find stopped pre-label task containers with corroborating identities."""
+
+    listed_sandboxes = {str(row.get("name") or "") for row in openshell_sandboxes}
+    candidates = []
+    for runtime in runtimes:
+        for identifier in list_managed_openshell_ids(runtime, all_states=True):
+            inspected = runtime_result(runtime, "inspect", identifier)
+            if inspected.timed_out or inspected.returncode != 0:
+                # A container may disappear after the inventory snapshot.  Accept
+                # that race only after an exact second inventory proves absence;
+                # otherwise the failed inspection leaves its identity unknown.
+                if identifier not in list_managed_openshell_ids(runtime, all_states=True):
+                    continue
+                raise QuiescenceFailure("legacy OpenShell container inspection failed")
+            try:
+                payload = json.loads(inspected.stdout)
+            except (TypeError, ValueError):
+                raise QuiescenceFailure("legacy OpenShell container inspection is malformed")
+            if not isinstance(payload, list) or len(payload) != 1 or not isinstance(payload[0], dict):
+                raise QuiescenceFailure("legacy OpenShell container inspection is ambiguous")
+            container = payload[0]
+            config = container.get("Config")
+            state = container.get("State")
+            labels = config.get("Labels") if isinstance(config, dict) else None
+            if not isinstance(state, dict) or not isinstance(labels, dict):
+                raise QuiescenceFailure("legacy OpenShell container inspection is incomplete")
+            sandbox = labels.get("openshell.ai/sandbox-name")
+            legacy_identity = (
+                state.get("Running") is False
+                and labels.get("openshell.ai/managed-by") == "openshell"
+                and isinstance(sandbox, str)
+                and sandbox.startswith("mac-task-")
+                and managed_task_sandbox_name.fullmatch(sandbox)
+                and sandbox not in listed_sandboxes
+                and all(
+                    not str(labels.get(key) or "").strip()
+                    for key in ("mac.owner", "mac.task-id", "mac.task.id")
+                )
+            )
+            if not legacy_identity:
+                continue
+            container_name = str(container.get("Name") or "").lstrip("/")
+            if not container_name or container_name == "openshell-" + sandbox:
+                # The normal OpenShell name is compatible but does not
+                # corroborate the unlabeled legacy identity strongly enough for
+                # this exact cleanup path.  Leave it untouched.
+                continue
+            if container_name != sandbox:
+                raise QuiescenceFailure("legacy OpenShell container identity is ambiguous")
+            candidates.append((runtime, identifier, sandbox))
+    return candidates
+
+
+def preserve_legacy_task_container(runtime, container_id, name):
+    recovery_root = mac_home / "openshell-recovery"
+    recovery_root.mkdir(mode=0o700, exist_ok=True)
+    require_private_directory(recovery_root)
+    recovery_id = hashlib.sha256(
+        ("legacy-container\0%s\0%s\0%s\0%s" % (container_id, name, generation, revision)).encode()
+    ).hexdigest()[:20]
+    destination = recovery_root / ("%s-%s" % (name, recovery_id))
+    if destination.exists():
+        require_private_directory(destination)
+        return recovery_id
+    temporary = Path(tempfile.mkdtemp(prefix=".preserve-", dir=str(recovery_root)))
+    temporary.chmod(0o700)
+    try:
+        copied = runtime_result(
+            runtime, "cp", "%s:/sandbox" % container_id, str(temporary / "workspace")
+        )
+        if copied.timed_out or copied.returncode != 0:
+            raise QuiescenceFailure("OpenShell legacy task preservation failed")
+        if not (temporary / "workspace").is_dir():
+            raise QuiescenceFailure("OpenShell legacy task preservation produced no workspace")
+        atomic_write_certificate(
+            temporary / "manifest.json",
+            {
+                "schema": "mac.openshell.legacy_task_preservation.v1",
+                "sandbox": name,
+                "container_id": container_id,
+                "runtime": runtime_identity(runtime),
+                "generation": generation,
+                "revision": revision,
+                "recovery_id": recovery_id,
+                "identity_evidence": {
+                    "container_name_matches_sandbox": True,
+                    "openshell_managed": True,
+                    "openshell_inventory_absent": True,
+                    "state": "stopped",
+                    "legacy_mac_labels_absent": True,
+                },
+            },
+        )
+        os.replace(temporary, destination)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return recovery_id
+
+
+def reconcile_legacy_task_containers(runtimes):
+    reconciled = []
+    preservation_ids = {}
+    for runtime, container_id, name in legacy_task_container_candidates(
+        runtimes, list_openshell_sandboxes()
+    ):
+        preservation_ids[name] = preserve_legacy_task_container(runtime, container_id, name)
+        removed = runtime_result(runtime, "rm", "-f", container_id)
+        if removed.timed_out or removed.returncode != 0:
+            raise QuiescenceFailure("OpenShell legacy task container deletion failed")
+        if container_id in list_managed_openshell_ids(runtime, all_states=True):
+            raise QuiescenceFailure("OpenShell legacy task container survived exact deletion")
+        reconciled.append(name)
+    return {
+        "reconciled": sorted(reconciled),
+        "reconciled_count": len(reconciled),
+        "preservation_ids": {
+            name: preservation_ids[name] for name in sorted(preservation_ids)
+        },
+    }
+
+
 def summarize_managed_task_sandboxes(sandboxes):
     managed = 0
     reap_eligible = 0
@@ -8440,10 +8563,12 @@ safe_container_id = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
 managed_sandbox_name = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 
 
-def list_managed_openshell_ids(runtime):
+def list_managed_openshell_ids(runtime, *, all_states=False):
+    state_args = ["-a"] if all_states else []
     listed = runtime_result(
         runtime,
         "ps",
+        *state_args,
         "--filter",
         "label=openshell.ai/managed-by=openshell",
         "--format",
@@ -9073,6 +9198,9 @@ try:
         retained = prove_legacy_nemoclaw_inactive(runtimes)
         sandbox = quiesce_openclaw_sandbox()
         openshell_task_sandboxes = reconcile_managed_task_sandboxes()
+        openshell_task_sandboxes["legacy_containers"] = (
+            reconcile_legacy_task_containers(runtimes)
+        )
         openshell_managed = prove_managed_openshell_inactive(runtimes)
         write_pre_source_certificate(
             certificate,

--- a/deploy/fleet-node-rollback-supervisor.py
+++ b/deploy/fleet-node-rollback-supervisor.py
@@ -615,6 +615,7 @@ class SystemdSupervisor(BaseSupervisor):
                 "expected": _state_word(logical),
                 "observed": _state_word(logical),
                 "stable_observations": self.stable_observations,
+                **({"pid": first[logical].pid} if logical in active_names else {}),
             }
             for logical, identity in self.names.items()
         }
@@ -744,6 +745,7 @@ class SupervisordSupervisor(BaseSupervisor):
                 "expected": ("running" if logical in active_names else "inactive"),
                 "observed": ("running" if logical in active_names else "inactive"),
                 "stable_observations": self.stable_observations,
+                **({"pid": first[logical].pid} if logical in active_names else {}),
             }
             for logical, identity in self.names.items()
         }
@@ -996,6 +998,7 @@ class LaunchdSupervisor(BaseSupervisor):
                 "expected": "running" if active else "absent",
                 "observed": "running" if active else "absent",
                 "stable_observations": self.stable_observations,
+                **({"pid": first[(domain, identity)].pid} if active else {}),
             }
         return observations
 
@@ -1012,6 +1015,77 @@ def wait_port_closed(port: int, deadline: Deadline, poll_seconds: float) -> None
         if result != 0:
             return
         deadline.pause(poll_seconds, "waiting for the control-plane port to close")
+
+
+def listener_processes(hosts: Sequence[str], port: int) -> Dict[int, List[str]]:
+    """Return exact TCP listener owners for the configured addresses."""
+    try:
+        import psutil
+    except ImportError as exc:
+        raise ProtocolError("psutil is unavailable for listener ownership inspection") from exc
+    expected = set(hosts)
+    owners: Dict[int, List[str]] = {}
+    # A global psutil.net_connections() requires elevated privileges on macOS,
+    # including in the local regression harness.  Per-process inspection still
+    # identifies same-user orphan workers while inaccessible foreign owners are
+    # handled safely below by the independent socket probe.
+    for process in psutil.process_iter():
+        try:
+            connections = process.net_connections(kind="tcp")
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess, OSError):
+            continue
+        for connection in connections:
+            if connection.status != psutil.CONN_LISTEN or not connection.laddr:
+                continue
+            address, bound_port = connection.laddr[:2]
+            address = str(address).strip("[]")
+            if bound_port != port or address not in expected:
+                continue
+            owners.setdefault(process.pid, []).append(address)
+    return owners
+
+
+def terminate_orphaned_hub_listeners(
+    hosts: Sequence[str], port: int, deadline: Deadline, poll_seconds: float
+) -> None:
+    """Remove only an unambiguously identified legacy ``mac.hub_serve`` owner."""
+    owners = listener_processes(hosts, port)
+    if not owners:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.settimeout(0.25)
+            listening = sock.connect_ex((hosts[0], port)) == 0
+        finally:
+            sock.close()
+        if listening:
+            raise ProtocolError("control-plane listener has no inspectable process owner")
+        return
+    if len(owners) != 1:
+        raise ProtocolError("control-plane listeners have ambiguous process ownership")
+    pid = next(iter(owners))
+    try:
+        import psutil
+
+        process = psutil.Process(pid)
+        created = process.create_time()
+        command = process.cmdline()
+    except (psutil.AccessDenied, psutil.NoSuchProcess, OSError) as exc:
+        raise ProtocolError("control-plane listener owner could not be inspected") from exc
+    if not any(part == "mac.hub_serve" or part.endswith("/mac.hub_serve.py") for part in command):
+        raise ProtocolError(
+            "control-plane listener is not owned by the supervised service or mac.hub_serve"
+        )
+    try:
+        process.terminate()
+    except (psutil.AccessDenied, psutil.NoSuchProcess) as exc:
+        raise ProtocolError("orphaned mac.hub_serve listener could not be terminated") from exc
+    while listener_processes(hosts, port):
+        try:
+            if psutil.Process(pid).create_time() != created:
+                raise ProtocolError("control-plane listener pid was reused during orphan cleanup")
+        except psutil.NoSuchProcess:
+            pass
+        deadline.pause(poll_seconds, "waiting for orphaned mac.hub_serve listener to exit")
 
 
 def wait_http_healthy(
@@ -1181,6 +1255,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="worker service state in the prior generation; required for restore",
     )
     parser.add_argument("--control-plane-port", required=True, type=int)
+    parser.add_argument("--control-plane-host", action="append", default=[])
     parser.add_argument("--health-path", default="/health")
     parser.add_argument("--receipt", required=True)
     parser.add_argument("--deadline-seconds", type=float, default=90.0)
@@ -1216,6 +1291,18 @@ def build_parser() -> argparse.ArgumentParser:
 def validate_args(args: argparse.Namespace) -> ServiceNames:
     if not 1 <= args.control_plane_port <= 65535:
         raise ProtocolError("control-plane port is out of range")
+    if not args.control_plane_host:
+        args.control_plane_host = ["127.0.0.1"]
+    normalized_hosts = []
+    for raw_host in args.control_plane_host:
+        host = raw_host.strip().strip("[]")
+        try:
+            socket.inet_pton(socket.AF_INET6 if ":" in host else socket.AF_INET, host)
+        except OSError as exc:
+            raise ProtocolError("control-plane host must be a numeric IP address") from exc
+        if host not in normalized_hosts:
+            normalized_hosts.append(host)
+    args.control_plane_host = normalized_hosts
     if not HEALTH_PATH_RE.fullmatch(args.health_path):
         raise ProtocolError("health path must be a query-free absolute HTTP path")
     if args.poll_seconds <= 0:
@@ -1298,6 +1385,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         supervisor = build_supervisor(args, names, runner, deadline)
         if args.action == "quiesce":
             services = supervisor.quiesce()
+            terminate_orphaned_hub_listeners(
+                args.control_plane_host,
+                args.control_plane_port,
+                deadline,
+                args.poll_seconds,
+            )
             wait_port_closed(args.control_plane_port, deadline, args.poll_seconds)
             health = "closed"
         else:
@@ -1339,7 +1432,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             "observed_at": utc_now(),
             "duration_ms": deadline.elapsed_ms(),
             "control_plane": {
-                "host": "127.0.0.1",
+                "hosts": args.control_plane_host,
                 "port": args.control_plane_port,
                 "health_path": args.health_path,
                 "mode": args.control_plane_mode,

--- a/docs/presentation/20260906T051311Z-a787bff1/build_deck.py
+++ b/docs/presentation/20260906T051311Z-a787bff1/build_deck.py
@@ -115,7 +115,10 @@ def hardening_slide() -> None:
             body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2
         )
         line(body, detail, 17, SLATE, after=12)
-    notes(slide, "Each point is a shipped fix, traced in AUDIT.md. None of them fixed the underlying problem.")
+    notes(
+        slide,
+        "Each point is a shipped fix, traced in AUDIT.md. None of them fixed the underlying problem.",
+    )
 
 
 def root_cause_slide() -> None:
@@ -181,7 +184,10 @@ def cutover_slide() -> None:
             body, head, 21, BLUE if index % 2 == 0 else AMBER, bold=True, first=index == 0, after=2
         )
         line(body, detail, 17, SLATE, after=12)
-    notes(slide, "Each point closes a gap between the manual cutover and durable, reproducible automation.")
+    notes(
+        slide,
+        "Each point closes a gap between the manual cutover and durable, reproducible automation.",
+    )
 
 
 def caught_live_slide() -> None:
@@ -216,7 +222,10 @@ def caught_live_slide() -> None:
         BLUE,
         bold=True,
     )
-    notes(slide, "This is the kind of bug a test suite doesn't catch: it only reproduces against real, prior state.")
+    notes(
+        slide,
+        "This is the kind of bug a test suite doesn't catch: it only reproduces against real, prior state.",
+    )
 
 
 def closing_slide() -> None:

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -9459,7 +9459,8 @@
       "src/mac/openshell/default-policy.yaml",
       "src/mac/openshell_policy.py",
       "src/mac/openshell_supervisor.py",
-      "src/mac/worker.py"
+      "src/mac/worker.py",
+      "src/mac/worker_subprocess.py"
     ],
     "type": "str"
   },
@@ -9481,7 +9482,8 @@
     "name": "MAC_OPENSHELL_SANDBOX_NAME",
     "retired": false,
     "sources": [
-      "src/mac/executor_sandbox.py"
+      "src/mac/executor_sandbox.py",
+      "src/mac/worker_subprocess.py"
     ],
     "type": "str"
   },

--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -800,6 +800,7 @@
     "name": "MAC_BIND_HOST",
     "retired": false,
     "sources": [
+      "deploy/fleet-node-install.sh",
       "deploy/k8s/mac-api/deployment.yaml",
       "deploy/systemd/mac.service",
       "src/mac/api.py",

--- a/src/mac/judgement.py
+++ b/src/mac/judgement.py
@@ -643,9 +643,10 @@ class JudgementProcess:
                     Finding(
                         kind="merged_task_not_reconciled",
                         task_id=task_id,
-                        summary=("PR #%d merged but %s is still %s" % (
-                            int(pr.get("number") or 0), task_id, state or "unknown"
-                        )),
+                        summary=(
+                            "PR #%d merged but %s is still %s"
+                            % (int(pr.get("number") or 0), task_id, state or "unknown")
+                        ),
                         detail={
                             "pr_number": int(pr.get("number") or 0),
                             "url": str(pr.get("url") or ""),

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -11080,9 +11080,7 @@ class ControlPlane:
         """
 
         try:
-            self._native_merge_queue().evict_for_task(
-                task_id, reason="owning task was cancelled"
-            )
+            self._native_merge_queue().evict_for_task(task_id, reason="owning task was cancelled")
         except Exception:  # noqa: BLE001 - cancellation must still succeed.
             logging.getLogger("mac.merge_queue").warning(
                 "failed to evict merge queue entry for cancelled task %s",

--- a/src/mac/task_flow_analytics.py
+++ b/src/mac/task_flow_analytics.py
@@ -1654,10 +1654,7 @@ class TaskFlowAnalyticsService:
                     dispatch_explanation_count += 1
                 except Exception:
                     dispatch_diagnostic = "failed"
-            elif (
-                dispatch_explainer is not None
-                and row["stage"] == TaskFlowStage.READY_QUEUE.value
-            ):
+            elif dispatch_explainer is not None and row["stage"] == TaskFlowStage.READY_QUEUE.value:
                 dispatch_diagnostic = "deferred"
             severity = "critical" if age >= float(critical_seconds) else "warning"
             reason = self._stranding_reason(

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -1931,9 +1931,7 @@ class MacWorker(
                 return self._stale_result(task_id, lease, str(exc))
             stdout = _coerce_process_output(exc.stdout)
             stderr = _coerce_process_output(exc.stderr)
-            process_tree_terminated = bool(
-                getattr(exc, "process_tree_terminated", False)
-            )
+            process_tree_terminated = bool(getattr(exc, "process_tree_terminated", False))
             sandbox_cleanup = getattr(exc, "sandbox_cleanup", {})
             execution = WorkerExecution(
                 124,

--- a/src/mac/worker.py
+++ b/src/mac/worker.py
@@ -1931,6 +1931,10 @@ class MacWorker(
                 return self._stale_result(task_id, lease, str(exc))
             stdout = _coerce_process_output(exc.stdout)
             stderr = _coerce_process_output(exc.stderr)
+            process_tree_terminated = bool(
+                getattr(exc, "process_tree_terminated", False)
+            )
+            sandbox_cleanup = getattr(exc, "sandbox_cleanup", {})
             execution = WorkerExecution(
                 124,
                 "executor timed out after %ss" % exc.timeout,
@@ -1938,7 +1942,8 @@ class MacWorker(
                 stderr=stderr,
                 metadata={
                     "timeout_seconds": exc.timeout,
-                    "process_tree_terminated": True,
+                    "process_tree_terminated": process_tree_terminated,
+                    "sandbox_cleanup": sandbox_cleanup,
                 },
             )
             evidence = (
@@ -1965,7 +1970,8 @@ class MacWorker(
                         "manual_repair_required": False,
                         "output_tail": _executor_output_tail(execution),
                         "timeout_seconds": exc.timeout,
-                        "process_tree_terminated": True,
+                        "process_tree_terminated": process_tree_terminated,
+                        "sandbox_cleanup": sandbox_cleanup,
                         "evidence_id": evidence.get("id") if evidence else None,
                     },
                 },

--- a/src/mac/worker_subprocess.py
+++ b/src/mac/worker_subprocess.py
@@ -171,6 +171,9 @@ def _cleanup_task_sandbox_after_timeout(name: str, task_dir: Path) -> Dict[str, 
         from mac import executor_sandbox
 
         outcome["harvested"] = executor_sandbox._sandbox_download(name, task_dir.name, task_dir)
+        if not outcome["harvested"]:
+            outcome["error"] = "sandbox harvest did not complete; retained for recovery"
+            return outcome
         outcome["deleted"] = executor_sandbox._sandbox_delete(name)
     except Exception as exc:  # noqa: BLE001 - report cleanup failure truthfully.
         outcome["error"] = str(exc)

--- a/src/mac/worker_subprocess.py
+++ b/src/mac/worker_subprocess.py
@@ -91,9 +91,7 @@ def _assert_approved_read_only_report_host_executor(
         raise RuntimeError("read-only repository report host artifacts differ from hub approval")
 
 
-def _terminate_process_tree(
-    process: subprocess.Popen[Any], *, grace_seconds: float = 1.0
-) -> bool:
+def _terminate_process_tree(process: subprocess.Popen[Any], *, grace_seconds: float = 1.0) -> bool:
     """Terminate *process* and every descendant, including new sessions.
 
     Executor children are allowed to create their own process groups (the test
@@ -163,9 +161,7 @@ def _cleanup_task_sandbox_after_timeout(name: str, task_dir: Path) -> Dict[str, 
     try:
         from mac import executor_sandbox
 
-        outcome["harvested"] = executor_sandbox._sandbox_download(
-            name, task_dir.name, task_dir
-        )
+        outcome["harvested"] = executor_sandbox._sandbox_download(name, task_dir.name, task_dir)
         outcome["deleted"] = executor_sandbox._sandbox_delete(name)
     except Exception as exc:  # noqa: BLE001 - report cleanup failure truthfully.
         outcome["error"] = str(exc)

--- a/src/mac/worker_subprocess.py
+++ b/src/mac/worker_subprocess.py
@@ -102,11 +102,13 @@ def _terminate_process_tree(process: subprocess.Popen[Any], *, grace_seconds: fl
     """
     alive: List[Any] = []
     descendants: List[Any] = []
+    tree_snapshot_verified = False
     try:
         import psutil
 
         parent = psutil.Process(process.pid)
         descendants = parent.children(recursive=True)
+        tree_snapshot_verified = True
         for child in reversed(descendants):
             try:
                 child.terminate()
@@ -125,6 +127,8 @@ def _terminate_process_tree(process: subprocess.Popen[Any], *, grace_seconds: fl
                 item.kill()
             except psutil.NoSuchProcess:
                 pass
+        if alive:
+            _, alive = psutil.wait_procs(alive, timeout=max(0.0, float(grace_seconds)))
     except Exception:  # noqa: BLE001 - process cleanup must retain a fallback.
         pass
 
@@ -139,14 +143,19 @@ def _terminate_process_tree(process: subprocess.Popen[Any], *, grace_seconds: fl
     except (ProcessLookupError, PermissionError, OSError):
         pass
     try:
+        process.wait(timeout=max(0.0, float(grace_seconds)))
+    except (subprocess.TimeoutExpired, ChildProcessError, OSError):
+        pass
+    direct_process_terminated = process.poll() is not None
+    try:
         import psutil
 
         descendants_alive = any(
             item.is_running() and item.status() != psutil.STATUS_ZOMBIE for item in descendants
         )
     except Exception:  # noqa: BLE001 - inability to verify is not success.
-        descendants_alive = bool(alive)
-    return not descendants_alive
+        return False
+    return tree_snapshot_verified and direct_process_terminated and not descendants_alive
 
 
 def _cleanup_task_sandbox_after_timeout(name: str, task_dir: Path) -> Dict[str, Any]:

--- a/src/mac/worker_subprocess.py
+++ b/src/mac/worker_subprocess.py
@@ -17,6 +17,7 @@ import subprocess
 import tempfile
 import threading
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -90,7 +91,9 @@ def _assert_approved_read_only_report_host_executor(
         raise RuntimeError("read-only repository report host artifacts differ from hub approval")
 
 
-def _terminate_process_tree(process: subprocess.Popen[Any], *, grace_seconds: float = 1.0) -> None:
+def _terminate_process_tree(
+    process: subprocess.Popen[Any], *, grace_seconds: float = 1.0
+) -> bool:
     """Terminate *process* and every descendant, including new sessions.
 
     Executor children are allowed to create their own process groups (the test
@@ -99,6 +102,8 @@ def _terminate_process_tree(process: subprocess.Popen[Any], *, grace_seconds: fl
     cross-platform recursive tree walk; the process-group fallback also catches
     descendants that race between the walk and termination.
     """
+    alive: List[Any] = []
+    descendants: List[Any] = []
     try:
         import psutil
 
@@ -135,6 +140,36 @@ def _terminate_process_tree(process: subprocess.Popen[Any], *, grace_seconds: fl
             process.kill()
     except (ProcessLookupError, PermissionError, OSError):
         pass
+    try:
+        import psutil
+
+        descendants_alive = any(
+            item.is_running() and item.status() != psutil.STATUS_ZOMBIE for item in descendants
+        )
+    except Exception:  # noqa: BLE001 - inability to verify is not success.
+        descendants_alive = bool(alive)
+    return not descendants_alive
+
+
+def _cleanup_task_sandbox_after_timeout(name: str, task_dir: Path) -> Dict[str, Any]:
+    """Harvest and delete the exact OpenShell sandbox after its CLI is killed."""
+    outcome: Dict[str, Any] = {
+        "sandbox": name,
+        "harvested": False,
+        "deleted": False,
+    }
+    if not name:
+        return outcome
+    try:
+        from mac import executor_sandbox
+
+        outcome["harvested"] = executor_sandbox._sandbox_download(
+            name, task_dir.name, task_dir
+        )
+        outcome["deleted"] = executor_sandbox._sandbox_delete(name)
+    except Exception as exc:  # noqa: BLE001 - report cleanup failure truthfully.
+        outcome["error"] = str(exc)
+    return outcome
 
 
 def _cargo_path_dirs() -> List[str]:
@@ -214,6 +249,17 @@ class SubprocessExecutor:
         )
 
         env = os.environ.copy()
+        task_sandbox_name = ""
+        if env.get("MAC_OPENSHELL_SANDBOX", "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }:
+            task_sandbox_name = env.get("MAC_OPENSHELL_SANDBOX_NAME", "").strip()
+            if not task_sandbox_name:
+                task_sandbox_name = "mac-task-" + uuid.uuid4().hex[:8]
+                env["MAC_OPENSHELL_SANDBOX_NAME"] = task_sandbox_name
         # These are task-scoped inputs, not worker defaults.  A long-lived
         # worker may itself have been launched from an operator shell (or an
         # older service definition) that carried values from a previous task.
@@ -325,12 +371,21 @@ class SubprocessExecutor:
                         self._cancel_reason = ""
                         self._active_process = process
                     timed_out = False
+                    process_tree_terminated = False
+                    sandbox_cleanup: Dict[str, Any] = {}
                     try:
                         process.wait(timeout=self.timeout)
                     except subprocess.TimeoutExpired:
                         timed_out = True
-                        _terminate_process_tree(process)
+                        process_tree_terminated = _terminate_process_tree(process)
                         process.wait()
+                        if task_sandbox_name:
+                            sandbox_cleanup = _cleanup_task_sandbox_after_timeout(
+                                task_sandbox_name, task_dir
+                            )
+                            process_tree_terminated = process_tree_terminated and bool(
+                                sandbox_cleanup.get("deleted")
+                            )
                     finally:
                         # A successful command may still have background
                         # descendants.  Retire them before releasing the task.
@@ -343,12 +398,15 @@ class SubprocessExecutor:
                     stdout = stdout_file.read()
                     stderr = stderr_file.read()
                     if timed_out:
-                        raise subprocess.TimeoutExpired(
+                        timeout_exc = subprocess.TimeoutExpired(
                             self.argv,
                             self.timeout or 0.0,
                             output=stdout,
                             stderr=stderr,
                         )
+                        timeout_exc.process_tree_terminated = process_tree_terminated
+                        timeout_exc.sandbox_cleanup = sandbox_cleanup
+                        raise timeout_exc
                     completed = subprocess.CompletedProcess(
                         self.argv,
                         int(process.returncode),
@@ -372,6 +430,10 @@ class SubprocessExecutor:
                     "metadata": {
                         **base_record["metadata"],
                         "timeout_seconds": self.timeout,
+                        "process_tree_terminated": bool(
+                            getattr(exc, "process_tree_terminated", False)
+                        ),
+                        "sandbox_cleanup": getattr(exc, "sandbox_cleanup", {}),
                     },
                 }
             )

--- a/tests/test_fleet_node_daemon_quiescence.py
+++ b/tests/test_fleet_node_daemon_quiescence.py
@@ -393,6 +393,21 @@ if args and args[0] == "rm":
     state_path.write_text(json.dumps(state), encoding="utf-8")
     raise SystemExit(0)
 
+if args and args[0] == "cp":
+    container_id, separator, source = args[1].partition(":")
+    if not separator or source != "/sandbox":
+        raise SystemExit(65)
+    if not any(item["Id"] == container_id for item in state.get("containers", [])):
+        raise SystemExit(66)
+    destination = Path(args[2])
+    destination.mkdir(parents=True)
+    (destination / "task.json").write_text(
+        json.dumps({{"container_id": container_id}}), encoding="utf-8"
+    )
+    state["copied"] = sorted(set(state.get("copied", [])) | {{container_id}})
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    raise SystemExit(0)
+
 print("unexpected " + runtime + " invocation", file=sys.stderr)
 raise SystemExit(64)
 """
@@ -456,6 +471,18 @@ def _openshell_container(
             },
         },
     }
+
+
+def _legacy_openshell_task_container(
+    container_id: str,
+    *,
+    sandbox: str = "mac-task-1e8ef5df",
+    running: bool = False,
+    container_name: str | None = None,
+) -> dict[str, Any]:
+    container = _openshell_container(container_id, sandbox=sandbox, running=running)
+    container["Name"] = "/" + (container_name or sandbox)
+    return container
 
 
 @dataclass
@@ -1196,6 +1223,78 @@ def test_stopped_openshell_managed_container_is_compatible_and_proved(
     }
     state = json.loads(run.docker_state.read_text(encoding="utf-8"))
     assert [item["Id"] for item in state["containers"]] == [container_id]
+
+
+def test_stopped_legacy_task_container_is_preserved_before_exact_deletion(
+    tmp_path: Path,
+) -> None:
+    container_id = "f" * 64
+    legacy = _legacy_openshell_task_container(container_id)
+    run = _run_quiescence(
+        tmp_path,
+        sandbox_source="none",
+        sandbox_present=False,
+        docker=[legacy],
+    )
+
+    receipt = _assert_success_marker(run)
+    proof = receipt["openshell_task_sandboxes"]["legacy_containers"]
+    assert proof["reconciled"] == ["mac-task-1e8ef5df"]
+    assert proof["reconciled_count"] == 1
+    calls = _call_lines(run)
+    copy_index = next(
+        index
+        for index, line in enumerate(calls)
+        if f"cp {container_id}:/sandbox" in line
+    )
+    delete_index = calls.index(f"docker:--context default rm -f {container_id}")
+    assert copy_index < delete_index
+    state = json.loads(run.docker_state.read_text(encoding="utf-8"))
+    assert state["copied"] == [container_id]
+    assert state["containers"] == []
+    recovery_dirs = list((run.mac_home / "openshell-recovery").iterdir())
+    assert len(recovery_dirs) == 1
+    manifest = json.loads((recovery_dirs[0] / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["schema"] == "mac.openshell.legacy_task_preservation.v1"
+    assert manifest["container_id"] == container_id
+    assert manifest["identity_evidence"] == {
+        "container_name_matches_sandbox": True,
+        "legacy_mac_labels_absent": True,
+        "openshell_inventory_absent": True,
+        "openshell_managed": True,
+        "state": "stopped",
+    }
+    assert (recovery_dirs[0] / "workspace" / "task.json").is_file()
+    _assert_no_secret(run)
+
+
+@pytest.mark.parametrize(
+    ("running", "container_name"),
+    [(True, None), (False, "some-other-container")],
+)
+def test_live_or_identity_ambiguous_legacy_task_container_is_never_deleted(
+    tmp_path: Path, running: bool, container_name: str | None
+) -> None:
+    container_id = "e" * 64
+    legacy = _legacy_openshell_task_container(
+        container_id, running=running, container_name=container_name
+    )
+    run = _run_quiescence(
+        tmp_path,
+        sandbox_source="none",
+        sandbox_present=False,
+        docker=[legacy],
+        extra_env={"MAC_DEPLOY_DAEMON_QUIESCENCE_TIMEOUT_SECONDS": "0.3"},
+    )
+
+    if running:
+        assert run.result.returncode != 0
+        assert not run.marker.exists()
+    else:
+        assert run.result.returncode != 0
+        assert not run.marker.exists()
+    assert not any(f"rm -f {container_id}" in line for line in _call_lines(run))
+    assert not any(f"cp {container_id}:/sandbox" in line for line in _call_lines(run))
 
 
 def _dead_pid() -> int:
@@ -2029,7 +2128,9 @@ def test_linux_podman_docker_symlink_is_classified_as_one_native_podman_store(
     calls = _call_lines(run)
     assert not any("context" in line for line in calls)
     assert sum(line.startswith("podman:system connection list") for line in calls) == 1
-    assert sum(line.startswith("podman:ps ") for line in calls) == 4
+    # Includes the all-states inventory used to identify stopped legacy task
+    # containers before the ordinary repeated-absence proof.
+    assert sum(line.startswith("podman:ps ") for line in calls) == 5
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fleet_node_daemon_quiescence.py
+++ b/tests/test_fleet_node_daemon_quiescence.py
@@ -1243,9 +1243,7 @@ def test_stopped_legacy_task_container_is_preserved_before_exact_deletion(
     assert proof["reconciled_count"] == 1
     calls = _call_lines(run)
     copy_index = next(
-        index
-        for index, line in enumerate(calls)
-        if f"cp {container_id}:/sandbox" in line
+        index for index, line in enumerate(calls) if f"cp {container_id}:/sandbox" in line
     )
     delete_index = calls.index(f"docker:--context default rm -f {container_id}")
     assert copy_index < delete_index

--- a/tests/test_fleet_node_rollback_supervisor.py
+++ b/tests/test_fleet_node_rollback_supervisor.py
@@ -458,6 +458,60 @@ def test_systemd_quiesce_proves_all_services_inactive_and_scrubs_selectors(
         assert item["pid"] == 0
 
 
+def test_quiesce_terminates_only_exact_orphaned_hub_listener(tmp_path: Path) -> None:
+    systemctl = _write_manager(tmp_path, "systemctl")
+    _write_state(tmp_path, _loaded_systemd_state())
+    listener = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import socket,time;s=socket.socket();s.bind(('127.0.0.1',0));print(s.getsockname()[1],flush=True);s.listen();time.sleep(30)",
+            "mac.hub_serve",
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        port = int(listener.stdout.readline())
+        command, receipt = _base_command(tmp_path, "quiesce", "systemd", port, SYSTEMD_NAMES)
+        command.extend(["--systemctl", str(systemctl)])
+        result = _run(command)
+        assert result.returncode == 0, result.stderr
+        assert listener.wait(timeout=5) != 0
+        _assert_passed_receipt(receipt, "quiesce", "systemd")
+    finally:
+        if listener.poll() is None:
+            listener.terminate()
+            listener.wait(timeout=5)
+
+
+def test_quiesce_refuses_to_terminate_an_unrelated_listener(tmp_path: Path) -> None:
+    systemctl = _write_manager(tmp_path, "systemctl")
+    _write_state(tmp_path, _loaded_systemd_state())
+    listener = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import socket,time;s=socket.socket();s.bind(('127.0.0.1',0));print(s.getsockname()[1],flush=True);s.listen();time.sleep(30)",
+            "unrelated-service",
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        port = int(listener.stdout.readline())
+        command, receipt = _base_command(tmp_path, "quiesce", "systemd", port, SYSTEMD_NAMES)
+        command.extend(["--systemctl", str(systemctl)])
+        result = _run(command)
+        assert result.returncode != 0
+        assert "listener is not owned" in result.stderr
+        assert listener.poll() is None
+        assert not receipt.exists()
+    finally:
+        listener.terminate()
+        listener.wait(timeout=5)
+
+
 def test_systemd_quiesce_stops_explicit_auxiliary_media_before_restore(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_gitops.py
+++ b/tests/test_gitops.py
@@ -243,7 +243,8 @@ def test_open_pull_request_does_not_reuse_an_unrelated_tasks_pr(monkeypatch) -> 
         result = open_pull_request(
             "https://github.com/x/y.git",
             head="mac/agent_rocky/%s-lease_new" % task_b,
-            title="Integrate conflicting approved task %s onto current main (%s)" % (task_a, task_b),
+            title="Integrate conflicting approved task %s onto current main (%s)"
+            % (task_a, task_b),
             body="- task: `%s`\n- head: `deadbeef`\n- base at push: `cafef00d`\n" % task_b,
         )
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1482,6 +1482,7 @@ def test_worker_timeout_harvests_finalizer_progress_artifact(tmp_path: Path):
     ][-1]
     assert timeout_transition.detail["reason"] == "executor_timeout"
     assert timeout_transition.detail["process_tree_terminated"] is True
+    assert timeout_transition.detail["sandbox_cleanup"] == {}
 
 
 def test_validate_git_remote_url_rejects_argv_smuggling():

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1345,12 +1345,13 @@ def test_subprocess_executor_timeout_kills_descendants_in_other_sessions(tmp_pat
     task_dir.mkdir()
     executor = SubprocessExecutor([sys.executable, str(executor_script)], timeout=0.5)
 
-    with pytest.raises(subprocess.TimeoutExpired):
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
         executor({"id": "task_timeout_tree"}, task_dir)
 
     child_pid = int((task_dir / "child.pid").read_text(encoding="utf-8"))
     import psutil
 
+    assert caught.value.process_tree_terminated is True
     assert (
         not psutil.pid_exists(child_pid)
         or psutil.Process(child_pid).status() == psutil.STATUS_ZOMBIE

--- a/tests/test_worker_subprocess.py
+++ b/tests/test_worker_subprocess.py
@@ -14,6 +14,7 @@ from mac.api_client import MacApiError
 from mac.worker_subprocess import (
     SubprocessExecutor,
     _cargo_path_dirs,
+    _cleanup_task_sandbox_after_timeout,
     _ensure_json_object,
     _terminate_process_tree,
 )
@@ -194,6 +195,28 @@ def test_executor_timeout_reports_failed_sandbox_delete_truthfully(tmp_path, mon
         executor({"id": "task_timeout_leak", "metadata": {}}, tmp_path)
 
     assert caught.value.process_tree_terminated is False
+
+
+def test_timeout_cleanup_retains_sandbox_when_harvest_fails(tmp_path, monkeypatch) -> None:
+    deleted = []
+    monkeypatch.setattr(
+        "mac.executor_sandbox._sandbox_download",
+        lambda _name, _workspace, _destination: False,
+    )
+    monkeypatch.setattr(
+        "mac.executor_sandbox._sandbox_delete",
+        lambda name: deleted.append(name) or True,
+    )
+
+    outcome = _cleanup_task_sandbox_after_timeout("mac-task-preserve", tmp_path)
+
+    assert outcome == {
+        "sandbox": "mac-task-preserve",
+        "harvested": False,
+        "deleted": False,
+        "error": "sandbox harvest did not complete; retained for recovery",
+    }
+    assert deleted == []
 
 
 def test_audit_failures_do_not_mask_task_execution() -> None:

--- a/tests/test_worker_subprocess.py
+++ b/tests/test_worker_subprocess.py
@@ -132,16 +132,16 @@ def test_executor_timeout_preserves_timeout_evidence(tmp_path) -> None:
     assert executor.has_active_process() is False
 
 
-def test_executor_timeout_harvests_and_deletes_exact_sandbox(
-    tmp_path, monkeypatch
-) -> None:
+def test_executor_timeout_harvests_and_deletes_exact_sandbox(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "mac-task-timeout")
     cleanups = []
     monkeypatch.setattr(
         "mac.worker_subprocess._cleanup_task_sandbox_after_timeout",
-        lambda name, workspace: cleanups.append((name, workspace))
-        or {"sandbox": name, "harvested": True, "deleted": True},
+        lambda name, workspace: (
+            cleanups.append((name, workspace))
+            or {"sandbox": name, "harvested": True, "deleted": True}
+        ),
     )
     executor = SubprocessExecutor(
         [sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.01
@@ -159,9 +159,7 @@ def test_executor_timeout_harvests_and_deletes_exact_sandbox(
     }
 
 
-def test_executor_timeout_reports_failed_sandbox_delete_truthfully(
-    tmp_path, monkeypatch
-) -> None:
+def test_executor_timeout_reports_failed_sandbox_delete_truthfully(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "mac-task-leaked")
     monkeypatch.setattr(

--- a/tests/test_worker_subprocess.py
+++ b/tests/test_worker_subprocess.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 import os
 import subprocess
@@ -14,6 +15,7 @@ from mac.worker_subprocess import (
     SubprocessExecutor,
     _cargo_path_dirs,
     _ensure_json_object,
+    _terminate_process_tree,
 )
 
 
@@ -130,6 +132,24 @@ def test_executor_timeout_preserves_timeout_evidence(tmp_path) -> None:
     assert records[-1]["metadata"]["timeout_seconds"] == 0.01
     assert records[-1]["metadata"]["process_tree_terminated"] is True
     assert executor.has_active_process() is False
+
+
+def test_process_tree_cleanup_reports_unverified_without_psutil(monkeypatch) -> None:
+    real_import = builtins.__import__
+
+    def import_without_psutil(name, *args, **kwargs):
+        if name == "psutil":
+            raise ImportError("psutil deliberately unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_psutil)
+    process = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        assert _terminate_process_tree(process, grace_seconds=0.2) is False
+    finally:
+        if process.poll() is None:
+            process.kill()
+        process.wait()
 
 
 def test_executor_timeout_harvests_and_deletes_exact_sandbox(tmp_path, monkeypatch) -> None:

--- a/tests/test_worker_subprocess.py
+++ b/tests/test_worker_subprocess.py
@@ -128,7 +128,54 @@ def test_executor_timeout_preserves_timeout_evidence(tmp_path) -> None:
 
     assert records[-1]["phase"] == "timeout"
     assert records[-1]["metadata"]["timeout_seconds"] == 0.01
+    assert records[-1]["metadata"]["process_tree_terminated"] is True
     assert executor.has_active_process() is False
+
+
+def test_executor_timeout_harvests_and_deletes_exact_sandbox(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "mac-task-timeout")
+    cleanups = []
+    monkeypatch.setattr(
+        "mac.worker_subprocess._cleanup_task_sandbox_after_timeout",
+        lambda name, workspace: cleanups.append((name, workspace))
+        or {"sandbox": name, "harvested": True, "deleted": True},
+    )
+    executor = SubprocessExecutor(
+        [sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.01
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
+        executor({"id": "task_timeout_sandbox", "metadata": {}}, tmp_path)
+
+    assert cleanups == [("mac-task-timeout", tmp_path)]
+    assert caught.value.process_tree_terminated is True
+    assert caught.value.sandbox_cleanup == {
+        "sandbox": "mac-task-timeout",
+        "harvested": True,
+        "deleted": True,
+    }
+
+
+def test_executor_timeout_reports_failed_sandbox_delete_truthfully(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")
+    monkeypatch.setenv("MAC_OPENSHELL_SANDBOX_NAME", "mac-task-leaked")
+    monkeypatch.setattr(
+        "mac.worker_subprocess._cleanup_task_sandbox_after_timeout",
+        lambda _name, _workspace: {"harvested": True, "deleted": False},
+    )
+    executor = SubprocessExecutor(
+        [sys.executable, "-c", "import time; time.sleep(5)"], timeout=0.01
+    )
+
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
+        executor({"id": "task_timeout_leak", "metadata": {}}, tmp_path)
+
+    assert caught.value.process_tree_terminated is False
 
 
 def test_audit_failures_do_not_mask_task_execution() -> None:


### PR DESCRIPTION
Closes the fleet-stranding recovery gaps observed during the 2026-09-08 physical-host rollout.

Tasks:
- `task_0255c029420430efa11c2ca6b34e5188`
- `task_896eb0cce1714010b19e6a272cbd36bc`
- `task_53b15db81d024b319a899a273af3a75c`

What changed:
- preserve a stopped, strongly corroborated legacy OpenShell task container before exact deletion; ambiguous/live identities remain fail-closed
- re-prove absence when a container vanishes between list and inspect
- terminate timed-out executor descendants across process groups, report verification truthfully, harvest before exact sandbox deletion, and retain the sandbox if harvesting fails
- recover deployment from an unambiguous orphaned `mac.hub_serve` listener while refusing unrelated or ambiguous listener owners
- regenerate environment metadata and restore the repository formatting gate

Validation:
- `make lint`
- integrated focused suites: 93 quiescence tests; 180 rollback/drain/environment tests; 19 timeout tests
- `scripts/run-contract-tests.sh`

The stopped HGX canary target is intentionally not restored or changed.
