### PR TITLE
Attest host report executors at startup

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -12733,7 +12733,11 @@ def add_report_executor_attestation_problem(message: str) -> None:
     report_executor_attestation_problems.append(message)
 
 
-if openshell_enabled and str(os.environ.get("MAC_WORKER_MODE") or "").strip() == "loop":
+# Darwin host installs have no OpenShell runtime to attest, but still bind the
+# executor, Python, wrapper script, and source tree by digest.  Run the same
+# loop-worker probe there so the startup proof can be matched to the hub's
+# current worker claim and approved for read-only repository reports.
+if str(os.environ.get("MAC_WORKER_MODE") or "").strip() == "loop":
     try:
         from mac.worker import _read_only_report_executor_attestation
 

--- a/tests/test_selftest_report_executor_attestation_crash.py
+++ b/tests/test_selftest_report_executor_attestation_crash.py
@@ -193,6 +193,25 @@ def test_obtainable_attestation_passes_cleanly(tmp_path, monkeypatch):
     }
 
 
+def test_host_loop_worker_serializes_obtainable_attestation(tmp_path, monkeypatch):
+    # A Darwin host executor is intentionally unsandboxed (ADR 0015), but its
+    # executable, interpreter, wrapper, and source tree are still digest-bound.
+    # Its startup proof must carry that attestation so controller approval can
+    # project the exact identity into read-only report subprocesses.
+    attestation = {"schema": "mac.report_repository_executor_attestation.v1"}
+    exit_code, report = _run_openshell_loop_worker_self_test(
+        tmp_path,
+        monkeypatch,
+        attestation=attestation,
+        extra_env={"MAC_OPENSHELL_SANDBOX": "0", "MAC_OPENSHELL_REQUIRED": "0"},
+    )
+
+    assert exit_code == 0, report["blocking_problems"]
+    assert report["status"] == "passed"
+    assert report["checks"]["report_repository_executor_attestation"] is True
+    assert report["report_repository_executor_attestation"] == attestation
+
+
 def test_invalid_openshell_create_args_still_blocks_startup(tmp_path, monkeypatch):
     # Fail-closed control: an invalid MAC_OPENSHELL_CREATE_ARGS is a genuine
     # misconfiguration that must remain blocking even though the (patched)


### PR DESCRIPTION
Fixes the Rocky read-only report approval blocker: macOS loop workers now serialize their digest-bound executor attestation in startup proof. Adds host-loop regression coverage.