### PR TITLE
Resolve MAC toolchain Git in fleet prerequisites

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -7316,8 +7316,23 @@ openshell_checks = (
     if openshell_required
     else [path_check("openshell-disabled-state", mac_home)]
 )
+# A node-local MAC toolchain is intentional onboarding state.  The remote
+# prerequisite shell is entered over SSH, whose default PATH commonly omits
+# ~/.mac/bin; prefer that sealed executable before considering the host Git.
+# This is essential for provider Ubuntu 22.04 images, where /usr/bin/git is
+# 2.34 but MAC supplies the >=2.38 merge-queue toolchain without sudo.
 git_cli = next(
-    (str(Path(candidate).resolve()) for candidate in (shutil.which("git"), "/opt/homebrew/bin/git", "/usr/local/bin/git", "/usr/bin/git") if candidate and Path(candidate).is_file()),
+    (
+        str(Path(candidate).resolve())
+        for candidate in (
+            mac_home / "bin" / "git",
+            shutil.which("git"),
+            "/opt/homebrew/bin/git",
+            "/usr/local/bin/git",
+            "/usr/bin/git",
+        )
+        if candidate and Path(candidate).is_file() and os.access(candidate, os.X_OK)
+    ),
     None,
 )
 if git_cli is None:

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -1277,6 +1277,11 @@ def test_typed_machine_onboarding_receipt_pins_required_cli_paths():
 
     assert 'path_check("mac-cli", mac_bin, executable=True)' in builder
     assert 'path_check("github-cli", github_cli, executable=True)' in builder
+    # The prerequisite runs in an SSH shell, whose PATH does not necessarily
+    # include the user-owned MAC toolchain.  Prefer its modern Git before the
+    # Ubuntu 22.04 system Git (2.34) so the merge-queue floor can be proved.
+    assert 'mac_home / "bin" / "git"' in builder
+    assert builder.index('mac_home / "bin" / "git"') < builder.index('shutil.which("git")')
     assert "MAC_PREREQ_NETWORK_PROVIDER=" in builder
     assert 'provider in {"tailscale", "headscale"}' in builder
     assert 'ipaddress.ip_network("100.64.0.0/10")' in builder


### PR DESCRIPTION
Fixes the HGX prerequisite resolver to prefer the active MAC user-scoped Git at ~/.mac/bin/git before SSH default PATH. Covers the Ubuntu 22.04 provider image where /usr/bin/git is below MAC\u2019s required Git floor.\n\nVerification: make lint; full scripts/run-contract-tests.sh (11,344 passed, 3 skipped, 1 xfailed; coverage selection 200 passed, 4 skipped).