### PR TITLE
Repair environment prerequisites: Give machine-set dispatch holds an automatic release (task_repair_e546422d8406f538b355e434)

### DIFF
--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -1,5 +1,16 @@
 [
   {
+    "default": 3600,
+    "description": "Maximum age in seconds for machine-set agent dispatch holds before automatic release.",
+    "family": "agent",
+    "name": "MAC_AGENT_DISPATCH_HOLD_TTL_SECONDS",
+    "retired": false,
+    "sources": [
+      "src/mac/services.py"
+    ],
+    "type": "int"
+  },
+  {
     "default": null,
     "description": "Acp setting: acp agent cmd.",
     "family": "acp",

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -327,6 +327,12 @@ MAX_EVIDENCE_ARTIFACT_BYTES = 50 * 1024 * 1024
 DEFAULT_EVIDENCE_ARTIFACT_TOTAL_BYTES = 50 * 1024 * 1024
 MAX_EVIDENCE_ARTIFACT_TOTAL_BYTES = 100 * 1024 * 1024
 AUTO_QUARANTINE_REASON = "auto_quarantine:consecutive_expiries_no_telemetry"
+MACHINE_DISPATCH_HOLD_PREFIXES = (
+    "auto_quarantine:",
+    "fleet_upgrade:",
+    "judgement:",
+    "source_convergence:",
+)
 BREAK_GLASS_AUTHORIZATION_SCHEMA = "mac.break_glass_authorization.v1"
 BREAK_GLASS_EXECUTION_BOUNDARY = "host"
 BREAK_GLASS_MIN_TTL_SECONDS = 60
@@ -379,6 +385,14 @@ def _agent_quarantine_threshold() -> int:
 
 def _agent_zombie_stream_age_seconds() -> int:
     return _env_int("MAC_AGENT_ZOMBIE_STREAM_AGE_SECONDS", 300, minimum=1)
+
+
+def _agent_dispatch_hold_ttl_seconds() -> int:
+    return _env_int("MAC_AGENT_DISPATCH_HOLD_TTL_SECONDS", 3600, minimum=1)
+
+
+def _machine_set_dispatch_hold(reason: Any) -> bool:
+    return str(reason or "").strip().startswith(MACHINE_DISPATCH_HOLD_PREFIXES)
 
 
 def _evidence_artifact_max_bytes() -> int:
@@ -16328,6 +16342,53 @@ class ControlPlane:
         self.agentbus_broadcast.publish_system("agent.resumed.v1", payload={"agent_id": agent_id})
         return agent
 
+    def _release_expired_machine_dispatch_holds(self, *, limit: int) -> List[JsonDict]:
+        ttl_seconds = _agent_dispatch_hold_ttl_seconds()
+        cutoff = (parse_time(utcnow()) - timedelta(seconds=ttl_seconds)).isoformat()
+        reason_filter = " OR ".join(
+            "dispatch_hold_reason LIKE ?" for _ in MACHINE_DISPATCH_HOLD_PREFIXES
+        )
+        rows = self.store.query_all(
+            "SELECT id, dispatch_hold_reason, dispatch_hold_at FROM agents "
+            "WHERE dispatch_hold = 1 AND dispatch_hold_at IS NOT NULL "
+            "AND dispatch_hold_at <= ? AND (%s) "
+            "ORDER BY dispatch_hold_at, id LIMIT ?" % reason_filter,
+            (
+                cutoff,
+                *(prefix + "%" for prefix in MACHINE_DISPATCH_HOLD_PREFIXES),
+                max(1, int(limit)),
+            ),
+        )
+        released: List[JsonDict] = []
+        for row in rows:
+            reason = str(row["dispatch_hold_reason"] or "")
+            if not _machine_set_dispatch_hold(reason):
+                continue
+            changed, agent = self.release_agent_dispatch_hold(str(row["id"]), reason)
+            if not changed:
+                continue
+            detail = {
+                "agent_id": str(row["id"]),
+                "released_reason": reason,
+                "held_since": row["dispatch_hold_at"],
+                "ttl_seconds": ttl_seconds,
+            }
+            released.append(detail)
+            self.record_log(
+                "agent.machine_dispatch_hold_expired",
+                layer="control_plane",
+                source="dispatcher.tick",
+                level="info",
+                subject_type="agent",
+                subject_id=str(row["id"]),
+                detail=detail,
+            )
+            self.agentbus_broadcast.publish_system(
+                "agent.resumed.v1",
+                payload={"agent_id": agent.id, "reason": "machine_hold_ttl_expired"},
+            )
+        return released
+
     def unconsumed_control_stream_age_seconds(self, agent_id: str) -> Optional[float]:
         agent = self.get_agent(agent_id)
         published_at = agent.last_control_stream_published_at
@@ -16699,7 +16760,8 @@ class ControlPlane:
         if {"status", "health_status"} & set(meaningful_changes):
             self.dispatch.invalidate_pull_round_cache()
         self._ensure_agent_nap_schedule(agent.id, actor=actor or agent_id)
-        self._release_auto_quarantine_on_heartbeat(agent_before)
+        if resources is not None and resources.get(REPORT_REPOSITORY_EXECUTOR_ATTESTATION_KEY):
+            self._release_auto_quarantine_on_heartbeat(agent_before)
         self._maybe_advance_reviews_on_heartbeat(agent_before)
         self._maybe_drain_notifications_on_heartbeat(agent_before)
         return agent
@@ -16764,7 +16826,7 @@ class ControlPlane:
 
         AUTO_QUARANTINE_REASON means "consecutive lease expiries with no
         executor telemetry" -- i.e. the hub believes this worker is a zombie.
-        A heartbeat is direct counter-evidence. Nothing else in the codebase
+        Executor telemetry on a heartbeat is direct counter-evidence. Nothing else in the codebase
         clears this hold: clear_agent_dispatch_hold has only operator callers,
         so a single fleet-wide event (a deploy expiring every in-flight lease)
         could bench every agent permanently. Observed live twice on 2026-07-31.
@@ -16789,7 +16851,7 @@ class ControlPlane:
                 level="info",
                 detail={
                     "agent_id": agent.id,
-                    "reason": "heartbeat proves the agent is not a zombie",
+                    "reason": "heartbeat executor telemetry proves the agent is not a zombie",
                     "released_reason": AUTO_QUARANTINE_REASON,
                     "held_since": agent.dispatch_hold_at,
                 },
@@ -18584,6 +18646,17 @@ class ControlPlane:
                 level="error",
                 detail={"error": str(exc)[:500]},
             )
+        try:
+            expired_dispatch_holds = self._release_expired_machine_dispatch_holds(limit=limit_value)
+        except Exception as exc:  # noqa: BLE001 - hold expiry must never stop dispatch.
+            expired_dispatch_holds = []
+            self.record_log(
+                "agent.machine_dispatch_hold_expiry_tick_failed",
+                layer="control_plane",
+                source="dispatcher.tick",
+                level="error",
+                detail={"error": str(exc)[:500]},
+            )
         expired_page = self._expire_leases_sweep_page(limit=limit_value)
         expired = [task.to_dict() for task in expired_page["tasks"]]
         try:
@@ -18789,6 +18862,7 @@ class ControlPlane:
         return {
             "stale_agents": stale_agents,
             "expired_ephemeral_agents": expired_ephemerals,
+            "expired_dispatch_holds": expired_dispatch_holds,
             "expired": expired,
             "workflow_runs": workflow_runs,
             "review_workflows": review_workflows,

--- a/src/mac/source_convergence_service.py
+++ b/src/mac/source_convergence_service.py
@@ -208,11 +208,6 @@ class SourceConvergenceService:
                 summary["blocked"] += 1
                 continue
 
-            self.cp.set_agent_dispatch_hold(
-                agent_id,
-                "%sgeneration=%d:desired=%s" % (_HOLD_PREFIX, generation, desired_sha[:12]),
-            )
-            summary["held"] += 1
             if dirty:
                 self._write_node(
                     state,
@@ -265,6 +260,11 @@ class SourceConvergenceService:
                 )
                 summary["blocked"] += 1
                 continue
+            self.cp.set_agent_dispatch_hold(
+                agent_id,
+                "%sgeneration=%d:desired=%s" % (_HOLD_PREFIX, generation, desired_sha[:12]),
+            )
+            summary["held"] += 1
             if str(row["current_task_id"] or "") or str(row["status"]) == AgentStatus.BUSY.value:
                 self._write_node(
                     state,

--- a/tests/test_agent_dispatch_hold.py
+++ b/tests/test_agent_dispatch_hold.py
@@ -1321,6 +1321,23 @@ def test_two_zero_telemetry_expiries_auto_quarantine_agent(monkeypatch):
     assert any(stream.topic == REFLECT_REQUEST_TOPIC for stream in streams)
 
 
+def test_tick_expires_machine_hold_but_preserves_operator_hold(monkeypatch):
+    monkeypatch.setenv("MAC_AGENT_DISPATCH_HOLD_TTL_SECONDS", "60")
+    cp = _make_cp()
+    machine = _register_agent(cp, "machine-held")
+    operator = _register_agent(cp, "operator-held")
+    cp.set_agent_dispatch_hold(machine.id, "source_convergence:generation=1")
+    cp.set_agent_dispatch_hold(operator.id, "operator:investigation")
+    old = "2000-01-01T00:00:00+00:00"
+    cp.store.execute("UPDATE agents SET dispatch_hold_at = ?", (old,))
+
+    result = cp.tick(limit=0)
+
+    assert [item["agent_id"] for item in result["expired_dispatch_holds"]] == [machine.id]
+    assert cp.get_agent(machine.id).dispatch_hold is False
+    assert cp.get_agent(operator.id).dispatch_hold is True
+
+
 def test_virtual_agent_lease_expiry_never_quarantines(monkeypatch):
     """A virtual, hub-driven agent (e.g. the hub_verify review verifier) has no
     worker process and by design emits no executor telemetry, so its expired

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -14980,8 +14980,8 @@ def test_one_malformed_dependency_policy_cannot_halt_the_whole_round(cp):
     del worker
 
 
-def test_heartbeat_releases_the_zombie_quarantine(cp):
-    """A heartbeat is counter-evidence to "this agent is a zombie".
+def test_heartbeat_executor_telemetry_releases_the_zombie_quarantine(cp):
+    """Executor telemetry is counter-evidence to "this agent is a zombie".
 
     AUTO_QUARANTINE_REASON has no automatic release anywhere in the codebase --
     clear_agent_dispatch_hold has only operator callers -- so one fleet-wide
@@ -14995,7 +14995,11 @@ def test_heartbeat_releases_the_zombie_quarantine(cp):
     cp.set_agent_dispatch_hold(agent.id, AUTO_QUARANTINE_REASON)
     assert cp.get_agent(agent.id).dispatch_hold is True
 
-    cp.heartbeat_agent(agent.id, status="idle")
+    cp.heartbeat_agent(
+        agent.id,
+        status="idle",
+        resources={"report_repository_executor_attestation": {"verified": True}},
+    )
 
     assert cp.get_agent(agent.id).dispatch_hold is False
 
@@ -15010,6 +15014,17 @@ def test_heartbeat_does_not_release_an_operator_hold(cp):
     held = cp.get_agent(agent.id)
     assert held.dispatch_hold is True
     assert "operator" in (held.dispatch_hold_reason or "")
+
+
+def test_heartbeat_without_executor_telemetry_keeps_zombie_quarantine(cp):
+    from mac.services import AUTO_QUARANTINE_REASON
+
+    agent = register_agent(cp, "w", ["python"])
+    cp.set_agent_dispatch_hold(agent.id, AUTO_QUARANTINE_REASON)
+
+    cp.heartbeat_agent(agent.id, status="idle")
+
+    assert cp.get_agent(agent.id).dispatch_hold is True
 
 
 def test_all_settled_still_settles_a_cancelled_child(cp):

--- a/tests/test_source_convergence_service.py
+++ b/tests/test_source_convergence_service.py
@@ -134,8 +134,31 @@ def test_controller_fails_closed_without_impact_plan(monkeypatch):
     node = cp.source_convergence_status(fleet_id=fleet.id)["nodes"][0]
     assert node["phase"] == "blocked"
     assert node["blocker_code"] == "operator_direction_required"
-    assert cp.get_agent(agent.id).dispatch_hold is True
+    assert cp.get_agent(agent.id).dispatch_hold is False
     assert cp.list_agentbus_streams(agent_id=agent.id) == []
+
+
+def test_controller_does_not_hold_dirty_checkout_it_will_not_remediate(monkeypatch):
+    cp, fleet, agent = _fixture()
+    monkeypatch.setenv("MAC_REVIEW_TICK_HUB_AGENT", agent.id)
+    cp.heartbeat_agent(
+        agent.id,
+        resources={
+            "source_state": {
+                "schema": "mac.worker_source_state.v1",
+                "commit_sha": OLD_SHA,
+                "tree_sha": "a" * 40,
+                "dirty": True,
+            }
+        },
+    )
+
+    result = cp.tick_source_convergence()
+
+    assert result["blocked"] == 1
+    assert cp.get_agent(agent.id).dispatch_hold is False
+    node = cp.source_convergence_status(fleet_id=fleet.id)["nodes"][0]
+    assert node["blocker_code"] == "dirty_checkout"
 
 
 def test_controller_preserves_unrelated_operator_hold(monkeypatch):


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_repair_e546422d8406f538b355e434`
- head: `ed430205362137c058671552a554f9cd6629fa30`
- base at push: `73f612f36575939656e0673def1ad54de3516044`
