### PR TITLE
Avoid jobs listing race in bounded fleet phases

### DIFF
--- a/deploy/deploy-mac-fleet.sh
+++ b/deploy/deploy-mac-fleet.sh
@@ -11135,12 +11135,12 @@ run_bounded_node_phase() {
           reaped_any=1
           if [ "$status" -ne 0 ]; then failed=1; fi
         elif [ "${phase_active[scan]:-0}" = 1 ] \
-            && { ! kill -0 "${phase_pids[scan]}" 2>/dev/null \
-              || ! jobs -pr | awk -v wanted="${phase_pids[scan]}" \
-                '$0 == wanted { found=1 } END { exit(found ? 0 : 1) }'; }; then
+            && ! kill -0 "${phase_pids[scan]}" 2>/dev/null; then
           # The child died before publishing its atomic status (for example,
-          # SIGKILL, or a `jobs -pr` race against a child that already
-          # exited). Reap it and synthesize a controller failure instead of
+          # SIGKILL). `jobs -pr` is deliberately not a liveness authority:
+          # on some shells it briefly omits a live child while that child is
+          # atomically publishing its status file. Reap it and synthesize a
+          # controller failure instead of
           # polling a receipt that can never appear. Say so explicitly: an
           # unexplained status=125 with no matching phase-log error reads as
           # a mysterious phase failure rather than what it is -- the
@@ -11179,9 +11179,7 @@ run_bounded_node_phase() {
         reaped_any=1
         if [ "$status" -ne 0 ]; then failed=1; fi
       elif [ "${phase_active[scan]:-0}" = 1 ] \
-          && { ! kill -0 "${phase_pids[scan]}" 2>/dev/null \
-            || ! jobs -pr | awk -v wanted="${phase_pids[scan]}" \
-              '$0 == wanted { found=1 } END { exit(found ? 0 : 1) }'; }; then
+          && ! kill -0 "${phase_pids[scan]}" 2>/dev/null; then
         echo "==> ${phase_agents[scan]}: ${phase} child exited without publishing its status file (status=125 synthesized); this is a controller/job-control condition, not necessarily a command failure inside the phase -- retry" >&2
         wait "${phase_pids[scan]}" 2>/dev/null || true
         phase_statuses[scan]=125

--- a/tests/test_deploy_fleet_drain.py
+++ b/tests/test_deploy_fleet_drain.py
@@ -757,6 +757,37 @@ run_bounded_node_phase {shlex.quote(str(specs))} die-before-status self_destruct
     assert "ERROR: victim: die-before-status failed with status 125" in result.stderr
 
 
+def test_bounded_node_phase_does_not_treat_jobs_listing_as_child_liveness(tmp_path):
+    # A 2026-09-10 HGX prerequisite command completed successfully but its
+    # child was temporarily absent from `jobs -pr` while publishing the
+    # atomic status file. The controller must use the child's PID instead.
+    deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+    bounded = (
+        "run_bounded_node_phase() {"
+        + deploy.split("run_bounded_node_phase() {", 1)[1].split(
+            "\n}\n\npreflight_probe_helper_source", 1
+        )[0]
+        + "\n}"
+    )
+    specs = tmp_path / "selected-specs"
+    specs.write_text("healthy|fixture\n", encoding="utf-8")
+    snippet = f"""set -euo pipefail
+TMPDIR_LOCAL={shlex.quote(str(tmp_path))}
+NODE_PARALLELISM=1
+BOUNDED_NODE_PHASE_AGGREGATE_FAILURES=0
+stable_worker_agent_id() {{ printf '%s\\n' "$1"; }}
+jobs() {{ return 0; }}
+live_worker() {{ sleep 0.2; printf 'completed\\n'; }}
+{bounded}
+run_bounded_node_phase {shlex.quote(str(specs))} jobs-race live_worker
+"""
+    result = subprocess.run(["bash", "-c", snippet], text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+    assert "healthy: jobs-race passed" in result.stdout
+    assert "status=125 synthesized" not in result.stderr
+
+
 def test_legacy_hub_bootstrap_preflights_onboarding_before_phase1():
     deploy = DEPLOY_SCRIPT.read_text(encoding="utf-8")
     legacy = deploy.split("legacy_hub_bootstrap() {", 1)[1].split(


### PR DESCRIPTION
Fixes the HGX bounded-phase controller race: a live child omitted transiently from `jobs -pr` is no longer synthesized as status 125. Full contract gate passed: 11,346 passed, 3 skipped, 1 xfailed; selected coverage 200 passed, 4 skipped; lint clean.