### PR TITLE
Correct grooming report contract and Postgres PATH precedence

### DIFF
--- a/scripts/start-test-postgres.sh
+++ b/scripts/start-test-postgres.sh
@@ -39,7 +39,13 @@ for brew_bin in \
   /opt/homebrew/bin \
   /usr/local/bin; do
   if [ -x "$brew_bin/pg_isready" ] || [ -x "$brew_bin/pg_ctl" ]; then
-    PATH="$brew_bin:${PATH:-}"
+    # Preserve explicit caller overrides (including CI/test shims for docker
+    # and podman).  These directories only fill commands missing from PATH;
+    # putting them first can silently bypass an operator's chosen executable.
+    case ":${PATH:-}:" in
+      *":$brew_bin:"*) ;;
+      *) PATH="${PATH:+${PATH}:}$brew_bin" ;;
+    esac
   fi
 done
 export PATH

--- a/src/mac/services.py
+++ b/src/mac/services.py
@@ -5528,14 +5528,7 @@ class ControlPlane:
                 for key, item in value.items():
                     child_path = "%s.%s" % (path, key)
                     if key in {"evidence_type", "expected_evidence_type"}:
-                        native_contract_value = (
-                            path == "metadata.execution_contract"
-                            and str(value.get("type") or "").strip().lower() == "operator_directive"
-                            and key == "evidence_type"
-                            and str(item or "").strip().lower() == "operator_result"
-                        )
-                        if not native_contract_value:
-                            paths.append(child_path)
+                        paths.append(child_path)
                     collect(item, child_path)
             elif isinstance(value, list):
                 for index, item in enumerate(value):
@@ -5615,8 +5608,7 @@ class ControlPlane:
                 "read-only repository reports require execution_contract to be an object"
             )
         execution = ensure_json_object(raw_execution)
-        execution_type = str(execution.get("type") or "").strip().lower()
-        if execution and execution_type not in {"repository", "operator_directive"}:
+        if execution and str(execution.get("type") or "").strip().lower() != "repository":
             raise ValidationError(
                 "read-only repository reports require a repository execution contract"
             )
@@ -5662,11 +5654,9 @@ class ControlPlane:
             contract = current
             canonical_execution: JsonDict = {
                 "schema": "mac.task_execution_contract.v1",
-                "type": "operator_directive",
-                "quality": "weak",
+                "type": "repository",
+                "quality": "strong",
                 "source": "registered_project",
-                "repository_required": False,
-                "evidence_type": "operator_result",
                 "repository_id": repo.id,
                 "repository_path": repo.path,
                 "repository_contract": contract,
@@ -5720,10 +5710,7 @@ class ControlPlane:
                     "read-only repository report execution_contract.schema is unsupported"
                 )
             canonical_execution["schema"] = "mac.task_execution_contract.v1"
-            canonical_execution["type"] = "operator_directive"
-            canonical_execution["quality"] = "weak"
-            canonical_execution["repository_required"] = False
-            canonical_execution["evidence_type"] = "operator_result"
+            canonical_execution["type"] = "repository"
             canonical_execution["repository_contract"] = contract
             origin_remote = str(origin.get("repository_url") or "").strip()
             if origin_remote:
@@ -5780,8 +5767,7 @@ class ControlPlane:
         execution = ensure_json_object(metadata.get("execution_contract"))
         if (
             execution.get("schema") != "mac.task_execution_contract.v1"
-            or str(execution.get("type") or "").strip().lower() != "operator_directive"
-            or str(execution.get("evidence_type") or "").strip().lower() != "operator_result"
+            or str(execution.get("type") or "").strip().lower() != "repository"
         ):
             raise ValidationError(
                 "read-only repository report lacks its normalized current execution contract"

--- a/tests/test_backlog_groomer.py
+++ b/tests/test_backlog_groomer.py
@@ -15,6 +15,7 @@ from mac.backlog_groomer import (
     build_grooming_description,
 )
 from mac.executor_scope import maybe_auto_decompose
+from mac.executor_prompt import task_evidence_type
 from mac.services import ControlPlane
 from mac.test_support import ephemeral_store
 
@@ -226,10 +227,9 @@ def test_grooming_task_passes_real_control_plane_normalization(tmp_path, monkeyp
         "schema": "mac.report_repository_access.v1",
         "mode": "read_only",
     }
-    assert task.metadata["execution_contract"]["type"] == "operator_directive"
-    assert task.metadata["execution_contract"]["evidence_type"] == "operator_result"
-    assert task.metadata["execution_contract"]["repository_required"] is False
+    assert task.metadata["execution_contract"]["type"] == "repository"
     assert task.metadata["execution_contract"]["repository_contract"]["project"] == "mac"
+    assert task_evidence_type(task.to_dict()) == "operator_result"
     assert "plan_steps" in task.description
 
     workspace = tmp_path / "workspace"

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -5916,9 +5916,7 @@ def test_registered_read_only_report_has_one_unambiguous_persisted_contract(cp, 
     )
     persisted = cp.get_task(created.id)
 
-    assert persisted.metadata["execution_contract"]["type"] == "operator_directive"
-    assert persisted.metadata["execution_contract"]["evidence_type"] == "operator_result"
-    assert persisted.metadata["execution_contract"]["repository_required"] is False
+    assert persisted.metadata["execution_contract"]["type"] == "repository"
     assert (
         persisted.metadata["execution_contract"]["repository_contract"]
         == (cp.get_project_repository("mac").metadata["repository_contract"])
@@ -5927,9 +5925,7 @@ def test_registered_read_only_report_has_one_unambiguous_persisted_contract(cp, 
     assert "repository_contract" not in {
         key: value for key, value in persisted.metadata.items() if key != "execution_contract"
     }
-    assert "evidence_type" not in {
-        key: value for key, value in persisted.metadata.items() if key != "execution_contract"
-    }
+    assert "evidence_type" not in json.dumps(persisted.metadata, sort_keys=True)
     assert metadata_declares_read_only_report_repository(persisted.metadata)
     assert persisted.id in {task.id for task in cp.ready_tasks()}
 
@@ -5937,7 +5933,7 @@ def test_registered_read_only_report_has_one_unambiguous_persisted_contract(cp, 
     assert _lease.agent_id == worker.id
     assert claimed.state == TaskState.CLAIMED.value
     assert metadata_declares_read_only_report_repository(claimed.metadata)
-    assert claimed.metadata["execution_contract"]["evidence_type"] == "operator_result"
+    assert "evidence_type" not in json.dumps(claimed.metadata, sort_keys=True)
 
 
 @pytest.mark.parametrize(
@@ -6158,11 +6154,7 @@ def test_read_only_report_child_uses_current_contract_and_invalid_batch_is_atomi
         == (cp.get_project_repository("mac").metadata["repository_contract"])
     )
     assert "repository_contract" not in child.metadata["origin"]
-    assert child.metadata["execution_contract"]["type"] == "operator_directive"
-    assert child.metadata["execution_contract"]["evidence_type"] == "operator_result"
-    assert "evidence_type" not in {
-        key: value for key, value in child.metadata.items() if key != "execution_contract"
-    }
+    assert "evidence_type" not in json.dumps(child.metadata, sort_keys=True)
 
     direct_parent = cp.create_task("Direct parent")
     before = cp.get_task(direct_parent.id)

--- a/tests/test_start_test_postgres_homebrew_path.py
+++ b/tests/test_start_test_postgres_homebrew_path.py
@@ -11,4 +11,7 @@ def test_helper_discovers_homebrew_postgres_without_relying_on_path():
     no pg_isready even though Homebrew postgresql@17 was listening."""
     source = SCRIPT.read_text(encoding="utf-8")
     assert "/opt/homebrew/opt/postgresql@17/bin" in source
-    assert 'PATH="$brew_bin:${PATH:-}"' in source
+    # Homebrew must be discoverable even under launchd's sparse PATH, but it
+    # must not override a caller-selected docker/podman executable.
+    assert 'PATH="${PATH:+${PATH}:}$brew_bin"' in source
+    assert 'PATH="$brew_bin:${PATH:-}"' not in source

--- a/tests/test_start_test_postgres_stale_lock.py
+++ b/tests/test_start_test_postgres_stale_lock.py
@@ -60,6 +60,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def test_homebrew_discovery_preserves_explicit_path_precedence():
+    source = SCRIPT.read_text(encoding="utf-8")
+    assert 'PATH="${PATH:+${PATH}:}$brew_bin"' in source
+    assert 'PATH="$brew_bin:${PATH:-}"' not in source
+
+
 @pytest.fixture()
 def short_tmp():
     """A short temp dir: a unix socket path is capped near 104 bytes, and


### PR DESCRIPTION
## Purpose

Correct the over-broad report-contract rewrite that landed in #785 while retaining the read-only repository report workflow. Also preserve explicit caller PATH precedence in the test Postgres bootstrap.

## Verification

- `scripts/run-contract-tests.sh`
  - 11,342 passed, 3 skipped, 1 xfailed
  - 200 passed, 4 skipped
