### PR TITLE
Backlog grooming must attach a read-only repository checkout (task_78ee00624e0349f9a984cb8a330a9b15)

### DIFF
--- a/src/mac/backlog_groomer.py
+++ b/src/mac/backlog_groomer.py
@@ -430,6 +430,11 @@ class BacklogGroomer:
             "origin": origin,
             # Repo-coupled (repo cloned) but held to an investigation write-up,
             # not code-substance verification — same contract as onboarding.
+            "deliverable": "report",
+            "report_repository_access": {
+                "schema": "mac.report_repository_access.v1",
+                "mode": "read_only",
+            },
             "evidence_type": "investigation",
         }
         return self.control_plane.create_task(

--- a/tests/test_backlog_groomer.py
+++ b/tests/test_backlog_groomer.py
@@ -164,6 +164,11 @@ def test_grooms_idle_opted_in_project():
     assert created["metadata"]["origin"]["type"] == "backlog_grooming"
     # repo-coupled (origin has url) but investigation-gated, not code
     assert created["metadata"]["origin"]["repository_url"] == "https://github.com/o/r"
+    assert created["metadata"]["deliverable"] == "report"
+    assert created["metadata"]["report_repository_access"] == {
+        "schema": "mac.report_repository_access.v1",
+        "mode": "read_only",
+    }
     assert created["metadata"]["evidence_type"] == "investigation"
 
 


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_78ee00624e0349f9a984cb8a330a9b15`
- head: `b64f06412e29924dc930a30861ef1f35939e51ea`
- base at push: `80e1168a3162b11cbe0eb4ccf19e4307c3c17aea`
