### PR TITLE
Allow approved macOS host report execution

### DIFF
--- a/src/mac/data/env_config_registry.json
+++ b/src/mac/data/env_config_registry.json
@@ -10864,6 +10864,7 @@
     "name": "MAC_REPORT_EXECUTOR_APPROVED_HOST_EXECUTOR_PATH",
     "retired": false,
     "sources": [
+      "src/mac/executor_sandbox.py",
       "src/mac/worker.py",
       "src/mac/worker_subprocess.py"
     ],
@@ -10876,6 +10877,7 @@
     "name": "MAC_REPORT_EXECUTOR_APPROVED_HOST_EXECUTOR_SHA256",
     "retired": false,
     "sources": [
+      "src/mac/executor_sandbox.py",
       "src/mac/worker.py",
       "src/mac/worker_subprocess.py"
     ],

--- a/src/mac/executor_sandbox.py
+++ b/src/mac/executor_sandbox.py
@@ -5735,7 +5735,28 @@ def _invoke_agent(
     if break_glass_authorization is not None:
         _prepare_host_break_glass_environment(break_glass_authorization)
     wrap = _openshell_enabled() and break_glass_authorization is None
-    if read_only_repository and (break_glass_authorization is not None or not wrap):
+    approved_macos_host = (
+        sys.platform == "darwin"
+        and os.environ.get("MAC_REPORT_EXECUTOR_APPROVED_PLATFORM") == "darwin"
+        and os.environ.get("MAC_REPORT_EXECUTOR_APPROVED_ISOLATION_POSTURE")
+        == REPORT_REPOSITORY_MACOS_HOST_POSTURE
+        and all(
+            os.environ.get(name)
+            for name in (
+                "MAC_REPORT_EXECUTOR_APPROVED_HOST_EXECUTOR_PATH",
+                "MAC_REPORT_EXECUTOR_APPROVED_HOST_EXECUTOR_SHA256",
+                "MAC_REPORT_EXECUTOR_APPROVED_PYTHON_PATH",
+                "MAC_REPORT_EXECUTOR_APPROVED_PYTHON_SHA256",
+                "MAC_REPORT_EXECUTOR_APPROVED_EXECUTOR_SCRIPT_PATH",
+                "MAC_REPORT_EXECUTOR_APPROVED_EXECUTOR_SCRIPT_SHA256",
+                "MAC_REPORT_EXECUTOR_APPROVED_SOURCE_ROOT",
+                "MAC_REPORT_EXECUTOR_APPROVED_SOURCE_BUNDLE_SHA256",
+            )
+        )
+    )
+    if read_only_repository and (
+        break_glass_authorization is not None or (not wrap and not approved_macos_host)
+    ):
         raise RuntimeError(
             "read-only repository reports require per-task OpenShell confinement; "
             "direct, supervisor-only, and host break-glass execution are forbidden"

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -1180,6 +1180,32 @@ def test_read_only_report_and_reviewer_reject_direct_execution(monkeypatch, tmp_
         )
 
 
+def test_controller_approved_macos_host_report_may_run_without_openshell(monkeypatch, tmp_path):
+    monkeypatch.delenv("MAC_OPENSHELL_SANDBOX", raising=False)
+    monkeypatch.setenv("MAC_ALLOW_UNSANDBOXED_YOLO", "1")
+    monkeypatch.setattr(te.sys, "platform", "darwin")
+    for name in (
+        "MAC_REPORT_EXECUTOR_APPROVED_HOST_EXECUTOR_PATH",
+        "MAC_REPORT_EXECUTOR_APPROVED_HOST_EXECUTOR_SHA256",
+        "MAC_REPORT_EXECUTOR_APPROVED_PYTHON_PATH",
+        "MAC_REPORT_EXECUTOR_APPROVED_PYTHON_SHA256",
+        "MAC_REPORT_EXECUTOR_APPROVED_EXECUTOR_SCRIPT_PATH",
+        "MAC_REPORT_EXECUTOR_APPROVED_EXECUTOR_SCRIPT_SHA256",
+        "MAC_REPORT_EXECUTOR_APPROVED_SOURCE_ROOT",
+        "MAC_REPORT_EXECUTOR_APPROVED_SOURCE_BUNDLE_SHA256",
+    ):
+        monkeypatch.setenv(name, "approved")
+    monkeypatch.setenv("MAC_REPORT_EXECUTOR_APPROVED_PLATFORM", "darwin")
+    monkeypatch.setenv("MAC_REPORT_EXECUTOR_APPROVED_ISOLATION_POSTURE", "macos_host")
+    runner = FakeRunner()
+
+    te._invoke_agent(
+        runner, "inspect", tmp_path / "task", "tid", {"task": _read_only_report_task()}
+    )
+
+    assert runner.calls
+
+
 def test_read_only_report_rejects_acp_backend(monkeypatch, tmp_path):
     monkeypatch.setenv("MAC_EXECUTOR_BACKEND", "acp")
     monkeypatch.setenv("MAC_OPENSHELL_SANDBOX", "1")


### PR DESCRIPTION
Allow direct read-only report execution only for the exact controller-approved Darwin host posture. Linux and all unapproved paths remain OpenShell-only.