### PR TITLE
Forward disabled OpenShell policy into quiescence

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -6761,6 +6761,10 @@ EOF
     "MAC_DEPLOY_DAEMON_RUNTIME_PATHS=$runtime_paths"
     "MAC_DEPLOY_DAEMON_RUNTIME_PATHS_CONFIGURED=$runtime_paths_configured"
   )
+  # MAC_DEPLOY_OPENSHELL_ENABLED is deployment policy rather than a secret.
+  # Forward it through this outer env -i boundary and the Python child
+  # allowlist below so an explicitly disabled node does not inventory a
+  # retired legacy gateway.
   for env_name in \
     USER LOGNAME TMPDIR SHELL \
     XDG_CONFIG_HOME XDG_DATA_HOME XDG_CACHE_HOME XDG_RUNTIME_DIR \
@@ -6779,6 +6783,7 @@ EOF
     MAC_DEPLOY_REVIEWED_OPENSHELL_ASSET_SHA256 \
     MAC_DEPLOY_REVIEWED_OPENSHELL_CLI_SHA256 \
     MAC_DEPLOY_REVIEWED_OPENSHELL_RECEIPT_SHA256 \
+    MAC_DEPLOY_OPENSHELL_ENABLED \
     MAC_OPENCLAW_SUBPROCESS_TIMEOUT_SECONDS \
     MAC_OPENCLAW_SANDBOX_DELETE_TIMEOUT_SECONDS; do
     env_value="${!env_name-}"
@@ -7167,6 +7172,11 @@ common_child_environment = (
     "XDG_CACHE_HOME",
     "XDG_RUNTIME_DIR",
     "DBUS_SESSION_BUS_ADDRESS",
+    # Deployment policy is authority, not test fixture state.  The phase-one
+    # gate runs in an isolated child, so this must be part of its production
+    # allowlist for an explicitly disabled OpenShell deployment to retire an
+    # unreachable legacy gateway.
+    "MAC_DEPLOY_OPENSHELL_ENABLED",
 )
 test_child_environment = (
     "FAKE_DAEMON_CALLS",
@@ -7183,7 +7193,6 @@ test_child_environment = (
     "FAKE_GATE_CAPTURE",
     "FAKE_STALE_SANDBOXES",
     "FAKE_LIVE_DRAIN_LISTS",
-    "MAC_DEPLOY_OPENSHELL_ENABLED",
 )
 
 

--- a/tests/test_fleet_node_daemon_quiescence.py
+++ b/tests/test_fleet_node_daemon_quiescence.py
@@ -817,6 +817,20 @@ def test_deploy_credentials_are_absent_from_gate_and_daemon_children(
     _assert_success_marker(run)
 
 
+def test_explicitly_disabled_openshell_skips_unreachable_legacy_inventory(
+    tmp_path: Path,
+) -> None:
+    """Phase-one policy must cross the isolated child-process boundary."""
+    run = _run_quiescence(
+        tmp_path,
+        openshell_mode="nonzero",
+        extra_env={"MAC_DEPLOY_OPENSHELL_ENABLED": "0"},
+    )
+
+    _assert_success_marker(run)
+    assert not any(line.startswith("openshell:") for line in _call_lines(run))
+
+
 def test_container_probe_gets_metadata_only_docker_config(tmp_path: Path) -> None:
     docker_config = tmp_path / "docker-config-with-auth"
     docker_config.mkdir()


### PR DESCRIPTION
Fixes the phase-one deployment boundary that stripped `MAC_DEPLOY_OPENSHELL_ENABLED` before the isolated daemon quiescence program. Adds a regression for an unreachable legacy inventory on an explicitly disabled node.