### PR TITLE
Keep Hermes gateway log anomalies non-fatal by default

### DIFF
--- a/deploy/fleet-node-install.sh
+++ b/deploy/fleet-node-install.sh
@@ -14652,9 +14652,25 @@ if [ "${MAC_CHAT_GATEWAY_IMPL:-openclaw}" = "openclaw" ]; then
     note_gateway_degraded "OpenClaw gateway log contains actionable errors"
   fi
 elif [ "$SUPERVISOR_KIND" = "systemd" ]; then
-  classify_gateway_logs "$LOG_DIR/hermes-gateway-journal.txt"
+  # Hermes is likewise a conversation surface, not a task-execution
+  # dependency.  Do not let a transient gateway traceback strand an otherwise
+  # healthy executor cohort.  Keep the strict opt-in available to operators
+  # who explicitly require chat health before accepting a deployment.
+  gateway_log="$LOG_DIR/hermes-gateway-journal.txt"
+  if ! classify_gateway_logs "$gateway_log"; then
+    if gateway_probe_is_fatal; then
+      exit 1
+    fi
+    note_gateway_degraded "Hermes gateway log contains actionable errors"
+  fi
 else
-  classify_gateway_logs "$LOG_DIR/hermes-gateway.log"
+  gateway_log="$LOG_DIR/hermes-gateway.log"
+  if ! classify_gateway_logs "$gateway_log"; then
+    if gateway_probe_is_fatal; then
+      exit 1
+    fi
+    note_gateway_degraded "Hermes gateway log contains actionable errors"
+  fi
 fi
 
 log "verifying hub health and local executor startup report"

--- a/tests/test_deploy_agent_configs.py
+++ b/tests/test_deploy_agent_configs.py
@@ -2800,6 +2800,30 @@ def test_gateway_log_classifier_failure_is_non_fatal_by_default_for_openclaw():
     )
 
 
+def test_gateway_log_classifier_failure_is_non_fatal_by_default_for_hermes():
+    # The Hermes branch must honor the same gateway-probe policy.  On
+    # 2026-09-10 a single transient traceback in Rocky's Hermes log bypassed
+    # this guard and stranded a healthy held fleet before it wrote its post
+    # manifest.
+    script = deploy_script_text()
+    call_site = script.split(
+        'elif [ "$SUPERVISOR_KIND" = "systemd" ]; then\n'
+        "  # Hermes is likewise a conversation surface, not a task-execution\n",
+        1,
+    )[1].split('log "verifying hub health', 1)[0]
+
+    assert call_site.count('if ! classify_gateway_logs "$gateway_log"; then') == 2
+    assert call_site.count("if gateway_probe_is_fatal; then") == 2
+    assert (
+        call_site.count('note_gateway_degraded "Hermes gateway log contains actionable errors"')
+        == 2
+    )
+    assert (
+        re.search(r'^\s*classify_gateway_logs "\$LOG_DIR/hermes-gateway', call_site, re.MULTILINE)
+        is None
+    )
+
+
 def test_fleet_deploy_treats_unconfigured_discord_startup_as_benign():
     script = deploy_script_text()
     classifier = script.split("classify_gateway_logs() {", 1)[1].split(


### PR DESCRIPTION
Fixes the Hermes branch of the fleet gateway-log classifier so transient chat-gateway errors do not strand healthy task executors. Adds regression coverage. Full contract suite: 624 passed; deployment-config suite: 143 passed; make lint clean.