### PR TITLE
Backlog grooming read-only reports must use native operator evidence (task_3133a05c42c9462aa134e5bb43fc9c49)

### DIFF
--- a/src/mac/backlog_groomer.py
+++ b/src/mac/backlog_groomer.py
@@ -10,11 +10,10 @@ Design (deliberately small — it reuses existing machinery):
 * On a slow schedule, for each opted-in project that is *going idle* (its
   count of pending/in-flight tasks is below a low-water mark) and is past its
   grooming cadence, create ONE **grooming task**.
-* The grooming task mirrors the onboarding "investigation" task: it is
-  repo-coupled (``origin.repository_url`` → MAC clones the repo) but declares
-  ``evidence_type: "investigation"`` so it is not held to code-substance
-  verification. Its prompt asks the agent to analyze the repo and emit a
-  prioritized backlog as ``plan_steps`` in ``mac-evidence.json``.
+* The grooming task is a native ``operator_directive`` report with read-only
+  repository context. Its prompt asks the agent to analyze the repo and emit a
+  prioritized backlog as ``plan_steps`` in ``mac-evidence.json`` using
+  ``operator_result`` evidence.
 * The executor's existing ``maybe_auto_decompose`` hook promotes those
   ``plan_steps`` into child tasks (inheriting the parent's project, so they are
   repo-coupled), which the normal hub tick then dispatches. No new promotion
@@ -170,9 +169,9 @@ def build_grooming_description(project: str, repo_url: str, backlog_size: int) -
         [
             "Autonomous backlog grooming for project %s (%s)." % (project, repo_url),
             "",
-            "MAC has cloned a clean, writable checkout for you at $MAC_TASK_REPO_WORKTREE.",
-            "This is READ-ONLY with respect to the remote: do NOT push or open a pull "
-            "request. This task produces a PLAN, not code.",
+            "MAC has prepared a clean checkout for you at $MAC_TASK_REPO_WORKTREE.",
+            "Treat the repository as READ-ONLY: do not modify files, commit, push, or "
+            "open a pull request. This task produces a PLAN, not code.",
             "",
             "Analyze the repository (start from README.md, AGENTS.md, PLAN.md, open "
             "issues/TODOs, failing or missing tests, and obvious gaps). Reconcile "
@@ -186,9 +185,10 @@ def build_grooming_description(project: str, repo_url: str, backlog_size: int) -
             '  - "description": what to do and how to know it is done (acceptance criteria)',
             '  - "required_capabilities": optional list (e.g. ["python"], ["docs"])',
             "",
-            "Evidence shape (evidence_type=investigation):",
-            '  {"plan_steps": [ {"title": "...", "description": "..."}, ... ],',
-            '   "rationale": "one line on how you prioritized"}',
+            "Evidence shape (evidence_type=operator_result):",
+            '  {"evidence_type": "operator_result",',
+            '   "summary": "one line on how you prioritized",',
+            '   "plan_steps": [ {"title": "...", "description": "..."}, ... ]}',
             "",
             "Keep each step small enough for one focused task. Do NOT include "
             "already-open work. Quality over quantity: fewer, well-scoped steps beat "
@@ -428,14 +428,13 @@ class BacklogGroomer:
         }
         metadata = {
             "origin": origin,
-            # Repo-coupled (repo cloned) but held to an investigation write-up,
-            # not code-substance verification — same contract as onboarding.
+            # The native read-only report path derives an operator_directive /
+            # operator_result contract while preserving repository context.
             "deliverable": "report",
             "report_repository_access": {
                 "schema": "mac.report_repository_access.v1",
                 "mode": "read_only",
             },
-            "evidence_type": "investigation",
         }
         return self.control_plane.create_task(
             "Groom backlog for %s" % project,

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -5528,7 +5528,14 @@ class ControlPlane:
                 for key, item in value.items():
                     child_path = "%s.%s" % (path, key)
                     if key in {"evidence_type", "expected_evidence_type"}:
-                        paths.append(child_path)
+                        native_contract_value = (
+                            path == "metadata.execution_contract"
+                            and str(value.get("type") or "").strip().lower() == "operator_directive"
+                            and key == "evidence_type"
+                            and str(item or "").strip().lower() == "operator_result"
+                        )
+                        if not native_contract_value:
+                            paths.append(child_path)
                     collect(item, child_path)
             elif isinstance(value, list):
                 for index, item in enumerate(value):
@@ -5608,7 +5615,8 @@ class ControlPlane:
                 "read-only repository reports require execution_contract to be an object"
             )
         execution = ensure_json_object(raw_execution)
-        if execution and str(execution.get("type") or "").strip().lower() != "repository":
+        execution_type = str(execution.get("type") or "").strip().lower()
+        if execution and execution_type not in {"repository", "operator_directive"}:
             raise ValidationError(
                 "read-only repository reports require a repository execution contract"
             )
@@ -5654,9 +5662,11 @@ class ControlPlane:
             contract = current
             canonical_execution: JsonDict = {
                 "schema": "mac.task_execution_contract.v1",
-                "type": "repository",
-                "quality": "strong",
+                "type": "operator_directive",
+                "quality": "weak",
                 "source": "registered_project",
+                "repository_required": False,
+                "evidence_type": "operator_result",
                 "repository_id": repo.id,
                 "repository_path": repo.path,
                 "repository_contract": contract,
@@ -5710,7 +5720,10 @@ class ControlPlane:
                     "read-only repository report execution_contract.schema is unsupported"
                 )
             canonical_execution["schema"] = "mac.task_execution_contract.v1"
-            canonical_execution["type"] = "repository"
+            canonical_execution["type"] = "operator_directive"
+            canonical_execution["quality"] = "weak"
+            canonical_execution["repository_required"] = False
+            canonical_execution["evidence_type"] = "operator_result"
             canonical_execution["repository_contract"] = contract
             origin_remote = str(origin.get("repository_url") or "").strip()
             if origin_remote:
@@ -5767,7 +5780,8 @@ class ControlPlane:
         execution = ensure_json_object(metadata.get("execution_contract"))
         if (
             execution.get("schema") != "mac.task_execution_contract.v1"
-            or str(execution.get("type") or "").strip().lower() != "repository"
+            or str(execution.get("type") or "").strip().lower() != "operator_directive"
+            or str(execution.get("evidence_type") or "").strip().lower() != "operator_result"
         ):
             raise ValidationError(
                 "read-only repository report lacks its normalized current execution contract"

--- a/tests/test_backlog_groomer.py
+++ b/tests/test_backlog_groomer.py
@@ -14,6 +14,9 @@ from mac.backlog_groomer import (
     ProjectGroomingPolicy,
     build_grooming_description,
 )
+from mac.executor_scope import maybe_auto_decompose
+from mac.services import ControlPlane
+from mac.test_support import ephemeral_store
 
 
 def _iso(dt: datetime) -> str:
@@ -70,6 +73,7 @@ def test_policy_parsing():
 def test_description_mentions_plan_steps_and_size():
     d = build_grooming_description("mac", "https://github.com/o/r", 5)
     assert "plan_steps" in d and "5 concrete" in d and "READ-ONLY" in d
+    assert "evidence_type=operator_result" in d
 
 
 # --------------------------------------------------------------------------- #
@@ -162,14 +166,82 @@ def test_grooms_idle_opted_in_project():
     created = cp.created[0]
     assert created["project"] == "mac"
     assert created["metadata"]["origin"]["type"] == "backlog_grooming"
-    # repo-coupled (origin has url) but investigation-gated, not code
+    # Repo context is requested, but no evidence override is supplied.
     assert created["metadata"]["origin"]["repository_url"] == "https://github.com/o/r"
     assert created["metadata"]["deliverable"] == "report"
     assert created["metadata"]["report_repository_access"] == {
         "schema": "mac.report_repository_access.v1",
         "mode": "read_only",
     }
-    assert created["metadata"]["evidence_type"] == "investigation"
+    assert "evidence_type" not in created["metadata"]
+
+
+def test_grooming_task_passes_real_control_plane_normalization(tmp_path, monkeypatch):
+    cp = ControlPlane(ephemeral_store(), secret_key="backlog-groomer-test-secret-key-32+")
+    repo = tmp_path / "mac"
+    contract_dir = repo / ".mac"
+    contract_dir.mkdir(parents=True)
+    (contract_dir / "project.yaml").write_text(
+        "\n".join(
+            [
+                "schema: mac.repository_contract.v1",
+                "project: mac",
+                "canonical_remote_url: https://github.com/o/r",
+                "default_branch: main",
+                "platforms: [darwin, linux, wsl2]",
+                "toolchain:",
+                "  required_commands: [python3]",
+                "bootstrap:",
+                "  command: python3 scripts/bootstrap-project.py",
+                "  creates: [.venv/bin/python]",
+                "test:",
+                "  command: pytest",
+                "evidence:",
+                "  required: [tests]",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cp.create_project(
+        "mac",
+        metadata={
+            "repository_url": "https://github.com/o/r",
+            "backlog_grooming": {"enabled": True},
+        },
+    )
+    cp.register_project_repository("mac", str(repo), project="mac")
+
+    report = _groomer(cp).run_once()
+
+    assert report["groomed_count"] == 1
+    task = cp.get_task(report["projects"][0]["task_id"])
+    assert "evidence_type" not in task.metadata
+    assert task.metadata["report_repository_access"] == {
+        "schema": "mac.report_repository_access.v1",
+        "mode": "read_only",
+    }
+    assert task.metadata["execution_contract"]["type"] == "operator_directive"
+    assert task.metadata["execution_contract"]["evidence_type"] == "operator_result"
+    assert task.metadata["execution_contract"]["repository_required"] is False
+    assert task.metadata["execution_contract"]["repository_contract"]["project"] == "mac"
+    assert "plan_steps" in task.description
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "mac-evidence.json").write_text(
+        '{"evidence_type":"operator_result","summary":"Prioritized work.",'
+        '"plan_steps":[{"title":"Add coverage","description":"Cover the gap."}]}',
+        encoding="utf-8",
+    )
+    posted = {}
+    monkeypatch.setattr(
+        "mac.executor_scope._hub_post_child_tasks",
+        lambda task_id, children: posted.update(task_id=task_id, children=children) or {},
+    )
+    assert maybe_auto_decompose(workspace, task.to_dict()) is True
+    assert posted["task_id"] == task.id
+    assert posted["children"] == [{"title": "Add coverage", "description": "Cover the gap."}]
 
 
 def test_skips_project_not_opted_in():

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -5916,7 +5916,9 @@ def test_registered_read_only_report_has_one_unambiguous_persisted_contract(cp, 
     )
     persisted = cp.get_task(created.id)
 
-    assert persisted.metadata["execution_contract"]["type"] == "repository"
+    assert persisted.metadata["execution_contract"]["type"] == "operator_directive"
+    assert persisted.metadata["execution_contract"]["evidence_type"] == "operator_result"
+    assert persisted.metadata["execution_contract"]["repository_required"] is False
     assert (
         persisted.metadata["execution_contract"]["repository_contract"]
         == (cp.get_project_repository("mac").metadata["repository_contract"])
@@ -5925,7 +5927,9 @@ def test_registered_read_only_report_has_one_unambiguous_persisted_contract(cp, 
     assert "repository_contract" not in {
         key: value for key, value in persisted.metadata.items() if key != "execution_contract"
     }
-    assert "evidence_type" not in json.dumps(persisted.metadata, sort_keys=True)
+    assert "evidence_type" not in {
+        key: value for key, value in persisted.metadata.items() if key != "execution_contract"
+    }
     assert metadata_declares_read_only_report_repository(persisted.metadata)
     assert persisted.id in {task.id for task in cp.ready_tasks()}
 
@@ -5933,7 +5937,7 @@ def test_registered_read_only_report_has_one_unambiguous_persisted_contract(cp, 
     assert _lease.agent_id == worker.id
     assert claimed.state == TaskState.CLAIMED.value
     assert metadata_declares_read_only_report_repository(claimed.metadata)
-    assert "evidence_type" not in json.dumps(claimed.metadata, sort_keys=True)
+    assert claimed.metadata["execution_contract"]["evidence_type"] == "operator_result"
 
 
 @pytest.mark.parametrize(
@@ -6154,7 +6158,11 @@ def test_read_only_report_child_uses_current_contract_and_invalid_batch_is_atomi
         == (cp.get_project_repository("mac").metadata["repository_contract"])
     )
     assert "repository_contract" not in child.metadata["origin"]
-    assert "evidence_type" not in json.dumps(child.metadata, sort_keys=True)
+    assert child.metadata["execution_contract"]["type"] == "operator_directive"
+    assert child.metadata["execution_contract"]["evidence_type"] == "operator_result"
+    assert "evidence_type" not in {
+        key: value for key, value in child.metadata.items() if key != "execution_contract"
+    }
 
     direct_parent = cp.create_task("Direct parent")
     before = cp.get_task(direct_parent.id)


### PR DESCRIPTION
Opened by the MAC agent that produced this change.

- task: `task_3133a05c42c9462aa134e5bb43fc9c49`
- head: `8b2641e8d96a2e4e10af1bbfb329050ba086272e`
- base at push: `f559e03002e393811d9a131f44eb843dace538b9`
